### PR TITLE
Fixes setup form filling.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/ViewModels/SetupViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/ViewModels/SetupViewModel.cs
@@ -26,8 +26,8 @@ namespace OrchardCore.Setup.ViewModels
         [Required]
         public string UserName { get; set; }
 
-        [EmailAddress]
         [Required]
+        [EmailAddress]
         public string Email { get; set; }
 
         [DataType(DataType.Password)]

--- a/src/OrchardCore.Modules/OrchardCore.Setup/ViewModels/SetupViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/ViewModels/SetupViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using OrchardCore.Data;
@@ -27,6 +27,7 @@ namespace OrchardCore.Setup.ViewModels
         public string UserName { get; set; }
 
         [EmailAddress]
+        [Required]
         public string Email { get; set; }
 
         [DataType(DataType.Password)]


### PR DESCRIPTION
Fixes #1489 

So, adding a require attribute on the email, allows the setup controller to return to the view earlier, before executing the setup service where the error was found by the users `ISetupEventHandler`.