### PR TITLE
Prevent MVC from populating an ApplicationPart for each module.

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
@@ -35,6 +35,8 @@ namespace OrchardCore.Mvc
         public static IServiceCollection AddMvcModules(this IServiceCollection services,
             IServiceProvider applicationServices)
         {
+            services.TryAddSingleton(new ApplicationPartManager());
+
             var builder = services.AddMvcCore(options =>
             {
                 // Do we need this?


### PR DESCRIPTION
**The issue**

- If, in `AddMvcCore()`, mvc can't resolve `ApplicationPartManager` it creates a new one, see [here](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs#L78).

- Then, it populates `ApplicationParts` with all discovered assemblies, see [here](https://github.com/aspnet/Mvc/blob/dev/src/Microsoft.AspNetCore.Mvc.Core/DependencyInjection/MvcCoreServiceCollectionExtensions.cs#L88).

- Notice that for doing this it needs to resolve the `IHostingEnvironment` service.

- But we don't want this because we could hit a controller of a module even it is not enabled. Then it may fail but only if it uses some unregistered services (startups of disabled modules are not executed).

- We just want to use our `ShellFeatureApplicationPart` which only return `Types` of enabled features.

**The fix**

- Before, this was not the case because we was not passing the full tenant services to the module startups, so the needed `IHostingEnvironment` service was not resolved (see above).

- So, to retrieve the same behavior we just need to create and register a new `ApplicationPartManager`, this before calling `AddMvcCore()`. Then, mvc will not try to populate `ApplicationParts` (see above).

- Then, if another module re-call `AddMvcCore()` (which was one of the goals), it is ok because an instance of `ApplicationPartManager` is already registered.

- So, now when we hit a controller of a disabled module, we get a not found page but without failing.

**Last thinkings**

- Maybe it would be more regular to have an `ApplicationPart` for each module, but first we would need to filter them to only the enabled ones. But the problem is that we are based on features, that's why we use a custom `ShellFeatureApplicationPart` which is aware of enabled features.


