### PR TITLE
Fixe some issues when using custom menu items.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
@@ -213,7 +213,7 @@ namespace OrchardCore.Menu.Controllers
                 return View(model);
             }
 
-            menuItem.Merge(contentItem.Content, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Union });
+            menuItem.Merge(contentItem.Content, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
 
             _session.Save(menu);
 

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItem.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItem.Thumbnail.cshtml
@@ -2,7 +2,15 @@
 
 <div class="card">
     <div class="card-body">
-        @await DisplayAsync(Model.Content)
+        @if(Model.Content != null)
+        {
+            @await DisplayAsync(Model.Content)
+        }
+        else
+        {
+            <h4 class="card-title">@Model.MenuItemType</h4>
+            <p>@Model.MenuItemDisplayName</p>
+        }
     </div>
     <div class="card-footer text-muted text-xs-right">
         <a class="btn btn-primary btn-sm thumbnail-link-create" asp-route-action="Create" asp-route-controller="Admin" asp-route-id="@Model.MenuItemType" asp-route-menuContentItemId="@Model.MenuContentItemId" asp-route-area="OrchardCore.Menu">@T["Add"]</a>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItem.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItem.Thumbnail.cshtml
@@ -9,7 +9,7 @@
         else
         {
             <h4 class="card-title">@Model.MenuItemType</h4>
-            <p>@Model.MenuItemDisplayName</p>
+            <p>@Model.MenuItemTypeDisplayName</p>
         }
     </div>
     <div class="card-footer text-muted text-xs-right">

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuPart.Edit.cshtml
@@ -56,7 +56,7 @@
                         var menuItem = await ContentManager.NewAsync(type.Name);
                         dynamic thumbnail = await ContentItemDisplayManager.BuildDisplayAsync(menuItem, updater, "Thumbnail");
                         thumbnail.MenuItemType = type.Name;
-                        thumbnail.MenuItemDisplayName = type.DisplayName;
+                        thumbnail.MenuItemTypeDisplayName = type.DisplayName;
                         thumbnail.MenuContentItemId = Model.MenuPart.ContentItem.ContentItemId;
                         <div class="col-sm-6">
                             @await DisplayAsync(thumbnail)

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuPart.Edit.cshtml
@@ -56,6 +56,7 @@
                         var menuItem = await ContentManager.NewAsync(type.Name);
                         dynamic thumbnail = await ContentItemDisplayManager.BuildDisplayAsync(menuItem, updater, "Thumbnail");
                         thumbnail.MenuItemType = type.Name;
+                        thumbnail.MenuItemDisplayName = type.DisplayName;
                         thumbnail.MenuContentItemId = Model.MenuPart.ContentItem.ContentItemId;
                         <div class="col-sm-6">
                             @await DisplayAsync(thumbnail)


### PR DESCRIPTION
Fixes #1405 

If a custom menu item has a bag part, bag part items are duplicated when saving the parent menu.

Fixes #1406 

When adding an menu item in a menu, for a custom menu item created through the admin UI, the `Thumbnail` box shows no title and description.

This because there is no driver to provide a sub shape for the `Content` zone and the `Thumbnail` display type. So, in `MenuItem.Thumbnail.cshtml` nothing is rendered with `DisplayAsync(Model.Content)`.

Here, when `Model.Content` is null, we fallback to display the menu item type as a title, and the menu item display text as a description.

Note: maybe good to have a description for a content type, as we have for a content part.


