### PR TITLE
Useless PackagePath lines in modules csproj files.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Demo/OrchardCore.Demo.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/OrchardCore.Demo.csproj
@@ -24,13 +24,4 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Views\Fake-Typed.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\UserProfile.Edit.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Features/OrchardCore.Features.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Features/OrchardCore.Features.csproj
@@ -19,16 +19,4 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement.Abstractions\OrchardCore.ResourceManagement.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Views\Items\AllFeaturesDeploymentStep.Edit.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\Items\AllFeaturesDeploymentStep.Summary.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\Items\AllFeaturesDeploymentStep.Thumbnail.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
@@ -28,13 +28,4 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Views\LuceneQuery.Edit.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\Query-Lucene.Link.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
@@ -21,32 +21,4 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Module.txt">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-      <Pack>true</Pack>
-    </None>
-    <None Update="Views\Admin\Edit.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\Admin\Create.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\Admin\Index.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\SqlQuery.Edit.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\Query - Copy.Summary.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\Query-Sql.Link.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\_ViewImports.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/OrchardCore.Templates.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/OrchardCore.Templates.csproj
@@ -21,10 +21,4 @@
     <PackageReference Include="Microsoft.Extensions.Localization" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="README.md">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
@@ -20,25 +20,4 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Views\User.Create.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\UserSaveButtons.Edit.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\UserButtons.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\UserFields.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\UserFields.Edit.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-    <None Update="Views\User.Edit.cshtml">
-      <PackagePath>assets\$(PackageId)\</PackagePath>
-    </None>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
These lines are added by VS, not so important for an user developing a module.

But maybe better to remove these lines in our modules to show they are useless when we reference our module target.