### PR TITLE
Fixes a couple of user validation issues

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
@@ -16,37 +16,42 @@
     var options = identityOptions.Value;
     var passwordOptions = new HtmlContentBuilder();
     IHtmlContent separator = HtmlString.Empty;
-    
+
     if (options.Password.RequireNonAlphanumeric)
     {
         passwordOptions.AppendHtml(separator).AppendHtml(T["one non-alphanumeric"]);
         separator = T[", "];
     }
-    
+
     if (options.Password.RequireUppercase)
     {
         passwordOptions.AppendHtml(separator).AppendHtml(T["one uppercase"]);
         separator = T[", "];
     }
-    
+
     if (options.Password.RequireLowercase)
     {
         passwordOptions.AppendHtml(separator).AppendHtml(T["one lowercase"]);
         separator = T[", "];
     }
-    
+
     if (options.Password.RequireDigit)
     {
         passwordOptions.AppendHtml(separator).AppendHtml(T["one digit"]);
         separator = T[", "];
     }
-    
+
     if (separator != HtmlString.Empty)
     {
         separator = T[" and "];
     }
 
     passwordOptions.AppendHtml(separator).AppendHtml(T["{0} characters in total", options.Password.RequiredLength]);
+
+    if (options.Password.RequiredUniqueChars > 1)
+    {
+        passwordOptions.AppendHtml(T[", with {0} unique characters", options.Password.RequiredUniqueChars]);
+    }
 
     var passwordTooltip = T["Password must have at least {0}.", passwordOptions];
 }

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -66,6 +66,7 @@ namespace OrchardCore.Users.Services
             if (!identityResult.Succeeded)
             {
                 ProcessValidationErrors(identityResult.Errors, user, reportError);
+                return null;
             }
 
             return user;
@@ -115,6 +116,9 @@ namespace OrchardCore.Users.Services
                         break;
                     case "PasswordTooShort":
                         reportError("Password", T["Passwords must be at least {0} characters.", _identityOptions.Value.Password.RequiredLength]);
+                        break;
+                    case "PasswordRequiresUniqueChars":
+                        reportError("Password", T["Passwords must contain at least {0} unqiue characters.", _identityOptions.Value.Password.RequiredUniqueChars]);
                         break;
 
                     // CurrentPassword

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -118,7 +118,7 @@ namespace OrchardCore.Users.Services
                         reportError("Password", T["Passwords must be at least {0} characters.", _identityOptions.Value.Password.RequiredLength]);
                         break;
                     case "PasswordRequiresUniqueChars":
-                        reportError("Password", T["Passwords must contain at least {0} unqiue characters.", _identityOptions.Value.Password.RequiredUniqueChars]);
+                        reportError("Password", T["Passwords must contain at least {0} unique characters.", _identityOptions.Value.Password.RequiredUniqueChars]);
                         break;
 
                     // CurrentPassword


### PR DESCRIPTION
* Fixes bug where UI would incorrectly say that user had been created if their password was not valid. Repro: Go to admin, create user, pick a password that won't satisfy the criteria required by `IdentityOptions`, complete all other fields correctly, save.
* Adds password RequiredUniqueChars UI validation (new validation property introduced in .net core 2.0)