### PR TITLE
Turning IContentHandler methods into async versions

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Fluid;
 using OrchardCore.Alias.Models;
 using OrchardCore.Alias.Settings;
@@ -29,8 +30,8 @@ namespace OrchardCore.Alias.Handlers
             _tagCache = tagCache;
             _liquidTemplateManager = liquidTemplateManager;
         }
-        
-        public override void Updated(UpdateContentContext context, AliasPart part)
+
+        public async override Task UpdatedAsync(UpdateContentContext context, AliasPart part)
         {
             // Compute the Path only if it's empty
             if (!String.IsNullOrEmpty(part.Alias))
@@ -45,10 +46,10 @@ namespace OrchardCore.Alias.Handlers
                 var templateContext = new TemplateContext();
                 templateContext.SetValue("ContentItem", part.ContentItem);
 
-                part.Alias = _liquidTemplateManager.RenderAsync(pattern, templateContext).GetAwaiter().GetResult();
+                part.Alias = await _liquidTemplateManager.RenderAsync(pattern, templateContext);
             }
         }
-        
+
         /// <summary>
         /// Get the pattern from the AutoroutePartSettings property for its type
         /// </summary>
@@ -61,19 +62,22 @@ namespace OrchardCore.Alias.Handlers
             return pattern;
         }
 
-        public override void Published(PublishContentContext context, AliasPart instance)
+        public override Task PublishedAsync(PublishContentContext context, AliasPart instance)
         {
             _tagCache.RemoveTag($"alias:{instance.Alias}");
+            return Task.CompletedTask;
         }
 
-        public override void Removed(RemoveContentContext context, AliasPart instance)
+        public override Task RemovedAsync(RemoveContentContext context, AliasPart instance)
         {
             _tagCache.RemoveTag($"alias:{instance.Alias}");
+            return Task.CompletedTask;
         }
 
-        public override void Unpublished(PublishContentContext context, AliasPart instance)
+        public override Task UnpublishedAsync(PublishContentContext context, AliasPart instance)
         {
             _tagCache.RemoveTag($"alias:{instance.Alias}");
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -110,9 +110,9 @@ namespace OrchardCore.Autoroute.Handlers
 
                 part.Path = await _liquidTemplateManager.RenderAsync(pattern, templateContext);
 
-                if (!IsPathUnique(part.Path, part))
+                if (!await IsPathUniqueAsync(part.Path, part))
                 {
-                    part.Path = GenerateUniquePath(part.Path, part);
+                    part.Path = await GenerateUniquePathAsync(part.Path, part);
                 }
 
                 part.Apply();
@@ -136,7 +136,7 @@ namespace OrchardCore.Autoroute.Handlers
             return pattern;
         }
 
-        private string GenerateUniquePath(string path, AutoroutePart context)
+        private async Task<string> GenerateUniquePathAsync(string path, AutoroutePart context)
         {
             var version = 1;
             var unversionedPath = path;
@@ -151,16 +151,16 @@ namespace OrchardCore.Autoroute.Handlers
             while (true)
             {
                 var versionedPath = $"{unversionedPath}-{version++}";
-                if (IsPathUnique(versionedPath, context))
+                if (await IsPathUniqueAsync(versionedPath, context))
                 {
                     return versionedPath;
                 }
             }
         }
 
-        private bool IsPathUnique(string path, AutoroutePart context)
+        private async Task<bool> IsPathUniqueAsync(string path, AutoroutePart context)
         {
-            return _session.QueryIndex<AutoroutePartIndex>(o => o.ContentItemId != context.ContentItem.ContentItemId && o.Path == path).CountAsync().GetAwaiter().GetResult() == 0;
+            return (await _session.QueryIndex<AutoroutePartIndex>(o => o.ContentItemId != context.ContentItem.ContentItemId && o.Path == path).CountAsync()) == 0;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Body/Handlers/BodyPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Body/Handlers/BodyPartHandler.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using OrchardCore.Body.Model;
 using OrchardCore.Body.Settings;
@@ -17,19 +18,19 @@ namespace OrchardCore.Body.Handlers
             _contentDefinitionManager = contentDefinitionManager;
         }
 
