### PR TITLE
Use FileExtensionContentTypeProvider in place of MimeMapping package.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.Logging;
 using OrchardCore.FileStorage;
 
@@ -14,6 +15,7 @@ namespace OrchardCore.Media.Controllers
     {
         private readonly IMediaFileStore _mediaFileStore;
         private readonly IAuthorizationService _authorizationService;
+        private readonly IContentTypeProvider _contentTypeProvider;
         private readonly ILogger _logger;
 
         public AdminController(
@@ -23,6 +25,7 @@ namespace OrchardCore.Media.Controllers
         {
             _mediaFileStore = mediaFileStore;
             _authorizationService = authorizationService;
+            _contentTypeProvider = new FileExtensionContentTypeProvider();
             _logger = logger;
         }
 
@@ -228,6 +231,8 @@ namespace OrchardCore.Media.Controllers
 
         public object CreateFileResult(IFileStoreEntry mediaFile)
         {
+            _contentTypeProvider.TryGetContentType(mediaFile.Name, out var contentType);
+
             return new
             {
                 name = mediaFile.Name,
@@ -235,7 +240,7 @@ namespace OrchardCore.Media.Controllers
                 folder = mediaFile.DirectoryPath,
                 url = _mediaFileStore.MapPathToPublicUrl(mediaFile.Path),
                 mediaPath = mediaFile.Path,
-                mime = MimeMapping.MimeUtility.GetMimeMapping(mediaFile.Path)
+                mime = contentType ?? "application/octet-stream"
             };
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -21,11 +21,12 @@ namespace OrchardCore.Media.Controllers
         public AdminController(
             IMediaFileStore mediaFileStore,
             IAuthorizationService authorizationService,
+            IContentTypeProvider contentTypeProvider,
             ILogger<AdminController> logger)
         {
             _mediaFileStore = mediaFileStore;
             _authorizationService = authorizationService;
-            _contentTypeProvider = new FileExtensionContentTypeProvider();
+            _contentTypeProvider = contentTypeProvider;
             _logger = logger;
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="MimeMapping" Version="1.0.1.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -153,7 +153,7 @@ namespace OrchardCore.Media
             services.AddRecipeExecutionStep<MediaStep>();
 
             // MIME types
-            services.AddSingleton<IContentTypeProvider, FileExtensionContentTypeProvider>();
+            services.TryAddSingleton<IContentTypeProvider, FileExtensionContentTypeProvider>();
         }
 
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -2,8 +2,8 @@ using System;
 using System.IO;
 using Fluid;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
@@ -13,6 +13,7 @@ using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Environment.Shell;
 using OrchardCore.FileStorage;
+using OrchardCore.FileStorage.FileSystem;
 using OrchardCore.Liquid;
 using OrchardCore.Media.Drivers;
 using OrchardCore.Media.Fields;
@@ -25,7 +26,6 @@ using OrchardCore.Media.Settings;
 using OrchardCore.Media.ViewModels;
 using OrchardCore.Modules;
 using OrchardCore.Recipes;
-using OrchardCore.FileStorage.FileSystem;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.Commands;
@@ -151,6 +151,9 @@ namespace OrchardCore.Media
             services.AddScoped<IContentPartFieldDefinitionDisplayDriver, MediaFieldSettingsDriver>();
 
             services.AddRecipeExecutionStep<MediaStep>();
+
+            // MIME types
+            services.AddSingleton<IContentTypeProvider, FileExtensionContentTypeProvider>();
         }
 
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)


### PR DESCRIPTION
Fixes #1226 

Right now i just used the `FileExtensionContentTypeProvider` class in place of the package. But maybe you want to register a `DefaultContentTypeProvider` service, the ability to provide additional mime types ...