### PR TITLE
Introduce built-in authorization support

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -15,11 +15,11 @@
     <XunitVersion>2.3.0-beta2-build3683</XunitVersion>
     <XunitRunnerVisualStudioVersion>2.3.0-beta2-build1317</XunitRunnerVisualStudioVersion>
     <FluidCoreVersion>1.0.0-beta-9422</FluidCoreVersion>
-    <YesSqlVersion>2.0.0-beta-1174</YesSqlVersion>
-    <YesSqlProvidersVersion>1.0.0-beta-1174</YesSqlProvidersVersion>
+    <YesSqlVersion>2.0.0-beta-1182</YesSqlVersion>
+    <YesSqlProvidersVersion>1.0.0-beta-1182</YesSqlProvidersVersion>
     <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
     <OAuthValidationPackageVersion>2.0.0-rc1-final</OAuthValidationPackageVersion>
-    <OpenIddictVersion>2.0.0-rc2-0810</OpenIddictVersion>
+    <OpenIddictVersion>2.0.0-rc2-0813</OpenIddictVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/Services/OpenIdAuthorizationStore.cs
@@ -91,9 +91,6 @@ namespace OrchardCore.OpenId.EntityFrameworkCore.Services
         async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindAsync(string subject, string client, CancellationToken cancellationToken)
             => (await FindAsync(subject, client, cancellationToken)).CastArray<IOpenIdAuthorization>();
 
-        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindAsync(string subject, string client, ImmutableArray<string> scopes, CancellationToken cancellationToken)
-            => (await FindAsync(subject, client, scopes, cancellationToken)).CastArray<IOpenIdAuthorization>();
-
         async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
             => await FindByIdAsync(identifier, cancellationToken);
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
@@ -11,10 +13,15 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using OpenIddict.Core;
+using OrchardCore.Mvc.ActionConstraints;
+using OrchardCore.OpenId.Abstractions.Models;
 using OrchardCore.OpenId.Services;
 using OrchardCore.OpenId.Services.Managers;
 using OrchardCore.OpenId.ViewModels;
