### PR TITLE
Fixes race conditions on building a project with multiple target frameworks.

### DIFF
--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
@@ -7,12 +7,16 @@
 
   <Target Name="EmbeddModuleNames" AfterTargets="AfterResolveReferences">
 
-    <ItemGroup>
-      <ModuleProjectReferences
-        Include="@(_MSBuildProjectReferenceExistent)"
-        Condition="Exists('%(RootDir)%(Directory)Module.txt') Or Exists('%(RootDir)%(Directory)obj\Module.txt') Or
-                   Exists('%(RootDir)%(Directory)Theme.txt') Or Exists('%(RootDir)%(Directory)obj\Theme.txt')" />
-    </ItemGroup>
+    <MSBuild
+      Targets="GetModuleProjectReference"
+      BuildInParallel="$(BuildInParallel)"
+      Projects="@(_MSBuildProjectReferenceExistent)"
+      Condition="'@(_MSBuildProjectReferenceExistent)' != ''"
+      SkipNonexistentTargets="true"
+      ContinueOnError="true">
+
+      <Output ItemName="ModuleProjectReferences" TaskParameter="TargetOutputs" />
+    </MSBuild>
 
     <ItemGroup>
       <ModuleProjectNames Include="%(ModuleProjectReferences.FileName)" />
@@ -48,6 +52,7 @@
       BuildInParallel="$(BuildInParallel)"
       Projects="@(ModuleProjectReferences)"
       Condition="'@(ModuleProjectReferences)' != ''"
+      SkipNonexistentTargets="true"
       ContinueOnError="true">
 
       <Output ItemName="ModuleLinkedRazorFiles" TaskParameter="TargetOutputs" />

--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="obj\module.names.map"
+      File="$(IntermediateOutputPath)module.names.map"
       Lines="@(ModuleNames)"
       Condition="'@(ModuleNames)' != ''"
       Overwrite="true"
@@ -28,7 +28,7 @@
       ContinueOnError="true" />
 
     <ItemGroup>
-      <EmbeddedResource Include="obj\module.names.map">
+      <EmbeddedResource Include="$(IntermediateOutputPath)module.names.map">
         <Link>module.names.map</Link>
       </EmbeddedResource>
     </ItemGroup>

--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
@@ -7,16 +7,12 @@
 
   <Target Name="EmbeddModuleNames" AfterTargets="AfterResolveReferences">
 
-    <MSBuild
-      Targets="GetModuleProjectReference"
-      BuildInParallel="$(BuildInParallel)"
-      Projects="@(_MSBuildProjectReferenceExistent)"
-      Condition="'@(_MSBuildProjectReferenceExistent)' != ''"
-      SkipNonexistentTargets="true"
-      ContinueOnError="true">
-
-      <Output ItemName="ModuleProjectReferences" TaskParameter="TargetOutputs" />
-    </MSBuild>
+    <ItemGroup>
+      <ModuleProjectReferences
+        Include="@(_MSBuildProjectReferenceExistent)"
+        Condition="Exists('%(RootDir)%(Directory)Module.txt') Or Exists('%(RootDir)%(Directory)obj\Module.txt') Or
+                   Exists('%(RootDir)%(Directory)Theme.txt') Or Exists('%(RootDir)%(Directory)obj\Theme.txt')" />
+    </ItemGroup>
 
     <ItemGroup>
       <ModuleProjectNames Include="%(ModuleProjectReferences.FileName)" />
@@ -52,7 +48,6 @@
       BuildInParallel="$(BuildInParallel)"
       Projects="@(ModuleProjectReferences)"
       Condition="'@(ModuleProjectReferences)' != ''"
-      SkipNonexistentTargets="true"
       ContinueOnError="true">
 
       <Output ItemName="ModuleLinkedRazorFiles" TaskParameter="TargetOutputs" />

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -34,6 +34,8 @@
       <ModuleAssets Include=".Modules\$(MSBuildProjectName)\$(ModuleType).txt" Condition="!Exists('$(ModuleType).txt')" />
     </ItemGroup>
 
+    <MakeDir Directories="$(IntermediateOutputPath)" ContinueOnError="True"/>
+
     <WriteLinesToFile
       File="$(IntermediateOutputPath)module.assets.map"
       Lines="@(ModuleAssets)"

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -47,15 +47,15 @@
     <Message Text="Generating manifest file: $(MSBuildProjectName)" Importance="high" Condition="!Exists('$(ModuleType).txt')" />
 
     <WriteLinesToFile
-      File="$(IntermediateOutputPath)$(ModuleType).txt"
+      File="obj\$(ModuleType).txt"
       Lines="$(ModuleManifest)"
       Condition="!Exists('$(ModuleType).txt')"
       Overwrite="true"
       Encoding="utf-8"
       ContinueOnError="true" />
     <Delete
-      Files="$(IntermediateOutputPath)$(ModuleType).txt"
-      Condition="Exists('$(IntermediateOutputPath)$(ModuleType).txt') and Exists('$(ModuleType).txt')"
+      Files="obj\$(ModuleType).txt"
+      Condition="Exists('obj\$(ModuleType).txt') and Exists('$(ModuleType).txt')"
       ContinueOnError="true" />
 
     <ItemGroup>
