### PR TITLE
Decouple the OpenID module from YesSql and introduce OrchardCore.OpenId.EntityFrameworkCore

### DIFF
--- a/OrchardCore.sln
+++ b/OrchardCore.sln
@@ -290,6 +290,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.Media.Azure", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.Https", "src\OrchardCore.Modules\OrchardCore.Https\OrchardCore.Https.csproj", "{5C795749-3907-4F12-A1EF-A7C4AFA0B92F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrchardCore.OpenId.EntityFrameworkCore", "src\OrchardCore.Modules\OrchardCore.OpenId.EntityFrameworkCore\OrchardCore.OpenId.EntityFrameworkCore.csproj", "{12C4BD5B-207C-4A90-9F9F-E41EABBCD157}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -816,6 +818,10 @@ Global
 		{5C795749-3907-4F12-A1EF-A7C4AFA0B92F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C795749-3907-4F12-A1EF-A7C4AFA0B92F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C795749-3907-4F12-A1EF-A7C4AFA0B92F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12C4BD5B-207C-4A90-9F9F-E41EABBCD157}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12C4BD5B-207C-4A90-9F9F-E41EABBCD157}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12C4BD5B-207C-4A90-9F9F-E41EABBCD157}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12C4BD5B-207C-4A90-9F9F-E41EABBCD157}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -963,6 +969,7 @@ Global
 		{F614EC10-090B-4334-8E53-0BCA997E73F0} = {F23AC6C2-DE44-4699-999D-3C478EF3D691}
 		{7BB7DDE2-5C66-4E0B-81A8-C0CBE6D3B4A2} = {90030E85-0C4F-456F-B879-443E8A3F220D}
 		{5C795749-3907-4F12-A1EF-A7C4AFA0B92F} = {A066395F-6F73-45DC-B5A6-B4E306110DCE}
+		{12C4BD5B-207C-4A90-9F9F-E41EABBCD157} = {A066395F-6F73-45DC-B5A6-B4E306110DCE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {46A1D25A-78D1-4476-9CBF-25B75E296341}

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -15,7 +15,7 @@
     <YesSqlVersion>2.0.0-beta-1111</YesSqlVersion>
     <YesSqlProvidersVersion>1.0.0-beta-1111</YesSqlProvidersVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
-    <OpenIddictVersion>2.0.0-rc2-0785</OpenIddictVersion>
+    <OpenIddictVersion>2.0.0-rc2-0789</OpenIddictVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -15,7 +15,7 @@
     <YesSqlVersion>2.0.0-beta-1111</YesSqlVersion>
     <YesSqlProvidersVersion>1.0.0-beta-1111</YesSqlProvidersVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
-    <OpenIddictVersion>2.0.0-rc2-0783</OpenIddictVersion>
+    <OpenIddictVersion>2.0.0-rc2-0785</OpenIddictVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdApplication.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdApplication.cs
@@ -4,7 +4,12 @@ using OrchardCore.OpenId.Abstractions.Models;
 
 namespace OrchardCore.OpenId.EntityFrameworkCore.Models
 {
-    public class OpenIdApplication<TKey> : OpenIddictApplication<TKey, OpenIdAuthorization<TKey>, OpenIdToken<TKey>>, IOpenIdApplication
+    public class OpenIdApplication<TKey> : OpenIdApplication<TKey, OpenIdAuthorization<TKey>, OpenIdToken<TKey>>
+        where TKey : IEquatable<TKey>
+    {
+    }
+
+    public class OpenIdApplication<TKey, TAuthorization, TToken> : OpenIddictApplication<TKey, TAuthorization, TToken>, IOpenIdApplication
         where TKey : IEquatable<TKey>
     {
         /// <summary>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdApplication.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdApplication.cs
@@ -1,0 +1,23 @@
+using System;
+using OpenIddict.Models;
+using OrchardCore.OpenId.Abstractions.Models;
+
+namespace OrchardCore.OpenId.EntityFrameworkCore.Models
+{
+    public class OpenIdApplication<TKey> : OpenIddictApplication<TKey, OpenIdAuthorization<TKey>, OpenIdToken<TKey>>, IOpenIdApplication
+        where TKey : IEquatable<TKey>
+    {
+        /// <summary>
+        /// Gets or sets if a consent form has to be fulfilled by 
+        /// the user after log in.
+        /// </summary>
+        public bool SkipConsent { get; set; }
+
+        public bool AllowPasswordFlow { get; set; }
+        public bool AllowClientCredentialsFlow { get; set; }
+        public bool AllowAuthorizationCodeFlow { get; set; }
+        public bool AllowRefreshTokenFlow { get; set; }
+        public bool AllowImplicitFlow { get; set; }
+        public bool AllowHybridFlow { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdAuthorization.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdAuthorization.cs
@@ -1,0 +1,11 @@
+using System;
+using OpenIddict.Models;
+using OrchardCore.OpenId.Abstractions.Models;
+
+namespace OrchardCore.OpenId.EntityFrameworkCore.Models
+{
+    public class OpenIdAuthorization<TKey> : OpenIddictAuthorization<TKey, OpenIdApplication<TKey>, OpenIdToken<TKey>>, IOpenIdAuthorization
+        where TKey : IEquatable<TKey>
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdAuthorization.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdAuthorization.cs
@@ -4,7 +4,12 @@ using OrchardCore.OpenId.Abstractions.Models;
 
 namespace OrchardCore.OpenId.EntityFrameworkCore.Models
 {
-    public class OpenIdAuthorization<TKey> : OpenIddictAuthorization<TKey, OpenIdApplication<TKey>, OpenIdToken<TKey>>, IOpenIdAuthorization
+    public class OpenIdAuthorization<TKey> : OpenIdAuthorization<TKey, OpenIdApplication<TKey>, OpenIdToken<TKey>>
+        where TKey : IEquatable<TKey>
+    {
+    }
+
+    public class OpenIdAuthorization<TKey, TApplication, TToken> : OpenIddictAuthorization<TKey, TApplication, TToken>, IOpenIdAuthorization
         where TKey : IEquatable<TKey>
     {
     }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdScope.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdScope.cs
@@ -1,0 +1,11 @@
+using System;
+using OpenIddict.Models;
+using OrchardCore.OpenId.Abstractions.Models;
+
+namespace OrchardCore.OpenId.EntityFrameworkCore.Models
+{
+    public class OpenIdScope<TKey> : OpenIddictScope<TKey>, IOpenIdScope
+        where TKey : IEquatable<TKey>
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdToken.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdToken.cs
@@ -1,0 +1,14 @@
+using System;
+using OpenIddict.Models;
+using OrchardCore.OpenId.Abstractions.Models;
+
+namespace OrchardCore.OpenId.EntityFrameworkCore.Models
+{
+    /// <summary>
+    /// Represents an OpenId token.
+    /// </summary>
+    public class OpenIdToken<TKey> : OpenIddictToken<TKey, OpenIdApplication<TKey>, OpenIdAuthorization<TKey>>, IOpenIdToken
+        where TKey : IEquatable<TKey>
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdToken.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdToken.cs
@@ -4,10 +4,12 @@ using OrchardCore.OpenId.Abstractions.Models;
 
 namespace OrchardCore.OpenId.EntityFrameworkCore.Models
 {
-    /// <summary>
-    /// Represents an OpenId token.
-    /// </summary>
-    public class OpenIdToken<TKey> : OpenIddictToken<TKey, OpenIdApplication<TKey>, OpenIdAuthorization<TKey>>, IOpenIdToken
+    public class OpenIdToken<TKey> : OpenIdToken<TKey, OpenIdApplication<TKey>, OpenIdAuthorization<TKey>>
+        where TKey : IEquatable<TKey>
+    {
+    }
+
+    public class OpenIdToken<TKey, TApplication, TAuthorization> : OpenIddictToken<TKey, TApplication, TAuthorization>, IOpenIdToken
         where TKey : IEquatable<TKey>
     {
     }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Module.txt
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Module.txt
@@ -1,0 +1,10 @@
+Name: OpenID (Entity Framework Core stores)
+AntiForgery: enabled
+Author: The Orchard Team
+Website: http://orchardproject.net
+Version: 2.0.x
+OrchardVersion: 2.0.x
+Description: This package provides an Entity Framework Core 2.x adapter for the OpenID module.
+FeatureDescription: Additional stores for the OpenID module.
+Dependencies: OrchardCore.OpenId
+Category: Security

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/OrchardCore.OpenId.EntityFrameworkCore.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/OrchardCore.OpenId.EntityFrameworkCore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OrchardCore.OpenId\OrchardCore.OpenId.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="$(OpenIddictVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdApplicationStore.cs
@@ -23,332 +23,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         }
 
         /// <summary>
-        /// Determines the number of applications that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of applications in the database.
-        /// </returns>
-        Task<long> IOpenIddictApplicationStore<IOpenIdApplication>.CountAsync(CancellationToken cancellationToken)
-            => CountAsync(cancellationToken);
-
-        /// <summary>
-        /// Determines the number of applications that match the specified query.
-        /// </summary>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of applications that match the specified query.
-        /// </returns>
-        Task<long> IOpenIddictApplicationStore<IOpenIdApplication>.CountAsync<TResult>(Func<IQueryable<IOpenIdApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
-            => CountAsync(query, cancellationToken);
-
-        /// <summary>
-        /// Creates a new application.
-        /// </summary>
-        /// <param name="application">The application to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the application.
-        /// </returns>
-        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.CreateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => await CreateAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Removes an existing application.
-        /// </summary>
-        /// <param name="application">The application to delete.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictApplicationStore<IOpenIdApplication>.DeleteAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => DeleteAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Retrieves an application using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client application corresponding to the identifier.
-        /// </returns>
-        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
-            => await FindByIdAsync(identifier, cancellationToken);
-
-        /// <summary>
-        /// Retrieves an application using its client identifier.
-        /// </summary>
-        /// <param name="identifier">The client identifier associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client application corresponding to the identifier.
-        /// </returns>
-        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
-            => await FindByClientIdAsync(identifier, cancellationToken);
-
-        /// <summary>
-        /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
-        /// </summary>
-        /// <param name="address">The post_logout_redirect_uri associated with the applications.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the client applications corresponding to the specified post_logout_redirect_uri.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.FindByPostLogoutRedirectUriAsync(string address, CancellationToken cancellationToken)
-            => (await FindByPostLogoutRedirectUriAsync(address, cancellationToken)).CastArray<IOpenIdApplication>();
-
-        /// <summary>
-        /// Retrieves all the applications associated with the specified redirect_uri.
-        /// </summary>
-        /// <param name="address">The redirect_uri associated with the applications.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the client applications corresponding to the specified redirect_uri.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.FindByRedirectUriAsync(string address, CancellationToken cancellationToken)
-            => (await FindByRedirectUriAsync(address, cancellationToken)).CastArray<IOpenIdApplication>();
-
-        /// <summary>
-        /// Executes the specified query and returns the first element.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the first element returned when executing the query.
-        /// </returns>
-        Task<TResult> IOpenIddictApplicationStore<IOpenIdApplication>.GetAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
-            TState state, CancellationToken cancellationToken)
-            => GetAsync(query, state, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the client identifier associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client identifier associated with the application.
-        /// </returns>
-        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => GetClientIdAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the client secret associated with an application.
-        /// Note: depending on the manager used to create the application,
-        /// the client secret may be hashed for security reasons.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client secret associated with the application.
-        /// </returns>
-        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientSecretAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => GetClientSecretAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the client type associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client type of the application (by default, "public").
-        /// </returns>
-        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientTypeAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => GetClientTypeAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the display name associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the display name associated with the application.
-        /// </returns>
-        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetDisplayNameAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => GetDisplayNameAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the unique identifier associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the unique identifier associated with the application.
-        /// </returns>
-        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => GetIdAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the logout callback addresses associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
-        /// result returns all the post_logout_redirect_uri associated with the application.
-        /// </returns>
-        Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetPostLogoutRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => GetPostLogoutRedirectUrisAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the callback addresses associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the redirect_uri associated with the application.
-        /// </returns>
-        Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => GetRedirectUrisAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
-        /// Instantiates a new application.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the instantiated application, that can be persisted in the database.
-        /// </returns>
-        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.InstantiateAsync(CancellationToken cancellationToken)
-            => await InstantiateAsync(cancellationToken);
-
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
-            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdApplication>();
-
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        Task<ImmutableArray<TResult>> IOpenIddictApplicationStore<IOpenIdApplication>.ListAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
-            TState state, CancellationToken cancellationToken)
-            => ListAsync(query, state, cancellationToken);
-
-        /// <summary>
-        /// Sets the client identifier associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="identifier">The client identifier associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientIdAsync(IOpenIdApplication application,
-            string identifier, CancellationToken cancellationToken)
-            => SetClientIdAsync((OpenIdApplication<TKey>) application, identifier, cancellationToken);
-
-        /// <summary>
-        /// Sets the client secret associated with an application.
-        /// Note: depending on the manager used to create the application,
-        /// the client secret may be hashed for security reasons.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="secret">The client secret associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientSecretAsync(IOpenIdApplication application, string secret, CancellationToken cancellationToken)
-            => SetClientSecretAsync((OpenIdApplication<TKey>) application, secret, cancellationToken);
-
-        /// <summary>
-        /// Sets the client type associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="type">The client type associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientTypeAsync(IOpenIdApplication application, string type, CancellationToken cancellationToken)
-            => SetClientTypeAsync((OpenIdApplication<TKey>) application, type, cancellationToken);
-
-        /// <summary>
-        /// Sets the display name associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="name">The display name associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetDisplayNameAsync(IOpenIdApplication application, string name, CancellationToken cancellationToken)
-            => SetDisplayNameAsync((OpenIdApplication<TKey>) application, name, cancellationToken);
-
-        /// <summary>
-        /// Sets the logout callback addresses associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="addresses">The logout callback addresses associated with the application </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetPostLogoutRedirectUrisAsync(IOpenIdApplication application,
-            ImmutableArray<string> addresses, CancellationToken cancellationToken)
-            => SetPostLogoutRedirectUrisAsync((OpenIdApplication<TKey>) application, addresses, cancellationToken);
-
-        /// <summary>
-        /// Sets the callback addresses associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="addresses">The callback addresses associated with the application </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetRedirectUrisAsync(IOpenIdApplication application,
-            ImmutableArray<string> addresses, CancellationToken cancellationToken)
-            => SetRedirectUrisAsync((OpenIdApplication<TKey>) application, addresses, cancellationToken);
-
-        /// <summary>
-        /// Updates an existing application.
-        /// </summary>
-        /// <param name="application">The application to update.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictApplicationStore<IOpenIdApplication>.UpdateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => UpdateAsync((OpenIdApplication<TKey>) application, cancellationToken);
-
-        /// <summary>
         /// Retrieves an application using its physical identifier.
         /// </summary>
         /// <param name="identifier">The unique identifier associated with the application.</param>
@@ -357,11 +31,11 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdApplication<TKey>> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base FindByIdAsync() method is called.
-            => await FindByIdAsync(identifier, cancellationToken);
+            => FindByIdAsync(identifier, cancellationToken);
 
         /// <summary>
         /// Retrieves the physical identifier associated with an application.
@@ -372,14 +46,14 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the application.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(OpenIdApplication<TKey> application, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base GetIdAsync() method is called.
-            => GetIdAsync((OpenIdApplication<TKey>) application, cancellationToken);
+            => GetIdAsync(application, cancellationToken);
 
         // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
-        public virtual Task<ImmutableArray<string>> GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<string>> GetGrantTypesAsync(OpenIdApplication<TKey> application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -388,28 +62,27 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
 
             var builder = ImmutableArray.CreateBuilder<string>();
 
-            var entity = (OpenIdApplication<TKey>) application;
-            if (entity.AllowAuthorizationCodeFlow)
+            if (application.AllowAuthorizationCodeFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
             }
 
-            if (entity.AllowClientCredentialsFlow)
+            if (application.AllowClientCredentialsFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.ClientCredentials);
             }
 
-            if (entity.AllowImplicitFlow)
+            if (application.AllowImplicitFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.Implicit);
             }
 
-            if (entity.AllowPasswordFlow)
+            if (application.AllowPasswordFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.Password);
             }
 
-            if (entity.AllowRefreshTokenFlow)
+            if (application.AllowRefreshTokenFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.RefreshToken);
             }
@@ -417,54 +90,176 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             return Task.FromResult(builder.ToImmutable());
         }
 
-        public virtual Task SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken)
+        public virtual Task SetGrantTypesAsync(OpenIdApplication<TKey> application, ImmutableArray<string> types, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            var entity = (OpenIdApplication<TKey>) application;
-
-            entity.AllowAuthorizationCodeFlow = types.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
-            entity.AllowClientCredentialsFlow = types.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials);
-            entity.AllowImplicitFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Implicit);
-            entity.AllowPasswordFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Password);
-            entity.AllowRefreshTokenFlow = types.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken);
+            application.AllowAuthorizationCodeFlow = types.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+            application.AllowClientCredentialsFlow = types.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials);
+            application.AllowImplicitFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Implicit);
+            application.AllowPasswordFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Password);
+            application.AllowRefreshTokenFlow = types.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken);
 
             return Task.CompletedTask;
         }
 
-        public virtual Task<bool> IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<bool> IsConsentRequiredAsync(OpenIdApplication<TKey> application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(!((OpenIdApplication<TKey>) application).SkipConsent);
+            return Task.FromResult(!application.SkipConsent);
         }
 
-        public virtual Task SetConsentRequiredAsync(IOpenIdApplication application, bool value, CancellationToken cancellationToken)
+        public virtual Task SetConsentRequiredAsync(OpenIdApplication<TKey> application, bool value, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            ((OpenIdApplication<TKey>) application).SkipConsent = !value;
+            application.SkipConsent = !value;
 
             return Task.CompletedTask;
         }
 
         // TODO: implement these methods.
-        public virtual Task<ImmutableArray<string>> GetRolesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<string>> GetRolesAsync(OpenIdApplication<TKey> application, CancellationToken cancellationToken)
             => Task.FromResult(ImmutableArray.Create<string>());
 
-        public virtual Task<ImmutableArray<IOpenIdApplication>> ListInRoleAsync(string role, CancellationToken cancellationToken)
-            => Task.FromResult(ImmutableArray.Create<IOpenIdApplication>());
+        public virtual Task<ImmutableArray<OpenIdApplication<TKey>>> ListInRoleAsync(string role, CancellationToken cancellationToken)
+            => Task.FromResult(ImmutableArray.Create<OpenIdApplication<TKey>>());
 
