### PR TITLE
Simpler Versionable option.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/ContentTypeSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/ContentTypeSettingsDisplayDriver.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
-using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentTypes.ViewModels;
 using OrchardCore.DisplayManagement.Views;
 
@@ -17,6 +17,7 @@ namespace OrchardCore.ContentTypes.Editors
                 model.Creatable = settings.Creatable;
                 model.Listable = settings.Listable;
                 model.Draftable = settings.Draftable;
+                model.Versionable = settings.Versionable;
                 model.Securable = settings.Securable;
                 model.Stereotype = settings.Stereotype;
             }).Location("Content:5");
@@ -31,6 +32,7 @@ namespace OrchardCore.ContentTypes.Editors
                 context.Builder.Creatable(model.Creatable);
                 context.Builder.Listable(model.Listable);
                 context.Builder.Draftable(model.Draftable);
+                context.Builder.Versionable(model.Versionable);
                 context.Builder.Securable(model.Securable);
                 context.Builder.Stereotype(model.Stereotype);
             }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/ContentDefinitionService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/ContentDefinitionService.cs
@@ -1,16 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using OrchardCore.Modules;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentManagement.Metadata.Settings;
-using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.ContentTypes.Events;
 using OrchardCore.ContentTypes.ViewModels;
+using OrchardCore.Modules;
 using OrchardCore.Mvc.Utilities;
 using YesSql;
 
@@ -96,7 +96,7 @@ namespace OrchardCore.ContentTypes.Services
             _contentDefinitionManager.StoreTypeDefinition(contentTypeDefinition);
             // Ensure it has its own part
             _contentDefinitionManager.AlterTypeDefinition(name, builder => builder.WithPart(name));
