### PR TITLE
Provides default route names for razor pages.

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/DefaultModularPageRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/DefaultModularPageRouteModelConvention.cs
@@ -16,8 +16,9 @@ namespace OrchardCore.Mvc.RazorPages
                     var moduleFolder = template.Substring(0, pageIndex);
                     var moduleId = moduleFolder.Substring(moduleFolder.LastIndexOf("/") + 1);
 
-                    selector.AttributeRouteModel.Template = moduleId + template
-                        .Replace("/Pages/", "/").Substring(pageIndex);
+                    template = moduleId + template.Replace("/Pages/", "/").Substring(pageIndex);
+                    selector.AttributeRouteModel.Name = template.Replace('/', '.');
+                    selector.AttributeRouteModel.Template = template;
                 }
             }
         }


### PR DESCRIPTION
- So, for a razor page defined in `/OrchardCore.Demo/Pages/Hello.cshtml`, the default route template is already `OrchardCore.Demo/Hello`.

- Then here we also provide a default route name `OrchardCore.Demo.Hello`.

- This is useful with tag helpers which look for the attribute `asp-route="OrchardCore.Demo.Hello"`.

- Otherwise, in the context of a razor page,  with another attribute we would need to know the full relative path which contains the extension folder `/Packages/OrchardCore.Demo/Pages/Hello`