### PR TITLE
Prevent VS from updating PackageAssetFiles in .csproj

### DIFF
--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -11,10 +11,6 @@
     <ModuleType Condition="'$(ModuleType)' == ''">Module</ModuleType>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageAssetFiles Include="**\*" Exclude="$(ExcludedFiles)" />
-  </ItemGroup>
-
   <Target Name="CheckManifestFile" AfterTargets="Build">
     <Message Text="Generating manifest file: $(MSBuildProjectName)" Importance="high" Condition="!Exists('$(ModuleType).txt')" />
     <WriteLinesToFile
@@ -32,6 +28,7 @@
 
   <Target Name="CopyPackageAssetFiles" Condition="'$(ApplicationDirectory)' != '' And Exists('$(ApplicationDirectory)')">
     <ItemGroup>
+      <PackageAssetFiles Include="**\*" Exclude="$(ExcludedFiles)" />
       <ApplicationAssetFiles Include="$(ApplicationDirectory)\Packages\$(MSBuildProjectName)\**\*" />
     </ItemGroup>
     <Delete


### PR DESCRIPTION
When you rename a razor file in a module, in the `.csproj` file VS updates the `PackageAssetFiles` that we define at the beginning of `O.Module.Targets.props` to manage module assets.

    <ItemGroup>
      <PackageAssetFiles Remove="Views\Renamed.cshtml" />
    </ItemGroup>

Here we define `PackageAssetFiles` later in the `Target` which uses it, so VS is not aware of it.

---

When you copy paste a razor file from another project, VS also adds

    <ItemGroup>
      <None Update="Views\Foo.cshtml">
        <PackagePath>assets\$(PackageId)\</PackagePath>
      </None>
    </ItemGroup>

I didn't find a way to prevent this but it is not so important and you can clean it yourself, it simply defines again what we already define for all assets, where to put them when we pack the module.