-            _contentDefinitionManager.AlterTypeDefinition(name, cfg => cfg.Creatable().Draftable().Listable().Securable());
+            _contentDefinitionManager.AlterTypeDefinition(name, cfg => cfg.Creatable().Draftable().Versionable().Listable().Securable());
 
             _contentDefinitionEventHandlers.Invoke(x => x.ContentTypeCreated(new ContentTypeCreatedContext { ContentTypeDefinition = contentTypeDefinition }), Logger);
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/ViewModels/ContentTypeSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/ViewModels/ContentTypeSettingsViewModel.cs
@@ -1,10 +1,11 @@
-﻿namespace OrchardCore.ContentTypes.ViewModels
+namespace OrchardCore.ContentTypes.ViewModels
 {
     public class ContentTypeSettingsViewModel
     {
         public bool Creatable { get; set; }
         public bool Listable { get; set; }
         public bool Draftable { get; set; }
+        public bool Versionable { get; set; }
         public bool Securable { get; set; }
         public string Stereotype { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
@@ -25,6 +25,14 @@
 </fieldset>
 
 <fieldset class="form-group">
+    <label asp-for="Versionable">
+        <input asp-for="Versionable" type="checkbox">
+        @T["Versionable"]
+        <span class="hint">@T["Determines if this content type supports versioning."]</span>
+    </label>
+</fieldset>
+
+<fieldset class="form-group">
     <label asp-for="Securable">
         <input asp-for="Securable" type="checkbox">
         @T["Securable"]

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Migrations.cs
@@ -1,5 +1,5 @@
-﻿using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.Data.Migration;
 
 namespace OrchardCore.Menu
@@ -17,6 +17,7 @@ namespace OrchardCore.Menu
         {
             _contentDefinitionManager.AlterTypeDefinition("Menu", menu => menu
                 .Draftable()
+                .Versionable()
                 .Creatable()
                 .Listable()
                 .WithPart("TitlePart", part => part.WithPosition("1"))

--- a/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
@@ -93,6 +93,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "False",
             "Stereotype": null
@@ -157,6 +158,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "False",
             "Stereotype": null
@@ -218,6 +220,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": null
@@ -282,6 +285,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "True",
             "Stereotype": null
@@ -351,6 +355,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": "Widget"
@@ -371,6 +376,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "True",
             "Stereotype": null
@@ -423,6 +429,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "True",
             "Stereotype": null
@@ -588,6 +595,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "False",
+            "Versionable": "False",
             "Listable": "False",
             "Securable": "False",
             "Stereotype": null
@@ -696,6 +704,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "False",
+            "Versionable": "False",
             "Listable": "False",
             "Securable": "False",
             "Stereotype": null
@@ -723,6 +732,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "False",
+            "Versionable": "False",
             "Listable": "False",
             "Securable": "False",
             "Stereotype": null

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -95,6 +95,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "False",
             "Stereotype": null
@@ -159,6 +160,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "False",
             "Stereotype": null
@@ -220,6 +222,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": null
@@ -284,6 +287,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "True",
             "Stereotype": null
@@ -355,6 +359,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": "Widget"
@@ -382,6 +387,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": "Widget"
@@ -402,6 +408,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": "Widget"
@@ -422,6 +429,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "True",
             "Stereotype": "Widget"
@@ -442,6 +450,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "False",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "False",
             "Stereotype": null
@@ -469,6 +478,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": "Widget"
@@ -489,6 +499,7 @@
           "Settings": {
             "Creatable": "False",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "False",
             "Securable": "True",
             "Stereotype": "Widget"
@@ -509,6 +520,7 @@
           "Settings": {
             "Creatable": "True",
             "Draftable": "True",
+            "Versionable": "True",
             "Listable": "True",
             "Securable": "True",
             "Stereotype": null

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettings.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace OrchardCore.ContentManagement.Metadata.Settings
+namespace OrchardCore.ContentManagement.Metadata.Settings
 {
     public class ContentTypeSettings
     {
@@ -14,6 +14,10 @@
         /// Used to determine if this content type supports draft versions
         /// </summary>
         public bool Draftable { get; set; }
+        /// <summary>
+        /// Used to determine if this content type supports versioning
+        /// </summary>
+        public bool Versionable { get; set; }
         /// <summary>
         /// Defines the stereotype of the type
         /// </summary>

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettingsExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettingsExtensions.cs
@@ -1,4 +1,4 @@
-﻿using OrchardCore.ContentManagement.Metadata.Builders;
+using OrchardCore.ContentManagement.Metadata.Builders;
 
 namespace OrchardCore.ContentManagement.Metadata.Settings
 {
@@ -18,6 +18,11 @@ namespace OrchardCore.ContentManagement.Metadata.Settings
         public static ContentTypeDefinitionBuilder Draftable(this ContentTypeDefinitionBuilder builder, bool draftable = true)
         {
             return builder.WithSetting("Draftable", draftable.ToString());
+        }
+
+        public static ContentTypeDefinitionBuilder Versionable(this ContentTypeDefinitionBuilder builder, bool versionable = true)
+        {
+            return builder.WithSetting("Versionable", versionable.ToString());
         }
 
         public static ContentTypeDefinitionBuilder Securable(this ContentTypeDefinitionBuilder builder, bool securable = true)

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -7,6 +7,7 @@ using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Builders;
+using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.Modules;
 using YesSql;
@@ -146,7 +147,17 @@ namespace OrchardCore.ContentManagement
                     // Save the previous version
                     _session.Save(contentItem);
 
-                    contentItem = await BuildNewVersionAsync(contentItem);
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // Check if not versionable, meaning we use only one version
+                    if (!(contentTypeDefinition?.Settings.ToObject<ContentTypeSettings>().Versionable ?? true))
+                    {
+                        contentItem.Published = false;
+                    }
+                    else
+                    {
+                        contentItem = await BuildNewVersionAsync(contentItem);
+                    }
                 }
 
                 // Save the new version


### PR DESCRIPTION
@sebastienros 

Maybe the simplest way to implement `Versionable`, only 3 lines of code in `DefautContentManager`.

The difficulty was to be `Not Versionable` but still `Draftable`, because currently this is when we use `options.IsDraftRequired` on a published item that we create a new version.

So here, the suggestion is to really use only one version, so when a draft is required on a published item, we simply make this unique and latest version a draft (published = false) without creating a new version.

- So, if `Not Versionable` publishing doesn't create any new versions, which was the 1st goal.

- If also `Draftable`, we can still save an item as a draft and then publish it. **The only "drawback"** is that we can't have at the same time a draft version and a published version.

- But **maybe "normal"** that if we want both versions at the same time we need to be `Versionable`. Here, `Not Versionable` **really stop the versioning process**.

If you don't like it, using another existing version for the draft is not so hard to implement, i already did it, let me know if you prefer. But this solution was so simple to do that i wanted to suggest it.

