### PR TITLE
Use the new OpenIddict application permissions feature

### DIFF
--- a/src/OrchardCore.Build/Dependencies.AspNetContrib.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetContrib.props
@@ -1,5 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <AspNetContribSecurityOAuthValidationPackageVersion>2.0.0-rc1-final</AspNetContribSecurityOAuthValidationPackageVersion>
-  </PropertyGroup>
-</Project>

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -1,7 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="..\..\src\OrchardCore.Build\Dependencies.AspNetCore.props" />
-  <Import Project="..\..\src\OrchardCore.Build\Dependencies.AspNetContrib.props" />
 
   <PropertyGroup>
     <!-- This value is deprecated and will be deleted in beta2 -->
@@ -19,7 +18,8 @@
     <YesSqlVersion>2.0.0-beta-1174</YesSqlVersion>
     <YesSqlProvidersVersion>1.0.0-beta-1174</YesSqlProvidersVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
-    <OpenIddictVersion>2.0.0-rc2-0789</OpenIddictVersion>
+    <OAuthValidationPackageVersion>2.0.0-rc1-final</OAuthValidationPackageVersion>
+    <OpenIddictVersion>2.0.0-rc2-0802</OpenIddictVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdApplication.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdApplication.cs
@@ -12,17 +12,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Models
     public class OpenIdApplication<TKey, TAuthorization, TToken> : OpenIddictApplication<TKey, TAuthorization, TToken>, IOpenIdApplication
         where TKey : IEquatable<TKey>
     {
-        /// <summary>
-        /// Gets or sets if a consent form has to be fulfilled by 
-        /// the user after log in.
-        /// </summary>
-        public bool SkipConsent { get; set; }
-
-        public bool AllowPasswordFlow { get; set; }
-        public bool AllowClientCredentialsFlow { get; set; }
-        public bool AllowAuthorizationCodeFlow { get; set; }
-        public bool AllowRefreshTokenFlow { get; set; }
-        public bool AllowImplicitFlow { get; set; }
-        public bool AllowHybridFlow { get; set; }
+        // Warning: to keep this entity compatible with standalone OpenIddict deployments,
+        // no property SHOULD be added to this model class. Instead, consider using the
+        // IOpenIdApplicationStore.GetPropertiesAsync/SetPropertiesAsync() methods,
+        // that allow storing additional properties without requiring schema changes.
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdAuthorization.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdAuthorization.cs
@@ -12,5 +12,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Models
     public class OpenIdAuthorization<TKey, TApplication, TToken> : OpenIddictAuthorization<TKey, TApplication, TToken>, IOpenIdAuthorization
         where TKey : IEquatable<TKey>
     {
+        // Warning: to keep this entity compatible with standalone OpenIddict deployments,
+        // no property SHOULD be added to this model class. Instead, consider using the
+        // IOpenIdAuthorizationStore.GetPropertiesAsync/SetPropertiesAsync() methods,
+        // that allow storing additional properties without requiring schema changes.
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdScope.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdScope.cs
@@ -7,5 +7,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Models
     public class OpenIdScope<TKey> : OpenIddictScope<TKey>, IOpenIdScope
         where TKey : IEquatable<TKey>
     {
+        // Warning: to keep this entity compatible with standalone OpenIddict deployments,
+        // no property SHOULD be added to this model class. Instead, consider using the
+        // IOpenIdScopeStore.GetPropertiesAsync/SetPropertiesAsync() methods,
+        // that allow storing additional properties without requiring schema changes.
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdToken.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Models/OpenIdToken.cs
@@ -12,5 +12,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Models
     public class OpenIdToken<TKey, TApplication, TAuthorization> : OpenIddictToken<TKey, TApplication, TAuthorization>, IOpenIdToken
         where TKey : IEquatable<TKey>
     {
+        // Warning: to keep this entity compatible with standalone OpenIddict deployments,
+        // no property SHOULD be added to this model class. Instead, consider using the
+        // IOpenIdTokenStore.GetPropertiesAsync/SetPropertiesAsync() methods,
+        // that allow storing additional properties without requiring schema changes.
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdApplicationStore.cs
@@ -3,13 +3,14 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
 using OpenIddict.Core;
 using OpenIddict.EntityFrameworkCore;
 using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Abstractions.Stores;
 using OrchardCore.OpenId.EntityFrameworkCore.Models;
+using OrchardCore.OpenId.Services;
 
 namespace OrchardCore.OpenId.EntityFrameworkCore.Services
 {
@@ -68,91 +69,94 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
             // To ensure this method can be safely used, the base GetIdAsync() method is called.
             => GetIdAsync(application, cancellationToken);
 
-        // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
-        public virtual Task<ImmutableArray<string>> GetGrantTypesAsync(TApplication application, CancellationToken cancellationToken)
+        public virtual async Task<bool> IsConsentRequiredAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            var builder = ImmutableArray.CreateBuilder<string>();
-
-            if (application.AllowAuthorizationCodeFlow)
+            var properties = await GetPropertiesAsync(application, cancellationToken);
+            if (properties.TryGetValue(OpenIdConstants.Properties.ConsentRequired, StringComparison.OrdinalIgnoreCase, out JToken value))
             {
-                builder.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+                return (bool) value;
             }
 
-            if (application.AllowClientCredentialsFlow)
-            {
-                builder.Add(OpenIdConnectConstants.GrantTypes.ClientCredentials);
-            }
-
-            if (application.AllowImplicitFlow)
-            {
-                builder.Add(OpenIdConnectConstants.GrantTypes.Implicit);
-            }
-
-            if (application.AllowPasswordFlow)
-            {
-                builder.Add(OpenIdConnectConstants.GrantTypes.Password);
-            }
-
-            if (application.AllowRefreshTokenFlow)
-            {
-                builder.Add(OpenIdConnectConstants.GrantTypes.RefreshToken);
-            }
-
-            return Task.FromResult(builder.ToImmutable());
+            return true;
         }
 
-        public virtual Task SetGrantTypesAsync(TApplication application, ImmutableArray<string> types, CancellationToken cancellationToken)
+        public virtual async Task SetConsentRequiredAsync(TApplication application, bool value, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            application.AllowAuthorizationCodeFlow = types.Contains(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
-            application.AllowClientCredentialsFlow = types.Contains(OpenIdConnectConstants.GrantTypes.ClientCredentials);
-            application.AllowImplicitFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Implicit);
-            application.AllowPasswordFlow = types.Contains(OpenIdConnectConstants.GrantTypes.Password);
-            application.AllowRefreshTokenFlow = types.Contains(OpenIdConnectConstants.GrantTypes.RefreshToken);
+            var properties = await GetPropertiesAsync(application, cancellationToken);
+            properties[OpenIdConstants.Properties.ConsentRequired] = new JValue(value);
 
-            return Task.CompletedTask;
+            await SetPropertiesAsync(application, properties, cancellationToken);
         }
 
-        public virtual Task<bool> IsConsentRequiredAsync(TApplication application, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<string>> GetRolesAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            return Task.FromResult(!application.SkipConsent);
+            var properties = await GetPropertiesAsync(application, cancellationToken);
+            if (properties.TryGetValue(OpenIdConstants.Properties.Roles, StringComparison.OrdinalIgnoreCase, out JToken value))
+            {
+                return value.ToObject<string[]>().ToImmutableArray();
+            }
+
+            return ImmutableArray.Create<string>();
         }
 
-        public virtual Task SetConsentRequiredAsync(TApplication application, bool value, CancellationToken cancellationToken)
+        public virtual async Task<ImmutableArray<TApplication>> ListInRoleAsync(string role, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(role))
+            {
+                throw new ArgumentException("The role name cannot be null or empty.", nameof(role));
+            }
+
+            // To optimize the efficiency of the query a bit, only applications whose stringified
+            // Properties column contains the specified role are returned. Once the applications
+            // are retrieved, a second pass is made to ensure only valid elements are returned.
+            // Implementers that use this method in a hot path may want to override this method
+            // to use SQL Server 2016 functions like JSON_VALUE to make the query more efficient.
+            IQueryable<TApplication> Query(IQueryable<TApplication> applications, string state)
+                => from application in applications
+                   where application.Properties.Contains(state)
+                   select application;
+
+            var builder = ImmutableArray.CreateBuilder<TApplication>();
+
+            foreach (var application in await ListAsync((applications, state) => Query(applications, state), role, cancellationToken))
+            {
+                var roles = await GetRolesAsync(application, cancellationToken);
+                if (roles.Contains(role, StringComparer.OrdinalIgnoreCase))
+                {
+                    builder.Add(application);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        public virtual async Task SetRolesAsync(TApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
         {
             if (application == null)
             {
                 throw new ArgumentNullException(nameof(application));
             }
 
-            application.SkipConsent = !value;
+            var properties = await GetPropertiesAsync(application, cancellationToken);
+            properties[OpenIdConstants.Properties.Roles] = new JArray(roles.ToArray());
 
-            return Task.CompletedTask;
+            await SetPropertiesAsync(application, properties, cancellationToken);
         }
-
-        // TODO: implement these methods.
-        public virtual Task<ImmutableArray<string>> GetRolesAsync(TApplication application, CancellationToken cancellationToken)
-            => Task.FromResult(ImmutableArray.Create<string>());
-
-        public virtual Task<ImmutableArray<TApplication>> ListInRoleAsync(string role, CancellationToken cancellationToken)
-            => Task.FromResult(ImmutableArray.Create<TApplication>());
-
-        public virtual Task SetRolesAsync(TApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
-            => Task.CompletedTask;
 
         // Note: the following methods are deliberately implemented as explicit methods so they are not
         // exposed by Intellisense. Their logic MUST be limited to dealing with casts and downcasts.
@@ -206,8 +210,14 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         Task<string> IOpenIddictApplicationStore<IOpenIdApplication>.GetIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
             => GetIdAsync((TApplication) application, cancellationToken);
 
+        Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetPermissionsAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetPermissionsAsync((TApplication) application, cancellationToken);
+
         Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetPostLogoutRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
             => GetPostLogoutRedirectUrisAsync((TApplication) application, cancellationToken);
+
+        Task<JObject> IOpenIddictApplicationStore<IOpenIdApplication>.GetPropertiesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
+            => GetPropertiesAsync((TApplication) application, cancellationToken);
 
         Task<ImmutableArray<string>> IOpenIddictApplicationStore<IOpenIdApplication>.GetRedirectUrisAsync(IOpenIdApplication application, CancellationToken cancellationToken)
             => GetRedirectUrisAsync((TApplication) application, cancellationToken);
@@ -236,9 +246,15 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         Task IOpenIddictApplicationStore<IOpenIdApplication>.SetDisplayNameAsync(IOpenIdApplication application, string name, CancellationToken cancellationToken)
             => SetDisplayNameAsync((TApplication) application, name, cancellationToken);
 
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetPermissionsAsync(IOpenIdApplication application, ImmutableArray<string> permissions, CancellationToken cancellationToken)
+            => SetPermissionsAsync((TApplication) application, permissions, cancellationToken);
+
         Task IOpenIddictApplicationStore<IOpenIdApplication>.SetPostLogoutRedirectUrisAsync(IOpenIdApplication application,
             ImmutableArray<string> addresses, CancellationToken cancellationToken)
             => SetPostLogoutRedirectUrisAsync((TApplication) application, addresses, cancellationToken);
+
+        Task IOpenIddictApplicationStore<IOpenIdApplication>.SetPropertiesAsync(IOpenIdApplication application, JObject properties, CancellationToken cancellationToken)
+            => SetPropertiesAsync((TApplication) application, properties, cancellationToken);
 
         Task IOpenIddictApplicationStore<IOpenIdApplication>.SetRedirectUrisAsync(IOpenIdApplication application,
             ImmutableArray<string> addresses, CancellationToken cancellationToken)
@@ -254,9 +270,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         async Task<IOpenIdApplication> IOpenIdApplicationStore.FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
             => await FindByPhysicalIdAsync(identifier, cancellationToken);
 
-        Task<ImmutableArray<string>> IOpenIdApplicationStore.GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken)
-            => GetGrantTypesAsync((TApplication) application, cancellationToken);
-
         Task<string> IOpenIdApplicationStore.GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken)
             => GetPhysicalIdAsync((TApplication) application, cancellationToken);
 
@@ -271,9 +284,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
 
         Task IOpenIdApplicationStore.SetConsentRequiredAsync(IOpenIdApplication application, bool value, CancellationToken cancellationToken)
             => SetConsentRequiredAsync((TApplication) application, value, cancellationToken);
-
-        Task IOpenIdApplicationStore.SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken)
-            => SetGrantTypesAsync((TApplication) application, types, cancellationToken);
 
         Task IOpenIdApplicationStore.SetRolesAsync(IOpenIdApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
             => SetRolesAsync((TApplication) application, roles, cancellationToken);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
 using OpenIddict.Core;
 using OpenIddict.EntityFrameworkCore;
 using OrchardCore.OpenId.Abstractions.Models;
@@ -104,6 +105,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
             => GetIdAsync((TAuthorization) authorization, cancellationToken);
 
+        Task<JObject> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetPropertiesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetPropertiesAsync((TAuthorization) authorization, cancellationToken);
+
         Task<ImmutableArray<string>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetScopesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
             => GetScopesAsync((TAuthorization) authorization, cancellationToken);
 
@@ -133,6 +137,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetApplicationIdAsync(IOpenIdAuthorization authorization,
             string identifier, CancellationToken cancellationToken)
             => SetApplicationIdAsync((TAuthorization) authorization, identifier, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetPropertiesAsync(IOpenIdAuthorization authorization, JObject properties, CancellationToken cancellationToken)
+            => SetPropertiesAsync((TAuthorization) authorization, properties, cancellationToken);
 
         Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetScopesAsync(IOpenIdAuthorization authorization,
             ImmutableArray<string> scopes, CancellationToken cancellationToken)

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdScopeStore.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
 using OpenIddict.Core;
 using OpenIddict.EntityFrameworkCore;
 using OrchardCore.OpenId.Abstractions.Models;
@@ -99,6 +100,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetNameAsync(IOpenIdScope scope, CancellationToken cancellationToken)
             => GetNameAsync((TScope) scope, cancellationToken);
 
+        Task<JObject> IOpenIddictScopeStore<IOpenIdScope>.GetPropertiesAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetPropertiesAsync((TScope) scope, cancellationToken);
+
         async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.InstantiateAsync(CancellationToken cancellationToken)
             => await InstantiateAsync(cancellationToken);
 
@@ -115,6 +119,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
 
         Task IOpenIddictScopeStore<IOpenIdScope>.SetNameAsync(IOpenIdScope scope, string name, CancellationToken cancellationToken)
             => SetNameAsync((TScope) scope, name, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.SetPropertiesAsync(IOpenIdScope scope, JObject properties, CancellationToken cancellationToken)
+            => SetPropertiesAsync((TScope) scope, properties, cancellationToken);
 
         Task IOpenIddictScopeStore<IOpenIdScope>.UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
             => UpdateAsync((TScope) scope, cancellationToken);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdTokenStore.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json.Linq;
 using OpenIddict.Core;
 using OpenIddict.EntityFrameworkCore;
 using OrchardCore.OpenId.Abstractions.Models;
@@ -125,6 +126,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetPayloadAsync(IOpenIdToken token, CancellationToken cancellationToken)
             => GetPayloadAsync((TToken) token, cancellationToken);
 
+        Task<JObject> IOpenIddictTokenStore<IOpenIdToken>.GetPropertiesAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetPropertiesAsync((TToken) token, cancellationToken);
+
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetReferenceIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
             => GetReferenceIdAsync((TToken) token, cancellationToken);
 
@@ -165,6 +169,9 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetPayloadAsync(IOpenIdToken token, string payload, CancellationToken cancellationToken)
             => SetPayloadAsync((TToken) token, payload, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetPropertiesAsync(IOpenIdToken token, JObject properties, CancellationToken cancellationToken)
+            => SetPropertiesAsync((TToken) token, properties, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetReferenceIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
             => SetReferenceIdAsync((TToken) token, identifier, cancellationToken);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Startup.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.OpenId.EntityFrameworkCore
             try
             {
                 Type contextType = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:ContextType"),
-                     keyType     = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:KeyType") ?? typeof(long);
+                     keyType     = GetConfigurationNodeAsType("Modules:OrchardCore.OpenId:EntityFrameworkCore:KeyType") ?? typeof(string);
 
                 if (contextType == null)
                 {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdApplicationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Abstractions/Stores/IOpenIdApplicationStore.cs
@@ -11,10 +11,6 @@ namespace OrchardCore.OpenId.Abstractions.Stores
         Task<IOpenIdApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken);
         Task<string> GetPhysicalIdAsync(IOpenIdApplication application, CancellationToken cancellationToken);
 
-        // TODO: remove these methods once per-application grant type limitation is added to OpenIddict.
-        Task<ImmutableArray<string>> GetGrantTypesAsync(IOpenIdApplication application, CancellationToken cancellationToken);
-        Task SetGrantTypesAsync(IOpenIdApplication application, ImmutableArray<string> types, CancellationToken cancellationToken);
-
         Task<bool> IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken);
         Task SetConsentRequiredAsync(IOpenIdApplication application, bool value, CancellationToken cancellationToken);
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -84,46 +84,6 @@ namespace OrchardCore.OpenId.Controllers
                 });
             }
 
-            if (request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) &&
-                !await _applicationManager.IsRefreshTokenFlowAllowedAsync(application, HttpContext.RequestAborted))
-            {
-                return View("Error", new ErrorViewModel
-                {
-                    Error = OpenIdConnectConstants.Errors.InvalidClient,
-                    ErrorDescription = T["Offline scope is not allowed for this OpenID Connect Application"]
-                });
-            }
-
-            if (request.IsAuthorizationCodeFlow() &&
-                !await _applicationManager.IsAuthorizationCodeFlowAllowedAsync(application, HttpContext.RequestAborted))
-            {
-                return View("Error", new ErrorViewModel
-                {
-                    Error = OpenIdConnectConstants.Errors.UnauthorizedClient,
-                    ErrorDescription = T["Authorization Code Flow is not allowed for this OpenID Connect Application"]
-                });
-            }
-
-            if (request.IsImplicitFlow() &&
-                !await _applicationManager.IsImplicitFlowAllowedAsync(application, HttpContext.RequestAborted))
-            {
-                return View("Error", new ErrorViewModel
-                {
-                    Error = OpenIdConnectConstants.Errors.UnauthorizedClient,
-                    ErrorDescription = T["Implicit Flow is not allowed for this OpenID Connect Application"]
-                });
-            }
-
-            if (request.IsHybridFlow() &&
-                !await _applicationManager.IsHybridFlowAllowedAsync(application, HttpContext.RequestAborted))
-            {
-                return View("Error", new ErrorViewModel
-                {
-                    Error = OpenIdConnectConstants.Errors.UnauthorizedClient,
-                    ErrorDescription = T["Hybrid Flow is not allowed for this OpenID Connect Application"]
-                });
-            }
-
             if (Request.HasFormContentType)
             {
                 if (!string.IsNullOrEmpty(Request.Form["submit.Accept"]))
@@ -198,79 +158,18 @@ namespace OrchardCore.OpenId.Controllers
                 return NotFound();
             }
 
-            var application = await _applicationManager.FindByClientIdAsync(request.ClientId, HttpContext.RequestAborted);
-            if (application == null)
-            {
-                return BadRequest(new OpenIdConnectResponse
-                {
-                    Error = OpenIdConnectConstants.Errors.InvalidClient,
-                    ErrorDescription = T["Details concerning the calling client application cannot be found in the database"]
-                });
-            }
-
-            if (request.HasScope(OpenIdConnectConstants.Scopes.OfflineAccess) &&
-                !await _applicationManager.IsRefreshTokenFlowAllowedAsync(application, HttpContext.RequestAborted))
-            {
-                return BadRequest(new OpenIdConnectResponse
-                {
-                    Error = OpenIdConnectConstants.Errors.InvalidRequest,
-                    ErrorDescription = T["Offline scope is not allowed for this OpenID Connect Application"]
-                });
-            }
-
             if (request.IsPasswordGrantType())
             {
-                if (!await _applicationManager.IsPasswordFlowAllowedAsync(application, HttpContext.RequestAborted))
-                {
-                    return BadRequest(new OpenIdConnectResponse
-                    {
-                        Error = OpenIdConnectConstants.Errors.UnauthorizedClient,
-                        ErrorDescription = T["Password Flow is not allowed for this OpenID Connect Application"]
-                    });
-                }
-
                 return await ExchangePasswordGrantType(request);
             }
 
             if (request.IsClientCredentialsGrantType())
             {
-                if (!await _applicationManager.IsClientCredentialsFlowAllowedAsync(application, HttpContext.RequestAborted))
-                {
-                    return BadRequest(new OpenIdConnectResponse
-                    {
-                        Error = OpenIdConnectConstants.Errors.UnauthorizedClient,
-                        ErrorDescription = T["Client Credentials Flow is not allowed for this OpenID Connect Application"]
-                    });
-                }
-
                 return await ExchangeClientCredentialsGrantType(request);
             }
 
-            if (request.IsAuthorizationCodeGrantType())
+            if (request.IsAuthorizationCodeGrantType() || request.IsRefreshTokenGrantType())
             {
-                if (!await _applicationManager.IsAuthorizationCodeFlowAllowedAsync(application, HttpContext.RequestAborted))
-                {
-                    return BadRequest(new OpenIdConnectResponse
-                    {
-                        Error = OpenIdConnectConstants.Errors.UnauthorizedClient,
-                        ErrorDescription = T["Authorization Code Flow is not allowed for this OpenID Connect Application"]
-                    });
-                }
-
-                return await ExchangeAuthorizationCodeOrRefreshTokenGrantType(request);
-            }
-
-            if (request.IsRefreshTokenGrantType())
-            {
-                if (!await _applicationManager.IsRefreshTokenFlowAllowedAsync(application, HttpContext.RequestAborted))
-                {
-                    return BadRequest(new OpenIdConnectResponse
-                    {
-                        Error = OpenIdConnectConstants.Errors.UnauthorizedClient,
-                        ErrorDescription = T["Refresh Token Flow is not allowed for this OpenID Connect Application"]
-                    });
-                }
-
                 return await ExchangeAuthorizationCodeOrRefreshTokenGrantType(request);
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AdminController.cs
@@ -132,8 +132,8 @@ namespace OrchardCore.OpenId.Controllers
                 Id = await _applicationManager.GetPhysicalIdAsync(application, HttpContext.RequestAborted),
                 LogoutRedirectUri = (await _applicationManager.GetPostLogoutRedirectUrisAsync(application, HttpContext.RequestAborted)).FirstOrDefault(),
                 RedirectUri = (await _applicationManager.GetRedirectUrisAsync(application, HttpContext.RequestAborted)).FirstOrDefault(),
-                SkipConsent = await _applicationManager.IsConsentRequiredAsync(application, HttpContext.RequestAborted),
-                Type = await _applicationManager.GetClientTypeAsync(application, HttpContext.RequestAborted)
+                SkipConsent = !await _applicationManager.IsConsentRequiredAsync(application, HttpContext.RequestAborted),
+                Type = (ClientType) Enum.Parse(typeof(ClientType), await _applicationManager.GetClientTypeAsync(application, HttpContext.RequestAborted), ignoreCase: true)
             };
 
             foreach (var role in await _roleProvider.GetRoleNamesAsync())

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdSettingsDisplayDriver.cs
@@ -67,7 +67,6 @@ namespace OrchardCore.OpenId.Drivers
                 model.AllowAuthorizationCodeFlow = settings.AllowAuthorizationCodeFlow;
                 model.AllowRefreshTokenFlow = settings.AllowRefreshTokenFlow;
                 model.AllowImplicitFlow = settings.AllowImplicitFlow;
-                model.AllowHybridFlow = settings.AllowHybridFlow;
                 model.UseRollingTokens = settings.UseRollingTokens;
             }).Location("Content:2").OnGroup(SettingsGroupId);
         }
@@ -98,7 +97,6 @@ namespace OrchardCore.OpenId.Drivers
                 settings.AllowAuthorizationCodeFlow = model.AllowAuthorizationCodeFlow;
                 settings.AllowRefreshTokenFlow = model.AllowRefreshTokenFlow;
                 settings.AllowImplicitFlow = model.AllowImplicitFlow;
-                settings.AllowHybridFlow = model.AllowHybridFlow;
                 settings.UseRollingTokens = model.UseRollingTokens;
 
                 if (_openIdServices.IsValidOpenIdSettings(settings, updater.ModelState) && _memoryCache.Get(RestartPendingCacheKey) == null)

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.Validation" Version="$(AspNetContribSecurityOAuthValidationPackageVersion)" />
+    <PackageReference Include="AspNet.Security.OAuth.Validation" Version="$(OAuthValidationPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion)" />
     <PackageReference Include="OpenIddict" Version="$(OpenIddictVersion)" />
   </ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/README.md
@@ -29,7 +29,6 @@ Available settings are:
 + Allow Client Credentials Flow: It requires Token Endpoint is enabled. More info at https://tools.ietf.org/html/rfc6749#section-1.3.4
 + Allow Authorization Code Flow: It requires Authorization and Token Endpoints are enabled. More info at http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
 + Allow Implicit Flow: It requires Authorization Endpoint is enabled. More info at http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth
-+ Allow Hybrid Flow: It requires Authorization and Token Endpoints. More info at http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth
 + Allow Refresh Token Flow: It allows to refresh access token using a refresh token. It can be used in combination with Password Flow, Authorization Code Flow and Hybrid Flow. More info at http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens
 
 A sample of OpenID Connect Settings recipe step:
@@ -51,8 +50,7 @@ A sample of OpenID Connect Settings recipe step:
       "AllowClientCredentialsFlow": false,
       "AllowAuthorizationCodeFlow": false,
       "AllowRefreshTokenFlow": false,
-      "AllowImplicitFlow": false,
-      "AllowHybridFlow": false
+      "AllowImplicitFlow": false
 }
 ```
 
@@ -75,7 +73,6 @@ OpenID Connect apps require the following configuration.
   + Allow Client Credentials Flow: It requires Token Endpoint is enabled. More info at https://tools.ietf.org/html/rfc6749#section-1.3.4
   + Allow Authorization Code Flow: It requires Authorization and Token Endpoints are enabled. More info at http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
   + Allow Implicit Flow: It requires Authorization Endpoint is enabled. More info at http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth
-  + Allow Hybrid Flow: It requires Authorization and Token Endpoints. More info at http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth
   + Allow Refresh Token Flow: It allows to refresh access token using a refresh token. It can be used in combination with Password Flow, Authorization Code Flow and Hybrid Flow. More info at http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens
   + Normalized RoleNames: This configuration is only required inf Client Credentials Flow is enabled. It determines the roles assined to the app when it is authenticated using that flow.
   + Redirect Options: Those options are only required when Implicit Flow, Authorization Code Flow or Allow Hybrid Flow is required:
@@ -99,8 +96,7 @@ OpenID Connect apps require the following configuration.
       "AllowClientCredentialsFlow": false,
       "AllowAuthorizationCodeFlow": false,
       "AllowRefreshTokenFlow": false,
-      "AllowImplicitFlow": false,
-      "AllowHybridFlow": false
+      "AllowImplicitFlow": false
 }
 ```
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdSettingsStep.cs
@@ -44,7 +44,6 @@ namespace OrchardCore.OpenId.Recipes
             settings.AllowAuthorizationCodeFlow = model.AllowAuthorizationCodeFlow;
             settings.AllowRefreshTokenFlow = model.AllowRefreshTokenFlow;
             settings.AllowImplicitFlow = model.AllowImplicitFlow;
-            settings.AllowHybridFlow = model.AllowHybridFlow;
             settings.UseRollingTokens = model.UseRollingTokens;
 
             await _openIdService.UpdateOpenIdSettingsAsync(settings);
@@ -69,7 +68,6 @@ namespace OrchardCore.OpenId.Recipes
         public bool AllowAuthorizationCodeFlow { get; set; }
         public bool AllowRefreshTokenFlow { get; set; }
         public bool AllowImplicitFlow { get; set; }
-        public bool AllowHybridFlow { get; set; }
         public bool UseRollingTokens { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdConfiguration.cs
@@ -139,25 +139,25 @@ namespace OrchardCore.OpenId
             {
                 options.UserinfoEndpointPath = "/OrchardCore.OpenId/UserInfo/Me";
             }
-            if (settings.AllowPasswordFlow)
+            if (settings.AllowAuthorizationCodeFlow)
             {
-                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.Password);
+                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
             }
             if (settings.AllowClientCredentialsFlow)
             {
                 options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.ClientCredentials);
             }
-            if (settings.AllowAuthorizationCodeFlow || settings.AllowHybridFlow)
+            if (settings.AllowImplicitFlow)
             {
-                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.AuthorizationCode);
+                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.Implicit);
+            }
+            if (settings.AllowPasswordFlow)
+            {
+                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.Password);
             }
             if (settings.AllowRefreshTokenFlow)
             {
                 options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.RefreshToken);
