### PR TITLE
Query liquid filter now passes object value as opposed to FluidValue as query parameters.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Liquid/QueryFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Liquid/QueryFilter.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.Queries.Liquid
 
             foreach (var name in arguments.Names)
             {
-                parameters.Add(name, arguments[name]);
+                parameters.Add(name, arguments[name].ToObjectValue());
             }
 
             var result = await _queryManager.ExecuteQueryAsync(query, parameters);

--- a/src/OrchardCore.Modules/OrchardCore.Queries/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/README.md
@@ -101,6 +101,14 @@ To access a named query, use the name as the input.
 The example above will iterate over all the results of the query name `RecentBlogPosts` and display the text representing the content item.
 Any available property on the results of the queries can be used. This example assumes the results will be content items.
 
+### Parameters
+
+The `query` filter allows you to pass in parameters to your paramterized queries. For example, a query called `ContentItems` that has two parameters (`contentType` and `limit`) can be called like this:
+
+```
+{% assign fiveBlogPosts = "ContentItems" | query: contentType: "BlogPost", limit: 5 %}
+```
+
 # Razor Helpers
 
 The `QueryAsync` and `ContentQueryAsync` OrchardRazorHelper extension methods (in the `OrchardCore.Queries` and `OrchardCore.ContentManagement` namespaces respectively) allow you to run queries directly from razor pages.


### PR DESCRIPTION
Fixes #1458

Adds docs on how to pass parameters to query filter