### PR TITLE
AddModularFolderRoute() convention for razor pages.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Demo/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Startup.cs
@@ -67,8 +67,17 @@ namespace OrchardCore.Demo
 
             services.Configure<RazorPagesOptions>(options =>
             {
+                // The module name (if specified) is already defined as a default folder path
+                // options.Conventions.AddModularFolderRoute("/OrchardCore.Demo/Pages", "Orchard Demo");
+
+                // Add a custom folder path
                 options.Conventions.AddModularFolderRoute("/OrchardCore.Demo/Pages", "Demo");
+
+                // Add a custom page route
                 options.Conventions.AddModularPageRoute("/OrchardCore.Demo/Pages/Hello", "Hello");
+
+                // This declaration would define an home page
+                options.Conventions.AddModularPageRoute("/OrchardCore.Demo/Pages/Hello", "");
             });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Startup.cs
@@ -67,6 +67,7 @@ namespace OrchardCore.Demo
 
             services.Configure<RazorPagesOptions>(options =>
             {
+                options.Conventions.AddModularFolderRoute("/OrchardCore.Demo/Pages", "Demo");
                 options.Conventions.AddModularPageRoute("/OrchardCore.Demo/Pages/Hello", "Hello");
             });
         }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ModularServiceCollectionExtensions.cs
@@ -51,7 +51,7 @@ namespace OrchardCore.Mvc
             AddModularFrameworkParts(applicationServices, builder.PartManager);
 
             builder.AddModularRazorViewEngine(applicationServices);
