### PR TITLE
Missing PrivateAssets attributes in OC.Application.Cms.Targets.csproj

### DIFF
--- a/src/OrchardCore/OrchardCore.Application.Cms.Targets/OrchardCore.Application.Cms.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Targets/OrchardCore.Application.Cms.Targets.csproj
@@ -22,8 +22,8 @@
   -->
 
   <ItemGroup>
-    <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Https\OrchardCore.Https.csproj" />
-    <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Media.Azure\OrchardCore.Media.Azure.csproj" />
+    <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Https\OrchardCore.Https.csproj" PrivateAssets="none" />
+    <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Media.Azure\OrchardCore.Media.Azure.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\OrchardCore.Application.Targets\OrchardCore.Application.Targets.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Localization\OrchardCore.Localization.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Liquid\OrchardCore.Liquid.csproj" PrivateAssets="none" />


### PR DESCRIPTION
See the comments in the related file.

    When a package is not directly referenced, e.g only through the reference of this bundle package,
    the files in its build folder are not evaluated on building if this folder is marked as private.
    This can be defined by using the 'PrivateAssets' attribute.
    
    Here, only project references are used but when packing the bundle they become package references,
    and with the same 'PrivateAssets' attribute.

