### PR TITLE
Fix error creating User from admin

### DIFF
--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserStore.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserStore.cs
@@ -41,7 +41,7 @@ namespace OrchardCore.Users.Services
         }
 
         #region IUserStore<IUser>
-        public Task<IdentityResult> CreateAsync(IUser user, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IdentityResult> CreateAsync(IUser user, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (user == null)
             {
@@ -50,7 +50,16 @@ namespace OrchardCore.Users.Services
 
             _session.Save(user);
 
-            return Task.FromResult(IdentityResult.Success);
+            try
+            {
+                await _session.CommitAsync();
+            }
+            catch
+            {
+                return IdentityResult.Failed();
+            }
+
+            return IdentityResult.Success;
         }
 
         public async Task<IdentityResult> DeleteAsync(IUser user, CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
Fixes #1068

I don't understand why it was working previously and since when there was this issue but the User wasn't stored anymore in database after CreateAsync.

I just added this in UserStore.cs in the CreateAsync method as it is done in UpdateAsync and DeleteAsync:
``` csharp
            try
            {
                await _session.CommitAsync();
            }
            catch
            {
                return IdentityResult.Failed();
            }

            return IdentityResult.Success;
```

The creation of a user from the step was still working though.