### PR TITLE
Fixes null reference with Orcharcore.Samples while in prod.

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRazorFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRazorFileProvider.cs
@@ -39,7 +39,7 @@ namespace OrchardCore.Mvc.RazorPages
                 }
             }
 
-            return null;
+            return new NotFoundDirectoryContents();
         }
 
         public IFileInfo GetFileInfo(string subpath)


### PR DESCRIPTION
- When a file provider is not part of a composite file provider, its `GetDirectoryContents()` should never return `null`. But in `Orcharcore.Samples` this is the case with our `ModularPageRazorFileProvider`.

- Our other file providers are always part of a composite file provider, so i let them as before. E.g the `ThemingFileProvider` return `null` since it was created, but here it's not an issue.

- So, i prefer to only update `ModularPageRazorFileProvider`. Then if it works let me know if it's better to update all file providers.

**Not sure it fixes the issue, we need to try it again when the new packages will be published.**