### PR TITLE
Don't render liquid when displaying the editor

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidShapes.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidShapes.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -38,7 +39,6 @@ namespace OrchardCore.Liquid.Services
         {
             builder.Describe("LiquidPart").OnProcessing(BuildViewModelAsync);
             builder.Describe("LiquidPart_Summary").OnProcessing(BuildViewModelAsync);
-            builder.Describe("LiquidPart_Edit").OnProcessing(BuildViewModelAsync);            
         }
     }
 }


### PR DESCRIPTION
Fixes #1345

The liquid string on a Liquid Part is now not rendered to HTML when building the editor.

This PR fixes this bug, but I also noticed something else that could be cleaned up:

I think we have duplication of code when it comes to creating the liquid part view model, it looks like the same values are set in both the `ShapeTableProvider`, and the `Driver`:

https://github.com/OrchardCMS/OrchardCore/blob/bug/1345/edit_liquid/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidShapes.cs#L32-L34

https://github.com/OrchardCMS/OrchardCore/blob/bug/1345/edit_liquid/src/OrchardCore.Modules/OrchardCore.Liquid/Drivers/LiquidPartDisplay.cs#L48-L50

Unrelated to this bug, so I left it in place, but if someone can confirm if one of these is redundant then I can create another PR to tidy this up.