### PR TITLE
Fixes po files locations

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -15,6 +15,7 @@ namespace OrchardCore.Localization
         private readonly IExtensionManager _extensionsManager;
         private readonly string _root;
         private readonly string _resourcesContainer;
+        private readonly string _applicationDataContainer;
         private readonly string _shellDataContainer;
 
         public ModularPoFileLocationProvider(
@@ -28,7 +29,8 @@ namespace OrchardCore.Localization
 
             _root = hostingEnvironment.ContentRootPath;
             _resourcesContainer = localizationOptions.Value.ResourcesPath; // Localization
-            _shellDataContainer = Path.Combine(shellOptions.Value.ShellsApplicationDataPath, shellOptions.Value.ShellsContainerName, shellSettings.Name);
+            _applicationDataContainer = Path.Combine(shellOptions.Value.ShellsApplicationDataPath);
+            _shellDataContainer = Path.Combine(_applicationDataContainer, shellOptions.Value.ShellsContainerName, shellSettings.Name);
         }
 
         public IEnumerable<string> GetLocations(string cultureName)
@@ -36,11 +38,11 @@ namespace OrchardCore.Localization
             // Load .po files in each extension folder first, based on the extensions order
             foreach (var extension in _extensionsManager.GetExtensions())
             {
-                yield return Path.Combine(_root, extension.SubPath, _resourcesContainer, cultureName, PoFileName);
+                yield return Path.Combine(_root, extension.SubPath, "App_Data", _resourcesContainer, cultureName, PoFileName);
             }
 
             // Then load global .po file for the applications
-            yield return Path.Combine(_root, _resourcesContainer, cultureName, PoFileName);
+            yield return Path.Combine(_applicationDataContainer, _resourcesContainer, cultureName, PoFileName);
 
             // Finally load tenant-specific .po file
             yield return Path.Combine(_shellDataContainer, _resourcesContainer, cultureName, PoFileName);

--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Localization
 
             _root = hostingEnvironment.ContentRootPath;
             _resourcesContainer = localizationOptions.Value.ResourcesPath; // Localization
-            _applicationDataContainer = Path.Combine(shellOptions.Value.ShellsApplicationDataPath);
+            _applicationDataContainer = shellOptions.Value.ShellsApplicationDataPath;
             _shellDataContainer = Path.Combine(_applicationDataContainer, shellOptions.Value.ShellsContainerName, shellSettings.Name);
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.Localization
     public class ModularPoFileLocationProvider : ILocalizationFileLocationProvider
     {
         private const string PoFileName = "OrchardCore.po";
+        private const string ExtensionDataFolder = "App_Data";
 
         private readonly IExtensionManager _extensionsManager;
         private readonly string _root;
@@ -38,10 +39,10 @@ namespace OrchardCore.Localization
             // Load .po files in each extension folder first, based on the extensions order
             foreach (var extension in _extensionsManager.GetExtensions())
             {
-                yield return Path.Combine(_root, extension.SubPath, "App_Data", _resourcesContainer, cultureName, PoFileName);
+                yield return Path.Combine(_root, extension.SubPath, ExtensionDataFolder, _resourcesContainer, cultureName, PoFileName);
             }
 
-            // Then load global .po file for the applications
+            // Then load global .po file for the application
             yield return Path.Combine(_applicationDataContainer, _resourcesContainer, cultureName, PoFileName);
 
             // Finally load tenant-specific .po file


### PR DESCRIPTION
Fixes #1294.

- For modules locations `[ModuleLocation]/App_Data/Localization/[CultureName]/...`, i have used **an hard coded term** `App_Data`. I could retrieve this term at the end of the `ShellsApplicationDataPath` but this one is configurable and might be different.

- Maybe better to just use `[ModuleLocation]/Localization/[CultureName]/...` and then update the doc. So, let me know if it is ok to use an hard coded term `App_Data` OR a simpler path without this term.