### PR TITLE
Fixing draft content item retrieval in AutorouteRoute

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutorouteRoute.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutorouteRoute.cs
@@ -78,22 +78,25 @@ namespace OrchardCore.Autoroute.Routing
             }
 
             var contentManager = context.RequestServices.GetService<IContentManager>();
-            var contentItem = await contentManager.GetAsync(contentItemId);
+            var contentItem = await contentManager.GetAsync(contentItemId, VersionOptions.Latest);
             return contentItem == null ? null : (await contentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem))?.DisplayRouteValues;
         }
 
         private async Task EnsureRouteData(RouteContext context, string contentItemId)
         {
             var displayRoutes = await GetContentItemDisplayRoutes(context.HttpContext, contentItemId);
+
             if (displayRoutes == null)
             {
                 return;
             }
+
             foreach (var key in _keys)
             {
                 if (displayRoutes.ContainsKey(key))
                     context.RouteData.Values[key] = displayRoutes[key];
             }
+
             context.RouteData.Routers.Add(_target);
         }
     }


### PR DESCRIPTION
Fixes the issue described in #1696. The bug was introduced with 2b276e23302acebebdfb2510ae452d05ac2e0ec5

The issue is that the private `GetContentItemDisplayRoutes` of `AutorouteRoute` added as part of that commit only looks for published content items rather than the latest version.