### PR TITLE
Fixes spaces for checkbox (OrchardCore.OpenId)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Create.cshtml
@@ -42,7 +42,8 @@
     <fieldset id="AllowAuthorizationCodeFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowAuthorizationCodeFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowAuthorizationCodeFlow" type="checkbox" data-toggle="collapse" data-target="#AllowAuthorizationCodeFlowRecommendedHint" class="form-check-input" checked="@Model.AllowAuthorizationCodeFlow" />@T["Allow Authorization Code Flow"]
+                <input asp-for="AllowAuthorizationCodeFlow" type="checkbox" data-toggle="collapse" data-target="#AllowAuthorizationCodeFlowRecommendedHint" class="form-check-input" checked="@Model.AllowAuthorizationCodeFlow" />
+                @T["Allow Authorization Code Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth</a></div>
@@ -52,7 +53,8 @@
     <fieldset id="AllowHybridFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowHybridFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowHybridFlow" type="checkbox" data-toggle="collapse" data-target="#AllowHybridFlowRecommendedHint" class="form-check-input" checked="@Model.AllowHybridFlow" />@T["Allow Hybrid Flow"]
+                <input asp-for="AllowHybridFlow" type="checkbox" data-toggle="collapse" data-target="#AllowHybridFlowRecommendedHint" class="form-check-input" checked="@Model.AllowHybridFlow" />
+                @T["Allow Hybrid Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth</a></div>
@@ -62,7 +64,8 @@
     <fieldset id="AllowImplicitFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowImplicitFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowImplicitFlow" type="checkbox" data-toggle="collapse" data-target="#AllowImplicitFlowRecommendedHint" class="form-check-input" checked="@Model.AllowImplicitFlow" />@T["Allow Implicit Flow"]
+                <input asp-for="AllowImplicitFlow" type="checkbox" data-toggle="collapse" data-target="#AllowImplicitFlowRecommendedHint" class="form-check-input" checked="@Model.AllowImplicitFlow" />
+                @T["Allow Implicit Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth</a></div>
@@ -72,7 +75,8 @@
     <fieldset id="AllowPasswordFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowPasswordFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowPasswordFlow" type="checkbox" data-toggle="collapse" data-target="#AllowPasswordFlowRecommendedHint" class="form-check-input" checked="@Model.AllowPasswordFlow" />@T["Allow Password Flow"]
+                <input asp-for="AllowPasswordFlow" type="checkbox" data-toggle="collapse" data-target="#AllowPasswordFlowRecommendedHint" class="form-check-input" checked="@Model.AllowPasswordFlow" />
+                @T["Allow Password Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="https://tools.ietf.org/html/rfc6749#section-1.3.3">https://tools.ietf.org/html/rfc6749#section-1.3.3</a></div>
@@ -82,7 +86,8 @@
     <fieldset id="AllowClientCredentialsFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowClientCredentialsFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowClientCredentialsFlow" type="checkbox" data-toggle="collapse" data-target="#AllowClientCredentialsFlowRecommendedHint" class="form-check-input" checked="@Model.AllowClientCredentialsFlow" />@T["Allow Client Credentials Flow"]
+                <input asp-for="AllowClientCredentialsFlow" type="checkbox" data-toggle="collapse" data-target="#AllowClientCredentialsFlowRecommendedHint" class="form-check-input" checked="@Model.AllowClientCredentialsFlow" />
+                @T["Allow Client Credentials Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="https://tools.ietf.org/html/rfc6749#section-1.3.4">https://tools.ietf.org/html/rfc6749#section-1.3.4</a></div>
@@ -92,7 +97,8 @@
     <fieldset id="AllowRefreshTokenFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowRefreshTokenFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowRefreshTokenFlow" type="checkbox" data-toggle="collapse" data-target="#AllowRefreshTokenFlowRecommendedHint" class="form-check-input" checked="@Model.AllowRefreshTokenFlow" disabled=@((Model.AllowPasswordFlow || Model.AllowAuthorizationCodeFlow || Model.AllowHybridFlow) ? null : "") />@T["Allow Refresh Token Flow"]
+                <input asp-for="AllowRefreshTokenFlow" type="checkbox" data-toggle="collapse" data-target="#AllowRefreshTokenFlowRecommendedHint" class="form-check-input" checked="@Model.AllowRefreshTokenFlow" disabled=@((Model.AllowPasswordFlow || Model.AllowAuthorizationCodeFlow || Model.AllowHybridFlow) ? null : "") />
+                @T["Allow Refresh Token Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens">http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens</a></div>
@@ -112,7 +118,8 @@
         </div>
         <div asp-validation-class-for="SkipConsent">
             <label class="form-check-label">
-                <input asp-for="SkipConsent" type="checkbox" class="form-check-input" checked="@Model.SkipConsent" /> @T["Skip user-consent screen"]
+                <input asp-for="SkipConsent" type="checkbox" class="form-check-input" checked="@Model.SkipConsent" />
+                @T["Skip user-consent screen"]
             </label>
             <div class="hint">@T["It skips the user-consent screen after login in identity server."]</div>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Edit.cshtml
@@ -31,7 +31,8 @@
     <fieldset class="form-group">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="UpdateClientSecret" type="checkbox" data-toggle="collapse" data-target="#clientSecretGroup" class="form-check-input" checked="@Model.UpdateClientSecret"/>@T["Set a new Client Secret"]
+                <input asp-for="UpdateClientSecret" type="checkbox" data-toggle="collapse" data-target="#clientSecretGroup" class="form-check-input" checked="@Model.UpdateClientSecret"/>
+                @T["Set a new Client Secret"]
                 <span asp-validation-for="UpdateClientSecret" class="text-danger">@T["Set a new Client Secret is required."]</span>
             </label>
         </div>
@@ -53,7 +54,8 @@
     <fieldset id="AllowAuthorizationCodeFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowAuthorizationCodeFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowAuthorizationCodeFlow" type="checkbox" data-toggle="collapse" data-target="#AllowAuthorizationCodeFlowRecommendedHint" class="form-check-input" checked="@Model.AllowAuthorizationCodeFlow" />@T["Allow Authorization Code Flow"]
+                <input asp-for="AllowAuthorizationCodeFlow" type="checkbox" data-toggle="collapse" data-target="#AllowAuthorizationCodeFlowRecommendedHint" class="form-check-input" checked="@Model.AllowAuthorizationCodeFlow" />
+                @T["Allow Authorization Code Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth</a></div>
@@ -63,7 +65,8 @@
     <fieldset id="AllowHybridFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowHybridFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowHybridFlow" type="checkbox" data-toggle="collapse" data-target="#AllowHybridFlowRecommendedHint" class="form-check-input" checked="@Model.AllowHybridFlow" />@T["Allow Hybrid Flow"]
+                <input asp-for="AllowHybridFlow" type="checkbox" data-toggle="collapse" data-target="#AllowHybridFlowRecommendedHint" class="form-check-input" checked="@Model.AllowHybridFlow" />
+                @T["Allow Hybrid Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth</a></div>
@@ -73,7 +76,8 @@
     <fieldset id="AllowImplicitFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowImplicitFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowImplicitFlow" type="checkbox" data-toggle="collapse" data-target="#AllowImplicitFlowRecommendedHint" class="form-check-input" checked="@Model.AllowImplicitFlow" />@T["Allow Implicit Flow"]
+                <input asp-for="AllowImplicitFlow" type="checkbox" data-toggle="collapse" data-target="#AllowImplicitFlowRecommendedHint" class="form-check-input" checked="@Model.AllowImplicitFlow" />
+                @T["Allow Implicit Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth</a></div>
@@ -83,7 +87,8 @@
     <fieldset id="AllowPasswordFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowPasswordFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowPasswordFlow" type="checkbox" data-toggle="collapse" data-target="#AllowPasswordFlowRecommendedHint" class="form-check-input" checked="@Model.AllowPasswordFlow" />@T["Allow Password Flow"]
+                <input asp-for="AllowPasswordFlow" type="checkbox" data-toggle="collapse" data-target="#AllowPasswordFlowRecommendedHint" class="form-check-input" checked="@Model.AllowPasswordFlow" />
+                @T["Allow Password Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="https://tools.ietf.org/html/rfc6749#section-1.3.3">https://tools.ietf.org/html/rfc6749#section-1.3.3</a></div>
@@ -93,7 +98,8 @@
     <fieldset id="AllowClientCredentialsFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowClientCredentialsFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowClientCredentialsFlow" type="checkbox" data-toggle="collapse" data-target="#AllowClientCredentialsFlowRecommendedHint" class="form-check-input" checked="@Model.AllowClientCredentialsFlow" />@T["Allow Client Credentials Flow"]
+                <input asp-for="AllowClientCredentialsFlow" type="checkbox" data-toggle="collapse" data-target="#AllowClientCredentialsFlowRecommendedHint" class="form-check-input" checked="@Model.AllowClientCredentialsFlow" />
+                @T["Allow Client Credentials Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="https://tools.ietf.org/html/rfc6749#section-1.3.4">https://tools.ietf.org/html/rfc6749#section-1.3.4</a></div>
@@ -103,7 +109,8 @@
     <fieldset id="AllowRefreshTokenFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowRefreshTokenFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowRefreshTokenFlow" type="checkbox" data-toggle="collapse" data-target="#AllowRefreshTokenFlowRecommendedHint" class="form-check-input" checked="@Model.AllowRefreshTokenFlow" disabled=@((Model.AllowPasswordFlow || Model.AllowAuthorizationCodeFlow || Model.AllowHybridFlow) ? null : "") />@T["Allow Refresh Token Flow"]
+                <input asp-for="AllowRefreshTokenFlow" type="checkbox" data-toggle="collapse" data-target="#AllowRefreshTokenFlowRecommendedHint" class="form-check-input" checked="@Model.AllowRefreshTokenFlow" disabled=@((Model.AllowPasswordFlow || Model.AllowAuthorizationCodeFlow || Model.AllowHybridFlow) ? null : "") />
+                @T["Allow Refresh Token Flow"]
             </label>
         </div>
         <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens">http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens</a></div>
@@ -123,7 +130,8 @@
         </div>
         <div asp-validation-class-for="SkipConsent">
             <label class="form-check-label">
-                <input asp-for="SkipConsent" type="checkbox" class="form-check-input" checked="@Model.SkipConsent" /> @T["Skip user-consent screen"]
+                <input asp-for="SkipConsent" type="checkbox" class="form-check-input" checked="@Model.SkipConsent" />
+                @T["Skip user-consent screen"]
             </label>
             <div class="hint">@T["It skips the user-consent screen after login in identity server."]</div>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdSettings.Edit.cshtml
@@ -6,7 +6,8 @@
     <fieldset class="form-group">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="TestingModeEnabled" type="checkbox" data-toggle="collapse active" data-target="#certArea" class="form-check-input" checked="@Model.TestingModeEnabled"/>@T["Enable Testing Mode"]
+                <input asp-for="TestingModeEnabled" type="checkbox" data-toggle="collapse active" data-target="#certArea" class="form-check-input" checked="@Model.TestingModeEnabled"/>
+                @T["Enable Testing Mode"]
             </label>
         </div>
         <span class="hint">@T["Disables https requirement and uses an ephemeral signing key."]</span>
@@ -98,7 +99,8 @@
     <fieldset class="form-group" asp-validation-class-for="EnableTokenEndpoint">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="EnableTokenEndpoint" class="form-check-input" />@T["Enable Token Endpoint"]
+                <input asp-for="EnableTokenEndpoint" class="form-check-input" />
+                @T["Enable Token Endpoint"]
             </label>
         </div>
         <span class="hint">@T["Enables action /OrchardCore.OpenId/Access/Token"]</span>
@@ -107,7 +109,8 @@
     <fieldset class="form-group" asp-validation-class-for="EnableAuthorizationEndpoint">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="EnableAuthorizationEndpoint" class="form-check-input" />@T["Enable Authorization Endpoint"]
+                <input asp-for="EnableAuthorizationEndpoint" class="form-check-input" />
+                @T["Enable Authorization Endpoint"]
             </label>
         </div>
         <span class="hint">@T["Enables action /OrchardCore.OpenId/Access/Authorize"]</span>
@@ -116,7 +119,8 @@
     <fieldset class="form-group" asp-validation-class-for="EnableLogoutEndpoint">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="EnableLogoutEndpoint" class="form-check-input" />@T["Enable Logout Endpoint"]
+                <input asp-for="EnableLogoutEndpoint" class="form-check-input" />
+                @T["Enable Logout Endpoint"]
             </label>
         </div>
         <span class="hint">@T["Enables action /OrchardCore.OpenId/Access/Logout"]</span>
@@ -125,7 +129,8 @@
     <fieldset class="form-group" asp-validation-class-for="EnableUserInfoEndpoint">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="EnableUserInfoEndpoint" class="form-check-input" />@T["Enable User Info Endpoint"]
+                <input asp-for="EnableUserInfoEndpoint" class="form-check-input" />
+                @T["Enable User Info Endpoint"]
             </label>
         </div>
         <span class="hint">@T["Enables action /OrchardCore.OpenId/UserInfo/Me"]</span>
@@ -136,7 +141,8 @@
     <fieldset class="form-group collapse" asp-validation-class-for="AllowAuthorizationCodeFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowAuthorizationCodeFlow" class="form-check-input" />@T["Allow Authorization Code Flow"]
+                <input asp-for="AllowAuthorizationCodeFlow" class="form-check-input" />
+                @T["Allow Authorization Code Flow"]
             </label>
         </div>
         <span class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth</a></span>
@@ -145,7 +151,8 @@
     <fieldset class="form-group collapse" asp-validation-class-for="AllowHybridFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowHybridFlow" class="form-check-input" />@T["Allow Hybrid Flow"]
+                <input asp-for="AllowHybridFlow" class="form-check-input" />
+                @T["Allow Hybrid Flow"]
             </label>
         </div>
         <span class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth</a></span>
@@ -154,7 +161,8 @@
     <fieldset class="form-group collapse" asp-validation-class-for="AllowImplicitFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowImplicitFlow" class="form-check-input" />@T["Allow Implicit Flow"]
+                <input asp-for="AllowImplicitFlow" class="form-check-input" />
+                @T["Allow Implicit Flow"]
             </label>
         </div>
         <span class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth</a></span>
@@ -163,7 +171,8 @@
     <fieldset class="form-group collapse" asp-validation-class-for="AllowPasswordFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowPasswordFlow" class="form-check-input" />@T["Allow Password Flow"]
+                <input asp-for="AllowPasswordFlow" class="form-check-input" />
+                @T["Allow Password Flow"]
             </label>
         </div>
         <span class="hint">@T["More info:"] <a href="https://tools.ietf.org/html/rfc6749#section-1.3.3">https://tools.ietf.org/html/rfc6749#section-1.3.3</a></span>
@@ -172,7 +181,8 @@
     <fieldset class="form-group collapse" asp-validation-class-for="AllowRefreshTokenFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowRefreshTokenFlow" class="form-check-input" />@T["Allow Refresh Token Flow"]
+                <input asp-for="AllowRefreshTokenFlow" class="form-check-input" />
+                @T["Allow Refresh Token Flow"]
             </label>
         </div>
         <span class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens">http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens</a></span>
@@ -181,7 +191,8 @@
     <fieldset class="form-group collapse" asp-validation-class-for="AllowClientCredentialsFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowClientCredentialsFlow" class="form-check-input" />@T["Allow Client Credentials Flow"]
+                <input asp-for="AllowClientCredentialsFlow" class="form-check-input" />
+                @T["Allow Client Credentials Flow"]
             </label>
         </div>
         <span class="hint">@T["More info:"] <a href="https://tools.ietf.org/html/rfc6749#section-1.3.4">https://tools.ietf.org/html/rfc6749#section-1.3.4</a></span>


### PR DESCRIPTION
Fixes spaces for checkbox.

Before:
![before 1](https://user-images.githubusercontent.com/7753794/31825441-f0d04ebe-b5ba-11e7-80c3-5ffdff2e7df1.JPG)

After:
![after](https://user-images.githubusercontent.com/7753794/31825575-5cadc4b8-b5bb-11e7-964d-340a5991b3e6.JPG)
