### PR TITLE
Fixes setup toggle button for connection string.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
@@ -164,7 +164,7 @@
 
                 <div class="input-group mb-2 mb-sm-0">
                     <input asp-for="ConnectionString" class="form-control pwd" type="password" />
-                    <div class="input-group-addon reveal" title="@T["Show/hide connection string"]"><i class="fa fa-eye-slash" aria-hidden="true"></i></div>
+                    <div class="input-group-prepend reveal" title="@T["Show/hide connection string"]"><button class="fa fa-eye-slash" aria-hidden="true"></button></div>
                 </div>
 
                 <span asp-validation-for="ConnectionString" class="text-danger"></span>
@@ -230,8 +230,10 @@
             var $pwd = $(".pwd");
             if ($pwd.attr('type') === 'password') {
                 $pwd.attr('type', 'text');
+                $(this).find('button').toggleClass('fa-eye-slash fa-eye');
             } else {
                 $pwd.attr('type', 'password');
+                $(this).find('button').toggleClass('fa-eye fa-eye-slash');
             }
         });
     })


### PR DESCRIPTION
So, as said in #1408 

- Changed the class with `input-group-append` and used a `<button>` with the fa icon.

- Didn't find where the fa icon was swithched to show the state, maybe through bootstrap.

- So, in the script at the end of the setup `Index.cshtml` (no need to use gulp) i just switched the fa icon class at the same place we swith the input type attribute between `password` and `text`.

![toggle1](https://user-images.githubusercontent.com/8586360/35372581-14167ce6-019b-11e8-9eab-a043c6bc6386.png)

![toggle2](https://user-images.githubusercontent.com/8586360/35372595-26f93f92-019b-11e8-9e73-fac5cba2ea8a.png)

