### PR TITLE
Fixes LayerMetadataWelder NRE

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerMetadataWelder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerMetadataWelder.cs
@@ -61,6 +61,11 @@ namespace OrchardCore.Layers.Drivers
 
             await context.Updater.TryUpdateModelAsync(viewModel, Prefix);
 
+            if (viewModel.LayerMetadata == null)
+            {
+                return null;
+            }
+
             if (String.IsNullOrEmpty(viewModel.LayerMetadata.Zone))
             {
                 context.Updater.ModelState.AddModelError("LayerMetadata.Zone", S["Zone is missing"]);


### PR DESCRIPTION
Fixes #1179 

`LayerMetadataWelder` is a `ContentDisplayDriver` not a `ContentPartDisplayDriver`. So it's called e.g when publishing a content item of any content type.

At the beginning of `UpdateAsync()` we can't check the following on the `ContentItem model` because layer metadata is added on the fly.

            var layerMetadata = model.As<LayerMetadata>();

            if (layerMetadata == null)
            {
                return null;
            }

So, here we check if coming from a form which include at least a LayerMetadata field (even if hidden).

            await context.Updater.TryUpdateModelAsync(viewModel, Prefix);

            if (viewModel.LayerMetadata == null)
            {
                return null;
            }
