### PR TITLE
Add missing  properties to OpenIdSettingsStep

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdSettingsStep.cs
@@ -45,6 +45,9 @@ namespace OrchardCore.OpenId.Recipes
             settings.AllowRefreshTokenFlow = model.AllowRefreshTokenFlow;
             settings.AllowImplicitFlow = model.AllowImplicitFlow;
             settings.UseRollingTokens = model.UseRollingTokens;
+            settings.CertificateStoreLocation = model.CertificateStoreLocation;
+            settings.CertificateStoreName = model.CertificateStoreName;
+            settings.CertificateThumbPrint = model.CertificateThumbPrint;
 
             await _openIdService.UpdateOpenIdSettingsAsync(settings);
         }


### PR DESCRIPTION
Despite we can set in a OpenIdSettingsStep within a recipe certificate values, CertificateStoreLocation, CertificateStoreName and CertificateThumbPrint, those were ignored