### PR TITLE
Local storage cleanup

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Content/Scripts/contentpreview.edit.js
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Content/Scripts/contentpreview.edit.js
@@ -56,7 +56,7 @@ $(function () {
         localStorage.setItem('contentpreview:' + previewId, JSON.stringify($.param(formData)));
     }
 
-    $(document).on('contentpreview:render', function () {        
+    $(document).on('contentpreview:render', function () {
         sendFormData();
     });
 
@@ -64,13 +64,15 @@ $(function () {
     $(window).on('storage', function (ev) {
         if (ev.originalEvent.key != 'contentpreview:ready:' + previewId) return; // ignore other keys
 
-        // triggered by the preview window the first time it is loaded in order 
+        // triggered by the preview window the first time it is loaded in order
         // to pre-render the view even if no contentpreview:render is already sent
         sendFormData();
     });    
 
     $(window).on('unload', function () {
+        localStorage.removeItem('contentpreview:' + previewId);
         // this will raise an event in the preview window to notify that the live preview is no longer active.
         localStorage.setItem('contentpreview:not-connected:' + previewId, '');
+        localStorage.removeItem('contentpreview:not-connected:' + previewId);
     });
 });

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -57,8 +57,6 @@
             $('#serverErrorWarning').hide();
         });
 
-        iframe.contentWindow.onbeforeunload = function () { return ""; }
-
         var preview = localStorage.getItem('contentpreview:@previewId');
 
         if (preview == null) {
@@ -73,7 +71,6 @@
 
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
     var iframe = document.getElementById('iframe');
-    var notConnectedWarning = document.getElementById('notConnectedWarning');
     var previewEventTimer = null;
     var previewRenderTimer = null;
 
@@ -102,14 +99,16 @@
 
             $.post(renderPreviewUrl, formData)
                 .done(function (data) {
-                    if (!iframe || !iframe.contentWindow) {
-                        iframe.contentWindow.document.open();
-                        iframe.contentWindow.document.close();
+                    if (iframe && iframe.contentWindow) {
+                        if (iframe.contentWindow.document.head.innerHTML == "") {
+                            iframe.contentWindow.document.write(data);
+                        }
+                        else {
+                            var body = data.substring(data.indexOf('<body>') + 6, data.indexOf('</body>'));
+                            iframe.contentWindow.document.body.innerHTML = body;
+                        }
+                        $(iframe.contentWindow).scrollTop(scrollTop);
                     }
-
-                    iframe.contentWindow.document.body.innerHTML = '';
-                    iframe.contentWindow.document.write(data);
-                    $(iframe.contentWindow).scrollTop(scrollTop);
                     $(serverErrorWarning).hide();
                 })
                 .fail(function (data) {

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -80,7 +80,24 @@
         }
     });
 
+    iframe.onload = function () {
+        if (previewRendering) {
+            $(this.contentWindow).scrollTop(scrollTop);
+            this.style.visibility = 'visible';
+
+            if (iframe2 && iframe2.contentWindow) {
+                iframe2.style.visibility = 'hidden';
+                iframe2.contentWindow.document.open();
+                iframe2.contentWindow.document.write(previewRenderData);
+                iframe2.contentWindow.document.close();
+            }
+            previewRendering = false;
+        }
+    }
+
     var previewRendering;
+    var previewRenderData;
+    var scrollTop = 0;
 
     function renderPreview(value) {
 
@@ -105,18 +122,19 @@
                 .done(function (data) {
                     if (iframe && iframe.contentWindow && iframe2 && iframe2.contentWindow) {
 
-                        // Under 'Chrome', after having written the frame, we need to use a delay before updating
-                        // the scroll position. Then, we use 2 frames to cancel the flicker that the delay causes.
+                        // A full writing of the frame document causes the iframe to be re-loaded.
+                        // So, better to update the scroll position on the related 'onload' event.
+                        // Then, we use 2 frames to cancel the flicker that this deferring causes.
 
-                        var scrollTop = $(iframe.contentWindow).scrollTop();
-                        ScrollAndShowFrame(iframe2, scrollTop);
-                        HideAndUpdateFrame(iframe, data);
+                        scrollTop = $(iframe.contentWindow).scrollTop();
+                        $(iframe2.contentWindow).scrollTop(scrollTop);
+                        iframe2.style.visibility = 'visible';
 
-                        setTimeout(function () {
-                            ScrollAndShowFrame(iframe, scrollTop);
-                            HideAndUpdateFrame(iframe2, data);
-                            previewRendering = false;
-                        }, 50);
+                        iframe.style.visibility = 'hidden';
+                        iframe.contentWindow.document.open();
+                        iframe.contentWindow.document.write(data);
+                        iframe.contentWindow.document.close();
+                        previewRenderData = data;
                     }
                     $(serverErrorWarning).hide();
                 })
@@ -136,18 +154,6 @@
             previewRendering = false;
             console.log('Error while previewing: ' + e);
         }
-    }
-
-    function HideAndUpdateFrame(frame, data) {
-        frame.style.visibility = 'hidden';
-        frame.contentWindow.document.open();
-        frame.contentWindow.document.write(data);
-        frame.contentWindow.document.close();
-    }
-
-    function ScrollAndShowFrame(frame, scrollTop) {
-        $(frame.contentWindow).scrollTop(scrollTop);
-        frame.style.visibility = 'visible';
     }
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -34,7 +34,7 @@
             else if (ev.key.indexOf('contentpreview:') !== -1) {
                 if (ev.originalEvent.newValue != null) {
                     clearTimeout(previewEventTimer);
-                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 300);
+                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 150);
                     $(notConnectedWarning).hide();
                 }
             }

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -17,7 +17,7 @@
     <button type="button" id="close-warning" class="close" aria-label="Close" style="position: relative; padding: 0 0 0 1rem; margin-top: -0.2rem;">
         <span aria-hidden="true">&times;</span>
     </button>
-    <span>@T["Preview Not Connected"] </span>
+    <span>@T["Preview Disconnected"] </span>
 </div>
 
 
