### PR TITLE
Activate a shell which may do migrations in an inner scope.

### DIFF
--- a/src/OrchardCore/OrchardCore.Modules/ModularTenantContainerMiddleware.cs
+++ b/src/OrchardCore/OrchardCore.Modules/ModularTenantContainerMiddleware.cs
@@ -74,9 +74,9 @@ namespace OrchardCore.Modules
                                     {
                                         await tenantEvent.ActivatedAsync();
                                     }
-
-                                    shellContext.IsActivated = true;
                                 }
+
+                                shellContext.IsActivated = true;
                             }
                         }
                         finally

--- a/src/OrchardCore/OrchardCore.Recipes.Implementations/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Implementations/Services/RecipeExecutor.cs
@@ -175,9 +175,9 @@ namespace OrchardCore.Recipes.Services
                         {
                             await tenantEvent.ActivatedAsync();
                         }
-
-                        shellContext.IsActivated = true;
                     }
+
+                    shellContext.IsActivated = true;
                 }
 
                 var recipeStepHandlers = scope.ServiceProvider.GetServices<IRecipeStepHandler>();

--- a/src/OrchardCore/OrchardCore.Recipes.Implementations/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Implementations/Services/RecipeExecutor.cs
@@ -162,20 +162,22 @@ namespace OrchardCore.Recipes.Services
             {
                 if (!shellContext.IsActivated)
                 {
-                    var tenantEvents = scope.ServiceProvider
-                        .GetServices<IModularTenantEvents>();
-
-                    foreach (var tenantEvent in tenantEvents)
+                    using (var activatingScope = shellContext.EnterServiceScope())
                     {
-                        await tenantEvent.ActivatingAsync();
-                    }
+                        var tenantEvents = scope.ServiceProvider.GetServices<IModularTenantEvents>();
 
-                    foreach (var tenantEvent in tenantEvents.Reverse())
-                    {
-                        await tenantEvent.ActivatedAsync();
-                    }
+                        foreach (var tenantEvent in tenantEvents)
+                        {
+                            await tenantEvent.ActivatingAsync();
+                        }
 
-                    shellContext.IsActivated = true;
+                        foreach (var tenantEvent in tenantEvents.Reverse())
+                        {
+                            await tenantEvent.ActivatedAsync();
+                        }
+
+                        shellContext.IsActivated = true;
+                    }
                 }
 
                 var recipeStepHandlers = scope.ServiceProvider.GetServices<IRecipeStepHandler>();


### PR DESCRIPTION
So the session used to do migrations is disposed earlier. And then the current request or other incoming ones (or in a background scope) can save to the database without a locking issue.

I saw this issue when working in the background, so when getting running shells i check if the shell `IsActivated` or `ActiveScopes == 0`, otherwise some migrations could be done. But there was still the case where the shell just get activated but still in the scope (and then the session) which activated it.

So, because we can't filter activated shells when active scopes > 0, i did this change.