-            }
-            if (settings.AllowImplicitFlow || settings.AllowHybridFlow)
-            {
-                options.GrantTypes.Add(OpenIdConnectConstants.GrantTypes.Implicit);
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdConstants.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdConstants.cs
@@ -1,0 +1,11 @@
+namespace OrchardCore.OpenId.Services
+{
+    public static class OpenIdConstants
+    {
+        public static class Properties
+        {
+            public const string ConsentRequired = "ConsentRequired";
+            public const string Roles = "Roles";
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdService.cs
@@ -53,7 +53,7 @@ namespace OrchardCore.OpenId.Services
             }
 
             if (!settings.AllowAuthorizationCodeFlow && !settings.AllowClientCredentialsFlow 
-                && !settings.AllowHybridFlow && !settings.AllowImplicitFlow && !settings.AllowPasswordFlow)
+                && !settings.AllowImplicitFlow && !settings.AllowPasswordFlow)
             {
                 modelState.AddModelError("", T["At least one OpenID Connect flow must be enabled."]);
                 return false;
@@ -118,11 +118,6 @@ namespace OrchardCore.OpenId.Services
                 modelState.AddModelError("AllowAuthorizationCodeFlow", T["Authorization Code Flow cannot be enabled if Authorization Endpoint and Token Endpoint are disabled"]);
                 return false;
             }
-            if (settings.AllowHybridFlow && (!settings.EnableAuthorizationEndpoint || !settings.EnableTokenEndpoint))
-            {
-                modelState.AddModelError("AllowAuthorizationHybridFlow", T["Authorization Hybrid cannot be enabled if Authorization Endpoint and Token Endpoint are disabled"]);
-                return false;
-            }
             if (settings.AllowRefreshTokenFlow)
             {
                 if (!settings.EnableTokenEndpoint)
@@ -130,7 +125,7 @@ namespace OrchardCore.OpenId.Services
                     modelState.AddModelError("AllowRefreshTokenFlow", T["Refresh Token Flow cannot be enabled if Token Endpoint is disabled"]);
                     return false;
                 }
-                if (!settings.AllowPasswordFlow && !settings.AllowAuthorizationCodeFlow && !settings.AllowHybridFlow)
+                if (!settings.AllowPasswordFlow && !settings.AllowAuthorizationCodeFlow)
                 {
                     modelState.AddModelError("AllowRefreshTokenFlow", T["Refresh Token Flow only can be enabled if Password Flow, Authorization Code Flow or Hybrid Flow are enabled"]);
                     return false;

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdSettings.cs
@@ -21,7 +21,6 @@ namespace OrchardCore.OpenId.Settings
         public bool AllowAuthorizationCodeFlow { get; set; }
         public bool AllowRefreshTokenFlow { get; set; }
         public bool AllowImplicitFlow { get; set; }
-        public bool AllowHybridFlow { get; set; }
         public bool UseRollingTokens { get; set; }
 
         public enum TokenFormat

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
@@ -27,7 +27,6 @@ namespace OrchardCore.OpenId.ViewModels
         public bool AllowAuthorizationCodeFlow { get; set; }
         public bool AllowRefreshTokenFlow { get; set; }
         public bool AllowImplicitFlow { get; set; }
-        public bool AllowHybridFlow { get; set; }
     }
 
     public class RoleEntry
@@ -35,5 +34,4 @@ namespace OrchardCore.OpenId.ViewModels
         public string Name { get; set; }
         public bool Selected { get; set; }
     }
-
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
@@ -31,6 +31,5 @@ namespace OrchardCore.OpenId.ViewModels
         public bool AllowAuthorizationCodeFlow { get; set; }
         public bool AllowRefreshTokenFlow { get; set; }
         public bool AllowImplicitFlow { get; set; }
-        public bool AllowHybridFlow { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdSettingsViewModel.cs
@@ -25,7 +25,6 @@ namespace OrchardCore.OpenId.ViewModels
         public bool AllowAuthorizationCodeFlow { get; set; }
         public bool AllowRefreshTokenFlow { get; set; }
         public bool AllowImplicitFlow { get; set; }
-        public bool AllowHybridFlow { get; set; }
         public bool UseRollingTokens { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Create.cshtml
@@ -1,4 +1,4 @@
-﻿@model CreateOpenIdApplicationViewModel
+@model CreateOpenIdApplicationViewModel
 @using OrchardCore.OpenId.ViewModels;
 @using OrchardCore.OpenId.Models;
 @using OrchardCore.OpenId.Settings;
@@ -50,17 +50,6 @@
         <div id="AllowAuthorizationCodeFlowRecommendedHint" class="hint collapse">@T["Recommended Parameters:"] grant_type = 'code', client_id, client_secret, resource = '@openIdSettings.Authority', scope ('openid, profile, roles)')</div>
     </fieldset>
 
-    <fieldset id="AllowHybridFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowHybridFlow">
-        <div class="form-check">
-            <label class="form-check-label">
-                <input asp-for="AllowHybridFlow" type="checkbox" data-toggle="collapse" data-target="#AllowHybridFlowRecommendedHint" class="form-check-input" checked="@Model.AllowHybridFlow" />
-                @T["Allow Hybrid Flow"]
-            </label>
-        </div>
-        <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth</a></div>
-        <div id="AllowHybridFlowRecommendedHint" class="hint collapse">@T["Recommended Parameters:"] grant_type = 'code id_token', client_id, client_secret, resource = '@openIdSettings.Authority', scope ('openid, profile, roles)')</div>
-    </fieldset>
-
     <fieldset id="AllowImplicitFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowImplicitFlow">
         <div class="form-check">
             <label class="form-check-label">
@@ -97,7 +86,7 @@
     <fieldset id="AllowRefreshTokenFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowRefreshTokenFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowRefreshTokenFlow" type="checkbox" data-toggle="collapse" data-target="#AllowRefreshTokenFlowRecommendedHint" class="form-check-input" checked="@Model.AllowRefreshTokenFlow" disabled=@((Model.AllowPasswordFlow || Model.AllowAuthorizationCodeFlow || Model.AllowHybridFlow) ? null : "") />
+                <input asp-for="AllowRefreshTokenFlow" type="checkbox" data-toggle="collapse" data-target="#AllowRefreshTokenFlowRecommendedHint" class="form-check-input" checked="@Model.AllowRefreshTokenFlow" disabled=@((Model.AllowPasswordFlow || Model.AllowAuthorizationCodeFlow) ? null : "") />
                 @T["Allow Refresh Token Flow"]
             </label>
         </div>
@@ -163,14 +152,6 @@
                 $("#AllowAuthorizationCodeFlow").prop("checked", false);
             }
 
-            if (@(openIdSettings.AllowHybridFlow.ToString().ToLower()) == true) {
-                $("#AllowHybridFlowFieldSet").collapse("show");
-            }
-            else {
-                $("#AllowHybridFlowFieldSet").collapse("hide");
-                $("#AllowHybridFlow").prop("checked", false);
-            }
-
             if (@(openIdSettings.AllowImplicitFlow.ToString().ToLower()) == true) {
                 $("#AllowImplicitFlowFieldSet").collapse("show");
             }
@@ -223,7 +204,7 @@
                 allowClientCredentialsFlow.prop("checked", false);
             }
 
-            var clientSecretHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowHybridFlowRecommendedHint, #AllowImplicitFlowRecommendedHint, #AllowRefreshTokenFlowRecommendedHint");
+            var clientSecretHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowImplicitFlowRecommendedHint, #AllowRefreshTokenFlowRecommendedHint");
 
             if (defaultType === $("#Type").val())
                 return;
@@ -242,7 +223,7 @@
         });
 
         function refreshOfflineAccessTip(defaultValue) {
-            var offlineAccessHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowHybridFlowRecommendedHint");
+            var offlineAccessHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint");
             var allowRefreshTokenFlow = $("#AllowRefreshTokenFlow");
             if (defaultValue === allowRefreshTokenFlow.prop('checked'))
                 return;
@@ -255,7 +236,7 @@
             }
         }
 