-        public override void GetContentItemAspect(ContentItemAspectContext context, BodyPart part)
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context, BodyPart part)
         {
             context.For<BodyAspect>(bodyAspect =>
             {
-
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
                 var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(p => p.PartDefinition.Name == nameof(BodyPart));
                 var settings = contentTypePartDefinition.GetSettings<BodyPartSettings>();
-
                 var body = part.Body;
 
                 bodyAspect.Body = new HtmlString(body);
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Controllers/PreviewController.cs
@@ -75,7 +75,7 @@ namespace OrchardCore.ContentPreview.Controllers
             }
 
             var contentItemType = Request.Form["ContentItemType"];
-            var contentItem = _contentManager.New(contentItemType);
+            var contentItem = await _contentManager.NewAsync(contentItemType);
 
             // Assign the ids from the currently edited item so that validation thinks
             // it's working on the same item. For instance if drivers are checking name unicity

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
@@ -5,6 +5,7 @@ using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.Environment.Navigation;
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Contents
 {
@@ -43,14 +44,15 @@ namespace OrchardCore.Contents
                 );
 
             var contentTypes = contentTypeDefinitions.Where(ctd => ctd.Settings.ToObject<ContentTypeSettings>().Creatable).OrderBy(ctd => ctd.DisplayName);
-            if (contentTypes.Any()) {
-                builder.Add(T["New"], "-1", newMenu =>
+            if (contentTypes.Any())
+            {
+                builder.Add(T["New"], "-1", async newMenu =>
                 {
                     newMenu.LinkToFirstChild(false).AddClass("new").Id("new");
                     foreach (var contentTypeDefinition in contentTypes)
                     {
-                        var ci = _contentManager.New(contentTypeDefinition.Name);
-                        var cim = _contentManager.PopulateAspect<ContentItemMetadata>(ci);
+                        var ci = await _contentManager.NewAsync(contentTypeDefinition.Name);
+                        var cim = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(ci);
                         var createRouteValues = cim.CreateRouteValues;
                         if (createRouteValues.Any())
                             newMenu.Add(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName), "5", item => item

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
@@ -1,9 +1,7 @@
-﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Xml.Linq;
-using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Routing;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Models;
 using OrchardCore.Feeds;
@@ -20,13 +18,13 @@ namespace OrchardCore.Contents.Feeds.Builders
             _contentManager = contentManager;
         }
 
-        public void Populate(FeedContext context)
+        public async Task PopulateAsync(FeedContext context)
         {
             foreach (var feedItem in context.Response.Items.OfType<FeedItem<ContentItem>>())
             {
                 var contentItem = feedItem.Item;
-                var contentItemMetadata = _contentManager.PopulateAspect<ContentItemMetadata>(contentItem);
-                var bodyAspect = _contentManager.PopulateAspect<BodyAspect>(contentItem);
+                var contentItemMetadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
+                var bodyAspect = await _contentManager.PopulateAspectAsync<BodyAspect>(contentItem);
                 var routes = contentItemMetadata.DisplayRouteValues;
 
                 // author is intentionally left empty as it could result in unwanted spam
@@ -65,7 +63,7 @@ namespace OrchardCore.Contents.Feeds.Builders
                 }
                 else
                 {
-                    context.Response.Contextualize(contextualize => 
+                    context.Response.Contextualize(contextualize =>
                     {
                         var request = contextualize.Url.ActionContext.HttpContext.Request;
                         var url = contextualize.Url.Action(routes["action"].ToString(), routes["controller"].ToString(), routes, request.Scheme);

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Handlers/ContentsHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Handlers/ContentsHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Routing;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Routing;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.Environment.Cache;
@@ -14,22 +15,25 @@ namespace OrchardCore.Contents.Handlers
             _tagCache = tagCache;
         }
 
-        public override void Published(PublishContentContext context)
+        public override Task PublishedAsync(PublishContentContext context)
         {
             _tagCache.RemoveTag($"contentitemid:{context.ContentItem.ContentItemId}");
+            return Task.CompletedTask;
         }
 
-        public override void Removed(RemoveContentContext context)
+        public override Task RemovedAsync(RemoveContentContext context)
         {
             _tagCache.RemoveTag($"contentitemid:{context.ContentItem.ContentItemId}");
+            return Task.CompletedTask;
         }
 
-        public override void Unpublished(PublishContentContext context)
+        public override Task UnpublishedAsync(PublishContentContext context)
         {
             _tagCache.RemoveTag($"contentitemid:{context.ContentItem.ContentItemId}");
+            return Task.CompletedTask;
         }
 
-        public override void GetContentItemAspect(ContentItemAspectContext context)
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context)
         {
             context.For<ContentItemMetadata>(metadata =>
             {
@@ -83,6 +87,8 @@ namespace OrchardCore.Contents.Handlers
                     };
                 }
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Indexing/AspectsContentIndexHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Indexing/AspectsContentIndexHandler.cs
@@ -14,9 +14,9 @@ namespace OrchardCore.Contents.Indexing
             _contentManager = contentManager;
         }
 
-        public Task BuildIndexAsync(BuildIndexContext context)
+        public async Task BuildIndexAsync(BuildIndexContext context)
         {
-            var body = _contentManager.PopulateAspect(context.ContentItem, new BodyAspect());
+            var body = await _contentManager.PopulateAspectAsync(context.ContentItem, new BodyAspect());
 
             if (body != null)
             {
@@ -28,7 +28,7 @@ namespace OrchardCore.Contents.Indexing
                     DocumentIndexOptions.Analyze | DocumentIndexOptions.Sanitize));
             }
 
-            var contentItemMetadata = _contentManager.PopulateAspect<ContentItemMetadata>(context.ContentItem);
+            var contentItemMetadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(context.ContentItem);
 
             if (contentItemMetadata?.DisplayText != null)
             {
@@ -46,8 +46,6 @@ namespace OrchardCore.Contents.Indexing
                     DocumentIndex.Types.Text,
                     DocumentIndexOptions.Store));
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Recipes/ContentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Recipes/ContentStep.cs
@@ -31,16 +31,16 @@ namespace OrchardCore.Contents.Recipes
 
             var model = context.Step.ToObject<ContentStepModel>();
 
-            foreach(JObject token in model.Data)
+            foreach (JObject token in model.Data)
             {
                 var contentItem = token.ToObject<ContentItem>();
-                
+
                 var existing = await _contentManager.GetVersionAsync(contentItem.ContentItemVersionId);
                 if (existing == null)
                 {
                     // Initializes the Id as it could be interpreted as an updated object when added back to YesSql
                     contentItem.Id = 0;
-                    _contentManager.Create(contentItem);
+                    await _contentManager.CreateAsync(contentItem);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/TagHelpers/ContentLinkTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/TagHelpers/ContentLinkTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -20,10 +21,10 @@ namespace OrchardCore.Contents.TagHelpers
         private const string ContentLinkDisplay = "display-for";
         private const string ContentLinkEdit = "edit-for";
         private const string ContentLinkRemove = "remove-for";
-		private const string ContentLinkCreate = "create-for";
-		private const string RoutePrefix = "asp-route-";
+        private const string ContentLinkCreate = "create-for";
+        private const string RoutePrefix = "asp-route-";
 
-		private readonly IContentManager _contentManager;
+        private readonly IContentManager _contentManager;
         private readonly IUrlHelperFactory _urlHelperFactory;
         private readonly IContentDefinitionManager _contentDefinitionManager;
 
@@ -71,7 +72,7 @@ namespace OrchardCore.Contents.TagHelpers
         [HtmlAttributeName(ContentLinkCreate)]
         public ContentItem CreateFor { get; set; }
 
-        public override void Process(TagHelperContext tagHelperContext, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext tagHelperContext, TagHelperOutput output)
         {
             ContentItemMetadata metadata = null;
             ContentItem contentItem = null;
@@ -81,79 +82,79 @@ namespace OrchardCore.Contents.TagHelpers
             if (DisplayFor != null)
             {
                 contentItem = DisplayFor;
-                metadata = _contentManager.PopulateAspect<ContentItemMetadata>(DisplayFor);
+                metadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(DisplayFor);
 
                 if (metadata.DisplayRouteValues == null)
                 {
                     return;
                 }
 
-				ApplyRouteValues(tagHelperContext, metadata.DisplayRouteValues);
+                ApplyRouteValues(tagHelperContext, metadata.DisplayRouteValues);
 
-				output.Attributes.SetAttribute("href", urlHelper.Action(metadata.DisplayRouteValues["action"].ToString(), metadata.DisplayRouteValues));
+                output.Attributes.SetAttribute("href", urlHelper.Action(metadata.DisplayRouteValues["action"].ToString(), metadata.DisplayRouteValues));
             }
             else if (EditFor != null)
             {
                 contentItem = EditFor;
-                metadata = _contentManager.PopulateAspect<ContentItemMetadata>(EditFor);
+                metadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(EditFor);
 
                 if (metadata.EditorRouteValues == null)
                 {
                     return;
                 }
 
-				ApplyRouteValues(tagHelperContext, metadata.EditorRouteValues);
+                ApplyRouteValues(tagHelperContext, metadata.EditorRouteValues);
 
-				output.Attributes.SetAttribute("href", urlHelper.Action(metadata.EditorRouteValues["action"].ToString(), metadata.EditorRouteValues));
+                output.Attributes.SetAttribute("href", urlHelper.Action(metadata.EditorRouteValues["action"].ToString(), metadata.EditorRouteValues));
             }
             else if (AdminFor != null)
             {
                 contentItem = AdminFor;
-                metadata = _contentManager.PopulateAspect<ContentItemMetadata>(AdminFor);
+                metadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(AdminFor);
 
                 if (metadata.AdminRouteValues == null)
                 {
                     return;
                 }
 
-				ApplyRouteValues(tagHelperContext, metadata.AdminRouteValues);
+                ApplyRouteValues(tagHelperContext, metadata.AdminRouteValues);
 
-				output.Attributes.SetAttribute("href", urlHelper.Action(metadata.AdminRouteValues["action"].ToString(), metadata.AdminRouteValues));
+                output.Attributes.SetAttribute("href", urlHelper.Action(metadata.AdminRouteValues["action"].ToString(), metadata.AdminRouteValues));
             }
             else if (RemoveFor != null)
             {
                 contentItem = RemoveFor;
-                metadata = _contentManager.PopulateAspect<ContentItemMetadata>(RemoveFor);
+                metadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(RemoveFor);
 
                 if (metadata.RemoveRouteValues == null)
                 {
                     return;
                 }
 
-				ApplyRouteValues(tagHelperContext, metadata.RemoveRouteValues);
+                ApplyRouteValues(tagHelperContext, metadata.RemoveRouteValues);
 
-				output.Attributes.SetAttribute("href", urlHelper.Action(metadata.RemoveRouteValues["action"].ToString(), metadata.RemoveRouteValues));
+                output.Attributes.SetAttribute("href", urlHelper.Action(metadata.RemoveRouteValues["action"].ToString(), metadata.RemoveRouteValues));
             }
             else if (CreateFor != null)
             {
                 contentItem = CreateFor;
-                metadata = _contentManager.PopulateAspect<ContentItemMetadata>(CreateFor);
+                metadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(CreateFor);
 
                 if (metadata.CreateRouteValues == null)
                 {
                     return;
                 }
 
-				ApplyRouteValues(tagHelperContext, metadata.CreateRouteValues);
+                ApplyRouteValues(tagHelperContext, metadata.CreateRouteValues);
 
-				output.Attributes.SetAttribute("href", urlHelper.Action(metadata.CreateRouteValues["action"].ToString(), metadata.CreateRouteValues));
+                output.Attributes.SetAttribute("href", urlHelper.Action(metadata.CreateRouteValues["action"].ToString(), metadata.CreateRouteValues));
             }
 
             // A self closing anchor tag will be rendered using the display text
             if (output.TagMode == TagMode.SelfClosing && metadata != null)
             {
                 output.TagMode = TagMode.StartTagAndEndTag;
-                if(!string.IsNullOrEmpty(metadata.DisplayText))
+                if (!string.IsNullOrEmpty(metadata.DisplayText))
                 {
                     output.Content.Append(metadata.DisplayText);
                 }
@@ -167,15 +168,15 @@ namespace OrchardCore.Contents.TagHelpers
             return;
         }
 
-		private void ApplyRouteValues(TagHelperContext tagHelperContext, RouteValueDictionary route)
-		{
-			foreach (var attribute in tagHelperContext.AllAttributes)
-			{
-				if (attribute.Name.StartsWith(RoutePrefix, System.StringComparison.OrdinalIgnoreCase))
-				{
-					route.Add(attribute.Name.Substring(RoutePrefix.Length), attribute.Value);
-				}
-			}
-		}
+        private void ApplyRouteValues(TagHelperContext tagHelperContext, RouteValueDictionary route)
+        {
+            foreach (var attribute in tagHelperContext.AllAttributes)
+            {
+                if (attribute.Name.StartsWith(RoutePrefix, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    route.Add(attribute.Name.Substring(RoutePrefix.Length), attribute.Value);
+                }
+            }
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/BodyAspect.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/BodyAspect.cshtml
@@ -1,11 +1,11 @@
-﻿@using OrchardCore.ContentManagement
+@using OrchardCore.ContentManagement
 @using OrchardCore.ContentManagement.Models
 
 @inject IContentManager ContentManager
 
 @{
     ContentItem contentItem = Model.ContentItem;
-    var bodyAspect = ContentManager.PopulateAspect<BodyAspect>(contentItem);
+    var bodyAspect = await ContentManager.PopulateAspectAsync<BodyAspect>(contentItem);
 }
 
 @Html.Raw(bodyAspect.Body)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.DetailAdmin.cshtml
@@ -12,7 +12,7 @@
     var tag = Tag(Model, "article");
 }
 
-<h1>@RenderTitleSegments(ContentManager.PopulateAspect<ContentItemMetadata>(contentItem).DisplayText)</h1>
+<h1>@RenderTitleSegments((await ContentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem)).DisplayText)</h1>
 
 <article>
     <header>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsMetadata.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsMetadata.cshtml
@@ -1,8 +1,8 @@
 @using OrchardCore.ContentManagement
 @inject IContentManager ContentManager
 
-@{ 
+@{
     ContentItem contentItem = Model.ContentItem;
-    var displayText = ContentManager.PopulateAspect<ContentItemMetadata>(contentItem).DisplayText;
+    var displayText = (await ContentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem)).DisplayText;
     Title.AddSegment(Html.Raw(Html.Encode(displayText)));
 }

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/Drivers/CustomSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/Drivers/CustomSettingsDisplayDriver.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.Layers.Drivers
         private readonly Lazy<IList<ContentTypeDefinition>> _contentTypeDefinitions;
 
         public CustomSettingsDisplayDriver(
-            CustomSettingsService customSettingsService, 
+            CustomSettingsService customSettingsService,
             IContentManager contentManager,
             IContentItemDisplayManager contentItemDisplayManager)
         {
@@ -37,7 +37,7 @@ namespace OrchardCore.Layers.Drivers
             _contentTypeDefinitions = new Lazy<IList<ContentTypeDefinition>>(() => _customSettingsService.GetSettingsTypes());
         }
 
-        public override Task<IDisplayResult> EditAsync(ISite site, BuildEditorContext context)
+        public override async Task<IDisplayResult> EditAsync(ISite site, BuildEditorContext context)
         {
             JToken property;
 
@@ -45,7 +45,7 @@ namespace OrchardCore.Layers.Drivers
 
             if (contentTypeDefinition == null)
             {
-                return Task.FromResult<IDisplayResult>(null);
+                return null;
             }
 
             ContentItem contentItem;
@@ -53,7 +53,7 @@ namespace OrchardCore.Layers.Drivers
 
             if (!site.Properties.TryGetValue(contentTypeDefinition.Name, out property))
             {
-                contentItem = _contentManager.New(contentTypeDefinition.Name);
+                contentItem = await _contentManager.NewAsync(contentTypeDefinition.Name);
                 isNew = true;
             }
             else
@@ -68,7 +68,7 @@ namespace OrchardCore.Layers.Drivers
                 ctx.Editor = await _contentItemDisplayManager.BuildEditorAsync(contentItem, context.Updater, isNew);
             }).Location("Content:3").OnGroup(contentTypeDefinition.Name);
 
-            return Task.FromResult<IDisplayResult>(shape);
+            return shape;
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ISite site, UpdateEditorContext context)
@@ -87,7 +87,7 @@ namespace OrchardCore.Layers.Drivers
 
             if (!site.Properties.TryGetValue(contentTypeDefinition.Name, out property))
             {
-                contentItem = _contentManager.New(contentTypeDefinition.Name);
+                contentItem = await _contentManager.NewAsync(contentTypeDefinition.Name);
                 isNew = true;
             }
             else

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentApiController.cs
@@ -61,7 +61,7 @@ namespace OrchardCore.Demo.Controllers
                 return Unauthorized();
             }
 
-            _contentManager.Create(contentItem);
+            await _contentManager.CreateAsync(contentItem);
 
             return new ObjectResult(contentItem);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/HomeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/HomeController.cs
@@ -52,9 +52,9 @@ namespace OrchardCore.Demo.Controllers
         }
 
         [HttpPost]
-        public ActionResult Index(string text)
+        public async Task<IActionResult> Index(string text)
         {
-            var contentItem = _contentManager.New("Foo");
+            var contentItem = await _contentManager.NewAsync("Foo");
 
             // Dynamic syntax
             contentItem.Content.TestContentPartA.Line = text + "blah";
@@ -67,7 +67,7 @@ namespace OrchardCore.Demo.Controllers
             // "Alter" syntax
             contentItem.Alter<TestContentPartA>(x => x.Line = text);
 
-            _contentManager.Create(contentItem);
+            await _contentManager.CreateAsync(contentItem);
 
             _logger.LogInformation("This is some log");
 
@@ -147,7 +147,7 @@ namespace OrchardCore.Demo.Controllers
 
             return "Check for logs";
         }
-        
+
         public IActionResult ShapePerformance()
         {
             return View();

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Views/Content/Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Views/Content/Display.cshtml
@@ -4,7 +4,7 @@
 
 @{
     ContentItem contentItem = Model.ContentItem;
-    var displayText = ContentManager.PopulateAspect<ContentItemMetadata>(contentItem).DisplayText;
+    var displayText = (await ContentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem)).DisplayText;
 }
 
 <h1>@RenderTitleSegments(displayText)</h1>

--- a/src/OrchardCore.Modules/OrchardCore.Feeds/Controllers/FeedController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Feeds/Controllers/FeedController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -59,25 +59,25 @@ namespace OrchardCore.Feeds.Controllers
             {
                 return NotFound();
             }
-            
-            var document = await context.Builder.ProcessAsync (context, async () =>
-            {
-                await bestQueryMatch.FeedQuery.ExecuteAsync(context);
 
-                _feedItemBuilder.Populate(context);
+            var document = await context.Builder.ProcessAsync(context, async () =>
+           {
+               await bestQueryMatch.FeedQuery.ExecuteAsync(context);
 
-                foreach (var contextualizer in context.Response.Contextualizers)
-                {
-                    if (ControllerContext != null)
-                    {
-                        contextualizer(new ContextualizeContext
-                        {
-                            ServiceProvider = _serviceProvider,
-                            Url = Url 
-                        });
-                    }
-                }
-            });
+               await _feedItemBuilder.PopulateAsync(context);
+
+               foreach (var contextualizer in context.Response.Contextualizers)
+               {
+                   if (ControllerContext != null)
+                   {
+                       contextualizer(new ContextualizeContext
+                       {
+                           ServiceProvider = _serviceProvider,
+                           Url = Url
+                       });
+                   }
+               }
+           });
 
             return Content(document.ToString(), "text/xml");
         }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.Flows.Controllers
         public IHtmlLocalizer T { get; }
 
         public ILogger Logger { get; set; }
-        
+
         public async Task<IActionResult> BuildEditor(string id, string prefix, string prefixesName, string contentTypesName, string targetId, bool flowmetadata)
         {
             if (String.IsNullOrWhiteSpace(id))
@@ -41,7 +41,7 @@ namespace OrchardCore.Flows.Controllers
                 return NotFound();
             }
 
-            var contentItem = _contentManager.New(id);
+            var contentItem = await _contentManager.NewAsync(id);
 
             // Does this editor need the flow metadata editor?
             if (flowmetadata)

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
@@ -56,7 +56,6 @@ namespace OrchardCore.Flows.Drivers
         public override async Task<IDisplayResult> UpdateAsync(BagPart part, BuildPartEditorContext context)
         {
             var contentItemDisplayManager = _serviceProvider.GetRequiredService<IContentItemDisplayManager>();
-
             var model = new BagPartEditViewModel { BagPart = part };
 
             await context.Updater.TryUpdateModelAsync(model, Prefix);
@@ -65,8 +64,7 @@ namespace OrchardCore.Flows.Drivers
 
             for (var i = 0; i < model.Prefixes.Length; i++)
             {
-                var contentItem = _contentManager.New(model.ContentTypes[i]);
-
+                var contentItem = await _contentManager.NewAsync(model.ContentTypes[i]);
                 var widgetModel = await contentItemDisplayManager.UpdateEditorAsync(contentItem, context.Updater, context.IsNew, htmlFieldPrefix: model.Prefixes[i]);
 
                 part.ContentItems.Add(contentItem);
@@ -79,6 +77,6 @@ namespace OrchardCore.Flows.Drivers
         {
             var settings = typePartDefinition.Settings.ToObject<BagPartSettings>();
             return settings.ContainedContentTypes.Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType));
-        }        
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplay.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.Flows.Drivers
 
             for (var i = 0; i < model.Prefixes.Length; i++)
             {
-                var contentItem = _contentManager.New(model.ContentTypes[i]);
+                var contentItem = await _contentManager.NewAsync(model.ContentTypes[i]);
 
                 contentItem.Weld(new FlowMetadata());
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Edit.cshtml
@@ -29,7 +29,7 @@
 
                     widgetEditor.Metadata.Alternates.Add("Widget_Edit__Bag");
                 }
-                    
+
                 @await DisplayAsync(widgetEditor)
 
                 @{ this.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = htmlFieldPrefix; }
@@ -46,11 +46,11 @@
         <div class="dropdown-menu">
             @foreach (var type in Model.ContainedContentTypeDefinitions)
             {
-                <a class="dropdown-item add-widget  btn-sm" 
-                   data-target-id="@widgetTemplatePlaceholderId" 
+                <a class="dropdown-item add-widget  btn-sm"
+                   data-target-id="@widgetTemplatePlaceholderId"
                    data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
                    data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
-                   data-widget-type="@type.Name" 
+                   data-widget-type="@type.Name"
                    data-flowmetadata="false"
                    href="javascript:;">@type.DisplayName</a>
             }
@@ -76,7 +76,7 @@
             Context.Items["BagPart.Edit:" + type.Name] = new object();
 
             // Render a mock widget so that its resources are included in the page
-            var contentItem = ContentManager.New(type.Name);
+            var contentItem = await ContentManager.NewAsync(type.Name);
             await DisplayAsync(await ContentItemDisplayManager.BuildEditorAsync(contentItem, Model.Updater, true, "", Guid.NewGuid().ToString("n")));
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -30,7 +30,7 @@
 
                     widgetEditor.Metadata.Alternates.Add("Widget_Edit__Flow");
                 }
-                    
+
                 @await DisplayAsync(widgetEditor)
 
                 @{ this.ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix = htmlFieldPrefix; }
@@ -47,11 +47,11 @@
         <div class="dropdown-menu">
             @foreach (var type in widgetContentTypes)
             {
-                <a class="dropdown-item add-widget  btn-sm" 
-                   data-target-id="@widgetTemplatePlaceholderId" 
+                <a class="dropdown-item add-widget  btn-sm"
+                   data-target-id="@widgetTemplatePlaceholderId"
                    data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
                    data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
-                   data-widget-type="@type.Name" 
+                   data-widget-type="@type.Name"
                    data-flowmetadata="true"
                    href="javascript:;">@type.DisplayName</a>
             }
@@ -67,7 +67,7 @@
         @foreach (var type in widgetContentTypes)
         {
             // Render a mock widget so that its resources are included in the page
-            var contentItem = ContentManager.New(type.Name);
+            var contentItem = await ContentManager.NewAsync(type.Name);
             await DisplayAsync(await ContentItemDisplayManager.BuildEditorAsync(contentItem, Model.Updater, true, "", Guid.NewGuid().ToString("n")));
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/Widget-Bag.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/Widget-Bag.Edit.cshtml
@@ -10,7 +10,7 @@
     <div class="widget-editor-header card-header text-muted">
         <button type="button" class="btn btn-outline-secondary btn-sm widget-editor-btn-toggle widget-editor-btn-collapse"><i class="fa fa-minus" aria-hidden="true"></i></button>
         <button type="button" class="btn btn-outline-secondary btn-sm widget-editor-btn-toggle widget-editor-btn-expand"><i class="fa fa-plus" aria-hidden="true"></i></button>
-        @T["{0} — <span class=\"hint\">{1}</span>", ContentManager.PopulateAspect<ContentItemMetadata>(contentItem).DisplayText, contentType]
+        @T["{0} — <span class=\"hint\">{1}</span>", (await ContentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem)).DisplayText, contentType]
         <div class="btn-group btn-group-sm float-right" role="group">
             @* We don't render an Insert button as the container type is not known here *@
             <button type="button" class="btn btn-secondary widget-delete" itemprop="RemoveUrl"><i class="fa fa-trash" aria-hidden="true"></i></button>

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/HomePageRoute.cs
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/HomePageRoute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -28,7 +28,7 @@ namespace OrchardCore.HomeRoute
                 {
                     context.RouteData.Values[entry.Key] = entry.Value;
                 }
-            }         
+            }
 
             await base.OnRouteMatched(context);
         }
@@ -64,7 +64,7 @@ namespace OrchardCore.HomeRoute
             }
 
             // Remove the values that should not be rendered in the query string
-            foreach(var key in tokens.Keys)
+            foreach (var key in tokens.Keys)
             {
                 context.Values.Remove(key);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/CreateIndexingTaskContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/CreateIndexingTaskContentHandler.cs
@@ -1,4 +1,5 @@
-﻿using OrchardCore.ContentManagement.Handlers;
+using System.Threading.Tasks;
+using OrchardCore.ContentManagement.Handlers;
 
 namespace OrchardCore.Indexing
 {
@@ -11,14 +12,14 @@ namespace OrchardCore.Indexing
             _indexingTaskManager = indexingTaskManager;
         }
 
-        public override void Published(PublishContentContext context)
+        public override Task PublishedAsync(PublishContentContext context)
         {
-            _indexingTaskManager.CreateTaskAsync(context.ContentItem, IndexingTaskTypes.Update).Wait();
+            return _indexingTaskManager.CreateTaskAsync(context.ContentItem, IndexingTaskTypes.Update);
         }
 
-        public override void Removed(RemoveContentContext context)
+        public override Task RemovedAsync(RemoveContentContext context)
         {
-            _indexingTaskManager.CreateTaskAsync(context.ContentItem, IndexingTaskTypes.Delete).Wait();
+            return _indexingTaskManager.CreateTaskAsync(context.ContentItem, IndexingTaskTypes.Delete);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Handlers/LayerMetadataHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Handlers/LayerMetadataHandler.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.Environment.Cache;
@@ -6,53 +7,58 @@ using OrchardCore.Layers.Models;
 
 namespace OrchardCore.Layers.Handlers
 {
-	public class LayerMetadataHandler : ContentHandlerBase
+    public class LayerMetadataHandler : ContentHandlerBase
     {
-		public const string LayerChangeToken = "OrchardCore.Layers:LayerMetadata";
+        public const string LayerChangeToken = "OrchardCore.Layers:LayerMetadata";
 
-		private readonly ISignal _signal;
+        private readonly ISignal _signal;
 
-		public LayerMetadataHandler(ISignal signal)
-		{
-			_signal = signal;
-		}
+        public LayerMetadataHandler(ISignal signal)
+        {
+            _signal = signal;
+        }
 
-		public override void Published(PublishContentContext context)
-		{
-			SignalLayerChanged(context.ContentItem);
-		}
+        public override Task PublishedAsync(PublishContentContext context)
+        {
+            SignalLayerChanged(context.ContentItem);
+            return Task.CompletedTask;
+        }
 
-		public override void Removed(RemoveContentContext context)
-		{
-			SignalLayerChanged(context.ContentItem);
-		}
+        public override Task RemovedAsync(RemoveContentContext context)
+        {
+            SignalLayerChanged(context.ContentItem);
+            return Task.CompletedTask;
+        }
 
-		public override void Unpublished(PublishContentContext context)
-		{
-			SignalLayerChanged(context.ContentItem);
-		}
+        public override Task UnpublishedAsync(PublishContentContext context)
+        {
+            SignalLayerChanged(context.ContentItem);
+            return Task.CompletedTask;
+        }
 
-		private void SignalLayerChanged(ContentItem contentItem)
-		{
-			var layerMetadata = contentItem.As<LayerMetadata>();
+        private void SignalLayerChanged(ContentItem contentItem)
+        {
+            var layerMetadata = contentItem.As<LayerMetadata>();
 
-			if (layerMetadata != null)
-			{
-				_signal.SignalToken(LayerChangeToken);
-			}
-		}
+            if (layerMetadata != null)
+            {
+                _signal.SignalToken(LayerChangeToken);
+            }
+        }
 
-		public override void GetContentItemAspect(ContentItemAspectContext context)
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context)
         {
             context.For<ContentItemMetadata>(metadata =>
             {
-				var layerMetadata = context.ContentItem.As<LayerMetadata>();
+                var layerMetadata = context.ContentItem.As<LayerMetadata>();
 
-				if (layerMetadata != null && !String.IsNullOrEmpty(layerMetadata.Title))
-				{
-					metadata.DisplayText = layerMetadata.Title;
-				}
-			});
+                if (layerMetadata != null && !string.IsNullOrEmpty(layerMetadata.Title))
+                {
+                    metadata.DisplayText = layerMetadata.Title;
+                }
+            });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Views/Admin/Index.cshtml
@@ -67,8 +67,8 @@
                             <div class="dropdown-menu">
                                 @foreach (var type in widgetContentTypes)
                                 {
-                                    var contentItem = ContentManager.New(type.Name);
-                                    var createRoute = ContentManager.PopulateAspect<ContentItemMetadata>(contentItem).CreateRouteValues;
+                                    var contentItem = await ContentManager.NewAsync(type.Name);
+                                    var createRoute = (await ContentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem)).CreateRouteValues;
                                     createRoute["returnUrl"] = Context.Request.Path;
                                     createRoute["LayerMetadata.Zone"] = zone;
                                     createRoute["LayerMetadata.Position"] = maxPosition + 1;

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/DisplayTextFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/DisplayTextFilter.cs
@@ -14,18 +14,18 @@ namespace OrchardCore.Liquid.Filters
             _contentManager = contentManager;
         }
 
-        public Task<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        public async Task<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
         {
             var contentItem = input.ToObjectValue() as ContentItem;
 
             if (contentItem == null)
             {
-                return Task.FromResult<FluidValue>(NilValue.Instance);
+                return NilValue.Instance;
             }
 
-            var contentItemMetadata = _contentManager.PopulateAspect<ContentItemMetadata>(contentItem);
+            var contentItemMetadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
 
-            return Task.FromResult<FluidValue>(new StringValue(contentItemMetadata.DisplayText ?? ""));
+            return new StringValue(contentItemMetadata.DisplayText ?? "");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/DisplayUrlFilter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
@@ -16,23 +16,23 @@ namespace OrchardCore.Liquid.Filters
             _contentManager = contentManager;
         }
 
-        public Task<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        public async Task<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
         {
             var contentItem = input.ToObjectValue() as ContentItem;
 
             if (contentItem == null)
             {
-                return Task.FromResult<FluidValue>(NilValue.Instance);
+                return NilValue.Instance;
             }
 
-            var contentItemMetadata = _contentManager.PopulateAspect<ContentItemMetadata>(contentItem);
+            var contentItemMetadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
 
             if (!ctx.AmbientValues.TryGetValue("UrlHelper", out var urlHelper))
             {
                 throw new ArgumentException("UrlHelper missing while invoking 'display_url'");
             }
 
-            return Task.FromResult<FluidValue>(new StringValue(((IUrlHelper)urlHelper).RouteUrl(contentItemMetadata.DisplayRouteValues)));
+            return new StringValue(((IUrlHelper)urlHelper).RouteUrl(contentItemMetadata.DisplayRouteValues));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Handlers/LiquidPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Handlers/LiquidPartHandler.cs
@@ -1,4 +1,5 @@
-﻿using Fluid;
+using System.Threading.Tasks;
+using Fluid;
 using Microsoft.AspNetCore.Html;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
@@ -16,7 +17,7 @@ namespace OrchardCore.Liquid.Handlers
             _contentDefinitionManager = contentDefinitionManager;
         }
 
-        public override void GetContentItemAspect(ContentItemAspectContext context, LiquidPart part)
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context, LiquidPart part)
         {
             context.For<BodyAspect>(bodyAspect =>
             {
@@ -30,6 +31,8 @@ namespace OrchardCore.Liquid.Handlers
                     bodyAspect.Body = HtmlString.Empty;
                 }
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
@@ -42,12 +42,12 @@ namespace OrchardCore.Lists.Feeds
         {
             var model = new ListFeedQueryViewModel();
 
-            if (!context.Updater.TryUpdateModelAsync(model).GetAwaiter().GetResult() || model.ContentItemId == null)
+            if (!await context.Updater.TryUpdateModelAsync(model) || model.ContentItemId == null)
             {
                 return;
             }
 
-            var contentItem = _contentManager.GetAsync(model.ContentItemId).GetAwaiter().GetResult();
+            var contentItem = await _contentManager.GetAsync(model.ContentItemId);
 
             if (contentItem == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Lists.Feeds
         {
             var model = new ListFeedQueryViewModel();
 
-            if(!context.Updater.TryUpdateModelAsync(model).GetAwaiter().GetResult() || model.ContentItemId == null)
+            if (!context.Updater.TryUpdateModelAsync(model).GetAwaiter().GetResult() || model.ContentItemId == null)
             {
                 return null;
             }
@@ -54,8 +54,8 @@ namespace OrchardCore.Lists.Feeds
                 return;
             }
 
-            var contentItemMetadata = _contentManager.PopulateAspect<ContentItemMetadata>(contentItem);
-            var bodyAspect = _contentManager.PopulateAspect<BodyAspect>(contentItem);
+            var contentItemMetadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
+            var bodyAspect = await _contentManager.PopulateAspectAsync<BodyAspect>(contentItem);
             var routes = contentItemMetadata.DisplayRouteValues;
 
             if (context.Format == "rss")

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListPartFeedHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListPartFeedHandler.cs
@@ -1,4 +1,5 @@
-﻿using OrchardCore.ContentManagement.Handlers;
+using System.Threading.Tasks;
+using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.Feeds.Models;
 using OrchardCore.Lists.Models;
 
@@ -6,13 +7,15 @@ namespace OrchardCore.Lists.Drivers
 {
     public class ListPartFeedHandler : ContentPartHandler<ListPart>
     {
-        public override void GetContentItemAspect(ContentItemAspectContext context, ListPart part)
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context, ListPart part)
         {
             context.For<FeedMetadata>(feedMetadata =>
             {
                 // If the value is not defined, it will be represented as null
                 feedMetadata.FeedProxyUrl = part.Content.FeedProxyUrl;
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Handlers/ListPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Handlers/ListPartHandler.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Routing;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Routing;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.Lists.Models;
@@ -7,7 +8,7 @@ namespace OrchardCore.Lists.Drivers
 {
     public class ListPartHandler : ContentPartHandler<ListPart>
     {
-        public override void GetContentItemAspect(ContentItemAspectContext context, ListPart part)
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context, ListPart part)
         {
             context.For<ContentItemMetadata>(contentItemMetadata =>
             {
@@ -19,6 +20,8 @@ namespace OrchardCore.Lists.Drivers
                     {"ContentItemId", context.ContentItem.ContentItemId}
                 };
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/RemotePublishing/MetaWeblogHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/RemotePublishing/MetaWeblogHandler.cs
@@ -156,23 +156,23 @@ namespace OrchardCore.Lists.RemotePublishing
                 context.RpcMethodResponse = new XRpcMethodResponse().Add(result);
             }
         }
-        
+
         private async Task<XRpcStruct> MetaWeblogNewMediaObjectAsync(string userName, string password, XRpcStruct file)
         {
             var user = await ValidateUserAsync(userName, password);
-            
+
             var name = file.Optional<string>("name");
             var bits = file.Optional<byte[]>("bits");
 
-            string directoryName = Path.GetDirectoryName(name);            
+            string directoryName = Path.GetDirectoryName(name);
             string filePath = _mediaFileStore.Combine(directoryName, Path.GetFileName(name));
             await _mediaFileStore.CreateFileFromStream(filePath, new MemoryStream(bits));
-             
+
             string publicUrl = _mediaFileStore.MapPathToPublicUrl(filePath);
 
             return new XRpcStruct() // Some clients require all optional attributes to be declared Wordpress responds in this way as well.
                 .Set("file", publicUrl)
-                .Set("url", publicUrl) 
+                .Set("url", publicUrl)
                 .Set("type", file.Optional<string>("type"));
         }
 
@@ -195,7 +195,7 @@ namespace OrchardCore.Lists.RemotePublishing
                     // User needs to at least have permission to edit its own blog posts to access the service
                     if (await _authorizationService.AuthorizeAsync(user, Permissions.EditContent, list))
                     {
-                        var metadata = _contentManager.PopulateAspect<ContentItemMetadata>(list);
+                        var metadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(list);
                         var displayRouteValues = metadata.DisplayRouteValues;
 
                         array.Add(new XRpcStruct()
@@ -240,7 +240,7 @@ namespace OrchardCore.Lists.RemotePublishing
 
             foreach (var contentItem in contentItems)
             {
-                var postStruct = CreateBlogStruct(context, contentItem);
+                var postStruct = await CreateBlogStructAsync(context, contentItem);
 
                 foreach (var driver in drivers)
                 {
@@ -274,8 +274,7 @@ namespace OrchardCore.Lists.RemotePublishing
             }
 
             var postType = GetContainedContentTypes(list).FirstOrDefault();
-
-            var contentItem = _contentManager.New(postType.Name);
+            var contentItem = await _contentManager.NewAsync(postType.Name);
 
             contentItem.Owner = userName;
             contentItem.Alter<ContainedPart>(x => x.ListContentItemId = list.ContentItemId);
@@ -285,7 +284,7 @@ namespace OrchardCore.Lists.RemotePublishing
                 driver.EditPost(content, contentItem);
             }
 
-            _contentManager.Create(contentItem, VersionOptions.Draft);
+            await _contentManager.CreateAsync(contentItem, VersionOptions.Draft);
 
             // try to get the UTC timezone by default
             var publishedUtc = content.Optional<DateTime?>("date_created_gmt");
@@ -336,7 +335,7 @@ namespace OrchardCore.Lists.RemotePublishing
 
             await CheckAccessAsync(Permissions.EditContent, user, contentItem);
 
-            var postStruct = CreateBlogStruct(context, contentItem);
+            var postStruct = await CreateBlogStructAsync(context, contentItem);
 
             foreach (var driver in _metaWeblogDrivers)
             {
@@ -452,9 +451,9 @@ namespace OrchardCore.Lists.RemotePublishing
             return await _membershipService.CreateClaimsPrincipal(storeUser);
         }
 
-        private XRpcStruct CreateBlogStruct(XmlRpcContext context, ContentItem contentItem)
+        private async Task<XRpcStruct> CreateBlogStructAsync(XmlRpcContext context, ContentItem contentItem)
         {
-            var metadata = _contentManager.PopulateAspect<ContentItemMetadata>(contentItem);
+            var metadata = await _contentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
 
             var url = context.Url.Action(
                 metadata.DisplayRouteValues["action"].ToString(),

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartFeed.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartFeed.cshtml
@@ -1,14 +1,14 @@
-﻿@using OrchardCore.Feeds.Models
+@using OrchardCore.Feeds.Models
 @using OrchardCore.ResourceManagement
 @using OrchardCore.ContentManagement
 
 @inject IResourceManager ResourceManager
 @inject IContentManager ContentManager
 
-@{ 
+@{
     ContentItem contentItem = Model.ContentItem;
-    var contentItemMetadata = ContentManager.PopulateAspect<ContentItemMetadata>(contentItem);
-    var feedMetadata = ContentManager.PopulateAspect<FeedMetadata>(contentItem);
+    var contentItemMetadata = await ContentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
+    var feedMetadata = await ContentManager.PopulateAspectAsync<FeedMetadata>(contentItem);
     ResourceManager.RegisterLink(new LinkEntry
     {
         Rel = "alternate",

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Handlers/MarkdownPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Handlers/MarkdownPartHandler.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
@@ -17,19 +18,19 @@ namespace OrchardCore.Markdown.Handlers
             _contentDefinitionManager = contentDefinitionManager;
         }
 
-        public override void GetContentItemAspect(ContentItemAspectContext context, MarkdownPart part)
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context, MarkdownPart part)
         {
             context.For<BodyAspect>(bodyAspect =>
             {
-
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
                 var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(p => p.PartDefinition.Name == nameof(MarkdownPart));
                 var settings = contentTypePartDefinition.GetSettings<MarkdownPartSettings>();
-
                 var html = Markdig.Markdown.ToHtml(part.Markdown ?? "");
 
                 bodyAspect.Body = new HtmlString(html);
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
@@ -56,7 +56,7 @@ namespace OrchardCore.Menu.Controllers
                 return Unauthorized();
             }
 
-            var contentItem = _contentManager.New(id);
+            var contentItem = await _contentManager.NewAsync(id);
 
             dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, this, true);
 
@@ -93,7 +93,7 @@ namespace OrchardCore.Menu.Controllers
                 return NotFound();
             }
 
-            var contentItem = _contentManager.New(id);
+            var contentItem = await _contentManager.NewAsync(id);
 
             var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, true);
 
@@ -112,7 +112,7 @@ namespace OrchardCore.Menu.Controllers
                 // Look for the target menu item in the hierarchy
                 var parentMenuItem = FindMenuItem(menu.Content, menuItemId);
 
-                // Couldn't find targetted menu item
+                // Couldn't find targeted menu item
                 if (parentMenuItem == null)
                 {
                     return NotFound();
@@ -275,11 +275,11 @@ namespace OrchardCore.Menu.Controllers
                 return null;
             }
 
-            var menuItems = (JArray) contentItem["MenuItemsListPart"]["MenuItems"];
+            var menuItems = (JArray)contentItem["MenuItemsListPart"]["MenuItems"];
 
             JObject result;
 
-            foreach(JObject menuItem in menuItems)
+            foreach (JObject menuItem in menuItems)
             {
                 // Search in inner menu items
                 result = FindMenuItem(menuItem, menuItemId);

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Handlers/MenuHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Handlers/MenuHandler.cs
@@ -1,11 +1,12 @@
-﻿using OrchardCore.ContentManagement.Handlers;
+using System.Threading.Tasks;
+using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.Menu.Models;
 
 namespace OrchardCore.Menu.Handlers
 {
     public class MenuContentHandler : ContentHandlerBase
     {
-        public override void Activating(ActivatingContentContext context)
+        public override Task ActivatingAsync(ActivatingContentContext context)
         {
             // When a Menu is created, we add a MenuPart to it
             if (context.ContentType == "Menu")
@@ -13,6 +14,8 @@ namespace OrchardCore.Menu.Handlers
                 context.Builder.Weld(nameof(MenuPart), new MenuPart());
                 context.Builder.Weld(nameof(MenuItemsListPart), new MenuItemsListPart());
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
@@ -52,7 +52,7 @@ namespace OrchardCore.Menu
                         return;
                     }
 
-                    menu.MenuName = contentManager.PopulateAspect<ContentItemMetadata>(menuContentItem).DisplayText;
+                    menu.MenuName = (await contentManager.PopulateAspectAsync<ContentItemMetadata>(menuContentItem)).DisplayText;
 
                     var menuItems = menuContentItem.As<MenuItemsListPart>()?.MenuItems;
 
@@ -64,7 +64,7 @@ namespace OrchardCore.Menu
                     // The first level of menu item shapes is created.
                     // Each other level is created when the menu item is displayed.
 
-                    foreach(var contentItem in menuItems)
+                    foreach (var contentItem in menuItems)
                     {
                         dynamic shape = await shapeFactory.CreateAsync("MenuItem", Arguments.From(new
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuPart.Edit.cshtml
@@ -3,7 +3,6 @@
 @inject OrchardCore.ContentManagement.Display.IContentItemDisplayManager ContentItemDisplayManager
 @inject OrchardCore.DisplayManagement.ModelBinding.IUpdateModelAccessor ModelUpdaterAccessor
 @inject OrchardCore.ContentManagement.Metadata.IContentDefinitionManager ContentDefinitionManager
-
 @*
     This template is used to render the editor for a Menu content item.
     It render the hierarchy of the menu items.
@@ -54,7 +53,7 @@
                 <div class="row">
                     @foreach (var type in menuItemContentTypes)
                     {
-                        var menuItem = ContentManager.New(type.Name);
+                        var menuItem = await ContentManager.NewAsync(type.Name);
                         dynamic thumbnail = await ContentItemDisplayManager.BuildDisplayAsync(menuItem, updater, "Thumbnail");
                         thumbnail.MenuItemType = type.Name;
                         thumbnail.MenuContentItemId = Model.MenuPart.ContentItem.ContentItemId;
@@ -72,7 +71,7 @@
 </div>
 
 <input asp-for="Hierarchy" type="hidden" value="" />
-<div id="msg-leave"style="display:none" data>@T["You have reordered the navigation."]</div>
+<div id="msg-leave" style="display:none" data>@T["You have reordered the navigation."]</div>
 
 <script at="Foot">
     var menuItemId;

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/NavigationShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/NavigationShapes.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -24,9 +23,9 @@ namespace OrchardCore.Navigation
                     menu.Classes.Add("menu");
                     menu.Metadata.Alternates.Add("Navigation__" + EncodeAlternateElement(menuName));
                 })
-                .OnProcessing(context =>
+                .OnProcessing(async context =>
                 {
-                    dynamic menu = context.Shape;
+                    var menu = context.Shape;
                     string menuName = menu.MenuName;
 
                     // Menu population is executed when processing the shape so that its value
@@ -35,21 +34,19 @@ namespace OrchardCore.Navigation
 
                     if ((bool)menu.HasItems)
                     {
-                        return Task.CompletedTask;
+                        return;
                     }
 
                     var navigationManager = context.ServiceProvider.GetRequiredService<INavigationManager>();
                     var shapeFactory = context.ServiceProvider.GetRequiredService<IShapeFactory>();
                     var httpContextAccessor = context.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
-
-                    IEnumerable<MenuItem> menuItems = navigationManager.BuildMenu(menuName, context.DisplayContext.ViewContext);
-
+                    var menuItems = navigationManager.BuildMenu(menuName, context.DisplayContext.ViewContext);
                     var httpContext = httpContextAccessor.HttpContext;
 
                     if (httpContext != null)
                     {
                         // adding query string parameters
-                        RouteData route = menu.RouteData;
+                        var route = menu.RouteData;
                         var routeData = new RouteValueDictionary(route.Values);
                         var query = httpContext.Request.Query;
 
@@ -66,7 +63,7 @@ namespace OrchardCore.Navigation
                     }
 
                     // TODO: Flag Selected menu item
-                    return NavigationHelper.PopulateMenuAsync(shapeFactory, menu, menu, menuItems, context.DisplayContext.ViewContext);
+                    await NavigationHelper.PopulateMenuAsync(shapeFactory, menu, menu, menuItems, context.DisplayContext.ViewContext);
                 });
 
             builder.Describe("NavigationItem")
@@ -74,7 +71,7 @@ namespace OrchardCore.Navigation
                 {
                     var menuItem = displaying.Shape;
                     var menu = menuItem.Menu;
-                    var menuName = menu.MenuName;
+                    string menuName = menu.MenuName;
                     int level = menuItem.Level;
 
                     menuItem.Metadata.Alternates.Add("NavigationItem__level__" + level);

--- a/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
@@ -1,4 +1,5 @@
-﻿using OrchardCore.ContentManagement;
+using System.Threading.Tasks;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.Title.Model;
 
@@ -6,12 +7,14 @@ namespace OrchardCore.Title.Handlers
 {
     public class TitlePartHandler : ContentPartHandler<TitlePart>
     {
-        public override void GetContentItemAspect(ContentItemAspectContext context, TitlePart part)
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context, TitlePart part)
         {
             context.For<ContentItemMetadata>(contentItemMetadata =>
             {
                 contentItemMetadata.DisplayText = part.Title;
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Controllers/AdminController.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.Widgets.Controllers
         public dynamic New { get; set; }
 
         public ILogger Logger { get; set; }
-        
+
         public async Task<IActionResult> BuildEditor(string id, string prefix, string prefixesName, string contentTypesName, string zonesName, string zone, string targetId)
         {
             if (String.IsNullOrWhiteSpace(id))
@@ -42,7 +42,7 @@ namespace OrchardCore.Widgets.Controllers
                 return NotFound();
             }
 
-            var contentItem = _contentManager.New(id);
+            var contentItem = await _contentManager.NewAsync(id);
 
             contentItem.Weld(new WidgetMetadata());
 

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Drivers/WidgetsListPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Drivers/WidgetsListPartDisplay.cs
@@ -105,7 +105,7 @@ namespace OrchardCore.Widgets.Drivers
                 var zone = model.Zones[i];
                 var prefix = model.Prefixes[i];
 
-                var contentItem = _contentManager.New(contentType);
+                var contentItem = await _contentManager.NewAsync(contentType);
 
                 contentItem.Weld(new WidgetMetadata());
 

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/WidgetsListPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/WidgetsListPart.Edit.cshtml
@@ -50,8 +50,8 @@
                                 <input type="hidden" asp-for="Prefixes" value="@prefix" />
                                 <input type="hidden" asp-for="ContentTypes" value="@widget.ContentType" />
                             </div>
-                                        }
-                                    }
+                        }
+                    }
                 </div>
 
                 <div class="btn-group ">
@@ -74,7 +74,7 @@
                 </div>
             </div>
         </div>
-                                    }
+    }
 
     @if (Context.Items["WidgetsListPart.Edit"] == null)
     {
@@ -84,10 +84,10 @@
         @foreach (var type in widgetContentTypes)
         {
             // Render a mock widget so that its resources are included in the page
-            var contentItem = ContentManager.New(type.Name);
+            var contentItem = await ContentManager.NewAsync(type.Name);
             await DisplayAsync(await ContentItemDisplayManager.BuildEditorAsync(contentItem, Model.Updater, true, "", Guid.NewGuid().ToString("n")));
         }
-        
+
         <script asp-src="/OrchardCore.Widgets/Scripts/widgetslist.edit.js" at="Foot" depends-on="admin"></script>
         <style asp-src="/OrchardCore.Widgets/Styles/widgetslist.edit.css"></style>
     }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentHandlerBase.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentHandlerBase.cs
@@ -4,129 +4,93 @@ namespace OrchardCore.ContentManagement.Handlers
 {
     public abstract class ContentHandlerBase : IContentHandler
     {
-        public virtual void Activating(ActivatingContentContext context) { }
         public virtual Task ActivatingAsync(ActivatingContentContext context)
         {
-            Activating(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Activated(ActivatedContentContext context) { }
         public virtual Task ActivatedAsync(ActivatedContentContext context)
         {
-            Activated(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Initializing(InitializingContentContext context) { }
         public virtual Task InitializingAsync(InitializingContentContext context)
         {
-            Initializing(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Initialized(InitializingContentContext context) { }
         public virtual Task InitializedAsync(InitializingContentContext context)
         {
-            Initialized(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Creating(CreateContentContext context) { }
         public virtual Task CreatingAsync(CreateContentContext context)
         {
-            Creating(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Created(CreateContentContext context) { }
         public virtual Task CreatedAsync(CreateContentContext context)
         {
-            Created(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Loading(LoadContentContext context) { }
         public virtual Task LoadingAsync(LoadContentContext context)
         {
-            Loading(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Loaded(LoadContentContext context) { }
         public virtual Task LoadedAsync(LoadContentContext context)
         {
-            Loaded(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Updating(UpdateContentContext context) { }
         public virtual Task UpdatingAsync(UpdateContentContext context)
         {
-            Updating(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Updated(UpdateContentContext context) { }
         public virtual Task UpdatedAsync(UpdateContentContext context)
         {
-            Updated(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Versioning(VersionContentContext context) { }
         public virtual Task VersioningAsync(VersionContentContext context)
         {
-            Versioning(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Versioned(VersionContentContext context) { }
         public virtual Task VersionedAsync(VersionContentContext context)
         {
-            Versioned(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Publishing(PublishContentContext context) { }
         public virtual Task PublishingAsync(PublishContentContext context)
         {
-            Publishing(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Published(PublishContentContext context) { }
         public virtual Task PublishedAsync(PublishContentContext context)
         {
-            Published(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Unpublishing(PublishContentContext context) { }
         public virtual Task UnpublishingAsync(PublishContentContext context)
         {
-            Unpublishing(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Unpublished(PublishContentContext context) { }
         public virtual Task UnpublishedAsync(PublishContentContext context)
         {
-            Unpublished(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Removing(RemoveContentContext context) { }
         public virtual Task RemovingAsync(RemoveContentContext context)
         {
-            Removing(context);
             return Task.CompletedTask;
         }
 
-        public virtual void Removed(RemoveContentContext context) { }
         public virtual Task RemovedAsync(RemoveContentContext context)
         {
-            Removed(context);
             return Task.CompletedTask;
         }
 
@@ -135,10 +99,8 @@ namespace OrchardCore.ContentManagement.Handlers
         //protected virtual void Cloning(CloneContentContext context) { }
         //protected virtual void Cloned(CloneContentContext context) { }
 
-        public virtual void GetContentItemAspect(ContentItemAspectContext context) { }
         public virtual Task GetContentItemAspectAsync(ContentItemAspectContext context)
         {
-            GetContentItemAspect(context);
             return Task.CompletedTask;
         }
     }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentHandlerBase.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentHandlerBase.cs
@@ -1,30 +1,145 @@
-﻿namespace OrchardCore.ContentManagement.Handlers
+using System.Threading.Tasks;
+
+namespace OrchardCore.ContentManagement.Handlers
 {
     public abstract class ContentHandlerBase : IContentHandler
     {
         public virtual void Activating(ActivatingContentContext context) { }
+        public virtual Task ActivatingAsync(ActivatingContentContext context)
+        {
+            Activating(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Activated(ActivatedContentContext context) { }
+        public virtual Task ActivatedAsync(ActivatedContentContext context)
+        {
+            Activated(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Initializing(InitializingContentContext context) { }
+        public virtual Task InitializingAsync(InitializingContentContext context)
+        {
+            Initializing(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Initialized(InitializingContentContext context) { }
+        public virtual Task InitializedAsync(InitializingContentContext context)
+        {
+            Initialized(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Creating(CreateContentContext context) { }
+        public virtual Task CreatingAsync(CreateContentContext context)
+        {
+            Creating(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Created(CreateContentContext context) { }
+        public virtual Task CreatedAsync(CreateContentContext context)
+        {
+            Created(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Loading(LoadContentContext context) { }
+        public virtual Task LoadingAsync(LoadContentContext context)
+        {
+            Loading(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Loaded(LoadContentContext context) { }
+        public virtual Task LoadedAsync(LoadContentContext context)
+        {
+            Loaded(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Updating(UpdateContentContext context) { }
+        public virtual Task UpdatingAsync(UpdateContentContext context)
+        {
+            Updating(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Updated(UpdateContentContext context) { }
+        public virtual Task UpdatedAsync(UpdateContentContext context)
+        {
+            Updated(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Versioning(VersionContentContext context) { }
+        public virtual Task VersioningAsync(VersionContentContext context)
+        {
+            Versioning(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Versioned(VersionContentContext context) { }
+        public virtual Task VersionedAsync(VersionContentContext context)
+        {
+            Versioned(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Publishing(PublishContentContext context) { }
+        public virtual Task PublishingAsync(PublishContentContext context)
+        {
+            Publishing(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Published(PublishContentContext context) { }
+        public virtual Task PublishedAsync(PublishContentContext context)
+        {
+            Published(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Unpublishing(PublishContentContext context) { }
+        public virtual Task UnpublishingAsync(PublishContentContext context)
+        {
+            Unpublishing(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Unpublished(PublishContentContext context) { }
+        public virtual Task UnpublishedAsync(PublishContentContext context)
+        {
+            Unpublished(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Removing(RemoveContentContext context) { }
+        public virtual Task RemovingAsync(RemoveContentContext context)
+        {
+            Removing(context);
+            return Task.CompletedTask;
+        }
+
         public virtual void Removed(RemoveContentContext context) { }
+        public virtual Task RemovedAsync(RemoveContentContext context)
+        {
+            Removed(context);
+            return Task.CompletedTask;
+        }
+
 
         // TODO: Implement Clone event
         //protected virtual void Cloning(CloneContentContext context) { }
         //protected virtual void Cloned(CloneContentContext context) { }
 
         public virtual void GetContentItemAspect(ContentItemAspectContext context) { }
+        public virtual Task GetContentItemAspectAsync(ContentItemAspectContext context)
+        {
+            GetContentItemAspect(context);
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentPartHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentPartHandler.cs
@@ -1,179 +1,179 @@
-﻿using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.ContentManagement.Handlers
 {
     public abstract class ContentPartHandler<TPart> : IContentPartHandler where TPart : ContentPart, new()
     {
-        void IContentPartHandler.Activated(ActivatedContentContext context, ContentPart part)
+        async Task IContentPartHandler.ActivatedAsync(ActivatedContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Activated(context, (TPart)part);
+                await ActivatedAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Activating(ActivatingContentContext context, ContentPart part)
+        async Task IContentPartHandler.ActivatingAsync(ActivatingContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Activating(context, (TPart)part);
+                await ActivatingAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Initializing(InitializingContentContext context, ContentPart part)
+        async Task IContentPartHandler.InitializingAsync(InitializingContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Initializing(context, (TPart)part);
+                await InitializingAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Initialized(InitializingContentContext context, ContentPart part)
+        async Task IContentPartHandler.InitializedAsync(InitializingContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Initialized(context, (TPart)part);
+                await InitializedAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Creating(CreateContentContext context, ContentPart part)
+        async Task IContentPartHandler.CreatingAsync(CreateContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Creating(context, (TPart)part);
+                await CreatingAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Created(CreateContentContext context, ContentPart part)
+        async Task IContentPartHandler.CreatedAsync(CreateContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Created(context, (TPart)part);
+                await CreatedAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Loading(LoadContentContext context, ContentPart part)
+        async Task IContentPartHandler.LoadingAsync(LoadContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Loading(context, (TPart)part);
+                await LoadingAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Loaded(LoadContentContext context, ContentPart part)
+        async Task IContentPartHandler.LoadedAsync(LoadContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Loaded(context, (TPart)part);
+                await LoadedAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Updating(UpdateContentContext context, ContentPart part)
+        async Task IContentPartHandler.UpdatingAsync(UpdateContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Updating(context, (TPart)part);
+                await UpdatingAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Updated(UpdateContentContext context, ContentPart part)
+        async Task IContentPartHandler.UpdatedAsync(UpdateContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Updated(context, (TPart)part);
+                await UpdatedAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Versioning(VersionContentContext context, ContentPart existing, ContentPart building)
+        async Task IContentPartHandler.VersioningAsync(VersionContentContext context, ContentPart existing, ContentPart building)
         {
             if (existing is TPart && building is TPart)
             {
-                Versioning(context, (TPart)existing, (TPart)building);
+                await VersioningAsync(context, (TPart)existing, (TPart)building);
             }
         }
 
-        void IContentPartHandler.Versioned(VersionContentContext context, ContentPart existing, ContentPart building)
+        async Task IContentPartHandler.VersionedAsync(VersionContentContext context, ContentPart existing, ContentPart building)
         {
             if (existing is TPart && building is TPart)
             {
-                Versioned(context, (TPart)existing, (TPart)building);
+                await VersionedAsync(context, (TPart)existing, (TPart)building);
             }
         }
 
-        void IContentPartHandler.Publishing(PublishContentContext context, ContentPart part)
+        async Task IContentPartHandler.PublishingAsync(PublishContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Publishing(context, (TPart)part);
+                await PublishingAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Published(PublishContentContext context, ContentPart part)
+        async Task IContentPartHandler.PublishedAsync(PublishContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Published(context, (TPart)part);
+                await PublishedAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Unpublishing(PublishContentContext context, ContentPart part)
+        async Task IContentPartHandler.UnpublishingAsync(PublishContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Unpublishing(context, (TPart)part);
+                await UnpublishingAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Unpublished(PublishContentContext context, ContentPart part)
+        async Task IContentPartHandler.UnpublishedAsync(PublishContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Unpublished(context, (TPart)part);
+                await UnpublishedAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Removing(RemoveContentContext context, ContentPart part)
+        async Task IContentPartHandler.RemovingAsync(RemoveContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Removing(context, (TPart)part);
+                await RemovingAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.Removed(RemoveContentContext context, ContentPart part)
+        async Task IContentPartHandler.RemovedAsync(RemoveContentContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                Removed(context, (TPart)part);
+                await RemovedAsync(context, (TPart)part);
             }
         }
 
-        void IContentPartHandler.GetContentItemAspect(ContentItemAspectContext context, ContentPart part)
+        async Task IContentPartHandler.GetContentItemAspectAsync(ContentItemAspectContext context, ContentPart part)
         {
             if (part is TPart)
             {
-                GetContentItemAspect(context, (TPart)part);
+                await GetContentItemAspectAsync(context, (TPart)part);
             }
         }
 
-        public virtual void Activated(ActivatedContentContext context, TPart instance) { }
-        public virtual void Activating(ActivatingContentContext context, TPart instance) { }
-        public virtual void Initializing(InitializingContentContext context, TPart instance) { }
-        public virtual void Initialized(InitializingContentContext context, TPart instance) { }
-        public virtual void Creating(CreateContentContext context, TPart instance) { }
-        public virtual void Created(CreateContentContext context, TPart instance) { }
-        public virtual void Loading(LoadContentContext context, TPart instance) { }
-        public virtual void Loaded(LoadContentContext context, TPart instance) { }
-        public virtual void Updating(UpdateContentContext context, TPart instance) { }
-        public virtual void Updated(UpdateContentContext context, TPart instance) { }
-        public virtual void Versioning(VersionContentContext context, TPart existing, TPart building) { }
-        public virtual void Versioned(VersionContentContext context, TPart existing, TPart building) { }
-        public virtual void Publishing(PublishContentContext context, TPart instance) { }
-        public virtual void Published(PublishContentContext context, TPart instance) { }
-        public virtual void Unpublishing(PublishContentContext context, TPart instance) { }
-        public virtual void Unpublished(PublishContentContext context, TPart instance) { }
-        public virtual void Removing(RemoveContentContext context, TPart instance) { }
-        public virtual void Removed(RemoveContentContext context, TPart instance) { }
-        public virtual void GetContentItemAspect(ContentItemAspectContext context, TPart part) { }
+        public virtual Task ActivatedAsync(ActivatedContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task ActivatingAsync(ActivatingContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task InitializingAsync(InitializingContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task InitializedAsync(InitializingContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task CreatingAsync(CreateContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task CreatedAsync(CreateContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task LoadingAsync(LoadContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task LoadedAsync(LoadContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task UpdatingAsync(UpdateContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task UpdatedAsync(UpdateContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task VersioningAsync(VersionContentContext context, TPart existing, TPart building) => Task.CompletedTask;
+        public virtual Task VersionedAsync(VersionContentContext context, TPart existing, TPart building) => Task.CompletedTask;
+        public virtual Task PublishingAsync(PublishContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task PublishedAsync(PublishContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task UnpublishingAsync(PublishContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task UnpublishedAsync(PublishContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task RemovingAsync(RemoveContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task RemovedAsync(RemoveContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task GetContentItemAspectAsync(ContentItemAspectContext context, TPart part) => Task.CompletedTask;
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentHandler.cs
@@ -1,25 +1,27 @@
-﻿namespace OrchardCore.ContentManagement.Handlers
+using System.Threading.Tasks;
+
+namespace OrchardCore.ContentManagement.Handlers
 {
     public interface IContentHandler
     {
-        void Activating(ActivatingContentContext context);
-        void Activated(ActivatedContentContext context);
-        void Initializing(InitializingContentContext context);
-        void Initialized(InitializingContentContext context);
-        void Creating(CreateContentContext context);
-        void Created(CreateContentContext context);
-        void Loading(LoadContentContext context);
-        void Loaded(LoadContentContext context);
-        void Updating(UpdateContentContext context);
-        void Updated(UpdateContentContext context);
-        void Versioning(VersionContentContext context);
-        void Versioned(VersionContentContext context);
-        void Publishing(PublishContentContext context);
-        void Published(PublishContentContext context);
-        void Unpublishing(PublishContentContext context);
-        void Unpublished(PublishContentContext context);
-        void Removing(RemoveContentContext context);
-        void Removed(RemoveContentContext context);
-        void GetContentItemAspect(ContentItemAspectContext context);
+        Task ActivatingAsync(ActivatingContentContext context);
+        Task ActivatedAsync(ActivatedContentContext context);
+        Task InitializingAsync(InitializingContentContext context);
+        Task InitializedAsync(InitializingContentContext context);
+        Task CreatingAsync(CreateContentContext context);
+        Task CreatedAsync(CreateContentContext context);
+        Task LoadingAsync(LoadContentContext context);
+        Task LoadedAsync(LoadContentContext context);
+        Task UpdatingAsync(UpdateContentContext context);
+        Task UpdatedAsync(UpdateContentContext context);
+        Task VersioningAsync(VersionContentContext context);
+        Task VersionedAsync(VersionContentContext context);
+        Task PublishingAsync(PublishContentContext context);
+        Task PublishedAsync(PublishContentContext context);
+        Task UnpublishingAsync(PublishContentContext context);
+        Task UnpublishedAsync(PublishContentContext context);
+        Task RemovingAsync(RemoveContentContext context);
+        Task RemovedAsync(RemoveContentContext context);
+        Task GetContentItemAspectAsync(ContentItemAspectContext context);
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentPartHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentPartHandler.cs
@@ -1,28 +1,30 @@
-﻿namespace OrchardCore.ContentManagement.Handlers
+using System.Threading.Tasks;
+
+namespace OrchardCore.ContentManagement.Handlers
 {
     /// <summary>
     /// An implementation of this class is called for all the parts of a content item.
     /// </summary>
     public interface IContentPartHandler
     {
-        void Activated(ActivatedContentContext context, ContentPart part);
-        void Activating(ActivatingContentContext context, ContentPart part);
-        void Initializing(InitializingContentContext context, ContentPart part);
-        void Initialized(InitializingContentContext context, ContentPart part);
-        void Creating(CreateContentContext context, ContentPart part);
-        void Created(CreateContentContext context, ContentPart part);
-        void Loading(LoadContentContext context, ContentPart part);
-        void Loaded(LoadContentContext context, ContentPart part);
-        void Updating(UpdateContentContext context, ContentPart part);
-        void Updated(UpdateContentContext context, ContentPart part);
-        void Versioning(VersionContentContext context, ContentPart existing, ContentPart building);
-        void Versioned(VersionContentContext context, ContentPart existing, ContentPart building);
-        void Publishing(PublishContentContext context, ContentPart part);
-        void Published(PublishContentContext context, ContentPart part);
-        void Unpublishing(PublishContentContext context, ContentPart part);
-        void Unpublished(PublishContentContext context, ContentPart part);
-        void Removing(RemoveContentContext context, ContentPart part);
-        void Removed(RemoveContentContext context, ContentPart part);
-        void GetContentItemAspect(ContentItemAspectContext context, ContentPart part);
+        Task ActivatedAsync(ActivatedContentContext context, ContentPart part);
+        Task ActivatingAsync(ActivatingContentContext context, ContentPart part);
+        Task InitializingAsync(InitializingContentContext context, ContentPart part);
+        Task InitializedAsync(InitializingContentContext context, ContentPart part);
+        Task CreatingAsync(CreateContentContext context, ContentPart part);
+        Task CreatedAsync(CreateContentContext context, ContentPart part);
+        Task LoadingAsync(LoadContentContext context, ContentPart part);
+        Task LoadedAsync(LoadContentContext context, ContentPart part);
+        Task UpdatingAsync(UpdateContentContext context, ContentPart part);
+        Task UpdatedAsync(UpdateContentContext context, ContentPart part);
+        Task VersioningAsync(VersionContentContext context, ContentPart existing, ContentPart building);
+        Task VersionedAsync(VersionContentContext context, ContentPart existing, ContentPart building);
+        Task PublishingAsync(PublishContentContext context, ContentPart part);
+        Task PublishedAsync(PublishContentContext context, ContentPart part);
+        Task UnpublishingAsync(PublishContentContext context, ContentPart part);
+        Task UnpublishedAsync(PublishContentContext context, ContentPart part);
+        Task RemovingAsync(RemoveContentContext context, ContentPart part);
+        Task RemovedAsync(RemoveContentContext context, ContentPart part);
+        Task GetContentItemAspectAsync(ContentItemAspectContext context, ContentPart part);
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs
@@ -14,20 +14,20 @@ namespace OrchardCore.ContentManagement
         /// The content item is not yet persisted!
         /// </remarks>
         /// <param name="contentType">The name of the content type</param>
-        ContentItem New(string contentType);
+        Task<ContentItem> NewAsync(string contentType);
 
         /// <summary>
         /// Creates (persists) a new content item
         /// </summary>
         /// <param name="contentItem">The content instance filled with all necessary data</param>
-        void Create(ContentItem contentItem);
+        Task CreateAsync(ContentItem contentItem);
 
         /// <summary>
         /// Creates (persists) a new content item with the specified version
         /// </summary>
         /// <param name="contentItem">The content instance filled with all necessary data</param>
         /// <param name="options">The version to create the item with</param>
-        void Create(ContentItem contentItem, VersionOptions options);
+        Task CreateAsync(ContentItem contentItem, VersionOptions options);
 
         /// <summary>
         /// Gets the published content item with the specified id
@@ -63,14 +63,14 @@ namespace OrchardCore.ContentManagement
         Task DiscardDraftAsync(ContentItem contentItem);
         Task PublishAsync(ContentItem contentItem);
         Task UnpublishAsync(ContentItem contentItem);
-        TAspect PopulateAspect<TAspect>(IContent content, TAspect aspect);
+        Task<TAspect> PopulateAspectAsync<TAspect>(IContent content, TAspect aspect);
     }
 
     public static class ContentManagerExtensions
     {
-        public static TAspect PopulateAspect<TAspect>(this IContentManager contentManager, IContent content) where TAspect : new()
+        public static Task<TAspect> PopulateAspectAsync<TAspect>(this IContentManager contentManager, IContent content) where TAspect : new()
         {
-            return contentManager.PopulateAspect(content, new TAspect());
+            return contentManager.PopulateAspectAsync(content, new TAspect());
         }
 
         public static async Task<bool> HasPublishedVersionAsync(this IContentManager contentManager, IContent content)

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.ContentManagement.Display
 
         public async Task<IShape> BuildDisplayAsync(ContentItem contentItem, IUpdateModel updater, string displayType, string groupId)
         {
-            if(contentItem == null)
+            if (contentItem == null)
             {
                 throw new ArgumentNullException(nameof(contentItem));
             }
@@ -169,11 +169,11 @@ namespace OrchardCore.ContentManagement.Display
 
             var updateContentContext = new UpdateContentContext(contentItem, updater);
 
-            _contentHandlers.Invoke(handler => handler.Updating(updateContentContext), Logger);
+            _contentHandlers.Invoke(handler => handler.UpdatingAsync(updateContentContext), Logger);
 
             await _handlers.InvokeAsync(handler => handler.UpdateEditorAsync(contentItem, context), Logger);
 
-            _contentHandlers.Reverse().Invoke(handler => handler.Updated(updateContentContext), Logger);
+            _contentHandlers.Reverse().Invoke(handler => handler.UpdatedAsync(updateContentContext), Logger);
 
             return context.Shape;
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
@@ -21,7 +21,7 @@ namespace OrchardCore.ContentManagement.Display
     /// <summary>
     /// The default implementation of <see cref="IContentItemDisplayManager"/>. It is used to render
     /// <see cref="ContentItem"/> objects by leveraging any <see cref="IContentDisplayHandler"/>
-    /// implementation. The resulting shapes are targetting the stereotype of the content item
+    /// implementation. The resulting shapes are targeting the stereotype of the content item
     /// to display.
     /// </summary>
     public class ContentItemDisplayManager : BaseDisplayManager, IContentItemDisplayManager
@@ -97,7 +97,7 @@ namespace OrchardCore.ContentManagement.Display
 
             await BindPlacementAsync(context);
 
-            await _handlers.InvokeAsync(handler => handler.BuildDisplayAsync(contentItem, context), Logger);
+            await _handlers.InvokeAsync(async handler => await handler.BuildDisplayAsync(contentItem, context), Logger);
 
             return context.Shape;
         }
@@ -133,7 +133,7 @@ namespace OrchardCore.ContentManagement.Display
 
             await BindPlacementAsync(context);
 
-            await _handlers.InvokeAsync(handler => handler.BuildEditorAsync(contentItem, context), Logger);
+            await _handlers.InvokeAsync(async handler => await handler.BuildEditorAsync(contentItem, context), Logger);
 
             return context.Shape;
         }
@@ -169,11 +169,11 @@ namespace OrchardCore.ContentManagement.Display
 
             var updateContentContext = new UpdateContentContext(contentItem, updater);
 
-            _contentHandlers.Invoke(handler => handler.UpdatingAsync(updateContentContext), Logger);
+            _contentHandlers.Invoke(async handler => await handler.UpdatingAsync(updateContentContext), Logger);
 
-            await _handlers.InvokeAsync(handler => handler.UpdateEditorAsync(contentItem, context), Logger);
+            await _handlers.InvokeAsync(async handler => await handler.UpdateEditorAsync(contentItem, context), Logger);
 
-            _contentHandlers.Reverse().Invoke(handler => handler.UpdatedAsync(updateContentContext), Logger);
+            _contentHandlers.Reverse().Invoke(async handler => await handler.UpdatedAsync(updateContentContext), Logger);
 
             return context.Shape;
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
@@ -169,11 +169,9 @@ namespace OrchardCore.ContentManagement.Display
 
             var updateContentContext = new UpdateContentContext(contentItem, updater);
 
-            _contentHandlers.Invoke(async handler => await handler.UpdatingAsync(updateContentContext), Logger);
-
+            await _contentHandlers.InvokeAsync(async handler => await handler.UpdatingAsync(updateContentContext), Logger);
             await _handlers.InvokeAsync(async handler => await handler.UpdateEditorAsync(contentItem, context), Logger);
-
-            _contentHandlers.Reverse().Invoke(async handler => await handler.UpdatedAsync(updateContentContext), Logger);
+            await _contentHandlers.Reverse().InvokeAsync(async handler => await handler.UpdatedAsync(updateContentContext), Logger);
 
             return context.Shape;
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -58,18 +58,18 @@ namespace OrchardCore.ContentManagement
             };
 
             // invoke handlers to weld aspects onto kernel
-            Handlers.Invoke(handler => handler.ActivatingAsync(context), _logger);
+            Handlers.Invoke(async handler => await handler.ActivatingAsync(context), _logger);
 
             var context2 = new ActivatedContentContext(context.Builder.Build());
 
             context2.ContentItem.ContentItemId = _idGenerator.GenerateUniqueId(context2.ContentItem);
 
-            ReversedHandlers.Invoke(handler => handler.ActivatedAsync(context2), _logger);
+            ReversedHandlers.Invoke(async handler => await handler.ActivatedAsync(context2), _logger);
 
             var context3 = new InitializingContentContext(context2.ContentItem);
 
-            Handlers.Invoke(handler => handler.InitializingAsync(context3), _logger);
-            ReversedHandlers.Invoke(handler => handler.InitializedAsync(context3), _logger);
+            Handlers.Invoke(async handler => await handler.InitializingAsync(context3), _logger);
+            ReversedHandlers.Invoke(async handler => await handler.InitializedAsync(context3), _logger);
 
             // composite result is returned
             return context3.ContentItem;
@@ -177,8 +177,8 @@ namespace OrchardCore.ContentManagement
                 var context = new LoadContentContext(contentItem);
 
                 // invoke handlers to acquire state, or at least establish lazy loading callbacks
-                Handlers.Invoke(handler => handler.LoadingAsync(context), _logger);
-                ReversedHandlers.Invoke(handler => handler.LoadedAsync(context), _logger);
+                Handlers.Invoke(async handler => await handler.LoadingAsync(context), _logger);
+                ReversedHandlers.Invoke(async handler => await handler.LoadedAsync(context), _logger);
 
                 loaded = context.ContentItem;
             }
@@ -218,7 +218,7 @@ namespace OrchardCore.ContentManagement
             var context = new PublishContentContext(contentItem, previous);
 
             // invoke handlers to acquire state, or at least establish lazy loading callbacks
-            Handlers.Invoke(handler => handler.PublishingAsync(context), _logger);
+            Handlers.Invoke(async handler => await handler.PublishingAsync(context), _logger);
 
             if (context.Cancel)
             {
@@ -235,7 +235,7 @@ namespace OrchardCore.ContentManagement
 
             _session.Save(contentItem);
 
-            ReversedHandlers.Invoke(handler => handler.PublishedAsync(context), _logger);
+            ReversedHandlers.Invoke(async handler => await handler.PublishedAsync(context), _logger);
         }
 
         public async Task UnpublishAsync(ContentItem contentItem)
@@ -272,13 +272,13 @@ namespace OrchardCore.ContentManagement
                 PublishingItem = null
             };
 
-            Handlers.Invoke(handler => handler.UnpublishingAsync(context), _logger);
+            Handlers.Invoke(async handler => await handler.UnpublishingAsync(context), _logger);
 
             publishedItem.Published = false;
 
             _session.Save(publishedItem);
 
-            ReversedHandlers.Invoke(handler => handler.UnpublishedAsync(context), _logger);
+            ReversedHandlers.Invoke(async handler => await handler.UnpublishedAsync(context), _logger);
         }
 
         protected async Task<ContentItem> BuildNewVersionAsync(ContentItem existingContentItem)
@@ -317,8 +317,8 @@ namespace OrchardCore.ContentManagement
 
             var context = new VersionContentContext(existingContentItem, buildingContentItem);
 
-            Handlers.Invoke(handler => handler.VersioningAsync(context), _logger);
-            ReversedHandlers.Invoke(handler => handler.VersionedAsync(context), _logger);
+            Handlers.Invoke(async handler => await handler.VersioningAsync(context), _logger);
+            ReversedHandlers.Invoke(async handler => await handler.VersionedAsync(context), _logger);
 
             return context.BuildingContentItem;
         }
@@ -347,9 +347,9 @@ namespace OrchardCore.ContentManagement
             var context = new CreateContentContext(contentItem);
 
             // invoke handlers to add information to persistent stores
-            Handlers.Invoke(handler => handler.CreatingAsync(context), _logger);
+            Handlers.Invoke(async handler => await handler.CreatingAsync(context), _logger);
 
-            ReversedHandlers.Invoke(handler => handler.CreatedAsync(context), _logger);
+            ReversedHandlers.Invoke(async handler => await handler.CreatedAsync(context), _logger);
 
             _session.Save(contentItem);
             _contentManagerSession.Store(contentItem);
@@ -359,10 +359,10 @@ namespace OrchardCore.ContentManagement
                 var publishContext = new PublishContentContext(contentItem, null);
 
                 // invoke handlers to acquire state, or at least establish lazy loading callbacks
-                Handlers.Invoke(handler => handler.PublishingAsync(publishContext), _logger);
+                Handlers.Invoke(async handler => await handler.PublishingAsync(publishContext), _logger);
 
                 // invoke handlers to acquire state, or at least establish lazy loading callbacks
-                ReversedHandlers.Invoke(handler => handler.PublishedAsync(publishContext), _logger);
+                ReversedHandlers.Invoke(async handler => await handler.PublishedAsync(publishContext), _logger);
             }
         }
 
@@ -374,7 +374,7 @@ namespace OrchardCore.ContentManagement
                 Aspect = aspect
             };
 
-            Handlers.Invoke(handler => handler.GetContentItemAspectAsync(context), _logger);
+            Handlers.Invoke(async handler => await handler.GetContentItemAspectAsync(context), _logger);
 
             return aspect;
         }
@@ -388,7 +388,7 @@ namespace OrchardCore.ContentManagement
 
             var context = new RemoveContentContext(contentItem);
 
-            Handlers.Invoke(handler => handler.RemovingAsync(context), _logger);
+            Handlers.Invoke(async handler => await handler.RemovingAsync(context), _logger);
 
             foreach (var version in activeVersions)
             {
@@ -397,7 +397,7 @@ namespace OrchardCore.ContentManagement
                 _session.Save(version);
             }
 
-            ReversedHandlers.Invoke(handler => handler.RemovedAsync(context), _logger);
+            ReversedHandlers.Invoke(async handler => await handler.RemovedAsync(context), _logger);
         }
 
         public async Task DiscardDraftAsync(ContentItem contentItem)
@@ -409,12 +409,12 @@ namespace OrchardCore.ContentManagement
 
             var context = new RemoveContentContext(contentItem);
 
-            Handlers.Invoke(handler => handler.RemovingAsync(context), _logger);
+            Handlers.Invoke(async handler => await handler.RemovingAsync(context), _logger);
 
             contentItem.Latest = false;
             _session.Save(contentItem);
 
-            ReversedHandlers.Invoke(handler => handler.RemovedAsync(context), _logger);
+            ReversedHandlers.Invoke(async handler => await handler.RemovedAsync(context), _logger);
 
             var publishedItem = await GetAsync(contentItem.ContentItemId, VersionOptions.Published);
 

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -58,18 +58,18 @@ namespace OrchardCore.ContentManagement
             };
 
             // invoke handlers to weld aspects onto kernel
-            Handlers.Invoke(handler => handler.Activating(context), _logger);
+            Handlers.Invoke(handler => handler.ActivatingAsync(context), _logger);
 
             var context2 = new ActivatedContentContext(context.Builder.Build());
 
             context2.ContentItem.ContentItemId = _idGenerator.GenerateUniqueId(context2.ContentItem);
 
-            ReversedHandlers.Invoke(handler => handler.Activated(context2), _logger);
+            ReversedHandlers.Invoke(handler => handler.ActivatedAsync(context2), _logger);
 
             var context3 = new InitializingContentContext(context2.ContentItem);
 
-            Handlers.Invoke(handler => handler.Initializing(context3), _logger);
-            ReversedHandlers.Invoke(handler => handler.Initialized(context3), _logger);
+            Handlers.Invoke(handler => handler.InitializingAsync(context3), _logger);
+            ReversedHandlers.Invoke(handler => handler.InitializedAsync(context3), _logger);
 
             // composite result is returned
             return context3.ContentItem;
@@ -120,7 +120,7 @@ namespace OrchardCore.ContentManagement
             {
                 // If the published version is requested and is already loaded, we can
                 // return it right away
-                if(_contentManagerSession.RecallPublishedItemId(contentItemId, out contentItem))
+                if (_contentManagerSession.RecallPublishedItemId(contentItemId, out contentItem))
                 {
                     return contentItem;
                 }
@@ -177,8 +177,8 @@ namespace OrchardCore.ContentManagement
                 var context = new LoadContentContext(contentItem);
 
                 // invoke handlers to acquire state, or at least establish lazy loading callbacks
-                Handlers.Invoke(handler => handler.Loading(context), _logger);
-                ReversedHandlers.Invoke(handler => handler.Loaded(context), _logger);
+                Handlers.Invoke(handler => handler.LoadingAsync(context), _logger);
+                ReversedHandlers.Invoke(handler => handler.LoadedAsync(context), _logger);
 
                 loaded = context.ContentItem;
             }
@@ -218,7 +218,7 @@ namespace OrchardCore.ContentManagement
             var context = new PublishContentContext(contentItem, previous);
 
             // invoke handlers to acquire state, or at least establish lazy loading callbacks
-            Handlers.Invoke(handler => handler.Publishing(context), _logger);
+            Handlers.Invoke(handler => handler.PublishingAsync(context), _logger);
 
             if (context.Cancel)
             {
@@ -235,7 +235,7 @@ namespace OrchardCore.ContentManagement
 
             _session.Save(contentItem);
 
-            ReversedHandlers.Invoke(handler => handler.Published(context), _logger);
+            ReversedHandlers.Invoke(handler => handler.PublishedAsync(context), _logger);
         }
 
         public async Task UnpublishAsync(ContentItem contentItem)
@@ -272,13 +272,13 @@ namespace OrchardCore.ContentManagement
                 PublishingItem = null
             };
 
-            Handlers.Invoke(handler => handler.Unpublishing(context), _logger);
+            Handlers.Invoke(handler => handler.UnpublishingAsync(context), _logger);
 
             publishedItem.Published = false;
-            
+
             _session.Save(publishedItem);
 
-            ReversedHandlers.Invoke(handler => handler.Unpublished(context), _logger);
+            ReversedHandlers.Invoke(handler => handler.UnpublishedAsync(context), _logger);
         }
 
         protected async Task<ContentItem> BuildNewVersionAsync(ContentItem existingContentItem)
@@ -317,8 +317,8 @@ namespace OrchardCore.ContentManagement
 
             var context = new VersionContentContext(existingContentItem, buildingContentItem);
 
-            Handlers.Invoke(handler => handler.Versioning(context), _logger);
-            ReversedHandlers.Invoke(handler => handler.Versioned(context), _logger);
+            Handlers.Invoke(handler => handler.VersioningAsync(context), _logger);
+            ReversedHandlers.Invoke(handler => handler.VersionedAsync(context), _logger);
 
             return context.BuildingContentItem;
         }
@@ -347,9 +347,9 @@ namespace OrchardCore.ContentManagement
             var context = new CreateContentContext(contentItem);
 
             // invoke handlers to add information to persistent stores
-            Handlers.Invoke(handler => handler.Creating(context), _logger);
+            Handlers.Invoke(handler => handler.CreatingAsync(context), _logger);
 
-            ReversedHandlers.Invoke(handler => handler.Created(context), _logger);
+            ReversedHandlers.Invoke(handler => handler.CreatedAsync(context), _logger);
 
             _session.Save(contentItem);
             _contentManagerSession.Store(contentItem);
@@ -359,10 +359,10 @@ namespace OrchardCore.ContentManagement
                 var publishContext = new PublishContentContext(contentItem, null);
 
                 // invoke handlers to acquire state, or at least establish lazy loading callbacks
-                Handlers.Invoke(handler => handler.Publishing(publishContext), _logger);
+                Handlers.Invoke(handler => handler.PublishingAsync(publishContext), _logger);
 
                 // invoke handlers to acquire state, or at least establish lazy loading callbacks
-                ReversedHandlers.Invoke(handler => handler.Published(publishContext), _logger);
+                ReversedHandlers.Invoke(handler => handler.PublishedAsync(publishContext), _logger);
             }
         }
 
@@ -374,7 +374,7 @@ namespace OrchardCore.ContentManagement
                 Aspect = aspect
             };
 
-            Handlers.Invoke(handler => handler.GetContentItemAspect(context), _logger);
+            Handlers.Invoke(handler => handler.GetContentItemAspectAsync(context), _logger);
 
             return aspect;
         }
@@ -388,7 +388,7 @@ namespace OrchardCore.ContentManagement
 
             var context = new RemoveContentContext(contentItem);
 
-            Handlers.Invoke(handler => handler.Removing(context), _logger);
+            Handlers.Invoke(handler => handler.RemovingAsync(context), _logger);
 
             foreach (var version in activeVersions)
             {
@@ -397,7 +397,7 @@ namespace OrchardCore.ContentManagement
                 _session.Save(version);
             }
 
-            ReversedHandlers.Invoke(handler => handler.Removed(context), _logger);
+            ReversedHandlers.Invoke(handler => handler.RemovedAsync(context), _logger);
         }
 
         public async Task DiscardDraftAsync(ContentItem contentItem)
@@ -409,12 +409,12 @@ namespace OrchardCore.ContentManagement
 
             var context = new RemoveContentContext(contentItem);
 
-            Handlers.Invoke(handler => handler.Removing(context), _logger);
+            Handlers.Invoke(handler => handler.RemovingAsync(context), _logger);
 
             contentItem.Latest = false;
             _session.Save(contentItem);
 
-            ReversedHandlers.Invoke(handler => handler.Removed(context), _logger);
+            ReversedHandlers.Invoke(handler => handler.RemovedAsync(context), _logger);
 
             var publishedItem = await GetAsync(contentItem.ContentItemId, VersionOptions.Published);
 

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
@@ -34,14 +34,14 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
         public ILogger Logger { get; set; }
 
-        public override Task ActivatingAsync(ActivatingContentContext context)
+        public override async Task ActivatingAsync(ActivatingContentContext context)
         {
             // This method is called on New()
             // Adds all the parts to a content item based on the content type definition.
 
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -50,19 +50,17 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                 // We create the part from it's known type or from a generic one
                 var part = _contentPartFactory.GetTypeActivator(partName).CreateInstance();
 
-                _partHandlers.Invoke(handler => handler.Activating(context, part), Logger);
+                await _partHandlers.InvokeAsync(async handler => await handler.ActivatingAsync(context, part), Logger);
 
                 context.Builder.Weld(typePartDefinition.Name, part);
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task ActivatedAsync(ActivatedContentContext context)
+        public override async Task ActivatedAsync(ActivatedContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -72,18 +70,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Activated(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.ActivatedAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task CreatingAsync(CreateContentContext context)
+        public override async Task CreatingAsync(CreateContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -94,18 +90,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Creating(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.CreatingAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task CreatedAsync(CreateContentContext context)
+        public override async Task CreatedAsync(CreateContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -116,18 +110,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Created(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.CreatedAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task InitializingAsync(InitializingContentContext context)
+        public override async Task InitializingAsync(InitializingContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -135,17 +127,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                 var activator = _contentPartFactory.GetTypeActivator(partName);
 
                 var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-                _partHandlers.Invoke(handler => handler.Initializing(context, part), Logger);
+                await _partHandlers.InvokeAsync(async handler => await handler.InitializingAsync(context, part), Logger);
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task InitializedAsync(InitializingContentContext context)
+        public override async Task InitializedAsync(InitializingContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -156,14 +146,12 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Initialized(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.InitializedAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task LoadingAsync(LoadContentContext context)
+        public override async Task LoadingAsync(LoadContentContext context)
         {
             // This method is called on Get()
             // Adds all the missing parts to a content item based on the content type definition.
@@ -173,7 +161,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
             {
-                return Task.CompletedTask;
+                return;
             }
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
@@ -187,7 +175,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     context.ContentItem.Weld(typePartDefinition.Name, part);
                 }
 
-                _partHandlers.Invoke(handler => handler.Loading(context, part), Logger);
+                await _partHandlers.InvokeAsync(async handler => await handler.LoadingAsync(context, part), Logger);
 
                 foreach (var partFieldDefinition in typePartDefinition.PartDefinition.Fields)
                 {
@@ -200,15 +188,13 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     }
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task LoadedAsync(LoadContentContext context)
+        public override async Task LoadedAsync(LoadContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -219,18 +205,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Loaded(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.LoadedAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task PublishingAsync(PublishContentContext context)
+        public override async Task PublishingAsync(PublishContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -240,18 +224,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Publishing(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.PublishingAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task PublishedAsync(PublishContentContext context)
+        public override async Task PublishedAsync(PublishContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -261,18 +243,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Published(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.PublishedAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task RemovingAsync(RemoveContentContext context)
+        public override async Task RemovingAsync(RemoveContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -282,18 +262,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Removing(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.RemovingAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task RemovedAsync(RemoveContentContext context)
+        public override async Task RemovedAsync(RemoveContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -303,18 +281,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Removed(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.RemovedAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task UnpublishingAsync(PublishContentContext context)
+        public override async Task UnpublishingAsync(PublishContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -324,18 +300,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Unpublishing(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.UnpublishingAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task UnpublishedAsync(PublishContentContext context)
+        public override async Task UnpublishedAsync(PublishContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -345,18 +319,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Unpublished(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.UnpublishedAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task UpdatingAsync(UpdateContentContext context)
+        public override async Task UpdatingAsync(UpdateContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -366,18 +338,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Updating(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.UpdatingAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task UpdatedAsync(UpdateContentContext context)
+        public override async Task UpdatedAsync(UpdateContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -387,18 +357,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Updated(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.UpdatedAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task VersioningAsync(VersionContentContext context)
+        public override async Task VersioningAsync(VersionContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -410,18 +378,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (buildingPart != null && existingPart != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Versioning(context, existingPart, buildingPart), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.VersioningAsync(context, existingPart, buildingPart), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task VersionedAsync(VersionContentContext context)
+        public override async Task VersionedAsync(VersionContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -433,18 +399,16 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (buildingPart != null && existingPart != null)
                 {
-                    _partHandlers.Invoke(handler => handler.Versioned(context, existingPart, buildingPart), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.VersionedAsync(context, existingPart, buildingPart), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
 
-        public override Task GetContentItemAspectAsync(ContentItemAspectContext context)
+        public override async Task GetContentItemAspectAsync(ContentItemAspectContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return Task.CompletedTask;
+                return;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -454,11 +418,9 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 if (part != null)
                 {
-                    _partHandlers.Invoke(handler => handler.GetContentItemAspect(context, part), Logger);
+                    await _partHandlers.InvokeAsync(async handler => await handler.GetContentItemAspectAsync(context, part), Logger);
                 }
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
@@ -3,6 +3,7 @@ using OrchardCore.Modules;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
+using System.Threading.Tasks;
 
 namespace OrchardCore.ContentManagement.Drivers.Coordinators
 {
@@ -33,14 +34,14 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
         public ILogger Logger { get; set; }
 
-        public override void Activating(ActivatingContentContext context)
+        public override Task ActivatingAsync(ActivatingContentContext context)
         {
             // This method is called on New()
             // Adds all the parts to a content item based on the content type definition.
 
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -53,13 +54,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
 
                 context.Builder.Weld(typePartDefinition.Name, part);
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Activated(ActivatedContentContext context)
+        public override Task ActivatedAsync(ActivatedContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -72,13 +75,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Activated(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Creating(CreateContentContext context)
+        public override Task CreatingAsync(CreateContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -92,13 +97,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Creating(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Created(CreateContentContext context)
+        public override Task CreatedAsync(CreateContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -112,13 +119,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Created(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Initializing(InitializingContentContext context)
+        public override Task InitializingAsync(InitializingContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -128,13 +137,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                 var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
                 _partHandlers.Invoke(handler => handler.Initializing(context, part), Logger);
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Initialized(InitializingContentContext context)
+        public override Task InitializedAsync(InitializingContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -148,9 +159,11 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Initialized(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Loading(LoadContentContext context)
+        public override Task LoadingAsync(LoadContentContext context)
         {
             // This method is called on Get()
             // Adds all the missing parts to a content item based on the content type definition.
@@ -160,7 +173,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
@@ -187,13 +200,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     }
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Loaded(LoadContentContext context)
+        public override Task LoadedAsync(LoadContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -207,13 +222,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Loaded(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Publishing(PublishContentContext context)
+        public override Task PublishingAsync(PublishContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -226,13 +243,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Publishing(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Published(PublishContentContext context)
+        public override Task PublishedAsync(PublishContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -245,13 +264,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Published(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Removing(RemoveContentContext context)
+        public override Task RemovingAsync(RemoveContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -264,13 +285,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Removing(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Removed(RemoveContentContext context)
+        public override Task RemovedAsync(RemoveContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -283,13 +306,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Removed(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Unpublishing(PublishContentContext context)
+        public override Task UnpublishingAsync(PublishContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -302,13 +327,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Unpublishing(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Unpublished(PublishContentContext context)
+        public override Task UnpublishedAsync(PublishContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -321,13 +348,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Unpublished(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Updating(UpdateContentContext context)
+        public override Task UpdatingAsync(UpdateContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -340,13 +369,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Updating(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Updated(UpdateContentContext context)
+        public override Task UpdatedAsync(UpdateContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -359,13 +390,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Updated(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Versioning(VersionContentContext context)
+        public override Task VersioningAsync(VersionContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -380,13 +413,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Versioning(context, existingPart, buildingPart), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Versioned(VersionContentContext context)
+        public override Task VersionedAsync(VersionContentContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -401,13 +436,15 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.Versioned(context, existingPart, buildingPart), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
-        
-        public override void GetContentItemAspect(ContentItemAspectContext context)
+
+        public override Task GetContentItemAspectAsync(ContentItemAspectContext context)
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
-                return;
+                return Task.CompletedTask;
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
@@ -420,6 +457,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                     _partHandlers.Invoke(handler => handler.GetContentItemAspect(context, part), Logger);
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentsHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentsHandler.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.Modules;
 
@@ -14,7 +15,7 @@ namespace OrchardCore.ContentManagement.Handlers
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public override void Creating(CreateContentContext context)
+        public override Task CreatingAsync(CreateContentContext context)
         {
             var utcNow = _clock.UtcNow;
             if (!context.ContentItem.CreatedUtc.HasValue)
@@ -28,9 +29,11 @@ namespace OrchardCore.ContentManagement.Handlers
             {
                 context.ContentItem.Owner = httpContext.User.Identity.Name;
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Updating(UpdateContentContext context)
+        public override Task UpdatingAsync(UpdateContentContext context)
         {
             var utcNow = _clock.UtcNow;
             context.ContentItem.ModifiedUtc = utcNow;
@@ -41,9 +44,11 @@ namespace OrchardCore.ContentManagement.Handlers
                 // publishing in a Workflow doesn't change it.
                 context.ContentItem.Author = httpContext.User.Identity.Name;
             }
+
+            return Task.CompletedTask;
         }
 
-        public override void Versioning(VersionContentContext context)
+        public override Task VersioningAsync(VersionContentContext context)
         {
             var utcNow = _clock.UtcNow;
 
@@ -51,9 +56,11 @@ namespace OrchardCore.ContentManagement.Handlers
             context.BuildingContentItem.CreatedUtc = context.ContentItem.CreatedUtc ?? utcNow;
             context.BuildingContentItem.PublishedUtc = context.ContentItem.PublishedUtc;
             context.BuildingContentItem.ModifiedUtc = utcNow;
+
+            return Task.CompletedTask;
         }
 
-        public override void Published(PublishContentContext context)
+        public override Task PublishedAsync(PublishContentContext context)
         {
             var utcNow = _clock.UtcNow;
 
@@ -64,12 +71,14 @@ namespace OrchardCore.ContentManagement.Handlers
             }
 
             context.ContentItem.PublishedUtc = utcNow;
+            return Task.CompletedTask;
         }
 
-        public override void Unpublished(PublishContentContext context)
+        public override Task UnpublishedAsync(PublishContentContext context)
         {
             var utcNow = _clock.UtcNow;
             context.ContentItem.PublishedUtc = null;
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Environment.Navigation/INavigationManager.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Navigation/INavigationManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 
 namespace OrchardCore.Environment.Navigation

--- a/src/OrchardCore/OrchardCore.Environment.Navigation/INavigationProvider.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Navigation/INavigationProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace OrchardCore.Environment.Navigation
+namespace OrchardCore.Environment.Navigation
 {
     public interface INavigationProvider
     {

--- a/src/OrchardCore/OrchardCore.Environment.Navigation/NavigationManager.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Navigation/NavigationManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -52,7 +53,7 @@ namespace OrchardCore.Environment.Navigation
                 }
                 catch (Exception e)
                 {
-                    _logger.LogError($"An exception occured while building the menu: {name}", e);
+                    _logger.LogError($"An exception occurred while building the menu: {name}", e);
                 }
             }
 

--- a/src/OrchardCore/OrchardCore.Feeds.Abstractions/IFeedItemBuilder.cs
+++ b/src/OrchardCore/OrchardCore.Feeds.Abstractions/IFeedItemBuilder.cs
@@ -1,9 +1,10 @@
-﻿using OrchardCore.Feeds.Models;
+using System.Threading.Tasks;
+using OrchardCore.Feeds.Models;
 
 namespace OrchardCore.Feeds
 {
     public interface IFeedItemBuilder
     {
-        void Populate(FeedContext context);
+        Task PopulateAsync(FeedContext context);
     }
 }

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/IMediaFactory.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/IMediaFactory.cs
@@ -1,10 +1,11 @@
-﻿using System.IO;
+using System.IO;
+using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 
 namespace OrchardCore.Media
 {
     public interface IMediaFactory
     {
-        IContent CreateMedia(Stream stream, string path, string mimeType, long length, string contentType);
+        Task<IContent> CreateMediaAsync(Stream stream, string path, string mimeType, long length, string contentType);
     }
 }

--- a/src/OrchardCore/OrchardCore.Media.Services/ImageFactory.cs
+++ b/src/OrchardCore/OrchardCore.Media.Services/ImageFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Media.Models;
@@ -52,15 +53,15 @@ namespace OrchardCore.Media
             _contentManager = contentManager;
         }
 
-        public IContent CreateMedia(Stream stream, string path, string mimeType, long length, string contentType)
+        public async Task<IContent> CreateMediaAsync(Stream stream, string path, string mimeType, long length, string contentType)
         {
             if (String.IsNullOrEmpty(contentType))
             {
                 contentType = "Image";
             }
 
-            var media = _contentManager.New(contentType);
-            
+            var media = await _contentManager.NewAsync(contentType);
+
             media.Alter<ImageMediaPart>(imagePart =>
             {
                 imagePart.Length = length;

--- a/src/OrchardCore/OrchardCore.Media.Services/MediaService.cs
+++ b/src/OrchardCore/OrchardCore.Media.Services/MediaService.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.Media
                     return null;
                 }
 
-                return mediaFactory.CreateMedia(stream, file.Path, mimeType, file.Length, contentType);
+                return await mediaFactory.CreateMediaAsync(stream, file.Path, mimeType, file.Length, contentType);
             }
         }
 

--- a/src/OrchardCore/OrchardCore.Media.Services/NullMediaFactory.cs
+++ b/src/OrchardCore/OrchardCore.Media.Services/NullMediaFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System.IO;
+using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 
 namespace OrchardCore.Media
@@ -7,9 +8,9 @@ namespace OrchardCore.Media
     {
         public static IMediaFactory Instance => new NullMediaFactory();
 
-        public IContent CreateMedia(Stream stream, string path, string mimeType, long length, string contentType)
+        public Task<IContent> CreateMediaAsync(Stream stream, string path, string mimeType, long length, string contentType)
         {
-            return null;
+            return Task.FromResult<IContent>(null);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
@@ -41,7 +42,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
             _resourceManager = resourceManager;
         }
 
-        public override void Process(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             output.SuppressOutput();
 
@@ -175,7 +176,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 {
                     definition.SetVersion(Version);
                 }
-                
+
                 // If At is specified then we also render it
                 if (At != ResourceLocation.Unspecified)
                 {
@@ -205,7 +206,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
             {
                 // Custom script content
 
-                var childContent = output.GetChildContentAsync().GetAwaiter().GetResult();
+                var childContent = await output.GetChildContentAsync();
 
                 var builder = new TagBuilder("script");
                 builder.InnerHtml.AppendHtml(childContent);


### PR DESCRIPTION
This PR turns `IContentHandler`'s methods into asynchronous ones, while still allowing child classes deriving from `ContentHandlerBase` to override the non-async ones.

#759 #763 
