### PR TITLE
Adds DisplayType property to BagPartViewModel to allow the value to be accessed by liquid

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
@@ -11,5 +11,6 @@ namespace OrchardCore.Flows.ViewModels
         public IEnumerable<ContentItem> ContentItems => BagPart.ContentItems;
         public BuildPartDisplayContext BuildPartDisplayContext { get; set; }
         public BagPartSettings Settings { get; set; }
+        public string DisplayType => Settings?.DisplayType;
     }
 }


### PR DESCRIPTION
It's currently not possible to fully implement an alternate liquid template for the Bag Part because the `DisplayType` property on the `BagPartSettings` is not accessible to liquid.

There were two options to fix this:

A) Add a member access strategy for `BagPartSettings`
B) Add a shortcut to the property to the `BagPartViewModel` class

I chose option B because it means that the other settings on `BagPartSettings` are still hidden, and because that's the way it's been done for `ContentItems`.