### PR TITLE
Fixes lucene queries editor, and required Query field.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Drivers/LuceneQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Drivers/LuceneQueryDisplayDriver.cs
@@ -42,10 +42,14 @@ namespace OrchardCore.Lucene.Drivers
                 // Extract query from the query string if we come from the main query editor
                 if (string.IsNullOrEmpty(query.Template))
                 {
-                    updater.TryUpdateModelAsync(model, "", m => m.Query);
+                    var queryStringModel = new QueryStringModel();
+                    updater.TryUpdateModelAsync(queryStringModel, "", m => m.Query);
+                    model.Query = queryStringModel.Query;
                 }
             }).Location("Content:5");
         }
+
+        internal class QueryStringModel { public string Query { get; set; } }
 
         public override async Task<IDisplayResult> UpdateAsync(LuceneQuery model, IUpdateModel updater)
         {
@@ -57,7 +61,7 @@ namespace OrchardCore.Lucene.Drivers
                 model.ReturnContentItems = viewModel.ReturnContentItems;
             }
 
-            return Edit(model);
+            return Edit(model, updater);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
@@ -40,17 +40,15 @@ namespace OrchardCore.Queries.Sql.Drivers
                 // Extract query from the query string if we come from the main query editor
                 if (string.IsNullOrEmpty(query.Template))
                 {
-                    updater.TryUpdateModelAsync(model, "", m => m.Query);
-
-                    // The value is empty for new queries, remove any errors
-                    if (string.IsNullOrEmpty(model.Query))
-                    {
-                        updater.ModelState.Clear();
-                    }
+                    var queryStringModel = new QueryStringModel();
+                    updater.TryUpdateModelAsync(queryStringModel, "", m => m.Query);
+                    model.Query = queryStringModel.Query;
                 }
 
             }).Location("Content:5");
         }
+
+        internal class QueryStringModel { public string Query { get; set; } }
 
         public override async Task<IDisplayResult> UpdateAsync(SqlQuery model, IUpdateModel updater)
         {


### PR DESCRIPTION
Fixes #894, fixes #1069.

- First i added, also for Lucene, `updater.ModelState.Clear()` and ` return Edit(model, updater)`.

- Then, for Lucene when coming from the main editor, `Query` is not null but `Index` is. So an error is added but not cleared.

- Errors are cleared when `Query` is empty for new queries, but it can be because it has not be filled in a normal edit, so this required field is no more checked.

- So, here we use an internal model with only one **unrequired** `Query` property, just to retrieve the query from the query string without adding any error, and without clearing "normal" errors.

- Then i did the same for sql.