### PR TITLE
build_display filter also allow a JObject input.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Filters/BuildDisplayFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Filters/BuildDisplayFilter.cs
@@ -26,7 +26,9 @@ namespace OrchardCore.Contents.Filters
                 }
             }
 
-            if (contentItem == null || contentItem.ContentItemId == null)
+            // If input is a 'JObject' but which not represents a 'ContentItem',
+            // a 'ContentItem' is still created but with some null properties.
+            if (contentItem?.ContentItemId == null)
             {
                 return NilValue.Instance;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Filters/BuildDisplayFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Filters/BuildDisplayFilter.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.Liquid;
@@ -13,9 +14,19 @@ namespace OrchardCore.Contents.Filters
     {
         public async Task<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
         {
-            var contentItem = input.ToObjectValue() as ContentItem;
+            var obj = input.ToObjectValue();
 
-            if (contentItem == null)
+            if (!(obj is ContentItem contentItem))
+            {
+                contentItem = null;
+
+                if (obj is JObject jObject)
+                {
+                    contentItem = jObject.ToObject<ContentItem>();
+                }
+            }
+
+            if (contentItem == null || contentItem.ContentItemId == null)
             {
                 return NilValue.Instance;
             }


### PR DESCRIPTION
@sebastienros 

Then, doing this i could do the following 2 things in the `LandingPage__Services` template.

    {% for item in Model.ContentItems %}
        {% display item | build_display: "Summary" %}
    {% endfor %}

    // this also works because we now allow JObject input
    {% for item in Model.BagPart.Content.ContentItems %}
        {% display item | build_display: "Summary" %}
    {% endfor %}

**So, it seems that we don't need anymore to put `.ContentItems` directly in the `BagPart` model**.

**Update**: Just saw that other filters use a `ContentItem` input. Maybe good to do the same to allow also a `JObject`. I tried it with `display_text` filter, it works. Let me know.