### PR TITLE
Adds auto-registration of types with service container.

### DIFF
--- a/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/Features/Attributes/ServiceAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/Features/Attributes/ServiceAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OrchardCore.Environment.Extensions.Features.Attributes
+{
+    /// <summary>
+    /// Apply this attribute to the type that should be used to register a service implementation.
+    /// Used in conjunction with <see cref="ServiceImplAttribute"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true)]
+    public class ServiceAttribute : Attribute
+    {
+        public ServiceAttribute() : this(ServiceLifetime.Scoped)
+        {
+        }
+
+        public ServiceAttribute(Type serviceType) : this(ServiceLifetime.Scoped, serviceType)
+        {
+        }
+
+        public ServiceAttribute(ServiceLifetime serviceLifetime)
+        {
+            ServiceLifetime = serviceLifetime;
+        }
+
+        public ServiceAttribute(ServiceLifetime serviceLifetime, Type serviceType)
+        {
+            ServiceType = serviceType;
+            ServiceLifetime = serviceLifetime;
+        }
+
+        public ServiceLifetime ServiceLifetime { get; }
+        public Type ServiceType { get; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/Features/Attributes/ServiceImplAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/Features/Attributes/ServiceImplAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace OrchardCore.Environment.Extensions.Features.Attributes
+{
+    /// <summary>
+    /// Use this attribute to automatically register the class with the service container.
+    /// To be used in conjunction with <seealso cref="ServiceAttribute"/>, where the <seealso cref="ServiceAttribute"/> is applied to the type to register this implementation as.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public class ServiceImplAttribute : Attribute
+    {
+    }
+}

--- a/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/Features/Attributes/ServiceOverrideAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/Features/Attributes/ServiceOverrideAttribute.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace OrchardCore.Environment.Extensions.Features.Attributes
+{
+    /// <summary>
+    /// Allows the annotated class to be registered instead of the class being overridden.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+
+    public class ServiceOverrideAttribute : ServiceImplAttribute
+    {
+        public ServiceOverrideAttribute(Type type) : this(type.FullName)
+        {
+        }
+
+        public ServiceOverrideAttribute(string typeName)
+        {
+            TypeName = typeName;
+        }
+
+        public string TypeName { get; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/OrchardCore.Environment.Extensions.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/OrchardCore.Environment.Extensions.Abstractions.csproj
@@ -11,8 +11,4 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Features\Attributes\" />
-  </ItemGroup>
-
 </Project>

--- a/src/OrchardCore/OrchardCore.Environment.Shell.Abstractions/IDependencyLoader.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell.Abstractions/IDependencyLoader.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OrchardCore.Environment.Shell
+{
+    /// <summary>
+    /// Implementing types perform auto-registration of the specified set of types (typically provided by a shell blueprint).
+    /// </summary>
+    public interface IDependencyLoader
+    {
+        /// <summary>
+        /// Selects all types that are annotated with <seealso cref="ServiceImplAttribute"/> and registers those types with the specified service container.
+        /// </summary>
+        /// <param name="types">The un-filtered set of types to look for service types (i.e. types annotated with <seealso cref="ServiceImplAttribute">).</param>
+        /// <param name="serviceCollection">The service container to register discovered types with.</param>
+        void RegisterDependencies(IEnumerable<Type> types, IServiceCollection serviceCollection);
+    }
+}

--- a/src/OrchardCore/OrchardCore.Environment.Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell/Builders/ShellContainerFactory.cs
@@ -14,14 +14,17 @@ namespace OrchardCore.Environment.Shell.Builders
         private readonly IServiceProvider _serviceProvider;
         private readonly ILogger _logger;
         private readonly ILoggerFactory _loggerFactory;
+        private readonly IDependencyLoader _dependencyLoader;
         private readonly IServiceCollection _applicationServices;
 
         public ShellContainerFactory(
             IServiceProvider serviceProvider,
             ILoggerFactory loggerFactory,
             ILogger<ShellContainerFactory> logger,
+            IDependencyLoader dependencyLoader,
             IServiceCollection applicationServices)
         {
+            _dependencyLoader = dependencyLoader;
             _applicationServices = applicationServices;
             _serviceProvider = serviceProvider;
             _loggerFactory = loggerFactory;
@@ -37,19 +40,18 @@ namespace OrchardCore.Environment.Shell.Builders
 
         public IServiceProvider CreateContainer(ShellSettings settings, ShellBlueprint blueprint)
         {
-            IServiceCollection tenantServiceCollection = _serviceProvider.CreateChildContainer(_applicationServices);
+            var tenantServiceCollection = _serviceProvider.CreateChildContainer(_applicationServices);
 
             tenantServiceCollection.AddSingleton(settings);
             tenantServiceCollection.AddSingleton(blueprint.Descriptor);
             tenantServiceCollection.AddSingleton(blueprint);
 
             AddCoreServices(tenantServiceCollection);
-            
+
+            // TODO: Use StartupLoader in RTM and then don't need to register the classes anymore then.
+
             // Execute IStartup registrations
-
-            // TODO: Use StartupLoader in RTM and then don't need to register the classes anymore then
-
-            IServiceCollection moduleServiceCollection = _serviceProvider.CreateChildContainer(_applicationServices);
+            var moduleServiceCollection = _serviceProvider.CreateChildContainer(_applicationServices);
 
             foreach (var dependency in blueprint.Dependencies.Where(t => typeof(OrchardCore.Modules.IStartup).IsAssignableFrom(t.Key)))
             {
@@ -57,17 +59,20 @@ namespace OrchardCore.Environment.Shell.Builders
                 tenantServiceCollection.AddSingleton(typeof(OrchardCore.Modules.IStartup), dependency.Key);
             }
 
-            // Add a default configuration if none has been provided
+            // Auto-register declared services for tenant.
+            _dependencyLoader.RegisterDependencies(blueprint.Dependencies.Keys, tenantServiceCollection);
+
+            // Add a default configuration if none has been provided.
             var configuration = new ConfigurationBuilder().AddInMemoryCollection().Build();
             moduleServiceCollection.TryAddSingleton(configuration);
             tenantServiceCollection.TryAddSingleton(configuration);
 
-            // Make shell settings available to the modules
+            // Make shell settings available to the modules.
             moduleServiceCollection.AddSingleton(settings);
 
             var moduleServiceProvider = moduleServiceCollection.BuildServiceProvider(true);
 
-            // Index all service descriptors by their feature id
+            // Index all service descriptors by their feature id.
             var featureAwareServiceCollection = new FeatureAwareServiceCollection(tenantServiceCollection);
 
             var startups = moduleServiceProvider.GetServices<OrchardCore.Modules.IStartup>();
@@ -75,8 +80,8 @@ namespace OrchardCore.Environment.Shell.Builders
             // IStartup instances are ordered by module dependency with an Order of 0 by default.
             // OrderBy performs a stable sort so order is preserved among equal Order values.
             startups = startups.OrderBy(s => s.Order);
-            
-            // Let any module add custom service descriptors to the tenant
+
+            // Let any module add custom service descriptors to the tenant.
             foreach (var startup in startups)
             {
                 var feature = blueprint.Dependencies.FirstOrDefault(x => x.Key == startup.GetType()).Value.FeatureInfo;
@@ -87,12 +92,12 @@ namespace OrchardCore.Environment.Shell.Builders
 
             (moduleServiceProvider as IDisposable).Dispose();
 
-            // add already instanciated services like DefaultOrchardHost
+            // Add already instantiated services like DefaultOrchardHost.
             var applicationServiceDescriptors = _applicationServices.Where(x => x.Lifetime == ServiceLifetime.Singleton);
-            
+
             var shellServiceProvider = tenantServiceCollection.BuildServiceProvider(true);
 
-            // Register all DIed types in ITypeFeatureProvider
+            // Register all DIed types in ITypeFeatureProvider.
             var typeFeatureProvider = shellServiceProvider.GetRequiredService<ITypeFeatureProvider>();
 
             foreach (var featureServiceCollection in featureAwareServiceCollection.FeatureCollections)
@@ -109,11 +114,11 @@ namespace OrchardCore.Environment.Shell.Builders
                     }
                     else
                     {
-                        // Factory, we can't know which type will be returned
+                        // Factory, we can't know which type will be returned.
                     }
                 }
             }
-            
+
             return shellServiceProvider;
         }
     }

--- a/src/OrchardCore/OrchardCore.Environment.Shell/DependencyLoader.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell/DependencyLoader.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Environment.Extensions.Features.Attributes;
+
+namespace OrchardCore.Environment.Shell
+{
+    public class DependencyLoader : IDependencyLoader
+    {
+        public void RegisterDependencies(IEnumerable<Type> types, IServiceCollection serviceCollection)
+        {
+            // Discover dependencies to be registered.
+            // Only types annotated with either [ServiceImpl] or [ServiceOverride] attributes are selected.
+            var dependenciesQuery =
+                from dependency in types
+                let dependencyTypeInfo = dependency.GetTypeInfo()
+                let hasDependencyAttribute = dependencyTypeInfo.GetCustomAttribute<ServiceImplAttribute>() != null
+                where hasDependencyAttribute && dependencyTypeInfo.IsClass && !dependencyTypeInfo.IsAbstract
+                select new DependencyInfo(dependency, dependencyTypeInfo);
+
+            var filteredDependencies = FilterSuppressedTypes(dependenciesQuery).ToList();
+
+            // For each dependency, select its service type(s) to be registered as.
+            foreach (var dependencyInfo in filteredDependencies)
+            {
+                var dependency = dependencyInfo.DependencyType;
+                var dependencyTypeInfo = dependencyInfo.DependencyTypeInfo;
+                var typesToCheck = (new[] { dependency, dependencyTypeInfo.BaseType }).Concat(dependencyTypeInfo.ImplementedInterfaces).ToList();
+                var serviceTypeInfos =
+                    (from type in typesToCheck
+                     let typeInfo = type.GetTypeInfo()
+                     let serviceAttributes = typeInfo.GetCustomAttributes<ServiceAttribute>()
+                     from serviceAttribute in serviceAttributes
+                     select new
+                     {
+                         Type = type,
+                         TypeInfo = typeInfo,
+                         ServiceAttribute = serviceAttribute
+                     }).ToList();
+
+                // Register the dependency by each of its declared service types.
+                foreach (var serviceTypeInfo in serviceTypeInfos)
+                {
+                    var serviceType = serviceTypeInfo.ServiceAttribute.ServiceType ?? serviceTypeInfo.Type;
+
+                    switch (serviceTypeInfo.ServiceAttribute.ServiceLifetime)
+                    {
+                        case ServiceLifetime.Transient:
+                            serviceCollection.AddTransient(serviceType, dependency);
+                            break;
+                        case ServiceLifetime.Singleton:
+                            serviceCollection.AddSingleton(serviceType, dependency);
+                            break;
+                        case ServiceLifetime.Scoped:
+                        default:
+                            serviceCollection.AddScoped(serviceType, dependency);
+                            break;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Filters out any types that have been overridden using the <seealso cref="ServiceOverrideAttribute"/>.
+        /// </summary>
+        private IEnumerable<DependencyInfo> FilterSuppressedTypes(IEnumerable<DependencyInfo> dependencies)
+        {
+            var excludedTypesQuery =
+                from dependency in dependencies
+                let typeInfo = dependency.DependencyType.GetTypeInfo()
+                let replacedType = typeInfo.GetCustomAttribute<ServiceOverrideAttribute>()
+                where replacedType != null
+                select replacedType.TypeName;
+
+            var excludedTypes = excludedTypesQuery.ToList();
+            return dependencies.Where(x => !excludedTypes.Contains(x.DependencyType.FullName));
+        }
+
+        private class DependencyInfo
+        {
+            public DependencyInfo(Type dependencyType, TypeInfo typeInfo)
+            {
+                DependencyType = dependencyType;
+                DependencyTypeInfo = typeInfo;
+            }
+
+            public Type DependencyType { get; }
+            public TypeInfo DependencyTypeInfo { get; }
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Environment.Shell/DependencyLoader.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell/DependencyLoader.cs
@@ -69,7 +69,7 @@ namespace OrchardCore.Environment.Shell
         {
             var excludedTypesQuery =
                 from dependency in dependencies
-                let typeInfo = dependency.DependencyType.GetTypeInfo()
+                let typeInfo = dependency.DependencyTypeInfo
                 let replacedType = typeInfo.GetCustomAttribute<ServiceOverrideAttribute>()
                 where replacedType != null
                 select replacedType.TypeName;

--- a/src/OrchardCore/OrchardCore.Environment.Shell/ShellServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell/ShellServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace OrchardCore.Environment.Shell
             services.AddSingleton<ShellHost>();
             services.AddSingleton<IShellHost>(sp => sp.GetRequiredService<ShellHost>());
             services.AddSingleton<IShellDescriptorManagerEventHandler>(sp => sp.GetRequiredService<ShellHost>());
+            services.AddSingleton<IDependencyLoader, DependencyLoader>();
 
             {
                 // Use a single default site by default, i.e. if AddMultiTenancy hasn't been called before

--- a/test/OrchardCore.Tests/Shell/DependencyLoaderTests.cs
+++ b/test/OrchardCore.Tests/Shell/DependencyLoaderTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Environment.Extensions.Features.Attributes;
+using OrchardCore.Environment.Shell;
+using Xunit;
+
+namespace OrchardCore.Tests.Shell
+{
+    public class DependencyLoaderTests
+    {
+        private readonly IDependencyLoader _dependencyLoader;
+
+        public DependencyLoaderTests()
+        {
+            _dependencyLoader = new DependencyLoader();
+        }
+
+        [Fact]
+        public void RegistersTypesWithServiceImplAttribute()
+        {
+            var serviceCollection = new ServiceCollection();
+            var blueprintTypes = new[] { typeof(IDiscoverableService), typeof(INonDiscoverableService), typeof(DiscoverableService), typeof(NonDiscoverableService) };
+
+            _dependencyLoader.RegisterDependencies(blueprintTypes, serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var discoverableService = serviceProvider.GetService<IDiscoverableService>();
+
+            Assert.NotNull(discoverableService);
+            Assert.IsType<DiscoverableService>(discoverableService);
+        }
+
+        [Fact]
+        public void DoesNotRegisterTypesWithoutServiceImplAttribute()
+        {
+            var serviceCollection = new ServiceCollection();
+            var blueprintTypes = new[] { typeof(IDiscoverableService), typeof(INonDiscoverableService), typeof(DiscoverableService), typeof(NonDiscoverableService) };
+
+            _dependencyLoader.RegisterDependencies(blueprintTypes, serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var nonDiscoverableService = serviceProvider.GetService<INonDiscoverableService>();
+
+            Assert.Null(nonDiscoverableService);
+        }
+
+        [Fact]
+        public void CanOverrideServicesUsingOverrideServiceAttribute()
+        {
+            var serviceCollection = new ServiceCollection();
+            var blueprintTypes = new[] { typeof(IDiscoverableService), typeof(DiscoverableService), typeof(OverrideDiscoverableService) };
+
+            _dependencyLoader.RegisterDependencies(blueprintTypes, serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var overridingDiscoverableService = serviceProvider.GetService<IDiscoverableService>();
+
+            Assert.IsType<OverrideDiscoverableService>(overridingDiscoverableService);
+        }
+
+        [Fact]
+        public void RegistersSelfSufficientTypes()
+        {
+            var serviceCollection = new ServiceCollection();
+            var blueprintTypes = new[] { typeof(SelfService) };
+
+            _dependencyLoader.RegisterDependencies(blueprintTypes, serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var selfService = serviceProvider.GetService<SelfService>();
+
+            Assert.NotNull(selfService);
+        }
+
+        [Fact]
+        public void RegistersTypesWithMultipleServices()
+        {
+            var serviceCollection = new ServiceCollection();
+            var blueprintTypes = new[] { typeof(MultipleServices), typeof(IMultipleServices) };
+
+            _dependencyLoader.RegisterDependencies(blueprintTypes, serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var service1 = serviceProvider.GetService<MultipleServices>();
+            var service2 = serviceProvider.GetService<IMultipleServices>();
+
+            Assert.NotNull(service1);
+            Assert.NotNull(service2);
+            Assert.IsType<MultipleServices>(service2);
+        }
+
+        [Fact]
+        public void RegistersTypesWithExternalServices()
+        {
+            var serviceCollection = new ServiceCollection();
+            var blueprintTypes = new[] { typeof(ImplementsExternalService) };
+
+            _dependencyLoader.RegisterDependencies(blueprintTypes, serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var service = serviceProvider.GetService<Microsoft.AspNetCore.Html.IHtmlContent>();
+
+            Assert.NotNull(service);
+            Assert.IsType<ImplementsExternalService>(service);
+        }
+
+        public static IEnumerable<Type> GetTypesFromBlueprint()
+        {
+            return new[]
+            {
+                typeof(IDiscoverableService),
+                typeof(INonDiscoverableService),
+                typeof(DiscoverableService),
+                typeof(NonDiscoverableService),
+                typeof(OverrideDiscoverableService)
+            };
+        }
+
+        [Service]
+        private interface IDiscoverableService
+        {
+        }
+
+        private interface INonDiscoverableService
+        {
+        }
+
+        [ServiceImpl]
+        private class DiscoverableService : IDiscoverableService
+        {
+        }
+
+        private class NonDiscoverableService : INonDiscoverableService
+        {
+        }
+
+        [ServiceOverride(typeof(DiscoverableService))]
+        private class OverrideDiscoverableService : IDiscoverableService
+        {
+        }
+
+        [ServiceImpl, Service]
+        private class SelfService
+        {
+        }
+
+        [Service(ServiceLifetime.Singleton)]
+        private interface IMultipleServices
+        {
+        }
+
+        [ServiceImpl, Service(ServiceLifetime.Singleton)]
+        private class MultipleServices : IMultipleServices
+        {
+        }
+
+        [ServiceImpl, Service(typeof(Microsoft.AspNetCore.Html.IHtmlContent))]
+        private class ImplementsExternalService : Microsoft.AspNetCore.Html.IHtmlContent
+        {
+            public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Shell/DependencyLoaderTests.cs
+++ b/test/OrchardCore.Tests/Shell/DependencyLoaderTests.cs
@@ -48,6 +48,20 @@ namespace OrchardCore.Tests.Shell
         }
 
         [Fact]
+        public void DoesNotRegisterTypesWithoutServiceAttribute()
+        {
+            var serviceCollection = new ServiceCollection();
+            var blueprintTypes = new[] { typeof(WontRegisterService) };
+
+            _dependencyLoader.RegisterDependencies(blueprintTypes, serviceCollection);
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var discoverableService = serviceProvider.GetService<WontRegisterService>();
+
+            Assert.Null(discoverableService);
+        }
+
+        [Fact]
         public void CanOverrideServicesUsingOverrideServiceAttribute()
         {
             var serviceCollection = new ServiceCollection();
@@ -144,6 +158,11 @@ namespace OrchardCore.Tests.Shell
 
         [ServiceImpl, Service]
         private class SelfService
+        {
+        }
+
+        [ServiceImpl]
+        private class WontRegisterService
         {
         }
 

--- a/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
@@ -10,6 +10,7 @@ using OrchardCore.Environment.Shell.Builders.Models;
 using OrchardCore.Environment.Shell.Descriptor.Models;
 using OrchardCore.Environment.Extensions.Features;
 using OrchardCore.Environment.Extensions;
+using Moq;
 
 namespace OrchardCore.Tests.Shell
 {
@@ -27,6 +28,7 @@ namespace OrchardCore.Tests.Shell
                 _applicationServiceProvider = applicationServices.BuildServiceProvider(),
                 new StubLoggerFactory(),
                 new NullLogger<ShellContainerFactory>(),
+                new Mock<IDependencyLoader>().Object,
                 applicationServices
             );
         }


### PR DESCRIPTION
This PR brings back automatic registration of types exposed by modules like we have in Orchard 1.
In Orchard 1, we can have a type registered with the service container automatically by having its interface derive from `IDependency`. With this PR, I chose to take a sightly different and more flexible approach by leveraging the following set of attributes:

- ServiceAttribute
- ServiceImplAttribute
- ServiceOverride : ServiceImplAttribute

**ServiceAttribute**
The `ServiceAttribute` marks a given type as the service as which an implementing type should be registered. This would typically be done on service interfaces. However, that is not required; you could also apply this attribute onto the implementing type directly. This would effectively register the type "as self".

This attributed allows you to specify the lifetime scope using the `ServiceLifetime` enum, and defaults to `ServiceLifetime.Scoped`.

It also allows you to optionally specify a different type to be registered as. This is useful in cases where you write a class that implements an interface from an external assembly, and you want to register your class as that external interface. I'll show an example below.

**ServiceImplAttribute**
The `ServiceImplAttribute` marks a given type as an implementing service that needs to be registered with the service container.

**ServiceOverrideAttribute**
The `ServiceOverrideAttribute` is a sub-class of `ServiceImplAttribute`, which means you can use it as well to mark a type for auto-registration. However, this attribute is used to override an existing service registration. This is useful where you for example have a custom module where you want to provide your own implementation of a given service, for which an out-of-box module already provided an implementation. This works the same way as in Orchard 1 using the `[FeatureOverride]` attribute.

The following shows a few examples of how you can now register your types from a module without having to do so via `Startup`.

**Example 1**
An interface representing the service, and a concrete implementation of that service:

```csharp
[Service]
interface IMyService {}

[ServiceImpl]
class MyService : IMyService {}

var service = serviceProvider.Resolve<IMyService>(); // Works
var service = serviceProvider.Resolve<MyService>(); // Fails
```

**Example 2**
A class representing the service and the concrete implementation:

```csharp
[ServiceImpl, Service]
class MyService {}

var service = serviceProvider.Resolve<MyService>(); // Works
```

**Example 3**
A class registered as a Singleton.

```csharp
[ServiceImpl, Service(ServiceLifetime.Singleton)]
class MyService {}
```

**Example 4**
A class overriding another implementing class.

```csharp
[Service]
interface IMyService {}

[ServiceImpl]
class MyDefaultService : IMyService {}

[ServiceOverride(typeof(MyDefaultService))]
class MyOverridingService : IMyService {}

var service = serviceProvider.Resolve<IMyService>();
Assert.IsType<MyOverridingService>(service); // True.
```

**Example 5**
A class registered as an interface from an external assembly.

```csharp
[ServiceImpl, Service(typeof(SomeExternalAssembly.ISomeExternalInterface))]
class MyService : SomeExternalAssembly.ISomeExternalInterface {}

var service = serviceProvider.Resolve<SomeExternalAssembly.ISomeExternalInterface>(); // Works
```