-            builder.AddModularRazorPages();
+            builder.AddModularRazorPages(applicationServices);
 
             // Use a custom IViewCompilerProvider so that all tenants reuse the same ICompilerCache instance
             builder.Services.Replace(new ServiceDescriptor(typeof(IViewCompilerProvider), typeof(SharedViewCompilerProvider), ServiceLifetime.Singleton));

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/DefaultModularPageRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/DefaultModularPageRouteModelConvention.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Mvc.RazorPages
     {
         public void Apply(PageRouteModel model)
         {
-            var pageName = model.ViewEnginePath.TrimStart('/');
+            var pageName = model.ViewEnginePath.Trim('/');
             var pagesIndex = pageName.LastIndexOf("/Pages/", StringComparison.Ordinal);
 
             if (pagesIndex == -1)

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/DefaultModularPageRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/DefaultModularPageRouteModelConvention.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace OrchardCore.Mvc.RazorPages

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
@@ -9,16 +9,13 @@ namespace OrchardCore.Mvc.RazorPages
 
         public ModularFolderRouteModelConvention(string folderPath, string route)
         {
-            if (!string.IsNullOrEmpty(folderPath))
-            {
-                _folderPath = folderPath.Trim('/');
-                _route = route.Trim('/');
-            }
+             _folderPath = folderPath?.Trim('/');
+            _route = route?.Trim('/');
         }
 
         public void Apply(PageRouteModel model)
         {
-            if (_folderPath == null)
+            if (_folderPath == null || _route == null)
             {
                 return;
             }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
@@ -40,7 +40,7 @@ namespace OrchardCore.Mvc.RazorPages
                     selector.AttributeRouteModel.SuppressLinkGeneration = true;
                 }
 
-                var template = _route + '/' + fileName;
+                var template = _route.Length > 0 ? _route + '/' + fileName : fileName;
 
                 model.Selectors.Add(new SelectorModel
                 {

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace OrchardCore.Mvc.RazorPages
+{
+    public class ModularFolderRouteModelConvention : IPageRouteModelConvention
+    {
+        private readonly string _folderPath;
+        private readonly string _route;
+
+        public ModularFolderRouteModelConvention(string folderPath, string route)
+        {
+            if (!string.IsNullOrEmpty(folderPath))
+            {
+                _folderPath = folderPath.Trim('/');
+                _route = route.Trim('/');
+            }
+        }
+
+        public void Apply(PageRouteModel model)
+        {
+            if (_folderPath == null)
+            {
+                return;
+            }
+
+            var index = model.ViewEnginePath.LastIndexOf('/');
+
+            if (index == -1)
+            {
+                return;
+            }
+
+            var fileName = model.ViewEnginePath.Substring(index + 1);
+            var pageName = _folderPath + '/' + fileName;
+
+            if (model.ViewEnginePath.EndsWith('/' + pageName))
+            {
+                foreach (var selector in model.Selectors)
+                {
+                    selector.AttributeRouteModel.SuppressLinkGeneration = true;
+                }
+
+                var template = _route + '/' + fileName;
+
+                model.Selectors.Add(new SelectorModel
+                {
+                    AttributeRouteModel = new AttributeRouteModel
+                    {
+                        Template = template,
+                        Name = template.Replace('/', '.')
+                    }
+                });
+            }
+        }
+    }
+
+    public static partial class PageConventionCollectionExtensions
+    {
+        public static PageConventionCollection AddModularFolderRoute(this PageConventionCollection conventions, string folderPath, string route)
+        {
+            conventions.Add(new ModularFolderRouteModelConvention(folderPath, route));
+            return conventions;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
@@ -23,17 +23,17 @@ namespace OrchardCore.Mvc.RazorPages
                 return;
             }
 
-            var index = model.ViewEnginePath.LastIndexOf('/');
+            var pageName = model.ViewEnginePath.Trim('/');
+            var fileIndex = pageName.LastIndexOf('/');
 
-            if (index == -1)
+            if (fileIndex == -1)
             {
                 return;
             }
 
-            var fileName = model.ViewEnginePath.Substring(index + 1);
-            var pageName = _folderPath + '/' + fileName;
+            var fileName = pageName.Substring(fileIndex + 1);
 
-            if (model.ViewEnginePath.EndsWith('/' + pageName))
+            if (pageName.EndsWith('/' + _folderPath + '/' + fileName))
             {
                 foreach (var selector in model.Selectors)
                 {

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageMvcCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageMvcCoreBuilderExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,12 +10,13 @@ namespace OrchardCore.Mvc.RazorPages
 {
     public static class ModularPageMvcCoreBuilderExtensions
     {
-        public static IMvcCoreBuilder AddModularRazorPages(this IMvcCoreBuilder builder)
+        public static IMvcCoreBuilder AddModularRazorPages(this IMvcCoreBuilder builder, IServiceProvider services)
         {
             builder.AddRazorPages(options =>
             {
                 options.RootDirectory = "/";
-                options.Conventions.Add(new DefaultModularPageRouteModelConvention());
+                var httpContextAccessor = services.GetRequiredService<IHttpContextAccessor>();
+                options.Conventions.Add(new DefaultModularPageRouteModelConvention(httpContextAccessor));
             });
 
             builder.Services.TryAddEnumerable(

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRouteModelConvention.cs
@@ -9,16 +9,13 @@ namespace OrchardCore.Mvc.RazorPages
 
         public ModularPageRouteModelConvention(string pageName, string route)
         {
-            if (!string.IsNullOrEmpty(pageName))
-            {
-                _pageName = pageName.Trim('/');
-                _route = route.Trim('/');
-            }
+            _pageName = pageName?.Trim('/');
+            _route = route?.Trim('/');
         }
 
         public void Apply(PageRouteModel model)
         {
-            if (_pageName == null)
+            if (_pageName == null || _route == null)
             {
                 return;
             }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRouteModelConvention.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Mvc.RazorPages
         {
             if (!string.IsNullOrEmpty(pageName))
             {
-                _pageName = pageName.TrimStart('/');
+                _pageName = pageName.Trim('/');
                 _route = route.Trim('/');
             }
         }
@@ -23,7 +23,9 @@ namespace OrchardCore.Mvc.RazorPages
                 return;
             }
 
-            if (model.ViewEnginePath.EndsWith('/' + _pageName))
+            var pageName = model.ViewEnginePath.Trim('/');
+
+            if (pageName.EndsWith('/' + _pageName))
             {
                 foreach (var selector in model.Selectors)
                 {

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRouteModelConvention.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace OrchardCore.Mvc.RazorPages
@@ -10,34 +9,40 @@ namespace OrchardCore.Mvc.RazorPages
 
         public ModularPageRouteModelConvention(string pageName, string route)
         {
-            _pageName = pageName;
-            _route = route;
+            if (!string.IsNullOrEmpty(pageName))
+            {
+                _pageName = pageName.TrimStart('/');
+                _route = route.Trim('/');
+            }
         }
 
         public void Apply(PageRouteModel model)
         {
-            if (!String.IsNullOrEmpty(_pageName) && model.ViewEnginePath.EndsWith(_pageName))
+            if (_pageName == null)
             {
-                if (_pageName[0] == '/' && _pageName.Contains("/Pages/") && !_pageName.StartsWith("/Pages/"))
-                {
-                    foreach (var selector in model.Selectors)
-                    {
-                        selector.AttributeRouteModel.SuppressLinkGeneration = true;
-                    }
+                return;
+            }
 
-                    model.Selectors.Add(new SelectorModel
-                    {
-                        AttributeRouteModel = new AttributeRouteModel
-                        {
-                            Template = _route
-                        }
-                    });
+            if (model.ViewEnginePath.EndsWith('/' + _pageName))
+            {
+                foreach (var selector in model.Selectors)
+                {
+                    selector.AttributeRouteModel.SuppressLinkGeneration = true;
                 }
+
+                model.Selectors.Add(new SelectorModel
+                {
+                    AttributeRouteModel = new AttributeRouteModel
+                    {
+                        Template = _route,
+                        Name = _route.Replace('/', '.')
+                    }
+                });
             }
         }
     }
 
-    public static class PageConventionCollectionExtensions
+    public static partial class PageConventionCollectionExtensions
     {
         public static PageConventionCollection AddModularPageRoute(this PageConventionCollection conventions, string pageName, string route)
         {


### PR DESCRIPTION
Fixes #1434 

- So, now we have the following default urls

      /.Modules/OrchardCore.Demo/Pages/Hello
      /OrchardCore.Demo/Pages/Hello
      /OrchardCore.Demo/Hello

- **Now we have a new `RazorPagesOptions` configuration helper**, so if we use e.g

      options.Conventions.AddModularFolderRoute("/OrchardCore.Demo/Pages", "Demo");

    We have these new urls.

      /Demo/Hello
      /Demo/OtherPage
      ...

- And we can still use e.g

      options.Conventions.AddModularPageRoute("/OrchardCore.Demo/Pages/Hello", "Hello");

    To have this url

      /Hello

**Update**

- And now if you use the following by passing an empty folder route or just `/`

      options.Conventions.AddModularFolderRoute("/OrchardCore.Demo/Pages", "");

    We have these new urls.

      /Hello
      /OtherPage
      ...

- Finally, by doing the following you define a new home page.

      options.Conventions.AddModularPageRoute("/OrchardCore.Demo/Pages/Hello", "");
