### PR TITLE
Fixes localizer factories.

### DIFF
--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectHtmlLocalizerFactory.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectHtmlLocalizerFactory.cs
@@ -31,9 +31,9 @@ namespace OrchardCore.Localization.PortableObject
                 index += 1;
             }
 
-            if (baseName.Length > index && baseName.IndexOf("Packages.", index) == index)
+            if (baseName.Length > index && baseName.IndexOf(".Modules.", index) == index)
             {
-                index += "Packages.".Length;
+                index += ".Modules.".Length;
             }
 
             var relativeName = baseName.Substring(index);

--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizerFactory.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizerFactory.cs
@@ -34,9 +34,9 @@ namespace OrchardCore.Localization.PortableObject
                 index += 1;
             }
 
-            if (baseName.Length > index && baseName.IndexOf("Packages.", index) == index)
+            if (baseName.Length > index && baseName.IndexOf(".Modules.", index) == index)
             {
-                index += "Packages.".Length;
+                index += ".Modules.".Length;
             }
 
             var relativeName = baseName.Substring(index);


### PR DESCRIPTION
- Because of 2 missing `Packages` strings which i replaced with `.Modules`. **Here i would prefer to reference `OC.Modules.Abstractions`** (which only references µsoft packages) to use our `ModulesPath` const  in place of hard coded strings. But maybe not a good idea. **Let me know**.

---

**Just for infos, maybe not so important**

- While debugging i could see resources as `OrchardCore.Cms.Web..Modules.TheBlogTheme.Views.Content-Blog` which is now resolved to `TheBlogTheme.Views.Content-Blog`, okay.

- But if i replace the `Content-Blog.liquid` template with a **database template**, because in this case we don't use a custom file provider, **we don't trigger our liquid view engine** and then no `POHtmlLocalizer` is associated with this template. In fact, it belongs to the parent view context and then here it is associated with `OrchardCore.Contents.Views.Item.Display`.

- **Warning**: Here i retrieve the fact that resource names are built from a path where `/` is replaced by `.` which is a valid folder / file character and then **which may produces name conflicts**. Note: we needed to fix the same kind of issue for modules asset files which are embedded resources.