### PR TITLE
Working on build_display liquid filter.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Filters/BuildDisplayFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Filters/BuildDisplayFilter.cs
@@ -25,9 +25,10 @@ namespace OrchardCore.Contents.Filters
                 throw new ArgumentException("Services missing while invoking 'build_display'");
             }
 
+            var displayType = arguments["type"].Or(arguments.At(0)).ToStringValue();
             var displayManager = ((IServiceProvider)services).GetRequiredService<IContentItemDisplayManager>();
 
-            return FluidValue.Create(await displayManager.BuildDisplayAsync(contentItem, null, arguments.At(0).ToStringValue()));
+            return FluidValue.Create(await displayManager.BuildDisplayAsync(contentItem, null, displayType));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Filters/BuildDisplayFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Filters/BuildDisplayFilter.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Values;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Display;
+using OrchardCore.Liquid;
+
+namespace OrchardCore.Contents.Filters
+{
+    public class BuildDisplayFilter : ILiquidFilter
+    {
+        public async Task<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        {
+            var contentItem = input.ToObjectValue() as ContentItem;
+
+            if (contentItem == null)
+            {
+                return NilValue.Instance;
+            }
+
+            if (!ctx.AmbientValues.TryGetValue("Services", out var services))
+            {
+                throw new ArgumentException("Services missing while invoking 'build_display'");
+            }
+
+            var displayManager = ((IServiceProvider)services).GetRequiredService<IContentItemDisplayManager>();
+
+            return FluidValue.Create(await displayManager.BuildDisplayAsync(contentItem, null, arguments.At(0).ToStringValue()));
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Module.txt
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Module.txt
@@ -1,4 +1,4 @@
-﻿Name: Contents
+Name: Contents
 AntiForgery: enabled
 Author: The Orchard Team
 Website: http://orchardproject.net
@@ -6,6 +6,6 @@ Version: 2.0.x
 OrchardVersion: 2.0
 Description: The contents module enables the edition and redering of content items.
 FeatureDescription: Content items creation and management.
-Dependencies: OrchardCore.Settings
+Dependencies: OrchardCore.Settings, OrchardCore.Liquid
 Category: Content Management
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/OrchardCore.Contents.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/OrchardCore.Contents.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentTypes.Abstractions\OrchardCore.ContentTypes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Feeds.Abstractions\OrchardCore.Feeds.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Indexing.Abstractions\OrchardCore.Indexing.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Liquid.Abstractions\OrchardCore.Liquid.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Scripting.Abstractions\OrchardCore.Scripting.Abstractions.csproj" />
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
-using OrchardCore.Modules;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
@@ -10,6 +9,7 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.Contents.Drivers;
 using OrchardCore.Contents.Feeds.Builders;
+using OrchardCore.Contents.Filters;
 using OrchardCore.Contents.Handlers;
 using OrchardCore.Contents.Indexing;
 using OrchardCore.Contents.Models;
@@ -22,7 +22,9 @@ using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Feeds;
 using OrchardCore.Indexing;
+using OrchardCore.Liquid;
 using OrchardCore.Lists.Settings;
+using OrchardCore.Modules;
 using OrchardCore.Mvc;
 using OrchardCore.Recipes;
 using OrchardCore.Scripting;
@@ -60,6 +62,8 @@ namespace OrchardCore.Contents
             // Feeds
             // TODO: Move to feature
             services.AddScoped<IFeedItemBuilder, CommonFeedItemBuilder>();
+
+            services.AddLiquidFilter<BuildDisplayFilter>("build_display");
         }
 
         public override void Configure(IApplicationBuilder builder, IRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
@@ -37,6 +37,7 @@ namespace OrchardCore.Flows.Drivers
             return Shape<BagPartViewModel>("BagPart", m =>
             {
                 m.BagPart = bagPart;
+                m.ContentItems = bagPart.ContentItems;
                 m.BuildPartDisplayContext = context;
                 m.Settings = context.TypePartDefinition.Settings.ToObject<BagPartSettings>();
             })

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
@@ -37,7 +37,6 @@ namespace OrchardCore.Flows.Drivers
             return Shape<BagPartViewModel>("BagPart", m =>
             {
                 m.BagPart = bagPart;
-                m.ContentItems = bagPart.ContentItems;
                 m.BuildPartDisplayContext = context;
                 m.Settings = context.TypePartDefinition.Settings.ToObject<BagPartSettings>();
             })

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.Flows.Models;
 
@@ -6,6 +8,7 @@ namespace OrchardCore.Flows.ViewModels
     public class BagPartViewModel
     {
         public BagPart BagPart { get; set; }
+        public List<ContentItem> ContentItems { get; set; }
         public BuildPartDisplayContext BuildPartDisplayContext { get; set; }
         public BagPartSettings Settings { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
@@ -8,7 +8,6 @@ namespace OrchardCore.Flows.ViewModels
     public class BagPartViewModel
     {
         public BagPart BagPart { get; set; }
-        public List<ContentItem> ContentItems => BagPart.ContentItems;
         public BuildPartDisplayContext BuildPartDisplayContext { get; set; }
         public BagPartSettings Settings { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Flows.ViewModels
     public class BagPartViewModel
     {
         public BagPart BagPart { get; set; }
-        public List<ContentItem> ContentItems { get; set; }
+        public List<ContentItem> ContentItems => BagPart.ContentItems;
         public BuildPartDisplayContext BuildPartDisplayContext { get; set; }
         public BagPartSettings Settings { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -337,6 +337,16 @@ Output
 Monday, September 11, 2017 3:29:26 PM
 ```
 
+### build_display
+
+Creates the display shape for a content item. It can be used in conjunction with `display` 
+to render a content item.
+
+Input
+```
+{% display mycontentitem | build_display: "Detail"  %}
+```
+
 ### shape
 
 Renders a specific named tag with its properties

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -194,7 +194,37 @@ Removes any alternates from an input shape.
 
 Input
 ```
-{{ my_shape | clean_alternates }}
+{{ my_shape | clear_alternates }}
+
+```
+
+### add_alternates
+
+Adds alternates to an input shape.
+
+Input
+```
+{{ my_shape | add_alternates: "alternate1 alternate2" }}
+
+```
+
+### clear_classes
+
+Removes any classes from an input shape.
+
+Input
+```
+{{ my_shape | clear_classes }}
+
+```
+
+### add_classes
+
+Adds classes to an input shape.
+
+Input
+```
+{{ my_shape | add_classes: "class1 class2" }}
 
 ```
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
@@ -28,19 +28,12 @@ namespace OrchardCore.Media.Filters
         public Task<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
         {
             var url = input.ToStringValue();
-            var alt = arguments.At(0).Or(arguments["tag"]);
-            var css = arguments.At(1).Or(arguments["class"]);
 
             var imgTag = $"<img src=\"{url}\"";
 
-            if (!alt.IsNil())
+            foreach (var name in arguments.Names)
             {
-                imgTag += $" alt=\"{alt.ToStringValue()}\"";
-            }
-
-            if (!css.IsNil())
-            {
-                imgTag += $" class=\"{css.ToStringValue()}\"";
+                imgTag += $" {name}=\"{arguments[name].ToStringValue()}\"";
             }
 
             imgTag += " />";
@@ -60,9 +53,9 @@ namespace OrchardCore.Media.Filters
                 url += "?";
             }
 
-            var width = arguments.At(0).Or(arguments["width"]);
-            var height = arguments.At(1).Or(arguments["height"]);
-            var mode = arguments.At(2).Or(arguments["mode"]);
+            var width = arguments["width"];
+            var height = arguments["height"];
+            var mode = arguments["mode"];
 
             if (!width.IsNil())
             {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
@@ -33,7 +34,7 @@ namespace OrchardCore.Media.Filters
 
             foreach (var name in arguments.Names)
             {
-                imgTag += $" {name}=\"{arguments[name].ToStringValue()}\"";
+                imgTag += $" {name.Replace("_", "-")}=\"{arguments[name].ToStringValue()}\"";
             }
 
             imgTag += " />";

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Content-Article.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Content-Article.liquid
@@ -1,4 +1,4 @@
-﻿{% zone "Header" %}
+{% zone "Header" %}
     <!-- Page Header -->
     <!-- Set your background image for this header on the line below. -->
     <header class="intro-header" style="background-image: url('{{ "~/TheBlogTheme/img/about-bg.jpg" | href }}')">
@@ -15,5 +15,5 @@
     </header>
 {% endzone %}
 
-{% display Model.Content.Contents_Metadata %}
+{% display Model.Content.Contents__Metadata %}
 {% display Model.Content.BodyPart %}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Content-BlogPost.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Content-BlogPost.liquid
@@ -1,4 +1,4 @@
-﻿{% zone "Header" %}
+{% zone "Header" %}
     <!-- Page Header -->
     <!-- Set your background image for this header on the line below. -->
     <header class="intro-header" style="background-image: url('{{ "~/TheBlogTheme/img/post-bg.jpg" | href }}')">
@@ -19,5 +19,5 @@
     </header>
 {% endzone %}
 
-{% display Model.Content.Contents_Metadata %}
+{% display Model.Content.Contents__Metadata %}
 {% display Model.Content.MarkdownPart %}

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -146,6 +146,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
                 foreach (var name in arguments.Names)
                 {
                     var argument = arguments[name];
+                    var propertyName = LowerKebabToPascalCase(name);
 
                     if (argument.Type == FluidValues.Array)
                     {
@@ -157,25 +158,25 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
                             if (type == FluidValues.String)
                             {
-                                obj[LowerKebabToPascalCase(name)] = values.Select(v => v.ToStringValue());
+                                obj[propertyName] = values.Select(v => v.ToStringValue());
                             }
                             else if (type == FluidValues.Number)
                             {
-                                obj[LowerKebabToPascalCase(name)] = values.Select(v => v.ToNumberValue());
+                                obj[propertyName] = values.Select(v => v.ToNumberValue());
                             }
                             else if (type == FluidValues.Boolean)
                             {
-                                obj[LowerKebabToPascalCase(name)] = values.Select(v => v.ToBooleanValue());
+                                obj[propertyName] = values.Select(v => v.ToBooleanValue());
                             }
                             else
                             {
-                                obj[LowerKebabToPascalCase(name)] = values.Select(v => v.ToObjectValue());
+                                obj[propertyName] = values.Select(v => v.ToObjectValue());
                             }
                         }
                     }
                     else
                     {
-                        obj[LowerKebabToPascalCase(name)] = argument.ToObjectValue();
+                        obj[propertyName] = argument.ToObjectValue();
                     }
                 }
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -19,6 +19,9 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
             filters.AddAsyncFilter("new_shape", NewShape);
             filters.AddAsyncFilter("shape_string", ShapeString);
             filters.AddAsyncFilter("clear_alternates", ClearAlternates);
+            filters.AddAsyncFilter("add_alternates", AddAlternates);
+            filters.AddAsyncFilter("clear_classes", ClearClasses);
+            filters.AddAsyncFilter("add_classes", AddClasses);
             filters.AddAsyncFilter("shape_type", ShapeType);
             filters.AddAsyncFilter("display_type", DisplayType);
             filters.AddAsyncFilter("shape_position", ShapePosition);
@@ -80,6 +83,52 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
             if(input.ToObjectValue() is Shape shape && shape.Metadata.Alternates.Count > 0)
             {
                 shape.Metadata.Alternates.Clear();
+            }
+
+            return Task.FromResult(input);
+        }
+
+        public static Task<FluidValue> AddAlternates(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            if (input.ToObjectValue() is Shape shape)
+            {
+                var alternates = arguments["alternates"].Or(arguments.At(0));
+
+                if (alternates.Type == FluidValues.Array)
+                {
+                    foreach (var value in alternates.Enumerate())
+                    {
+                        shape.Metadata.Alternates.Add(value.ToStringValue());
+                    }
+                }
+            }
+
+            return Task.FromResult(input);
+        }
+
+        public static Task<FluidValue> ClearClasses(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            if (input.ToObjectValue() is Shape shape && shape.Classes.Count > 0)
+            {
+                shape.Classes.Clear();
+            }
+
+            return Task.FromResult(input);
+        }
+
+        public static Task<FluidValue> AddClasses(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            if (input.ToObjectValue() is Shape shape)
+            {
+                var classes = arguments["classes"].Or(arguments.At(0));
+
+                if (classes.Type == FluidValues.Array)
+                {
+                    foreach (var value in classes.Enumerate())
+                    {
+                        shape.Classes.Add(value.ToStringValue());
+                    }
+                }
             }
 
             return Task.FromResult(input);

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -80,7 +80,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
         public static Task<FluidValue> ClearAlternates(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if(input.ToObjectValue() is Shape shape && shape.Metadata.Alternates.Count > 0)
+            if(input.ToObjectValue() is IShape shape && shape.Metadata.Alternates.Count > 0)
             {
                 shape.Metadata.Alternates.Clear();
             }
@@ -90,11 +90,20 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
         public static Task<FluidValue> AddAlternates(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (input.ToObjectValue() is Shape shape)
+            if (input.ToObjectValue() is IShape shape)
             {
                 var alternates = arguments["alternates"].Or(arguments.At(0));
 
-                if (alternates.Type == FluidValues.Array)
+                if (alternates.Type == FluidValues.String)
+                {
+                    var values = alternates.ToStringValue().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                    foreach (var value in values)
+                    {
+                        shape.Classes.Add(value);
+                    }
+                }
+                else if (alternates.Type == FluidValues.Array)
                 {
                     foreach (var value in alternates.Enumerate())
                     {
@@ -108,7 +117,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
         public static Task<FluidValue> ClearClasses(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (input.ToObjectValue() is Shape shape && shape.Classes.Count > 0)
+            if (input.ToObjectValue() is IShape shape && shape.Classes.Count > 0)
             {
                 shape.Classes.Clear();
             }
@@ -118,11 +127,20 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
         public static Task<FluidValue> AddClasses(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (input.ToObjectValue() is Shape shape)
+            if (input.ToObjectValue() is IShape shape)
             {
                 var classes = arguments["classes"].Or(arguments.At(0));
 
-                if (classes.Type == FluidValues.Array)
+                if (classes.Type == FluidValues.String)
+                {
+                    var values = classes.ToStringValue().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+                    foreach (var value in values)
+                    {
+                        shape.Classes.Add(value);
+                    }
+                }
+                else if (classes.Type == FluidValues.Array)
                 {
                     foreach (var value in classes.Enumerate())
                     {
@@ -136,7 +154,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
         public static Task<FluidValue> ShapeType(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (input.ToObjectValue() is Shape shape)
+            if (input.ToObjectValue() is IShape shape)
             {
                 shape.Metadata.Type = arguments["type"].Or(arguments.At(0)).ToStringValue();
             }
@@ -146,7 +164,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
         public static Task<FluidValue> DisplayType(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (input.ToObjectValue() is Shape shape)
+            if (input.ToObjectValue() is IShape shape)
             {
                 shape.Metadata.DisplayType = arguments["type"].Or(arguments.At(0)).ToStringValue();
             }
@@ -156,7 +174,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
         public static Task<FluidValue> ShapePosition(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (input.ToObjectValue() is Shape shape)
+            if (input.ToObjectValue() is IShape shape)
             {
                 shape.Metadata.Position = arguments["position"].Or(arguments.At(0)).ToStringValue();
             }
@@ -166,7 +184,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
         public static Task<FluidValue> ShapeTab(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            if (input.ToObjectValue() is Shape shape)
+            if (input.ToObjectValue() is IShape shape)
             {
                 shape.Metadata.Tab = arguments["tab"].Or(arguments.At(0)).ToStringValue();
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -144,7 +145,38 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
                 foreach (var name in arguments.Names)
                 {
-                    obj[LowerKebabToPascalCase(name)] = arguments[name].ToObjectValue();
+                    var argument = arguments[name];
+
+                    if (argument.Type == FluidValues.Array)
+                    {
+                        var values = argument.Enumerate();
+
+                        if (values.Count() > 0)
+                        {
+                            var type = values.First().Type;
+
+                            if (type == FluidValues.String)
+                            {
+                                obj[LowerKebabToPascalCase(name)] = values.Select(v => v.ToStringValue());
+                            }
+                            else if (type == FluidValues.Number)
+                            {
+                                obj[LowerKebabToPascalCase(name)] = values.Select(v => v.ToNumberValue());
+                            }
+                            else if (type == FluidValues.Boolean)
+                            {
+                                obj[LowerKebabToPascalCase(name)] = values.Select(v => v.ToBooleanValue());
+                            }
+                            else
+                            {
+                                obj[LowerKebabToPascalCase(name)] = values.Select(v => v.ToObjectValue());
+                            }
+                        }
+                    }
+                    else
+                    {
+                        obj[LowerKebabToPascalCase(name)] = argument.ToObjectValue();
+                    }
                 }
             }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -141,8 +141,6 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
             if (obj != null)
             {
-                var properties = new Dictionary<string, object>();
-
                 foreach (var name in arguments.Names)
                 {
                     var argument = arguments[name];

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Fluid;

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -88,7 +88,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         {
             if (input.ToObjectValue() is Shape shape)
             {
-                shape.Metadata.Type = arguments.At(0).ToStringValue();
+                shape.Metadata.Type = arguments["type"].Or(arguments.At(0)).ToStringValue();
             }
 
             return Task.FromResult(input);
@@ -98,7 +98,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         {
             if (input.ToObjectValue() is Shape shape)
             {
-                shape.Metadata.DisplayType = arguments.At(0).ToStringValue();
+                shape.Metadata.DisplayType = arguments["type"].Or(arguments.At(0)).ToStringValue();
             }
 
             return Task.FromResult(input);
@@ -108,7 +108,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         {
             if (input.ToObjectValue() is Shape shape)
             {
-                shape.Metadata.Position = arguments.At(0).ToStringValue();
+                shape.Metadata.Position = arguments["position"].Or(arguments.At(0)).ToStringValue();
             }
 
             return Task.FromResult(input);
@@ -118,7 +118,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         {
             if (input.ToObjectValue() is Shape shape)
             {
-                shape.Metadata.Tab = arguments.At(0).ToStringValue();
+                shape.Metadata.Tab = arguments["tab"].Or(arguments.At(0)).ToStringValue();
             }
 
             return Task.FromResult(input);
@@ -128,7 +128,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         {
             if (input.ToObjectValue() is Shape shape && shape.Items != null)
             {
-                shape.Remove(arguments.At(0).ToStringValue());
+                shape.Remove(arguments["item"].Or(arguments.At(0)).ToStringValue());
             }
 
             return Task.FromResult(input);

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -116,9 +116,9 @@ namespace OrchardCore.DisplayManagement.Liquid
 
                 foreach (var item in shape.Items)
                 {
-                    // The prefix is the Name of the part. It also works for named parts,
+                    // It also works for named parts,
                     // so we can access Model.Content.MyNamedPart
-                    if (item is IShape itemShape && itemShape.Metadata.Prefix == n)
+                    if (item is IShape itemShape && itemShape.Metadata.Name == n)
                     {
                         return item;
                     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/HelperTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/HelperTag.cs
@@ -67,7 +67,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
 
             var arguments = (FilterArguments)(await _arguments.EvaluateAsync(context)).ToObjectValue();
 
-            var helper = _helper ?? arguments.At(0).ToStringValue();
+            var helper = _helper ?? arguments["helper_name"].Or(arguments.At(0)).ToStringValue();
             var tagHelperSharedState = services.GetRequiredService<TagHelperSharedState>();
 
             if (tagHelperSharedState.TagHelperDescriptors == null)

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/NamedHelperTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/NamedHelperTag.cs
@@ -32,6 +32,14 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
             {
                 if (DefaultArguments.TryGetValue(node.Term.Name, out var name))
                 {
+                    foreach (var argument in arguments)
+                    {
+                        if (argument.Name == name)
+                        {
+                            return arguments;
+                        }
+                    }
+
                     arguments[0] = new FilterArgument(name, DefaultFluidParser.BuildTermExpression(defaultArgument));
                 }
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/RenderSectionTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/RenderSectionTag.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
 
             var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
 
-            var name = arguments.At(0).ToStringValue();
+            var name = arguments["name"].Or(arguments.At(0)).ToStringValue();
             var required = arguments.HasNamed("required") ? Convert.ToBoolean(arguments["required"].ToStringValue()) : false;
             var zone = layout[name];
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/RenderTitleSegmentsTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/RenderTitleSegmentsTag.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
             var titleBuilder = ((IServiceProvider)services).GetRequiredService<IPageTitleBuilder>();
             var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
 
-            var segment = new HtmlString(arguments.At(0).ToStringValue());
+            var segment = new HtmlString(arguments["segment"].Or(arguments.At(0)).ToStringValue());
             var position = arguments.HasNamed("position") ? arguments["position"].ToStringValue() : "0";
             var separator = arguments.HasNamed("separator") ? new HtmlString(arguments["separator"].ToStringValue()) : null;
 


### PR DESCRIPTION
Fixes #1136, fixes #1109, fixes #1140, fixes #1147.

- **Warning**: For testing i worked with the agency theme with a named bagpart `Features`. First i selected the `BlogPost` type which already has a markdown part. Then i could add an item but **when republishing the landing page i lost this blog post item**. I suspect it is because of the autoroute part.

- So, i created a `Feature` content type with just a title part and a markdown part.

- Then in the landing page i added the following.

      {% if Model.ContentItem.Content.Features.ContentItems.size > 0 %}
      <!-- Features -->
      <section id="features">
      ...
          <div class="row text-center">
            {% display Model.Content.Features %} // this line render the named bag part
      ...
      </section>
      {% endif %}

- Then i created the `BagPart__LandingPage__Features` template where i could access `Model.BagPart`. **But i could not access `Model.BagPart.ContentItems` because it is not a direct property of the model**.

- So, i needed to add `ContentItems` as a direct property of `BagPartViewModel`. **Let me know if it is ok**.

- Then i used this in the `BagPart__LandingPage__Features` template.

      {% for feature in Model.ContentItems %}
      <div class="col-md-4">
        {% display feature | build_display: "Detail"  %}
      </div>
      {% endfor %}

---

- When we call `BuildDisplayAsync()` in the filter we pass null for the `updater ` parameter, and nothing for the `groupId` parameter whose default value is `""`. **Let me know if it is ok**.

- for the `displayType` we don't check anything and then we pass an empty string if not set or set to `""`. Then, in this case, `BuildDisplayAsync()` already use a default of `"Detail"`.