### PR TITLE
Prevents duplicate resource names.

### DIFF
--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -60,7 +60,10 @@
       <EmbeddedResource Remove="@(EmbeddedResource)" />
       <EmbeddedResource Include="@(ModuleAssetFiles)" />
       <EmbeddedResource Update="@(EmbeddedResource)" Condition="'%(EmbeddedResource.Link)' == ''">
-        <LogicalName>$([System.String]::new('$(MSBuildProjectName)\%(RelativeDir)%(FileName)%(Extension)').Replace('\', '.').Replace('/', '.'))</LogicalName>
+        <LogicalName>$([System.String]::new('$(MSBuildProjectName).%(RelativeDir)%(FileName)%(Extension)').Replace('\', '>').Replace('/', '>'))</LogicalName>
+      </EmbeddedResource>
+      <EmbeddedResource Update="@(EmbeddedResource)" Condition="'%(EmbeddedResource.Link)' != ''">
+        <LogicalName>$([System.String]::new('$(MSBuildProjectName).%(EmbeddedResource.Link)').Replace('\', '>').Replace('/', '>'))</LogicalName>
       </EmbeddedResource>
       <EmbeddedResource Include="obj\module.assets.map">
         <Link>module.assets.map</Link>

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/ModularApplicationContext.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/ModularApplicationContext.cs
@@ -78,6 +78,8 @@ namespace OrchardCore.Modules
         public static string ContentRoot = ContentPath + "/";
         private const string ModuleAssetsMap = "module.assets.map";
 
+        private readonly string _baseNamespace;
+        private readonly DateTimeOffset _lastModified;
         private readonly IDictionary<string, IFileInfo> _fileInfos = new Dictionary<string, IFileInfo>();
 
         public Module(string name)
@@ -96,6 +98,9 @@ namespace OrchardCore.Modules
                 Assets = Enumerable.Empty<Asset>();
                 AssetPaths = Enumerable.Empty<string>();
             }
+
+            _baseNamespace = Name + '.';
+            _lastModified = DateTimeOffset.UtcNow;
         }
 
         public string Name { get; }
@@ -117,7 +122,7 @@ namespace OrchardCore.Modules
                 {
                     if (!_fileInfos.TryGetValue(subpath, out fileInfo))
                     {
-                        var resourcePath = Name + '.' + subpath.Replace('/', '>');
+                        var resourcePath = _baseNamespace + subpath.Replace('/', '>');
                         var fileName = Path.GetFileName(subpath);
 
                         if (Assembly.GetManifestResourceInfo(resourcePath) == null)
@@ -126,7 +131,7 @@ namespace OrchardCore.Modules
                         }
 
                         _fileInfos[subpath] = fileInfo = new EmbeddedResourceFileInfo(
-                            Assembly, resourcePath, fileName, DateTimeOffset.UtcNow);
+                            Assembly, resourcePath, fileName, _lastModified);
                     }
                 }
             }

--- a/src/OrchardCore/OrchardCore.Modules/ModuleEmbeddedFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Modules/ModuleEmbeddedFileProvider.cs
@@ -90,8 +90,10 @@ namespace OrchardCore.Modules
 
                 if (index != -1)
                 {
-                    return _environment.GetModule(path.Substring(0, index))
-                        .GetFileInfo(path.Substring(index + 1));
+                    var moduleName = path.Substring(0, index);
+                    var fileSubPath = path.Substring(index + 1);
+
+                    return _environment.GetModule(moduleName).GetFileInfo(fileSubPath);
                 }
             }
 


### PR DESCRIPTION
Prevents from having duplicate resource names as mentioned by @sfmskywalker on skipe.

    "Views/foo/bar.cshtml" => "Views.foo.bar.cshtml".
    "Views/foo.bar.cshtml" => "Views.foo.bar.cshtml".

So, here we use directly `GetManifestResourceInfo()`, not through the aspnet `EmbeddedFileProvider`, this to have more control on the resource names. Then we can use a separator character which is an invalid character for a path / filename but a valid character for a resource name.

    "Views/foo/bar.cshtml" => "Views>foo>bar.cshtml".
    "Views/foo.bar.cshtml" => "Views>foo.bar.cshtml".

Needs to be tried by @sfmskywalker to see if it is ok for its use case.
I also need to redo some tests tomorrow for linked items, view precompilation ...
But seems to work.

