### PR TITLE
Lucene writter concurrency issues

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
@@ -86,10 +86,12 @@ namespace OrchardCore.Lucene
         {
             lock (this)
             {
-                if (_writers.TryRemove(indexName, out var writer))
+                if (_writers.TryGetValue(indexName, out var writer))
                 {
                     writer.Dispose();
                 }
+
+                _writers.TryRemove(indexName, out writer);
 
                 if (_indexPools.TryRemove(indexName, out var reader))
                 {
@@ -264,8 +266,8 @@ namespace OrchardCore.Lucene
 
             if (close)
             {
-                _writers.TryRemove(indexName, out writer);
                 writer.Dispose();
+                _writers.TryRemove(indexName, out writer);
             }
 
             _timestamps[indexName] = _clock.UtcNow;

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
@@ -262,6 +262,11 @@ namespace OrchardCore.Lucene
                 return new IndexWriter(directory, config);
             });
 
+            if (writer.IsClosed)
+            {
+                return;
+            }
+
             action?.Invoke(writer);
 
             if (close)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexingState.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexingState.cs
@@ -44,19 +44,29 @@ namespace OrchardCore.Lucene
             }
             else
             {
-                _content.Add(new JProperty(indexName, 0));
+                lock (this)
+                {
+                    _content.Add(new JProperty(indexName, 0));
+                }
+
                 return 0;
             }
         }
 
         public void SetLastTaskId(string indexName, int taskId)
         {
-            _content[indexName] = taskId;
+            lock (this)
+            {
+                _content[indexName] = taskId;
+            }
         }
 
         public void Update()
         {
-            File.WriteAllText(_indexSettingsFilename, _content.ToString(Newtonsoft.Json.Formatting.Indented));
+            lock (this)
+            {
+                File.WriteAllText(_indexSettingsFilename, _content.ToString(Newtonsoft.Json.Formatting.Indented));
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1484 

- The main point is to prevent from creating and or using an index writer while deleting it.

- Note: in some places, an improvement would be to use a different lock object for each index writer.

- Then, as i have tried, i could get rid of all concurrent issues unless for `Directory.Delete()` when it is quicly recalled. In this case `Directory.Exists` still returns true and just adding a delay fixes the issue.

    We could maintain an internal list initialized in the ctor and updated when creating / deleting a directory. Or use more complex code to check if the directory is owned by another process. Here i don't talk about a non disposed index writer, but a thread which has already called `Directory.Delete()`.

- So, for the above specific case, the simplest solution was to use try catch blocks as done here.
