### PR TITLE
Fixes bad feature id renaming

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Manifest.cs
@@ -8,7 +8,7 @@ using OrchardCore.Modules.Manifest;
 )]
 
 [assembly: Feature(
-    Id = "OrchardCore.Media.Azure",
+    Id = "OrchardCore.Media.Azure.Storage",
     Name = "Azure Media Storage",
     Description = "Enables support for storing media files in, and serving them to clients directly from, Microsoft Azure Blob Storage.",
     Category = "Hosting"


### PR DESCRIPTION
Most of the time, for the first feature of a module we use an id equal to the module id (as when defining only one feature through the module attribute itself). This allows to have default types which are tied to this feature without having to decorate them.

But here, the only one service is registered in the startup which is decorated with `[Feature("OrchardCore.Media.Azure.Storage")]`. So, we need to remove this attribute or rename the first feature to `OrchardCore.Media.Azure.Storage` as it was originally, and that i changed by mistake.