@@ -28,13 +28,14 @@
 <script type="text/javascript">
     $(function() {
         $(window).on('storage', function (ev) {
-            if (ev.originalEvent.key.indexOf('contentpreview:not-connected:') !== -1) {
+            if (ev.key.indexOf('contentpreview:not-connected:') !== -1) {
                 $(notConnectedWarning).show();
             }
-            else if (ev.originalEvent.key.indexOf('contentpreview:') !== -1) {
-                $(notConnectedWarning).hide();
-                renderPreview(ev.originalEvent.newValue);
-                localStorage.removeItem('contentpreview:@previewId');
+            else if (ev.key.indexOf('contentpreview:') !== -1) {
+                if (ev.originalEvent.newValue != null) {
+                    $(notConnectedWarning).hide();
+                    renderPreview(ev.originalEvent.newValue);
+                }
             }
         });
 
@@ -45,11 +46,16 @@
 
         iframe.contentWindow.onbeforeunload = function () { return ""; }
 
-        // notify the editor to render the preview
-        localStorage.setItem('contentpreview:ready:@previewId', '');
-        localStorage.removeItem('contentpreview:ready:@previewId');
-        renderPreview(localStorage.getItem('contentpreview:@previewId'));
-        localStorage.removeItem('contentpreview:@previewId');
+        var preview = localStorage.getItem('contentpreview:@previewId');
+
+        if (preview == null) {
+            // notify the editor to render the preview
+            localStorage.setItem('contentpreview:ready:@previewId', '');
+            localStorage.removeItem('contentpreview:ready:@previewId');
+        }
+        else {
+            renderPreview(preview);
+        }
     });
 
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -34,10 +34,17 @@
 <resources type="Footer" />
 
 <script type="text/javascript">
+    var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
+    var iframe = document.getElementById('iframe');
+    var previewEventTimer = null;
+    var previewRenderTimer = null;
+    var previewHeadRefresh = false;
+
     $(function () {
         $(window).on('storage', function (ev) {
             if (ev.key.indexOf('contentpreview:not-connected:') !== -1) {
                 $(notConnectedWarning).show();
+                previewHeadRefresh = true;
             }
             else if (ev.key.indexOf('contentpreview:') !== -1) {
                 if (ev.originalEvent.newValue != null) {
@@ -69,10 +76,9 @@
         }
     });
 
-    var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
-    var iframe = document.getElementById('iframe');
-    var previewEventTimer = null;
-    var previewRenderTimer = null;
+    iframe.onload = function () {
+        previewHeadRefresh = true;
+    }
 
     var scrollTop;
     var rendering;
@@ -100,10 +106,16 @@
             $.post(renderPreviewUrl, formData)
                 .done(function (data) {
                     if (iframe && iframe.contentWindow) {
-                        if (iframe.contentWindow.document.head.innerHTML == "") {
+                        if (iframe.contentWindow.document.head.innerHTML == '') {
                             iframe.contentWindow.document.write(data);
+                            previewHeadRefresh = false;
                         }
                         else {
+                            if (previewHeadRefresh) {
+                                previewHeadRefresh = false;
+                                var head = data.substring(data.indexOf('<head>') + 6, data.indexOf('</head>'));
+                                iframe.contentWindow.document.head.innerHTML = head;
+                            }
                             var body = data.substring(data.indexOf('<body>') + 6, data.indexOf('</body>'));
                             iframe.contentWindow.document.body.innerHTML = body;
                         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -14,10 +14,18 @@
 </iframe>
 
 <div id="notConnectedWarning" class="alert alert-info alert-dismissible fade show collapse" role="alert" style="position:fixed; height:60px; top:10px;right:40px; display:none; z-index:999999;">
-    <button type="button" id="close-warning" class="close" aria-label="Close" style="position: relative; padding: 0 0 0 1rem; margin-top: -0.2rem;">
+    <button type="button" id="close-connect-warning" class="close" aria-label="Close" style="position: relative; padding: 0 0 0 1rem; margin-top: -0.2rem;">
         <span aria-hidden="true">&times;</span>
     </button>
     <span>@T["Preview Disconnected"] </span>
+</div>
+
+<div id="serverErrorWarning" class="alert alert-warning alert-dismissible fade show" role="alert" style="position:fixed; top:10px;right:40px; display:none; z-index:999999;">
+    <button type="button" id="close-server-warning" class="close" aria-label="Close" style="position: relative; padding: 0 0 0 1rem; margin-top: -0.2rem;">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <p>@T["Preview Error"] </p>
+    <ul></ul>
 </div>
 
 
@@ -41,8 +49,12 @@
         });
 
         // override default behaviour of Bootstrap's. We only hide, not remove the alert.
-        $('#close-warning').on('click', function(){
+        $('#close-connect-warning').on('click', function(){
             $('#notConnectedWarning').hide();
+        });
+
+        $('#close-server-warning').on('click', function () {
+            $('#serverErrorWarning').hide();
         });
 
         iframe.contentWindow.onbeforeunload = function () { return ""; }
@@ -94,12 +106,16 @@
                     iframe.contentWindow.document.body.innerHTML = '';
                     iframe.contentWindow.document.write(data);
                     $(iframe.contentWindow).scrollTop(scrollTop);
+                    $(serverErrorWarning).hide();
                 })
                 .fail(function (data) {
-                    if (data.responseJSON && data.responseJSON != undefined && data.responseJSON.errors) {
+                    if (data.responseJSON && data.responseJSON.errors) {
+                        var ul = $('#serverErrorWarning ul').empty();
                         data.responseJSON.errors.forEach(function (error) {
                             console.error(error);
+                            $('<li/>').text(error).appendTo(ul);
                         });
+                        $(serverErrorWarning).show();
                     }
                 })
                 .always(function () {

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -9,7 +9,11 @@
 
 <resources type="Header" />
 
-<iframe id="iframe" style="position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden;z-index:999990;">
+<iframe id="iframe" style="visibility:hidden; position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden;z-index:999990;">
+    Your browser doesn't support iframes
+</iframe>
+
+<iframe id="iframe2" style="visibility:hidden; position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden;z-index:999990;">
     Your browser doesn't support iframes
 </iframe>
 
@@ -36,15 +40,14 @@
 <script type="text/javascript">
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
     var iframe = document.getElementById('iframe');
+    var iframe2 = document.getElementById('iframe2');
     var previewEventTimer = null;
     var previewRenderTimer = null;
-    var previewHeadRefresh = false;
 
     $(function () {
         $(window).on('storage', function (ev) {
             if (ev.key.indexOf('contentpreview:not-connected:') !== -1) {
                 $(notConnectedWarning).show();
-                previewHeadRefresh = true;
             }
             else if (ev.key.indexOf('contentpreview:') !== -1) {
                 if (ev.originalEvent.newValue != null) {
@@ -76,50 +79,53 @@
         }
     });
 
-    iframe.onload = function () {
-        previewHeadRefresh = true;
-    }
-
-    var scrollTop;
-    var rendering;
+    var previewRendering;
 
     function renderPreview(value) {
 
-        if (rendering) {
+        if (previewRendering) {
             clearTimeout(previewRenderTimer);
             previewRenderTimer = setTimeout(function () { renderPreview(value); }, 150);
             return;
         }
 
-        rendering = true;
+        previewRendering = true;
         clearTimeout(previewRenderTimer);
 
         try {
             var formData = JSON.parse(value);
             if (!formData) {
-                rendering = false;
+                previewRendering = false;
                 return;
             }
 
-            scrollTop = $(iframe.contentWindow).scrollTop();
-
             $.post(renderPreviewUrl, formData)
                 .done(function (data) {
-                    if (iframe && iframe.contentWindow) {
-                        if (iframe.contentWindow.document.head.innerHTML == '') {
-                            iframe.contentWindow.document.write(data);
-                            previewHeadRefresh = false;
-                        }
-                        else {
-                            if (previewHeadRefresh) {
-                                previewHeadRefresh = false;
-                                var head = data.substring(data.indexOf('<head>') + 6, data.indexOf('</head>'));
-                                iframe.contentWindow.document.head.innerHTML = head;
-                            }
-                            var body = data.substring(data.indexOf('<body>') + 6, data.indexOf('</body>'));
-                            iframe.contentWindow.document.body.innerHTML = body;
-                        }
-                        $(iframe.contentWindow).scrollTop(scrollTop);
+                    if (iframe && iframe.contentWindow && iframe2 && iframe2.contentWindow) {
+
+                        // Under 'Chrome' (not 'Firefox') writing correctly the full frame
+                        // implies that we need a delay before updating the scroll position.
+                        // This delay adds some flickering that we cancel by using 2 frames.
+
+                        var scrollTop = $(iframe.contentWindow).scrollTop();
+                        $(iframe2.contentWindow).scrollTop(scrollTop);
+                        iframe.style.visibility = 'hidden';
+                        iframe2.style.visibility = 'visible';
+
+                        iframe.contentWindow.document.open();
+                        iframe.contentWindow.document.write(data);
+                        iframe.contentWindow.document.close();
+
+                        setTimeout(function () {
+                            $(iframe.contentWindow).scrollTop(scrollTop);
+                            iframe2.style.visibility = 'hidden';
+                            iframe.style.visibility = 'visible';
+
+                            iframe2.contentWindow.document.open();
+                            iframe2.contentWindow.document.write(data);
+                            iframe2.contentWindow.document.close();
+                            previewRendering = false;
+                        }, 50);
                     }
                     $(serverErrorWarning).hide();
                 })
@@ -132,13 +138,11 @@
                         });
                         $(serverErrorWarning).show();
                     }
-                })
-                .always(function () {
-                    rendering = false;
+                    previewRendering = false;
                 });
         }
         catch (e) {
-            rendering = false;
+            previewRendering = false;
             console.log('Error while previewing: ' + e);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -75,6 +75,7 @@
     var iframe = document.getElementById('iframe');
     var notConnectedWarning = document.getElementById('notConnectedWarning');
     var previewEventTimer = null;
+    var previewRenderTimer = null;
 
     var scrollTop;
     var rendering;
@@ -82,10 +83,13 @@
     function renderPreview(value) {
 
         if (rendering) {
+            clearTimeout(previewRenderTimer);
+            previewRenderTimer = setTimeout(function () { renderPreview(value); }, 150);
             return;
         }
 
         rendering = true;
+        clearTimeout(previewRenderTimer);
 
         try {
             var formData = JSON.parse(value);

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -85,8 +85,8 @@
     function renderPreview(value) {
 
         if (previewRendering) {
+            // Defer the last rendering
             clearTimeout(previewRenderTimer);
-            // Defer the last captured value while rendering
             previewRenderTimer = setTimeout(function () { renderPreview(value); }, 100);
             return;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -51,6 +51,7 @@
             }
             else if (ev.key.indexOf('contentpreview:') !== -1) {
                 if (ev.originalEvent.newValue != null) {
+                    // Smooth event cascading
                     clearTimeout(previewEventTimer);
                     previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 150);
                     $(notConnectedWarning).hide();
@@ -85,7 +86,8 @@
 
         if (previewRendering) {
             clearTimeout(previewRenderTimer);
-            previewRenderTimer = setTimeout(function () { renderPreview(value); }, 150);
+            // Defer the last captured value while rendering
+            previewRenderTimer = setTimeout(function () { renderPreview(value); }, 100);
             return;
         }
 
@@ -103,27 +105,16 @@
                 .done(function (data) {
                     if (iframe && iframe.contentWindow && iframe2 && iframe2.contentWindow) {
 
-                        // Under 'Chrome' (not 'Firefox') writing correctly the full frame
-                        // implies that we need a delay before updating the scroll position.
-                        // This delay adds some flickering that we cancel by using 2 frames.
+                        // Under 'Chrome', after having written the frame, we need to use a delay before updating
+                        // the scroll position. Then, we use 2 frames to cancel the flicker that the delay causes.
 
                         var scrollTop = $(iframe.contentWindow).scrollTop();
-                        $(iframe2.contentWindow).scrollTop(scrollTop);
-                        iframe.style.visibility = 'hidden';
-                        iframe2.style.visibility = 'visible';
-
-                        iframe.contentWindow.document.open();
-                        iframe.contentWindow.document.write(data);
-                        iframe.contentWindow.document.close();
+                        ScrollAndShowFrame(iframe2, scrollTop);
+                        HideAndUpdateFrame(iframe, data);
 
                         setTimeout(function () {
-                            $(iframe.contentWindow).scrollTop(scrollTop);
-                            iframe2.style.visibility = 'hidden';
-                            iframe.style.visibility = 'visible';
-
-                            iframe2.contentWindow.document.open();
-                            iframe2.contentWindow.document.write(data);
-                            iframe2.contentWindow.document.close();
+                            ScrollAndShowFrame(iframe, scrollTop);
+                            HideAndUpdateFrame(iframe2, data);
                             previewRendering = false;
                         }, 50);
                     }
@@ -145,6 +136,18 @@
             previewRendering = false;
             console.log('Error while previewing: ' + e);
         }
+    }
+
+    function HideAndUpdateFrame(frame, data) {
+        frame.style.visibility = 'hidden';
+        frame.contentWindow.document.open();
+        frame.contentWindow.document.write(data);
+        frame.contentWindow.document.close();
+    }
+
+    function ScrollAndShowFrame(frame, scrollTop) {
+        $(frame.contentWindow).scrollTop(scrollTop);
+        frame.style.visibility = 'visible';
     }
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -26,15 +26,16 @@
 <resources type="Footer" />
 
 <script type="text/javascript">
-    $(function() {
+    $(function () {
         $(window).on('storage', function (ev) {
             if (ev.key.indexOf('contentpreview:not-connected:') !== -1) {
                 $(notConnectedWarning).show();
             }
             else if (ev.key.indexOf('contentpreview:') !== -1) {
                 if (ev.originalEvent.newValue != null) {
+                    clearTimeout(previewEventTimer);
+                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 300);
                     $(notConnectedWarning).hide();
-                    renderPreview(ev.originalEvent.newValue);
                 }
             }
         });
@@ -61,58 +62,53 @@
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
     var iframe = document.getElementById('iframe');
     var notConnectedWarning = document.getElementById('notConnectedWarning');
+    var previewEventTimer = null;
 
     var scrollTop;
     var rendering;
 
     function renderPreview(value) {
 
-        renderRequested = true;
-
-        // Squashes all event calls into one
         if (rendering) {
             return;
         }
 
-        // Pump renderPreview calls
-        while (renderRequested) {
-            renderRequested = false;
-            rendering = true;
-            try {
+        rendering = true;
 
-                var formData = JSON.parse(value);
-                if (!formData) return;
-
-                scrollTop = $(iframe.contentWindow).scrollTop();
-
-                $.post(renderPreviewUrl, formData)
-                    .done(function (data) {
-                        if (!iframe || !iframe.contentWindow) {
-                            iframe.contentWindow.document.open();
-                            iframe.contentWindow.document.close();
-                        }
-
-                        iframe.contentWindow.document.body.innerHTML = '';
-                        iframe.contentWindow.document.write(data);
-                        $(iframe.contentWindow).scrollTop(scrollTop);
-                    })
-                    .fail(function (data) {
-                        if (data.responseJSON && data.responseJSON.errors) {
-                            responseJSON.errors.forEach(function (error) {
-                                console.error(error);
-                            });
-                        }
-                    })
-                    .always(function () {
-                    }
-                );
-            }
-            catch (e) {
-                console.log('Error while previewing: ' + e);
-            }
-            finally {
+        try {
+            var formData = JSON.parse(value);
+            if (!formData) {
                 rendering = false;
+                return;
             }
+
+            scrollTop = $(iframe.contentWindow).scrollTop();
+
+            $.post(renderPreviewUrl, formData)
+                .done(function (data) {
+                    if (!iframe || !iframe.contentWindow) {
+                        iframe.contentWindow.document.open();
+                        iframe.contentWindow.document.close();
+                    }
+
+                    iframe.contentWindow.document.body.innerHTML = '';
+                    iframe.contentWindow.document.write(data);
+                    $(iframe.contentWindow).scrollTop(scrollTop);
+                })
+                .fail(function (data) {
+                    if (data.responseJSON && data.responseJSON != undefined && data.responseJSON.errors) {
+                        data.responseJSON.errors.forEach(function (error) {
+                            console.error(error);
+                        });
+                    }
+                })
+                .always(function () {
+                    rendering = false;
+                });
+        }
+        catch (e) {
+            rendering = false;
+            console.log('Error while previewing: ' + e);
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Content/templatepreview.edit.js
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Content/templatepreview.edit.js
@@ -1,11 +1,21 @@
 var editor;
 
-function storeTemplate(nameElement) {
-    var template = { "description": nameElement.value, "content": editor.getValue() };
-    localStorage.setItem('OrchardCore.templates', JSON.stringify(template));
-}
-
 function initializeTemplatePreview(nameElement, editorElement) {
+
+    var antiforgerytoken = $("[name='__RequestVerificationToken']").val();
+
+    sendFormData = function (nameElement) {
+
+        var formData = {
+            'Name': nameElement.value,
+            'Content': editor.getValue(),
+            '__RequestVerificationToken': antiforgerytoken
+        };
+
+        // store the form data to pass it in the event handler
+        localStorage.setItem('OrchardCore.templates', JSON.stringify($.param(formData)));
+    }
+
     editor = CodeMirror.fromTextArea(editorElement, {
         lineNumbers: true,
         styleActiveLine: true,
@@ -14,7 +24,7 @@ function initializeTemplatePreview(nameElement, editorElement) {
     });
 
     editor.on('change', function (cm) {
-        storeTemplate(nameElement);
+        sendFormData(nameElement);
     });
 
     window.addEventListener('storage', function (ev) {
@@ -22,17 +32,17 @@ function initializeTemplatePreview(nameElement, editorElement) {
 
         // triggered by the preview window the first time it is loaded in order
         // to pre-render the view even if no contentpreview:render is already sent
-        storeTemplate(nameElement);
+        sendFormData(nameElement);
     }, false);
 
     $(nameElement)
-        .on('input', function () { storeTemplate(nameElement); })
-        .on('propertychange', function () { storeTemplate(nameElement); })
-        .on('change', function () { storeTemplate(nameElement); })
+        .on('input', function () { sendFormData(nameElement); })
+        .on('propertychange', function () { sendFormData(nameElement); })
+        .on('change', function () { sendFormData(nameElement); })
         .on('keyup', function (event) {
             // handle backspace
             if (event.keyCode == 46 || event.ctrlKey) {
-                storeTemplate(nameElement);
+                sendFormData(nameElement);
             }
         });
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Content/templatepreview.edit.js
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Content/templatepreview.edit.js
@@ -35,4 +35,11 @@ function initializeTemplatePreview(nameElement, editorElement) {
                 storeTemplate(nameElement);
             }
         });
+
+    $(window).on('unload', function () {
+        localStorage.removeItem('OrchardCore.templates');
+        // this will raise an event in the preview window to notify that the live preview is no longer active.
+        localStorage.setItem('OrchardCore.templates:not-connected', '');
+        localStorage.removeItem('OrchardCore.templates:not-connected');
+   });
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -1,15 +1,38 @@
+using System;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
 using OrchardCore.Admin;
 using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.Templates.ViewModels;
 
 namespace OrchardCore.Templates.Controllers
 {
     [Admin]
     public class PreviewController : Controller, IUpdateModel
     {
+        private readonly IMemoryCache _memoryCache;
+
+        public PreviewController(IMemoryCache memoryCache)
+        {
+            _memoryCache = memoryCache;
+        }
+
         public IActionResult Index()
         {
             return View();
+        }
+
+        [HttpPost]
+        public void SetTemplate()
+        {
+            var name = Request.Form["Name"];
+            var content = Request.Form["Content"];
+
+            if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(content))
+            {
+                _memoryCache.Set("OrchardCore.PreviewTemplate", new TemplateViewModel { Name = name, Content = content },
+                    new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromSeconds(30)));
+            }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -1,20 +1,38 @@
-using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Caching.Memory;
-using OrchardCore.Admin;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Display;
 using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.Modules;
+using OrchardCore.Settings;
 using OrchardCore.Templates.ViewModels;
 
 namespace OrchardCore.Templates.Controllers
 {
-    [Admin]
     public class PreviewController : Controller, IUpdateModel
     {
-        private readonly IMemoryCache _memoryCache;
+        private readonly IContentManager _contentManager;
+        private readonly IContentAliasManager _contentAliasManager;
+        private readonly IContentItemDisplayManager _contentItemDisplayManager;
+        private readonly IAuthorizationService _authorizationService;
+        private readonly ISiteService _siteService;
+        private readonly IClock _clock;
 
-        public PreviewController(IMemoryCache memoryCache)
+        public PreviewController(
+            IContentManager contentManager,
+            IContentAliasManager contentAliasManager,
+            IContentItemDisplayManager contentItemDisplayManager,
+            IAuthorizationService authorizationService,
+            ISiteService siteService,
+            IClock clock)
         {
-            _memoryCache = memoryCache;
+            _contentManager = contentManager;
+            _contentAliasManager = contentAliasManager;
+            _contentItemDisplayManager = contentItemDisplayManager;
+            _authorizationService = authorizationService;
+            _siteService = siteService;
+            _clock = clock;
         }
 
         public IActionResult Index()
@@ -23,16 +41,49 @@ namespace OrchardCore.Templates.Controllers
         }
 
         [HttpPost]
-        public void SetTemplate()
+        public async Task<IActionResult> Render()
         {
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageTemplates))
+            {
+                return Unauthorized();
+            }
+
             var name = Request.Form["Name"];
             var content = Request.Form["Content"];
 
             if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(content))
             {
-                _memoryCache.Set("OrchardCore.PreviewTemplate", new TemplateViewModel { Name = name, Content = content },
-                    new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromSeconds(15)));
+                HttpContext.Items["OrchardCore.PreviewTemplate"] = new TemplateViewModel { Name = name, Content = content };
             }
+
+            var alias = Request.Form["Alias"].ToString();
+
+            string contentItemId;
+            if (string.IsNullOrEmpty(alias) || alias == "/" || alias.EndsWith("Preview/Index"))
+            {
+                var homeRoute = _siteService.GetSiteSettingsAsync().GetAwaiter().GetResult().HomeRoute;
+                contentItemId = homeRoute["contentItemId"]?.ToString();
+            }
+            else
+            {
+                contentItemId = await _contentAliasManager.GetContentItemIdAsync("slug:" + alias);
+            }
+
+            if (string.IsNullOrEmpty(contentItemId))
+            {
+                return NotFound();
+            }
+
+            var contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.Published);
+
+            if (contentItem == null)
+            {
+                return NotFound();
+            }
+
+            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, this, "Detail");
+
+            return View(model);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -31,7 +31,7 @@ namespace OrchardCore.Templates.Controllers
             if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(content))
             {
                 _memoryCache.Set("OrchardCore.PreviewTemplate", new TemplateViewModel { Name = name, Content = content },
-                    new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromSeconds(30)));
+                    new MemoryCacheEntryOptions().SetSlidingExpiration(TimeSpan.FromSeconds(15)));
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -61,7 +61,7 @@ namespace OrchardCore.Templates.Controllers
             string contentItemId;
             if (string.IsNullOrEmpty(alias) || alias == "/" || alias.EndsWith("Preview/Index"))
             {
-                var homeRoute = _siteService.GetSiteSettingsAsync().GetAwaiter().GetResult().HomeRoute;
+                var homeRoute = (await _siteService.GetSiteSettingsAsync()).HomeRoute;
                 contentItemId = homeRoute["contentItemId"]?.ToString();
             }
             else

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.DisplayManagement.ModelBinding;
-using OrchardCore.Modules;
 using OrchardCore.Settings;
 using OrchardCore.Templates.ViewModels;
 
@@ -17,22 +16,19 @@ namespace OrchardCore.Templates.Controllers
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly ISiteService _siteService;
-        private readonly IClock _clock;
 
         public PreviewController(
             IContentManager contentManager,
             IContentAliasManager contentAliasManager,
             IContentItemDisplayManager contentItemDisplayManager,
             IAuthorizationService authorizationService,
-            ISiteService siteService,
-            IClock clock)
+            ISiteService siteService)
         {
             _contentManager = contentManager;
             _contentAliasManager = contentAliasManager;
             _contentItemDisplayManager = contentItemDisplayManager;
             _authorizationService = authorizationService;
             _siteService = siteService;
-            _clock = clock;
         }
 
         public IActionResult Index()
@@ -59,7 +55,7 @@ namespace OrchardCore.Templates.Controllers
             var alias = Request.Form["Alias"].ToString();
 
             string contentItemId;
-            if (string.IsNullOrEmpty(alias) || alias == "/" || alias.EndsWith("Preview/Index"))
+            if (string.IsNullOrEmpty(alias) || alias == "/")
             {
                 var homeRoute = (await _siteService.GetSiteSettingsAsync()).HomeRoute;
                 contentItemId = homeRoute["contentItemId"]?.ToString();

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Services/PreviewTemplatesProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Services/PreviewTemplatesProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Caching.Memory;
 using OrchardCore.Templates.Models;
 using OrchardCore.Templates.ViewModels;
 
@@ -13,7 +12,7 @@ namespace OrchardCore.Templates.Services
     {
         private readonly Lazy<TemplatesDocument> _templatesDocument;
 
-        public PreviewTemplatesProvider(IHttpContextAccessor httpContextAccessor, IMemoryCache memoryCache)
+        public PreviewTemplatesProvider(IHttpContextAccessor httpContextAccessor)
         {
             _templatesDocument = new Lazy<TemplatesDocument>(() =>
             {

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Services/PreviewTemplatesProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Services/PreviewTemplatesProvider.cs
@@ -19,15 +19,12 @@ namespace OrchardCore.Templates.Services
             {
                 var httpContext = httpContextAccessor.HttpContext;
 
-                if (!httpContext.Request.Cookies.ContainsKey("orchard:templates"))
-                {
-                    return null;
-                }
-
                 var templatesDocument = new TemplatesDocument();
 
-                if (memoryCache.TryGetValue<TemplateViewModel>("OrchardCore.PreviewTemplate", out var viewModel))
+                if (httpContext.Items.TryGetValue("OrchardCore.PreviewTemplate", out var model))
                 {
+                    var viewModel = model as TemplateViewModel;
+
                     if (viewModel == null || viewModel.Name == null)
                     {
                         return templatesDocument;

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -38,11 +38,13 @@
     var contentPreviewUrl = $(document.getElementById('contentPreviewUrl')).data('value');
     var previewEventTimer = null;
     var previewRenderTimer = null;
+    var previewHeadRefresh = false;
 
     $(function () {
         $(window).on('storage', function (ev) {
             if (ev.key == 'OrchardCore.templates:not-connected') {
                 $(notConnectedWarning).show();
+                previewHeadRefresh = true;
             }
             else if (ev.key == 'OrchardCore.templates') {
                 if (ev.originalEvent.newValue != null) {
@@ -112,10 +114,16 @@
             $.post(renderPreviewUrl, formData)
                 .done(function (data) {
                     if (iframe && iframe.contentWindow) {
-                        if (iframe.contentWindow.document.head.innerHTML == "") {
+                        if (iframe.contentWindow.document.head.innerHTML == '') {
                             iframe.contentWindow.document.write(data);
+                            previewHeadRefresh = false;
                         }
                         else {
+                            if (previewHeadRefresh) {
+                                previewHeadRefresh = false;
+                                var head = data.substring(data.indexOf('<head>') + 6, data.indexOf('</head>'));
+                                iframe.contentWindow.document.head.innerHTML == head;
+                            }
                             var body = data.substring(data.indexOf('<body>') + 6, data.indexOf('</body>'));
                             iframe.contentWindow.document.body.innerHTML = body;
                         }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -27,7 +27,7 @@
 <script type="text/javascript">
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
 
-    $(function () {
+    $(function() {
         $(window).on('storage', function (ev) {
             if (ev.key == 'OrchardCore.templates:not-connected') {
                 $(notConnectedWarning).show();

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -84,6 +84,19 @@
     });
 
     iframe.onload = function () {
+        if (previewRendering) {
+            $(this.contentWindow).scrollTop(scrollTop);
+            this.style.visibility = 'visible';
+
+            if (iframe2 && iframe2.contentWindow) {
+                iframe2.style.visibility = 'hidden';
+                iframe2.contentWindow.document.open();
+                iframe2.contentWindow.document.write(previewRenderData);
+                iframe2.contentWindow.document.close();
+            }
+            previewRendering = false;
+        }
+
         if (this.contentWindow && this.contentWindow.location.pathname != indexPreviewUrl) {
             contentPreviewUrl = this.contentWindow.location.pathname;
             if (iframe2 && iframe2.contentWindow) {
@@ -93,6 +106,8 @@
     }
 
     var previewRendering;
+    var previewRenderData;
+    var scrollTop = 0;
 
     function renderPreview(value) {
 
@@ -118,18 +133,19 @@
                 .done(function (data) {
                     if (iframe && iframe.contentWindow && iframe2 && iframe2.contentWindow) {
 
-                        // Under 'Chrome', after having written the frame, we need to use a delay before updating
-                        // the scroll position. Then, we use 2 frames to cancel the flicker that the delay causes.
+                        // A full writing of the frame document causes the iframe to be re-loaded.
+                        // So, better to update the scroll position on the related 'onload' event.
+                        // Then, we use 2 frames to cancel the flicker that this deferring causes.
 
-                        var scrollTop = $(iframe.contentWindow).scrollTop();
-                        ScrollAndShowFrame(iframe2, scrollTop);
-                        HideAndUpdateFrame(iframe, data);
+                        scrollTop = $(iframe.contentWindow).scrollTop();
+                        $(iframe2.contentWindow).scrollTop(scrollTop);
+                        iframe2.style.visibility = 'visible';
 
-                        setTimeout(function () {
-                            ScrollAndShowFrame(iframe, scrollTop);
-                            HideAndUpdateFrame(iframe2, data);
-                            previewRendering = false;
-                        }, 50);
+                        iframe.style.visibility = 'hidden';
+                        iframe.contentWindow.document.open();
+                        iframe.contentWindow.document.write(data);
+                        iframe.contentWindow.document.close();
+                        previewRenderData = data;
                     }
                     $(serverErrorWarning).hide();
                 })
@@ -148,18 +164,6 @@
             previewRendering = false;
             console.log('Error while previewing: ' + e);
         }
-    }
-
-    function HideAndUpdateFrame(frame, data) {
-        frame.style.visibility = 'hidden';
-        frame.contentWindow.document.open();
-        frame.contentWindow.document.write(data);
-        frame.contentWindow.document.close();
-    }
-
-    function ScrollAndShowFrame(frame, scrollTop) {
-        $(frame.contentWindow).scrollTop(scrollTop);
-        frame.style.visibility = 'visible';
     }
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -22,20 +22,24 @@
 
 <resources type="Footer" />
 
+<div id="setTemplateUrl" style="display:none" data-value="@Url.Action("SetTemplate", "Preview", new { area = "OrchardCore.Templates" })"></div>
 <div id="renderPreviewUrl" style="display:none" data-value="@Url.Content("~/")"></div>
 
 <script type="text/javascript">
+    var setTemplateUrl = $(document.getElementById('setTemplateUrl')).data('value');
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
+    var previewEventTimer = null;
 
-    $(function() {
+    $(function () {
         $(window).on('storage', function (ev) {
             if (ev.key == 'OrchardCore.templates:not-connected') {
                 $(notConnectedWarning).show();
             }
             else if (ev.key == 'OrchardCore.templates') {
                 if (ev.originalEvent.newValue != null) {
+                    clearTimeout(previewEventTimer);
+                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 300);
                     $(notConnectedWarning).hide();
-                    renderPreview(ev.originalEvent.newValue);
                 }
             }
         });
@@ -63,12 +67,7 @@
     iframe.onload = function () {
         renderPreviewUrl = this.contentWindow.location;
         $(iframe.contentWindow).scrollTop(scrollTop);
-
-        var count = Cookies.get('orchard:templates:count');
-        Cookies.remove("orchard:templates:count", { path: "/" });
-        for (i = 0; i < count; i++) {
-            Cookies.remove("orchard:templates:" + i, { path: "/" });
-        }
+        Cookies.remove("orchard:templates");
     }
 
     var scrollTop;
@@ -76,41 +75,38 @@
 
     function renderPreview(value) {
 
-        renderRequested = true;
-
-        // Squashes all event calls into one
         if (rendering) {
             return;
         }
 
-        // Pump renderPreview calls
-        while (renderRequested) {
-            renderRequested = false;
-            rendering = true;
-            try {
-                var formData = value;
-                if (!formData) return;
+        rendering = true;
 
-                var encoded = window.btoa(unescape(encodeURIComponent(formData)));
-
-                var chunks = Math.floor(encoded.length / 1364) + 1;
-                Cookies.set("orchard:templates:count", chunks, { path: "/" });
-
-                for (i = 0; i < chunks; i++) {
-                    var chunk = encoded.slice(i * 1364, (i + 1) * 1364);
-                    Cookies.remove("orchard:templates:" + i, { path: "/" });
-                    Cookies.set("orchard:templates:" + i, chunk, { path: "/" });
-                }
-
-                scrollTop = $(iframe.contentWindow).scrollTop();
-                iframe.contentWindow.location = renderPreviewUrl;
-            }
-            catch (e) {
-                console.error('Error while previewing: ' + e);
-            }
-            finally {
+        try {
+            var formData = JSON.parse(value);
+            if (!formData) {
                 rendering = false;
+                return;
             }
+
+            Cookies.set("orchard:templates", true);
+            $.post(setTemplateUrl, formData)
+                .done(function () {
+                    try {
+                        iframe.contentWindow.location = renderPreviewUrl;
+                        scrollTop = $(iframe.contentWindow).scrollTop();
+                    }
+                    catch (e) {
+                        rendering = false;
+                        console.log('Error while previewing: ' + e);
+                    }
+                })
+                .always(function () {
+                    rendering = false;
+                });
+        }
+        catch (e) {
+            rendering = false;
+            console.log('Error while previewing: ' + e);
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -9,7 +9,11 @@
 
 <resources type="Header" />
 
-<iframe id="iframe" style="position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">
+<iframe id="iframe" style="visibility:hidden; position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden;z-index:999990;">
+    Your browser doesn't support iframes
+</iframe>
+
+<iframe id="iframe2" style="visibility:hidden; position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden;z-index:999990;">
     Your browser doesn't support iframes
 </iframe>
 
@@ -36,6 +40,8 @@
 <script type="text/javascript">
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
     var contentPreviewUrl = $(document.getElementById('contentPreviewUrl')).data('value');
+    var iframe = document.getElementById('iframe');
+    var iframe2 = document.getElementById('iframe2');
     var previewEventTimer = null;
     var previewRenderTimer = null;
 
@@ -74,30 +80,30 @@
         }
     });
 
-    var iframe = document.getElementById('iframe');
-
     iframe.onload = function () {
-        contentPreviewUrl = this.contentWindow.location.pathname;
+        if (!this.contentWindow.location.pathname.endsWith("Preview/Index")) {
+            contentPreviewUrl = this.contentWindow.location.pathname;
+            iframe2.contentWindow.location = this.contentWindow.location;
+        }
     }
 
-    var rendering;
-    var scrollTop;
+    var previewRendering;
 
     function renderPreview(value) {
 
-        if (rendering) {
+        if (previewRendering) {
             clearTimeout(previewRenderTimer);
             previewRenderTimer = setTimeout(function () { renderPreview(value); }, 150);
         }
 
-        rendering = true;
+        previewRendering = true;
         clearTimeout(previewRenderTimer);
 
         try {
 
             var formData = JSON.parse(value);
             if (!formData) {
-                rendering = false;
+                previewRendering = false;
                 return;
             }
 
@@ -108,19 +114,33 @@
 
             formData += '&' + $.param({ 'Alias': alias });
 
-            scrollTop = $(iframe.contentWindow).scrollTop();
-
             $.post(renderPreviewUrl, formData)
                 .done(function (data) {
-                    if (iframe && iframe.contentWindow) {
-                        if (iframe.contentWindow.document.head.innerHTML == '') {
-                            iframe.contentWindow.document.write(data);
-                        }
-                        else {
-                            var body = data.substring(data.indexOf('<body>') + 6, data.indexOf('</body>'));
-                            iframe.contentWindow.document.body.innerHTML = body;
-                        }
-                        $(iframe.contentWindow).scrollTop(scrollTop);
+                    if (iframe && iframe.contentWindow && iframe2 && iframe2.contentWindow) {
+
+                        // Under 'Chrome' (not 'Firefox') writing correctly the full frame
+                        // implies that we need a delay before updating the scroll position.
+                        // This delay adds some flickering that we cancel by using 2 frames.
+
+                        var scrollTop = $(iframe.contentWindow).scrollTop();
+                        $(iframe2.contentWindow).scrollTop(scrollTop);
+                        iframe.style.visibility = 'hidden';
+                        iframe2.style.visibility = 'visible';
+
+                        iframe.contentWindow.document.open();
+                        iframe.contentWindow.document.write(data);
+                        iframe.contentWindow.document.close();
+
+                        setTimeout(function () {
+                            $(iframe.contentWindow).scrollTop(scrollTop);
+                            iframe2.style.visibility = 'hidden';
+                            iframe.style.visibility = 'visible';
+
+                            iframe2.contentWindow.document.open();
+                            iframe2.contentWindow.document.write(data);
+                            iframe2.contentWindow.document.close();
+                            previewRendering = false;
+                        }, 50);
                     }
                     $(serverErrorWarning).hide();
                 })
@@ -134,11 +154,11 @@
                     }
                 })
                 .always(function () {
-                    rendering = false;
+                    previewRendering = false;
                 });
         }
         catch (e) {
-            rendering = false;
+            previewRendering = false;
             console.log('Error while previewing: ' + e);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -9,7 +9,11 @@
 
 <resources type="Header" />
 
-<iframe id="iframe" style="position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">
+<iframe id="irenderingframe" style="visibility:hidden; position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">
+    Your browser doesn't support iframes
+</iframe>
+
+<iframe id="inoflickerframe" style="visibility:hidden; position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">
     Your browser doesn't support iframes
 </iframe>
 
@@ -39,7 +43,7 @@
             else if (ev.key == 'OrchardCore.templates') {
                 if (ev.originalEvent.newValue != null) {
                     clearTimeout(previewEventTimer);
-                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 250);
+                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 150);
                     $(notConnectedWarning).hide();
                 }
             }
@@ -62,16 +66,32 @@
         }
     });
 
-    var iframe = document.getElementById('iframe');
+    var irenderingframe = document.getElementById('irenderingframe');
+    var inoflickerframe = document.getElementById('inoflickerframe');
     var notConnectedWarning = document.getElementById('notConnectedWarning');
 
-    iframe.onload = function () {
+    irenderingframe.onload = function () {
+        var scrollTop = $(inoflickerframe.contentWindow).scrollTop();
+        $(irenderingframe.contentWindow).scrollTop(scrollTop);
+        irenderingframe.style.visibility = "visible";
+        inoflickerframe.style.visibility = "hidden";
+
         renderPreviewUrl = this.contentWindow.location;
-        $(iframe.contentWindow).scrollTop(scrollTop);
+        // the no flicker frame is loaded once to be fully initialized
+        if (inoflickerframe.contentWindow.location.href != renderPreviewUrl.href) {
+            inoflickerframe.contentWindow.location = renderPreviewUrl;
+        }
+        else {
+            Cookies.remove("orchard:templates");
+            inoflickerframe.contentWindow.document.head.innerHTML = this.contentWindow.document.head.innerHTML;
+            inoflickerframe.contentWindow.document.body.innerHTML = this.contentWindow.document.body.innerHTML;
+        }
+    }
+
+    inoflickerframe.onload = function () {
         Cookies.remove("orchard:templates");
     }
 
-    var scrollTop;
     var rendering;
 
     function renderPreview(value) {
@@ -95,8 +115,11 @@
                 .done(function () {
                     try {
                         Cookies.set("orchard:templates", true);
-                        iframe.contentWindow.location = renderPreviewUrl;
-                        scrollTop = $(iframe.contentWindow).scrollTop();
+                        irenderingframe.contentWindow.location = renderPreviewUrl;
+                        var scrollTop = $(irenderingframe.contentWindow).scrollTop();
+                        $(inoflickerframe.contentWindow).scrollTop(scrollTop);
+                        inoflickerframe.style.visibility = "visible";
+                        irenderingframe.style.visibility = "hidden";
                     }
                     catch (e) {
                         console.log('Error while previewing: ' + e);

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -38,7 +38,7 @@
             else if (ev.key == 'OrchardCore.templates') {
                 if (ev.originalEvent.newValue != null) {
                     clearTimeout(previewEventTimer);
-                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 300);
+                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 250);
                     $(notConnectedWarning).hide();
                 }
             }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -39,7 +39,7 @@
             else if (ev.key == 'OrchardCore.templates') {
                 if (ev.originalEvent.newValue != null) {
                     clearTimeout(previewEventTimer);
-                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 150);
+                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 250);
                     $(notConnectedWarning).hide();
                 }
             }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -38,13 +38,11 @@
     var contentPreviewUrl = $(document.getElementById('contentPreviewUrl')).data('value');
     var previewEventTimer = null;
     var previewRenderTimer = null;
-    var previewHeadRefresh = false;
 
     $(function () {
         $(window).on('storage', function (ev) {
             if (ev.key == 'OrchardCore.templates:not-connected') {
                 $(notConnectedWarning).show();
-                previewHeadRefresh = true;
             }
             else if (ev.key == 'OrchardCore.templates') {
                 if (ev.originalEvent.newValue != null) {
@@ -107,6 +105,7 @@
             if (alias == 'blank') {
                 alias = '/';
             }
+
             formData += '&' + $.param({ 'Alias': alias });
 
             scrollTop = $(iframe.contentWindow).scrollTop();
@@ -116,14 +115,8 @@
                     if (iframe && iframe.contentWindow) {
                         if (iframe.contentWindow.document.head.innerHTML == '') {
                             iframe.contentWindow.document.write(data);
-                            previewHeadRefresh = false;
                         }
                         else {
-                            if (previewHeadRefresh) {
-                                previewHeadRefresh = false;
-                                var head = data.substring(data.indexOf('<head>') + 6, data.indexOf('</head>'));
-                                iframe.contentWindow.document.head.innerHTML == head;
-                            }
                             var body = data.substring(data.indexOf('<body>') + 6, data.indexOf('</body>'));
                             iframe.contentWindow.document.body.innerHTML = body;
                         }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -3,12 +3,22 @@
     Title.AddSegment(T["Template Preview"]);
 }
 
-<script asp-name="jquery" at="Foot"></script>
+<style asp-name="bootstrap" use-cdn="true"></style>
+<script asp-name="bootstrap" use-cdn="true" at="Foot"></script>
 <script asp-src="/OrchardCore.Templates/js.cookie.js" depends-on="jquery" at="Foot"></script>
+
+<resources type="Header" />
 
 <iframe id="iframe" style="position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">
     Your browser doesn't support iframes
 </iframe>
+
+<div id="notConnectedWarning" class="alert alert-info alert-dismissible fade show collapse" role="alert" style="position:fixed; height:60px; top:10px;right:40px; display:none; z-index:999999;">
+    <button type="button" id="close-warning" class="close" aria-label="Close" style="position: relative; padding: 0 0 0 1rem; margin-top: -0.2rem;">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <span>@T["Preview Disconnected"] </span>
+</div>
 
 <resources type="Footer" />
 
@@ -17,20 +27,38 @@
 <script type="text/javascript">
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
 
-    $(function() {
+    $(function () {
         $(window).on('storage', function (ev) {
-            if (ev.key != "OrchardCore.templates") return;
-
-            renderPreview(ev.originalEvent.newValue)
+            if (ev.key == 'OrchardCore.templates:not-connected') {
+                $(notConnectedWarning).show();
+            }
+            else if (ev.key == 'OrchardCore.templates') {
+                if (ev.originalEvent.newValue != null) {
+                    $(notConnectedWarning).hide();
+                    renderPreview(ev.originalEvent.newValue);
+                }
+            }
         });
-        
-        // notify the editor to render the preview
-        localStorage.setItem('OrchardCore.templates:ready', '');
-        localStorage.removeItem('OrchardCore.templates:ready');        
-        renderPreview(localStorage.getItem('OrchardCore.templates'));
+
+        // override default behaviour of Bootstrap's. We only hide, not remove the alert.
+        $('#close-warning').on('click', function () {
+            $('#notConnectedWarning').hide();
+        });
+
+        var preview = localStorage.getItem('OrchardCore.templates');
+
+        if (preview == null) {
+            // notify the editor to render the preview
+            localStorage.setItem('OrchardCore.templates:ready', '');
+            localStorage.removeItem('OrchardCore.templates:ready');
+        }
+        else {
+            renderPreview(preview);
+        }
     });
 
     var iframe = document.getElementById('iframe');
+    var notConnectedWarning = document.getElementById('notConnectedWarning');
 
     iframe.onload = function () {
         renderPreviewUrl = this.contentWindow.location;

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -9,11 +9,7 @@
 
 <resources type="Header" />
 
-<iframe id="irenderingframe" style="visibility:hidden; position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">
-    Your browser doesn't support iframes
-</iframe>
-
-<iframe id="inoflickerframe" style="visibility:hidden; position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">
+<iframe id="iframe" style="position:fixed; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%; border:none; margin:0; padding:0; overflow:hidden; z-index:999999;">
     Your browser doesn't support iframes
 </iframe>
 
@@ -24,14 +20,22 @@
     <span>@T["Preview Disconnected"] </span>
 </div>
 
+<div id="serverErrorWarning" class="alert alert-warning alert-dismissible fade show" role="alert" style="position:fixed; top:10px;right:40px; display:none; z-index:999999;">
+    <button type="button" id="close-server-warning" class="close" aria-label="Close" style="position: relative; padding: 0 0 0 1rem; margin-top: -0.2rem;">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <p>@T["Preview Error"] </p>
+    <ul></ul>
+</div>
+
+<div id="renderPreviewUrl" style="display:none" data-value="@Url.Action("Render", "Preview" , new { area="OrchardCore.Templates" })"></div>
+<div id="contentPreviewUrl" style="display:none" data-value="@Url.Content("~/")"></div>
+
 <resources type="Footer" />
 
-<div id="setTemplateUrl" style="display:none" data-value="@Url.Action("SetTemplate", "Preview", new { area = "OrchardCore.Templates" })"></div>
-<div id="renderPreviewUrl" style="display:none" data-value="@Url.Content("~/")"></div>
-
 <script type="text/javascript">
-    var setTemplateUrl = $(document.getElementById('setTemplateUrl')).data('value');
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
+    var contentPreviewUrl = $(document.getElementById('contentPreviewUrl')).data('value');
     var previewEventTimer = null;
     var previewRenderTimer = null;
 
@@ -54,6 +58,10 @@
             $('#notConnectedWarning').hide();
         });
 
+        $('#close-server-warning').on('click', function () {
+            $('#serverErrorWarning').hide();
+        });
+
         var preview = localStorage.getItem('OrchardCore.templates');
 
         if (preview == null) {
@@ -66,33 +74,14 @@
         }
     });
 
-    var irenderingframe = document.getElementById('irenderingframe');
-    var inoflickerframe = document.getElementById('inoflickerframe');
-    var notConnectedWarning = document.getElementById('notConnectedWarning');
+    var iframe = document.getElementById('iframe');
 
-    irenderingframe.onload = function () {
-        var scrollTop = $(inoflickerframe.contentWindow).scrollTop();
-        $(irenderingframe.contentWindow).scrollTop(scrollTop);
-        irenderingframe.style.visibility = "visible";
-        inoflickerframe.style.visibility = "hidden";
-
-        renderPreviewUrl = this.contentWindow.location;
-        // the no flicker frame is loaded once to be fully initialized
-        if (inoflickerframe.contentWindow.location.href != renderPreviewUrl.href) {
-            inoflickerframe.contentWindow.location = renderPreviewUrl;
-        }
-        else {
-            Cookies.remove("orchard:templates");
-            inoflickerframe.contentWindow.document.head.innerHTML = this.contentWindow.document.head.innerHTML;
-            inoflickerframe.contentWindow.document.body.innerHTML = this.contentWindow.document.body.innerHTML;
-        }
-    }
-
-    inoflickerframe.onload = function () {
-        Cookies.remove("orchard:templates");
+    iframe.onload = function () {
+        contentPreviewUrl = this.contentWindow.location.pathname;
     }
 
     var rendering;
+    var scrollTop;
 
     function renderPreview(value) {
 
@@ -105,24 +94,42 @@
         clearTimeout(previewRenderTimer);
 
         try {
+
             var formData = JSON.parse(value);
             if (!formData) {
                 rendering = false;
                 return;
             }
 
-            $.post(setTemplateUrl, formData)
-                .done(function () {
-                    try {
-                        Cookies.set("orchard:templates", true);
-                        irenderingframe.contentWindow.location = renderPreviewUrl;
-                        var scrollTop = $(irenderingframe.contentWindow).scrollTop();
-                        $(inoflickerframe.contentWindow).scrollTop(scrollTop);
-                        inoflickerframe.style.visibility = "visible";
-                        irenderingframe.style.visibility = "hidden";
+            var alias = contentPreviewUrl || "";
+            if (alias == 'blank') {
+                alias = '/';
+            }
+            formData += '&' + $.param({ 'Alias': alias });
+
+            scrollTop = $(iframe.contentWindow).scrollTop();
+
+            $.post(renderPreviewUrl, formData)
+                .done(function (data) {
+                    if (iframe && iframe.contentWindow) {
+                        if (iframe.contentWindow.document.head.innerHTML == "") {
+                            iframe.contentWindow.document.write(data);
+                        }
+                        else {
+                            var body = data.substring(data.indexOf('<body>') + 6, data.indexOf('</body>'));
+                            iframe.contentWindow.document.body.innerHTML = body;
+                        }
+                        $(iframe.contentWindow).scrollTop(scrollTop);
                     }
-                    catch (e) {
-                        console.log('Error while previewing: ' + e);
+                    $(serverErrorWarning).hide();
+                })
+                .fail(function (data) {
+                    if (data.status) {
+                        var ul = $('#serverErrorWarning ul').empty();
+                        var error = 'Status code ' + data.status;
+                        console.error(error);
+                        $('<li/>').text(error).appendTo(ul);
+                        $(serverErrorWarning).show();
                     }
                 })
                 .always(function () {

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -29,6 +29,7 @@
     var setTemplateUrl = $(document.getElementById('setTemplateUrl')).data('value');
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
     var previewEventTimer = null;
+    var previewRenderTimer = null;
 
     $(function () {
         $(window).on('storage', function (ev) {
@@ -38,7 +39,7 @@
             else if (ev.key == 'OrchardCore.templates') {
                 if (ev.originalEvent.newValue != null) {
                     clearTimeout(previewEventTimer);
-                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 250);
+                    previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 150);
                     $(notConnectedWarning).hide();
                 }
             }
@@ -76,10 +77,12 @@
     function renderPreview(value) {
 
         if (rendering) {
-            return;
+            clearTimeout(previewRenderTimer);
+            previewRenderTimer = setTimeout(function () { renderPreview(value); }, 150);
         }
 
         rendering = true;
+        clearTimeout(previewRenderTimer);
 
         try {
             var formData = JSON.parse(value);
@@ -88,15 +91,14 @@
                 return;
             }
 
-            Cookies.set("orchard:templates", true);
             $.post(setTemplateUrl, formData)
                 .done(function () {
                     try {
+                        Cookies.set("orchard:templates", true);
                         iframe.contentWindow.location = renderPreviewUrl;
                         scrollTop = $(iframe.contentWindow).scrollTop();
                     }
                     catch (e) {
-                        rendering = false;
                         console.log('Error while previewing: ' + e);
                     }
                 })

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -32,12 +32,14 @@
     <ul></ul>
 </div>
 
+<div id="indexPreviewUrl" style="display:none" data-value="@Url.Action("Index", "Preview" , new { area="OrchardCore.Templates" })"></div>
 <div id="renderPreviewUrl" style="display:none" data-value="@Url.Action("Render", "Preview" , new { area="OrchardCore.Templates" })"></div>
 <div id="contentPreviewUrl" style="display:none" data-value="@Url.Content("~/")"></div>
 
 <resources type="Footer" />
 
 <script type="text/javascript">
+    var indexPreviewUrl = $(document.getElementById('indexPreviewUrl')).data('value');
     var renderPreviewUrl = $(document.getElementById('renderPreviewUrl')).data('value');
     var contentPreviewUrl = $(document.getElementById('contentPreviewUrl')).data('value');
     var iframe = document.getElementById('iframe');
@@ -52,6 +54,7 @@
             }
             else if (ev.key == 'OrchardCore.templates') {
                 if (ev.originalEvent.newValue != null) {
+                    // Smooth event cascading
                     clearTimeout(previewEventTimer);
                     previewEventTimer = setTimeout(function () { renderPreview(ev.originalEvent.newValue); }, 150);
                     $(notConnectedWarning).hide();
@@ -81,9 +84,11 @@
     });
 
     iframe.onload = function () {
-        if (!this.contentWindow.location.pathname.endsWith("Preview/Index")) {
+        if (this.contentWindow && this.contentWindow.location.pathname != indexPreviewUrl) {
             contentPreviewUrl = this.contentWindow.location.pathname;
-            iframe2.contentWindow.location = this.contentWindow.location;
+            if (iframe2 && iframe2.contentWindow) {
+                iframe2.contentWindow.location = this.contentWindow.location;
+            }
         }
     }
 
@@ -92,8 +97,9 @@
     function renderPreview(value) {
 
         if (previewRendering) {
+            // Defer the last rendering
             clearTimeout(previewRenderTimer);
-            previewRenderTimer = setTimeout(function () { renderPreview(value); }, 150);
+            previewRenderTimer = setTimeout(function () { renderPreview(value); }, 100);
         }
 
         previewRendering = true;
@@ -106,39 +112,22 @@
                 previewRendering = false;
                 return;
             }
-
-            var alias = contentPreviewUrl || "";
-            if (alias == 'blank') {
-                alias = '/';
-            }
-
-            formData += '&' + $.param({ 'Alias': alias });
+            formData += '&' + $.param({ 'Alias': contentPreviewUrl || "" });
 
             $.post(renderPreviewUrl, formData)
                 .done(function (data) {
                     if (iframe && iframe.contentWindow && iframe2 && iframe2.contentWindow) {
 
-                        // Under 'Chrome' (not 'Firefox') writing correctly the full frame
-                        // implies that we need a delay before updating the scroll position.
-                        // This delay adds some flickering that we cancel by using 2 frames.
+                        // Under 'Chrome', after having written the frame, we need to use a delay before updating
+                        // the scroll position. Then, we use 2 frames to cancel the flicker that the delay causes.
 
                         var scrollTop = $(iframe.contentWindow).scrollTop();
-                        $(iframe2.contentWindow).scrollTop(scrollTop);
-                        iframe.style.visibility = 'hidden';
-                        iframe2.style.visibility = 'visible';
-
-                        iframe.contentWindow.document.open();
-                        iframe.contentWindow.document.write(data);
-                        iframe.contentWindow.document.close();
+                        ScrollAndShowFrame(iframe2, scrollTop);
+                        HideAndUpdateFrame(iframe, data);
 
                         setTimeout(function () {
-                            $(iframe.contentWindow).scrollTop(scrollTop);
-                            iframe2.style.visibility = 'hidden';
-                            iframe.style.visibility = 'visible';
-
-                            iframe2.contentWindow.document.open();
-                            iframe2.contentWindow.document.write(data);
-                            iframe2.contentWindow.document.close();
+                            ScrollAndShowFrame(iframe, scrollTop);
+                            HideAndUpdateFrame(iframe2, data);
                             previewRendering = false;
                         }, 50);
                     }
@@ -152,8 +141,6 @@
                         $('<li/>').text(error).appendTo(ul);
                         $(serverErrorWarning).show();
                     }
-                })
-                .always(function () {
                     previewRendering = false;
                 });
         }
@@ -161,6 +148,18 @@
             previewRendering = false;
             console.log('Error while previewing: ' + e);
         }
+    }
+
+    function HideAndUpdateFrame(frame, data) {
+        frame.style.visibility = 'hidden';
+        frame.contentWindow.document.open();
+        frame.contentWindow.document.write(data);
+        frame.contentWindow.document.close();
+    }
+
+    function ScrollAndShowFrame(frame, scrollTop) {
+        $(frame.contentWindow).scrollTop(scrollTop);
+        frame.style.visibility = 'visible';
     }
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Render.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Render.cshtml
@@ -1,0 +1,1 @@
+@await DisplayAsync(Model)


### PR DESCRIPTION
First, because i saw that items in the local storage was growing up, i did the following.

1. When we set an item in the local storage just to trigger an event, we remove it just after.

- **Note**: Before clicking the preview button, preview data may have been already set in the local storage, this if a component has already sent a `contentpreview:render` event.

2. So, the preview window sends a `:ready` event only if preview data are not already set. Otherwise we just render them. Here, we need to render them in place of just sending a `:ready` event, this because the editor window might set again exactly the same data, so no event is sent.

3. Preview data are removed from the local storage when the related editor window is unloaded. Because of this new event, in the preview window we check if preview data are not null before rendering them.

**This way the local storage is kept clean**.

- **Warning**: To be able to re-connect a preview window, in `Preview/Index.cshtml` we removed the `previewId` term when checking the event key. I'm not against because it's cool to allow re-connection, but this means that we can't use multiple preview windows related to different editors at the same time. So, i didn't re-introduce the `previewId` term but **let me know if it is ok or needs to be changed**.

4. Finally, the `Preview Disconnected` warning is also implemented when previewing `Templates`.




