### PR TITLE
Don't show irrelevant menu items

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
@@ -35,9 +35,9 @@ namespace OrchardCore.Contents
             var contentTypeDefinitions = _contentDefinitionManager.ListTypeDefinitions().OrderBy(d => d.Name);
 
             builder.Add(T["Content"], "1.4", content => content
-                .Permission(Permissions.EditOwnContent)
                 .AddClass("content").Id("content")
                 .Add(T["Content Items"], "1", contentItems => contentItems
+                    .Permission(Permissions.EditOwnContent)
                     .Action("List", "Admin", new { area = "OrchardCore.Contents" })
                     .LocalNav())
                 );

--- a/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Layers.Drivers;
@@ -30,6 +30,7 @@ namespace OrchardCore.Layers
                         )))
                 .Add(T["Content"], design => design
                     .Add(T["Layers"], "5", layers => layers
+                        .Permission(Permissions.ManageLayers)
                         .Action("Index", "Admin", new { area = "OrchardCore.Layers" })
                         .LocalNav()
                     ));

--- a/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
@@ -23,6 +23,7 @@ namespace OrchardCore.Media
             builder
                 .Add(S["Content"], design => design
                     .Add(S["Assets"], "3", layers => layers
+                        .Permission(Permissions.ManageOwnMedia)
                         .Action("Index", "Admin", new { area = "OrchardCore.Media" })
                         .LocalNav()
                     ));

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -26,8 +26,13 @@ namespace OrchardCore.Media.Controllers
             _logger = logger;
         }
 
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageOwnMedia))
+            {
+                return Unauthorized();
+            }
+
             return View();
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -23,7 +23,6 @@ namespace OrchardCore.Settings
             builder.Add(T["Design"], design => design
                 .Add(T["Settings"], "1", settings => settings
                     .Add(T["General"], T["General"], entry => entry
-                        .Permission(Permissions.ManageGroupSettings)
                         .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "general" })
                         .LocalNav()
                     )

--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 
@@ -23,6 +23,7 @@ namespace OrchardCore.Settings
             builder.Add(T["Design"], design => design
                 .Add(T["Settings"], "1", settings => settings
                     .Add(T["General"], T["General"], entry => entry
+                        .Permission(Permissions.ManageGroupSettings)
                         .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "general" })
                         .LocalNav()
                     )


### PR DESCRIPTION
Changes BuildMenu so that only menu items that are clickable, or contain child items that are clickable, are included in the menu.

First part of fix for #1089 