### PR TITLE
Allow double slashes in asset paths.

### DIFF
--- a/src/OrchardCore/OrchardCore.Modules/ModuleEmbeddedFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Modules/ModuleEmbeddedFileProvider.cs
@@ -107,7 +107,7 @@ namespace OrchardCore.Modules
 
         private string NormalizePath(string path)
         {
-            return path.Replace('\\', '/').Trim('/');
+            return path.Replace('\\', '/').Trim('/').Replace("//", "/");
         }
     }
 }


### PR DESCRIPTION
Fixes #1408 

It now works for `/OrchardCore.Resources/Scripts//ui/icons.svg`.

Didn't check yet for `the visibility toggle for the connection string is broken` issue.

**Update**: ~~The `visibility toggle for the connection string`  works for me in debug mode or through the command line.~~

**Update**: i found a fix for the toggle button, i will do another PR because this one is only a patch and it solve another issue related to static asset paths.