### PR TITLE
Adds support for scoped method providers

### DIFF
--- a/src/OrchardCore/OrchardCore.Scripting.Abstractions/IScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.Abstractions/IScriptingManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace OrchardCore.Scripting
 {
@@ -16,11 +16,12 @@ namespace OrchardCore.Scripting
         IScriptingEngine GetScriptingEngine(string prefix);
 
         /// <summary>
-        /// Executes some prefixed script by looking for a mathcing scripting engine.
+        /// Executes some prefixed script by looking for a matching scripting engine.
         /// </summary>
         /// <param name="directive">The directive to execute. A directive is made of a </param>
+        /// <param name="scopedMethodProviders">A list of method providers scoped to the script evaluation.</param>
         /// <returns>The result of the script if any.</returns>
-        object Evaluate(string directive);
+        object Evaluate(string directive, IEnumerable<IGlobalMethodProvider> scopedMethodProviders = null);
 
         /// <summary>
         /// The list of available method providers for this <see cref="IScriptingManager"/>

--- a/src/OrchardCore/OrchardCore.Scripting.Core/DefaultScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.Core/DefaultScriptingManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -10,7 +10,7 @@ namespace OrchardCore.Scripting
         private readonly IServiceProvider _serviceProvider;
 
         public DefaultScriptingManager(
-            IEnumerable<IScriptingEngine> engines, 
+            IEnumerable<IScriptingEngine> engines,
             IEnumerable<IGlobalMethodProvider> globalMethodProviders,
             IServiceProvider serviceProvider)
         {
@@ -21,7 +21,7 @@ namespace OrchardCore.Scripting
 
         public IList<IGlobalMethodProvider> GlobalMethodProviders { get; }
 
-        public object Evaluate(string directive)
+        public object Evaluate(string directive, IEnumerable<IGlobalMethodProvider> scopedMethodProviders = null)
         {
             var directiveIndex = directive.IndexOf(":");
 
@@ -31,7 +31,7 @@ namespace OrchardCore.Scripting
             }
 
             var prefix = directive.Substring(0, directiveIndex);
-            var script = directive.Substring(directiveIndex+1);
+            var script = directive.Substring(directiveIndex + 1);
 
             var engine = GetScriptingEngine(prefix);
             if (engine == null)
@@ -39,13 +39,14 @@ namespace OrchardCore.Scripting
                 return directive;
             }
 
-            var scope = engine.CreateScope(GlobalMethodProviders.SelectMany(x => x.GetMethods()), _serviceProvider);
+            var methodProviders = scopedMethodProviders != null ? GlobalMethodProviders.Concat(scopedMethodProviders) : GlobalMethodProviders;
+            var scope = engine.CreateScope(methodProviders.SelectMany(x => x.GetMethods()), _serviceProvider);
             return engine.Evaluate(scope, script);
         }
 
         public IScriptingEngine GetScriptingEngine(string prefix)
         {
-            return _engines.FirstOrDefault(x => x.Prefix == prefix);    
+            return _engines.FirstOrDefault(x => x.Prefix == prefix);
         }
     }
 }


### PR DESCRIPTION
This PR updates `IScriptingManager` to add support for scoped method providers, where the consumer can provide a list of method providers that should be scoped to the created `IScriptingScope`.

Fixes #1335 