### PR TITLE
Liquid syntax errors are displayed on every request

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidTemplateManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidTemplateManager.cs
@@ -37,24 +37,18 @@ namespace OrchardCore.Liquid.Services
 
             var result = _memoryCache.GetOrCreate(source, (ICacheEntry e) =>
             {
-                if (LiquidViewTemplate.TryParse(source, out var parsed, out errors))
+                if (!LiquidViewTemplate.TryParse(source, out var parsed, out errors))
                 {
-                    // Define a default sliding expiration to prevent the 
-                    // cache from being filled and still apply some micro-caching
-                    // in case the template is use commonly
-                    e.SetSlidingExpiration(TimeSpan.FromSeconds(30));
-                    return parsed;
+                    // If the source string cannot be parsed, create a template that contains the parser errors
+                    LiquidViewTemplate.TryParse(String.Join(System.Environment.NewLine, errors), out parsed, out errors);
                 }
-                else
-                {
-                    return null;
-                }
-            });
 
-            if (result == null)
-            {
-                LiquidViewTemplate.TryParse(String.Join(System.Environment.NewLine, errors), out result, out errors);
-            }
+                // Define a default sliding expiration to prevent the 
+                // cache from being filled and still apply some micro-caching
+                // in case the template is use commonly
+                e.SetSlidingExpiration(TimeSpan.FromSeconds(30));
+                return parsed;
+            });
 
             return result.RenderAsync(_liquidOptions, _serviceProvider, textWriter, encoder, context);
         }


### PR DESCRIPTION
... as opposed to depending on if the parsed template has been cached or not

Previously, liquid syntax errors were displayed only if the `LiquidViewTemplate` was not in the cache. This meant that if the template had not been requested in the previous 30 seconds, syntax errors would be displayed. Otherwise, syntax errors would have been hidden away.

This PR makes sure that syntax errors are displayed regardless of whether the template was in the cache or not.