### PR TITLE
html_classify liquid filter.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -103,13 +103,13 @@ Output
 Bonjour!
 ```
 
-### html_classify
+### html_class
 
 Converts a string into a friendly html class.
 
 Input
 ```
-{{ "LandingPage" | html_classify }}
+{{ "LandingPage" | html_class }}
 ```
 
 Output

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -103,6 +103,20 @@ Output
 Bonjour!
 ```
 
+### html_classify
+
+Converts a string into a friendly html class.
+
+Input
+```
+{{ "LandingPage" | html_classify }}
+```
+
+Output
+```
+landing-page
+```
+
 ### Markdownify
 
 Converts a Markdown string to HTML.

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         public static FilterCollection WithLiquidViewFilters(this FilterCollection filters)
         {
             filters.AddAsyncFilter("t", Localize);
-            filters.AddAsyncFilter("html_classify", HtmlClassify);
+            filters.AddAsyncFilter("html_class", HtmlClass);
             filters.AddAsyncFilter("new_shape", NewShape);
             filters.AddAsyncFilter("shape_string", ShapeString);
             filters.AddAsyncFilter("clear_alternates", ClearAlternates);
@@ -51,7 +51,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
                 .GetString(input.ToStringValue(), parameters.ToArray())));
         }
 
-        public static Task<FluidValue> HtmlClassify(FluidValue input, FilterArguments arguments, TemplateContext context)
+        public static Task<FluidValue> HtmlClass(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
 
             return Task.FromResult<FluidValue>(new StringValue(input.ToStringValue().HtmlClassify()));

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -8,6 +8,7 @@ using Fluid.Values;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Localization;
 using OrchardCore.DisplayManagement.Shapes;
+using OrchardCore.Mvc.Utilities;
 
 namespace OrchardCore.DisplayManagement.Liquid.Filters
 {
@@ -16,6 +17,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         public static FilterCollection WithLiquidViewFilters(this FilterCollection filters)
         {
             filters.AddAsyncFilter("t", Localize);
+            filters.AddAsyncFilter("html_classify", HtmlClassify);
             filters.AddAsyncFilter("new_shape", NewShape);
             filters.AddAsyncFilter("shape_string", ShapeString);
             filters.AddAsyncFilter("clear_alternates", ClearAlternates);
@@ -47,6 +49,12 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
             return Task.FromResult<FluidValue>(new StringValue(((IViewLocalizer)localizer)
                 .GetString(input.ToStringValue(), parameters.ToArray())));
+        }
+
+        public static Task<FluidValue> HtmlClassify(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+
+            return Task.FromResult<FluidValue>(new StringValue(input.ToStringValue().HtmlClassify()));
         }
 
         public static async Task<FluidValue> NewShape(FluidValue input, FilterArguments arguments, TemplateContext context)


### PR DESCRIPTION
Can be useful when overriding some templates. See #1172 for an example with the `Widget` template.