### PR TITLE
Remove deprecated GetTypeInfo().

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Commons/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Commons/Startup.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Reflection;
 using Microsoft.AspNetCore.Builder;
-using OrchardCore.Modules;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.BackgroundTasks;
@@ -13,6 +11,7 @@ using OrchardCore.DisplayManagement.TagHelpers;
 using OrchardCore.Environment.Cache;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Shell.Data;
+using OrchardCore.Modules;
 using OrchardCore.Mvc;
 using OrchardCore.ResourceManagement;
 using OrchardCore.ResourceManagement.TagHelpers;
@@ -40,8 +39,8 @@ namespace OrchardCore.Commons
 
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
-            serviceProvider.AddTagHelpers(typeof(ResourcesTagHelper).GetTypeInfo().Assembly);
-            serviceProvider.AddTagHelpers(typeof(ShapeTagHelper).GetTypeInfo().Assembly);
+            serviceProvider.AddTagHelpers(typeof(ResourcesTagHelper).Assembly);
+            serviceProvider.AddTagHelpers(typeof(ShapeTagHelper).Assembly);
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -68,7 +67,7 @@ namespace OrchardCore.Contents
 
         public override void Configure(IApplicationBuilder builder, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
-            serviceProvider.AddTagHelpers(typeof(ContentLinkTagHelper).GetTypeInfo().Assembly);
+            serviceProvider.AddTagHelpers(typeof(ContentLinkTagHelper).Assembly);
 
             routes.MapAreaRoute(
                 name: "DisplayContentItem",

--- a/src/OrchardCore/OrchardCore.BackgroundTasks/BackgroundTaskService.cs
+++ b/src/OrchardCore/OrchardCore.BackgroundTasks/BackgroundTaskService.cs
@@ -137,7 +137,7 @@ namespace OrchardCore.BackgroundTasks
 
         private string GetGroupName(IBackgroundTask task)
         {
-            var attributes = task.GetType().GetTypeInfo().GetCustomAttributes<BackgroundTaskAttribute>().ToList();
+            var attributes = task.GetType().GetCustomAttributes<BackgroundTaskAttribute>().ToList();
 
             if (attributes.Count == 0)
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using OrchardCore.DisplayManagement.Shapes;
 
@@ -184,7 +183,7 @@ namespace OrchardCore.DisplayManagement.Zones
             {
                 result = null;
             }
-            else if (binder.ReturnType.GetTypeInfo().IsValueType)
+            else if (binder.ReturnType.IsValueType)
             {
                 result = Activator.CreateInstance(binder.ReturnType);
             }

--- a/src/OrchardCore/OrchardCore.Environment.Commands/DefaultCommandHandler.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Commands/DefaultCommandHandler.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using OrchardCore.Modules;
 using Microsoft.Extensions.Localization;
+using OrchardCore.Modules;
 
 namespace OrchardCore.Environment.Commands
 {
@@ -164,7 +164,7 @@ namespace OrchardCore.Environment.Commands
 
         private static object ConvertToType(Type type, string value)
         {
-            if (type.GetTypeInfo().IsEnum)
+            if (type.IsEnum)
             {
                 try
                 {

--- a/src/OrchardCore/OrchardCore.Environment.Extensions/ExtensionManager.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions/ExtensionManager.cs
@@ -241,7 +241,7 @@ namespace OrchardCore.Environment.Extensions
 
         private static string GetSourceFeatureNameForType(Type type, string extensionId)
         {
-            var attribute = type.GetTypeInfo().GetCustomAttributes<FeatureAttribute>(false).FirstOrDefault();
+            var attribute = type.GetCustomAttributes<FeatureAttribute>(false).FirstOrDefault();
 
             return attribute?.FeatureName ?? extensionId;
         }
@@ -335,8 +335,7 @@ namespace OrchardCore.Environment.Extensions
 
         private bool IsComponentType(Type type)
         {
-            var typeInfo = type.GetTypeInfo();
-            return typeInfo.IsClass && !typeInfo.IsAbstract && typeInfo.IsPublic;
+            return type.IsClass && !type.IsAbstract && type.IsPublic;
         }
 
         private IFeatureInfo[] Order(IEnumerable<IFeatureInfo> featuresToOrder)

--- a/src/OrchardCore/OrchardCore.Environment.Shell.Abstractions/Builders/Extensions/ServiceProviderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell.Abstractions/Builders/Extensions/ServiceProviderExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace OrchardCore.Environment.Shell.Builders
@@ -22,10 +21,8 @@ namespace OrchardCore.Environment.Shell.Builders
                 // Register the singleton instances to all containers
                 if (service.Lifetime == ServiceLifetime.Singleton)
                 {
-                    var serviceTypeInfo = service.ServiceType.GetTypeInfo();
-
                     // Treat open-generic registrations differently
-                    if (serviceTypeInfo.IsGenericType && serviceTypeInfo.GenericTypeArguments.Length == 0)
+                    if (service.ServiceType.IsGenericType && service.ServiceType.GenericTypeArguments.Length == 0)
                     {
                         // There is no Func based way to register an open-generic type, instead of
                         // tenantServiceCollection.AddSingleton(typeof(IEnumerable<>), typeof(List<>));

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/RequireFeaturesAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/RequireFeaturesAttribute.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.Modules
 
         public static IList<string> GetRequiredFeatureNamesForType(Type type)
         {
-            var attribute = type.GetTypeInfo().GetCustomAttributes<RequireFeaturesAttribute>(false).FirstOrDefault();
+            var attribute = type.GetCustomAttributes<RequireFeaturesAttribute>(false).FirstOrDefault();
 
             return attribute?.RequiredFeatureNames ?? Array.Empty<string>();
         }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using OrchardCore.Modules;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
@@ -13,6 +12,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures.Internal;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using OrchardCore.Modules;
 using OrchardCore.Mvc.LocationExpander;
 using OrchardCore.Mvc.ModelBinding;
 using OrchardCore.Mvc.RazorPages;
@@ -84,13 +84,13 @@ namespace OrchardCore.Mvc
 
         private static void AddDefaultFrameworkParts(ApplicationPartManager partManager)
         {
-            var mvcTagHelpersAssembly = typeof(InputTagHelper).GetTypeInfo().Assembly;
+            var mvcTagHelpersAssembly = typeof(InputTagHelper).Assembly;
             if (!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcTagHelpersAssembly))
             {
                 partManager.ApplicationParts.Add(new AssemblyPart(mvcTagHelpersAssembly));
             }
 
-            var mvcRazorAssembly = typeof(UrlResolutionTagHelper).GetTypeInfo().Assembly;
+            var mvcRazorAssembly = typeof(UrlResolutionTagHelper).Assembly;
             if (!partManager.ApplicationParts.OfType<AssemblyPart>().Any(p => p.Assembly == mvcRazorAssembly))
             {
                 partManager.ApplicationParts.Add(new AssemblyPart(mvcRazorAssembly));

--- a/src/OrchardCore/OrchardCore.Mvc.Core/ShellFeatureApplicationPart.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/ShellFeatureApplicationPart.cs
@@ -45,7 +45,7 @@ namespace OrchardCore.Mvc
             get
             {
                 var shellBluePrint = _httpContextAccessor.HttpContext.RequestServices?.GetRequiredService<ShellBlueprint>();
-                return shellBluePrint?.Dependencies.Keys.Select(type => type.GetTypeInfo()) ?? Enumerable.Empty<TypeInfo>();
+                return shellBluePrint?.Dependencies.Keys.Select(type => IntrospectionExtensions.GetTypeInfo(type)) ?? Enumerable.Empty<TypeInfo>();
             }
         }
 

--- a/src/OrchardCore/OrchardCore.Mvc.Core/TagHelperApplicationPart.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/TagHelperApplicationPart.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -19,6 +19,6 @@ namespace OrchardCore.Mvc
         public override string Name => _assembly.GetName().Name + ".TagHelpers";
 
         public IEnumerable<TypeInfo> Types => _assembly.ExportedTypes
-            .Select(t => t.GetTypeInfo()).Where(t => t.IsSubclassOf(typeof(TagHelper)));
+            .Select(t => IntrospectionExtensions.GetTypeInfo(t)).Where(t => t.IsSubclassOf(typeof(TagHelper)));
     }
 }

--- a/src/OrchardCore/OrchardCore.Nancy.Core/AssemblyCatalogs/AmbientAssemblyCatalog.cs
+++ b/src/OrchardCore/OrchardCore.Nancy.Core/AssemblyCatalogs/AmbientAssemblyCatalog.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Http;
@@ -28,7 +28,7 @@ namespace OrchardCore.Nancy.AssemblyCatalogs
         {
             var shellBluePrint = _httpContextAccessor.HttpContext.RequestServices.GetRequiredService<ShellBlueprint>();
             return shellBluePrint.Dependencies.Keys
-                .Select(type => type.GetTypeInfo().Assembly)
+                .Select(type => type.Assembly)
                 .ToArray();
         }
     }

--- a/test/OrchardCore.Tests/Localization/PoParserTests.cs
+++ b/test/OrchardCore.Tests/Localization/PoParserTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using OrchardCore.Localization;
 using OrchardCore.Localization.PortableObject;
 using Xunit;
@@ -187,7 +186,7 @@ namespace OrchardCore.Tests.Localization
         {
             var parser = new PoParser();
 
-            var testAssembly = typeof(PoParserTests).GetTypeInfo().Assembly;
+            var testAssembly = typeof(PoParserTests).Assembly;
             using (var resource = testAssembly.GetManifestResourceStream("OrchardCore.Tests.Localization.PoFiles." + resourceName + ".po"))
             {
                 using (var reader = new StreamReader(resource))


### PR DESCRIPTION
Fixes #1192 

There is still 2 places where we implement the `IApplicationPartTypeProvider` interface and where we need to return an `IEnumerable<TypeInfo>`. I think that this interface will change in a future version and it will be time to change these 2 custom implementations. Meanwhile, in these 2 places, even if it will also be deprecated, we use `System.Reflection.IntrospectionExtensions.GetTypeInfo(type)`.