### PR TITLE
Fixes string length limit of assembly attribute parameter.

### DIFF
--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
@@ -27,8 +27,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleNamesAttribute">
-        <_Parameter1>@(ModuleNames)</_Parameter1>
+      <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleNameAttribute">
+        <_Parameter1>%(ModuleNames.Identity)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
@@ -54,8 +54,8 @@
 
     <ItemGroup>
       <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleMarkerAttribute" />
-      <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAssetsAttribute">
-        <_Parameter1>@(ModuleAssets)</_Parameter1>
+      <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAssetAttribute">
+        <_Parameter1>%(ModuleAssets.Identity)</_Parameter1>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/Manifest/ManifestAttributes.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/Manifest/ManifestAttributes.cs
@@ -92,36 +92,36 @@ namespace OrchardCore.Modules.Manifest
     }
 
     /// <summary>
-    /// Names of modules referenced by the application, auto generated on building.
+    /// Enlists the package or project name of a referenced module, auto generated on building.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
-    public class ModuleNamesAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+    public class ModuleNameAttribute : Attribute
     {
-        public ModuleNamesAttribute(string names)
+        public ModuleNameAttribute(string name)
         {
-            Names = names ?? String.Empty;
+            Name = name ?? String.Empty;
         }
 
         /// <Summary>
-        /// A semicolon-separated list of module names.
+        /// The package or project name of the referenced module.
         /// </Summary>
-        public string Names { get; }
+        public string Name { get; }
     }
 
     /// <summary>
-    /// Maps module assets to their project location while in debug mode, auto generated on building.
+    /// Maps a module asset to its project location while in debug mode, auto generated on building.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false, Inherited = false)]
-    public class ModuleAssetsAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
+    public class ModuleAssetAttribute : Attribute
     {
-        public ModuleAssetsAttribute(string assets)
+        public ModuleAssetAttribute(string asset)
         {
-            Assets = assets ?? String.Empty;
+            Asset = asset ?? String.Empty;
         }
 
         /// <Summary>
-        /// A semicolon-separated list of module assets in the form of '{ModuleAssetPath}|{ProjectAssetPath}'.
+        /// A module asset in the form of '{ModuleAssetPath}|{ProjectAssetPath}'.
         /// </Summary>
-        public string Assets { get; }
+        public string Asset { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/ModularApplicationContext.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/ModularApplicationContext.cs
@@ -64,9 +64,8 @@ namespace OrchardCore.Modules
             Name = application;
             Assembly = Assembly.Load(new AssemblyName(application));
 
-            ModuleNames = Assembly.GetCustomAttribute<ModuleNamesAttribute>()?.Names
-                .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-                .ToArray() ?? Enumerable.Empty<string>();
+            ModuleNames = Assembly.GetCustomAttributes<ModuleNameAttribute>()
+                .Select(m => m.Name).ToArray();
         }
 
         public string Name { get; }
@@ -93,9 +92,8 @@ namespace OrchardCore.Modules
 
                 Assembly = Assembly.Load(new AssemblyName(name));
 
-                Assets = Assembly.GetCustomAttribute<ModuleAssetsAttribute>()?.Assets
-                    .Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(a => new Asset(a)).ToArray() ?? Enumerable.Empty<Asset>();
+                Assets = Assembly.GetCustomAttributes<ModuleAssetAttribute>()
+                    .Select(a => new Asset(a.Asset)).ToArray();
 
                 AssetPaths = Assets.Select(a => a.ModuleAssetPath).ToArray();
 


### PR DESCRIPTION
Related to the comment of @jpiquot in #1483 

There are different strategies. Because most of the path mappings are composed with the same directory paths we can reduce a lot the string lenght. But there are special cases with linked assets coming from another project, but could be easily implemented by keeping the full paths for these ones.

Here i used the simplest way by splitting the assets attribute into multiple ones.

@jpiquot could you re-try it? For infos, how many resources do you have? Are you sure you don't include large folders of asset inputs which are not used on the front end? As the node_modules folder (which is automatically excluded).


