### PR TITLE
Tag helper for image resizing

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -18,7 +18,7 @@ namespace OrchardCore.Media.Processing
 
     internal class ImageSharpUrlFormatter
     {
-        public static string GetMediaResizeUrl(string path, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
+        public static string GetImageResizeUrl(string path, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
         {
             if (string.IsNullOrEmpty(path) || (!width.HasValue && !height.HasValue))
             {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.Media.Processing
     {
         public static string GetMediaResizeUrl(string path, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
         {
-            if (string.IsNullOrEmpty(path))
+            if (string.IsNullOrEmpty(path) || (!width.HasValue && !height.HasValue))
             {
                 return path;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Web;
+
+namespace OrchardCore.Media.Processing
+{
+    public enum ResizeMode
+    {
+        Undefined,
+        Max,
+        Crop,
+        Pad,
+        BoxPad,
+        Min,
+        Stretch
+    }
+
+    internal class ImageSharpUrlFormatter
+    {
+        public static string GetMediaResizeUrl(string path, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return path;
+            }
+
+            var pathParts = path.Split('?');
+            var query = HttpUtility.ParseQueryString(pathParts.Length > 1 ? pathParts[1] : string.Empty);
+
+            if (width.HasValue)
+            {
+                query["width"] = width.ToString();
+            }
+
+            if (height.HasValue)
+            {
+                query["height"] = height.ToString();
+            }
+
+            if (resizeMode != ResizeMode.Undefined)
+            {
+                query["rmode"] = resizeMode.ToString().ToLower();
+            }
+
+            return $"{pathParts[0]}?{query.ToString()}";
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -107,6 +107,10 @@ To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to _ViewIm
 
 `<img media-src="Model.Field.Paths[0]" alt="..." media-width="100" media-height="240" media-resize-mode="Crop" />`
 
+Alternatively the Asset Url can be resolved independently and the `src` attribute used:
+
+`<img src="@OrchardCore.AssetUrl(Model.Field.Paths[0])" alt="..." media-width="100" media-height="240" media-resize-mode="Crop" />`
+
 
 ## CREDITS
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -97,6 +97,12 @@ To obtain the correct URL for an asset, use the `AssetUrl` helper extension meth
 
 `<img src="@OrchardCore.AssetUrl(Model.Field.Paths[0])" alt="..." />`
 
+### Razor image resizing tag helpers
+
+To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to _ViewImports. Width, height and resize mode can be set using `media-width`, `media-height` and `media-resize-mode` respectively. e.g.:
+
+`<img src="@OrchardCore.AssetUrl(Model.Field.Paths[0])" alt="..." media-width="100" media-height="240" media-resize-mode="Crop" />`
+
 
 ## CREDITS
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -95,13 +95,17 @@ Stretches the resized image to fit the bounds of its container.
 
 To obtain the correct URL for an asset, use the `AssetUrl` helper extension method on the view's base `OrchardCore` property, e.g.:
 
-`<img src="@OrchardCore.AssetUrl(Model.Field.Paths[0])" alt="..." />`
+`@OrchardCore.AssetUrl(Model.Field.Paths[0])`
+
+To obtain the correct URL for a resized asset use `AssetUrl` with the optional width, height and resizeMode parameters, e.g.:
+
+`@OrchardCore.AssetUrl(Model.Field.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Crop)`
 
 ### Razor image resizing tag helpers
 
-To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to _ViewImports. Width, height and resize mode can be set using `media-width`, `media-height` and `media-resize-mode` respectively. e.g.:
+To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to _ViewImports. `media-src` is used to obtain the correct URL for the asset and set the `src` attribute. Width, height and resize mode can be set using `media-width`, `media-height` and `media-resize-mode` respectively. e.g.:
 
-`<img src="@OrchardCore.AssetUrl(Model.Field.Paths[0])" alt="..." media-width="100" media-height="240" media-resize-mode="Crop" />`
+`<img media-src="Model.Field.Paths[0]" alt="..." media-width="100" media-height="240" media-resize-mode="Crop" />`
 
 
 ## CREDITS

--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -103,13 +103,13 @@ To obtain the correct URL for a resized asset use `AssetUrl` with the optional w
 
 ### Razor image resizing tag helpers
 
-To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to _ViewImports. `media-src` is used to obtain the correct URL for the asset and set the `src` attribute. Width, height and resize mode can be set using `media-width`, `media-height` and `media-resize-mode` respectively. e.g.:
+To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to _ViewImports. `asset-src` is used to obtain the correct URL for the asset and set the `src` attribute. Width, height and resize mode can be set using `img-width`, `img-height` and `img-resize-mode` respectively. e.g.:
 
-`<img media-src="Model.Field.Paths[0]" alt="..." media-width="100" media-height="240" media-resize-mode="Crop" />`
+`<img asset-src="Model.Field.Paths[0]" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" />`
 
 Alternatively the Asset Url can be resolved independently and the `src` attribute used:
 
-`<img src="@OrchardCore.AssetUrl(Model.Field.Paths[0])" alt="..." media-width="100" media-height="240" media-resize-mode="Crop" />`
+`<img src="@OrchardCore.AssetUrl(Model.Field.Paths[0])" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" />`
 
 
 ## CREDITS

--- a/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
@@ -21,12 +21,12 @@ namespace OrchardCore.DisplayManagement.Razor
         public static string AssetUrl(this OrchardRazorHelper razorHelper, string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
         {
             var resolvedAssetPath = razorHelper.AssetUrl(assetPath);
-            return razorHelper.MediaResizeUrl(resolvedAssetPath, width, height, resizeMode);
+            return razorHelper.ImageResizeUrl(resolvedAssetPath, width, height, resizeMode);
         }
 
-        public static string MediaResizeUrl(this OrchardRazorHelper razorHelper, string mediaPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
+        public static string ImageResizeUrl(this OrchardRazorHelper razorHelper, string imagePath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
         {
-            return ImageSharpUrlFormatter.GetMediaResizeUrl(mediaPath, width, height, resizeMode);
+            return ImageSharpUrlFormatter.GetImageResizeUrl(imagePath, width, height, resizeMode);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
@@ -21,7 +21,12 @@ namespace OrchardCore.DisplayManagement.Razor
         public static string AssetUrl(this OrchardRazorHelper razorHelper, string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
         {
             var resolvedAssetPath = razorHelper.AssetUrl(assetPath);
-            return ImageSharpUrlFormatter.GetMediaResizeUrl(resolvedAssetPath, width, height, resizeMode);
+            return razorHelper.MediaResizeUrl(resolvedAssetPath, width, height, resizeMode);
+        }
+
+        public static string MediaResizeUrl(this OrchardRazorHelper razorHelper, string mediaPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
+        {
+            return ImageSharpUrlFormatter.GetMediaResizeUrl(mediaPath, width, height, resizeMode);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Media;
+using OrchardCore.Media.Processing;
 
 namespace OrchardCore.DisplayManagement.Razor
 {
@@ -15,6 +16,12 @@ namespace OrchardCore.DisplayManagement.Razor
             }
 
             return mediaFileStore.MapPathToPublicUrl(assetPath);
+        }
+
+        public static string AssetUrl(this OrchardRazorHelper razorHelper, string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
+        {
+            var resolvedAssetPath = razorHelper.AssetUrl(assetPath);
+            return ImageSharpUrlFormatter.GetMediaResizeUrl(resolvedAssetPath, width, height, resizeMode);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Media.TagHelpers
     [HtmlTargetElement("img", Attributes = ImageSizeHeightAttributeName + "," + ImageSizeModeAttributeName)]
     public class ImageResizeTagHelper : TagHelper
     {
-        private const string ImageSizeAttributePrefix = "media-";
+        private const string ImageSizeAttributePrefix = "img-";
 
         private const string ImageSizeWidthAttributeName = ImageSizeAttributePrefix + "width";
         private const string ImageSizeHeightAttributeName = ImageSizeAttributePrefix + "height";
@@ -35,14 +35,14 @@ namespace OrchardCore.Media.TagHelpers
                 return;
             }
 
-            var mediaSrc = Src ?? output.Attributes["src"]?.Value.ToString();
+            var imgSrc = output.Attributes["src"]?.Value.ToString() ?? Src;
 
-            if (string.IsNullOrEmpty(mediaSrc))
+            if (string.IsNullOrEmpty(imgSrc))
             {
                 return;
             }
 
-            var resizedSrc = ImageSharpUrlFormatter.GetMediaResizeUrl(mediaSrc, ImageWidth, ImageHeight, ResizeMode);
+            var resizedSrc = ImageSharpUrlFormatter.GetImageResizeUrl(imgSrc, ImageWidth, ImageHeight, ResizeMode);
             output.Attributes.SetAttribute("src", resizedSrc);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
@@ -1,0 +1,49 @@
+using System.Web;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using OrchardCore.Media.Processing;
+
+namespace OrchardCore.Media.TagHelpers
+{
+    [HtmlTargetElement("img", Attributes = ImageSizeWidthAttributeName)]
+    [HtmlTargetElement("img", Attributes = ImageSizeHeightAttributeName)]
+    [HtmlTargetElement("img", Attributes = ImageSizeWidthAttributeName + "," + ImageSizeModeAttributeName)]
+    [HtmlTargetElement("img", Attributes = ImageSizeHeightAttributeName + "," + ImageSizeModeAttributeName)]
+    public class ImageResizeTagHelper : TagHelper
+    {
+        private const string ImageSizeAttributePrefix = "media-";
+
+        private const string ImageSizeWidthAttributeName = ImageSizeAttributePrefix + "width";
+        private const string ImageSizeHeightAttributeName = ImageSizeAttributePrefix + "height";
+        private const string ImageSizeModeAttributeName = ImageSizeAttributePrefix + "resize-mode";
+
+        [HtmlAttributeName(ImageSizeWidthAttributeName)]
+        public int? ImageWidth { get; set; }
+
+        [HtmlAttributeName(ImageSizeHeightAttributeName)]
+        public int? ImageHeight { get; set; }
+
+        [HtmlAttributeName(ImageSizeModeAttributeName)]
+        public ResizeMode ResizeMode { get; set; }
+
+        [HtmlAttributeName("src")]
+        public string Src { get; set; }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (!ImageWidth.HasValue && !ImageHeight.HasValue)
+            {
+                return;
+            }
+
+            var mediaSrc = Src ?? output.Attributes["src"]?.Value.ToString();
+
+            if (string.IsNullOrEmpty(mediaSrc))
+            {
+                return;
+            }
+
+            var resizedSrc = ImageSharpUrlFormatter.GetMediaResizeUrl(mediaSrc, ImageWidth, ImageHeight, ResizeMode);
+            output.Attributes.SetAttribute("src", resizedSrc);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -1,0 +1,57 @@
+using System.Web;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace OrchardCore.Media.TagHelpers
+{
+    public enum ResizeMode
+    {
+        Undefined,
+        Max,
+        Crop,
+        Pad,
+        BoxPad,
+        Min,
+        Stretch
+    }
+
+    [HtmlTargetElement("img", Attributes = ImageSizeWidthAttributeName)]
+    [HtmlTargetElement("img", Attributes = ImageSizeHeightAttributeName)]
+    [HtmlTargetElement("img", Attributes = ImageSizeModeAttributeName)]
+    public class ImageTagHelper : TagHelper
+    {
+        private const string ImageSizeAttributePrefix = "media-";
+        private const string ImageSizeWidthAttributeName = ImageSizeAttributePrefix + "width";
+        private const string ImageSizeHeightAttributeName = ImageSizeAttributePrefix + "height";
+        private const string ImageSizeModeAttributeName = ImageSizeAttributePrefix + "resize-mode";
+
+        [HtmlAttributeName(ImageSizeWidthAttributeName)]
+        public int? ImageWidth { get; set; }
+
+        [HtmlAttributeName(ImageSizeHeightAttributeName)]
+        public int? ImageHeight { get; set; }
+
+        [HtmlAttributeName(ImageSizeModeAttributeName)]
+        public ResizeMode ResizeMode { get; set; }
+
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            var src = output.Attributes["src"].Value.ToString();
+            var srcParts = src.Split('?');
+            var query = HttpUtility.ParseQueryString(srcParts.Length > 1 ? srcParts[1] : string.Empty);
+
+            if (ImageWidth.HasValue) {
+                query["width"] = ImageWidth.ToString();
+            }
+
+            if (ImageHeight.HasValue) {
+                query["height"] = ImageHeight.ToString();
+            }
+
+            if (ResizeMode != ResizeMode.Undefined) {
+                query["rmode"] = ResizeMode.ToString().ToLower();
+            }
+
+            output.Attributes.SetAttribute("src", $"{srcParts[0]}?{query.ToString()}");
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -4,18 +4,17 @@ using OrchardCore.Media.Processing;
 
 namespace OrchardCore.Media.TagHelpers
 {
-    [HtmlTargetElement("img", Attributes = ImageSrcAttributeName)]
+    [HtmlTargetElement("img", Attributes = AssetSrcAttributeName)]
     public class ImageTagHelper : TagHelper
     {
-        private const string ImageSizeAttributePrefix = "media-";
-        private const string ImageSrcAttributeName = ImageSizeAttributePrefix + "src";
+        private const string AssetSrcAttributeName = "asset-src";
 
         private readonly IMediaFileStore _mediaFileStore;
 
         public override int Order => -10;
 
-        [HtmlAttributeName(ImageSrcAttributeName)]
-        public string MediaSrc { get; set; }
+        [HtmlAttributeName(AssetSrcAttributeName)]
+        public string AssetSrc { get; set; }
 
         public ImageTagHelper(IMediaFileStore mediaFileStore)
         {
@@ -24,12 +23,12 @@ namespace OrchardCore.Media.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (string.IsNullOrEmpty(MediaSrc))
+            if (string.IsNullOrEmpty(AssetSrc))
             {
                 return;
             }
 
-            var resolvedSrc = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(MediaSrc) : MediaSrc;
+            var resolvedSrc = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(AssetSrc) : AssetSrc;
             output.Attributes.SetAttribute("src", resolvedSrc);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -14,12 +14,14 @@ namespace OrchardCore.Media.TagHelpers
         Stretch
     }
 
-    [HtmlTargetElement("img", Attributes = ImageSizeWidthAttributeName)]
-    [HtmlTargetElement("img", Attributes = ImageSizeHeightAttributeName)]
-    [HtmlTargetElement("img", Attributes = ImageSizeModeAttributeName)]
+    [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeWidthAttributeName)]
+    [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeHeightAttributeName)]
+    [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeModeAttributeName)]
     public class ImageTagHelper : TagHelper
     {
+        private const string SrcRequiredPrefx = "src,";
         private const string ImageSizeAttributePrefix = "media-";
+
         private const string ImageSizeWidthAttributeName = ImageSizeAttributePrefix + "width";
         private const string ImageSizeHeightAttributeName = ImageSizeAttributePrefix + "height";
         private const string ImageSizeModeAttributeName = ImageSizeAttributePrefix + "resize-mode";
@@ -33,21 +35,31 @@ namespace OrchardCore.Media.TagHelpers
         [HtmlAttributeName(ImageSizeModeAttributeName)]
         public ResizeMode ResizeMode { get; set; }
 
+        [HtmlAttributeName("src")]
+        public string Src { get; set; }
+
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            var src = output.Attributes["src"].Value.ToString();
-            var srcParts = src.Split('?');
+            if (string.IsNullOrEmpty(Src))
+            {
+                return;
+            }
+
+            var srcParts = Src.Split('?');
             var query = HttpUtility.ParseQueryString(srcParts.Length > 1 ? srcParts[1] : string.Empty);
 
-            if (ImageWidth.HasValue) {
+            if (ImageWidth.HasValue)
+            {
                 query["width"] = ImageWidth.ToString();
             }
 
-            if (ImageHeight.HasValue) {
+            if (ImageHeight.HasValue)
+            {
                 query["height"] = ImageHeight.ToString();
             }
 
-            if (ResizeMode != ResizeMode.Undefined) {
+            if (ResizeMode != ResizeMode.Undefined)
+            {
                 query["rmode"] = ResizeMode.ToString().ToLower();
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -16,6 +16,8 @@ namespace OrchardCore.Media.TagHelpers
 
     [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeWidthAttributeName)]
     [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeHeightAttributeName)]
+    [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeWidthAttributeName + "," + ImageSizeModeAttributeName)]
+    [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeHeightAttributeName + "," + ImageSizeModeAttributeName)]
     public class ImageTagHelper : TagHelper
     {
         private const string SrcRequiredPrefx = "src,";

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -35,16 +35,23 @@ namespace OrchardCore.Media.TagHelpers
         public ResizeMode ResizeMode { get; set; }
 
         [HtmlAttributeName(ImageSrcAttributeName)]
-        public string Src { get; set; }
+        public string MediaSrc { get; set; }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (string.IsNullOrEmpty(Src))
+            if (string.IsNullOrEmpty(MediaSrc))
             {
                 return;
             }
 
-            var resolvedSrc = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(Src) : Src;
+            var resolvedSrc = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(MediaSrc) : MediaSrc;
+
+            if (!ImageWidth.HasValue && !ImageHeight.HasValue)
+            {
+                output.Attributes.SetAttribute("src", resolvedSrc);
+                return;
+            }
+
             var resizedSrc = ImageSharpUrlFormatter.GetMediaResizeUrl(resolvedSrc, ImageWidth, ImageHeight, ResizeMode);
 
             output.Attributes.SetAttribute("src", resizedSrc);

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -16,7 +16,6 @@ namespace OrchardCore.Media.TagHelpers
 
     [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeWidthAttributeName)]
     [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeHeightAttributeName)]
-    [HtmlTargetElement("img", Attributes = SrcRequiredPrefx + ImageSizeModeAttributeName)]
     public class ImageTagHelper : TagHelper
     {
         private const string SrcRequiredPrefx = "src,";

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -5,37 +5,22 @@ using OrchardCore.Media.Processing;
 namespace OrchardCore.Media.TagHelpers
 {
     [HtmlTargetElement("img", Attributes = ImageSrcAttributeName)]
-    [HtmlTargetElement("img", Attributes = ImageSrcAttributeName + "," + ImageSizeWidthAttributeName)]
-    [HtmlTargetElement("img", Attributes = ImageSrcAttributeName + "," + ImageSizeHeightAttributeName)]
-    [HtmlTargetElement("img", Attributes = ImageSrcAttributeName + "," + ImageSizeWidthAttributeName + "," + ImageSizeModeAttributeName)]
-    [HtmlTargetElement("img", Attributes = ImageSrcAttributeName + "," + ImageSizeHeightAttributeName + "," + ImageSizeModeAttributeName)]
     public class ImageTagHelper : TagHelper
     {
         private const string ImageSizeAttributePrefix = "media-";
-
         private const string ImageSrcAttributeName = ImageSizeAttributePrefix + "src";
-        private const string ImageSizeWidthAttributeName = ImageSizeAttributePrefix + "width";
-        private const string ImageSizeHeightAttributeName = ImageSizeAttributePrefix + "height";
-        private const string ImageSizeModeAttributeName = ImageSizeAttributePrefix + "resize-mode";
 
         private readonly IMediaFileStore _mediaFileStore;
+
+        public override int Order => -10;
+
+        [HtmlAttributeName(ImageSrcAttributeName)]
+        public string MediaSrc { get; set; }
 
         public ImageTagHelper(IMediaFileStore mediaFileStore)
         {
             _mediaFileStore = mediaFileStore;
         }
-
-        [HtmlAttributeName(ImageSizeWidthAttributeName)]
-        public int? ImageWidth { get; set; }
-
-        [HtmlAttributeName(ImageSizeHeightAttributeName)]
-        public int? ImageHeight { get; set; }
-
-        [HtmlAttributeName(ImageSizeModeAttributeName)]
-        public ResizeMode ResizeMode { get; set; }
-
-        [HtmlAttributeName(ImageSrcAttributeName)]
-        public string MediaSrc { get; set; }
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
@@ -45,16 +30,7 @@ namespace OrchardCore.Media.TagHelpers
             }
 
             var resolvedSrc = _mediaFileStore != null ? _mediaFileStore.MapPathToPublicUrl(MediaSrc) : MediaSrc;
-
-            if (!ImageWidth.HasValue && !ImageHeight.HasValue)
-            {
-                output.Attributes.SetAttribute("src", resolvedSrc);
-                return;
-            }
-
-            var resizedSrc = ImageSharpUrlFormatter.GetMediaResizeUrl(resolvedSrc, ImageWidth, ImageHeight, ResizeMode);
-
-            output.Attributes.SetAttribute("src", resizedSrc);
+            output.Attributes.SetAttribute("src", resolvedSrc);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageTagHelper.cs
@@ -4,6 +4,7 @@ using OrchardCore.Media.Processing;
 
 namespace OrchardCore.Media.TagHelpers
 {
+    [HtmlTargetElement("img", Attributes = ImageSrcAttributeName)]
     [HtmlTargetElement("img", Attributes = ImageSrcAttributeName + "," + ImageSizeWidthAttributeName)]
     [HtmlTargetElement("img", Attributes = ImageSrcAttributeName + "," + ImageSizeHeightAttributeName)]
     [HtmlTargetElement("img", Attributes = ImageSrcAttributeName + "," + ImageSizeWidthAttributeName + "," + ImageSizeModeAttributeName)]


### PR DESCRIPTION
Added tag helper for razor to provide same functionality as the liquid image resize filters ([http://orchardcore.readthedocs.io/en/dev/OrchardCore.Modules/OrchardCore.Media/README/#image-resizing-filters](http://orchardcore.readthedocs.io/en/dev/OrchardCore.Modules/OrchardCore.Media/README/#image-resizing-filters))

Added example code to the docs.