-        public virtual Task SetRolesAsync(IOpenIdApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
+        public virtual Task SetRolesAsync(OpenIdApplication<TKey> application, ImmutableArray<string> roles, CancellationToken cancellationToken)
             => Task.CompletedTask;
+
+        // Note: the following methods are deliberately implemented as explicit methods so they are not
+        // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
+        // Developers who need to customize the logic SHOULD override the methods taking concretes types.
+
+        // -------------------------------------------------------------
+        // Methods defined by the IOpenIddictApplicationStore interface:
+        // -------------------------------------------------------------
+
+        Task<long> IOpenIddictApplicationStore<IOpenIdApplication>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        Task<long> IOpenIddictApplicationStore<IOpenIdApplication>.CountAsync<TResult>(Func<IQueryable<IOpenIdApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.CreateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.DeleteAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByClientIdAsync(identifier, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.FindByPostLogoutRedirectUriAsync(string address, CancellationToken cancellationToken)
+            => (await FindByPostLogoutRedirectUriAsync(address, cancellationToken)).CastArray<IOpenIdApplication>();
+
+        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.FindByRedirectUriAsync(string address, CancellationToken cancellationToken)
+            => (await FindByRedirectUriAsync(address, cancellationToken)).CastArray<IOpenIdApplication>();
+
+        Task<TResult> IOpenIddictApplicationStore<IOpenIdApplication>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetClientIdAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientSecretAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetClientSecretAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientTypeAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetClientTypeAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetDisplayNameAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetDisplayNameAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetIdAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetPostLogoutRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetPostLogoutRedirectUrisAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetRedirectUrisAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdApplication>();
+
+        Task<ImmutableArray<TResult>> IOpenIddictApplicationStore<IOpenIdApplication>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientIdAsync(IOpenIdApplication application,
+            string identifier, CancellationToken cancellationToken)
+            => SetClientIdAsync((OpenIdApplication<TKey>) application, identifier, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientSecretAsync(IOpenIdApplication application, string secret, CancellationToken cancellationToken)
+            => SetClientSecretAsync((OpenIdApplication<TKey>) application, secret, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientTypeAsync(IOpenIdApplication application, string type, CancellationToken cancellationToken)
+            => SetClientTypeAsync((OpenIdApplication<TKey>) application, type, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetDisplayNameAsync(IOpenIdApplication application, string name, CancellationToken cancellationToken)
+            => SetDisplayNameAsync((OpenIdApplication<TKey>) application, name, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetPostLogoutRedirectUrisAsync(IOpenIdApplication application,
+            ImmutableArray<string> addresses, CancellationToken cancellationToken)
+            => SetPostLogoutRedirectUrisAsync((OpenIdApplication<TKey>) application, addresses, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetRedirectUrisAsync(IOpenIdApplication application,
+            ImmutableArray<string> addresses, CancellationToken cancellationToken)
+            => SetRedirectUrisAsync((OpenIdApplication<TKey>) application, addresses, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.UpdateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        // ---------------------------------------------------------
+        // Methods defined by the IOpenIdApplicationStore interface:
+        // ---------------------------------------------------------
+
+        async Task<IOpenIdApplication> IOpenIdApplicationStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByPhysicalIdAsync(identifier, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIdApplicationStore.GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetGrantTypesAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<string> IOpenIdApplicationStore.GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetPhysicalIdAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIdApplicationStore.GetRolesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetRolesAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        Task<bool> IOpenIdApplicationStore.IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => IsConsentRequiredAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdApplication>> IOpenIdApplicationStore.ListInRoleAsync(string role, CancellationToken cancellationToken)
+            => (await ListInRoleAsync(role, cancellationToken)).CastArray<IOpenIdApplication>();
+
+        Task IOpenIdApplicationStore.SetConsentRequiredAsync(IOpenIdApplication application, bool value, CancellationToken cancellationToken)
+            => SetConsentRequiredAsync((OpenIdApplication<TKey>) application, value, cancellationToken);
+
+        Task IOpenIdApplicationStore.SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken)
+            => SetGrantTypesAsync((OpenIdApplication<TKey>) application, types, cancellationToken);
+
+        Task IOpenIdApplicationStore.SetRolesAsync(IOpenIdApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
+            => SetRolesAsync((OpenIdApplication<TKey>) application, roles, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdApplicationStore.cs
@@ -348,6 +348,36 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         Task IOpenIddictApplicationStore<IOpenIdApplication>.UpdateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
             => UpdateAsync((OpenIdApplication<TKey>) application, cancellationToken);
 
+        /// <summary>
+        /// Retrieves an application using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base FindByIdAsync() method is called.
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the application.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base GetIdAsync() method is called.
+            => GetIdAsync((OpenIdApplication<TKey>) application, cancellationToken);
+
         // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
         public virtual Task<ImmutableArray<string>> GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
         {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
@@ -315,5 +315,35 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// </returns>
         Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.UpdateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
             => UpdateAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Retrieves an authorization using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The physical identifier associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorization corresponding to the identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base FindByIdAsync() method is called.
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the authorization.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base GetIdAsync() method is called.
+            => GetIdAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using OpenIddict.Core;
 using OpenIddict.EntityFrameworkCore;
-using OrchardCore.OpenId.Abstractions;
 using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Abstractions.Stores;
 using OrchardCore.OpenId.EntityFrameworkCore.Models;
@@ -25,298 +24,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         }
 
         /// <summary>
-        /// Determines the number of authorizations that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of authorizations in the database.
-        /// </returns>
-        Task<long> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CountAsync(CancellationToken cancellationToken)
-            => CountAsync(cancellationToken);
-
-        /// <summary>
-        /// Determines the number of authorizations that match the specified query.
-        /// </summary>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of authorizations that match the specified query.
-        /// </returns>
-        Task<long> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CountAsync<TResult>(Func<IQueryable<IOpenIdAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
-            => CountAsync(query, cancellationToken);
-
-        /// <summary>
-        /// Creates a new authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the authorization.
-        /// </returns>
-        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CreateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => await CreateAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
-        /// Removes an existing authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization to delete.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.DeleteAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => DeleteAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the authorizations corresponding to the specified
-        /// subject and associated with the application identifier.
-        /// </summary>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="client">The client associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorizations corresponding to the subject/client.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindAsync(string subject, string client, CancellationToken cancellationToken)
-            => (await FindAsync(subject, client, cancellationToken)).CastArray<IOpenIdAuthorization>();
-
-        /// <summary>
-        /// Retrieves an authorization using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorization corresponding to the identifier.
-        /// </returns>
-        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
-            => await FindByIdAsync(identifier, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the optional application identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the application identifier associated with the authorization.
-        /// </returns>
-        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetApplicationIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => GetApplicationIdAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
-        /// Executes the specified query and returns the first element.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the first element returned when executing the query.
-        /// </returns>
-        Task<TResult> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
-            TState state, CancellationToken cancellationToken)
-            => GetAsync(query, state, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the unique identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the unique identifier associated with the authorization.
-        /// </returns>
-        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => GetIdAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the scopes associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the scopes associated with the specified authorization.
-        /// </returns>
-        Task<ImmutableArray<string>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetScopesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => GetScopesAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the status associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the status associated with the specified authorization.
-        /// </returns>
-        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetStatusAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => GetStatusAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the subject associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the subject associated with the specified authorization.
-        /// </returns>
-        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetSubjectAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => GetSubjectAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the type associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the type associated with the specified authorization.
-        /// </returns>
-        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetTypeAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => GetTypeAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
-        /// Instantiates a new authorization.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the instantiated authorization, that can be persisted in the database.
-        /// </returns>
-        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.InstantiateAsync(CancellationToken cancellationToken)
-            => await InstantiateAsync(cancellationToken);
-
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
-            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdAuthorization>();
-
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        Task<ImmutableArray<TResult>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
-            TState state, CancellationToken cancellationToken)
-            => ListAsync(query, state, cancellationToken);
-
-        /// <summary>
-        /// Lists the ad-hoc authorizations that are marked as invalid or have no
-        /// valid token attached and that can be safely removed from the database.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
-            => (await ListInvalidAsync(count, offset, cancellationToken)).CastArray<IOpenIdAuthorization>();
-
-        /// <summary>
-        /// Sets the application identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="identifier">The unique identifier associated with the client application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetApplicationIdAsync(IOpenIdAuthorization authorization,
-            string identifier, CancellationToken cancellationToken)
-            => SetApplicationIdAsync((OpenIdAuthorization<TKey>) authorization, identifier, cancellationToken);
-
-        /// <summary>
-        /// Sets the scopes associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="scopes">The scopes associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetScopesAsync(IOpenIdAuthorization authorization,
-            ImmutableArray<string> scopes, CancellationToken cancellationToken)
-            => SetScopesAsync((OpenIdAuthorization<TKey>) authorization, scopes, cancellationToken);
-
-        /// <summary>
-        /// Sets the status associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="status">The status associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetStatusAsync(IOpenIdAuthorization authorization,
-            string status, CancellationToken cancellationToken)
-            => SetStatusAsync((OpenIdAuthorization<TKey>) authorization, status, cancellationToken);
-
-        /// <summary>
-        /// Sets the subject associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetSubjectAsync(IOpenIdAuthorization authorization,
-            string subject, CancellationToken cancellationToken)
-            => SetSubjectAsync((OpenIdAuthorization<TKey>) authorization, subject, cancellationToken);
-
-        /// <summary>
-        /// Sets the type associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="type">The type associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetTypeAsync(IOpenIdAuthorization authorization,
-            string type, CancellationToken cancellationToken)
-            => SetTypeAsync((OpenIdAuthorization<TKey>) authorization, type, cancellationToken);
-
-        /// <summary>
-        /// Updates an existing authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization to update.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.UpdateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
-            => UpdateAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
-
-        /// <summary>
         /// Retrieves an authorization using its physical identifier.
         /// </summary>
         /// <param name="identifier">The physical identifier associated with the authorization.</param>
@@ -325,11 +32,11 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdAuthorization<TKey>> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base FindByIdAsync() method is called.
-            => await FindByIdAsync(identifier, cancellationToken);
+            => FindByIdAsync(identifier, cancellationToken);
 
         /// <summary>
         /// Retrieves the physical identifier associated with an authorization.
@@ -340,10 +47,106 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the authorization.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(OpenIdAuthorization<TKey> authorization, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base GetIdAsync() method is called.
+            => GetIdAsync(authorization, cancellationToken);
+
+        // Note: the following methods are deliberately implemented as explicit methods so they are not
+        // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
+        // Developers who need to customize the logic SHOULD override the methods taking concretes types.
+
+        // ---------------------------------------------------------------
+        // Methods defined by the IOpenIddictAuthorizationStore interface:
+        // ---------------------------------------------------------------
+
+        Task<long> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        Task<long> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CountAsync<TResult>(Func<IQueryable<IOpenIdAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CreateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.DeleteAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindAsync(string subject, string client, CancellationToken cancellationToken)
+            => (await FindAsync(subject, client, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetApplicationIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetApplicationIdAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        Task<TResult> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
             => GetIdAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetScopesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetScopesAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetStatusAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetStatusAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetSubjectAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetSubjectAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetTypeAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetTypeAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        Task<ImmutableArray<TResult>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListInvalidAsync(count, offset, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetApplicationIdAsync(IOpenIdAuthorization authorization,
+            string identifier, CancellationToken cancellationToken)
+            => SetApplicationIdAsync((OpenIdAuthorization<TKey>) authorization, identifier, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetScopesAsync(IOpenIdAuthorization authorization,
+            ImmutableArray<string> scopes, CancellationToken cancellationToken)
+            => SetScopesAsync((OpenIdAuthorization<TKey>) authorization, scopes, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetStatusAsync(IOpenIdAuthorization authorization,
+            string status, CancellationToken cancellationToken)
+            => SetStatusAsync((OpenIdAuthorization<TKey>) authorization, status, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetSubjectAsync(IOpenIdAuthorization authorization,
+            string subject, CancellationToken cancellationToken)
+            => SetSubjectAsync((OpenIdAuthorization<TKey>) authorization, subject, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetTypeAsync(IOpenIdAuthorization authorization,
+            string type, CancellationToken cancellationToken)
+            => SetTypeAsync((OpenIdAuthorization<TKey>) authorization, type, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.UpdateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        // -----------------------------------------------------------
+        // Methods defined by the IOpenIdAuthorizationStore interface:
+        // -----------------------------------------------------------
+
+        async Task<IOpenIdAuthorization> IOpenIdAuthorizationStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByPhysicalIdAsync(identifier, cancellationToken);
+
+        Task<string> IOpenIdAuthorizationStore.GetPhysicalIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetPhysicalIdAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
@@ -1,0 +1,319 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using OpenIddict.Core;
+using OpenIddict.EntityFrameworkCore;
+using OrchardCore.OpenId.Abstractions;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
+using OrchardCore.OpenId.EntityFrameworkCore.Models;
+
+namespace OrchardCore.OpenId.EntityFrameworkCore.Services
+{
+    public class OpenIdAuthorizationStore<TContext, TKey> :
+        OpenIddictAuthorizationStore<OpenIdAuthorization<TKey>, OpenIdApplication<TKey>, OpenIdToken<TKey>, TContext, TKey>,
+        IOpenIdAuthorizationStore
+        where TContext : DbContext
+        where TKey : IEquatable<TKey>
+    {
+        public OpenIdAuthorizationStore(TContext context)
+            : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Determines the number of authorizations that exist in the database.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the number of authorizations in the database.
+        /// </returns>
+        Task<long> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        /// <summary>
+        /// Determines the number of authorizations that match the specified query.
+        /// </summary>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the number of authorizations that match the specified query.
+        /// </returns>
+        Task<long> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CountAsync<TResult>(Func<IQueryable<IOpenIdAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        /// <summary>
+        /// Creates a new authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the authorization.
+        /// </returns>
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CreateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Removes an existing authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization to delete.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.DeleteAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the authorizations corresponding to the specified
+        /// subject and associated with the application identifier.
+        /// </summary>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="client">The client associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorizations corresponding to the subject/client.
+        /// </returns>
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindAsync(string subject, string client, CancellationToken cancellationToken)
+            => (await FindAsync(subject, client, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        /// <summary>
+        /// Retrieves an authorization using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorization corresponding to the identifier.
+        /// </returns>
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the optional application identifier associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the application identifier associated with the authorization.
+        /// </returns>
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetApplicationIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetApplicationIdAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Executes the specified query and returns the first element.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the first element returned when executing the query.
+        /// </returns>
+        Task<TResult> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the unique identifier associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the unique identifier associated with the authorization.
+        /// </returns>
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetIdAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the scopes associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scopes associated with the specified authorization.
+        /// </returns>
+        Task<ImmutableArray<string>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetScopesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetScopesAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the status associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the status associated with the specified authorization.
+        /// </returns>
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetStatusAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetStatusAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the subject associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the subject associated with the specified authorization.
+        /// </returns>
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetSubjectAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetSubjectAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the type associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the type associated with the specified authorization.
+        /// </returns>
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetTypeAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetTypeAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+
+        /// <summary>
+        /// Instantiates a new authorization.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
+        /// returns the instantiated authorization, that can be persisted in the database.
+        /// </returns>
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <param name="count">The number of results to return.</param>
+        /// <param name="offset">The number of results to skip.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        Task<ImmutableArray<TResult>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        /// <summary>
+        /// Lists the ad-hoc authorizations that are marked as invalid or have no
+        /// valid token attached and that can be safely removed from the database.
+        /// </summary>
+        /// <param name="count">The number of results to return.</param>
+        /// <param name="offset">The number of results to skip.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListInvalidAsync(count, offset, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        /// <summary>
+        /// Sets the application identifier associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="identifier">The unique identifier associated with the client application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetApplicationIdAsync(IOpenIdAuthorization authorization,
+            string identifier, CancellationToken cancellationToken)
+            => SetApplicationIdAsync((OpenIdAuthorization<TKey>) authorization, identifier, cancellationToken);
+
+        /// <summary>
+        /// Sets the scopes associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="scopes">The scopes associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetScopesAsync(IOpenIdAuthorization authorization,
+            ImmutableArray<string> scopes, CancellationToken cancellationToken)
+            => SetScopesAsync((OpenIdAuthorization<TKey>) authorization, scopes, cancellationToken);
+
+        /// <summary>
+        /// Sets the status associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="status">The status associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetStatusAsync(IOpenIdAuthorization authorization,
+            string status, CancellationToken cancellationToken)
+            => SetStatusAsync((OpenIdAuthorization<TKey>) authorization, status, cancellationToken);
+
+        /// <summary>
+        /// Sets the subject associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="subject">The subject associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetSubjectAsync(IOpenIdAuthorization authorization,
+            string subject, CancellationToken cancellationToken)
+            => SetSubjectAsync((OpenIdAuthorization<TKey>) authorization, subject, cancellationToken);
+
+        /// <summary>
+        /// Sets the type associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="type">The type associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetTypeAsync(IOpenIdAuthorization authorization,
+            string type, CancellationToken cancellationToken)
+            => SetTypeAsync((OpenIdAuthorization<TKey>) authorization, type, cancellationToken);
+
+        /// <summary>
+        /// Updates an existing authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.UpdateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdAuthorization<TKey>) authorization, cancellationToken);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
@@ -69,6 +69,21 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => DeleteAsync((OpenIdScope<TKey>) scope, cancellationToken);
 
         /// <summary>
+        /// Retrieves a scope using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scope corresponding to the identifier.
+        /// </returns>
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base FindByIdAsync() method is called.
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        /// <summary>
         /// Executes the specified query and returns the first element.
         /// </summary>
         /// <typeparam name="TState">The state type.</typeparam>
@@ -96,6 +111,18 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// </returns>
         Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetDescriptionAsync(IOpenIdScope scope, CancellationToken cancellationToken)
             => GetDescriptionAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the unique identifier associated with a scope.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the unique identifier associated with the scope.
+        /// </returns>
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetIdAsync((OpenIdScope<TKey>) scope, cancellationToken);
 
         /// <summary>
         /// Retrieves the name associated with a scope.
@@ -184,5 +211,35 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// </returns>
         Task IOpenIddictScopeStore<IOpenIdScope>.UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
             => UpdateAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        /// <summary>
+        /// Retrieves a scope using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The physical identifier associated with the scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scope corresponding to the identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base FindByIdAsync() method is called.
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with a scope.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the scope.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base GetIdAsync() method is called.
+            => GetIdAsync((OpenIdScope<TKey>) scope, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using OpenIddict.Core;
+using OpenIddict.EntityFrameworkCore;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
+using OrchardCore.OpenId.EntityFrameworkCore.Models;
+
+namespace OrchardCore.OpenId.EntityFrameworkCore.Services
+{
+    public class OpenIdScopeStore<TContext, TKey> :
+        OpenIddictScopeStore<OpenIdScope<TKey>, TContext, TKey>, IOpenIdScopeStore
+        where TContext : DbContext
+        where TKey : IEquatable<TKey>
+    {
+        public OpenIdScopeStore(TContext context)
+            : base(context)
+        {
+        }
+
+        /// <summary>
+        /// Determines the number of scopes that exist in the database.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the number of scopes in the database.
+        /// </returns>
+        Task<long> IOpenIddictScopeStore<IOpenIdScope>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        /// <summary>
+        /// Determines the number of scopes that match the specified query.
+        /// </summary>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the number of scopes that match the specified query.
+        /// </returns>
+        Task<long> IOpenIddictScopeStore<IOpenIdScope>.CountAsync<TResult>(Func<IQueryable<IOpenIdScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        /// <summary>
+        /// Creates a new scope.
+        /// </summary>
+        /// <param name="scope">The scope to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the scope.
+        /// </returns>
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.CreateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        /// <summary>
+        /// Removes an existing scope.
+        /// </summary>
+        /// <param name="scope">The scope to delete.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictScopeStore<IOpenIdScope>.DeleteAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        /// <summary>
+        /// Executes the specified query and returns the first element.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the first element returned when executing the query.
+        /// </returns>
+        Task<TResult> IOpenIddictScopeStore<IOpenIdScope>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the description associated with a scope.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the description associated with the specified scope.
+        /// </returns>
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetDescriptionAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetDescriptionAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the name associated with a scope.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the name associated with the specified scope.
+        /// </returns>
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetNameAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetNameAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        /// <summary>
+        /// Instantiates a new scope.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the instantiated scope, that can be persisted in the database.
+        /// </returns>
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <param name="count">The number of results to return.</param>
+        /// <param name="offset">The number of results to skip.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        async Task<ImmutableArray<IOpenIdScope>> IOpenIddictScopeStore<IOpenIdScope>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdScope>();
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        Task<ImmutableArray<TResult>> IOpenIddictScopeStore<IOpenIdScope>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        /// <summary>
+        /// Sets the description associated with a scope.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="description">The description associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictScopeStore<IOpenIdScope>.SetDescriptionAsync(IOpenIdScope scope, string description, CancellationToken cancellationToken)
+            => SetDescriptionAsync((OpenIdScope<TKey>) scope, description, cancellationToken);
+
+        /// <summary>
+        /// Sets the name associated with a scope.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="name">The name associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictScopeStore<IOpenIdScope>.SetNameAsync(IOpenIdScope scope, string name, CancellationToken cancellationToken)
+            => SetNameAsync((OpenIdScope<TKey>) scope, name, cancellationToken);
+
+        /// <summary>
+        /// Updates an existing scope.
+        /// </summary>
+        /// <param name="scope">The scope to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        Task IOpenIddictScopeStore<IOpenIdScope>.UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdScope<TKey>) scope, cancellationToken);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
@@ -23,196 +23,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         }
 
         /// <summary>
-        /// Determines the number of scopes that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of scopes in the database.
-        /// </returns>
-        Task<long> IOpenIddictScopeStore<IOpenIdScope>.CountAsync(CancellationToken cancellationToken)
-            => CountAsync(cancellationToken);
-
-        /// <summary>
-        /// Determines the number of scopes that match the specified query.
-        /// </summary>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of scopes that match the specified query.
-        /// </returns>
-        Task<long> IOpenIddictScopeStore<IOpenIdScope>.CountAsync<TResult>(Func<IQueryable<IOpenIdScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
-            => CountAsync(query, cancellationToken);
-
-        /// <summary>
-        /// Creates a new scope.
-        /// </summary>
-        /// <param name="scope">The scope to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the scope.
-        /// </returns>
-        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.CreateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => await CreateAsync((OpenIdScope<TKey>) scope, cancellationToken);
-
-        /// <summary>
-        /// Removes an existing scope.
-        /// </summary>
-        /// <param name="scope">The scope to delete.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictScopeStore<IOpenIdScope>.DeleteAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => DeleteAsync((OpenIdScope<TKey>) scope, cancellationToken);
-
-        /// <summary>
-        /// Retrieves a scope using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the scope corresponding to the identifier.
-        /// </returns>
-        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
-            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
-            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
-            // To ensure this method can be safely used, the base FindByIdAsync() method is called.
-            => await FindByIdAsync(identifier, cancellationToken);
-
-        /// <summary>
-        /// Executes the specified query and returns the first element.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the first element returned when executing the query.
-        /// </returns>
-        Task<TResult> IOpenIddictScopeStore<IOpenIdScope>.GetAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
-            TState state, CancellationToken cancellationToken)
-            => GetAsync(query, state, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the description associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the description associated with the specified scope.
-        /// </returns>
-        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetDescriptionAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => GetDescriptionAsync((OpenIdScope<TKey>) scope, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the unique identifier associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the unique identifier associated with the scope.
-        /// </returns>
-        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => GetIdAsync((OpenIdScope<TKey>) scope, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the name associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the name associated with the specified scope.
-        /// </returns>
-        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetNameAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => GetNameAsync((OpenIdScope<TKey>) scope, cancellationToken);
-
-        /// <summary>
-        /// Instantiates a new scope.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the instantiated scope, that can be persisted in the database.
-        /// </returns>
-        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.InstantiateAsync(CancellationToken cancellationToken)
-            => await InstantiateAsync(cancellationToken);
-
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdScope>> IOpenIddictScopeStore<IOpenIdScope>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
-            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdScope>();
-
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        Task<ImmutableArray<TResult>> IOpenIddictScopeStore<IOpenIdScope>.ListAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
-            TState state, CancellationToken cancellationToken)
-            => ListAsync(query, state, cancellationToken);
-
-        /// <summary>
-        /// Sets the description associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="description">The description associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictScopeStore<IOpenIdScope>.SetDescriptionAsync(IOpenIdScope scope, string description, CancellationToken cancellationToken)
-            => SetDescriptionAsync((OpenIdScope<TKey>) scope, description, cancellationToken);
-
-        /// <summary>
-        /// Sets the name associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="name">The name associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictScopeStore<IOpenIdScope>.SetNameAsync(IOpenIdScope scope, string name, CancellationToken cancellationToken)
-            => SetNameAsync((OpenIdScope<TKey>) scope, name, cancellationToken);
-
-        /// <summary>
-        /// Updates an existing scope.
-        /// </summary>
-        /// <param name="scope">The scope to update.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictScopeStore<IOpenIdScope>.UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => UpdateAsync((OpenIdScope<TKey>) scope, cancellationToken);
-
-        /// <summary>
         /// Retrieves a scope using its physical identifier.
         /// </summary>
         /// <param name="identifier">The physical identifier associated with the scope.</param>
@@ -221,11 +31,11 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdScope<TKey>> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base FindByIdAsync() method is called.
-            => await FindByIdAsync(identifier, cancellationToken);
+            => FindByIdAsync(identifier, cancellationToken);
 
         /// <summary>
         /// Retrieves the physical identifier associated with a scope.
@@ -236,10 +46,77 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the scope.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(OpenIdScope<TKey> scope, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base GetIdAsync() method is called.
+            => GetIdAsync(scope, cancellationToken);
+
+        // Note: the following methods are deliberately implemented as explicit methods so they are not
+        // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
+        // Developers who need to customize the logic SHOULD override the methods taking concretes types.
+
+        // -------------------------------------------------------
+        // Methods defined by the IOpenIddictScopeStore interface:
+        // -------------------------------------------------------
+
+        Task<long> IOpenIddictScopeStore<IOpenIdScope>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        Task<long> IOpenIddictScopeStore<IOpenIdScope>.CountAsync<TResult>(Func<IQueryable<IOpenIdScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.CreateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.DeleteAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        Task<TResult> IOpenIddictScopeStore<IOpenIdScope>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetDescriptionAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetDescriptionAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
             => GetIdAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetNameAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetNameAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdScope>> IOpenIddictScopeStore<IOpenIdScope>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdScope>();
+
+        Task<ImmutableArray<TResult>> IOpenIddictScopeStore<IOpenIdScope>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.SetDescriptionAsync(IOpenIdScope scope, string description, CancellationToken cancellationToken)
+            => SetDescriptionAsync((OpenIdScope<TKey>) scope, description, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.SetNameAsync(IOpenIdScope scope, string name, CancellationToken cancellationToken)
+            => SetNameAsync((OpenIdScope<TKey>) scope, name, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdScope<TKey>) scope, cancellationToken);
+
+        // ---------------------------------------------------
+        // Methods defined by the IOpenIdScopeStore interface:
+        // ---------------------------------------------------
+
+        async Task<IOpenIdScope> IOpenIdScopeStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByPhysicalIdAsync(identifier, cancellationToken);
+
+        Task<string> IOpenIdScopeStore.GetPhysicalIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetPhysicalIdAsync((OpenIdScope<TKey>) scope, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
@@ -12,8 +12,18 @@ using OrchardCore.OpenId.EntityFrameworkCore.Models;
 
 namespace OrchardCore.OpenId.EntityFrameworkCore.Services
 {
-    public class OpenIdScopeStore<TContext, TKey> :
-        OpenIddictScopeStore<OpenIdScope<TKey>, TContext, TKey>, IOpenIdScopeStore
+    public class OpenIdScopeStore<TContext, TKey> : OpenIdScopeStore<OpenIdScope<TKey>, TContext, TKey>
+        where TContext : DbContext
+        where TKey : IEquatable<TKey>
+    {
+        public OpenIdScopeStore(TContext context)
+            : base(context)
+        {
+        }
+    }
+
+    public class OpenIdScopeStore<TScope, TContext, TKey> : OpenIddictScopeStore<TScope, TContext, TKey>, IOpenIdScopeStore
+        where TScope : OpenIdScope<TKey>, new()
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
@@ -31,7 +41,7 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the identifier.
         /// </returns>
-        public virtual Task<OpenIdScope<TKey>> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<TScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base FindByIdAsync() method is called.
@@ -46,7 +56,7 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the scope.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(OpenIdScope<TKey> scope, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(TScope scope, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base GetIdAsync() method is called.
@@ -67,10 +77,10 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => CountAsync(query, cancellationToken);
 
         async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.CreateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => await CreateAsync((OpenIdScope<TKey>) scope, cancellationToken);
+            => await CreateAsync((TScope) scope, cancellationToken);
 
         Task IOpenIddictScopeStore<IOpenIdScope>.DeleteAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => DeleteAsync((OpenIdScope<TKey>) scope, cancellationToken);
+            => DeleteAsync((TScope) scope, cancellationToken);
 
         async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
             => await FindByIdAsync(identifier, cancellationToken);
@@ -81,13 +91,13 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => GetAsync(query, state, cancellationToken);
 
         Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetDescriptionAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => GetDescriptionAsync((OpenIdScope<TKey>) scope, cancellationToken);
+            => GetDescriptionAsync((TScope) scope, cancellationToken);
 
         Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => GetIdAsync((OpenIdScope<TKey>) scope, cancellationToken);
+            => GetIdAsync((TScope) scope, cancellationToken);
 
         Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetNameAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => GetNameAsync((OpenIdScope<TKey>) scope, cancellationToken);
+            => GetNameAsync((TScope) scope, cancellationToken);
 
         async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.InstantiateAsync(CancellationToken cancellationToken)
             => await InstantiateAsync(cancellationToken);
@@ -101,13 +111,13 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => ListAsync(query, state, cancellationToken);
 
         Task IOpenIddictScopeStore<IOpenIdScope>.SetDescriptionAsync(IOpenIdScope scope, string description, CancellationToken cancellationToken)
-            => SetDescriptionAsync((OpenIdScope<TKey>) scope, description, cancellationToken);
+            => SetDescriptionAsync((TScope) scope, description, cancellationToken);
 
         Task IOpenIddictScopeStore<IOpenIdScope>.SetNameAsync(IOpenIdScope scope, string name, CancellationToken cancellationToken)
-            => SetNameAsync((OpenIdScope<TKey>) scope, name, cancellationToken);
+            => SetNameAsync((TScope) scope, name, cancellationToken);
 
         Task IOpenIddictScopeStore<IOpenIdScope>.UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => UpdateAsync((OpenIdScope<TKey>) scope, cancellationToken);
+            => UpdateAsync((TScope) scope, cancellationToken);
 
         // ---------------------------------------------------
         // Methods defined by the IOpenIdScopeStore interface:
@@ -117,6 +127,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => await FindByPhysicalIdAsync(identifier, cancellationToken);
 
         Task<string> IOpenIdScopeStore.GetPhysicalIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
-            => GetPhysicalIdAsync((OpenIdScope<TKey>) scope, cancellationToken);
+            => GetPhysicalIdAsync((TScope) scope, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdTokenStore.cs
@@ -23,426 +23,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         }
 
         /// <summary>
-        /// Determines the number of tokens that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of applications in the database.
-        /// </returns>
-        Task<long> IOpenIddictTokenStore<IOpenIdToken>.CountAsync(CancellationToken cancellationToken)
-            => CountAsync(cancellationToken);
-
-        /// <summary>
-        /// Determines the number of tokens that match the specified query.
-        /// </summary>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of tokens that match the specified query.
-        /// </returns>
-        Task<long> IOpenIddictTokenStore<IOpenIdToken>.CountAsync<TResult>(Func<IQueryable<IOpenIdToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
-            => CountAsync(query, cancellationToken);
-
-        /// <summary>
-        /// Creates a new token.
-        /// </summary>
-        /// <param name="token">The token to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the token.
-        /// </returns>
-        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.CreateAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => await CreateAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Removes a token.
-        /// </summary>
-        /// <param name="token">The token to delete.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.DeleteAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => DeleteAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified application identifier.
-        /// </summary>
-        /// <param name="identifier">The application identifier associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified application.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
-            => (await FindByApplicationIdAsync(identifier, cancellationToken)).CastArray<IOpenIdToken>();
-
-        /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified authorization identifier.
-        /// </summary>
-        /// <param name="identifier">The authorization identifier associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified authorization.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
-            => (await FindByAuthorizationIdAsync(identifier, cancellationToken)).CastArray<IOpenIdToken>();
-
-        /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified reference identifier.
-        /// Note: the reference identifier may be hashed or encrypted for security reasons.
-        /// </summary>
-        /// <param name="identifier">The reference identifier associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified reference identifier.
-        /// </returns>
-        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
-            => await FindByReferenceIdAsync(identifier, cancellationToken);
-
-        /// <summary>
-        /// Retrieves a token using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the token corresponding to the unique identifier.
-        /// </returns>
-        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
-            => await FindByIdAsync(identifier, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified subject.
-        /// </summary>
-        /// <param name="subject">The subject associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified subject.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindBySubjectAsync(string subject, CancellationToken cancellationToken)
-            => (await FindBySubjectAsync(subject, cancellationToken)).CastArray<IOpenIdToken>();
-
-        /// <summary>
-        /// Executes the specified query and returns the first element.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the first element returned when executing the query.
-        /// </returns>
-        Task<TResult> IOpenIddictTokenStore<IOpenIdToken>.GetAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
-            TState state, CancellationToken cancellationToken)
-            => GetAsync(query, state, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the optional application identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the application identifier associated with the token.
-        /// </returns>
-        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetApplicationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetApplicationIdAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the optional authorization identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorization identifier associated with the token.
-        /// </returns>
-        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetAuthorizationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetAuthorizationIdAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the creation date associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the creation date associated with the specified token.
-        /// </returns>
-        Task<DateTimeOffset?> IOpenIddictTokenStore<IOpenIdToken>.GetCreationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetCreationDateAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the expiration date associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the expiration date associated with the specified token.
-        /// </returns>
-        Task<DateTimeOffset?> IOpenIddictTokenStore<IOpenIdToken>.GetExpirationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetExpirationDateAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the unique identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the unique identifier associated with the token.
-        /// </returns>
-        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetIdAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the payload associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the payload associated with the specified token.
-        /// </returns>
-        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetPayloadAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetPayloadAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the reference identifier associated with a token.
-        /// Note: depending on the manager used to create the token,
-        /// the reference identifier may be hashed for security reasons.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the reference identifier associated with the specified token.
-        /// </returns>
-        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetReferenceIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetReferenceIdAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the status associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the status associated with the specified token.
-        /// </returns>
-        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetStatusAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetStatusAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the subject associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the subject associated with the specified token.
-        /// </returns>
-        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetSubjectAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetSubjectAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Retrieves the token type associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the token type associated with the specified token.
-        /// </returns>
-        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetTokenTypeAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetTokenTypeAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
-        /// Instantiates a new token.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the instantiated token, that can be persisted in the database.
-        /// </returns>
-        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.InstantiateAsync(CancellationToken cancellationToken)
-            => await InstantiateAsync(cancellationToken);
-
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
-            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdToken>();
-
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        Task<ImmutableArray<TResult>> IOpenIddictTokenStore<IOpenIdToken>.ListAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
-            TState state, CancellationToken cancellationToken)
-            => ListAsync(query, state, cancellationToken);
-
-        /// <summary>
-        /// Lists the tokens that are marked as expired or invalid
-        /// and that can be safely removed from the database.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
-        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
-            => (await ListInvalidAsync(count, offset, cancellationToken)).CastArray<IOpenIdToken>();
-
-        /// <summary>
-        /// Sets the application identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="identifier">The unique identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetApplicationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
-            => SetApplicationIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
-
-        /// <summary>
-        /// Sets the authorization identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="identifier">The unique identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetAuthorizationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
-            => SetAuthorizationIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
-
-        /// <summary>
-        /// Sets the creation date associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="date">The creation date.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetCreationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
-            => SetCreationDateAsync((OpenIdToken<TKey>) token, date, cancellationToken);
-
-        /// <summary>
-        /// Sets the expiration date associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="date">The expiration date.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetExpirationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
-            => SetExpirationDateAsync((OpenIdToken<TKey>) token, date, cancellationToken);
-
-        /// <summary>
-        /// Sets the payload associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="payload">The payload associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetPayloadAsync(IOpenIdToken token, string payload, CancellationToken cancellationToken)
-            => SetPayloadAsync((OpenIdToken<TKey>) token, payload, cancellationToken);
-
-        /// <summary>
-        /// Sets the reference identifier associated with a token.
-        /// Note: depending on the manager used to create the token,
-        /// the reference identifier may be hashed for security reasons.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="identifier">The reference identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetReferenceIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
-            => SetReferenceIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
-
-        /// <summary>
-        /// Sets the status associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="status">The status associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetStatusAsync(IOpenIdToken token, string status, CancellationToken cancellationToken)
-            => SetStatusAsync((OpenIdToken<TKey>) token, status, cancellationToken);
-
-        /// <summary>
-        /// Sets the subject associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="subject">The subject associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetSubjectAsync(IOpenIdToken token, string subject, CancellationToken cancellationToken)
-            => SetSubjectAsync((OpenIdToken<TKey>) token, subject, cancellationToken);
-
-        /// <summary>
-        /// Sets the token type associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="type">The token type associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.SetTokenTypeAsync(IOpenIdToken token, string type, CancellationToken cancellationToken)
-            => SetTokenTypeAsync((OpenIdToken<TKey>) token, type, cancellationToken);
-
-        /// <summary>
-        /// Updates an existing token.
-        /// </summary>
-        /// <param name="token">The token to update.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
-        Task IOpenIddictTokenStore<IOpenIdToken>.UpdateAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => UpdateAsync((OpenIdToken<TKey>) token, cancellationToken);
-
-        /// <summary>
         /// Retrieves a token using its physical identifier.
         /// </summary>
         /// <param name="identifier">The physical identifier associated with the token.</param>
@@ -451,11 +31,11 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token corresponding to the physical identifier.
         /// </returns>
-        public virtual async Task<IOpenIdToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdToken<TKey>> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base FindByIdAsync() method is called.
-            => await FindByIdAsync(identifier, cancellationToken);
+            => FindByIdAsync(identifier, cancellationToken);
 
         /// <summary>
         /// Retrieves the physical identifier associated with a token.
@@ -466,10 +46,134 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(OpenIdToken<TKey> token, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base GetIdAsync() method is called.
+            => GetIdAsync(token, cancellationToken);
+
+        // Note: the following methods are deliberately implemented as explicit methods so they are not
+        // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
+        // Developers who need to customize the logic SHOULD override the methods taking concretes types.
+
+        // -------------------------------------------------------
+        // Methods defined by the IOpenIddictTokenStore interface:
+        // -------------------------------------------------------
+
+        Task<long> IOpenIddictTokenStore<IOpenIdToken>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        Task<long> IOpenIddictTokenStore<IOpenIdToken>.CountAsync<TResult>(Func<IQueryable<IOpenIdToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.CreateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.DeleteAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
+            => (await FindByApplicationIdAsync(identifier, cancellationToken)).CastArray<IOpenIdToken>();
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
+            => (await FindByAuthorizationIdAsync(identifier, cancellationToken)).CastArray<IOpenIdToken>();
+
+        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByReferenceIdAsync(identifier, cancellationToken);
+
+        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindBySubjectAsync(string subject, CancellationToken cancellationToken)
+            => (await FindBySubjectAsync(subject, cancellationToken)).CastArray<IOpenIdToken>();
+
+        Task<TResult> IOpenIddictTokenStore<IOpenIdToken>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetApplicationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetApplicationIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetAuthorizationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetAuthorizationIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<DateTimeOffset?> IOpenIddictTokenStore<IOpenIdToken>.GetCreationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetCreationDateAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<DateTimeOffset?> IOpenIddictTokenStore<IOpenIdToken>.GetExpirationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetExpirationDateAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
             => GetIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetPayloadAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetPayloadAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetReferenceIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetReferenceIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetStatusAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetStatusAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetSubjectAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetSubjectAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetTokenTypeAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetTokenTypeAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdToken>();
+
+        Task<ImmutableArray<TResult>> IOpenIddictTokenStore<IOpenIdToken>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListInvalidAsync(count, offset, cancellationToken)).CastArray<IOpenIdToken>();
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetApplicationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+            => SetApplicationIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetAuthorizationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+            => SetAuthorizationIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetCreationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+            => SetCreationDateAsync((OpenIdToken<TKey>) token, date, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetExpirationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+            => SetExpirationDateAsync((OpenIdToken<TKey>) token, date, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetPayloadAsync(IOpenIdToken token, string payload, CancellationToken cancellationToken)
+            => SetPayloadAsync((OpenIdToken<TKey>) token, payload, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetReferenceIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+            => SetReferenceIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetStatusAsync(IOpenIdToken token, string status, CancellationToken cancellationToken)
+            => SetStatusAsync((OpenIdToken<TKey>) token, status, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetSubjectAsync(IOpenIdToken token, string subject, CancellationToken cancellationToken)
+            => SetSubjectAsync((OpenIdToken<TKey>) token, subject, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetTokenTypeAsync(IOpenIdToken token, string type, CancellationToken cancellationToken)
+            => SetTokenTypeAsync((OpenIdToken<TKey>) token, type, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.UpdateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        // ---------------------------------------------------
+        // Methods defined by the IOpenIdTokenStore interface:
+        // ---------------------------------------------------
+
+        async Task<IOpenIdToken> IOpenIdTokenStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByPhysicalIdAsync(identifier, cancellationToken);
+
+        Task<string> IOpenIdTokenStore.GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetPhysicalIdAsync((OpenIdToken<TKey>) token, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdTokenStore.cs
@@ -441,5 +441,35 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// </returns>
         Task IOpenIddictTokenStore<IOpenIdToken>.UpdateAsync(IOpenIdToken token, CancellationToken cancellationToken)
             => UpdateAsync((OpenIdToken<TKey>) token, cancellationToken);
+
+        /// <summary>
+        /// Retrieves a token using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The physical identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the token corresponding to the physical identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base FindByIdAsync() method is called.
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the token.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            // Note: unlike the YesSql-specific models, the default OpenIddict models used by
+            // the Entity Framework Core stores don't have distinct physical/logical identifiers.
+            // To ensure this method can be safely used, the base GetIdAsync() method is called.
+            => GetIdAsync((OpenIdToken<TKey>) token, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdTokenStore.cs
@@ -12,8 +12,23 @@ using OrchardCore.OpenId.EntityFrameworkCore.Models;
 
 namespace OrchardCore.OpenId.EntityFrameworkCore.Services
 {
-    public class OpenIdTokenStore<TContext, TKey> :
-        OpenIddictTokenStore<OpenIdToken<TKey>, OpenIdApplication<TKey>, OpenIdAuthorization<TKey>, TContext, TKey>, IOpenIdTokenStore
+    public class OpenIdTokenStore<TContext, TKey> : OpenIdTokenStore<OpenIdToken<TKey>,
+                                                                     OpenIdApplication<TKey>,
+                                                                     OpenIdAuthorization<TKey>, TContext, TKey>
+        where TContext : DbContext
+        where TKey : IEquatable<TKey>
+    {
+        public OpenIdTokenStore(TContext context)
+            : base(context)
+        {
+        }
+    }
+
+    public class OpenIdTokenStore<TToken, TApplication, TAuthorization, TContext, TKey> :
+        OpenIddictTokenStore<TToken, TApplication, TAuthorization, TContext, TKey>, IOpenIdTokenStore
+        where TToken : OpenIdToken<TKey, TApplication, TAuthorization>, new()
+        where TApplication : OpenIdApplication<TKey, TAuthorization, TToken>, new()
+        where TAuthorization : OpenIdAuthorization<TKey, TApplication, TToken>, new()
         where TContext : DbContext
         where TKey : IEquatable<TKey>
     {
@@ -31,7 +46,7 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token corresponding to the physical identifier.
         /// </returns>
-        public virtual Task<OpenIdToken<TKey>> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<TToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base FindByIdAsync() method is called.
@@ -46,7 +61,7 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(OpenIdToken<TKey> token, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(TToken token, CancellationToken cancellationToken)
             // Note: unlike the YesSql-specific models, the default OpenIddict models used by
             // the Entity Framework Core stores don't have distinct physical/logical identifiers.
             // To ensure this method can be safely used, the base GetIdAsync() method is called.
@@ -67,10 +82,10 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => CountAsync(query, cancellationToken);
 
         async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.CreateAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => await CreateAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => await CreateAsync((TToken) token, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.DeleteAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => DeleteAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => DeleteAsync((TToken) token, cancellationToken);
 
         async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
             => (await FindByApplicationIdAsync(identifier, cancellationToken)).CastArray<IOpenIdToken>();
@@ -93,34 +108,34 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => GetAsync(query, state, cancellationToken);
 
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetApplicationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetApplicationIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetApplicationIdAsync((TToken) token, cancellationToken);
 
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetAuthorizationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetAuthorizationIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetAuthorizationIdAsync((TToken) token, cancellationToken);
 
         Task<DateTimeOffset?> IOpenIddictTokenStore<IOpenIdToken>.GetCreationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetCreationDateAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetCreationDateAsync((TToken) token, cancellationToken);
 
         Task<DateTimeOffset?> IOpenIddictTokenStore<IOpenIdToken>.GetExpirationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetExpirationDateAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetExpirationDateAsync((TToken) token, cancellationToken);
 
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetIdAsync((TToken) token, cancellationToken);
 
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetPayloadAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetPayloadAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetPayloadAsync((TToken) token, cancellationToken);
 
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetReferenceIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetReferenceIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetReferenceIdAsync((TToken) token, cancellationToken);
 
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetStatusAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetStatusAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetStatusAsync((TToken) token, cancellationToken);
 
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetSubjectAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetSubjectAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetSubjectAsync((TToken) token, cancellationToken);
 
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetTokenTypeAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetTokenTypeAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetTokenTypeAsync((TToken) token, cancellationToken);
 
         async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.InstantiateAsync(CancellationToken cancellationToken)
             => await InstantiateAsync(cancellationToken);
@@ -137,34 +152,34 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => (await ListInvalidAsync(count, offset, cancellationToken)).CastArray<IOpenIdToken>();
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetApplicationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
-            => SetApplicationIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
+            => SetApplicationIdAsync((TToken) token, identifier, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetAuthorizationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
-            => SetAuthorizationIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
+            => SetAuthorizationIdAsync((TToken) token, identifier, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetCreationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
-            => SetCreationDateAsync((OpenIdToken<TKey>) token, date, cancellationToken);
+            => SetCreationDateAsync((TToken) token, date, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetExpirationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
-            => SetExpirationDateAsync((OpenIdToken<TKey>) token, date, cancellationToken);
+            => SetExpirationDateAsync((TToken) token, date, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetPayloadAsync(IOpenIdToken token, string payload, CancellationToken cancellationToken)
-            => SetPayloadAsync((OpenIdToken<TKey>) token, payload, cancellationToken);
+            => SetPayloadAsync((TToken) token, payload, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetReferenceIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
-            => SetReferenceIdAsync((OpenIdToken<TKey>) token, identifier, cancellationToken);
+            => SetReferenceIdAsync((TToken) token, identifier, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetStatusAsync(IOpenIdToken token, string status, CancellationToken cancellationToken)
-            => SetStatusAsync((OpenIdToken<TKey>) token, status, cancellationToken);
+            => SetStatusAsync((TToken) token, status, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetSubjectAsync(IOpenIdToken token, string subject, CancellationToken cancellationToken)
-            => SetSubjectAsync((OpenIdToken<TKey>) token, subject, cancellationToken);
+            => SetSubjectAsync((TToken) token, subject, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetTokenTypeAsync(IOpenIdToken token, string type, CancellationToken cancellationToken)
-            => SetTokenTypeAsync((OpenIdToken<TKey>) token, type, cancellationToken);
+            => SetTokenTypeAsync((TToken) token, type, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.UpdateAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => UpdateAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => UpdateAsync((TToken) token, cancellationToken);
 
         // ---------------------------------------------------
         // Methods defined by the IOpenIdTokenStore interface:
@@ -174,6 +189,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             => await FindByPhysicalIdAsync(identifier, cancellationToken);
 
         Task<string> IOpenIdTokenStore.GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
-            => GetPhysicalIdAsync((OpenIdToken<TKey>) token, cancellationToken);
+            => GetPhysicalIdAsync((TToken) token, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Startup.cs
@@ -27,8 +27,10 @@ namespace OrchardCore.OpenId.EntityFrameworkCore
             // invalid configuration doesn't prevent the entire application from loading correctly.
             try
             {
-                Type contextType = GetContextType(), keyType = GetKeyType();
-                if (contextType == null || keyType == null)
+                Type contextType = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:ContextType"),
+                     keyType     = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:KeyType") ?? typeof(long);
+
+                if (contextType == null)
                 {
                     _logger.LogWarning("The OpenID Connect module is not correctly configured.");
 
@@ -68,21 +70,10 @@ namespace OrchardCore.OpenId.EntityFrameworkCore
 
         private (Type applicationType, Type authorizationType, Type scopeType, Type tokenType) GetEntityTypes(Type keyType)
         {
-            Type GetEntityType(string node)
-            {
-                var name = _configuration[node];
-                if (string.IsNullOrEmpty(name))
-                {
-                    return null;
-                }
-
-                return Type.GetType(name, throwOnError: true, ignoreCase: true);
-            }
-
-            Type applicationType   = GetEntityType("Modules:OrchardCore.OpenId:EntityFrameworkCore:ApplicationType"),
-                 authorizationType = GetEntityType("Modules:OrchardCore.OpenId:EntityFrameworkCore:AuthorizationType"),
-                 scopeType         = GetEntityType("Modules:OrchardCore.OpenId:EntityFrameworkCore:ScopeType"),
-                 tokenType         = GetEntityType("Modules:OrchardCore.OpenId:EntityFrameworkCore:TokenType");
+            Type applicationType   = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:ApplicationType"),
+                 authorizationType = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:AuthorizationType"),
+                 scopeType         = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:ScopeType"),
+                 tokenType         = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:TokenType");
 
             if (applicationType != null && authorizationType != null && scopeType != null && tokenType != null)
             {
@@ -96,23 +87,12 @@ namespace OrchardCore.OpenId.EntityFrameworkCore
                 tokenType:         typeof(OpenIdToken<>).MakeGenericType(keyType));
         }
 
-        private Type GetContextType()
+        private Type GetConfigurationNodeAsType(string node)
         {
-            var name = _configuration["Modules:OrchardCore.OpenId:EntityFrameworkCore:ContextType"];
+            var name = _configuration[node];
             if (string.IsNullOrEmpty(name))
             {
                 return null;
-            }
-
-            return Type.GetType(name, throwOnError: true, ignoreCase: true);
-        }
-
-        private Type GetKeyType()
-        {
-            var name = _configuration["Modules:OrchardCore.OpenId:EntityFrameworkCore:KeyType"];
-            if (string.IsNullOrEmpty(name))
-            {
-                return typeof(long);
             }
 
             return Type.GetType(name, throwOnError: true, ignoreCase: true);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Startup.cs
@@ -1,11 +1,11 @@
 using System;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using OrchardCore.Modules;
 using OrchardCore.OpenId.Abstractions.Stores;
+using OrchardCore.OpenId.EntityFrameworkCore.Models;
 using OrchardCore.OpenId.EntityFrameworkCore.Services;
 
 namespace OrchardCore.OpenId.EntityFrameworkCore
@@ -23,26 +23,77 @@ namespace OrchardCore.OpenId.EntityFrameworkCore
 
         public override void ConfigureServices(IServiceCollection services)
         {
-            Type contextType = GetContextType(), keyType = GetKeyType();
-            if (contextType == null || keyType == null)
+            // Note: the generic stores types are constructed in a try/catch block to ensure an
+            // invalid configuration doesn't prevent the entire application from loading correctly.
+            try
             {
-                _logger.LogWarning("The OpenID Connect module is not correctly configured.");
+                Type contextType = GetContextType(), keyType = GetKeyType();
+                if (contextType == null || keyType == null)
+                {
+                    _logger.LogWarning("The OpenID Connect module is not correctly configured.");
 
-                return;
+                    return;
+                }
+
+                var (applicationType, authorizationType, scopeType, tokenType) = GetEntityTypes(keyType);
+
+                services.Replace(ServiceDescriptor.Scoped(
+                    typeof(IOpenIdApplicationStore),
+                    typeof(OpenIdApplicationStore<,,,,>).MakeGenericType(
+                        applicationType, authorizationType,
+                        tokenType, contextType, keyType)));
+
+                services.Replace(ServiceDescriptor.Scoped(
+                    typeof(IOpenIdAuthorizationStore),
+                    typeof(OpenIdAuthorizationStore<,,,,>).MakeGenericType(
+                        authorizationType, applicationType,
+                        tokenType, contextType, keyType)));
+
+                services.Replace(ServiceDescriptor.Scoped(
+                    typeof(IOpenIdScopeStore),
+                    typeof(OpenIdScopeStore<,,>).MakeGenericType(
+                        scopeType, contextType, keyType)));
+
+                services.Replace(ServiceDescriptor.Scoped(
+                    typeof(IOpenIdTokenStore),
+                    typeof(OpenIdTokenStore<,,,,>).MakeGenericType(
+                        tokenType, applicationType,
+                        authorizationType, contextType, keyType)));
+            }
+            catch (Exception exception)
+            {
+                _logger.LogWarning(exception, "An error occurred while registering the OpenID Entity Framework Core stores.");
+            }
+        }
+
+        private (Type applicationType, Type authorizationType, Type scopeType, Type tokenType) GetEntityTypes(Type keyType)
+        {
+            Type GetEntityType(string node)
+            {
+                var name = _configuration[node];
+                if (string.IsNullOrEmpty(name))
+                {
+                    return null;
+                }
+
+                return Type.GetType(name, throwOnError: true, ignoreCase: true);
             }
 
-            services.Replace(ServiceDescriptor.Scoped(
-                typeof(IOpenIdApplicationStore),
-                typeof(OpenIdApplicationStore<,>).MakeGenericType(contextType, keyType)));
-            services.Replace(ServiceDescriptor.Scoped(
-                typeof(IOpenIdAuthorizationStore),
-                typeof(OpenIdAuthorizationStore<,>).MakeGenericType(contextType, keyType)));
-            services.Replace(ServiceDescriptor.Scoped(
-                typeof(IOpenIdScopeStore),
-                typeof(OpenIdScopeStore<,>).MakeGenericType(contextType, keyType)));
-            services.Replace(ServiceDescriptor.Scoped(
-                typeof(IOpenIdTokenStore),
-                typeof(OpenIdTokenStore<,>).MakeGenericType(contextType, keyType)));
+            Type applicationType   = GetEntityType("Modules:OrchardCore.OpenId:EntityFrameworkCore:ApplicationType"),
+                 authorizationType = GetEntityType("Modules:OrchardCore.OpenId:EntityFrameworkCore:AuthorizationType"),
+                 scopeType         = GetEntityType("Modules:OrchardCore.OpenId:EntityFrameworkCore:ScopeType"),
+                 tokenType         = GetEntityType("Modules:OrchardCore.OpenId:EntityFrameworkCore:TokenType");
+
+            if (applicationType != null && authorizationType != null && scopeType != null && tokenType != null)
+            {
+                return (applicationType, authorizationType, scopeType, tokenType);
+            }
+
+            return (
+                applicationType:   typeof(OpenIdApplication<>).MakeGenericType(keyType),
+                authorizationType: typeof(OpenIdAuthorization<>).MakeGenericType(keyType),
+                scopeType:         typeof(OpenIdScope<>).MakeGenericType(keyType),
+                tokenType:         typeof(OpenIdToken<>).MakeGenericType(keyType));
         }
 
         private Type GetContextType()
@@ -53,13 +104,7 @@ namespace OrchardCore.OpenId.EntityFrameworkCore
                 return null;
             }
 
-            var type = Type.GetType(name, throwOnError: false, ignoreCase: true);
-            if (type == null || !typeof(DbContext).IsAssignableFrom(type))
-            {
-                return null;
-            }
-
-            return type;
+            return Type.GetType(name, throwOnError: true, ignoreCase: true);
         }
 
         private Type GetKeyType()
@@ -70,14 +115,7 @@ namespace OrchardCore.OpenId.EntityFrameworkCore
                 return typeof(long);
             }
 
-            var type = Type.GetType(name, throwOnError: false, ignoreCase: true);
-            if (type == null || (type != typeof(Guid) && type != typeof(int) &&
-                                 type != typeof(long) && type != typeof(string)))
-            {
-                return null;
-            }
-
-            return type;
+            return Type.GetType(name, throwOnError: true, ignoreCase: true);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Startup.cs
@@ -1,0 +1,83 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using OrchardCore.Modules;
+using OrchardCore.OpenId.Abstractions.Stores;
+using OrchardCore.OpenId.EntityFrameworkCore.Services;
+
+namespace OrchardCore.OpenId.EntityFrameworkCore
+{
+    public class Startup : StartupBase
+    {
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<Startup> _logger;
+
+        public Startup(IConfiguration configuration, ILogger<Startup> logger)
+        {
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            Type contextType = GetContextType(), keyType = GetKeyType();
+            if (contextType == null || keyType == null)
+            {
+                _logger.LogWarning("The OpenID Connect module is not correctly configured.");
+
+                return;
+            }
+
+            services.Replace(ServiceDescriptor.Scoped(
+                typeof(IOpenIdApplicationStore),
+                typeof(OpenIdApplicationStore<,>).MakeGenericType(contextType, keyType)));
+            services.Replace(ServiceDescriptor.Scoped(
+                typeof(IOpenIdAuthorizationStore),
+                typeof(OpenIdAuthorizationStore<,>).MakeGenericType(contextType, keyType)));
+            services.Replace(ServiceDescriptor.Scoped(
+                typeof(IOpenIdScopeStore),
+                typeof(OpenIdScopeStore<,>).MakeGenericType(contextType, keyType)));
+            services.Replace(ServiceDescriptor.Scoped(
+                typeof(IOpenIdTokenStore),
+                typeof(OpenIdTokenStore<,>).MakeGenericType(contextType, keyType)));
+        }
+
+        private Type GetContextType()
+        {
+            var name = _configuration["Modules:OrchardCore.OpenId:EntityFrameworkCore:ContextType"];
+            if (string.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
+            var type = Type.GetType(name, throwOnError: false, ignoreCase: true);
+            if (type == null || !typeof(DbContext).IsAssignableFrom(type))
+            {
+                return null;
+            }
+
+            return type;
+        }
+
+        private Type GetKeyType()
+        {
+            var name = _configuration["Modules:OrchardCore.OpenId:EntityFrameworkCore:KeyType"];
+            if (string.IsNullOrEmpty(name))
+            {
+                return typeof(long);
+            }
+
+            var type = Type.GetType(name, throwOnError: false, ignoreCase: true);
+            if (type == null || (type != typeof(Guid) && type != typeof(int) &&
+                                 type != typeof(long) && type != typeof(string)))
+            {
+                return null;
+            }
+
+            return type;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Models/IOpenIdApplication.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Models/IOpenIdApplication.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.OpenId.Abstractions.Models
+{
+    public interface IOpenIdApplication
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Models/IOpenIdAuthorization.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Models/IOpenIdAuthorization.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.OpenId.Abstractions.Models
+{
+    public interface IOpenIdAuthorization
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Models/IOpenIdScope.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Models/IOpenIdScope.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.OpenId.Abstractions.Models
+{
+    public interface IOpenIdScope
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Models/IOpenIdToken.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Models/IOpenIdToken.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.OpenId.Abstractions.Models
+{
+    public interface IOpenIdToken
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdApplicationStore.cs
@@ -1,0 +1,22 @@
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+
+namespace OrchardCore.OpenId.Abstractions.Stores
+{
+    public interface IOpenIdApplicationStore : IOpenIddictApplicationStore<IOpenIdApplication>
+    {
+        // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
+        Task<ImmutableArray<string>> GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken);
+        Task SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken);
+
+        Task<bool> IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken);
+        Task SetConsentRequiredAsync(IOpenIdApplication application, bool value, CancellationToken cancellationToken);
+
+        Task<ImmutableArray<string>> GetRolesAsync(IOpenIdApplication application, CancellationToken cancellationToken);
+        Task<ImmutableArray<IOpenIdApplication>> ListInRoleAsync(string role, CancellationToken cancellationToken);
+        Task SetRolesAsync(IOpenIdApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdApplicationStore.cs
@@ -8,6 +8,9 @@ namespace OrchardCore.OpenId.Abstractions.Stores
 {
     public interface IOpenIdApplicationStore : IOpenIddictApplicationStore<IOpenIdApplication>
     {
+        Task<IOpenIdApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken);
+        Task<string> GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken);
+
         // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
         Task<ImmutableArray<string>> GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken);
         Task SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdAuthorizationStore.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
 
@@ -5,5 +7,7 @@ namespace OrchardCore.OpenId.Abstractions.Stores
 {
     public interface IOpenIdAuthorizationStore : IOpenIddictAuthorizationStore<IOpenIdAuthorization>
     {
+        Task<IOpenIdAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken);
+        Task<string> GetPhysicalIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdAuthorizationStore.cs
@@ -1,0 +1,9 @@
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+
+namespace OrchardCore.OpenId.Abstractions.Stores
+{
+    public interface IOpenIdAuthorizationStore : IOpenIddictAuthorizationStore<IOpenIdAuthorization>
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdScopeStore.cs
@@ -1,0 +1,9 @@
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+
+namespace OrchardCore.OpenId.Abstractions.Stores
+{
+    public interface IOpenIdScopeStore : IOpenIddictScopeStore<IOpenIdScope>
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdScopeStore.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
 
@@ -5,5 +7,7 @@ namespace OrchardCore.OpenId.Abstractions.Stores
 {
     public interface IOpenIdScopeStore : IOpenIddictScopeStore<IOpenIdScope>
     {
+        Task<IOpenIdScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken);
+        Task<string> GetPhysicalIdAsync(IOpenIdScope scope, CancellationToken cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdTokenStore.cs
@@ -1,0 +1,9 @@
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+
+namespace OrchardCore.OpenId.Abstractions.Stores
+{
+    public interface IOpenIdTokenStore : IOpenIddictTokenStore<IOpenIdToken>
+    {
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdTokenStore.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+using System.Threading.Tasks;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
 
@@ -5,5 +7,7 @@ namespace OrchardCore.OpenId.Abstractions.Stores
 {
     public interface IOpenIdTokenStore : IOpenIddictTokenStore<IOpenIdToken>
     {
+        Task<IOpenIdToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken);
+        Task<string> GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -15,8 +15,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using OpenIddict.Core;
-using OrchardCore.OpenId.Models;
 using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Services.Managers;
 using OrchardCore.OpenId.ViewModels;
 using OrchardCore.Security;
 using OrchardCore.Users;
@@ -26,7 +26,7 @@ namespace OrchardCore.OpenId.Controllers
     [Authorize]
     public class AccessController : Controller
     {
-        private readonly OpenIddictApplicationManager<OpenIdApplication> _applicationManager;
+        private readonly OpenIdApplicationManager _applicationManager;
         private readonly IOptions<IdentityOptions> _identityOptions;
         private readonly SignInManager<IUser> _signInManager;
         private readonly IOpenIdService _openIdService;
@@ -35,7 +35,7 @@ namespace OrchardCore.OpenId.Controllers
         private readonly IStringLocalizer<AccessController> T;
 
         public AccessController(
-            OpenIddictApplicationManager<OpenIdApplication> applicationManager,
+            OpenIdApplicationManager applicationManager,
             IOptions<IdentityOptions> identityOptions,
             IStringLocalizer<AccessController> localizer,
             IOpenIdService openIdService,
@@ -84,7 +84,8 @@ namespace OrchardCore.OpenId.Controllers
                 });
             }
 
-            if (request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) && !application.AllowRefreshTokenFlow)
+            if (request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) &&
+                !await _applicationManager.IsRefreshTokenFlowAllowedAsync(application, HttpContext.RequestAborted))
             {
                 return View("Error", new ErrorViewModel
                 {
@@ -93,7 +94,8 @@ namespace OrchardCore.OpenId.Controllers
                 });
             }
 
-            if (request.IsAuthorizationCodeFlow() && !application.AllowAuthorizationCodeFlow)
+            if (request.IsAuthorizationCodeFlow() &&
+                !await _applicationManager.IsAuthorizationCodeFlowAllowedAsync(application, HttpContext.RequestAborted))
             {
                 return View("Error", new ErrorViewModel
                 {
@@ -102,7 +104,8 @@ namespace OrchardCore.OpenId.Controllers
                 });
             }
 
-            if (request.IsImplicitFlow() && !application.AllowImplicitFlow)
+            if (request.IsImplicitFlow() &&
+                !await _applicationManager.IsImplicitFlowAllowedAsync(application, HttpContext.RequestAborted))
             {
                 return View("Error", new ErrorViewModel
                 {
@@ -111,7 +114,8 @@ namespace OrchardCore.OpenId.Controllers
                 });
             }
 
-            if (request.IsHybridFlow() && !application.AllowHybridFlow)
+            if (request.IsHybridFlow() &&
+                !await _applicationManager.IsHybridFlowAllowedAsync(application, HttpContext.RequestAborted))
             {
                 return View("Error", new ErrorViewModel
                 {
@@ -132,14 +136,14 @@ namespace OrchardCore.OpenId.Controllers
                 }
             }
 
-            if (application.SkipConsent)
+            if (await _applicationManager.IsConsentRequiredAsync(application, HttpContext.RequestAborted))
             {
                 return await IssueAccessIdentityTokensAsync(request);
             }
 
             return View(new AuthorizeViewModel
             {
-                ApplicationName = application.DisplayName,
+                ApplicationName = await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted),
                 RequestId = request.RequestId,
                 Scope = request.Scope
             });
@@ -204,7 +208,8 @@ namespace OrchardCore.OpenId.Controllers
                 });
             }
 
-            if (request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) && !application.AllowRefreshTokenFlow)
+            if (request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) &&
+                !await _applicationManager.IsRefreshTokenFlowAllowedAsync(application, HttpContext.RequestAborted))
             {
                 return BadRequest(new OpenIdConnectResponse
                 {
@@ -215,7 +220,7 @@ namespace OrchardCore.OpenId.Controllers
 
             if (request.IsPasswordGrantType())
             {
-                if (!application.AllowPasswordFlow)
+                if (!await _applicationManager.IsPasswordFlowAllowedAsync(application, HttpContext.RequestAborted))
                 {
                     return BadRequest(new OpenIdConnectResponse
                     {
@@ -229,7 +234,7 @@ namespace OrchardCore.OpenId.Controllers
 
             if (request.IsClientCredentialsGrantType())
             {
-                if (!application.AllowClientCredentialsFlow)
+                if (!await _applicationManager.IsClientCredentialsFlowAllowedAsync(application, HttpContext.RequestAborted))
                 {
                     return BadRequest(new OpenIdConnectResponse
                     {
@@ -243,7 +248,7 @@ namespace OrchardCore.OpenId.Controllers
 
             if (request.IsAuthorizationCodeGrantType())
             {
-                if (!application.AllowAuthorizationCodeFlow)
+                if (!await _applicationManager.IsAuthorizationCodeFlowAllowedAsync(application, HttpContext.RequestAborted))
                 {
                     return BadRequest(new OpenIdConnectResponse
                     {
@@ -257,7 +262,7 @@ namespace OrchardCore.OpenId.Controllers
 
             if (request.IsRefreshTokenGrantType())
             {
-                if (!application.AllowRefreshTokenFlow)
+                if (!await _applicationManager.IsRefreshTokenFlowAllowedAsync(application, HttpContext.RequestAborted))
                 {
                     return BadRequest(new OpenIdConnectResponse
                     {
@@ -290,19 +295,19 @@ namespace OrchardCore.OpenId.Controllers
                 OpenIdConnectConstants.Claims.Name,
                 OpenIdConnectConstants.Claims.Role);
 
-            identity.AddClaim(OpenIdConnectConstants.Claims.Subject, application.ClientId);
+            identity.AddClaim(OpenIdConnectConstants.Claims.Subject, request.ClientId);
             identity.AddClaim(OpenIdConnectConstants.Claims.Name,
                 await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted),
                 OpenIdConnectConstants.Destinations.AccessToken,
                 OpenIdConnectConstants.Destinations.IdentityToken);
 
-            foreach (var roleName in application.RoleNames)
+            foreach (var role in await _applicationManager.GetRolesAsync(application, HttpContext.RequestAborted))
             {
-                identity.AddClaim(identity.RoleClaimType, roleName,
+                identity.AddClaim(identity.RoleClaimType, role,
                     OpenIdConnectConstants.Destinations.AccessToken,
                     OpenIdConnectConstants.Destinations.IdentityToken);
 
-                foreach (var claim in await _roleManager.GetClaimsAsync(await _roleManager.FindByIdAsync(roleName)))
+                foreach (var claim in await _roleManager.GetClaimsAsync(await _roleManager.FindByIdAsync(role)))
                 {
                     identity.AddClaim(claim.Type, claim.Value, OpenIdConnectConstants.Destinations.AccessToken,
                                                                OpenIdConnectConstants.Destinations.IdentityToken);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AdminController.cs
@@ -8,12 +8,13 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
-using OpenIddict.Core;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.Navigation;
+using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Models;
 using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Services.Managers;
 using OrchardCore.OpenId.ViewModels;
 using OrchardCore.Security.Services;
 using OrchardCore.Settings;
@@ -29,7 +30,7 @@ namespace OrchardCore.OpenId.Controllers
         private readonly ISiteService _siteService;
         private readonly IShapeFactory _shapeFactory;
         private readonly IRoleProvider _roleProvider;
-        private readonly OpenIddictApplicationManager<OpenIdApplication> _applicationManager;
+        private readonly OpenIdApplicationManager _applicationManager;
         private readonly INotifier _notifier;
         private readonly IOpenIdService _openIdService;
         private readonly IEnumerable<IPasswordValidator<IUser>> _passwordValidators;
@@ -42,7 +43,7 @@ namespace OrchardCore.OpenId.Controllers
             IStringLocalizer<AdminController> stringLocalizer,
             IAuthorizationService authorizationService,
             IRoleProvider roleProvider,
-            OpenIddictApplicationManager<OpenIdApplication> applicationManager,
+            OpenIdApplicationManager applicationManager,
             IEnumerable<IPasswordValidator<IUser>> passwordValidators,
             UserManager<IUser> userManager,
             IOptions<IdentityOptions> identityOptions,
@@ -80,20 +81,22 @@ namespace OrchardCore.OpenId.Controllers
             var siteSettings = await _siteService.GetSiteSettingsAsync();
             var pager = new Pager(pagerParameters, siteSettings.PageSize);
 
-            var results = await _applicationManager.ListAsync(pager.PageSize, pager.GetStartIndex(), HttpContext.RequestAborted);
-
-            var pagerShape = await _shapeFactory.CreateAsync("Pager", new
-            {
-                TotalItemCount = await _applicationManager.CountAsync(HttpContext.RequestAborted)
-            });
-
             var model = new OpenIdApplicationsIndexViewModel
             {
-                Applications = results
-                    .Select(x => new OpenIdApplicationEntry { Application = x })
-                    .ToList(),
-                Pager = pagerShape
+                Pager = await _shapeFactory.CreateAsync("Pager", new
+                {
+                    TotalItemCount = await _applicationManager.CountAsync(HttpContext.RequestAborted)
+                })
             };
+
+            foreach (var application in await _applicationManager.ListAsync(pager.PageSize, pager.GetStartIndex(), HttpContext.RequestAborted))
+            {
+                model.Applications.Add(new OpenIdApplicationEntry
+                {
+                    ApplicationId = await _applicationManager.GetIdAsync(application, HttpContext.RequestAborted),
+                    DisplayName = await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted)
+                });
+            }
 
             return View(model);
         }
@@ -117,27 +120,30 @@ namespace OrchardCore.OpenId.Controllers
                 return NotFound();
             }
 
-            var model = new EditOpenIdApplicationViewModel()
+            var model = new EditOpenIdApplicationViewModel
             {
-                Id = id,
-                DisplayName = application.DisplayName,
-                RedirectUri = application.RedirectUris.FirstOrDefault(),
-                LogoutRedirectUri = application.PostLogoutRedirectUris.FirstOrDefault(),
-                ClientId = application.ClientId,
-                Type = application.Type,
-                SkipConsent = application.SkipConsent,
-                RoleEntries = (await _roleProvider.GetRoleNamesAsync())
-                    .Select(r => new RoleEntry()
-                    {
-                        Name = r,
-                        Selected = application.RoleNames.Contains(r),
-                    }).ToList(),
-                AllowAuthorizationCodeFlow = application.AllowAuthorizationCodeFlow,
-                AllowClientCredentialsFlow = application.AllowClientCredentialsFlow,
-                AllowImplicitFlow = application.AllowImplicitFlow,
-                AllowPasswordFlow = application.AllowPasswordFlow,
-                AllowRefreshTokenFlow = application.AllowRefreshTokenFlow
+                AllowAuthorizationCodeFlow = await _applicationManager.IsAuthorizationCodeFlowAllowedAsync(application, HttpContext.RequestAborted),
+                AllowClientCredentialsFlow = await _applicationManager.IsClientCredentialsFlowAllowedAsync(application, HttpContext.RequestAborted),
+                AllowImplicitFlow = await _applicationManager.IsImplicitFlowAllowedAsync(application, HttpContext.RequestAborted),
+                AllowPasswordFlow = await _applicationManager.IsPasswordFlowAllowedAsync(application, HttpContext.RequestAborted),
+                AllowRefreshTokenFlow = await _applicationManager.IsRefreshTokenFlowAllowedAsync(application, HttpContext.RequestAborted),
+                ClientId = await _applicationManager.GetClientIdAsync(application, HttpContext.RequestAborted),
+                DisplayName = await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted),
+                Id = await _applicationManager.GetIdAsync(application, HttpContext.RequestAborted),
+                LogoutRedirectUri = (await _applicationManager.GetPostLogoutRedirectUrisAsync(application, HttpContext.RequestAborted)).FirstOrDefault(),
+                RedirectUri = (await _applicationManager.GetRedirectUrisAsync(application, HttpContext.RequestAborted)).FirstOrDefault(),
+                SkipConsent = await _applicationManager.IsConsentRequiredAsync(application, HttpContext.RequestAborted),
+                Type = await _applicationManager.GetClientTypeAsync(application, HttpContext.RequestAborted)
             };
+
+            foreach (var role in await _roleProvider.GetRoleNamesAsync())
+            {
+                model.RoleEntries.Add(new RoleEntry
+                {
+                    Name = role,
+                    Selected = await _applicationManager.IsInRoleAsync(application, role, HttpContext.RequestAborted)
+                });
+            }
 
             ViewData["OpenIdSettings"] = openIdSettings;
             ViewData["ReturnUrl"] = returnUrl;
@@ -162,7 +168,7 @@ namespace OrchardCore.OpenId.Controllers
                 await ValidateClientSecretAsync(user, model.ClientSecret, (key, message) => ModelState.AddModelError(key, message));
             }
 
-            OpenIdApplication application = null;
+            IOpenIdApplication application = null;
 
             if (ModelState.IsValid)
             {
@@ -172,7 +178,8 @@ namespace OrchardCore.OpenId.Controllers
                     return NotFound();
                 }
 
-                if (application.Type == ClientType.Public && model.Type == ClientType.Confidential && !model.UpdateClientSecret)
+                if (model.Type == ClientType.Confidential && !model.UpdateClientSecret &&
+                    await _applicationManager.IsPublicAsync(application, HttpContext.RequestAborted))
                 {
                     ModelState.AddModelError(nameof(model.UpdateClientSecret), T["Setting a new client secret is required"]);
                 }
@@ -191,47 +198,7 @@ namespace OrchardCore.OpenId.Controllers
                 return View(model);
             }
 
-            // If the application was confidential and is now public, the client secret must be reset.
-            if (application.Type == ClientType.Confidential && model.Type == ClientType.Public)
-            {
-                model.UpdateClientSecret = true;
-                model.ClientSecret = null;
-            }
-
-            application.DisplayName = model.DisplayName;
-            application.ClientId = model.ClientId;
-            application.Type = model.Type;
-            application.SkipConsent = model.SkipConsent;
-            application.AllowAuthorizationCodeFlow = model.AllowAuthorizationCodeFlow;
-            application.AllowClientCredentialsFlow = model.AllowClientCredentialsFlow;
-            application.AllowImplicitFlow = model.AllowImplicitFlow;
-            application.AllowPasswordFlow = model.AllowPasswordFlow;
-            application.AllowRefreshTokenFlow = model.AllowRefreshTokenFlow;
-            application.AllowHybridFlow = model.AllowHybridFlow;
-
-            if (application.Type == ClientType.Confidential && application.AllowClientCredentialsFlow)
-            {
-                application.RoleNames = new HashSet<string>(model.RoleEntries.Where(r => r.Selected).Select(r => r.Name));
-            }
-
-            if (!string.IsNullOrEmpty(model.RedirectUri))
-            {
-                application.RedirectUris = new HashSet<string> { model.RedirectUri };
-            }
-
-            if (!string.IsNullOrEmpty(model.LogoutRedirectUri))
-            {
-                application.PostLogoutRedirectUris = new HashSet<string> { model.LogoutRedirectUri };
-            }
-
-            if (model.UpdateClientSecret)
-            {
-                await _applicationManager.UpdateAsync(application, model.ClientSecret, HttpContext.RequestAborted);
-            }
-            else
-            {
-                await _applicationManager.UpdateAsync(application, HttpContext.RequestAborted);
-            }
+            await _applicationManager.UpdateAsync(application, model, HttpContext.RequestAborted);
 
             if (string.IsNullOrEmpty(returnUrl))
             {
@@ -248,17 +215,19 @@ namespace OrchardCore.OpenId.Controllers
             {
                 return Unauthorized();
             }
-            
+
             var openIdSettings = await _openIdService.GetOpenIdSettingsAsync();
             if (!_openIdService.IsValidOpenIdSettings(openIdSettings))
             {
                 _notifier.Warning(H["OpenID Connect settings are not properly configured."]);
             }
 
-            var model = new CreateOpenIdApplicationViewModel()
+            var model = new CreateOpenIdApplicationViewModel();
+
+            foreach (var role in await _roleProvider.GetRoleNamesAsync())
             {
-                RoleEntries = (await _roleProvider.GetRoleNamesAsync()).Select(r => new RoleEntry() { Name = r }).ToList()
-            };
+                model.RoleEntries.Add(new RoleEntry { Name = role });
+            }
 
             ViewData["OpenIdSettings"] = openIdSettings;
             ViewData["ReturnUrl"] = returnUrl;
@@ -296,46 +265,16 @@ namespace OrchardCore.OpenId.Controllers
                 return View("Create", model);
             }
 
-            var roleNames = new HashSet<string>();
-            if (model.Type == ClientType.Confidential && model.AllowClientCredentialsFlow)
-            {
-                roleNames = new HashSet<string>(model.RoleEntries.Where(r => r.Selected).Select(r => r.Name));
-            }
-
-            var application = new OpenIdApplication
-            {
-                ApplicationId = Guid.NewGuid().ToString("n"),
-                DisplayName = model.DisplayName,
-                ClientId = model.ClientId,
-                Type = model.Type,
-                SkipConsent = model.SkipConsent,
-                RoleNames = roleNames,
-                AllowAuthorizationCodeFlow = model.AllowAuthorizationCodeFlow,
-                AllowClientCredentialsFlow = model.AllowClientCredentialsFlow,
-                AllowImplicitFlow = model.AllowImplicitFlow,
-                AllowPasswordFlow = model.AllowPasswordFlow,
-                AllowRefreshTokenFlow = model.AllowRefreshTokenFlow,
-                AllowHybridFlow = model.AllowHybridFlow
-            };
-
-            if (!string.IsNullOrEmpty(model.RedirectUri))
-            {
-                application.RedirectUris = new HashSet<string> { model.RedirectUri };
-            }
-
-            if (!string.IsNullOrEmpty(model.LogoutRedirectUri))
-            {
-                application.PostLogoutRedirectUris = new HashSet<string> { model.LogoutRedirectUri };
-            }
-
-            await _applicationManager.CreateAsync(application, model.ClientSecret, HttpContext.RequestAborted);
+            await _applicationManager.CreateAsync(model, HttpContext.RequestAborted);
 
             if (string.IsNullOrEmpty(returnUrl))
             {
                 return RedirectToAction("Index");
             }
+
             return LocalRedirect(returnUrl);
         }
+
         private async Task<bool> ValidateClientSecretAsync(IUser user, string password, Action<string, string> reportError)
         {
             if (string.IsNullOrEmpty(password))
@@ -355,21 +294,21 @@ namespace OrchardCore.OpenId.Controllers
                     {
                         switch (error.Code)
                         {
-                            case "PasswordRequiresDigit":
-                                reportError("ClientSecret", T["Passwords must have at least one digit ('0'-'9')."]);
-                                break;
-                            case "PasswordRequiresLower":
-                                reportError("ClientSecret", T["Passwords must have at least one lowercase ('a'-'z')."]);
-                                break;
-                            case "PasswordRequiresUpper":
-                                reportError("ClientSecret", T["Passwords must have at least one uppercase('A'-'Z')."]);
-                                break;
-                            case "PasswordRequiresNonAlphanumeric":
-                                reportError("ClientSecret", T["Passwords must have at least one non letter or digit character."]);
-                                break;
-                            case "PasswordTooShort":
-                                reportError("ClientSecret", T["Passwords must be at least {0} characters.", _identityOptions.Value.Password.RequiredLength]);
-                                break;
+                        case "PasswordRequiresDigit":
+                            reportError("ClientSecret", T["Passwords must have at least one digit ('0'-'9')."]);
+                            break;
+                        case "PasswordRequiresLower":
+                            reportError("ClientSecret", T["Passwords must have at least one lowercase ('a'-'z')."]);
+                            break;
+                        case "PasswordRequiresUpper":
+                            reportError("ClientSecret", T["Passwords must have at least one uppercase('A'-'Z')."]);
+                            break;
+                        case "PasswordRequiresNonAlphanumeric":
+                            reportError("ClientSecret", T["Passwords must have at least one non letter or digit character."]);
+                            break;
+                        case "PasswordTooShort":
+                            reportError("ClientSecret", T["Passwords must be at least {0} characters.", _identityOptions.Value.Password.RequiredLength]);
+                            break;
                         }
                     }
                 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AdminController.cs
@@ -93,8 +93,8 @@ namespace OrchardCore.OpenId.Controllers
             {
                 model.Applications.Add(new OpenIdApplicationEntry
                 {
-                    ApplicationId = await _applicationManager.GetIdAsync(application, HttpContext.RequestAborted),
-                    DisplayName = await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted)
+                    DisplayName = await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted),
+                    Id = await _applicationManager.GetPhysicalIdAsync(application, HttpContext.RequestAborted)
                 });
             }
 
@@ -114,7 +114,7 @@ namespace OrchardCore.OpenId.Controllers
                 _notifier.Warning(H["OpenID Connect settings are not properly configured."]);
             }
 
-            var application = await _applicationManager.FindByIdAsync(id, HttpContext.RequestAborted);
+            var application = await _applicationManager.FindByPhysicalIdAsync(id, HttpContext.RequestAborted);
             if (application == null)
             {
                 return NotFound();
@@ -129,7 +129,7 @@ namespace OrchardCore.OpenId.Controllers
                 AllowRefreshTokenFlow = await _applicationManager.IsRefreshTokenFlowAllowedAsync(application, HttpContext.RequestAborted),
                 ClientId = await _applicationManager.GetClientIdAsync(application, HttpContext.RequestAborted),
                 DisplayName = await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted),
-                Id = await _applicationManager.GetIdAsync(application, HttpContext.RequestAborted),
+                Id = await _applicationManager.GetPhysicalIdAsync(application, HttpContext.RequestAborted),
                 LogoutRedirectUri = (await _applicationManager.GetPostLogoutRedirectUrisAsync(application, HttpContext.RequestAborted)).FirstOrDefault(),
                 RedirectUri = (await _applicationManager.GetRedirectUrisAsync(application, HttpContext.RequestAborted)).FirstOrDefault(),
                 SkipConsent = await _applicationManager.IsConsentRequiredAsync(application, HttpContext.RequestAborted),
@@ -172,7 +172,7 @@ namespace OrchardCore.OpenId.Controllers
 
             if (ModelState.IsValid)
             {
-                application = await _applicationManager.FindByIdAsync(model.Id, HttpContext.RequestAborted);
+                application = await _applicationManager.FindByPhysicalIdAsync(model.Id, HttpContext.RequestAborted);
                 if (application == null)
                 {
                     return NotFound();
@@ -324,7 +324,7 @@ namespace OrchardCore.OpenId.Controllers
                 return Unauthorized();
             }
 
-            var application = await _applicationManager.FindByIdAsync(id, HttpContext.RequestAborted);
+            var application = await _applicationManager.FindByPhysicalIdAsync(id, HttpContext.RequestAborted);
             if (application == null)
             {
                 return NotFound();

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Migrations.cs
@@ -9,9 +9,8 @@ namespace OrchardCore.OpenId
         public int Create()
         {
             SchemaBuilder.CreateMapIndexTable(nameof(OpenIdApplicationIndex), table => table
-                .Column<string>(nameof(OpenIdApplicationIndex.ApplicationId), c => c.WithLength(48))
-                .Column<string>(nameof(OpenIdApplicationIndex.ClientId))
-                );
+                .Column<string>(nameof(OpenIdApplicationIndex.ApplicationId), column => column.WithLength(48))
+                .Column<string>(nameof(OpenIdApplicationIndex.ClientId)));
 
             SchemaBuilder.CreateReduceIndexTable(nameof(OpenIdApplicationByPostLogoutRedirectUriIndex), table => table
                 .Column<string>(nameof(OpenIdApplicationByPostLogoutRedirectUriIndex.PostLogoutRedirectUri))
@@ -26,17 +25,20 @@ namespace OrchardCore.OpenId
                 .Column<int>(nameof(OpenIdApplicationByRoleNameIndex.Count)));
 
             SchemaBuilder.CreateMapIndexTable(nameof(OpenIdAuthorizationIndex), table => table
-                .Column<string>(nameof(OpenIdAuthorizationIndex.AuthorizationId), c => c.WithLength(48))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.ApplicationId), c => c.WithLength(48))
+                .Column<string>(nameof(OpenIdAuthorizationIndex.AuthorizationId), column => column.WithLength(48))
+                .Column<string>(nameof(OpenIdAuthorizationIndex.ApplicationId), column => column.WithLength(48))
                 .Column<string>(nameof(OpenIdAuthorizationIndex.Status))
                 .Column<string>(nameof(OpenIdAuthorizationIndex.Subject))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.Type))
-                );
+                .Column<string>(nameof(OpenIdAuthorizationIndex.Type)));
+
+            SchemaBuilder.CreateMapIndexTable(nameof(OpenIdScopeIndex), table => table
+                .Column<string>(nameof(OpenIdScopeIndex.Name))
+                .Column<string>(nameof(OpenIdScopeIndex.ScopeId), column => column.WithLength(48)));
 
             SchemaBuilder.CreateMapIndexTable(nameof(OpenIdTokenIndex), table => table
-                .Column<string>(nameof(OpenIdTokenIndex.TokenId), c => c.WithLength(48))
-                .Column<string>(nameof(OpenIdTokenIndex.ApplicationId), c => c.WithLength(48))
-                .Column<string>(nameof(OpenIdTokenIndex.AuthorizationId), c => c.WithLength(48))
+                .Column<string>(nameof(OpenIdTokenIndex.TokenId), column => column.WithLength(48))
+                .Column<string>(nameof(OpenIdTokenIndex.ApplicationId), column => column.WithLength(48))
+                .Column<string>(nameof(OpenIdTokenIndex.AuthorizationId), column => column.WithLength(48))
                 .Column<DateTimeOffset>(nameof(OpenIdTokenIndex.ExpirationDate))
                 .Column<string>(nameof(OpenIdTokenIndex.ReferenceId))
                 .Column<string>(nameof(OpenIdTokenIndex.Status))

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Migrations.cs
@@ -1,6 +1,6 @@
 using System;
 using OrchardCore.Data.Migration;
-using OrchardCore.OpenId.Indexes;
+using OrchardCore.OpenId.YesSql.Indexes;
 
 namespace OrchardCore.OpenId
 {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Models/CertificateInfo.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Models/CertificateInfo.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Cryptography.X509Certificates;
 
 namespace OrchardCore.OpenId.Models

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Models/ClientType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Models/ClientType.cs
@@ -1,0 +1,8 @@
+namespace OrchardCore.OpenId.Models
+{
+    public enum ClientType
+    {
+        Confidential,
+        Public
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -1,22 +1,21 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using OpenIddict.Core;
-using OrchardCore.OpenId.Models;
+using OrchardCore.OpenId.Services.Managers;
+using OrchardCore.OpenId.ViewModels;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Recipes.Services;
-using System.Collections.Generic;
 
 namespace OrchardCore.OpenId.Recipes
 {
     public class OpenIdApplicationStep : IRecipeStepHandler
     {
-        private readonly OpenIddictApplicationManager<OpenIdApplication> _applicationManager;
+        private readonly OpenIdApplicationManager _applicationManager;
 
         /// <summary>
         /// This recipe step adds an OpenID Connect app.
         /// </summary>
-        public OpenIdApplicationStep(OpenIddictApplicationManager<OpenIdApplication> applicationManager)
+        public OpenIdApplicationStep(OpenIdApplicationManager applicationManager)
         {
             _applicationManager = applicationManager;
         }
@@ -28,62 +27,8 @@ namespace OrchardCore.OpenId.Recipes
                 return;
             }
 
-            var model = context.Step.ToObject<OpenIdApplicationStepModel>();
-            var application = new OpenIdApplication();
-            if (model.Id != 0)
-            {
-                application = await _applicationManager.FindByIdAsync(model.Id.ToString(), CancellationToken.None);
-            }
-            application.ClientId = model.ClientId;
-            application.DisplayName = model.DisplayName;
-            application.AllowAuthorizationCodeFlow = model.AllowAuthorizationCodeFlow;
-            application.AllowClientCredentialsFlow = model.AllowClientCredentialsFlow;
-            application.AllowHybridFlow = model.AllowHybridFlow;
-            application.AllowImplicitFlow = model.AllowImplicitFlow;
-            application.AllowPasswordFlow = model.AllowPasswordFlow;
-            application.AllowRefreshTokenFlow = model.AllowRefreshTokenFlow;
-            application.SkipConsent = model.SkipConsent;
-            application.RoleNames = new HashSet<string>(model.RoleNames);
-            application.Type = model.Type;
-
-            if (!string.IsNullOrEmpty(model.LogoutRedirectUri))
-            {
-                application.PostLogoutRedirectUris = new HashSet<string> { model.LogoutRedirectUri };
-            }
-
-            if (!string.IsNullOrEmpty(model.RedirectUri))
-            {
-                application.RedirectUris = new HashSet<string> { model.RedirectUri };
-            }
-
-            if (model.Type == ClientType.Confidential)
-            {
-                await _applicationManager.CreateAsync(application, model.ClientSecret, CancellationToken.None);
-            }
-
-            else
-            {
-                await _applicationManager.CreateAsync(application, CancellationToken.None);
-            }
+            var model = context.Step.ToObject<CreateOpenIdApplicationViewModel>();
+            await _applicationManager.CreateAsync(model, CancellationToken.None);
         }
-    }
-
-    public class OpenIdApplicationStepModel
-    {
-        public string ClientId { get; set; }
-        public string ClientSecret { get; set; }
-        public string DisplayName { get; set; }
-        public int Id { get; set; }
-        public string LogoutRedirectUri { get; set; }
-        public string RedirectUri { get; set; }
-        public ClientType Type { get; set; }
-        public bool SkipConsent { get; set; }
-        public List<string> RoleNames { get; set; } = new List<string>();
-        public bool AllowPasswordFlow { get; set; }
-        public bool AllowClientCredentialsFlow { get; set; }
-        public bool AllowAuthorizationCodeFlow { get; set; }
-        public bool AllowRefreshTokenFlow { get; set; }
-        public bool AllowImplicitFlow { get; set; }
-        public bool AllowHybridFlow { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/IOpenIdService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/IOpenIdService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.OpenId.Settings;

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdApplicationManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdApplicationManager.cs
@@ -92,6 +92,25 @@ namespace OrchardCore.OpenId.Services.Managers
             return await CreateAsync(application, cancellationToken);
         }
 
+        /// <summary>
+        /// Retrieves an application using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        public virtual Task<IOpenIdApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            return Store.FindByPhysicalIdAsync(identifier, cancellationToken);
+        }
+
         public virtual new async Task<ClientType> GetClientTypeAsync(IOpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -116,6 +135,25 @@ namespace OrchardCore.OpenId.Services.Managers
             }
 
             return Store.GetGrantTypesAsync(application, cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the application.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Store.GetPhysicalIdAsync(application, cancellationToken);
         }
 
         public virtual async Task<bool> IsGrantTypeAllowedAsync(IOpenIdApplication application, string type, CancellationToken cancellationToken)

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdApplicationManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdApplicationManager.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AspNet.Security.OpenIdConnect.Primitives;
+using Microsoft.Extensions.Logging;
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
+using OrchardCore.OpenId.Models;
+using OrchardCore.OpenId.ViewModels;
+
+namespace OrchardCore.OpenId.Services.Managers
+{
+    public class OpenIdApplicationManager : OpenIddictApplicationManager<IOpenIdApplication>
+    {
+        public OpenIdApplicationManager(
+            IOpenIdApplicationStore store,
+            ILogger<OpenIdApplicationManager> logger)
+            : base(store, logger)
+        {
+        }
+
+        protected new IOpenIdApplicationStore Store => (IOpenIdApplicationStore) base.Store;
+
+        public virtual async Task<IOpenIdApplication> CreateAsync(CreateOpenIdApplicationViewModel model, CancellationToken cancellationToken)
+        {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            var application = await Store.InstantiateAsync(cancellationToken);
+            if (application == null)
+            {
+                throw new InvalidOperationException("An error occurred while trying to create a new application");
+            }
+
+            await Store.SetClientIdAsync(application, model.ClientId, cancellationToken);
+            await Store.SetClientSecretAsync(application, model.ClientSecret, cancellationToken);
+            await Store.SetClientTypeAsync(application, model.Type.ToString(), cancellationToken);
+            await Store.SetDisplayNameAsync(application, model.DisplayName, cancellationToken);
+            await Store.SetRolesAsync(application, model.RoleEntries.Select(role => role.Name).ToImmutableArray(), cancellationToken);
+
+            if (!string.IsNullOrEmpty(model.LogoutRedirectUri))
+            {
+                await Store.SetPostLogoutRedirectUrisAsync(application, ImmutableArray.Create(model.LogoutRedirectUri), cancellationToken);
+            }
+
+            if (!string.IsNullOrEmpty(model.RedirectUri))
+            {
+                await Store.SetRedirectUrisAsync(application, ImmutableArray.Create(model.RedirectUri), cancellationToken);
+            }
+
+            var builder = ImmutableArray.CreateBuilder<string>();
+
+            if (model.AllowAuthorizationCodeFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+            }
+
+            if (model.AllowClientCredentialsFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.ClientCredentials);
+            }
+
+            if (model.AllowImplicitFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.Implicit);
+            }
+
+            if (model.AllowPasswordFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.Password);
+            }
+
+            if (model.AllowRefreshTokenFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.RefreshToken);
+            }
+
+            await Store.SetGrantTypesAsync(application, builder.ToImmutable(), cancellationToken);
+
+            var secret = await Store.GetClientSecretAsync(application, cancellationToken);
+            if (!string.IsNullOrEmpty(secret))
+            {
+                await Store.SetClientSecretAsync(application, /* secret: */ null, cancellationToken);
+                return await CreateAsync(application, secret, cancellationToken);
+            }
+
+            return await CreateAsync(application, cancellationToken);
+        }
+
+        public virtual new async Task<ClientType> GetClientTypeAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            if (!Enum.TryParse(await Store.GetClientTypeAsync(application, cancellationToken), /* ignoreCase: */ true, out ClientType type))
+            {
+                throw new InvalidOperationException("The client type associated with the application is not supported.");
+            }
+
+            return type;
+        }
+
+        // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
+        public virtual Task<ImmutableArray<string>> GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Store.GetGrantTypesAsync(application, cancellationToken);
+        }
+
+        public virtual async Task<bool> IsGrantTypeAllowedAsync(IOpenIdApplication application, string type, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return (await Store.GetGrantTypesAsync(application, cancellationToken)).Contains(type, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public Task<bool> IsAuthorizationCodeFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => IsGrantTypeAllowedAsync(application, OpenIdConnectConstants.GrantTypes.AuthorizationCode, cancellationToken);
+
+        public Task<bool> IsClientCredentialsFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => IsGrantTypeAllowedAsync(application, OpenIdConnectConstants.GrantTypes.ClientCredentials, cancellationToken);
+
+        public async Task<bool> IsHybridFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => await IsAuthorizationCodeFlowAllowedAsync(application, cancellationToken) &&
+               await IsImplicitFlowAllowedAsync(application, cancellationToken);
+
+        public Task<bool> IsImplicitFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => IsGrantTypeAllowedAsync(application, OpenIdConnectConstants.GrantTypes.Implicit, cancellationToken);
+
+        public Task<bool> IsPasswordFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => IsGrantTypeAllowedAsync(application, OpenIdConnectConstants.GrantTypes.Password, cancellationToken);
+
+        public Task<bool> IsRefreshTokenFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => IsGrantTypeAllowedAsync(application, OpenIdConnectConstants.GrantTypes.RefreshToken, cancellationToken);
+
+        public virtual Task<bool> IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Store.IsConsentRequiredAsync(application, cancellationToken);
+        }
+
+        public virtual async Task AddToRoleAsync(IOpenIdApplication application, string role, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            var roles = await Store.GetRolesAsync(application, cancellationToken);
+            await Store.SetRolesAsync(application, roles.Add(role), cancellationToken);
+            await UpdateAsync(application, cancellationToken);
+        }
+
+        public virtual Task<ImmutableArray<string>> GetRolesAsync(IOpenIdApplication application, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Store.GetRolesAsync(application, cancellationToken);
+        }
+
+        public virtual async Task<bool> IsInRoleAsync(IOpenIdApplication application, string role, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            if (string.IsNullOrEmpty(role))
+            {
+                throw new ArgumentException("The role name cannot be null or empty.", nameof(role));
+            }
+
+            return (await Store.GetRolesAsync(application, cancellationToken)).Contains(role, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public virtual Task<ImmutableArray<IOpenIdApplication>> ListInRoleAsync(string role, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (string.IsNullOrEmpty(role))
+            {
+                throw new ArgumentException("The role name cannot be null or empty.", nameof(role));
+            }
+
+            return Store.ListInRoleAsync(role, cancellationToken);
+        }
+
+        public virtual async Task RemoveFromRoleAsync(IOpenIdApplication application, string role, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            if (string.IsNullOrEmpty(role))
+            {
+                throw new ArgumentException("The role name cannot be null or empty.", nameof(role));
+            }
+
+            var roles = await Store.GetRolesAsync(application, cancellationToken);
+            await Store.SetRolesAsync(application, roles.Remove(role, StringComparer.OrdinalIgnoreCase), cancellationToken);
+            await UpdateAsync(application, cancellationToken);
+        }
+
+        public virtual async Task UpdateAsync(IOpenIdApplication application, EditOpenIdApplicationViewModel model, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            await Store.SetClientIdAsync(application, model.ClientId, cancellationToken);
+            await Store.SetClientTypeAsync(application, model.Type.ToString(), cancellationToken);
+            await Store.SetDisplayNameAsync(application, model.DisplayName, cancellationToken);
+            await Store.SetRolesAsync(application, model.RoleEntries.Select(role => role.Name).ToImmutableArray(), cancellationToken);
+
+            var builder = ImmutableArray.CreateBuilder<string>();
+
+            if (model.AllowAuthorizationCodeFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+            }
+
+            if (model.AllowClientCredentialsFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.ClientCredentials);
+            }
+
+            if (model.AllowImplicitFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.Implicit);
+            }
+
+            if (model.AllowPasswordFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.Password);
+            }
+
+            if (model.AllowRefreshTokenFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.RefreshToken);
+            }
+
+            await Store.SetGrantTypesAsync(application, builder.ToImmutable(), cancellationToken);
+
+            if (!string.IsNullOrEmpty(model.LogoutRedirectUri))
+            {
+                await Store.SetPostLogoutRedirectUrisAsync(application, ImmutableArray.Create(model.LogoutRedirectUri), cancellationToken);
+            }
+
+            if (!string.IsNullOrEmpty(model.RedirectUri))
+            {
+                await Store.SetRedirectUrisAsync(application, ImmutableArray.Create(model.RedirectUri), cancellationToken);
+            }
+
+            if (model.UpdateClientSecret)
+            {
+                await UpdateAsync(application, model.ClientSecret, cancellationToken);
+            }
+            else
+            {
+                await UpdateAsync(application, cancellationToken);
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdAuthorizationManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdAuthorizationManager.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Logging;
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
+
+namespace OrchardCore.OpenId.Services.Managers
+{
+    public class OpenIdAuthorizationManager : OpenIddictAuthorizationManager<IOpenIdAuthorization>
+    {
+        public OpenIdAuthorizationManager(
+            IOpenIdAuthorizationStore store,
+            ILogger<OpenIdAuthorizationManager> logger)
+            : base(store, logger)
+        {
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdAuthorizationManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdAuthorizationManager.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
@@ -12,6 +15,46 @@ namespace OrchardCore.OpenId.Services.Managers
             ILogger<OpenIdAuthorizationManager> logger)
             : base(store, logger)
         {
+        }
+
+        protected new IOpenIdAuthorizationStore Store => (IOpenIdAuthorizationStore) base.Store;
+
+        /// <summary>
+        /// Retrieves an authorization using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorization corresponding to the identifier.
+        /// </returns>
+        public virtual Task<IOpenIdAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            return Store.FindByPhysicalIdAsync(identifier, cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the authorization.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        {
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            return Store.GetPhysicalIdAsync(authorization, cancellationToken);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdScopeManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdScopeManager.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
@@ -12,6 +15,48 @@ namespace OrchardCore.OpenId.Services.Managers
             ILogger<OpenIdScopeManager> logger)
             : base(store, logger)
         {
+        }
+
+        protected new IOpenIdScopeStore Store => (IOpenIdScopeStore) base.Store;
+
+        /// <summary>
+        /// Retrieves a scope using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The physical identifier associated with the scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the scope corresponding to the identifier.
+        /// </returns>
+        public virtual Task<IOpenIdScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Store.FindByPhysicalIdAsync(identifier, cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the authorization.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            return Store.GetPhysicalIdAsync(scope, cancellationToken);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdScopeManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdScopeManager.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Logging;
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
+
+namespace OrchardCore.OpenId.Services.Managers
+{
+    public class OpenIdScopeManager : OpenIddictScopeManager<IOpenIdScope>
+    {
+        public OpenIdScopeManager(
+            IOpenIdScopeStore store,
+            ILogger<OpenIdScopeManager> logger)
+            : base(store, logger)
+        {
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdTokenManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdTokenManager.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
@@ -12,6 +15,46 @@ namespace OrchardCore.OpenId.Services.Managers
             ILogger<OpenIdTokenManager> logger)
             : base(store, logger)
         {
+        }
+
+        protected new IOpenIdTokenStore Store => (IOpenIdTokenStore) base.Store;
+
+        /// <summary>
+        /// Retrieves a token using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The physical identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the token corresponding to the physical identifier.
+        /// </returns>
+        public virtual Task<IOpenIdToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            return Store.FindByPhysicalIdAsync(identifier, cancellationToken);
+        }
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the token.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Store.GetPhysicalIdAsync(token, cancellationToken);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdTokenManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdTokenManager.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Logging;
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
+
+namespace OrchardCore.OpenId.Services.Managers
+{
+    public class OpenIdTokenManager : OpenIddictTokenManager<IOpenIdToken>
+    {
+        public OpenIdTokenManager(
+            IOpenIdTokenStore store,
+            ILogger<OpenIdTokenManager> logger)
+            : base(store, logger)
+        {
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdApplicationRoleRemovedEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdApplicationRoleRemovedEventHandler.cs
@@ -1,24 +1,23 @@
 using System.Threading.Tasks;
+using OrchardCore.OpenId.Services.Managers;
 using OrchardCore.Security;
 
 namespace OrchardCore.OpenId.Services
 {
     public class OpenIdApplicationRoleRemovedEventHandler : IRoleRemovedEventHandler
     {
-        private readonly OpenIdApplicationStore _store;
+        private readonly OpenIdApplicationManager _manager;
 
-        public OpenIdApplicationRoleRemovedEventHandler(OpenIdApplicationStore store)
+        public OpenIdApplicationRoleRemovedEventHandler(OpenIdApplicationManager manager)
         {
-            _store = store;
+            _manager = manager;
         }
 
         public async Task RoleRemovedAsync(string roleName)
         {
-            var apps = await _store.GetAppsInRoleAsync(roleName);
-
-            foreach (var app in apps)
+            foreach (var application in await _manager.ListInRoleAsync(roleName))
             {
-                await _store.RemoveFromRoleAsync(app, roleName);
+                await _manager.RemoveFromRoleAsync(application, roleName);
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdConfiguration.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenIddict;
 using OrchardCore.Environment.Shell;
-using OrchardCore.OpenId.Models;
+using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Services;
 using OrchardCore.OpenId.Settings;
 
@@ -91,7 +91,7 @@ namespace OrchardCore.OpenId
                 return;
             }
 
-            options.ProviderType = typeof(OpenIddictProvider<OpenIdApplication, OpenIdAuthorization, OpenIdScope, OpenIdToken>);
+            options.ProviderType = typeof(OpenIddictProvider<IOpenIdApplication, IOpenIdAuthorization, IOpenIdScope, IOpenIdToken>);
             options.DataProtectionProvider = _dataProtectionProvider;
             options.RequireClientIdentification = true;
             options.EnableRequestCaching = true;

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -13,11 +13,14 @@ using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Modules;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
 using OrchardCore.OpenId.Drivers;
-using OrchardCore.OpenId.Indexes;
-using OrchardCore.OpenId.Models;
 using OrchardCore.OpenId.Recipes;
 using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Services.Managers;
+using OrchardCore.OpenId.YesSql.Indexes;
+using OrchardCore.OpenId.YesSql.Services;
 using OrchardCore.Recipes;
 using OrchardCore.Security;
 using OrchardCore.Security.Permissions;
@@ -41,6 +44,15 @@ namespace OrchardCore.OpenId
 
         public override void ConfigureServices(IServiceCollection services)
         {
+            // Note: only the core OpenIddict services (e.g managers and custom stores) are registered here.
+            // The OpenIddict/JWT/validation handlers are lazily registered as active authentication handlers
+            // depending on the OpenID settings. See the OpenIdConfiguration.cs file for more information.
+            services.AddOpenIddict<IOpenIdApplication, IOpenIdAuthorization, IOpenIdScope, IOpenIdToken>()
+                .AddApplicationManager<OpenIdApplicationManager>()
+                .AddAuthorizationManager<OpenIdAuthorizationManager>()
+                .AddScopeManager<OpenIdScopeManager>()
+                .AddTokenManager<OpenIdTokenManager>();
+
             services.AddScoped<IDataMigration, Migrations>();
             services.AddScoped<IPermissionProvider, Permissions>();
             services.AddSingleton<IIndexProvider, OpenIdApplicationIndexProvider>();
@@ -53,22 +65,21 @@ namespace OrchardCore.OpenId
             services.AddRecipeExecutionStep<OpenIdSettingsStep>();
             services.AddRecipeExecutionStep<OpenIdApplicationStep>();
 
-            services.AddScoped<OpenIdApplicationStore>();
-
             services.AddScoped<IRoleRemovedEventHandler, OpenIdApplicationRoleRemovedEventHandler>();
 
-            // Note: only the core OpenIddict services (e.g managers and custom stores) are registered here.
-            // The OpenIddict/JWT/validation handlers are lazily registered as active authentication handlers
-            // depending on the OpenID settings. See the OpenIdConfiguration.cs file for more information.
-            services.AddOpenIddict<OpenIdApplication, OpenIdAuthorization, OpenIdScope, OpenIdToken>()
-                .AddApplicationStore<OpenIdApplicationStore>()
-                .AddAuthorizationStore<OpenIdAuthorizationStore>()
-                .AddScopeStore<OpenIdScopeStore>()
-                .AddTokenStore<OpenIdTokenStore>();
+            services.TryAddScoped<OpenIdApplicationManager>();
+            services.TryAddScoped<OpenIdAuthorizationManager>();
+            services.TryAddScoped<OpenIdScopeManager>();
+            services.TryAddScoped<OpenIdTokenManager>();
 
-            // Register the OpenIddict handler/provider in the DI container.
-            services.TryAddScoped<OpenIddictHandler>();
-            services.TryAddScoped<OpenIddictProvider<OpenIdApplication, OpenIdAuthorization, OpenIdScope, OpenIdToken>>();
+            // If no store was explicitly registered at the host level, add the default YesSql-based stores.
+            // They can be later replaced or overriden by a module like the Entity Framework Core module.
+            services.TryAddScoped<IOpenIdApplicationStore, OpenIdApplicationStore>();
+            services.TryAddScoped<IOpenIdAuthorizationStore, OpenIdAuthorizationStore>();
+            services.TryAddScoped<IOpenIdScopeStore, OpenIdScopeStore>();
+            services.TryAddScoped<IOpenIdTokenStore, OpenIdTokenStore>();
+
+            services.TryAddScoped<OpenIddictProvider<IOpenIdApplication, IOpenIdAuthorization, IOpenIdScope, IOpenIdToken>>();
 
             // Register the options initializers required by OpenIddict,
             // the JWT handler and the aspnet-contrib validation handler.

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -56,8 +56,9 @@ namespace OrchardCore.OpenId
             services.AddScoped<IDataMigration, Migrations>();
             services.AddScoped<IPermissionProvider, Permissions>();
             services.AddSingleton<IIndexProvider, OpenIdApplicationIndexProvider>();
-            services.AddSingleton<IIndexProvider, OpenIdTokenIndexProvider>();
             services.AddSingleton<IIndexProvider, OpenIdAuthorizationIndexProvider>();
+            services.AddSingleton<IIndexProvider, OpenIdScopeIndexProvider>();
+            services.AddSingleton<IIndexProvider, OpenIdTokenIndexProvider>();
             services.AddScoped<INavigationProvider, AdminMenu>();
 
             services.AddScoped<IDisplayDriver<ISite>, OpenIdSiteSettingsDisplayDriver>();

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
@@ -1,6 +1,6 @@
-﻿using OrchardCore.OpenId.Models;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using OrchardCore.OpenId.Models;
 
 namespace OrchardCore.OpenId.ViewModels
 {
@@ -21,7 +21,7 @@ namespace OrchardCore.OpenId.ViewModels
         [DataType(DataType.Password)]
         [Compare("ClientSecret")]
         public string ConfirmClientSecret { get; set; }
-        public List<RoleEntry> RoleEntries { get; set; } = new List<RoleEntry>();
+        public List<RoleEntry> RoleEntries { get; } = new List<RoleEntry>();
         public bool AllowPasswordFlow { get; set; }
         public bool AllowClientCredentialsFlow { get; set; }
         public bool AllowAuthorizationCodeFlow { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using OrchardCore.OpenId.Models;
-using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using OrchardCore.OpenId.Models;
 
 namespace OrchardCore.OpenId.ViewModels
 {
@@ -28,7 +25,7 @@ namespace OrchardCore.OpenId.ViewModels
         [DataType(DataType.Password)]
         [Compare("ClientSecret")]
         public string ConfirmClientSecret { get; set; }
-        public List<RoleEntry> RoleEntries { get; set; } = new List<RoleEntry>();
+        public List<RoleEntry> RoleEntries { get; } = new List<RoleEntry>();
         public bool AllowPasswordFlow { get; set; }
         public bool AllowClientCredentialsFlow { get; set; }
         public bool AllowAuthorizationCodeFlow { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdApplicationIndexViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdApplicationIndexViewModel.cs
@@ -10,8 +10,8 @@ namespace OrchardCore.OpenId.ViewModels
 
     public class OpenIdApplicationEntry
     {
-        public string ApplicationId { get; set; }
         public string DisplayName { get; set; }
+        public string Id { get; set; }
         public bool IsChecked { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdApplicationIndexViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdApplicationIndexViewModel.cs
@@ -1,17 +1,17 @@
-﻿using System.Collections.Generic;
-using OrchardCore.OpenId.Models;
+using System.Collections.Generic;
 
 namespace OrchardCore.OpenId.ViewModels
 {
     public class OpenIdApplicationsIndexViewModel
     {
-        public IList<OpenIdApplicationEntry> Applications { get; set; }
+        public IList<OpenIdApplicationEntry> Applications { get; } = new List<OpenIdApplicationEntry>();
         public dynamic Pager { get; set; }
     }
 
     public class OpenIdApplicationEntry
     {
-        public OpenIdApplication Application { get; set; }
+        public string ApplicationId { get; set; }
+        public string DisplayName { get; set; }
         public bool IsChecked { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Index.cshtml
@@ -19,8 +19,8 @@
             <li class="list-group-item">
                 <div class="properties">
                     <div class="related float-xs-right">
-                        <a asp-action="Edit" asp-route-id="@entry.ApplicationId" class="btn btn-primary btn-sm">@T["Edit"]</a>
-                        <a class="delete btn btn-danger btn-sm" asp-route-id="@entry.ApplicationId" role="button" asp-action="Delete" itemprop="UnsafeUrl RemoveUrl">@T["Delete"]</a>
+                        <a asp-action="Edit" asp-route-id="@entry.Id" class="btn btn-primary btn-sm">@T["Edit"]</a>
+                        <a class="delete btn btn-danger btn-sm" asp-route-id="@entry.Id" role="button" asp-action="Delete" itemprop="UnsafeUrl RemoveUrl">@T["Delete"]</a>
                     </div>
                     @entry.DisplayName
                 </div>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model OpenIdApplicationsIndexViewModel
+@model OpenIdApplicationsIndexViewModel
 @using OrchardCore.OpenId.ViewModels;
 
 <h1>@RenderTitleSegments(T["OpenID Connect Applications"])</h1>
@@ -19,10 +19,10 @@
             <li class="list-group-item">
                 <div class="properties">
                     <div class="related float-xs-right">
-                        <a asp-action="Edit" asp-route-id="@entry.Application.Id" class="btn btn-primary btn-sm">@T["Edit"]</a>
-                        <a class="delete btn btn-danger btn-sm" asp-route-id="@entry.Application.Id" role="button" asp-action="Delete" itemprop="UnsafeUrl RemoveUrl">@T["Delete"]</a>
+                        <a asp-action="Edit" asp-route-id="@entry.ApplicationId" class="btn btn-primary btn-sm">@T["Edit"]</a>
+                        <a class="delete btn btn-danger btn-sm" asp-route-id="@entry.ApplicationId" role="button" asp-action="Delete" itemprop="UnsafeUrl RemoveUrl">@T["Delete"]</a>
                     </div>
-                    @entry.Application.DisplayName
+                    @entry.DisplayName
                 </div>
             </li>
         }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdApplicationIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdApplicationIndex.cs
@@ -1,8 +1,8 @@
 using System.Linq;
-using OrchardCore.OpenId.Models;
+using OrchardCore.OpenId.YesSql.Models;
 using YesSql.Indexes;
 
-namespace OrchardCore.OpenId.Indexes
+namespace OrchardCore.OpenId.YesSql.Indexes
 {
     public class OpenIdApplicationIndex : MapIndex
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdAuthorizationIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdAuthorizationIndex.cs
@@ -1,7 +1,7 @@
-using OrchardCore.OpenId.Models;
+using OrchardCore.OpenId.YesSql.Models;
 using YesSql.Indexes;
 
-namespace OrchardCore.OpenId.Indexes
+namespace OrchardCore.OpenId.YesSql.Indexes
 {
     public class OpenIdAuthorizationIndex : MapIndex
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdScopeIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdScopeIndex.cs
@@ -1,0 +1,24 @@
+using OrchardCore.OpenId.YesSql.Models;
+using YesSql.Indexes;
+
+namespace OrchardCore.OpenId.YesSql.Indexes
+{
+    public class OpenIdScopeIndex : MapIndex
+    {
+        public string Name { get; set; }
+        public string ScopeId { get; set; }
+    }
+
+    public class OpenIdScopeIndexProvider : IndexProvider<OpenIdScope>
+    {
+        public override void Describe(DescribeContext<OpenIdScope> context)
+        {
+            context.For<OpenIdScopeIndex>()
+                .Map(scope => new OpenIdScopeIndex
+                {
+                    Name = scope.Name,
+                    ScopeId = scope.ScopeId
+                });
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdTokenIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdTokenIndex.cs
@@ -1,8 +1,8 @@
 using System;
-using OrchardCore.OpenId.Models;
+using OrchardCore.OpenId.YesSql.Models;
 using YesSql.Indexes;
 
-namespace OrchardCore.OpenId.Indexes
+namespace OrchardCore.OpenId.YesSql.Indexes
 {
     public class OpenIdTokenIndex : MapIndex
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdApplication.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdApplication.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Models;
 
-namespace OrchardCore.OpenId.Models
+namespace OrchardCore.OpenId.YesSql.Models
 {
-    public class OpenIdApplication
+    public class OpenIdApplication : IOpenIdApplication
     {
         /// <summary>
         /// Gets or sets the unique identifier
@@ -74,11 +76,5 @@ namespace OrchardCore.OpenId.Models
         public bool AllowRefreshTokenFlow { get; set; }
         public bool AllowImplicitFlow { get; set; }
         public bool AllowHybridFlow { get; set; }
-    }
-
-    public enum ClientType
-    {
-        Confidential,
-        Public
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdAuthorization.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdAuthorization.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using OrchardCore.OpenId.Abstractions.Models;
 
-namespace OrchardCore.OpenId.Models
+namespace OrchardCore.OpenId.YesSql.Models
 {
-    public class OpenIdAuthorization
+    public class OpenIdAuthorization : IOpenIdAuthorization
     {
         /// <summary>
         /// Gets or sets the unique identifier

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdScope.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdScope.cs
@@ -1,8 +1,9 @@
-namespace OrchardCore.OpenId.Models
-{
-    public class OpenIdScope
-    {
+using OrchardCore.OpenId.Abstractions.Models;
 
+namespace OrchardCore.OpenId.YesSql.Models
+{
+    public class OpenIdScope : IOpenIdScope
+    {
         /// <summary>
         /// Gets or sets the unique identifier
         /// associated with the current scope.

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdToken.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdToken.cs
@@ -1,11 +1,12 @@
 using System;
+using OrchardCore.OpenId.Abstractions.Models;
 
-namespace OrchardCore.OpenId.Models
+namespace OrchardCore.OpenId.YesSql.Models
 {
     /// <summary>
     /// Represents an OpenId token.
     /// </summary>
-    public class OpenIdToken
+    public class OpenIdToken : IOpenIdToken
     {
         /// <summary>
         /// Gets or sets the unique identifier

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdApplicationStore.cs
@@ -1,0 +1,677 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using AspNet.Security.OpenIdConnect.Primitives;
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
+using OrchardCore.OpenId.Models;
+using OrchardCore.OpenId.YesSql.Indexes;
+using OrchardCore.OpenId.YesSql.Models;
+using YesSql;
+
+namespace OrchardCore.OpenId.YesSql.Services
+{
+    public class OpenIdApplicationStore : IOpenIdApplicationStore
+    {
+        private readonly ISession _session;
+
+        public OpenIdApplicationStore(ISession session)
+        {
+            _session = session;
+        }
+
+        /// <summary>
+        /// Determines the number of applications that exist in the database.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the number of applications in the database.
+        /// </returns>
+        public virtual async Task<long> CountAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _session.Query<OpenIdApplication>().CountAsync();
+        }
+
+        /// <summary>
+        /// Determines the number of applications that match the specified query.
+        /// </summary>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the number of applications that match the specified query.
+        /// </returns>
+        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<IOpenIdApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Creates a new application.
+        /// </summary>
+        /// <param name="application">The application to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the application.
+        /// </returns>
+        public virtual async Task<IOpenIdApplication> CreateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _session.Save(application);
+            await _session.CommitAsync();
+
+            return application;
+        }
+
+        /// <summary>
+        /// Removes an existing application.
+        /// </summary>
+        /// <param name="application">The application to delete.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task DeleteAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _session.Delete(application);
+
+            return _session.CommitAsync();
+        }
+
+        /// <summary>
+        /// Retrieves an application using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdApplication> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _session.GetAsync<OpenIdApplication>(int.Parse(identifier, CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Retrieves an application using its client identifier.
+        /// </summary>
+        /// <param name="identifier">The client identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdApplication> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _session.Query<OpenIdApplication, OpenIdApplicationIndex>(index => index.ClientId == identifier).FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
+        /// </summary>
+        /// <param name="address">The post_logout_redirect_uri associated with the applications.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
+        /// returns the client applications corresponding to the specified post_logout_redirect_uri.
+        /// </returns>
+        public virtual async Task<ImmutableArray<IOpenIdApplication>> FindByPostLogoutRedirectUriAsync(string address, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(address))
+            {
+                throw new ArgumentException("The address cannot be null or empty.", nameof(address));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ImmutableArray.CreateRange<IOpenIdApplication>(
+                await _session.Query<OpenIdApplication, OpenIdApplicationByPostLogoutRedirectUriIndex>(
+                    index => index.PostLogoutRedirectUri == address).ListAsync());
+        }
+
+        /// <summary>
+        /// Retrieves all the applications associated with the specified redirect_uri.
+        /// </summary>
+        /// <param name="address">The redirect_uri associated with the applications.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
+        /// returns the client applications corresponding to the specified redirect_uri.
+        /// </returns>
+        public virtual async Task<ImmutableArray<IOpenIdApplication>> FindByRedirectUriAsync(string address, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(address))
+            {
+                throw new ArgumentException("The address cannot be null or empty.", nameof(address));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ImmutableArray.CreateRange<IOpenIdApplication>(
+                await _session.Query<OpenIdApplication, OpenIdApplicationByRedirectUriIndex>(
+                    index => index.RedirectUri == address).ListAsync());
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns the first element.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the first element returned when executing the query.
+        /// </returns>
+        public virtual Task<TResult> GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Retrieves the client identifier associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client identifier associated with the application.
+        /// </returns>
+        public virtual Task<string> GetClientIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(((OpenIdApplication) application).ClientId);
+        }
+
+        /// <summary>
+        /// Retrieves the client secret associated with an application.
+        /// Note: depending on the manager used to create the application,
+        /// the client secret may be hashed for security reasons.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client secret associated with the application.
+        /// </returns>
+        public virtual Task<string> GetClientSecretAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(((OpenIdApplication) application).ClientSecret);
+        }
+
+        /// <summary>
+        /// Retrieves the client type associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client type of the application (by default, "public").
+        /// </returns>
+        public virtual Task<string> GetClientTypeAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            // Optimization: avoid double-allocating strings for well-known values.
+            switch (((OpenIdApplication) application).Type)
+            {
+                case ClientType.Confidential:
+                    return Task.FromResult(OpenIddictConstants.ClientTypes.Confidential);
+
+                case ClientType.Public:
+                    return Task.FromResult(OpenIddictConstants.ClientTypes.Public);
+            }
+
+            return Task.FromResult(((OpenIdApplication) application).Type.ToString().ToLowerInvariant());
+        }
+
+        /// <summary>
+        /// Retrieves the display name associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the display name associated with the application.
+        /// </returns>
+        public virtual Task<string> GetDisplayNameAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(((OpenIdApplication) application).DisplayName);
+        }
+
+        /// <summary>
+        /// Retrieves the unique identifier associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the unique identifier associated with the application.
+        /// </returns>
+        public virtual Task<string> GetIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(((OpenIdApplication) application).ApplicationId);
+        }
+
+        /// <summary>
+        /// Retrieves the logout callback addresses associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
+        /// result returns all the post_logout_redirect_uri associated with the application.
+        /// </returns>
+        public virtual Task<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(ImmutableArray.CreateRange(((OpenIdApplication) application).PostLogoutRedirectUris));
+        }
+
+        /// <summary>
+        /// Retrieves the callback addresses associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the redirect_uri associated with the application.
+        /// </returns>
+        public virtual Task<ImmutableArray<string>> GetRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(ImmutableArray.CreateRange(((OpenIdApplication) application).RedirectUris));
+        }
+
+        /// <summary>
+        /// Instantiates a new application.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
+        /// returns the instantiated application, that can be persisted in the database.
+        /// </returns>
+        public virtual Task<IOpenIdApplication> InstantiateAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IOpenIdApplication>(new OpenIdApplication { ApplicationId = Guid.NewGuid().ToString("n") });
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <param name="count">The number of results to return.</param>
+        /// <param name="offset">The number of results to skip.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual async Task<ImmutableArray<IOpenIdApplication>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+        {
+            var query = _session.Query<OpenIdApplication>();
+
+            if (offset.HasValue)
+            {
+                query = query.Skip(offset.Value);
+            }
+
+            if (count.HasValue)
+            {
+                query = query.Take(count.Value);
+            }
+
+            return ImmutableArray.CreateRange<IOpenIdApplication>(await query.ListAsync());
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Sets the client identifier associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="identifier">The client identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetClientIdAsync(IOpenIdApplication application,
+            string identifier, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            ((OpenIdApplication) application).ClientId = identifier;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the client secret associated with an application.
+        /// Note: depending on the manager used to create the application,
+        /// the client secret may be hashed for security reasons.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="secret">The client secret associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetClientSecretAsync(IOpenIdApplication application, string secret, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            ((OpenIdApplication) application).ClientSecret = secret;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the client type associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="type">The client type associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetClientTypeAsync(IOpenIdApplication application, string type, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            if (!Enum.TryParse(type, out ClientType value))
+            {
+                throw new ArgumentException("The specified client type is not valid.");
+            }
+
+            ((OpenIdApplication) application).Type = value;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the display name associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="name">The display name associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetDisplayNameAsync(IOpenIdApplication application, string name, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            ((OpenIdApplication) application).DisplayName = name;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the logout callback addresses associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="addresses">The logout callback addresses associated with the application </param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetPostLogoutRedirectUrisAsync(IOpenIdApplication application,
+            ImmutableArray<string> addresses, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            ((OpenIdApplication) application).PostLogoutRedirectUris = new HashSet<string>(addresses);
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the callback addresses associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="addresses">The callback addresses associated with the application </param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetRedirectUrisAsync(IOpenIdApplication application,
+            ImmutableArray<string> addresses, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            ((OpenIdApplication) application).RedirectUris = new HashSet<string>(addresses);
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Updates an existing application.
+        /// </summary>
+        /// <param name="application">The application to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task UpdateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _session.Save(application);
+
+            return _session.CommitAsync();
+        }
+
+        // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
+        public virtual Task<ImmutableArray<string>> GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            var builder = ImmutableArray.CreateBuilder<string>();
+
+            var entity = (OpenIdApplication) application;
+            if (entity.AllowAuthorizationCodeFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+            }
+
+            if (entity.AllowClientCredentialsFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.ClientCredentials);
+            }
+
+            if (entity.AllowImplicitFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.Implicit);
+            }
+
+            if (entity.AllowPasswordFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.Password);
+            }
+
+            if (entity.AllowRefreshTokenFlow)
+            {
+                builder.Add(OpenIdConnectConstants.GrantTypes.RefreshToken);
+            }
+
+            return Task.FromResult(builder.ToImmutable());
+        }
+
+        public virtual Task SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            var entity = (OpenIdApplication) application;
+
+            entity.AllowAuthorizationCodeFlow = types.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+            entity.AllowClientCredentialsFlow = types.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials);
+            entity.AllowImplicitFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Implicit);
+            entity.AllowPasswordFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Password);
+            entity.AllowRefreshTokenFlow = types.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken);
+
+            return Task.CompletedTask;
+        }
+
+        public virtual Task<bool> IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(!((OpenIdApplication) application).SkipConsent);
+        }
+
+        public virtual Task SetConsentRequiredAsync(IOpenIdApplication application, bool value, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            ((OpenIdApplication) application).SkipConsent = !value;
+
+            return Task.CompletedTask;
+        }
+
+        public virtual Task<ImmutableArray<string>> GetRolesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(ImmutableArray.CreateRange(((OpenIdApplication) application).RoleNames));
+        }
+
+        public virtual async Task<ImmutableArray<IOpenIdApplication>> ListInRoleAsync(string role, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(role))
+            {
+                throw new ArgumentException("The role name cannot be null or empty.", nameof(role));
+            }
+
+            return ImmutableArray.CreateRange<IOpenIdApplication>(
+                await _session.Query<OpenIdApplication, OpenIdApplicationByRoleNameIndex>(index => index.RoleName == role).ListAsync());
+        }
+
+        public virtual Task SetRolesAsync(IOpenIdApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            ((OpenIdApplication) application).RoleNames = new HashSet<string>(roles);
+            _session.Save(application);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdApplicationStore.cs
@@ -116,7 +116,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.GetAsync<OpenIdApplication>(int.Parse(identifier, CultureInfo.InvariantCulture));
+            return await _session.Query<OpenIdApplication, OpenIdApplicationIndex>(index => index.ApplicationId == identifier).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -138,6 +138,27 @@ namespace OrchardCore.OpenId.YesSql.Services
             cancellationToken.ThrowIfCancellationRequested();
 
             return await _session.Query<OpenIdApplication, OpenIdApplicationIndex>(index => index.ClientId == identifier).FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Retrieves an application using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the client application corresponding to the identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _session.GetAsync<OpenIdApplication>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -308,6 +329,25 @@ namespace OrchardCore.OpenId.YesSql.Services
             }
 
             return Task.FromResult(((OpenIdApplication) application).ApplicationId);
+        }
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with an application.
+        /// </summary>
+        /// <param name="application">The application.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the application.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            return Task.FromResult(((OpenIdApplication) application).Id.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdApplicationStore.cs
@@ -50,7 +50,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the number of applications that match the specified query.
         /// </returns>
-        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<IOpenIdApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<OpenIdApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
         /// <summary>
@@ -61,7 +61,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the application.
         /// </returns>
-        public virtual async Task<IOpenIdApplication> CreateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual async Task<OpenIdApplication> CreateAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -84,7 +84,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task DeleteAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task DeleteAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -107,7 +107,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdApplication> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdApplication> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -116,7 +116,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.Query<OpenIdApplication, OpenIdApplicationIndex>(index => index.ApplicationId == identifier).FirstOrDefaultAsync();
+            return _session.Query<OpenIdApplication, OpenIdApplicationIndex>(index => index.ApplicationId == identifier).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdApplication> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdApplication> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -137,7 +137,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.Query<OpenIdApplication, OpenIdApplicationIndex>(index => index.ClientId == identifier).FirstOrDefaultAsync();
+            return _session.Query<OpenIdApplication, OpenIdApplicationIndex>(index => index.ClientId == identifier).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client application corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -158,7 +158,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.GetAsync<OpenIdApplication>(int.Parse(identifier, CultureInfo.InvariantCulture));
+            return _session.GetAsync<OpenIdApplication>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
         /// returns the client applications corresponding to the specified post_logout_redirect_uri.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdApplication>> FindByPostLogoutRedirectUriAsync(string address, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdApplication>> FindByPostLogoutRedirectUriAsync(string address, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(address))
             {
@@ -179,7 +179,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return ImmutableArray.CreateRange<IOpenIdApplication>(
+            return ImmutableArray.CreateRange(
                 await _session.Query<OpenIdApplication, OpenIdApplicationByPostLogoutRedirectUriIndex>(
                     index => index.PostLogoutRedirectUri == address).ListAsync());
         }
@@ -193,7 +193,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
         /// returns the client applications corresponding to the specified redirect_uri.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdApplication>> FindByRedirectUriAsync(string address, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdApplication>> FindByRedirectUriAsync(string address, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(address))
             {
@@ -202,7 +202,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return ImmutableArray.CreateRange<IOpenIdApplication>(
+            return ImmutableArray.CreateRange(
                 await _session.Query<OpenIdApplication, OpenIdApplicationByRedirectUriIndex>(
                     index => index.RedirectUri == address).ListAsync());
         }
@@ -220,7 +220,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// whose result returns the first element returned when executing the query.
         /// </returns>
         public virtual Task<TResult> GetAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
+            Func<IQueryable<OpenIdApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
@@ -233,14 +233,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client identifier associated with the application.
         /// </returns>
-        public virtual Task<string> GetClientIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<string> GetClientIdAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(((OpenIdApplication) application).ClientId);
+            return Task.FromResult(application.ClientId);
         }
 
         /// <summary>
@@ -254,14 +254,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client secret associated with the application.
         /// </returns>
-        public virtual Task<string> GetClientSecretAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<string> GetClientSecretAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(((OpenIdApplication) application).ClientSecret);
+            return Task.FromResult(application.ClientSecret);
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the client type of the application (by default, "public").
         /// </returns>
-        public virtual Task<string> GetClientTypeAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<string> GetClientTypeAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -281,7 +281,7 @@ namespace OrchardCore.OpenId.YesSql.Services
             }
 
             // Optimization: avoid double-allocating strings for well-known values.
-            switch (((OpenIdApplication) application).Type)
+            switch (application.Type)
             {
                 case ClientType.Confidential:
                     return Task.FromResult(OpenIddictConstants.ClientTypes.Confidential);
@@ -290,7 +290,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                     return Task.FromResult(OpenIddictConstants.ClientTypes.Public);
             }
 
-            return Task.FromResult(((OpenIdApplication) application).Type.ToString().ToLowerInvariant());
+            return Task.FromResult(application.Type.ToString().ToLowerInvariant());
         }
 
         /// <summary>
@@ -302,14 +302,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the display name associated with the application.
         /// </returns>
-        public virtual Task<string> GetDisplayNameAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<string> GetDisplayNameAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(((OpenIdApplication) application).DisplayName);
+            return Task.FromResult(application.DisplayName);
         }
 
         /// <summary>
@@ -321,14 +321,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the application.
         /// </returns>
-        public virtual Task<string> GetIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<string> GetIdAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(((OpenIdApplication) application).ApplicationId);
+            return Task.FromResult(application.ApplicationId);
         }
 
         /// <summary>
@@ -340,14 +340,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the application.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(((OpenIdApplication) application).Id.ToString(CultureInfo.InvariantCulture));
+            return Task.FromResult(application.Id.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -359,14 +359,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
         /// result returns all the post_logout_redirect_uri associated with the application.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(ImmutableArray.CreateRange(((OpenIdApplication) application).PostLogoutRedirectUris));
+            return Task.FromResult(ImmutableArray.CreateRange(application.PostLogoutRedirectUris));
         }
 
         /// <summary>
@@ -378,14 +378,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the redirect_uri associated with the application.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<string>> GetRedirectUrisAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(ImmutableArray.CreateRange(((OpenIdApplication) application).RedirectUris));
+            return Task.FromResult(ImmutableArray.CreateRange(application.RedirectUris));
         }
 
         /// <summary>
@@ -396,8 +396,8 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
         /// returns the instantiated application, that can be persisted in the database.
         /// </returns>
-        public virtual Task<IOpenIdApplication> InstantiateAsync(CancellationToken cancellationToken)
-            => Task.FromResult<IOpenIdApplication>(new OpenIdApplication { ApplicationId = Guid.NewGuid().ToString("n") });
+        public virtual Task<OpenIdApplication> InstantiateAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new OpenIdApplication { ApplicationId = Guid.NewGuid().ToString("n") });
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
@@ -409,7 +409,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdApplication>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdApplication>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             var query = _session.Query<OpenIdApplication>();
 
@@ -423,7 +423,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 query = query.Take(count.Value);
             }
 
-            return ImmutableArray.CreateRange<IOpenIdApplication>(await query.ListAsync());
+            return ImmutableArray.CreateRange(await query.ListAsync());
         }
 
         /// <summary>
@@ -439,7 +439,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
         public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
+            Func<IQueryable<OpenIdApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
@@ -452,7 +452,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetClientIdAsync(IOpenIdApplication application,
+        public virtual Task SetClientIdAsync(OpenIdApplication application,
             string identifier, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -460,7 +460,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(application));
             }
 
-            ((OpenIdApplication) application).ClientId = identifier;
+            application.ClientId = identifier;
 
             return Task.CompletedTask;
         }
@@ -476,14 +476,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetClientSecretAsync(IOpenIdApplication application, string secret, CancellationToken cancellationToken)
+        public virtual Task SetClientSecretAsync(OpenIdApplication application, string secret, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            ((OpenIdApplication) application).ClientSecret = secret;
+            application.ClientSecret = secret;
 
             return Task.CompletedTask;
         }
@@ -497,7 +497,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetClientTypeAsync(IOpenIdApplication application, string type, CancellationToken cancellationToken)
+        public virtual Task SetClientTypeAsync(OpenIdApplication application, string type, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -509,7 +509,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentException("The specified client type is not valid.");
             }
 
-            ((OpenIdApplication) application).Type = value;
+            application.Type = value;
 
             return Task.CompletedTask;
         }
@@ -523,14 +523,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetDisplayNameAsync(IOpenIdApplication application, string name, CancellationToken cancellationToken)
+        public virtual Task SetDisplayNameAsync(OpenIdApplication application, string name, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            ((OpenIdApplication) application).DisplayName = name;
+            application.DisplayName = name;
 
             return Task.CompletedTask;
         }
@@ -544,7 +544,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetPostLogoutRedirectUrisAsync(IOpenIdApplication application,
+        public virtual Task SetPostLogoutRedirectUrisAsync(OpenIdApplication application,
             ImmutableArray<string> addresses, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -552,7 +552,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(application));
             }
 
-            ((OpenIdApplication) application).PostLogoutRedirectUris = new HashSet<string>(addresses);
+            application.PostLogoutRedirectUris = new HashSet<string>(addresses);
 
             return Task.CompletedTask;
         }
@@ -566,7 +566,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetRedirectUrisAsync(IOpenIdApplication application,
+        public virtual Task SetRedirectUrisAsync(OpenIdApplication application,
             ImmutableArray<string> addresses, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -574,7 +574,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(application));
             }
 
-            ((OpenIdApplication) application).RedirectUris = new HashSet<string>(addresses);
+            application.RedirectUris = new HashSet<string>(addresses);
 
             return Task.CompletedTask;
         }
@@ -587,7 +587,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task UpdateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task UpdateAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -602,7 +602,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
-        public virtual Task<ImmutableArray<string>> GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<string>> GetGrantTypesAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
@@ -611,28 +611,27 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             var builder = ImmutableArray.CreateBuilder<string>();
 
-            var entity = (OpenIdApplication) application;
-            if (entity.AllowAuthorizationCodeFlow)
+            if (application.AllowAuthorizationCodeFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
             }
 
-            if (entity.AllowClientCredentialsFlow)
+            if (application.AllowClientCredentialsFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.ClientCredentials);
             }
 
-            if (entity.AllowImplicitFlow)
+            if (application.AllowImplicitFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.Implicit);
             }
 
-            if (entity.AllowPasswordFlow)
+            if (application.AllowPasswordFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.Password);
             }
 
-            if (entity.AllowRefreshTokenFlow)
+            if (application.AllowRefreshTokenFlow)
             {
                 builder.Add(OpenIdConnectConstants.GrantTypes.RefreshToken);
             }
@@ -640,78 +639,199 @@ namespace OrchardCore.OpenId.YesSql.Services
             return Task.FromResult(builder.ToImmutable());
         }
 
-        public virtual Task SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken)
+        public virtual Task SetGrantTypesAsync(OpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            var entity = (OpenIdApplication) application;
-
-            entity.AllowAuthorizationCodeFlow = types.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
-            entity.AllowClientCredentialsFlow = types.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials);
-            entity.AllowImplicitFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Implicit);
-            entity.AllowPasswordFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Password);
-            entity.AllowRefreshTokenFlow = types.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken);
+            application.AllowAuthorizationCodeFlow = types.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+            application.AllowClientCredentialsFlow = types.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials);
+            application.AllowImplicitFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Implicit);
+            application.AllowPasswordFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Password);
+            application.AllowRefreshTokenFlow = types.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken);
 
             return Task.CompletedTask;
         }
 
-        public virtual Task<bool> IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<bool> IsConsentRequiredAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(!((OpenIdApplication) application).SkipConsent);
+            return Task.FromResult(!application.SkipConsent);
         }
 
-        public virtual Task SetConsentRequiredAsync(IOpenIdApplication application, bool value, CancellationToken cancellationToken)
+        public virtual Task SetConsentRequiredAsync(OpenIdApplication application, bool value, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            ((OpenIdApplication) application).SkipConsent = !value;
+            application.SkipConsent = !value;
 
             return Task.CompletedTask;
         }
 
-        public virtual Task<ImmutableArray<string>> GetRolesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<string>> GetRolesAsync(OpenIdApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(ImmutableArray.CreateRange(((OpenIdApplication) application).RoleNames));
+            return Task.FromResult(ImmutableArray.CreateRange(application.RoleNames));
         }
 
-        public virtual async Task<ImmutableArray<IOpenIdApplication>> ListInRoleAsync(string role, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdApplication>> ListInRoleAsync(string role, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(role))
             {
                 throw new ArgumentException("The role name cannot be null or empty.", nameof(role));
             }
 
-            return ImmutableArray.CreateRange<IOpenIdApplication>(
-                await _session.Query<OpenIdApplication, OpenIdApplicationByRoleNameIndex>(index => index.RoleName == role).ListAsync());
+            return ImmutableArray.CreateRange(await _session.Query<OpenIdApplication, OpenIdApplicationByRoleNameIndex>(index => index.RoleName == role).ListAsync());
         }
 
-        public virtual Task SetRolesAsync(IOpenIdApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
+        public virtual Task SetRolesAsync(OpenIdApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            ((OpenIdApplication) application).RoleNames = new HashSet<string>(roles);
+            application.RoleNames = new HashSet<string>(roles);
             _session.Save(application);
 
             return Task.CompletedTask;
         }
+
+        // Note: the following methods are deliberately implemented as explicit methods so they are not
+        // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
+        // Developers who need to customize the logic SHOULD override the methods taking concretes types.
+
+        // -------------------------------------------------------------
+        // Methods defined by the IOpenIddictApplicationStore interface:
+        // -------------------------------------------------------------
+
+        Task<long> IOpenIddictApplicationStore<IOpenIdApplication>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        Task<long> IOpenIddictApplicationStore<IOpenIdApplication>.CountAsync<TResult>(Func<IQueryable<IOpenIdApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.CreateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdApplication) application, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.DeleteAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdApplication) application, cancellationToken);
+
+        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByClientIdAsync(identifier, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.FindByPostLogoutRedirectUriAsync(string address, CancellationToken cancellationToken)
+            => (await FindByPostLogoutRedirectUriAsync(address, cancellationToken)).CastArray<IOpenIdApplication>();
+
+        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.FindByRedirectUriAsync(string address, CancellationToken cancellationToken)
+            => (await FindByRedirectUriAsync(address, cancellationToken)).CastArray<IOpenIdApplication>();
+
+        Task<TResult> IOpenIddictApplicationStore<IOpenIdApplication>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetClientIdAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientSecretAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetClientSecretAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetClientTypeAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetClientTypeAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetDisplayNameAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetDisplayNameAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetIdAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetPostLogoutRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetPostLogoutRedirectUrisAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetRedirectUrisAsync((OpenIdApplication) application, cancellationToken);
+
+        async Task<IOpenIdApplication> IOpenIddictApplicationStore<IOpenIdApplication>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdApplication>> IOpenIddictApplicationStore<IOpenIdApplication>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdApplication>();
+
+        Task<ImmutableArray<TResult>> IOpenIddictApplicationStore<IOpenIdApplication>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdApplication>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientIdAsync(IOpenIdApplication application,
+            string identifier, CancellationToken cancellationToken)
+            => SetClientIdAsync((OpenIdApplication) application, identifier, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientSecretAsync(IOpenIdApplication application, string secret, CancellationToken cancellationToken)
+            => SetClientSecretAsync((OpenIdApplication) application, secret, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetClientTypeAsync(IOpenIdApplication application, string type, CancellationToken cancellationToken)
+            => SetClientTypeAsync((OpenIdApplication) application, type, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetDisplayNameAsync(IOpenIdApplication application, string name, CancellationToken cancellationToken)
+            => SetDisplayNameAsync((OpenIdApplication) application, name, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetPostLogoutRedirectUrisAsync(IOpenIdApplication application,
+            ImmutableArray<string> addresses, CancellationToken cancellationToken)
+            => SetPostLogoutRedirectUrisAsync((OpenIdApplication) application, addresses, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetRedirectUrisAsync(IOpenIdApplication application,
+            ImmutableArray<string> addresses, CancellationToken cancellationToken)
+            => SetRedirectUrisAsync((OpenIdApplication) application, addresses, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.UpdateAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdApplication) application, cancellationToken);
+
+        // ---------------------------------------------------------
+        // Methods defined by the IOpenIdApplicationStore interface:
+        // ---------------------------------------------------------
+
+        async Task<IOpenIdApplication> IOpenIdApplicationStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByPhysicalIdAsync(identifier, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIdApplicationStore.GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetGrantTypesAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<string> IOpenIdApplicationStore.GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetPhysicalIdAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIdApplicationStore.GetRolesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetRolesAsync((OpenIdApplication) application, cancellationToken);
+
+        Task<bool> IOpenIdApplicationStore.IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => IsConsentRequiredAsync((OpenIdApplication) application, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdApplication>> IOpenIdApplicationStore.ListInRoleAsync(string role, CancellationToken cancellationToken)
+            => (await ListInRoleAsync(role, cancellationToken)).CastArray<IOpenIdApplication>();
+
+        Task IOpenIdApplicationStore.SetConsentRequiredAsync(IOpenIdApplication application, bool value, CancellationToken cancellationToken)
+            => SetConsentRequiredAsync((OpenIdApplication) application, value, cancellationToken);
+
+        Task IOpenIdApplicationStore.SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken)
+            => SetGrantTypesAsync((OpenIdApplication) application, types, cancellationToken);
+
+        Task IOpenIdApplicationStore.SetRolesAsync(IOpenIdApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
+            => SetRolesAsync((OpenIdApplication) application, roles, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdAuthorizationStore.cs
@@ -146,6 +146,27 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            return await _session.Query<OpenIdAuthorization, OpenIdAuthorizationIndex>(index => index.AuthorizationId == identifier).FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Retrieves an authorization using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The physical identifier associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorization corresponding to the identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
             return await _session.GetAsync<OpenIdAuthorization>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
@@ -202,6 +223,25 @@ namespace OrchardCore.OpenId.YesSql.Services
             }
 
             return Task.FromResult(((OpenIdAuthorization) authorization).AuthorizationId);
+        }
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the authorization.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        {
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            return Task.FromResult(((OpenIdAuthorization) authorization).Id.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdAuthorizationStore.cs
@@ -49,7 +49,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the number of authorizations that match the specified query.
         /// </returns>
-        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<IOpenIdAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<OpenIdAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the authorization.
         /// </returns>
-        public virtual async Task<IOpenIdAuthorization> CreateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual async Task<OpenIdAuthorization> CreateAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
@@ -83,7 +83,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task DeleteAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task DeleteAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
@@ -108,7 +108,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorizations corresponding to the subject/client.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdAuthorization>> FindAsync(string subject, string client, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdAuthorization>> FindAsync(string subject, string client, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(subject))
             {
@@ -122,7 +122,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return ImmutableArray.CreateRange<IOpenIdAuthorization>(
+            return ImmutableArray.CreateRange(
                 await _session.Query<OpenIdAuthorization, OpenIdAuthorizationIndex>(
                     index => index.ApplicationId == client &&
                              index.Subject == subject).ListAsync());
@@ -137,7 +137,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdAuthorization> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdAuthorization> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -146,7 +146,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.Query<OpenIdAuthorization, OpenIdAuthorizationIndex>(index => index.AuthorizationId == identifier).FirstOrDefaultAsync();
+            return _session.Query<OpenIdAuthorization, OpenIdAuthorizationIndex>(index => index.AuthorizationId == identifier).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -167,7 +167,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.GetAsync<OpenIdAuthorization>(int.Parse(identifier, CultureInfo.InvariantCulture));
+            return _session.GetAsync<OpenIdAuthorization>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -179,14 +179,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the authorization.
         /// </returns>
-        public virtual Task<string> GetApplicationIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task<string> GetApplicationIdAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(((OpenIdAuthorization) authorization).ApplicationId?.ToString(CultureInfo.InvariantCulture));
+            return Task.FromResult(authorization.ApplicationId?.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// whose result returns the first element returned when executing the query.
         /// </returns>
         public virtual Task<TResult> GetAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
+            Func<IQueryable<OpenIdAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
@@ -215,14 +215,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the authorization.
         /// </returns>
-        public virtual Task<string> GetIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task<string> GetIdAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(((OpenIdAuthorization) authorization).AuthorizationId);
+            return Task.FromResult(authorization.AuthorizationId);
         }
 
         /// <summary>
@@ -234,14 +234,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the authorization.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(((OpenIdAuthorization) authorization).Id.ToString(CultureInfo.InvariantCulture));
+            return Task.FromResult(authorization.Id.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -253,14 +253,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scopes associated with the specified authorization.
         /// </returns>
-        public virtual Task<ImmutableArray<string>> GetScopesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task<ImmutableArray<string>> GetScopesAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(ImmutableArray.CreateRange(((OpenIdAuthorization) authorization).Scopes));
+            return Task.FromResult(ImmutableArray.CreateRange(authorization.Scopes));
         }
 
         /// <summary>
@@ -272,14 +272,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetStatusAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task<string> GetStatusAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(((OpenIdAuthorization) authorization).Status);
+            return Task.FromResult(authorization.Status);
         }
 
         /// <summary>
@@ -291,14 +291,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetSubjectAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task<string> GetSubjectAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(((OpenIdAuthorization) authorization).Subject);
+            return Task.FromResult(authorization.Subject);
         }
 
         /// <summary>
@@ -310,14 +310,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the type associated with the specified authorization.
         /// </returns>
-        public virtual Task<string> GetTypeAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task<string> GetTypeAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(((OpenIdAuthorization) authorization).Type);
+            return Task.FromResult(authorization.Type);
         }
 
         /// <summary>
@@ -328,8 +328,8 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
         /// returns the instantiated authorization, that can be persisted in the database.
         /// </returns>
-        public virtual Task<IOpenIdAuthorization> InstantiateAsync(CancellationToken cancellationToken)
-            => Task.FromResult<IOpenIdAuthorization>(new OpenIdAuthorization { AuthorizationId = Guid.NewGuid().ToString("n") });
+        public virtual Task<OpenIdAuthorization> InstantiateAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new OpenIdAuthorization { AuthorizationId = Guid.NewGuid().ToString("n") });
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
@@ -341,7 +341,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdAuthorization>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdAuthorization>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             var query = _session.Query<OpenIdAuthorization>();
 
@@ -355,7 +355,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 query = query.Take(count.Value);
             }
 
-            return ImmutableArray.CreateRange<IOpenIdAuthorization>(await query.ListAsync());
+            return ImmutableArray.CreateRange(await query.ListAsync());
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
         public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
+            Func<IQueryable<OpenIdAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
@@ -386,7 +386,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdAuthorization>> ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdAuthorization>> ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             IQuery<OpenIdAuthorization> query = _session.Query<OpenIdAuthorization, OpenIdAuthorizationIndex>(
                 authorization => authorization.Status != OpenIddictConstants.Statuses.Valid ||
@@ -405,7 +405,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 query = query.Take(count.Value);
             }
 
-            return ImmutableArray.CreateRange<IOpenIdAuthorization>(await query.ListAsync());
+            return ImmutableArray.CreateRange(await query.ListAsync());
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetApplicationIdAsync(IOpenIdAuthorization authorization,
+        public virtual Task SetApplicationIdAsync(OpenIdAuthorization authorization,
             string identifier, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -427,11 +427,11 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             if (string.IsNullOrEmpty(identifier))
             {
-                ((OpenIdAuthorization) authorization).ApplicationId = null;
+                authorization.ApplicationId = null;
             }
             else
             {
-                ((OpenIdAuthorization) authorization).ApplicationId = identifier;
+                authorization.ApplicationId = identifier;
             }
 
             return Task.CompletedTask;
@@ -446,7 +446,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetScopesAsync(IOpenIdAuthorization authorization,
+        public virtual Task SetScopesAsync(OpenIdAuthorization authorization,
             ImmutableArray<string> scopes, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -454,7 +454,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            ((OpenIdAuthorization) authorization).Scopes = new HashSet<string>(scopes);
+            authorization.Scopes = new HashSet<string>(scopes);
 
             return Task.CompletedTask;
         }
@@ -468,7 +468,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetStatusAsync(IOpenIdAuthorization authorization,
+        public virtual Task SetStatusAsync(OpenIdAuthorization authorization,
             string status, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -476,7 +476,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            ((OpenIdAuthorization) authorization).Status = status;
+            authorization.Status = status;
 
             return Task.CompletedTask;
         }
@@ -490,7 +490,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetSubjectAsync(IOpenIdAuthorization authorization,
+        public virtual Task SetSubjectAsync(OpenIdAuthorization authorization,
             string subject, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -498,7 +498,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            ((OpenIdAuthorization) authorization).Subject = subject;
+            authorization.Subject = subject;
 
             return Task.CompletedTask;
         }
@@ -512,7 +512,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetTypeAsync(IOpenIdAuthorization authorization,
+        public virtual Task SetTypeAsync(OpenIdAuthorization authorization,
             string type, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -520,7 +520,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            ((OpenIdAuthorization) authorization).Type = type;
+            authorization.Type = type;
 
             return Task.CompletedTask;
         }
@@ -533,7 +533,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task UpdateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+        public virtual Task UpdateAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
             {
@@ -546,5 +546,101 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             return _session.CommitAsync();
         }
+
+        // Note: the following methods are deliberately implemented as explicit methods so they are not
+        // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
+        // Developers who need to customize the logic SHOULD override the methods taking concretes types.
+
+        // ---------------------------------------------------------------
+        // Methods defined by the IOpenIddictAuthorizationStore interface:
+        // ---------------------------------------------------------------
+
+        Task<long> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        Task<long> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CountAsync<TResult>(Func<IQueryable<IOpenIdAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.CreateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.DeleteAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindAsync(string subject, string client, CancellationToken cancellationToken)
+            => (await FindAsync(subject, client, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetApplicationIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetApplicationIdAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        Task<TResult> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetIdAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        Task<ImmutableArray<string>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetScopesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetScopesAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetStatusAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetStatusAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetSubjectAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetSubjectAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetTypeAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetTypeAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        Task<ImmutableArray<TResult>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdAuthorization>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListInvalidAsync(count, offset, cancellationToken)).CastArray<IOpenIdAuthorization>();
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetApplicationIdAsync(IOpenIdAuthorization authorization,
+            string identifier, CancellationToken cancellationToken)
+            => SetApplicationIdAsync((OpenIdAuthorization) authorization, identifier, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetScopesAsync(IOpenIdAuthorization authorization,
+            ImmutableArray<string> scopes, CancellationToken cancellationToken)
+            => SetScopesAsync((OpenIdAuthorization) authorization, scopes, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetStatusAsync(IOpenIdAuthorization authorization,
+            string status, CancellationToken cancellationToken)
+            => SetStatusAsync((OpenIdAuthorization) authorization, status, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetSubjectAsync(IOpenIdAuthorization authorization,
+            string subject, CancellationToken cancellationToken)
+            => SetSubjectAsync((OpenIdAuthorization) authorization, subject, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetTypeAsync(IOpenIdAuthorization authorization,
+            string type, CancellationToken cancellationToken)
+            => SetTypeAsync((OpenIdAuthorization) authorization, type, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.UpdateAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdAuthorization) authorization, cancellationToken);
+
+        // -----------------------------------------------------------
+        // Methods defined by the IOpenIdAuthorizationStore interface:
+        // -----------------------------------------------------------
+
+        async Task<IOpenIdAuthorization> IOpenIdAuthorizationStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByPhysicalIdAsync(identifier, cancellationToken);
+
+        Task<string> IOpenIdAuthorizationStore.GetPhysicalIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetPhysicalIdAsync((OpenIdAuthorization) authorization, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdScopeStore.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Abstractions.Stores;
 using OrchardCore.OpenId.YesSql.Indexes;
@@ -46,7 +47,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the number of scopes that match the specified query.
         /// </returns>
-        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<IOpenIdScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<OpenIdScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the scope.
         /// </returns>
-        public virtual async Task<IOpenIdScope> CreateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        public virtual async Task<OpenIdScope> CreateAsync(OpenIdScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
@@ -80,7 +81,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task DeleteAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        public virtual Task DeleteAsync(OpenIdScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
@@ -103,7 +104,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdScope> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdScope> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -112,7 +113,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.Query<OpenIdScope, OpenIdScopeIndex>(index => index.ScopeId == identifier).FirstOrDefaultAsync();
+            return _session.Query<OpenIdScope, OpenIdScopeIndex>(index => index.ScopeId == identifier).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -124,7 +125,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the scope corresponding to the identifier.
         /// </returns>
-        public virtual async Task<IOpenIdScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -133,7 +134,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.GetAsync<OpenIdScope>(int.Parse(identifier, CultureInfo.InvariantCulture));
+            return _session.GetAsync<OpenIdScope>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -149,7 +150,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// whose result returns the first element returned when executing the query.
         /// </returns>
         public virtual Task<TResult> GetAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
+            Func<IQueryable<OpenIdScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
@@ -162,14 +163,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the description associated with the specified scope.
         /// </returns>
-        public virtual Task<string> GetDescriptionAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        public virtual Task<string> GetDescriptionAsync(OpenIdScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(((OpenIdScope) scope).Description);
+            return Task.FromResult(scope.Description);
         }
 
         /// <summary>
@@ -181,14 +182,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the scope.
         /// </returns>
-        public virtual Task<string> GetIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        public virtual Task<string> GetIdAsync(OpenIdScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(((OpenIdScope) scope).ScopeId);
+            return Task.FromResult(scope.ScopeId);
         }
 
         /// <summary>
@@ -200,14 +201,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the scope.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(OpenIdScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(((OpenIdScope) scope).Id.ToString(CultureInfo.InvariantCulture));
+            return Task.FromResult(scope.Id.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -219,14 +220,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the name associated with the specified scope.
         /// </returns>
-        public virtual Task<string> GetNameAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        public virtual Task<string> GetNameAsync(OpenIdScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(((OpenIdScope) scope).Name);
+            return Task.FromResult(scope.Name);
         }
 
         /// <summary>
@@ -237,8 +238,8 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the instantiated scope, that can be persisted in the database.
         /// </returns>
-        public virtual Task<IOpenIdScope> InstantiateAsync(CancellationToken cancellationToken)
-            => Task.FromResult<IOpenIdScope>(new OpenIdScope { ScopeId = Guid.NewGuid().ToString("n") });
+        public virtual Task<OpenIdScope> InstantiateAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new OpenIdScope { ScopeId = Guid.NewGuid().ToString("n") });
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
@@ -250,9 +251,9 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdScope>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdScope>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
-            var query = _session.Query<IOpenIdScope>();
+            var query = _session.Query<OpenIdScope>();
 
             if (offset.HasValue)
             {
@@ -280,7 +281,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
         public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
+            Func<IQueryable<OpenIdScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
@@ -293,14 +294,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetDescriptionAsync(IOpenIdScope scope, string description, CancellationToken cancellationToken)
+        public virtual Task SetDescriptionAsync(OpenIdScope scope, string description, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            ((OpenIdScope) scope).Description = description;
+            scope.Description = description;
 
             return Task.CompletedTask;
         }
@@ -314,14 +315,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetNameAsync(IOpenIdScope scope, string name, CancellationToken cancellationToken)
+        public virtual Task SetNameAsync(OpenIdScope scope, string name, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            ((OpenIdScope) scope).Name = name;
+            scope.Name = name;
 
             return Task.CompletedTask;
         }
@@ -334,7 +335,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+        public virtual Task UpdateAsync(OpenIdScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
@@ -347,5 +348,72 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             return _session.CommitAsync();
         }
+
+        // Note: the following methods are deliberately implemented as explicit methods so they are not
+        // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
+        // Developers who need to customize the logic SHOULD override the methods taking concretes types.
+
+        // -------------------------------------------------------
+        // Methods defined by the IOpenIddictScopeStore interface:
+        // -------------------------------------------------------
+
+        Task<long> IOpenIddictScopeStore<IOpenIdScope>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        Task<long> IOpenIddictScopeStore<IOpenIdScope>.CountAsync<TResult>(Func<IQueryable<IOpenIdScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.CreateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdScope) scope, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.DeleteAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdScope) scope, cancellationToken);
+
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        Task<TResult> IOpenIddictScopeStore<IOpenIdScope>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetDescriptionAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetDescriptionAsync((OpenIdScope) scope, cancellationToken);
+
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetIdAsync((OpenIdScope) scope, cancellationToken);
+
+        Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetNameAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetNameAsync((OpenIdScope) scope, cancellationToken);
+
+        async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdScope>> IOpenIddictScopeStore<IOpenIdScope>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdScope>();
+
+        Task<ImmutableArray<TResult>> IOpenIddictScopeStore<IOpenIdScope>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdScope>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.SetDescriptionAsync(IOpenIdScope scope, string description, CancellationToken cancellationToken)
+            => SetDescriptionAsync((OpenIdScope) scope, description, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.SetNameAsync(IOpenIdScope scope, string name, CancellationToken cancellationToken)
+            => SetNameAsync((OpenIdScope) scope, name, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdScope) scope, cancellationToken);
+
+        // ---------------------------------------------------
+        // Methods defined by the IOpenIdScopeStore interface:
+        // ---------------------------------------------------
+
+        async Task<IOpenIdScope> IOpenIdScopeStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByPhysicalIdAsync(identifier, cancellationToken);
+
+        Task<string> IOpenIdScopeStore.GetPhysicalIdAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetPhysicalIdAsync((OpenIdScope) scope, cancellationToken);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdTokenStore.cs
@@ -179,6 +179,27 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            return await _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.TokenId == identifier).FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Retrieves a token using its physical identifier.
+        /// </summary>
+        /// <param name="identifier">The physical identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the token corresponding to the physical identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
             return await _session.GetAsync<OpenIdToken>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
@@ -332,6 +353,25 @@ namespace OrchardCore.OpenId.YesSql.Services
             }
 
             return Task.FromResult(((OpenIdToken) token).Payload);
+        }
+
+        /// <summary>
+        /// Retrieves the physical identifier associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the physical identifier associated with the token.
+        /// </returns>
+        public virtual Task<string> GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).Id.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdTokenStore.cs
@@ -1,0 +1,742 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using OpenIddict.Core;
+using OrchardCore.OpenId.Abstractions.Models;
+using OrchardCore.OpenId.Abstractions.Stores;
+using OrchardCore.OpenId.YesSql.Indexes;
+using OrchardCore.OpenId.YesSql.Models;
+using YesSql;
+
+namespace OrchardCore.OpenId.YesSql.Services
+{
+    public class OpenIdTokenStore : IOpenIdTokenStore
+    {
+        private readonly ISession _session;
+
+        public OpenIdTokenStore(ISession session)
+        {
+            _session = session;
+        }
+
+        /// <summary>
+        /// Determines the number of tokens that exist in the database.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the number of applications in the database.
+        /// </returns>
+        public virtual async Task<long> CountAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _session.Query<OpenIdToken>().CountAsync();
+        }
+
+        /// <summary>
+        /// Determines the number of tokens that match the specified query.
+        /// </summary>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the number of tokens that match the specified query.
+        /// </returns>
+        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<IOpenIdToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Creates a new token.
+        /// </summary>
+        /// <param name="token">The token to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the token.
+        /// </returns>
+        public virtual async Task<IOpenIdToken> CreateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _session.Save(token);
+            await _session.CommitAsync();
+
+            return token;
+        }
+
+        /// <summary>
+        /// Removes a token.
+        /// </summary>
+        /// <param name="token">The token to delete.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
+        public virtual Task DeleteAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _session.Delete(token);
+
+            return _session.CommitAsync();
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified application identifier.
+        /// </summary>
+        /// <param name="identifier">The application identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified application.
+        /// </returns>
+        public virtual async Task<ImmutableArray<IOpenIdToken>> FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ImmutableArray.CreateRange<IOpenIdToken>(
+                await _session.Query<OpenIdToken, OpenIdTokenIndex>(
+                    index => index.ApplicationId == identifier).ListAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified authorization identifier.
+        /// </summary>
+        /// <param name="identifier">The authorization identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified authorization.
+        /// </returns>
+        public virtual async Task<ImmutableArray<IOpenIdToken>> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ImmutableArray.CreateRange<IOpenIdToken>(
+                await _session.Query<OpenIdToken, OpenIdTokenIndex>(
+                    index => index.AuthorizationId == identifier).ListAsync());
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified reference identifier.
+        /// Note: the reference identifier may be hashed or encrypted for security reasons.
+        /// </summary>
+        /// <param name="identifier">The reference identifier associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified reference identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdToken> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.ReferenceId == identifier).FirstOrDefaultAsync();
+        }
+
+        /// <summary>
+        /// Retrieves a token using its unique identifier.
+        /// </summary>
+        /// <param name="identifier">The unique identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the token corresponding to the unique identifier.
+        /// </returns>
+        public virtual async Task<IOpenIdToken> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(identifier))
+            {
+                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return await _session.GetAsync<OpenIdToken>(int.Parse(identifier, CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Retrieves the list of tokens corresponding to the specified subject.
+        /// </summary>
+        /// <param name="subject">The subject associated with the tokens.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the tokens corresponding to the specified subject.
+        /// </returns>
+        public virtual async Task<ImmutableArray<IOpenIdToken>> FindBySubjectAsync(string subject, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ImmutableArray.CreateRange<IOpenIdToken>(await _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.Subject == subject).ListAsync());
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns the first element.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the first element returned when executing the query.
+        /// </returns>
+        public virtual Task<TResult> GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Retrieves the optional application identifier associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the application identifier associated with the token.
+        /// </returns>
+        public virtual Task<string> GetApplicationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).ApplicationId?.ToString(CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Retrieves the optional authorization identifier associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the authorization identifier associated with the token.
+        /// </returns>
+        public virtual Task<string> GetAuthorizationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).AuthorizationId?.ToString(CultureInfo.InvariantCulture));
+        }
+
+        /// <summary>
+        /// Retrieves the creation date associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the creation date associated with the specified token.
+        /// </returns>
+        public virtual Task<DateTimeOffset?> GetCreationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).CreationDate);
+        }
+
+        /// <summary>
+        /// Retrieves the expiration date associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the expiration date associated with the specified token.
+        /// </returns>
+        public virtual Task<DateTimeOffset?> GetExpirationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).ExpirationDate);
+        }
+
+        /// <summary>
+        /// Retrieves the unique identifier associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the unique identifier associated with the token.
+        /// </returns>
+        public virtual Task<string> GetIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).TokenId);
+        }
+
+        /// <summary>
+        /// Retrieves the payload associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the payload associated with the specified token.
+        /// </returns>
+        public virtual Task<string> GetPayloadAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).Payload);
+        }
+
+        /// <summary>
+        /// Retrieves the reference identifier associated with a token.
+        /// Note: depending on the manager used to create the token,
+        /// the reference identifier may be hashed for security reasons.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the reference identifier associated with the specified token.
+        /// </returns>
+        public virtual Task<string> GetReferenceIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).ReferenceId);
+        }
+
+        /// <summary>
+        /// Retrieves the status associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the status associated with the specified token.
+        /// </returns>
+        public virtual Task<string> GetStatusAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).Status);
+        }
+
+        /// <summary>
+        /// Retrieves the subject associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the subject associated with the specified token.
+        /// </returns>
+        public virtual Task<string> GetSubjectAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).Subject);
+        }
+
+        /// <summary>
+        /// Retrieves the token type associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the token type associated with the specified token.
+        /// </returns>
+        public virtual Task<string> GetTokenTypeAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(((OpenIdToken) token).Type);
+        }
+
+        /// <summary>
+        /// Instantiates a new token.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the instantiated token, that can be persisted in the database.
+        /// </returns>
+        public virtual Task<IOpenIdToken> InstantiateAsync(CancellationToken cancellationToken)
+            => Task.FromResult<IOpenIdToken>(new OpenIdToken { TokenId = Guid.NewGuid().ToString("n") } );
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <param name="count">The number of results to return.</param>
+        /// <param name="offset">The number of results to skip.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual async Task<ImmutableArray<IOpenIdToken>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+        {
+            var query = _session.Query<OpenIdToken>();
+
+            if (offset.HasValue)
+            {
+                query = query.Skip(offset.Value);
+            }
+
+            if (count.HasValue)
+            {
+                query = query.Take(count.Value);
+            }
+
+            return ImmutableArray.CreateRange<IOpenIdToken>(await query.ListAsync());
+        }
+
+        /// <summary>
+        /// Executes the specified query and returns all the corresponding elements.
+        /// </summary>
+        /// <typeparam name="TState">The state type.</typeparam>
+        /// <typeparam name="TResult">The result type.</typeparam>
+        /// <param name="query">The query to execute.</param>
+        /// <param name="state">The optional state.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        /// <summary>
+        /// Lists the tokens that are marked as expired or invalid
+        /// and that can be safely removed from the database.
+        /// </summary>
+        /// <param name="count">The number of results to return.</param>
+        /// <param name="offset">The number of results to skip.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns all the elements returned when executing the specified query.
+        /// </returns>
+        public virtual async Task<ImmutableArray<IOpenIdToken>> ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
+        {
+            IQuery<OpenIdToken> query = _session.Query<OpenIdToken, OpenIdTokenIndex>(
+                token => token.ExpirationDate < DateTimeOffset.UtcNow ||
+                         token.Status != OpenIddictConstants.Statuses.Valid);
+
+            if (offset.HasValue)
+            {
+                query = query.Skip(offset.Value);
+            }
+
+            if (count.HasValue)
+            {
+                query = query.Take(count.Value);
+            }
+
+            return ImmutableArray.CreateRange<IOpenIdToken>(await query.ListAsync());
+        }
+
+        /// <summary>
+        /// Sets the application identifier associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="identifier">The unique identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetApplicationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (string.IsNullOrEmpty(identifier))
+            {
+                ((OpenIdToken) token).ApplicationId = null;
+            }
+            else
+            {
+                ((OpenIdToken) token).ApplicationId = identifier;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the authorization identifier associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="identifier">The unique identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetAuthorizationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (string.IsNullOrEmpty(identifier))
+            {
+                ((OpenIdToken) token).AuthorizationId = null;
+            }
+            else
+            {
+                ((OpenIdToken) token).AuthorizationId = identifier;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the creation date associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="date">The creation date.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetCreationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            ((OpenIdToken) token).CreationDate = date?.UtcDateTime;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the expiration date associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="date">The expiration date.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetExpirationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            ((OpenIdToken) token).ExpirationDate = date?.UtcDateTime;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the payload associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="payload">The payload associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetPayloadAsync(IOpenIdToken token, string payload, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            ((OpenIdToken) token).Payload = payload;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the reference identifier associated with a token.
+        /// Note: depending on the manager used to create the token,
+        /// the reference identifier may be hashed for security reasons.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="identifier">The reference identifier associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetReferenceIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            ((OpenIdToken) token).ReferenceId = identifier;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the status associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="status">The status associated with the authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetStatusAsync(IOpenIdToken token, string status, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (string.IsNullOrEmpty(status))
+            {
+                throw new ArgumentException("The status cannot be null or empty.", nameof(status));
+            }
+
+            ((OpenIdToken) token).Status = status;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the subject associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="subject">The subject associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetSubjectAsync(IOpenIdToken token, string subject, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
+            }
+
+            ((OpenIdToken) token).Subject = subject;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Sets the token type associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="type">The token type associated with the token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetTokenTypeAsync(IOpenIdToken token, string type, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            if (string.IsNullOrEmpty(type))
+            {
+                throw new ArgumentException("The token type cannot be null or empty.", nameof(type));
+            }
+
+            ((OpenIdToken) token).Type = type;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Updates an existing token.
+        /// </summary>
+        /// <param name="token">The token to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task UpdateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            _session.Save(token);
+
+            return _session.CommitAsync();
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdTokenStore.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the number of tokens that match the specified query.
         /// </returns>
-        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<IOpenIdToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+        public virtual Task<long> CountAsync<TResult>(Func<IQueryable<OpenIdToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
         /// <summary>
@@ -58,7 +58,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result returns the token.
         /// </returns>
-        public virtual async Task<IOpenIdToken> CreateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual async Task<OpenIdToken> CreateAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -79,7 +79,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <param name="token">The token to delete.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>A <see cref="Task"/> that can be used to monitor the asynchronous operation.</returns>
-        public virtual Task DeleteAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task DeleteAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -102,7 +102,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified application.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdToken>> FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdToken>> FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -111,7 +111,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return ImmutableArray.CreateRange<IOpenIdToken>(
+            return ImmutableArray.CreateRange(
                 await _session.Query<OpenIdToken, OpenIdTokenIndex>(
                     index => index.ApplicationId == identifier).ListAsync());
         }
@@ -125,7 +125,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified authorization.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdToken>> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdToken>> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -134,7 +134,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return ImmutableArray.CreateRange<IOpenIdToken>(
+            return ImmutableArray.CreateRange(
                 await _session.Query<OpenIdToken, OpenIdTokenIndex>(
                     index => index.AuthorizationId == identifier).ListAsync());
         }
@@ -149,7 +149,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified reference identifier.
         /// </returns>
-        public virtual async Task<IOpenIdToken> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdToken> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -158,7 +158,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.ReferenceId == identifier).FirstOrDefaultAsync();
+            return _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.ReferenceId == identifier).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token corresponding to the unique identifier.
         /// </returns>
-        public virtual async Task<IOpenIdToken> FindByIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdToken> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -179,7 +179,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.TokenId == identifier).FirstOrDefaultAsync();
+            return _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.TokenId == identifier).FirstOrDefaultAsync();
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token corresponding to the physical identifier.
         /// </returns>
-        public virtual async Task<IOpenIdToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+        public virtual Task<OpenIdToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
             {
@@ -200,7 +200,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return await _session.GetAsync<OpenIdToken>(int.Parse(identifier, CultureInfo.InvariantCulture));
+            return _session.GetAsync<OpenIdToken>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -212,7 +212,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the tokens corresponding to the specified subject.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdToken>> FindBySubjectAsync(string subject, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdToken>> FindBySubjectAsync(string subject, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(subject))
             {
@@ -221,7 +221,7 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            return ImmutableArray.CreateRange<IOpenIdToken>(await _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.Subject == subject).ListAsync());
+            return ImmutableArray.CreateRange(await _session.Query<OpenIdToken, OpenIdTokenIndex>(index => index.Subject == subject).ListAsync());
         }
 
         /// <summary>
@@ -237,7 +237,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// whose result returns the first element returned when executing the query.
         /// </returns>
         public virtual Task<TResult> GetAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
+            Func<IQueryable<OpenIdToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
@@ -250,14 +250,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the application identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetApplicationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetApplicationIdAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).ApplicationId?.ToString(CultureInfo.InvariantCulture));
+            return Task.FromResult(token.ApplicationId?.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -269,14 +269,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the authorization identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetAuthorizationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetAuthorizationIdAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).AuthorizationId?.ToString(CultureInfo.InvariantCulture));
+            return Task.FromResult(token.AuthorizationId?.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -288,14 +288,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the creation date associated with the specified token.
         /// </returns>
-        public virtual Task<DateTimeOffset?> GetCreationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<DateTimeOffset?> GetCreationDateAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).CreationDate);
+            return Task.FromResult(token.CreationDate);
         }
 
         /// <summary>
@@ -307,14 +307,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the expiration date associated with the specified token.
         /// </returns>
-        public virtual Task<DateTimeOffset?> GetExpirationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<DateTimeOffset?> GetExpirationDateAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).ExpirationDate);
+            return Task.FromResult(token.ExpirationDate);
         }
 
         /// <summary>
@@ -326,14 +326,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the unique identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetIdAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).TokenId);
+            return Task.FromResult(token.TokenId);
         }
 
         /// <summary>
@@ -345,14 +345,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the payload associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetPayloadAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetPayloadAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).Payload);
+            return Task.FromResult(token.Payload);
         }
 
         /// <summary>
@@ -364,14 +364,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the physical identifier associated with the token.
         /// </returns>
-        public virtual Task<string> GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetPhysicalIdAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).Id.ToString(CultureInfo.InvariantCulture));
+            return Task.FromResult(token.Id.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -385,14 +385,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the reference identifier associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetReferenceIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetReferenceIdAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).ReferenceId);
+            return Task.FromResult(token.ReferenceId);
         }
 
         /// <summary>
@@ -404,14 +404,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the status associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetStatusAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetStatusAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).Status);
+            return Task.FromResult(token.Status);
         }
 
         /// <summary>
@@ -423,14 +423,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the subject associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetSubjectAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetSubjectAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).Subject);
+            return Task.FromResult(token.Subject);
         }
 
         /// <summary>
@@ -442,14 +442,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        public virtual Task<string> GetTokenTypeAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task<string> GetTokenTypeAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            return Task.FromResult(((OpenIdToken) token).Type);
+            return Task.FromResult(token.Type);
         }
 
         /// <summary>
@@ -460,8 +460,8 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the instantiated token, that can be persisted in the database.
         /// </returns>
-        public virtual Task<IOpenIdToken> InstantiateAsync(CancellationToken cancellationToken)
-            => Task.FromResult<IOpenIdToken>(new OpenIdToken { TokenId = Guid.NewGuid().ToString("n") } );
+        public virtual Task<OpenIdToken> InstantiateAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new OpenIdToken { TokenId = Guid.NewGuid().ToString("n") } );
 
         /// <summary>
         /// Executes the specified query and returns all the corresponding elements.
@@ -473,7 +473,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdToken>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdToken>> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             var query = _session.Query<OpenIdToken>();
 
@@ -487,7 +487,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 query = query.Take(count.Value);
             }
 
-            return ImmutableArray.CreateRange<IOpenIdToken>(await query.ListAsync());
+            return ImmutableArray.CreateRange(await query.ListAsync());
         }
 
         /// <summary>
@@ -503,7 +503,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
         public virtual Task<ImmutableArray<TResult>> ListAsync<TState, TResult>(
-            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
+            Func<IQueryable<OpenIdToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
@@ -518,7 +518,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
         /// whose result returns all the elements returned when executing the specified query.
         /// </returns>
-        public virtual async Task<ImmutableArray<IOpenIdToken>> ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<OpenIdToken>> ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             IQuery<OpenIdToken> query = _session.Query<OpenIdToken, OpenIdTokenIndex>(
                 token => token.ExpirationDate < DateTimeOffset.UtcNow ||
@@ -534,7 +534,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 query = query.Take(count.Value);
             }
 
-            return ImmutableArray.CreateRange<IOpenIdToken>(await query.ListAsync());
+            return ImmutableArray.CreateRange(await query.ListAsync());
         }
 
         /// <summary>
@@ -546,7 +546,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetApplicationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+        public virtual Task SetApplicationIdAsync(OpenIdToken token, string identifier, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -555,11 +555,11 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             if (string.IsNullOrEmpty(identifier))
             {
-                ((OpenIdToken) token).ApplicationId = null;
+                token.ApplicationId = null;
             }
             else
             {
-                ((OpenIdToken) token).ApplicationId = identifier;
+                token.ApplicationId = identifier;
             }
 
             return Task.CompletedTask;
@@ -574,7 +574,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetAuthorizationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+        public virtual Task SetAuthorizationIdAsync(OpenIdToken token, string identifier, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -583,11 +583,11 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             if (string.IsNullOrEmpty(identifier))
             {
-                ((OpenIdToken) token).AuthorizationId = null;
+                token.AuthorizationId = null;
             }
             else
             {
-                ((OpenIdToken) token).AuthorizationId = identifier;
+                token.AuthorizationId = identifier;
             }
 
             return Task.CompletedTask;
@@ -602,14 +602,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetCreationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+        public virtual Task SetCreationDateAsync(OpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            ((OpenIdToken) token).CreationDate = date?.UtcDateTime;
+            token.CreationDate = date?.UtcDateTime;
 
             return Task.CompletedTask;
         }
@@ -623,14 +623,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetExpirationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+        public virtual Task SetExpirationDateAsync(OpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            ((OpenIdToken) token).ExpirationDate = date?.UtcDateTime;
+            token.ExpirationDate = date?.UtcDateTime;
 
             return Task.CompletedTask;
         }
@@ -644,14 +644,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetPayloadAsync(IOpenIdToken token, string payload, CancellationToken cancellationToken)
+        public virtual Task SetPayloadAsync(OpenIdToken token, string payload, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            ((OpenIdToken) token).Payload = payload;
+            token.Payload = payload;
 
             return Task.CompletedTask;
         }
@@ -667,14 +667,14 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetReferenceIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+        public virtual Task SetReferenceIdAsync(OpenIdToken token, string identifier, CancellationToken cancellationToken)
         {
             if (token == null)
             {
                 throw new ArgumentNullException(nameof(token));
             }
 
-            ((OpenIdToken) token).ReferenceId = identifier;
+            token.ReferenceId = identifier;
 
             return Task.CompletedTask;
         }
@@ -688,7 +688,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetStatusAsync(IOpenIdToken token, string status, CancellationToken cancellationToken)
+        public virtual Task SetStatusAsync(OpenIdToken token, string status, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -700,7 +700,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentException("The status cannot be null or empty.", nameof(status));
             }
 
-            ((OpenIdToken) token).Status = status;
+            token.Status = status;
 
             return Task.CompletedTask;
         }
@@ -714,7 +714,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetSubjectAsync(IOpenIdToken token, string subject, CancellationToken cancellationToken)
+        public virtual Task SetSubjectAsync(OpenIdToken token, string subject, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -726,7 +726,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
             }
 
-            ((OpenIdToken) token).Subject = subject;
+            token.Subject = subject;
 
             return Task.CompletedTask;
         }
@@ -740,7 +740,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetTokenTypeAsync(IOpenIdToken token, string type, CancellationToken cancellationToken)
+        public virtual Task SetTokenTypeAsync(OpenIdToken token, string type, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -752,7 +752,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentException("The token type cannot be null or empty.", nameof(type));
             }
 
-            ((OpenIdToken) token).Type = type;
+            token.Type = type;
 
             return Task.CompletedTask;
         }
@@ -765,7 +765,7 @@ namespace OrchardCore.OpenId.YesSql.Services
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task UpdateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+        public virtual Task UpdateAsync(OpenIdToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -778,5 +778,129 @@ namespace OrchardCore.OpenId.YesSql.Services
 
             return _session.CommitAsync();
         }
+
+        // Note: the following methods are deliberately implemented as explicit methods so they are not
+        // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
+        // Developers who need to customize the logic SHOULD override the methods taking concretes types.
+
+        // -------------------------------------------------------
+        // Methods defined by the IOpenIddictTokenStore interface:
+        // -------------------------------------------------------
+
+        Task<long> IOpenIddictTokenStore<IOpenIdToken>.CountAsync(CancellationToken cancellationToken)
+            => CountAsync(cancellationToken);
+
+        Task<long> IOpenIddictTokenStore<IOpenIdToken>.CountAsync<TResult>(Func<IQueryable<IOpenIdToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
+            => CountAsync(query, cancellationToken);
+
+        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.CreateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => await CreateAsync((OpenIdToken) token, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.DeleteAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => DeleteAsync((OpenIdToken) token, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
+            => (await FindByApplicationIdAsync(identifier, cancellationToken)).CastArray<IOpenIdToken>();
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
+            => (await FindByAuthorizationIdAsync(identifier, cancellationToken)).CastArray<IOpenIdToken>();
+
+        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByReferenceIdAsync(identifier, cancellationToken);
+
+        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByIdAsync(identifier, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.FindBySubjectAsync(string subject, CancellationToken cancellationToken)
+            => (await FindBySubjectAsync(subject, cancellationToken)).CastArray<IOpenIdToken>();
+
+        Task<TResult> IOpenIddictTokenStore<IOpenIdToken>.GetAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => GetAsync(query, state, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetApplicationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetApplicationIdAsync((OpenIdToken) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetAuthorizationIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetAuthorizationIdAsync((OpenIdToken) token, cancellationToken);
+
+        Task<DateTimeOffset?> IOpenIddictTokenStore<IOpenIdToken>.GetCreationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetCreationDateAsync((OpenIdToken) token, cancellationToken);
+
+        Task<DateTimeOffset?> IOpenIddictTokenStore<IOpenIdToken>.GetExpirationDateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetExpirationDateAsync((OpenIdToken) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetIdAsync((OpenIdToken) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetPayloadAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetPayloadAsync((OpenIdToken) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetReferenceIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetReferenceIdAsync((OpenIdToken) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetStatusAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetStatusAsync((OpenIdToken) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetSubjectAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetSubjectAsync((OpenIdToken) token, cancellationToken);
+
+        Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetTokenTypeAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetTokenTypeAsync((OpenIdToken) token, cancellationToken);
+
+        async Task<IOpenIdToken> IOpenIddictTokenStore<IOpenIdToken>.InstantiateAsync(CancellationToken cancellationToken)
+            => await InstantiateAsync(cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.ListAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListAsync(count, offset, cancellationToken)).CastArray<IOpenIdToken>();
+
+        Task<ImmutableArray<TResult>> IOpenIddictTokenStore<IOpenIdToken>.ListAsync<TState, TResult>(
+            Func<IQueryable<IOpenIdToken>, TState, IQueryable<TResult>> query,
+            TState state, CancellationToken cancellationToken)
+            => ListAsync(query, state, cancellationToken);
+
+        async Task<ImmutableArray<IOpenIdToken>> IOpenIddictTokenStore<IOpenIdToken>.ListInvalidAsync(int? count, int? offset, CancellationToken cancellationToken)
+            => (await ListInvalidAsync(count, offset, cancellationToken)).CastArray<IOpenIdToken>();
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetApplicationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+            => SetApplicationIdAsync((OpenIdToken) token, identifier, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetAuthorizationIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+            => SetAuthorizationIdAsync((OpenIdToken) token, identifier, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetCreationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+            => SetCreationDateAsync((OpenIdToken) token, date, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetExpirationDateAsync(IOpenIdToken token, DateTimeOffset? date, CancellationToken cancellationToken)
+            => SetExpirationDateAsync((OpenIdToken) token, date, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetPayloadAsync(IOpenIdToken token, string payload, CancellationToken cancellationToken)
+            => SetPayloadAsync((OpenIdToken) token, payload, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetReferenceIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
+            => SetReferenceIdAsync((OpenIdToken) token, identifier, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetStatusAsync(IOpenIdToken token, string status, CancellationToken cancellationToken)
+            => SetStatusAsync((OpenIdToken) token, status, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetSubjectAsync(IOpenIdToken token, string subject, CancellationToken cancellationToken)
+            => SetSubjectAsync((OpenIdToken) token, subject, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetTokenTypeAsync(IOpenIdToken token, string type, CancellationToken cancellationToken)
+            => SetTokenTypeAsync((OpenIdToken) token, type, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.UpdateAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => UpdateAsync((OpenIdToken) token, cancellationToken);
+
+        // ---------------------------------------------------
+        // Methods defined by the IOpenIdTokenStore interface:
+        // ---------------------------------------------------
+
+        async Task<IOpenIdToken> IOpenIdTokenStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
+            => await FindByPhysicalIdAsync(identifier, cancellationToken);
+
+        Task<string> IOpenIdTokenStore.GetPhysicalIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetPhysicalIdAsync((OpenIdToken) token, cancellationToken);
     }
 }

--- a/src/OrchardCore/OrchardCore.Application.Cms.Targets/OrchardCore.Application.Cms.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Targets/OrchardCore.Application.Cms.Targets.csproj
@@ -56,6 +56,7 @@
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Mvc\OrchardCore.Mvc.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Navigation\OrchardCore.Navigation.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.OpenId\OrchardCore.OpenId.csproj" PrivateAssets="none" />
+    <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.OpenId.EntityFrameworkCore\OrchardCore.OpenId.EntityFrameworkCore.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Recipes\OrchardCore.Recipes.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Resources\OrchardCore.Resources.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.ResponseCache\OrchardCore.ResponseCache.csproj" PrivateAssets="none" />


### PR DESCRIPTION
Similarly to what's been done for the OrchardCore.Users module, this PR decouples the OpenID module (and more specifically its 2 controllers) from the YesSql entities so the YesSql stores can be replaced by different implementations (this PR includes a new `OrchardCore.OpenId.EntityFrameworkCore` based on the official OpenIddict EF Core 2.0 stores).

Major things that have changed:

  - New (empty) models abstractions/markers have been introduced: `IOpenIdApplication`/`IOpenIdAuthorization`/`IOpenIdScope`/`IOpenIdToken`. They are part of the main `OrchardCore.OpenId` module as introducing an abstractions package didn't seem necessary nor useful.

  - New stores abstractions have been added: `IOpenIdApplicationStore`/`IOpenIdAuthorizationStore`/`IOpenIdScopeStore`/`IOpenIdTokenStore`. They are all non-generic and derive from the generic OpenIddict stores (e.g `IOpenIdApplicationStore` derives from `IOpenIddictApplicationStore<IOpenIdApplication>`. Dealing with these abstractions is only necessary if you plan to write custom stores (i.e not based on YesSql nor EF Core).

  - New non-generic managers have been created: `OpenIdApplicationManager`/`OpenIdAuthorizationManager`/`OpenIdScopeManager`/`OpenIdTokenManager`. This allows getting rid of the generics in the controllers and exposing Orchard-specific methods that are used in the controllers.

  - The controllers have been revamped not to use the YesSql-specific entities. Instead of directly operating on the models, they rely on the application manager to update the model properties (that will itself delegate this task to the registered store).

  - New (partially) generic EF Core models and stores have been introduced in a separate `OrchardCore.OpenId.EntityFrameworkCore` module. The stores inherit from the OpenIddict EF Core stores AND **explicitly** implement the Orchard stores interfaces to perform the necessary casts. This pattern proved to be useful as one can create a custom store based on the EF Core one without being forced to deal with casts/downcasts. I plan to generalize this pattern and adopt it for both the YesSql stores and the Orchard-specific methods in the EF Core stores.

Here's an example of a custom store based on `OrchardCore.OpenId.EntityFrameworkCore`:

```csharp
public class MyStore : OpenIdApplicationStore<MyContext, string>
{
    public MyStore(MyContext context)
        : base(context)
    {
    }

    public override Task<OpenIdApplication<string>> CreateAsync(
        OpenIdApplication<string> application, CancellationToken cancellationToken)
    {
        // No cast is required as you directly operate on the concrete entity, not the abstraction.
        var name = application.DisplayName;

        return base.CreateAsync(application, cancellationToken);
    }
}
```

@sebastienros @jersiovic please let me know what you think when you have a sec' :sweat_smile: 

Note: it's still a WIP, don't merge this PR yet.