### PR TITLE
Fixes connectionString always required in setup.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
@@ -244,6 +244,14 @@
                 $pwd.focus();
             }
         });
+
+        $("#DatabaseProvider").change(function () {
+            $("#DatabaseProvider option:selected").each(function () {
+                $(this).data("connection-string").toLowerCase() === "true"
+                    ? $(".pwd").attr('required', 'required')
+                    : $(".pwd").removeAttr('required');
+            });
+        });
     })
     //]]>
 </script>


### PR DESCRIPTION
E.g when selecting sqlite the connectionString is still required.

So i quickly added a piece of jquery to fix it. But just to show the idea, needs to be reviewed

Maybe better to add it in `setup.js` but too lazy to install gulp.