### PR TITLE
Adding support for ORCHARD_APP_DATA environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,12 @@ script:
         docker login -u="$DOCKER_USER" -p="$DOCKER_PASS";
         docker push orchardproject/orchardcore-cms-linux;
     fi;
+  - if [[ "$TRAVIS_BRANCH" == "dev" ]] && [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+        cd $TRAVIS_BUILD_DIR/src/OrchardCore.Cms.Web;
+        dotnet publish -c Release -o $TRAVIS_BUILD_DIR/.build/release;
+        cd $TRAVIS_BUILD_DIR;
+        docker build -t orchardproject/orchardcore-cms-linux:dev .;
+        docker login -u="$DOCKER_USER" -p="$DOCKER_PASS";
+        docker push orchardproject/orchardcore-cms-linux;
+    fi;
   - if test "$TRAVIS_OS_NAME" == "linux"; then dotnet test -c Release ./test/OrchardCore.Tests/OrchardCore.Tests.csproj; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,11 @@
 # A prerequisite is a published application in the .build/release  
 
 FROM microsoft/dotnet:2.0-runtime 
-WORKDIR /app
 
+EXPOSE 80
+ENV ASPNETCORE_URLS http://+:80
+
+WORKDIR /app
 COPY .build/release .
 
-ENV ASPNETCORE_URLS http://+:80
 ENTRYPOINT ["dotnet", "OrchardCore.Cms.Web.dll"]
-EXPOSE 80

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,16 @@ build_script:
         docker push orchardproject/orchardcore-cms-windows
       }
 
+      if ($IsDevBranch -eq $true)
+      {
+        cd $env:APPVEYOR_BUILD_FOLDER\src\OrchardCore.Cms.Web
+        dotnet publish -c Release -o $env:APPVEYOR_BUILD_FOLDER\.build\release
+        cd $env:APPVEYOR_BUILD_FOLDER
+        docker build -t orchardproject/orchardcore-cms-windows:dev .
+        docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
+        docker push orchardproject/orchardcore-cms-windows
+      }
+
 test_script:
   - dotnet test -c Release .\test\OrchardCore.Tests\OrchardCore.Tests.csproj
 clone_depth: 1

--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -14,7 +14,6 @@ namespace OrchardCore.Localization
 
         private readonly IExtensionManager _extensionsManager;
         private readonly string _root;
-        private readonly string _rootContainer;
         private readonly string _resourcesContainer;
         private readonly string _shellContainer;
         private readonly string _shellName;
@@ -29,7 +28,6 @@ namespace OrchardCore.Localization
             _extensionsManager = extensionsManager;
 
             _root = hostingEnvironment.ContentRootPath;
-            _rootContainer = shellOptions.Value.ShellsRootContainerName; // App_Data
             _resourcesContainer = localizationOptions.Value.ResourcesPath; // Localization
             _shellContainer = shellOptions.Value.ShellsContainerName;
             _shellName = shellSettings.Name;
@@ -40,14 +38,14 @@ namespace OrchardCore.Localization
             // Load .po files in each extension folder first, based on the extensions order
             foreach (var extension in _extensionsManager.GetExtensions())
             {
-                yield return Path.Combine(_root, extension.SubPath, _rootContainer, _resourcesContainer, cultureName, PoFileName);
+                yield return Path.Combine(_root, extension.SubPath, _resourcesContainer, cultureName, PoFileName);
             }
 
             // Then load global .po file for the applications
-            yield return Path.Combine(_root, _rootContainer, _resourcesContainer, cultureName, PoFileName);
+            yield return Path.Combine(_root, _resourcesContainer, cultureName, PoFileName);
 
             // Finally load tenant-specific .po file
-            yield return Path.Combine(_root, _rootContainer, _shellContainer, _shellName, _resourcesContainer, cultureName, PoFileName);
+            yield return Path.Combine(_root, _shellContainer, _shellName, _resourcesContainer, cultureName, PoFileName);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -12,14 +12,12 @@ using Lucene.Net.Index;
 using Lucene.Net.Search;
 using Lucene.Net.Store;
 using Lucene.Net.Util;
-using Microsoft.AspNetCore.Hosting;
-using OrchardCore.Modules;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Indexing;
+using OrchardCore.Modules;
 using Directory = System.IO.Directory;
