### PR TITLE
Restores Demo reference to Cms.Web project

### DIFF
--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\OrchardCore.Modules\OrchardCore.Demo\OrchardCore.Demo.csproj" />
     <ProjectReference Include="..\OrchardCore\OrchardCore.Hosting.Console\OrchardCore.Hosting.Console.csproj" />
     <ProjectReference Include="..\OrchardCore\OrchardCore.Logging.NLog\OrchardCore.Logging.NLog.csproj" />
     <ProjectReference Include="..\OrchardCore\OrchardCore.Application.Cms.Targets\OrchardCore.Application.Cms.Targets.csproj" />


### PR DESCRIPTION
The .Demo module was removed from the CMS target project, this also meant that it was removed from the Cms.Web project.

This PR restores the reference to the Cms.Web project, but **not** to the Cms.Targets project.