### PR TITLE
Fixes invalid cast when using razor to execute a SQL query 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Razor/ContentQueryOrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Razor/ContentQueryOrchardRazorHelperExtensions.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrchardCore.DisplayManagement.Razor;
@@ -16,7 +15,32 @@ namespace OrchardCore.ContentManagement
 
         public static async Task<IEnumerable<ContentItem>> ContentQueryAsync(this OrchardRazorHelper razorHelper, string queryName, IDictionary<string, object> parameters)
         {
-            return (await razorHelper.QueryAsync(queryName, parameters)).Select(o => ((JObject)o).ToObject<ContentItem>());
+            var results = await razorHelper.QueryAsync(queryName, parameters);
+            var contentItems = new List<ContentItem>();
+
+            foreach (var result in results)
+            {
+                if (!(result is ContentItem contentItem))
+                {
+                    contentItem = null;
+
+                    if (result is JObject jObject)
+                    {
+                        contentItem = jObject.ToObject<ContentItem>();
+                    }
+                }
+
+                // If input is a 'JObject' but which not represents a 'ContentItem',
+                // a 'ContentItem' is still created but with some null properties.
+                if (contentItem?.ContentItemId == null)
+                {
+                    continue;
+                }
+
+                contentItems.Add(contentItem);
+            }
+
+            return contentItems;
         }
     }
 }


### PR DESCRIPTION
There was an incorrect assumption that queries will always return `JObject`. SQL queries will return `ContentItems` if `Return Documents` is ticked.

In this instance, we were trying to do an invalid cast.

The logic for creating a strongly typed `ContentItem` is now the same as is used in `BuildDisplayFilter`.