@@ -27,6 +34,7 @@ namespace OrchardCore.OpenId.Controllers
     public class AccessController : Controller
     {
         private readonly OpenIdApplicationManager _applicationManager;
+        private readonly OpenIdAuthorizationManager _authorizationManager;
         private readonly IOptions<IdentityOptions> _identityOptions;
         private readonly SignInManager<IUser> _signInManager;
         private readonly IOpenIdService _openIdService;
@@ -36,6 +44,7 @@ namespace OrchardCore.OpenId.Controllers
 
         public AccessController(
             OpenIdApplicationManager applicationManager,
+            OpenIdAuthorizationManager authorizationManager,
             IOptions<IdentityOptions> identityOptions,
             IStringLocalizer<AccessController> localizer,
             IOpenIdService openIdService,
@@ -45,6 +54,7 @@ namespace OrchardCore.OpenId.Controllers
         {
             T = localizer;
             _applicationManager = applicationManager;
+            _authorizationManager = authorizationManager;
             _identityOptions = identityOptions;
             _openIdService = openIdService;
             _signInManager = signInManager;
@@ -52,89 +62,105 @@ namespace OrchardCore.OpenId.Controllers
             _roleManager = roleManager;
         }
 
-        [HttpGet, HttpPost]
+        [AllowAnonymous, HttpGet, HttpPost, IgnoreAntiforgeryToken]
         public async Task<IActionResult> Authorize()
         {
-            var response = HttpContext.GetOpenIdConnectResponse();
-            if (response != null)
-            {
-                return View("Error", new ErrorViewModel
-                {
-                    Error = response.Error,
-                    ErrorDescription = response.ErrorDescription
-                });
-            }
-
-            // If the request is missing, this likely means that
-            // this endpoint was not enabled in the settings.
-            // In this case, simply return a 404 response.
             var request = HttpContext.GetOpenIdConnectRequest();
-            if (request == null)
+
+            // Retrieve the claims stored in the authentication cookie.
+            // If they can't be extracted, redirect the user to the login page.
+            var result = await HttpContext.AuthenticateAsync();
+            if (!result.Succeeded || request.HasPrompt(OpenIdConnectConstants.Prompts.Login))
             {
-                return NotFound();
+                return RedirectToLoginPage(request);
             }
 
-            var application = await _applicationManager.FindByClientIdAsync(request.ClientId, HttpContext.RequestAborted);
+            // If a max_age parameter was provided, ensure that the cookie is not too old.
+            // If it's too old, automatically redirect the user agent to the login page.
+            if (request.MaxAge != null && result.Properties.IssuedUtc != null &&
+                DateTimeOffset.UtcNow - result.Properties.IssuedUtc > TimeSpan.FromSeconds(request.MaxAge.Value))
+            {
+                return RedirectToLoginPage(request);
+            }
+
+            var application = await _applicationManager.FindByClientIdAsync(request.ClientId);
             if (application == null)
             {
                 return View("Error", new ErrorViewModel
                 {
                     Error = OpenIdConnectConstants.Errors.InvalidClient,
-                    ErrorDescription = T["Details concerning the calling client application cannot be found in the database"]
+                    ErrorDescription = T["The specified 'client_id' parameter is invalid."]
                 });
             }
 
-            if (Request.HasFormContentType)
+            // Unless prompt=consent was specified, skip the consent form
+            // if the client application doesn't require explicit approval
+            // or if an authorization matching the criteria already exists.
+            if (!request.HasPrompt(OpenIdConnectConstants.Prompts.Consent))
             {
-                if (!string.IsNullOrEmpty(Request.Form["submit.Accept"]))
+                if (!await _applicationManager.IsConsentRequiredAsync(application))
                 {
-                    return await IssueAccessIdentityTokensAsync(request);
+                    return await IssueTokensAsync(request, application, result.Principal);
                 }
-                else if (!string.IsNullOrEmpty(Request.Form["submit.Deny"]))
+
+                if (!await _authorizationManager.IsConsentRequired(result.Principal,
+                     await _applicationManager.GetIdAsync(application),
+                     ImmutableArray.CreateRange(request.GetScopes())))
                 {
-                    return Forbid(OpenIdConnectServerDefaults.AuthenticationScheme);
+                    return await IssueTokensAsync(request, application, result.Principal);
                 }
             }
 
-            if (!await _applicationManager.IsConsentRequiredAsync(application, HttpContext.RequestAborted))
+            // At this stage, return an error if prompt=none was specified since
+            // the request cannot succeed without requiring explicit user consent.
+            if (request.HasPrompt(OpenIdConnectConstants.Prompts.None))
             {
-                return await IssueAccessIdentityTokensAsync(request);
+                return RedirectToClient(new OpenIdConnectResponse
+                {
+                    Error = OpenIdConnectConstants.Errors.ConsentRequired,
+                    ErrorDescription = T["Interactive user consent is required."]
+                });
             }
 
             return View(new AuthorizeViewModel
             {
-                ApplicationName = await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted),
+                ApplicationName = await _applicationManager.GetDisplayNameAsync(application),
                 RequestId = request.RequestId,
                 Scope = request.Scope
             });
         }
 
-        [AllowAnonymous, HttpGet]
-        public async Task<IActionResult> Logout()
+        [ActionName(nameof(Authorize))]
+        [FormValueRequired("submit." + nameof(Accept)), HttpPost]
+        public async Task<IActionResult> Accept()
         {
-            var response = HttpContext.GetOpenIdConnectResponse();
-            if (response != null)
+            var request = HttpContext.GetOpenIdConnectRequest();
+
+            var application = await _applicationManager.FindByClientIdAsync(request.ClientId);
+            if (application == null)
             {
                 return View("Error", new ErrorViewModel
                 {
-                    Error = response.Error,
-                    ErrorDescription = response.ErrorDescription
+                    Error = OpenIdConnectConstants.Errors.InvalidClient,
+                    ErrorDescription = T["The specified 'client_id' parameter is invalid."]
                 });
             }
 
-            // If the request is missing, this likely means that
-            // this endpoint was not enabled in the settings.
-            // In this case, simply return a 404 response.
-            var request = HttpContext.GetOpenIdConnectRequest();
-            if (request == null)
-            {
-                return NotFound();
-            }
+            return await IssueTokensAsync(request, application, User);
+        }
 
+        [ActionName(nameof(Authorize))]
+        [FormValueRequired("submit." + nameof(Deny)), HttpPost]
+        public IActionResult Deny()
+        {
+            return Forbid(OpenIdConnectServerDefaults.AuthenticationScheme);
+        }
+
+        [AllowAnonymous, HttpGet]
+        public async Task<IActionResult> Logout()
+        {
             await _signInManager.SignOutAsync();
 
-            // Returning a SignOutResult will ask OpenIddict to redirect the user agent
-            // to the post_logout_redirect_uri specified by the client application.
             return SignOut(OpenIdConnectServerDefaults.AuthenticationScheme);
         }
 
@@ -149,15 +175,7 @@ namespace OrchardCore.OpenId.Controllers
             // To prevent effective CSRF/session fixation attacks, this action MUST NOT return
             // an authentication cookie or try to establish an ASP.NET Core user session.
 
-            // If the request is missing, this likely means that
-            // this endpoint was not enabled in the settings.
-            // In this case, simply return a 404 response.
             var request = HttpContext.GetOpenIdConnectRequest();
-            if (request == null)
-            {
-                return NotFound();
-            }
-
             if (request.IsPasswordGrantType())
             {
                 return await ExchangePasswordGrantType(request);
@@ -176,16 +194,49 @@ namespace OrchardCore.OpenId.Controllers
             throw new NotSupportedException("The specified grant type is not supported.");
         }
 
+        public override void OnActionExecuting(ActionExecutingContext context)
+        {
+            var response = context.HttpContext.GetOpenIdConnectResponse();
+            if (response != null)
+            {
+                var provider = context.HttpContext.RequestServices.GetRequiredService<IModelMetadataProvider>();
+
+                context.Result = new ViewResult
+                {
+                    ViewName = "Error",
+                    ViewData = new ViewDataDictionary(provider, context.ModelState)
+                    {
+                        Model = new ErrorViewModel
+                        {
+                            Error = response.Error,
+                            ErrorDescription = response.ErrorDescription
+                        }
+                    }
+                };
+
+                return;
+            }
+
+            // If the request is missing, this likely means that
+            // this endpoint was not enabled in the settings.
+            // In this case, simply return a 404 response.
+            var request = context.HttpContext.GetOpenIdConnectRequest();
+            if (request == null)
+            {
+                context.Result = new NotFoundResult();
+            }
+        }
+
         private async Task<IActionResult> ExchangeClientCredentialsGrantType(OpenIdConnectRequest request)
         {
             // Note: client authentication is always enforced by OpenIddict before this action is invoked.
-            var application = await _applicationManager.FindByClientIdAsync(request.ClientId, HttpContext.RequestAborted);
+            var application = await _applicationManager.FindByClientIdAsync(request.ClientId);
             if (application == null)
             {
                 return BadRequest(new OpenIdConnectResponse
                 {
                     Error = OpenIdConnectConstants.Errors.InvalidClient,
-                    ErrorDescription = T["The client application is unknown."]
+                    ErrorDescription = T["The specified 'client_id' parameter is invalid."]
                 });
             }
 
@@ -196,11 +247,11 @@ namespace OrchardCore.OpenId.Controllers
 
             identity.AddClaim(OpenIdConnectConstants.Claims.Subject, request.ClientId);
             identity.AddClaim(OpenIdConnectConstants.Claims.Name,
-                await _applicationManager.GetDisplayNameAsync(application, HttpContext.RequestAborted),
+                await _applicationManager.GetDisplayNameAsync(application),
                 OpenIdConnectConstants.Destinations.AccessToken,
                 OpenIdConnectConstants.Destinations.IdentityToken);
 
-            foreach (var role in await _applicationManager.GetRolesAsync(application, HttpContext.RequestAborted))
+            foreach (var role in await _applicationManager.GetRolesAsync(application))
             {
                 identity.AddClaim(identity.RoleClaimType, role,
                     OpenIdConnectConstants.Destinations.AccessToken,
@@ -208,8 +259,9 @@ namespace OrchardCore.OpenId.Controllers
 
                 foreach (var claim in await _roleManager.GetClaimsAsync(await _roleManager.FindByIdAsync(role)))
                 {
-                    identity.AddClaim(claim.Type, claim.Value, OpenIdConnectConstants.Destinations.AccessToken,
-                                                               OpenIdConnectConstants.Destinations.IdentityToken);
+                    identity.AddClaim(claim.Type, claim.Value,
+                        OpenIdConnectConstants.Destinations.AccessToken,
+                        OpenIdConnectConstants.Destinations.IdentityToken);
                 }
             }
 
@@ -269,14 +321,10 @@ namespace OrchardCore.OpenId.Controllers
         private async Task<IActionResult> ExchangeAuthorizationCodeOrRefreshTokenGrantType(OpenIdConnectRequest request)
         {
             // Retrieve the claims principal stored in the authorization code/refresh token.
-            //var info = await HttpContext.Authentication.GetAuthenticateInfoAsync(
-            var info = await HttpContext.AuthenticateAsync(
-                OpenIdConnectServerDefaults.AuthenticationScheme);
+            var info = await HttpContext.AuthenticateAsync(OpenIdConnectServerDefaults.AuthenticationScheme);
+            Debug.Assert(info.Principal != null, "The user principal shouldn't be null.");
 
             // Retrieve the user profile corresponding to the authorization code/refresh token.
-            // Note: if you want to automatically invalidate the authorization code/refresh token
-            // when the user password/roles change, use the following line instead:
-            // var user = _signInManager.ValidateSecurityStampAsync(info.Principal);
             var user = await _userManager.GetUserAsync(info.Principal);
             if (user == null)
             {
@@ -304,10 +352,11 @@ namespace OrchardCore.OpenId.Controllers
             return SignIn(ticket.Principal, ticket.Properties, ticket.AuthenticationScheme);
         }
 
-        private async Task<IActionResult> IssueAccessIdentityTokensAsync(OpenIdConnectRequest request)
+        private async Task<IActionResult> IssueTokensAsync(OpenIdConnectRequest request,
+            IOpenIdApplication application, ClaimsPrincipal principal)
         {
             // Retrieve the profile of the logged in user.
-            var user = await _userManager.GetUserAsync(User);
+            var user = await _userManager.GetUserAsync(principal);
             if (user == null)
             {
                 return View("Error", new ErrorViewModel
@@ -318,6 +367,15 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var ticket = await CreateTicketAsync(request, user);
+
+            var authorization = await _authorizationManager.ReplaceAsync(principal,
+                await _applicationManager.GetIdAsync(application),
+                ImmutableArray.CreateRange(ticket.GetScopes()),
+                ImmutableDictionary.CreateRange(ticket.Properties.Items));
+
+            // Attach the authorization identifier to the authentication ticket.
+            ticket.SetProperty(OpenIddictConstants.Properties.AuthorizationId,
+                await _authorizationManager.GetIdAsync(authorization));
 
             // Returning a SignInResult will ask OpenIddict to issue the appropriate access/identity tokens.
             return SignIn(ticket.Principal, ticket.Properties, ticket.AuthenticationScheme);
@@ -406,6 +464,48 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             return settings.Audiences;
+        }
+
+        private IActionResult RedirectToClient(OpenIdConnectResponse response)
+        {
+            var properties = new AuthenticationProperties(new Dictionary<string, string>
+            {
+                [OpenIdConnectConstants.Properties.Error] = response.Error,
+                [OpenIdConnectConstants.Properties.ErrorDescription] = response.ErrorDescription,
+                [OpenIdConnectConstants.Properties.ErrorUri] = response.ErrorUri,
+            });
+
+            return Forbid(properties, OpenIdConnectServerDefaults.AuthenticationScheme);
+        }
+
+        private IActionResult RedirectToLoginPage(OpenIdConnectRequest request)
+        {
+            // If the client application requested promptless authentication,
+            // return an error indicating that the user is not logged in.
+            if (request.HasPrompt(OpenIdConnectConstants.Prompts.None))
+            {
+                return RedirectToClient(new OpenIdConnectResponse
+                {
+                    Error = OpenIdConnectConstants.Errors.LoginRequired,
+                    ErrorDescription = T["The user is not logged in."]
+                });
+            }
+
+            string GetRedirectUrl()
+            {
+                // Override the prompt parameter to prevent infinite authentication/authorization loops.
+                var parameters = Request.Query.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+                parameters[OpenIdConnectConstants.Parameters.Prompt] = "continue";
+
+                return Request.PathBase + Request.Path + QueryString.Create(parameters);
+            }
+
+            var properties = new AuthenticationProperties
+            {
+                RedirectUri = GetRedirectUrl()
+            };
+
+            return Challenge(properties, IdentityConstants.ApplicationScheme);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdApplicationManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdApplicationManager.cs
@@ -150,21 +150,6 @@ namespace OrchardCore.OpenId.Services.Managers
             return Store.GetPhysicalIdAsync(application, cancellationToken);
         }
 
-        public Task<bool> IsAuthorizationCodeFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken = default)
-            => HasPermissionAsync(application, OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode, cancellationToken);
-
-        public Task<bool> IsClientCredentialsFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken = default)
-            => HasPermissionAsync(application, OpenIddictConstants.Permissions.GrantTypes.ClientCredentials, cancellationToken);
-
-        public Task<bool> IsImplicitFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken = default)
-            => HasPermissionAsync(application, OpenIddictConstants.Permissions.GrantTypes.Implicit, cancellationToken);
-
-        public Task<bool> IsPasswordFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken = default)
-            => HasPermissionAsync(application, OpenIddictConstants.Permissions.GrantTypes.Password, cancellationToken);
-
-        public Task<bool> IsRefreshTokenFlowAllowedAsync(IOpenIdApplication application, CancellationToken cancellationToken = default)
-            => HasPermissionAsync(application, OpenIddictConstants.Permissions.GrantTypes.RefreshToken, cancellationToken);
-
         public virtual Task<bool> IsConsentRequiredAsync(IOpenIdApplication application, CancellationToken cancellationToken = default)
         {
             if (application == null)

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdAuthorizationManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/Managers/OpenIdAuthorizationManager.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Immutable;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using AspNet.Security.OpenIdConnect.Primitives;
 using Microsoft.Extensions.Logging;
 using OpenIddict.Core;
 using OrchardCore.OpenId.Abstractions.Models;
@@ -55,6 +58,102 @@ namespace OrchardCore.OpenId.Services.Managers
             }
 
             return Store.GetPhysicalIdAsync(authorization, cancellationToken);
+        }
+
+        public virtual async Task<bool> IsConsentRequired(ClaimsPrincipal principal, string client,
+            ImmutableArray<string> scopes, CancellationToken cancellationToken = default)
+        {
+            if (principal == null)
+            {
+                throw new ArgumentNullException(nameof(principal));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client cannot be null or empty.", nameof(client));
+            }
+
+            var subject = principal.FindFirstValue(OpenIdConnectConstants.Claims.Subject) ??
+                          principal.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new InvalidOperationException("The subject claim cannot be extracted from the principal.");
+            }
+
+            // Retrieve the authorizations associated with the logged in user
+            // and the client application and that contain the requested scopes.
+            // If at least one matching authorization can be found, return false
+            // to indicate that explicit user consent is not required.
+            foreach (var authorization in await FindAsync(subject, client, cancellationToken))
+            {
+                if (await IsValidAsync(authorization, cancellationToken) &&
+                    await IsPermanentAsync(authorization, cancellationToken) &&
+                    await HasScopesAsync(authorization, scopes, cancellationToken))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public virtual async Task<IOpenIdAuthorization> ReplaceAsync(ClaimsPrincipal principal, string client,
+            ImmutableArray<string> scopes, ImmutableDictionary<string, string> properties, CancellationToken cancellationToken = default)
+        {
+            if (principal == null)
+            {
+                throw new ArgumentNullException(nameof(principal));
+            }
+
+            if (string.IsNullOrEmpty(client))
+            {
+                throw new ArgumentException("The client cannot be null or empty.", nameof(client));
+            }
+
+            var subject = principal.FindFirstValue(OpenIdConnectConstants.Claims.Subject) ??
+                          principal.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            if (string.IsNullOrEmpty(subject))
+            {
+                throw new InvalidOperationException("The subject claim cannot be extracted from the principal.");
+            }
+
+            // Remove all the existing authorizations associated with the user and the client application.
+            foreach (var authorization in await FindAsync(subject, client, cancellationToken))
+            {
+                // If the authorization exactly matches the requested scopes,
+                // use it as-is instead of creating a fresh new authorization.
+                if (await IsValidAsync(authorization, cancellationToken) &&
+                    await IsPermanentAsync(authorization, cancellationToken) &&
+                    await HasScopesAsync(authorization, scopes, cancellationToken))
+                {
+                    return authorization;
+                }
+
+                await DeleteAsync(authorization, cancellationToken);
+            }
+
+            var descriptor = new OpenIddictAuthorizationDescriptor
+            {
+                ApplicationId = client,
+                Principal = principal,
+                Status = OpenIddictConstants.Statuses.Valid,
+                Subject = subject,
+                Type = OpenIddictConstants.AuthorizationTypes.Permanent
+            };
+
+            foreach (var scope in scopes)
+            {
+                descriptor.Scopes.Add(scope);
+            }
+
+            foreach (var property in properties)
+            {
+                descriptor.Properties.Add(property);
+            }
+
+            return await CreateAsync(descriptor, cancellationToken);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdConfiguration.cs
@@ -93,8 +93,9 @@ namespace OrchardCore.OpenId
 
             options.ProviderType = typeof(OpenIddictProvider<IOpenIdApplication, IOpenIdAuthorization, IOpenIdScope, IOpenIdToken>);
             options.DataProtectionProvider = _dataProtectionProvider;
-            options.RequireClientIdentification = true;
+            options.ApplicationCanDisplayErrors = true;
             options.EnableRequestCaching = true;
+            options.RequireClientIdentification = true;
 
             if (settings.AccessTokenFormat == OpenIdSettings.TokenFormat.JWT)
             {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -4,6 +4,7 @@ using AspNet.Security.OpenIdConnect.Server;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -100,6 +101,9 @@ namespace OrchardCore.OpenId
                 ServiceDescriptor.Transient<IPostConfigureOptions<OpenIddictOptions>, OpenIddictInitializer>(),
                 ServiceDescriptor.Transient<IPostConfigureOptions<OpenIddictOptions>, OpenIdConnectServerInitializer>()
             });
+
+            // Disabling same-site is required for OpenID's module prompt=none support to work correctly.
+            services.ConfigureApplicationCookie(options => options.Cookie.SameSite = SameSiteMode.None);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/YesSql/Services/OpenIdAuthorizationStore.cs
@@ -129,45 +129,6 @@ namespace OrchardCore.OpenId.YesSql.Services
         }
 
         /// <summary>
-        /// Retrieves the authorizations corresponding to the specified subject, associated with
-        /// the application identifier and for which the specified scopes have been granted.
-        /// </summary>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="client">The client associated with the authorization.</param>
-        /// <param name="scopes">The minimal scopes associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the authorizations corresponding to the specified subject/client/scopes.
-        /// </returns>
-        public virtual async Task<ImmutableArray<OpenIdAuthorization>> FindAsync(
-            string subject, string client, ImmutableArray<string> scopes, CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
-
-            if (string.IsNullOrEmpty(client))
-            {
-                throw new ArgumentException("The client cannot be null or empty.", nameof(client));
-            }
-
-            var builder = ImmutableArray.CreateBuilder<OpenIdAuthorization>();
-
-            foreach (var authorization in await FindAsync(subject, client, cancellationToken))
-            {
-                var set = new HashSet<string>(await GetScopesAsync(authorization, cancellationToken), StringComparer.Ordinal);
-                if (set.IsSupersetOf(scopes))
-                {
-                    builder.Add(authorization);
-                }
-            }
-
-            return builder.ToImmutable();
-        }
-
-        /// <summary>
         /// Retrieves an authorization using its unique identifier.
         /// </summary>
         /// <param name="identifier">The unique identifier associated with the authorization.</param>
@@ -648,9 +609,6 @@ namespace OrchardCore.OpenId.YesSql.Services
 
         async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindAsync(string subject, string client, CancellationToken cancellationToken)
             => (await FindAsync(subject, client, cancellationToken)).CastArray<IOpenIdAuthorization>();
-
-        async Task<ImmutableArray<IOpenIdAuthorization>> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindAsync(string subject, string client, ImmutableArray<string> scopes, CancellationToken cancellationToken)
-            => (await FindAsync(subject, client, scopes, cancellationToken)).CastArray<IOpenIdAuthorization>();
 
         async Task<IOpenIdAuthorization> IOpenIddictAuthorizationStore<IOpenIdAuthorization>.FindByIdAsync(string identifier, CancellationToken cancellationToken)
             => await FindByIdAsync(identifier, cancellationToken);


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/1118 and https://github.com/OrchardCMS/OrchardCore/issues/1119.

With this PR, a permanent authorization is now automatically inserted in the database when submitting the consent form, so that future authorization requests are transparently processed without displaying the consent form (as long as no new scope is requested). This is the same approach used by Google for their OAuth2 experience.