-        $("#AllowClientCredentialsFlow, #AllowPasswordFlow, #AllowAuthorizationCodeFlow, #AllowHybridFlow, #AllowImplicitFlow, #AllowRefreshTokenFlow").change(function () {
+        $("#AllowClientCredentialsFlow, #AllowPasswordFlow, #AllowAuthorizationCodeFlow, #AllowImplicitFlow, #AllowRefreshTokenFlow").change(function () {
             refreshFlows();
         });
 
@@ -270,7 +251,7 @@
         function refreshAllowRefreshTokenFlowVisibility() {
             var allowRefreshTokenFlow = $("#AllowRefreshTokenFlow");
 
-            if (($("#AllowPasswordFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked') || $("#AllowHybridFlow").prop('checked'))) {
+            if ($("#AllowPasswordFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked')) {
                 allowRefreshTokenFlow.removeAttr("disabled");
             }
             else {
@@ -284,7 +265,7 @@
             var redirectSection = $("#RedirectSection");
             var skipConsent = $("#SkipConsent");
 
-            if (($("#AllowImplicitFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked') || $("#AllowHybridFlow").prop('checked'))) {
+            if ($("#AllowImplicitFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked')) {
                 redirectSection.collapse("show");
             }
             else {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Admin/Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@model EditOpenIdApplicationViewModel
+@model EditOpenIdApplicationViewModel
 @using OrchardCore.OpenId.ViewModels;
 @using OrchardCore.OpenId.Models;
 @using OrchardCore.OpenId.Settings;
@@ -62,17 +62,6 @@
         <div id="AllowAuthorizationCodeFlowRecommendedHint" class="hint collapse">@T["Recommended Parameters:"] grant_type = 'code', client_id, client_secret, resource = '@openIdSettings.Authority', scope ('openid, profile, roles)')</div>
     </fieldset>
 
-    <fieldset id="AllowHybridFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowHybridFlow">
-        <div class="form-check">
-            <label class="form-check-label">
-                <input asp-for="AllowHybridFlow" type="checkbox" data-toggle="collapse" data-target="#AllowHybridFlowRecommendedHint" class="form-check-input" checked="@Model.AllowHybridFlow" />
-                @T["Allow Hybrid Flow"]
-            </label>
-        </div>
-        <div class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth</a></div>
-        <div id="AllowHybridFlowRecommendedHint" class="hint collapse">@T["Recommended Parameters:"] grant_type = 'code id_token', client_id, client_secret, resource = '@openIdSettings.Authority', scope ('openid, profile, roles)')</div>
-    </fieldset>
-
     <fieldset id="AllowImplicitFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowImplicitFlow">
         <div class="form-check">
             <label class="form-check-label">
@@ -109,7 +98,7 @@
     <fieldset id="AllowRefreshTokenFlowFieldSet" class="form-group collapse" asp-validation-class-for="AllowRefreshTokenFlow">
         <div class="form-check">
             <label class="form-check-label">
-                <input asp-for="AllowRefreshTokenFlow" type="checkbox" data-toggle="collapse" data-target="#AllowRefreshTokenFlowRecommendedHint" class="form-check-input" checked="@Model.AllowRefreshTokenFlow" disabled=@((Model.AllowPasswordFlow || Model.AllowAuthorizationCodeFlow || Model.AllowHybridFlow) ? null : "") />
+                <input asp-for="AllowRefreshTokenFlow" type="checkbox" data-toggle="collapse" data-target="#AllowRefreshTokenFlowRecommendedHint" class="form-check-input" checked="@Model.AllowRefreshTokenFlow" disabled=@((Model.AllowPasswordFlow || Model.AllowAuthorizationCodeFlow) ? null : "") />
                 @T["Allow Refresh Token Flow"]
             </label>
         </div>
@@ -175,14 +164,6 @@
                 $("#AllowAuthorizationCodeFlow").prop("checked", false);
             }
 
-            if (@(openIdSettings.AllowHybridFlow.ToString().ToLower()) == true) {
-                $("#AllowHybridFlowFieldSet").collapse("show");
-            }
-            else {
-                $("#AllowHybridFlowFieldSet").collapse("hide");
-                $("#AllowHybridFlow").prop("checked", false);
-            }
-
             if (@(openIdSettings.AllowImplicitFlow.ToString().ToLower()) == true) {
                 $("#AllowImplicitFlowFieldSet").collapse("show");
             }
@@ -232,7 +213,7 @@
                 allowClientCredentialsFlow.prop("checked", false);
             }
 
-            var clientSecretHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowHybridFlowRecommendedHint, #AllowImplicitFlowRecommendedHint, #AllowRefreshTokenFlowRecommendedHint");
+            var clientSecretHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowImplicitFlowRecommendedHint, #AllowRefreshTokenFlowRecommendedHint");
 
             if (defaultType === $("#Type").val())
                 return;
@@ -251,7 +232,7 @@
         });
 
         function refreshOfflineAccessTip(defaultValue) {
-            var offlineAccessHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint, #AllowHybridFlowRecommendedHint");
+            var offlineAccessHints = $("#AllowPasswordFlowRecommendedHint, #AllowAuthorizationCodeFlowRecommendedHint");
             var allowRefreshTokenFlow = $("#AllowRefreshTokenFlow");
             if (defaultValue === allowRefreshTokenFlow.prop('checked'))
                 return;
@@ -264,7 +245,7 @@
             }
         }
 
-        $("#AllowClientCredentialsFlow, #AllowPasswordFlow, #AllowAuthorizationCodeFlow, #AllowHybridFlow, #AllowImplicitFlow, #AllowRefreshTokenFlow").change(function () {
+        $("#AllowClientCredentialsFlow, #AllowPasswordFlow, #AllowAuthorizationCodeFlow, #AllowImplicitFlow, #AllowRefreshTokenFlow").change(function () {
             refreshFlows();
         });
 
@@ -279,7 +260,7 @@
         function refreshAllowRefreshTokenFlowVisibility() {
             var allowRefreshTokenFlow = $("#AllowRefreshTokenFlow");
 
-            if (($("#AllowPasswordFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked') || $("#AllowHybridFlow").prop('checked'))) {
+            if ($("#AllowPasswordFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked')) {
                 allowRefreshTokenFlow.removeAttr("disabled");
             }
             else {
@@ -293,7 +274,7 @@
             var redirectSection = $("#RedirectSection");
             var skipConsent = $("#SkipConsent");
 
-            if (($("#AllowImplicitFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked') || $("#AllowHybridFlow").prop('checked'))) {
+            if ($("#AllowImplicitFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked')) {
                 redirectSection.collapse("show");
             }
             else {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdSettings.Edit.cshtml
@@ -158,16 +158,6 @@
         <span class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth</a></span>
     </fieldset>
 
-    <fieldset class="form-group collapse" asp-validation-class-for="AllowHybridFlow">
-        <div class="form-check">
-            <label class="form-check-label">
-                <input asp-for="AllowHybridFlow" class="form-check-input" />
-                @T["Allow Hybrid Flow"]
-            </label>
-        </div>
-        <span class="hint">@T["More info:"] <a href="http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth">http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth</a></span>
-    </fieldset>
-
     <fieldset class="form-group collapse" asp-validation-class-for="AllowImplicitFlow">
         <div class="form-check">
             <label class="form-check-label">
@@ -227,7 +217,7 @@
             $("#@Html.IdFor(m => m.CertificateThumbPrint)").children("option").hide();
             $("#@Html.IdFor(m => m.CertificateThumbPrint)").children("option[data-StoreLocation=" + $("#@Html.IdFor(m => m.CertificateStoreLocation)").val() + "][data-StoreName=" + $(this).val() + "]").show();
         });
-        $("#@Html.IdFor(m => m.EnableTokenEndpoint), #@Html.IdFor(m => m.EnableAuthorizationEndpoint), #@Html.IdFor(m => m.AllowPasswordFlow), #@Html.IdFor(m => m.AllowAuthorizationCodeFlow), #@Html.IdFor(m => m.AllowHybridFlow)").change(function () {
+        $("#@Html.IdFor(m => m.EnableTokenEndpoint), #@Html.IdFor(m => m.EnableAuthorizationEndpoint), #@Html.IdFor(m => m.AllowPasswordFlow), #@Html.IdFor(m => m.AllowAuthorizationCodeFlow)").change(function () {
             refreshEndpoints();
         });
         function refreshTokenTypeHint() {
@@ -242,7 +232,7 @@
         }
         function refreshEndpoints() {
             refreshEnableTokenEndpoint();
-            refreshAllowAuthorizationCodeFlowAndHybridFlowVisibility();
+            refreshAllowAuthorizationCodeFlowVisibility();
             refreshEnableAuthorizationEndpoint();
             refreshAllowRefreshTokenFlowVisibility();
         }
@@ -266,24 +256,20 @@
             }
             allowImplicitFlow.parent().parent().parent().collapse(enableAuthorizationEndpoint.prop("checked") ? "show" : "hide");
         }
-        function refreshAllowAuthorizationCodeFlowAndHybridFlowVisibility() {
+        function refreshAllowAuthorizationCodeFlowVisibility() {
             var allowAuthorizationCodeFlow = $("#@Html.IdFor(m => m.AllowAuthorizationCodeFlow)");
-            var allowHybridFlow = $("#@Html.IdFor(m => m.AllowHybridFlow)");
             if ($("#@Html.IdFor(m => m.EnableTokenEndpoint)").prop("checked") && $("#@Html.IdFor(m => m.EnableAuthorizationEndpoint)").prop("checked")) {
                 allowAuthorizationCodeFlow.parent().parent().parent().collapse("show");
-                allowHybridFlow.parent().parent().parent().collapse("show");
             }
             else {
                 allowAuthorizationCodeFlow.prop("checked", false);
                 allowAuthorizationCodeFlow.parent().parent().parent().collapse("hide");
-                allowHybridFlow.prop("checked", false);
-                allowHybridFlow.parent().parent().parent().collapse("hide");
             }
         }
         function refreshAllowRefreshTokenFlowVisibility() {
             var allowRefreshTokenFlow = $("#@Html.IdFor(m => m.AllowRefreshTokenFlow)");
             if ($("#@Html.IdFor(m => m.EnableTokenEndpoint)").prop("checked")
-                && ($("#@Html.IdFor(m => m.AllowPasswordFlow)").prop("checked") || $("#@Html.IdFor(m => m.AllowAuthorizationCodeFlow)").prop("checked") || $("#@Html.IdFor(m => m.AllowHybridFlow)").prop("checked"))) {
+                && ($("#@Html.IdFor(m => m.AllowPasswordFlow)").prop("checked") || $("#@Html.IdFor(m => m.AllowAuthorizationCodeFlow)").prop("checked"))) {
                 allowRefreshTokenFlow.parent().parent().parent().collapse("show");
             }
             else {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdApplicationIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Indexes/OpenIdApplicationIndex.cs
@@ -76,7 +76,7 @@ namespace OrchardCore.OpenId.YesSql.Indexes
                 });
 
             context.For<OpenIdApplicationByRoleNameIndex, string>()
-                .Map(application => application.RoleNames.Select(role => new OpenIdApplicationByRoleNameIndex
+                .Map(application => application.Roles.Select(role => new OpenIdApplicationByRoleNameIndex
                 {
                     RoleName = role,
                     Count = 1

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdApplication.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdApplication.cs
@@ -1,5 +1,5 @@
-using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
+using Newtonsoft.Json.Linq;
 using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Models;
 
@@ -39,18 +39,34 @@ namespace OrchardCore.OpenId.YesSql.Models
         public int Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the logout callback URLs
-        /// associated with the current application.
+        /// Gets or sets the permissions associated with the application.
         /// </summary>
-        public ISet<string> PostLogoutRedirectUris { get; set; }
-            = new HashSet<string>(StringComparer.Ordinal);
+        public ImmutableArray<string> Permissions { get; set; }
+            = ImmutableArray.Create<string>();
 
         /// <summary>
-        /// Gets or sets the callback URLs
+        /// Gets the logout callback URLs associated with the current application.
+        /// </summary>
+        public ImmutableArray<string> PostLogoutRedirectUris { get; set; }
+            = ImmutableArray.Create<string>();
+
+        /// <summary>
+        /// Gets or sets the additional properties
         /// associated with the current application.
         /// </summary>
-        public ISet<string> RedirectUris { get; set; }
-            = new HashSet<string>(StringComparer.Ordinal);
+        public virtual JObject Properties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the callback URLs associated with the current application.
+        /// </summary>
+        public ImmutableArray<string> RedirectUris { get; set; }
+            = ImmutableArray.Create<string>();
+
+        /// <summary>
+        /// Gets or sets the roles associated with the application.
+        /// </summary>
+        public ImmutableArray<string> Roles { get; set; }
+            = ImmutableArray.Create<string>();
 
         /// <summary>
         /// Gets or sets the application type
@@ -59,22 +75,9 @@ namespace OrchardCore.OpenId.YesSql.Models
         public ClientType Type { get; set; }
 
         /// <summary>
-        /// Gets or sets if a consent form has to be fulfilled by 
-        /// the user after log in.
+        /// Gets or sets a boolean indicating whether an explicit consent should be
+        /// granted by the resource owner when authorizing an application.
         /// </summary>
-        public bool SkipConsent { get; set; }
-
-        /// <summary>
-        /// Gets or sets the RoleNames assined to the app.
-        /// </summary>
-        public ISet<string> RoleNames { get; set; }
-            = new HashSet<string>(StringComparer.Ordinal);
-
-        public bool AllowPasswordFlow { get; set; }
-        public bool AllowClientCredentialsFlow { get; set; }
-        public bool AllowAuthorizationCodeFlow { get; set; }
-        public bool AllowRefreshTokenFlow { get; set; }
-        public bool AllowImplicitFlow { get; set; }
-        public bool AllowHybridFlow { get; set; }
+        public bool RequireConsent { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdAuthorization.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdAuthorization.cs
@@ -1,5 +1,5 @@
-using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
+using Newtonsoft.Json.Linq;
 using OrchardCore.OpenId.Abstractions.Models;
 
 namespace OrchardCore.OpenId.YesSql.Models
@@ -25,9 +25,16 @@ namespace OrchardCore.OpenId.YesSql.Models
         public int Id { get; set; }
 
         /// <summary>
+        /// Gets or sets the additional properties
+        /// associated with the current authorization.
+        /// </summary>
+        public virtual JObject Properties { get; set; }
+
+        /// <summary>
         /// Gets or sets the scopes associated with the current authorization.
         /// </summary>
-        public ISet<string> Scopes { get; set; } = new HashSet<string>(StringComparer.Ordinal);
+        public ImmutableArray<string> Scopes { get; set; }
+            = ImmutableArray.Create<string>();
 
         /// <summary>
         /// Gets or sets the status of the current authorization.

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdScope.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdScope.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json.Linq;
 using OrchardCore.OpenId.Abstractions.Models;
 
 namespace OrchardCore.OpenId.YesSql.Models
@@ -27,5 +28,11 @@ namespace OrchardCore.OpenId.YesSql.Models
         /// associated with the current scope.
         /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional properties
+        /// associated with the current scope.
+        /// </summary>
+        public virtual JObject Properties { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdToken.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Models/OpenIdToken.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json.Linq;
 using OrchardCore.OpenId.Abstractions.Models;
 
 namespace OrchardCore.OpenId.YesSql.Models
@@ -49,6 +50,12 @@ namespace OrchardCore.OpenId.YesSql.Models
         /// and may be encrypted for security reasons.
         /// </summary>
         public string Payload { get; set; }
+
+        /// <summary>
+        /// Gets or sets the additional properties
+        /// associated with the current token.
+        /// </summary>
+        public virtual JObject Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the reference identifier associated

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdAuthorizationStore.cs
@@ -1,10 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Abstractions.Stores;
@@ -245,6 +245,25 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         /// <summary>
+        /// Retrieves the additional properties associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
+        /// result returns all the additional properties associated with the authorization.
+        /// </returns>
+        public virtual Task<JObject> GetPropertiesAsync(OpenIdAuthorization authorization, CancellationToken cancellationToken)
+        {
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            return Task.FromResult(authorization.Properties ?? new JObject());
+        }
+
+        /// <summary>
         /// Retrieves the scopes associated with an authorization.
         /// </summary>
         /// <param name="authorization">The authorization.</param>
@@ -260,7 +279,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            return Task.FromResult(ImmutableArray.CreateRange(authorization.Scopes));
+            return Task.FromResult(authorization.Scopes);
         }
 
         /// <summary>
@@ -438,6 +457,27 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         /// <summary>
+        /// Sets the additional properties associated with an authorization.
+        /// </summary>
+        /// <param name="authorization">The authorization.</param>
+        /// <param name="properties">The additional properties associated with the authorization </param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetPropertiesAsync(OpenIdAuthorization authorization, JObject properties, CancellationToken cancellationToken)
+        {
+            if (authorization == null)
+            {
+                throw new ArgumentNullException(nameof(authorization));
+            }
+
+            authorization.Properties = properties;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Sets the scopes associated with an authorization.
         /// </summary>
         /// <param name="authorization">The authorization.</param>
@@ -454,7 +494,7 @@ namespace OrchardCore.OpenId.YesSql.Services
                 throw new ArgumentNullException(nameof(authorization));
             }
 
-            authorization.Scopes = new HashSet<string>(scopes);
+            authorization.Scopes = scopes;
 
             return Task.CompletedTask;
         }
@@ -584,6 +624,9 @@ namespace OrchardCore.OpenId.YesSql.Services
         Task<string> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetIdAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
             => GetIdAsync((OpenIdAuthorization) authorization, cancellationToken);
 
+        Task<JObject> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetPropertiesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
+            => GetPropertiesAsync((OpenIdAuthorization) authorization, cancellationToken);
+
         Task<ImmutableArray<string>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.GetScopesAsync(IOpenIdAuthorization authorization, CancellationToken cancellationToken)
             => GetScopesAsync((OpenIdAuthorization) authorization, cancellationToken);
 
@@ -613,6 +656,9 @@ namespace OrchardCore.OpenId.YesSql.Services
         Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetApplicationIdAsync(IOpenIdAuthorization authorization,
             string identifier, CancellationToken cancellationToken)
             => SetApplicationIdAsync((OpenIdAuthorization) authorization, identifier, cancellationToken);
+
+        Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetPropertiesAsync(IOpenIdAuthorization authorization, JObject properties, CancellationToken cancellationToken)
+            => SetPropertiesAsync((OpenIdAuthorization) authorization, properties, cancellationToken);
 
         Task IOpenIddictAuthorizationStore<IOpenIdAuthorization>.SetScopesAsync(IOpenIdAuthorization authorization,
             ImmutableArray<string> scopes, CancellationToken cancellationToken)

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdScopeStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdScopeStore.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Abstractions.Stores;
@@ -193,6 +194,25 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         /// <summary>
+        /// Retrieves the name associated with a scope.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
+        /// whose result returns the name associated with the specified scope.
+        /// </returns>
+        public virtual Task<string> GetNameAsync(OpenIdScope scope, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            return Task.FromResult(scope.Name);
+        }
+
+        /// <summary>
         /// Retrieves the physical identifier associated with a scope.
         /// </summary>
         /// <param name="scope">The scope.</param>
@@ -212,22 +232,22 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         /// <summary>
-        /// Retrieves the name associated with a scope.
+        /// Retrieves the additional properties associated with a scope.
         /// </summary>
         /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the name associated with the specified scope.
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
+        /// result returns all the additional properties associated with the scope.
         /// </returns>
-        public virtual Task<string> GetNameAsync(OpenIdScope scope, CancellationToken cancellationToken)
+        public virtual Task<JObject> GetPropertiesAsync(OpenIdScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
             {
                 throw new ArgumentNullException(nameof(scope));
             }
 
-            return Task.FromResult(scope.Name);
+            return Task.FromResult(scope.Properties ?? new JObject());
         }
 
         /// <summary>
@@ -328,6 +348,27 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         /// <summary>
+        /// Sets the additional properties associated with a scope.
+        /// </summary>
+        /// <param name="scope">The scope.</param>
+        /// <param name="properties">The additional properties associated with the scope </param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetPropertiesAsync(OpenIdScope scope, JObject properties, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            scope.Properties = properties;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Updates an existing scope.
         /// </summary>
         /// <param name="scope">The scope to update.</param>
@@ -386,6 +427,9 @@ namespace OrchardCore.OpenId.YesSql.Services
         Task<string> IOpenIddictScopeStore<IOpenIdScope>.GetNameAsync(IOpenIdScope scope, CancellationToken cancellationToken)
             => GetNameAsync((OpenIdScope) scope, cancellationToken);
 
+        Task<JObject> IOpenIddictScopeStore<IOpenIdScope>.GetPropertiesAsync(IOpenIdScope scope, CancellationToken cancellationToken)
+            => GetPropertiesAsync((OpenIdScope) scope, cancellationToken);
+
         async Task<IOpenIdScope> IOpenIddictScopeStore<IOpenIdScope>.InstantiateAsync(CancellationToken cancellationToken)
             => await InstantiateAsync(cancellationToken);
 
@@ -402,6 +446,9 @@ namespace OrchardCore.OpenId.YesSql.Services
 
         Task IOpenIddictScopeStore<IOpenIdScope>.SetNameAsync(IOpenIdScope scope, string name, CancellationToken cancellationToken)
             => SetNameAsync((OpenIdScope) scope, name, cancellationToken);
+
+        Task IOpenIddictScopeStore<IOpenIdScope>.SetPropertiesAsync(IOpenIdScope scope, JObject properties, CancellationToken cancellationToken)
+            => SetPropertiesAsync((OpenIdScope) scope, properties, cancellationToken);
 
         Task IOpenIddictScopeStore<IOpenIdScope>.UpdateAsync(IOpenIdScope scope, CancellationToken cancellationToken)
             => UpdateAsync((OpenIdScope) scope, cancellationToken);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdTokenStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdTokenStore.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Abstractions.Stores;
@@ -375,6 +376,25 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         /// <summary>
+        /// Retrieves the additional properties associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose
+        /// result returns all the additional properties associated with the token.
+        /// </returns>
+        public virtual Task<JObject> GetPropertiesAsync(OpenIdToken token, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            return Task.FromResult(token.Properties ?? new JObject());
+        }
+
+        /// <summary>
         /// Retrieves the reference identifier associated with a token.
         /// Note: depending on the manager used to create the token,
         /// the reference identifier may be hashed for security reasons.
@@ -657,6 +677,27 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         /// <summary>
+        /// Sets the additional properties associated with a token.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="properties">The additional properties associated with the token </param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
+        /// </returns>
+        public virtual Task SetPropertiesAsync(OpenIdToken token, JObject properties, CancellationToken cancellationToken)
+        {
+            if (token == null)
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            token.Properties = properties;
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
         /// Sets the reference identifier associated with a token.
         /// Note: depending on the manager used to create the token,
         /// the reference identifier may be hashed for security reasons.
@@ -837,6 +878,9 @@ namespace OrchardCore.OpenId.YesSql.Services
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetPayloadAsync(IOpenIdToken token, CancellationToken cancellationToken)
             => GetPayloadAsync((OpenIdToken) token, cancellationToken);
 
+        Task<JObject> IOpenIddictTokenStore<IOpenIdToken>.GetPropertiesAsync(IOpenIdToken token, CancellationToken cancellationToken)
+            => GetPropertiesAsync((OpenIdToken) token, cancellationToken);
+
         Task<string> IOpenIddictTokenStore<IOpenIdToken>.GetReferenceIdAsync(IOpenIdToken token, CancellationToken cancellationToken)
             => GetReferenceIdAsync((OpenIdToken) token, cancellationToken);
 
@@ -877,6 +921,9 @@ namespace OrchardCore.OpenId.YesSql.Services
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetPayloadAsync(IOpenIdToken token, string payload, CancellationToken cancellationToken)
             => SetPayloadAsync((OpenIdToken) token, payload, cancellationToken);
+
+        Task IOpenIddictTokenStore<IOpenIdToken>.SetPropertiesAsync(IOpenIdToken token, JObject properties, CancellationToken cancellationToken)
+            => SetPropertiesAsync((OpenIdToken) token, properties, cancellationToken);
 
         Task IOpenIddictTokenStore<IOpenIdToken>.SetReferenceIdAsync(IOpenIdToken token, string identifier, CancellationToken cancellationToken)
             => SetReferenceIdAsync((OpenIdToken) token, identifier, cancellationToken);


### PR DESCRIPTION
Depends on https://github.com/openiddict/openiddict-core/pull/541.

This PR does 4 things:

  - It removes the "is this application allowed to use the requested flow?" checks from `AccessController` since it will be transparently done by OpenIddict once the corresponding PR is merged.

  - It updates the Orchard application manager to map the `Allow*Flow` properties of the admin view models to the corresponding OpenIddict app permissions.

  - It removes the Orchard-specific properties from the EF Core `OpenId*` models to ensure the OpenID module is compatible with non-Orchard OpenIddict deployments. Orchard-specific properties are now stored as JSON values using the new `IOpenIddict*Store.Get/SetPropertiesAsync()` APIs.

  - It implements roles support in the EF Core application store (it was left as a TODO in the previous PR). With this PR, both the YesSql and EF Core now offer the same exact features.

@jersiovic FYI, I removed `AllowHybridFlow` from the views since the hybrid flow is automatically (and only) enabled when both the implicit and code flows are enabled. It doesn't make much sense to have a separate option (and there's no dedicated `grant_type` for the hybrid flow anyway, so it's hard to represent it).