@@ -67,7 +67,7 @@
       <EmbeddedResource Include="$(IntermediateOutputPath)module.assets.map">
         <Link>module.assets.map</Link>
       </EmbeddedResource>
-      <EmbeddedResource Include="$(IntermediateOutputPath)$(ModuleType).txt" Condition="!Exists('$(ModuleType).txt')">
+      <EmbeddedResource Include="obj\$(ModuleType).txt" Condition="!Exists('$(ModuleType).txt')">
         <Link>$(ModuleType).txt</Link>
       </EmbeddedResource>
     </ItemGroup>
@@ -81,8 +81,6 @@
       </EmbeddedResource>
     </ItemGroup>
   </Target>
-
-  <Target Name="GetModuleProjectReference" Returns="$(MSBuildProjectFullPath)" />
 
   <Target Name="GetModuleLinkedRazorFiles" Returns="@(ModuleLinkedRazorFiles)">
     <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <WriteLinesToFile
-      File="obj\module.assets.map"
+      File="$(IntermediateOutputPath)module.assets.map"
       Lines="@(ModuleAssets)"
       Condition="'@(ModuleAssets)' != ''"
       Overwrite="true"
@@ -62,7 +62,7 @@
       <EmbeddedResource Update="@(EmbeddedResource)" Condition="'%(EmbeddedResource.Link)' == ''">
         <LogicalName>$([System.String]::new('$(MSBuildProjectName)\%(RelativeDir)%(FileName)%(Extension)').Replace('\', '.').Replace('/', '.'))</LogicalName>
       </EmbeddedResource>
-      <EmbeddedResource Include="obj\module.assets.map">
+      <EmbeddedResource Include="$(IntermediateOutputPath)module.assets.map">
         <Link>module.assets.map</Link>
       </EmbeddedResource>
       <EmbeddedResource Include="obj\$(ModuleType).txt" Condition="!Exists('$(ModuleType).txt')">

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -31,7 +31,7 @@
         Include=".Modules\$(MSBuildProjectName)\%(ModuleAssetFiles.Link)|%(ModuleAssetFiles.FullPath)"
         Condition="'%(ModuleAssetFiles.Link)' != ''" />
 
-    <ModuleAssets Include=".Modules\$(MSBuildProjectName)\$(ModuleType).txt" Condition="!Exists  ('$(ModuleType).txt')" />
+      <ModuleAssets Include=".Modules\$(MSBuildProjectName)\$(ModuleType).txt" Condition="!Exists('$(ModuleType).txt')" />
     </ItemGroup>
 
     <WriteLinesToFile
@@ -45,15 +45,15 @@
     <Message Text="Generating manifest file: $(MSBuildProjectName)" Importance="high" Condition="!Exists('$(ModuleType).txt')" />
 
     <WriteLinesToFile
-      File="obj\$(ModuleType).txt"
+      File="$(IntermediateOutputPath)$(ModuleType).txt"
       Lines="$(ModuleManifest)"
       Condition="!Exists('$(ModuleType).txt')"
       Overwrite="true"
       Encoding="utf-8"
       ContinueOnError="true" />
     <Delete
-      Files="obj\$(ModuleType).txt"
-      Condition="Exists('obj\$(ModuleType).txt') and Exists('$(ModuleType).txt')"
+      Files="$(IntermediateOutputPath)$(ModuleType).txt"
+      Condition="Exists('$(IntermediateOutputPath)$(ModuleType).txt') and Exists('$(ModuleType).txt')"
       ContinueOnError="true" />
 
     <ItemGroup>
@@ -65,7 +65,7 @@
       <EmbeddedResource Include="$(IntermediateOutputPath)module.assets.map">
         <Link>module.assets.map</Link>
       </EmbeddedResource>
-      <EmbeddedResource Include="obj\$(ModuleType).txt" Condition="!Exists('$(ModuleType).txt')">
+      <EmbeddedResource Include="$(IntermediateOutputPath)$(ModuleType).txt" Condition="!Exists('$(ModuleType).txt')">
         <Link>$(ModuleType).txt</Link>
       </EmbeddedResource>
     </ItemGroup>
@@ -79,6 +79,8 @@
       </EmbeddedResource>
     </ItemGroup>
   </Target>
+
+  <Target Name="GetModuleProjectReference" Returns="$(MSBuildProjectFullPath)" />
 
   <Target Name="GetModuleLinkedRazorFiles" Returns="@(ModuleLinkedRazorFiles)">
     <ItemGroup>


### PR DESCRIPTION
Fixes #1323 

Multiple parallel build can be triggered on the same project when it targets multiple frameworks. In this case, each build tries to write to the same mapping file.

We only get a warning and each build would have written the same content, but better to fix it by using the `$(IntermediateOutputPath)` which depends on the `$(TargetFramework)`.

Finally i did the same when we generate a manifest file, even if i couldn't repro the issue for this small file. Then i needed to change the way the app lookup for module projects references, this to not rely on the manifest file locations.

 Here, to grab all module project references, the app call a specific target on all project references, so only module projects return a value. This was not possible before because of a msbuild issue, it was failing on the 1st project which is not a module and which doesn't define this target. But this issue has been fixed and we can now use the `SkipNonexistentTargets` parameter.