-using LuceneNetCodecs = Lucene.Net.Codecs;
 
 namespace OrchardCore.Lucene
 {
@@ -30,7 +28,6 @@ namespace OrchardCore.Lucene
     public class LuceneIndexManager : IDisposable
     {
         private readonly IClock _clock;
-        private readonly IHostingEnvironment _hostingEnvironment;
         private readonly ILogger<LuceneIndexManager> _logger;
         private readonly string _rootPath;
         private readonly DirectoryInfo _rootDirectory;
@@ -43,18 +40,15 @@ namespace OrchardCore.Lucene
 
         public LuceneIndexManager(
             IClock clock,
-            IHostingEnvironment hostingEnvironment,
             IOptions<ShellOptions> shellOptions,
             ShellSettings shellSettings,
             ILogger<LuceneIndexManager> logger
             )
         {
             _clock = clock;
-            _hostingEnvironment = hostingEnvironment;
             _logger = logger;
             _rootPath = Path.Combine(
-                _hostingEnvironment.ContentRootPath,
-                shellOptions.Value.ShellsRootContainerName,
+                shellOptions.Value.ShellsApplicationDataPath,
                 shellOptions.Value.ShellsContainerName,
                 shellSettings.Name, "Lucene");
 

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexingState.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexingState.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using Microsoft.AspNetCore.Hosting;
+using System.IO;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Environment.Shell;
@@ -13,20 +12,15 @@ namespace OrchardCore.Lucene
     public class LuceneIndexingState
     {
         private readonly string _indexSettingsFilename;
-        private readonly IHostingEnvironment _hostingEnvironment;
         private readonly JObject _content;
 
         public LuceneIndexingState(
-            IHostingEnvironment hostingEnvironment,
             IOptions<ShellOptions> shellOptions,
             ShellSettings shellSettings
             )
         {
-            _hostingEnvironment = hostingEnvironment;
-
             _indexSettingsFilename = Path.Combine(
-                _hostingEnvironment.ContentRootPath,
-                shellOptions.Value.ShellsRootContainerName, 
+                shellOptions.Value.ShellsApplicationDataPath, 
                 shellOptions.Value.ShellsContainerName, 
                 shellSettings.Name, 
                 "lucene.status.json");

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -155,8 +155,7 @@ namespace OrchardCore.Media
 
         private string GetMediaPath(IHostingEnvironment env, ShellOptions shellOptions, ShellSettings shellSettings)
         {
-            var relativeMediaPath = Path.Combine(shellOptions.ShellsRootContainerName, shellOptions.ShellsContainerName, shellSettings.Name, "Media");
-            return env.ContentRootFileProvider.GetFileInfo(relativeMediaPath).PhysicalPath;
+            return Path.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellSettings.Name, "Media");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -78,16 +78,16 @@ namespace OrchardCore.OpenId
             services.TryAddEnumerable(new[]
             {
                 // Orchard-specific initializers:
-                ServiceDescriptor.Singleton<IConfigureOptions<AuthenticationOptions>, OpenIdConfiguration>(),
-                ServiceDescriptor.Singleton<IConfigureOptions<OpenIddictOptions>, OpenIdConfiguration>(),
-                ServiceDescriptor.Singleton<IConfigureOptions<JwtBearerOptions>, OpenIdConfiguration>(),
-                ServiceDescriptor.Singleton<IConfigureOptions<OAuthValidationOptions>, OpenIdConfiguration>(),
+                ServiceDescriptor.Transient<IConfigureOptions<AuthenticationOptions>, OpenIdConfiguration>(),
+                ServiceDescriptor.Transient<IConfigureOptions<OpenIddictOptions>, OpenIdConfiguration>(),
+                ServiceDescriptor.Transient<IConfigureOptions<JwtBearerOptions>, OpenIdConfiguration>(),
+                ServiceDescriptor.Transient<IConfigureOptions<OAuthValidationOptions>, OpenIdConfiguration>(),
 
                 // Built-in initializers:
-                ServiceDescriptor.Singleton<IPostConfigureOptions<JwtBearerOptions>, JwtBearerPostConfigureOptions>(),
-                ServiceDescriptor.Singleton<IPostConfigureOptions<OAuthValidationOptions>, OAuthValidationInitializer>(),
-                ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIddictOptions>, OpenIddictInitializer>(),
-                ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIddictOptions>, OpenIdConnectServerInitializer>()
+                ServiceDescriptor.Transient<IPostConfigureOptions<JwtBearerOptions>, JwtBearerPostConfigureOptions>(),
+                ServiceDescriptor.Transient<IPostConfigureOptions<OAuthValidationOptions>, OAuthValidationInitializer>(),
+                ServiceDescriptor.Transient<IPostConfigureOptions<OpenIddictOptions>, OpenIddictInitializer>(),
+                ServiceDescriptor.Transient<IPostConfigureOptions<OpenIddictOptions>, OpenIdConnectServerInitializer>()
             });
         }
     }

--- a/src/OrchardCore/OrchardCore.Application.Cms.Targets/ServiceExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Targets/ServiceExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Environment.Commands;
 using OrchardCore.Environment.Extensions;
@@ -19,7 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddThemingHost();
             services.AddManifestDefinition("Theme.txt", "theme");
             services.AddExtensionLocation("Themes");
-            services.AddSitesFolder("App_Data", "Sites");
+            services.AddSitesFolder();
             services.AddCommands();
             services.AddAuthentication();
             services.AddModules(modules => 

--- a/src/OrchardCore/OrchardCore.Data/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data/ServiceCollectionExtensions.cs
@@ -2,12 +2,11 @@ using System;
 using System.Data;
 using System.IO;
 using System.Linq;
-using Microsoft.AspNetCore.Hosting;
-using OrchardCore.Modules;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OrchardCore.Data.Migration;
 using OrchardCore.Environment.Shell;
+using OrchardCore.Modules;
 using YesSql;
 using YesSql.Indexes;
 using YesSql.Provider.MySql;
@@ -35,7 +34,6 @@ namespace OrchardCore.Data
 			services.AddSingleton<IStore>(sp =>
             {
                 var shellSettings = sp.GetService<ShellSettings>();
-                var hostingEnvironment = sp.GetService<IHostingEnvironment>();
 
                 if (shellSettings.DatabaseProvider == null)
                 {
@@ -52,7 +50,7 @@ namespace OrchardCore.Data
                     case "Sqlite":
                         var shellOptions = sp.GetService<IOptions<ShellOptions>>();
                         var option = shellOptions.Value;
-                        var databaseFolder = Path.Combine(hostingEnvironment.ContentRootPath, option.ShellsRootContainerName, option.ShellsContainerName, shellSettings.Name);
+                        var databaseFolder = Path.Combine(option.ShellsApplicationDataPath, option.ShellsContainerName, shellSettings.Name);
                         var databaseFile = Path.Combine(databaseFolder, "yessql.db");
                         Directory.CreateDirectory(databaseFolder);
                         storeConfiguration.UseSqLite($"Data Source={databaseFile};Cache=Shared", IsolationLevel.ReadUncommitted);

--- a/src/OrchardCore/OrchardCore.Environment.Shell.Data/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell.Data/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell.Data.Descriptors;
 using OrchardCore.Environment.Shell.Descriptor;
 
@@ -12,16 +13,11 @@ namespace OrchardCore.Environment.Shell.Data
         /// <param name="services"></param>
         /// <param name="sitesPath"></param>
         /// <returns></returns>
-        public static IServiceCollection AddSitesFolder(this IServiceCollection services, string rootPath, string sitesPath)
+        public static IServiceCollection AddSitesFolder(this IServiceCollection services)
         {
-            services.Configure<ShellOptions>(options =>
-            {
-                options.ShellsRootContainerName = rootPath;
-                options.ShellsContainerName = sitesPath;
-            });
-
             services.AddSingleton<IShellSettingsConfigurationProvider, ShellSettingsConfigurationProvider>();
             services.AddSingleton<IShellSettingsManager, ShellSettingsManager>();
+            services.AddTransient<IConfigureOptions<ShellOptions>, ShellOptionsSetup>();
 
             return services;
         }

--- a/src/OrchardCore/OrchardCore.Environment.Shell/ShellOptions.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell/ShellOptions.cs
@@ -1,11 +1,11 @@
-﻿namespace OrchardCore.Environment.Shell
+namespace OrchardCore.Environment.Shell
 {
     public class ShellOptions
     {
         /// <summary>
         /// The root container
         /// </summary>
-        public string ShellsRootContainerName { get; set; }
+        public string ShellsApplicationDataPath { get; set; }
 
         /// <summary>
         /// The container for shells

--- a/src/OrchardCore/OrchardCore.Environment.Shell/ShellOptionsSetup.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell/ShellOptionsSetup.cs
@@ -1,18 +1,40 @@
-﻿using Microsoft.Extensions.Options;
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
 
 namespace OrchardCore.Environment.Shell
 {
     /// <summary>
     /// Sets up default options for <see cref="ShellOptions"/>.
     /// </summary>
-    public class ShellOptionsSetup : ConfigureOptions<ShellOptions>
+    public class ShellOptionsSetup : IConfigureOptions<ShellOptions>
     {
-        /// <summary>
-        /// Initializes a new instance of <see cref="ShellOptions"/>.
-        /// </summary>
-        public ShellOptionsSetup()
-            : base(options => { })
+        private const string OrchardAppData = "ORCHARD_APP_DATA";
+        private const string DefaultAppDataPath = "App_Data";
+        private const string DefaultSitesPath = "Sites";
+
+        private readonly IHostingEnvironment _hostingEnvironment;
+
+        public ShellOptionsSetup(IHostingEnvironment hostingEnvironment)
         {
+            _hostingEnvironment = hostingEnvironment;
+        }
+
+        public void Configure(ShellOptions options)
+        {
+            var appData = System.Environment.GetEnvironmentVariable(OrchardAppData);
+
+            if (!String.IsNullOrEmpty(appData))
+            {
+                options.ShellsApplicationDataPath = Path.Combine(_hostingEnvironment.ContentRootPath, appData);
+            }
+            else
+            {
+                options.ShellsApplicationDataPath = Path.Combine(_hostingEnvironment.ContentRootPath, DefaultAppDataPath);
+            }
+
+            options.ShellsContainerName = DefaultSitesPath;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Environment.Shell/ShellSettingsConfigurationProvider.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell/ShellSettingsConfigurationProvider.cs
@@ -1,8 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Parser;
 using OrchardCore.Yaml.Parser;
@@ -26,21 +25,22 @@ namespace OrchardCore.Environment.Shell
 
         public void AddSource(IConfigurationBuilder builder)
         {
-            foreach (var tenant in
-                _hostingEnvironment.ContentRootFileProvider.GetDirectoryContents(
-                    Path.Combine(
-                        _optionsAccessor.Value.ShellsRootContainerName,
-                        _optionsAccessor.Value.ShellsContainerName)))
+            var tenantSettingsPath = Path.Combine(
+                        _optionsAccessor.Value.ShellsApplicationDataPath,
+                        _optionsAccessor.Value.ShellsContainerName);
+
+            var tenants = Directory.GetDirectories(tenantSettingsPath);
+
+            foreach (var tenant in tenants)
             {
-                builder
-                    .AddYamlFile(ObtainSettingsPath(tenant.PhysicalPath));
+                builder.AddYamlFile(GetSettingsFilePath(tenant));
             }
         }
 
         public void SaveToSource(string name, IDictionary<string, string> configuration)
         {
-            var settingsFile = ObtainSettingsPath(Path.Combine(
-                        _optionsAccessor.Value.ShellsRootContainerName,
+            var settingsFile = GetSettingsFilePath(Path.Combine(
+                        _optionsAccessor.Value.ShellsApplicationDataPath,
                         _optionsAccessor.Value.ShellsContainerName,
                         name));
 
@@ -67,6 +67,6 @@ namespace OrchardCore.Environment.Shell
             return (value ?? "~");
         }
 
-        private string ObtainSettingsPath(string tenantPath) => Path.Combine(tenantPath, "Settings.txt");
+        private string GetSettingsFilePath(string tenantFolderPath) => Path.Combine(tenantFolderPath, "Settings.txt");
     }
 }

--- a/src/OrchardCore/OrchardCore.StorageProviders.FileSystem/FileSystemStore.cs
+++ b/src/OrchardCore/OrchardCore.StorageProviders.FileSystem/FileSystemStore.cs
@@ -145,6 +145,9 @@ namespace OrchardCore.StorageProviders.FileSystem
         {
             try
             {
+                // Remove trailing slashes
+                subpath = subpath.TrimStart('/', '\\');
+
                 // Use CreateSubdirectory to ensure the directory doesn't go over its boundaries
                 new DirectoryInfo(_localPath).CreateSubdirectory(subpath);
                 return Task.FromResult(true);


### PR DESCRIPTION
Setting `ORCHARD_APP_DATA` environment variable to `Foo` will store the tenants (and lucene indices, and media ,...) in the folder `[ContentRootPath]\Foo`.

Setting it to a UNC will work too, like `C:\temp\mytenants`.

We can now use a shared drive to store tenants, and use it in Docker. For Azure App Services Containers use these two variables:
`ORCHARD_APP_DATA=/home`
`WEBSITES_ENABLE_APP_SERVICE_STORAGE=true`

Then restarting the container, updating it, or activating several of them in the same app will just work.