### PR TITLE
Remove the unique constraint on OpenIdTokenIndex.ReferenceId

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Migrations.cs
@@ -40,7 +40,7 @@ namespace OrchardCore.OpenId
                 .Column<string>(nameof(OpenIdTokenIndex.ApplicationId), column => column.WithLength(48))
                 .Column<string>(nameof(OpenIdTokenIndex.AuthorizationId), column => column.WithLength(48))
                 .Column<DateTimeOffset>(nameof(OpenIdTokenIndex.ExpirationDate))
-                .Column<string>(nameof(OpenIdTokenIndex.ReferenceId), column => column.Unique())
+                .Column<string>(nameof(OpenIdTokenIndex.ReferenceId))
                 .Column<string>(nameof(OpenIdTokenIndex.Status))
                 .Column<string>(nameof(OpenIdTokenIndex.Subject)));
 


### PR DESCRIPTION
Unlike EF Core, YesSql doesn't seem to handle unique constraints on nullable columns well, which causes "duplicate entry" SQL exceptions (EF Core uses a filtered index to deal with nullable columns).

/cc @sebastienros 