### PR TITLE
Prevent unnecessary compilation in incremental build

### DIFF
--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
@@ -22,6 +22,7 @@
     <WriteLinesToFile
       File="$(IntermediateOutputPath)module.names.map"
       Lines="@(ModuleNames)"
+      WriteOnlyWhenDifferent="true"
       Condition="'@(ModuleNames)' != ''"
       Overwrite="true"
       Encoding="utf-8"

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -41,6 +41,7 @@
     <WriteLinesToFile
       File="$(IntermediateOutputPath)module.assets.map"
       Lines="@(ModuleAssets)"
+      WriteOnlyWhenDifferent="true"
       Condition="'@(ModuleAssets)' != ''"
       Overwrite="true"
       Encoding="utf-8"
@@ -51,6 +52,7 @@
     <WriteLinesToFile
       File="obj\$(ModuleType).txt"
       Lines="$(ModuleManifest)"
+      WriteOnlyWhenDifferent="true"
       Condition="!Exists('$(ModuleType).txt')"
       Overwrite="true"
       Encoding="utf-8"


### PR DESCRIPTION
There are custom targets that generate modules.*.map files to be embedded as resources. These files were regenerated on every incremental build causing the CoreCompile target to always see at least one input file that was newer than the output assembly. This caused the assemblies to be recompiled on every command-line build. (In VS, the "fast up-to-date" check masks the problem.)

On my machine, this reduces incremental `dotnet build` of the solution from ~1m15s to ~0m40s using .NET Core SDK v2.1.100-preview-007326.