### PR TITLE
Update ImageSharp.Web to beta3

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.0-dev000064" />
+    <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.0-beta0003" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileSystemResolver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileSystemResolver.cs
@@ -16,6 +16,7 @@ namespace OrchardCore.Media.Processing
     /// </summary>
     public class MediaFileSystemResolver : IImageResolver
     {
+        private readonly IBufferManager bufferManager;
         private readonly IMediaFileStore _mediaStore;
 
         /// <summary>
@@ -23,10 +24,11 @@ namespace OrchardCore.Media.Processing
         /// </summary>
         private readonly ImageSharpMiddlewareOptions options;
 
-        public MediaFileSystemResolver(IMediaFileStore mediaStore, IOptions<ImageSharpMiddlewareOptions> options)
+        public MediaFileSystemResolver(IMediaFileStore mediaStore, IBufferManager bufferManager, IOptions<ImageSharpMiddlewareOptions> options)
         {
             _mediaStore = mediaStore;
             this.options = options.Value;
+            this.bufferManager = bufferManager;
         }
 
         /// <inheritdoc/>
@@ -42,7 +44,7 @@ namespace OrchardCore.Media.Processing
         }
 
         /// <inheritdoc/>
-        public async Task<byte[]> ResolveImageAsync(HttpContext context, ILogger logger)
+        public async Task<IByteBuffer> ResolveImageAsync(HttpContext context, ILogger logger)
         {
             // Path has already been correctly parsed before here.
 
@@ -55,13 +57,13 @@ namespace OrchardCore.Media.Processing
                 return null;
             }
 
-            byte[] buffer;
+            IByteBuffer buffer;
 
             using (var stream = await _mediaStore.GetFileStreamAsync(filePath))
             {
                 // Buffer is returned to the pool in the middleware
-                buffer = BufferDataPool.Rent((int)stream.Length);
-                await stream.ReadAsync(buffer, 0, (int)stream.Length);
+                buffer = this.bufferManager.Allocate((int)stream.Length);
+                await stream.ReadAsync(buffer.Array, 0, buffer.Length);
             }
 
             return buffer;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -32,6 +32,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.DependencyInjection;
+using SixLabors.ImageSharp.Web.Memory;
 using SixLabors.ImageSharp.Web.Processors;
 
 namespace OrchardCore.Media
@@ -88,6 +89,7 @@ namespace OrchardCore.Media
                         options.Configuration = Configuration.Default;
                         options.MaxBrowserCacheDays = 7;
                         options.MaxCacheDays = 365;
+                        options.CachedNameLength = 12;
                         options.OnValidate = validation =>
                         {
                             // Force some parameters to prevent disk filling.
@@ -142,9 +144,11 @@ namespace OrchardCore.Media
                         options.OnProcessed = _ => { };
                         options.OnPrepareResponse = _ => { };
                     })
-                    .SetUriParser<QueryCollectionUriParser>()
-                    .SetCache<PhysicalFileSystemCache>()
+                    .SetRequestParser<QueryCollectionRequestParser>()
+                    .SetBufferManager<PooledBufferManager>()
+                    .SetCacheHash<CacheHash>()
                     .SetAsyncKeyLock<AsyncKeyLock>()
+                    .SetCache<PhysicalFileSystemCache>()
                     .AddResolver<MediaFileSystemResolver>()
                     .AddProcessor<ResizeWebProcessor>();
 


### PR DESCRIPTION
Updates to the latest beta. 

New options and a smarter API. Less allocations also