### PR TITLE
Streamline centalized package version management

### DIFF
--- a/OrchardCore.sln
+++ b/OrchardCore.sln
@@ -301,6 +301,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{184139CF
 		src\OrchardCore.Build\Dependencies.props = src\OrchardCore.Build\Dependencies.props
 		NuGet.config = NuGet.config
 		src\OrchardCore.Build\OrchardCore.Commons.props = src\OrchardCore.Build\OrchardCore.Commons.props
+		src\OrchardCore.Build\OrchardCore.Commons.targets = src\OrchardCore.Build\OrchardCore.Commons.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.Email", "src\OrchardCore.Modules\OrchardCore.Email\OrchardCore.Email.csproj", "{B3E9EC5B-171E-43FB-8620-7FC24D0A985A}"

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -1,198 +1,198 @@
 <Project>
-  <PropertyGroup>
-    <LibuvPackageVersion>1.10.0</LibuvPackageVersion>
-    <MicrosoftApplicationInsightsAspNetCorePackageVersion>2.2.1</MicrosoftApplicationInsightsAspNetCorePackageVersion>
-    <MicrosoftAspNetCorePackageVersion>2.0.2</MicrosoftAspNetCorePackageVersion>
-    <MicrosoftAspNetCoreAllPackageVersion>2.0.6</MicrosoftAspNetCoreAllPackageVersion>
-    <MicrosoftAspNetCoreAntiforgeryPackageVersion>2.0.2</MicrosoftAspNetCoreAntiforgeryPackageVersion>
-    <MicrosoftAspNetCoreApplicationInsightsHostingStartupPackageVersion>2.0.2</MicrosoftAspNetCoreApplicationInsightsHostingStartupPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreAuthenticationAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationCorePackageVersion>2.0.2</MicrosoftAspNetCoreAuthenticationCorePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationFacebookPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationGooglePackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationGooglePackageVersion>
-    <MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationMicrosoftAccountPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationOAuthPackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationOAuthPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationOpenIdConnectPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationPackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationPackageVersion>
-    <MicrosoftAspNetCoreAuthenticationTwitterPackageVersion>2.0.3</MicrosoftAspNetCoreAuthenticationTwitterPackageVersion>
-    <MicrosoftAspNetCoreAuthorizationPackageVersion>2.0.3</MicrosoftAspNetCoreAuthorizationPackageVersion>
-    <MicrosoftAspNetCoreAuthorizationPolicyPackageVersion>2.0.3</MicrosoftAspNetCoreAuthorizationPolicyPackageVersion>
-    <MicrosoftAspNetCoreAzureAppServicesHostingStartupPackageVersion>2.0.2</MicrosoftAspNetCoreAzureAppServicesHostingStartupPackageVersion>
-    <MicrosoftAspNetCoreAzureAppServicesIntegrationPackageVersion>2.0.2</MicrosoftAspNetCoreAzureAppServicesIntegrationPackageVersion>
-    <MicrosoftAspNetCoreAzureAppServicesSiteExtensionPackageVersion>2.0.2</MicrosoftAspNetCoreAzureAppServicesSiteExtensionPackageVersion>
-    <MicrosoftAspNetCoreBufferingPackageVersion>0.2.2</MicrosoftAspNetCoreBufferingPackageVersion>
-    <MicrosoftAspNetCoreCookiePolicyPackageVersion>2.0.3</MicrosoftAspNetCoreCookiePolicyPackageVersion>
-    <MicrosoftAspNetCoreCorsPackageVersion>2.0.2</MicrosoftAspNetCoreCorsPackageVersion>
-    <MicrosoftAspNetCoreCryptographyInternalPackageVersion>2.0.2</MicrosoftAspNetCoreCryptographyInternalPackageVersion>
-    <MicrosoftAspNetCoreCryptographyKeyDerivationPackageVersion>2.0.2</MicrosoftAspNetCoreCryptographyKeyDerivationPackageVersion>
-    <MicrosoftAspNetCoreDataProtectionAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreDataProtectionAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreDataProtectionAzureStoragePackageVersion>2.0.2</MicrosoftAspNetCoreDataProtectionAzureStoragePackageVersion>
-    <MicrosoftAspNetCoreDataProtectionExtensionsPackageVersion>2.0.2</MicrosoftAspNetCoreDataProtectionExtensionsPackageVersion>
-    <MicrosoftAspNetCoreDataProtectionPackageVersion>2.0.2</MicrosoftAspNetCoreDataProtectionPackageVersion>
-    <MicrosoftAspNetCoreDataProtectionRedisPackageVersion>0.3.2</MicrosoftAspNetCoreDataProtectionRedisPackageVersion>
-    <MicrosoftAspNetCoreDataProtectionSystemWebPackageVersion>2.0.2</MicrosoftAspNetCoreDataProtectionSystemWebPackageVersion>
-    <MicrosoftAspNetCoreDiagnosticsAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreDiagnosticsAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreDiagnosticsElmPackageVersion>0.2.2</MicrosoftAspNetCoreDiagnosticsElmPackageVersion>
-    <MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>2.0.2</MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>
-    <MicrosoftAspNetCoreDiagnosticsIdentityServicePackageVersion>2.0.2</MicrosoftAspNetCoreDiagnosticsIdentityServicePackageVersion>
-    <MicrosoftAspNetCoreDiagnosticsPackageVersion>2.0.2</MicrosoftAspNetCoreDiagnosticsPackageVersion>
-    <MicrosoftAspNetCoreHostingAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreHostingAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHostingPackageVersion>2.0.2</MicrosoftAspNetCoreHostingPackageVersion>
-    <MicrosoftAspNetCoreHostingServerAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreHostingServerAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHostingWindowsServicesPackageVersion>2.0.2</MicrosoftAspNetCoreHostingWindowsServicesPackageVersion>
-    <MicrosoftAspNetCoreHtmlAbstractionsPackageVersion>2.0.1</MicrosoftAspNetCoreHtmlAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHttpAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreHttpAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreHttpExtensionsPackageVersion>2.0.2</MicrosoftAspNetCoreHttpExtensionsPackageVersion>
-    <MicrosoftAspNetCoreHttpFeaturesPackageVersion>2.0.2</MicrosoftAspNetCoreHttpFeaturesPackageVersion>
-    <MicrosoftAspNetCoreHttpOverridesPackageVersion>2.0.2</MicrosoftAspNetCoreHttpOverridesPackageVersion>
-    <MicrosoftAspNetCoreHttpPackageVersion>2.0.2</MicrosoftAspNetCoreHttpPackageVersion>
-    <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>2.0.2</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
-    <MicrosoftAspNetCoreIdentityPackageVersion>2.0.2</MicrosoftAspNetCoreIdentityPackageVersion>
-    <MicrosoftAspNetCoreIdentityServiceAbstractionsPackageVersion>2.0.1</MicrosoftAspNetCoreIdentityServiceAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreIdentityServiceAzureKeyVaultPackageVersion>2.0.1</MicrosoftAspNetCoreIdentityServiceAzureKeyVaultPackageVersion>
-    <MicrosoftAspNetCoreIdentityServiceCorePackageVersion>2.0.1</MicrosoftAspNetCoreIdentityServiceCorePackageVersion>
-    <MicrosoftAspNetCoreIdentityServiceEntityFrameworkCorePackageVersion>2.0.1</MicrosoftAspNetCoreIdentityServiceEntityFrameworkCorePackageVersion>
-    <MicrosoftAspNetCoreIdentityServiceIntegratedWebClientPackageVersion>2.0.1</MicrosoftAspNetCoreIdentityServiceIntegratedWebClientPackageVersion>
-    <MicrosoftAspNetCoreIdentityServiceMvcPackageVersion>2.0.1</MicrosoftAspNetCoreIdentityServiceMvcPackageVersion>
-    <MicrosoftAspNetCoreIdentityServicePackageVersion>2.0.1</MicrosoftAspNetCoreIdentityServicePackageVersion>
-    <MicrosoftAspNetCoreIdentityServiceSpecificationTestsPackageVersion>2.0.1</MicrosoftAspNetCoreIdentityServiceSpecificationTestsPackageVersion>
-    <MicrosoftAspNetCoreIdentitySpecificationTestsPackageVersion>2.0.1</MicrosoftAspNetCoreIdentitySpecificationTestsPackageVersion>
-    <MicrosoftAspNetCoreJsonPatchPackageVersion>2.0.1</MicrosoftAspNetCoreJsonPatchPackageVersion>
-    <MicrosoftAspNetCoreLocalizationPackageVersion>2.0.2</MicrosoftAspNetCoreLocalizationPackageVersion>
-    <MicrosoftAspNetCoreLocalizationRoutingPackageVersion>2.0.2</MicrosoftAspNetCoreLocalizationRoutingPackageVersion>
-    <MicrosoftAspNetCoreMiddlewareAnalysisPackageVersion>2.0.2</MicrosoftAspNetCoreMiddlewareAnalysisPackageVersion>
-    <MicrosoftAspNetCoreMvcAbstractionsPackageVersion>2.0.3</MicrosoftAspNetCoreMvcAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreMvcApiExplorerPackageVersion>2.0.3</MicrosoftAspNetCoreMvcApiExplorerPackageVersion>
-    <MicrosoftAspNetCoreMvcCorePackageVersion>2.0.3</MicrosoftAspNetCoreMvcCorePackageVersion>
-    <MicrosoftAspNetCoreMvcCorsPackageVersion>2.0.3</MicrosoftAspNetCoreMvcCorsPackageVersion>
-    <MicrosoftAspNetCoreMvcDataAnnotationsPackageVersion>2.0.3</MicrosoftAspNetCoreMvcDataAnnotationsPackageVersion>
-    <MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>2.0.3</MicrosoftAspNetCoreMvcFormattersJsonPackageVersion>
-    <MicrosoftAspNetCoreMvcFormattersXmlPackageVersion>2.0.3</MicrosoftAspNetCoreMvcFormattersXmlPackageVersion>
-    <MicrosoftAspNetCoreMvcLocalizationPackageVersion>2.0.3</MicrosoftAspNetCoreMvcLocalizationPackageVersion>
-    <MicrosoftAspNetCoreMvcPackageVersion>2.0.3</MicrosoftAspNetCoreMvcPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>2.0.2</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorPackageVersion>2.0.3</MicrosoftAspNetCoreMvcRazorPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorPagesPackageVersion>2.0.3</MicrosoftAspNetCoreMvcRazorPagesPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion>2.0.3</MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion>
-    <MicrosoftAspNetCoreMvcTagHelpersPackageVersion>2.0.3</MicrosoftAspNetCoreMvcTagHelpersPackageVersion>
-    <MicrosoftAspNetCoreMvcViewFeaturesPackageVersion>2.0.3</MicrosoftAspNetCoreMvcViewFeaturesPackageVersion>
-    <MicrosoftAspNetCoreMvcWebApiCompatShimPackageVersion>2.0.3</MicrosoftAspNetCoreMvcWebApiCompatShimPackageVersion>
-    <MicrosoftAspNetCoreNodeServicesPackageVersion>2.0.3</MicrosoftAspNetCoreNodeServicesPackageVersion>
-    <MicrosoftAspNetCoreNodeServicesSocketsPackageVersion>2.0.1</MicrosoftAspNetCoreNodeServicesSocketsPackageVersion>
-    <MicrosoftAspNetCoreOwinPackageVersion>2.0.2</MicrosoftAspNetCoreOwinPackageVersion>
-    <MicrosoftAspNetCoreProxyPackageVersion>0.3.1</MicrosoftAspNetCoreProxyPackageVersion>
-    <MicrosoftAspNetCoreRazorLanguagePackageVersion>2.0.2</MicrosoftAspNetCoreRazorLanguagePackageVersion>
-    <MicrosoftAspNetCoreRazorPackageVersion>2.0.2</MicrosoftAspNetCoreRazorPackageVersion>
-    <MicrosoftAspNetCoreRazorRuntimePackageVersion>2.0.2</MicrosoftAspNetCoreRazorRuntimePackageVersion>
-    <MicrosoftAspNetCoreResponseCachingAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreResponseCachingAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreResponseCachingPackageVersion>2.0.2</MicrosoftAspNetCoreResponseCachingPackageVersion>
-    <MicrosoftAspNetCoreResponseCompressionPackageVersion>2.0.2</MicrosoftAspNetCoreResponseCompressionPackageVersion>
-    <MicrosoftAspNetCoreRewritePackageVersion>2.0.2</MicrosoftAspNetCoreRewritePackageVersion>
-    <MicrosoftAspNetCoreRoutingAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreRoutingAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreRoutingPackageVersion>2.0.2</MicrosoftAspNetCoreRoutingPackageVersion>
-    <MicrosoftAspNetCoreServerHttpSysPackageVersion>2.0.2</MicrosoftAspNetCoreServerHttpSysPackageVersion>
-    <MicrosoftAspNetCoreServerIISIntegrationPackageVersion>2.0.2</MicrosoftAspNetCoreServerIISIntegrationPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelCorePackageVersion>2.0.2</MicrosoftAspNetCoreServerKestrelCorePackageVersion>
-    <MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>2.0.2</MicrosoftAspNetCoreServerKestrelHttpsPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelPackageVersion>2.0.2</MicrosoftAspNetCoreServerKestrelPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelTransportAbstractionsPackageVersion>2.0.2</MicrosoftAspNetCoreServerKestrelTransportAbstractionsPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelTransportLibuvPackageVersion>2.0.2</MicrosoftAspNetCoreServerKestrelTransportLibuvPackageVersion>
-    <MicrosoftAspNetCoreServerKestrelTransportSocketsPackageVersion>2.0.2</MicrosoftAspNetCoreServerKestrelTransportSocketsPackageVersion>
-    <MicrosoftAspNetCoreSessionPackageVersion>2.0.2</MicrosoftAspNetCoreSessionPackageVersion>
-    <MicrosoftAspNetCoreSpaServicesPackageVersion>2.0.3</MicrosoftAspNetCoreSpaServicesPackageVersion>
-    <MicrosoftAspNetCoreStaticFilesPackageVersion>2.0.2</MicrosoftAspNetCoreStaticFilesPackageVersion>
-    <MicrosoftAspNetCoreTestHostPackageVersion>2.0.2</MicrosoftAspNetCoreTestHostPackageVersion>
-    <MicrosoftAspNetCoreWebSocketsPackageVersion>2.0.2</MicrosoftAspNetCoreWebSocketsPackageVersion>
-    <MicrosoftAspNetCoreWebUtilitiesPackageVersion>2.0.2</MicrosoftAspNetCoreWebUtilitiesPackageVersion>
-    <MicrosoftAspNetIdentityAspNetCoreCompatPackageVersion>0.3.1</MicrosoftAspNetIdentityAspNetCoreCompatPackageVersion>
-    <MicrosoftAspNetIdentityEntityFrameworkPackageVersion>2.2.1</MicrosoftAspNetIdentityEntityFrameworkPackageVersion>
-    <MicrosoftAspNetWebApiClientPackageVersion>5.2.4</MicrosoftAspNetWebApiClientPackageVersion>
-    <MicrosoftAzureKeyVaultPackageVersion>2.3.2</MicrosoftAzureKeyVaultPackageVersion>
-    <MicrosoftBuildPackageVersion>15.6.82</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildRuntimePackageVersion>15.6.82</MicrosoftBuildRuntimePackageVersion>
-    <MicrosoftBuildTasksCorePackageVersion>15.6.82</MicrosoftBuildTasksCorePackageVersion>
-    <MicrosoftBuildUtilitiesCorePackageVersion>15.6.82</MicrosoftBuildUtilitiesCorePackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>2.7.0</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>2.7.0</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.7.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisRazorPackageVersion>2.0.2</MicrosoftCodeAnalysisRazorPackageVersion>
-    <MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>2.0.1</MicrosoftCodeAnalysisRazorWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisRemoteRazorPackageVersion>2.0.1</MicrosoftCodeAnalysisRemoteRazorPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>2.7.0</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftCSharpPackageVersion>4.4.1</MicrosoftCSharpPackageVersion>
-    <MicrosoftDataSqliteCorePackageVersion>2.0.1</MicrosoftDataSqliteCorePackageVersion>
-    <MicrosoftDataSqlitePackageVersion>2.0.1</MicrosoftDataSqlitePackageVersion>
-    <MicrosoftDotNetWatcherToolsPackageVersion>2.0.1</MicrosoftDotNetWatcherToolsPackageVersion>
-    <MicrosoftEntityFrameworkCoreDesignPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreDesignPackageVersion>
-    <MicrosoftEntityFrameworkCoreInMemoryPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreInMemoryPackageVersion>
-    <MicrosoftEntityFrameworkCorePackageVersion>2.0.2</MicrosoftEntityFrameworkCorePackageVersion>
-    <MicrosoftEntityFrameworkCoreRelationalDesignSpecificationTestsPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreRelationalDesignSpecificationTestsPackageVersion>
-    <MicrosoftEntityFrameworkCoreRelationalPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreRelationalPackageVersion>
-    <MicrosoftEntityFrameworkCoreRelationalSpecificationTestsPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreRelationalSpecificationTestsPackageVersion>
-    <MicrosoftEntityFrameworkCoreSpecificationTestsPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreSpecificationTestsPackageVersion>
-    <MicrosoftEntityFrameworkCoreSqliteCorePackageVersion>2.0.2</MicrosoftEntityFrameworkCoreSqliteCorePackageVersion>
-    <MicrosoftEntityFrameworkCoreSqlitePackageVersion>2.0.2</MicrosoftEntityFrameworkCoreSqlitePackageVersion>
-    <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
-    <MicrosoftEntityFrameworkCoreToolsDotNetPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreToolsDotNetPackageVersion>
-    <MicrosoftEntityFrameworkCoreToolsPackageVersion>2.0.2</MicrosoftEntityFrameworkCoreToolsPackageVersion>
-    <MicrosoftExtensionsCachingAbstractionsPackageVersion>2.0.1</MicrosoftExtensionsCachingAbstractionsPackageVersion>
-    <MicrosoftExtensionsCachingMemoryPackageVersion>2.0.1</MicrosoftExtensionsCachingMemoryPackageVersion>
-    <MicrosoftExtensionsCachingRedisPackageVersion>2.0.1</MicrosoftExtensionsCachingRedisPackageVersion>
-    <MicrosoftExtensionsCachingSqlConfigToolsPackageVersion>2.0.1</MicrosoftExtensionsCachingSqlConfigToolsPackageVersion>
-    <MicrosoftExtensionsCachingSqlServerPackageVersion>2.0.1</MicrosoftExtensionsCachingSqlServerPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.0.1</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>2.0.1</MicrosoftExtensionsConfigurationAzureKeyVaultPackageVersion>
-    <MicrosoftExtensionsConfigurationBinderPackageVersion>2.0.1</MicrosoftExtensionsConfigurationBinderPackageVersion>
-    <MicrosoftExtensionsConfigurationCommandLinePackageVersion>2.0.1</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.0.1</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>2.0.1</MicrosoftExtensionsConfigurationFileExtensionsPackageVersion>
-    <MicrosoftExtensionsConfigurationIniPackageVersion>2.0.1</MicrosoftExtensionsConfigurationIniPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.0.1</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>2.0.1</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>2.0.1</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
-    <MicrosoftExtensionsConfigurationXmlPackageVersion>2.0.1</MicrosoftExtensionsConfigurationXmlPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>2.0.0</MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.0.0</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>2.0.4</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsDiagnosticAdapterPackageVersion>2.0.1</MicrosoftExtensionsDiagnosticAdapterPackageVersion>
-    <MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>2.0.1</MicrosoftExtensionsFileProvidersAbstractionsPackageVersion>
-    <MicrosoftExtensionsFileProvidersCompositePackageVersion>2.0.1</MicrosoftExtensionsFileProvidersCompositePackageVersion>
-    <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>2.0.1</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
-    <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.0.1</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
-    <MicrosoftExtensionsFileSystemGlobbingPackageVersion>2.0.1</MicrosoftExtensionsFileSystemGlobbingPackageVersion>
-    <MicrosoftExtensionsHostingAbstractionsPackageVersion>2.0.2</MicrosoftExtensionsHostingAbstractionsPackageVersion>
-    <MicrosoftExtensionsIdentityCorePackageVersion>2.0.2</MicrosoftExtensionsIdentityCorePackageVersion>
-    <MicrosoftExtensionsIdentityStoresPackageVersion>2.0.2</MicrosoftExtensionsIdentityStoresPackageVersion>
-    <MicrosoftExtensionsLocalizationAbstractionsPackageVersion>2.0.2</MicrosoftExtensionsLocalizationAbstractionsPackageVersion>
-    <MicrosoftExtensionsLocalizationPackageVersion>2.0.2</MicrosoftExtensionsLocalizationPackageVersion>
-    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>2.0.1</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
-    <MicrosoftExtensionsLoggingAzureAppServicesPackageVersion>2.0.1</MicrosoftExtensionsLoggingAzureAppServicesPackageVersion>
-    <MicrosoftExtensionsLoggingConfigurationPackageVersion>2.0.1</MicrosoftExtensionsLoggingConfigurationPackageVersion>
-    <MicrosoftExtensionsLoggingConsolePackageVersion>2.0.1</MicrosoftExtensionsLoggingConsolePackageVersion>
-    <MicrosoftExtensionsLoggingDebugPackageVersion>2.0.1</MicrosoftExtensionsLoggingDebugPackageVersion>
-    <MicrosoftExtensionsLoggingEventSourcePackageVersion>2.0.1</MicrosoftExtensionsLoggingEventSourcePackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>2.0.1</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftExtensionsLoggingTraceSourcePackageVersion>2.0.1</MicrosoftExtensionsLoggingTraceSourcePackageVersion>
-    <MicrosoftExtensionsObjectPoolPackageVersion>2.0.0</MicrosoftExtensionsObjectPoolPackageVersion>
-    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>2.0.1</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
-    <MicrosoftExtensionsOptionsPackageVersion>2.0.1</MicrosoftExtensionsOptionsPackageVersion>
-    <MicrosoftExtensionsPrimitivesPackageVersion>2.0.0</MicrosoftExtensionsPrimitivesPackageVersion>
-    <MicrosoftExtensionsSecretManagerToolsPackageVersion>2.0.1</MicrosoftExtensionsSecretManagerToolsPackageVersion>
-    <MicrosoftExtensionsWebEncodersPackageVersion>2.0.1</MicrosoftExtensionsWebEncodersPackageVersion>
-    <MicrosoftNetHttpHeadersPackageVersion>2.0.2</MicrosoftNetHttpHeadersPackageVersion>
-    <MicrosoftOwinSecurityInteropPackageVersion>2.0.3</MicrosoftOwinSecurityInteropPackageVersion>
-    <MicrosoftVisualStudioWebBrowserLinkPackageVersion>2.0.2</MicrosoftVisualStudioWebBrowserLinkPackageVersion>
-    <MicrosoftVisualStudioWebCodeGenerationContractsPackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGenerationContractsPackageVersion>
-    <MicrosoftVisualStudioWebCodeGenerationCorePackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGenerationCorePackageVersion>
-    <MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion>
-    <MicrosoftVisualStudioWebCodeGenerationEntityFrameworkCorePackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGenerationEntityFrameworkCorePackageVersion>
-    <MicrosoftVisualStudioWebCodeGenerationPackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGenerationPackageVersion>
-    <MicrosoftVisualStudioWebCodeGenerationTemplatingPackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGenerationTemplatingPackageVersion>
-    <MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion>
-    <MicrosoftVisualStudioWebCodeGenerationUtilsPackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGenerationUtilsPackageVersion>
-    <MicrosoftVisualStudioWebCodeGeneratorsMvcPackageVersion>2.0.3</MicrosoftVisualStudioWebCodeGeneratorsMvcPackageVersion>
-    <MicrosoftWebXdtExtensionsPackageVersion>2.0.1</MicrosoftWebXdtExtensionsPackageVersion>
-  </PropertyGroup>
+  <ItemGroup>
+    <PackageManagement Include="Libuv" Version="1.10.0" />
+    <PackageManagement Include="Microsoft.Application.Insights.AspNetCore" Version="2.2.1" />
+    <PackageManagement Include="Microsoft.AspNetCore" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.All" Version="2.0.6" />
+    <PackageManagement Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Application.Insights.Hosting.Startup" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.Facebook" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.Google" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.OAuth" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.Twitter" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authorization" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authorization.Policy" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Azure.App.Services.Hosting.Startup" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Azure.App.Services.Integration" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Azure.App.Services.Site.Extension" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Buffering" Version="0.2.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Cookie.Policy" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Cors" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Cryptography.Internal" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Cryptography.Key.Derivation" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.DataProtection.Azure.Storage" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.DataProtection" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.3.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Elm" Version="0.2.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Entity.Framework.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Identity.Service" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Hosting" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Hosting.Windows.Services" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Http.Features" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Http.Overrides" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Http" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Entity.Framework.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Abstractions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Azure.Key.Vault" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Core" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Entity.Framework.Core" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Integrated.WebClient" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Mvc" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Specification.Tests" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Specification.Tests" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Json.Patch" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Localization" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Localization.Routing" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Middleware.Analysis" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Api.Explorer" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Cors" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Localization" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.Pages" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Web.Api.Compat.Shim" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Node.Services" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Node.Services.Sockets" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Owin" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Proxy" Version="0.3.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Razor.Language" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Razor" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.ResponseCaching" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.ResponseCompression" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Rewrite" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Routing" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.Http.Sys" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Session" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Spa.Services" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Test.Host" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Web.Sockets" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Web.Utilities" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNet.Identity.AspNetCore.Compat" Version="0.3.1" />
+    <PackageManagement Include="Microsoft.AspNet.Identity.Entity.Framework" Version="2.2.1" />
+    <PackageManagement Include="Microsoft.AspNet.Web.Api.Client" Version="5.2.4" />
+    <PackageManagement Include="Microsoft.Azure.Key.Vault" Version="2.3.2" />
+    <PackageManagement Include="Microsoft.Build" Version="15.6.82" />
+    <PackageManagement Include="Microsoft.Build.Runtime" Version="15.6.82" />
+    <PackageManagement Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />
+    <PackageManagement Include="Microsoft.Build.Utilities.Core" Version="15.6.82" />
+    <PackageManagement Include="Microsoft.CodeAnalysis.Common" Version="2.7.0" />
+    <PackageManagement Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
+    <PackageManagement Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.7.0" />
+    <PackageManagement Include="Microsoft.CodeAnalysis.Razor" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.CodeAnalysis.Remote.Razor" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.7.0" />
+    <PackageManagement Include="Microsoft.CSharp" Version="4.4.1" />
+    <PackageManagement Include="Microsoft.Data.Sqlite.Core" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Data.Sqlite" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Design" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.In.Memory" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Relational.Design.Specification.Tests" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Relational" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Relational.Specification.Tests" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Specification.Tests" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Sqlite.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Sqlite" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Sql.Server" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Tools.Dot.Net" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Entity.Framework.Core.Tools" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Caching.Memory" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Caching.Redis" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Caching.Sql.Config.Tools" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Caching.Sql.Server" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.Environment.Variables" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.User.Secrets" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.Xml" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageManagement Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageManagement Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
+    <PackageManagement Include="Microsoft.Extensions.Diagnostic.Adapter" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.FileProviders.Abstractions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.FileProviders.Composite" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Extensions.Identity.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Extensions.Identity.Stores" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Extensions.Localization.Abstractions" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Extensions.Localization" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.Azure.App.Services" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.Configuration" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.Event.Source" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.Trace.Source" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Object.Pool" Version="2.0.0" />
+    <PackageManagement Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Options" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
+    <PackageManagement Include="Microsoft.Extensions.Secret.Manager.Tools" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Web.Encoders" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Net.Http.Headers" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.Owin.Security.Interop" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Browser.Link" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Contracts" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Core" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Design" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Entity.Framework.Core" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Templating" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Tools" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Utils" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generators.Mvc" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.Web.Xdt.Extensions" Version="2.0.1" />
+  </ItemGroup>
 </Project>

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -10,6 +10,9 @@
       we don't need to specify a specific version (including security pathes).
     -->
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0</RuntimeFrameworkVersion>
+
+    <!-- Special case - this property is used by a DotNetCliToolReference -->
+    <DotNetXunitVersion>2.3.0-beta2-build3683</DotNetXunitVersion>
   </PropertyGroup>
   
   <ItemGroup>
@@ -17,7 +20,6 @@
     <PackageManagement Include="xunit.analyzers" Version="0.3.0" />
     <PackageManagement Include="xunit" Version="2.3.0-beta2-build3683" />
     <PackageManagement Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
-    <PackageManagement Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
     <PackageManagement Include="Fluid.Core" Version="1.0.0-beta-9442" />
     <PackageManagement Include="YesSql" Version="2.0.0-beta-1194" />
     <PackageManagement Include="YesSql.Core" Version="2.0.0-beta-1194" />

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -10,17 +10,42 @@
       we don't need to specify a specific version (including security pathes).
     -->
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0</RuntimeFrameworkVersion>
-    <TestSdkVersion>15.3.0</TestSdkVersion>
-    <XunitAnalyzers>0.3.0</XunitAnalyzers>
-    <XunitVersion>2.3.0-beta2-build3683</XunitVersion>
-    <XunitRunnerVisualStudioVersion>2.3.0-beta2-build1317</XunitRunnerVisualStudioVersion>
-    <FluidCoreVersion>1.0.0-beta-9442</FluidCoreVersion>
-    <YesSqlVersion>2.0.0-beta-1194</YesSqlVersion>
-    <YesSqlProvidersVersion>1.0.0-beta-1194</YesSqlProvidersVersion>
-    <NewtonsoftJsonVersion>10.0.3</NewtonsoftJsonVersion>
-    <OAuthValidationPackageVersion>2.0.0-rc2-final</OAuthValidationPackageVersion>
-    <OpenIddictVersion>2.0.0-rc2-final</OpenIddictVersion>
-    <LuceneNetVersion>4.8.0-beta00005</LuceneNetVersion>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageManagement Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageManagement Include="xunit.analyzers" Version="0.3.0" />
+    <PackageManagement Include="xunit" Version="2.3.0-beta2-build3683" />
+    <PackageManagement Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
+    <PackageManagement Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <PackageManagement Include="Fluid.Core" Version="1.0.0-beta-9442" />
+    <PackageManagement Include="YesSql" Version="2.0.0-beta-1194" />
+    <PackageManagement Include="YesSql.Core" Version="2.0.0-beta-1194" />
+    <PackageManagement Include="YesSql.Providers" Version="1.0.0-beta-1194" />
+    <PackageManagement Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1194" />
+    <PackageManagement Include="YesSql.Provider.SqLite" Version="1.0.0-beta-1194" />
+    <PackageManagement Include="YesSql.Provider.MySql" Version="1.0.0-beta-1194" />
+    <PackageManagement Include="YesSql.Provider.SqlServer" Version="1.0.0-beta-1194" />
+    <PackageManagement Include="Nancy" Version="2.0.0-clinteastwood" />
+    <PackageManagement Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageManagement Include="AspNet.Security.OAuth.Validation" Version="2.0.0-rc2-final" />
+    <PackageManagement Include="OpenIddict" Version="2.0.0-rc2-final" />
+    <PackageManagement Include="OpenIddict.Core" Version="2.0.0-rc2-final" />
+    <PackageManagement Include="OpenIddict.EntityFrameworkCore" Version="2.0.0-rc2-final" />
+    <PackageManagement Include="Lucene.Net" Version="4.8.0-beta00005" />
+    <PackageManagement Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00005" />
+    <PackageManagement Include="Lucene.Net.QueryParser" Version="4.8.0-beta00005" />    
+    <PackageManagement Include="YamlDotNet" Version="4.2.1" />
+    <PackageManagement Include="NLog.Web.AspNetCore" Version="4.5.0-rc2" />
+    <PackageManagement Include="Castle.Core" Version="4.1.1" />
+    <PackageManagement Include="SQLitePCLRaw.bundle_green" Version="1.1.10-*" />
+    <PackageManagement Include="Irony.Core" Version="1.0.7" />
+    <PackageManagement Include="ncrontab" Version="3.3.0" />
+    <PackageManagement Include="Jint" Version="3.0.0-beta-1138" />
+    <PackageManagement Include="Moq" Version="4.7.99" />
+    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.0-beta0003" />
+    <PackageManagement Include="Markdig" Version="0.13.1" />
+    <PackageManagement Include="WindowsAzure.Storage" Version="8.5.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Build/OrchardCore.Commons.targets
+++ b/src/OrchardCore.Build/OrchardCore.Commons.targets
@@ -11,16 +11,18 @@
            File="$(MSBuildProjectFullPath)" />
   </Target>
 
-  <Target Name="ApplyPackageManagement" BeforeTargets="CollectPackageReferences;_GenerateDotnetCliToolReferenceSpecs" DependsOnTargets="ApplyPackageManagementItems" />
+  <Target Name="ApplyPackageManagement" BeforeTargets="CollectPackageReferences" DependsOnTargets="ApplyPackageManagementItems" />
 
   <Target Name="ApplyPackageManagementItems" Inputs="@(PackageManagement)" Outputs="%(PackageManagement.Identity)">
     <PropertyGroup>
       <_PackageManagementIdentity>%(PackageManagement.Identity)</_PackageManagementIdentity>
       <_PackageManagementVersion>%(PackageManagement.Version)</_PackageManagementVersion>
     </PropertyGroup>
+    <Warning Condition=" '%(PackageReference.Identity)' == '$(_PackageManagementIdentity)' and '%(PackageReference.Version)' == '$(_PackageManagementVersion)' "
+             Text="PackageReference %(PackageReference.Identity)@%(PackageReference.Version) Version attribute is not needed" 
+             File="$(MSBuildProjectFullPath)" />
     <ItemGroup>
       <PackageReference Condition=" '%(Identity)' == '$(_PackageManagementIdentity)' " Version="$(_PackageManagementVersion)" ManagedVersion="true" />
-      <DotNetCliToolReference Condition=" '%(Identity)' == '$(_PackageManagementIdentity)' " Version="$(_PackageManagementVersion)" ManagedVersion="true" />
     </ItemGroup>
   </Target>
 

--- a/src/OrchardCore.Build/OrchardCore.Commons.targets
+++ b/src/OrchardCore.Build/OrchardCore.Commons.targets
@@ -11,4 +11,35 @@
            File="$(MSBuildProjectFullPath)" />
   </Target>
 
+  <Target Name="ApplyPackageManagement" BeforeTargets="CollectPackageReferences;_GenerateDotnetCliToolReferenceSpecs" DependsOnTargets="ApplyPackageManagementItems" />
+
+  <Target Name="ApplyPackageManagementItems" Inputs="@(PackageManagement)" Outputs="%(PackageManagement.Identity)">
+    <PropertyGroup>
+      <_PackageManagementIdentity>%(PackageManagement.Identity)</_PackageManagementIdentity>
+      <_PackageManagementVersion>%(PackageManagement.Version)</_PackageManagementVersion>
+    </PropertyGroup>
+    <ItemGroup>
+      <PackageReference Condition=" '%(Identity)' == '$(_PackageManagementIdentity)' " Version="$(_PackageManagementVersion)" ManagedVersion="true" />
+      <DotNetCliToolReference Condition=" '%(Identity)' == '$(_PackageManagementIdentity)' " Version="$(_PackageManagementVersion)" ManagedVersion="true" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="BeforePackageManagement" BeforeTargets="ApplyPackageManagement">
+    <Message Text="BeforePackageManagement: %(PackageReference.Identity)@%(PackageReference.Version)" Importance="low" />
+  </Target>
+
+  <Target Name="AfterPackageManagement" AfterTargets="ApplyPackageManagement">
+    <Message Text="AfterPackageManagement: %(PackageReference.Identity)@%(PackageReference.Version)" Importance="low" />
+
+    <ItemGroup>
+      <UnmanagedPackageReference Include="@(PackageReference)" />
+      <UnmanagedPackageReference Remove="@(UnmanagedPackageReference)" Condition=" '%(UnmanagedPackageReference.ManagedVersion)' == 'true' " />
+      <UnmanagedPackageReference Remove="@(UnmanagedPackageReference)" Condition=" '%(UnmanagedPackageReference.IsImplicitlyDefined)' == 'true' " />
+      <UnmanagedPackageReference Remove="@(UnmanagedPackageReference)" Condition=" $([System.String]::Copy('%(Identity)').StartsWith('System.')) " />
+    </ItemGroup>
+    <Warning Condition=" '@(UnmanagedPackageReference)' != '' "
+             Text="%(UnmanagedPackageReference.Identity)@%(UnmanagedPackageReference.Version) is an unmanaged PackageReference" 
+             File="$(MSBuildProjectFullPath)" />
+  </Target>
+
 </Project>

--- a/src/OrchardCore.Build/OrchardCore.Commons.targets
+++ b/src/OrchardCore.Build/OrchardCore.Commons.targets
@@ -1,0 +1,14 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="VerifyIncludeBuildOutputProperty" AfterTargets="BeforeCompile" BeforeTargets="CoreCompile">
+    <PropertyGroup>
+      <_HasCompileItems Condition=" '@(Compile)' == '' ">false</_HasCompileItems>
+      <_HasCompileItems Condition=" '@(Compile)' != '' ">true</_HasCompileItems>
+    </PropertyGroup>
+    
+    <Error Condition=" '$(_HasCompileItems)' == 'false' and '$(IncludeBuildOutput)' != 'false' " 
+           Text="Project contains no 'Compile' items. Set &lt;IncludeBuildOutput&gt;false&lt;/IncludeBuildOutput&gt; in $(MSBuildProjectFile)." 
+           File="$(MSBuildProjectFullPath)" />
+  </Target>
+
+</Project>

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" />
 
     <!-- This reference is necessary for view precompilation to work on publish -->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="$(MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion)" PrivateAssets="All" />

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore" />
 
     <!-- This reference is necessary for view precompilation to work on publish -->
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="$(MicrosoftAspNetCoreMvcRazorViewCompilationPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Necessary as we reference the Project and not the Package -->

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -30,5 +30,6 @@
   <!-- Necessary as we reference the Project and not the Package -->
   <Import Project="..\OrchardCore\OrchardCore.Application.Cms.Targets\OrchardCore.Application.Cms.Targets.targets" />
   <Import Project="..\OrchardCore\OrchardCore.Application.Targets\OrchardCore.Application.Targets.targets" />
+  <Import Project="..\OrchardCore.Build\OrchardCore.Commons.targets" />
 
 </Project>

--- a/src/OrchardCore.Modules/Directory.Build.props
+++ b/src/OrchardCore.Modules/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <Import Project="..\OrchardCore.Build\OrchardCore.Commons.props" />
   <Import Project="..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 

--- a/src/OrchardCore.Modules/Directory.Build.targets
+++ b/src/OrchardCore.Modules/Directory.Build.targets
@@ -1,4 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="..\OrchardCore.Build\OrchardCore.Commons.targets" />
   <Import Project="..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.targets" />
 
   <PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Admin/OrchardCore.Admin.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/OrchardCore.Admin.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Antiforgery/OrchardCore.Antiforgery.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Antiforgery/OrchardCore.Antiforgery.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="$(MicrosoftAspNetCoreAntiforgeryPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Authentication/OrchardCore.Authentication.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Authentication/OrchardCore.Authentication.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="$(MicrosoftAspNetCoreAuthenticationPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Commons/OrchardCore.Commons.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Commons/OrchardCore.Commons.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/OrchardCore.ContentFields.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/OrchardCore.ContentFields.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/OrchardCore.ContentPreview.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/OrchardCore.ContentPreview.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/OrchardCore.ContentTypes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/OrchardCore.ContentTypes.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/OrchardCore.Contents.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/OrchardCore.Contents.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.DataProtection/OrchardCore.DataProtection.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection/OrchardCore.DataProtection.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="$(MicrosoftAspNetCoreDataProtectionPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Demo/OrchardCore.Demo.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/OrchardCore.Demo.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/OrchardCore.Deployment.Remote.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/OrchardCore.Deployment.Remote.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/OrchardCore.Deployment.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/OrchardCore.Deployment.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Diagnostics.Elm/OrchardCore.Diagnostics.Elm.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Diagnostics.Elm/OrchardCore.Diagnostics.Elm.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Elm" Version="$(MicrosoftAspNetCoreDiagnosticsElmPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.Elm" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Diagnostics/OrchardCore.Diagnostics.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Diagnostics/OrchardCore.Diagnostics.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="$(MicrosoftAspNetCoreDiagnosticsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/OrchardCore.DynamicCache.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/OrchardCore.DynamicCache.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 

--- a/src/OrchardCore.Modules/OrchardCore.Feeds/OrchardCore.Feeds.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Feeds/OrchardCore.Feeds.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="$(MicrosoftAspNetCoreMvcAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Https/OrchardCore.Https.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Https/OrchardCore.Https.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="$(MicrosoftAspNetCoreRewritePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Rewrite" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/OrchardCore.Indexing.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/OrchardCore.Indexing.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/OrchardCore.Liquid.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/OrchardCore.Liquid.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluid.Core" Version="$(FluidCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Fluid.Core" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Lists/OrchardCore.Lists.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/OrchardCore.Lists.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="$(MicrosoftAspNetCoreMvcLocalizationPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lucene.Net.Analysis.Common" Version="$(LuceneNetVersion)" />
-    <PackageReference Include="Lucene.Net.QueryParser" Version="$(LuceneNetVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Lucene.Net.Analysis.Common" />
+    <PackageReference Include="Lucene.Net.QueryParser" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.13.1" />
+    <PackageReference Include="Markdig" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.13.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="$(MicrosoftAspNetCoreMvcTagHelpersPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.0-beta0003" />
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="SixLabors.ImageSharp.Web" Version="1.0.0-beta0003" />
+    <PackageReference Include="SixLabors.ImageSharp.Web" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/OrchardCore.Menu.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/OrchardCore.Menu.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Nancy.HelloWorld/OrchardCore.Nancy.HelloWorld.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Nancy.HelloWorld/OrchardCore.Nancy.HelloWorld.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
+    <PackageReference Include="Nancy" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/OrchardCore.Navigation.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/OrchardCore.Navigation.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/OrchardCore.OpenId.EntityFrameworkCore.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId.EntityFrameworkCore/OrchardCore.OpenId.EntityFrameworkCore.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="$(OpenIddictVersion)" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -21,9 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNet.Security.OAuth.Validation" Version="$(OAuthValidationPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(MicrosoftAspNetCoreAuthenticationJwtBearerPackageVersion)" />
-    <PackageReference Include="OpenIddict" Version="$(OpenIddictVersion)" />
+    <PackageReference Include="AspNet.Security.OAuth.Validation" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="OpenIddict" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Irony.Core" Version="1.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Irony.Core" Version="1.0.7" />
+    <PackageReference Include="Irony.Core" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.ResponseCache/OrchardCore.ResponseCache.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ResponseCache/OrchardCore.ResponseCache.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" Version="$(MicrosoftAspNetCoreResponseCachingPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.ResponseCaching" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Roles/OrchardCore.Roles.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/OrchardCore.Roles.csproj
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="$(MicrosoftAspNetCoreIdentityPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Scripting/OrchardCore.Scripting.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Scripting/OrchardCore.Scripting.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Settings/OrchardCore.Settings.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/OrchardCore.Settings.csproj
@@ -17,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Setup/OrchardCore.Setup.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/OrchardCore.Setup.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="$(MicrosoftAspNetCoreIdentityPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/OrchardCore.Templates.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/OrchardCore.Templates.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="$(MicrosoftExtensionsLocalizationPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/OrchardCore.Tenants.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/OrchardCore.Tenants.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/OrchardCore.Themes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/OrchardCore.Themes.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Title/OrchardCore.Title.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Title/OrchardCore.Title.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="$(MicrosoftAspNetCoreIdentityPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
@@ -24,9 +24,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="ncrontab" Version="3.3.0" />
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
-    <PackageReference Include="ncrontab" Version="3.3.0" />
+    <PackageReference Include="ncrontab" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.XmlRpc/OrchardCore.XmlRpc.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.XmlRpc/OrchardCore.XmlRpc.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="$(MicrosoftAspNetCoreMvcFormattersXmlPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
+++ b/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
@@ -23,15 +23,15 @@
   <ItemGroup>
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="$(MicrosoftAspNetCoreServerIISIntegrationPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="$(MicrosoftAspNetCoreDiagnosticsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
   </ItemGroup>
 
   <Import Project="..\OrchardCore.Build\OrchardCore.Commons.targets" />

--- a/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
+++ b/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
@@ -34,4 +34,6 @@
     <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
   </ItemGroup>
 
+  <Import Project="..\OrchardCore.Build\OrchardCore.Commons.targets" />
+
 </Project>

--- a/src/OrchardCore.Nancy.Web/OrchardCore.Nancy.Web.csproj
+++ b/src/OrchardCore.Nancy.Web/OrchardCore.Nancy.Web.csproj
@@ -22,12 +22,12 @@
   <ItemGroup>
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(MicrosoftAspNetCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="$(MicrosoftAspNetCoreServerIISIntegrationPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="$(MicrosoftAspNetCoreDiagnosticsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/OrchardCore.Nancy.Web/OrchardCore.Nancy.Web.csproj
+++ b/src/OrchardCore.Nancy.Web/OrchardCore.Nancy.Web.csproj
@@ -31,4 +31,6 @@
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
 
+  <Import Project="..\OrchardCore.Build\OrchardCore.Commons.targets" />
+
 </Project>

--- a/src/OrchardCore.Themes/Directory.Build.props
+++ b/src/OrchardCore.Themes/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <Import Project="..\OrchardCore.Build\OrchardCore.Commons.props" />
   <Import Project="..\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.props" />
   <Import Project="..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />

--- a/src/OrchardCore.Themes/Directory.Build.targets
+++ b/src/OrchardCore.Themes/Directory.Build.targets
@@ -1,4 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Import Project="..\OrchardCore.Build\OrchardCore.Commons.targets" />
   <Import Project="..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.targets" />
 
   <PropertyGroup>

--- a/src/OrchardCore.Themes/SafeMode/SafeMode.csproj
+++ b/src/OrchardCore.Themes/SafeMode/SafeMode.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="$(MicrosoftAspNetCoreMvcTagHelpersPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj
+++ b/src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="$(MicrosoftAspNetCoreMvcTagHelpersPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
+++ b/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="$(MicrosoftAspNetCoreMvcTagHelpersPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Themes/TheBlogTheme/TheBlogTheme.csproj
+++ b/src/OrchardCore.Themes/TheBlogTheme/TheBlogTheme.csproj
@@ -24,8 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Themes/TheTheme/TheTheme.csproj
+++ b/src/OrchardCore.Themes/TheTheme/TheTheme.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/Directory.Build.props
+++ b/src/OrchardCore/Directory.Build.props
@@ -1,4 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
   <Import Project="..\OrchardCore.Build\OrchardCore.Commons.props" />
 
   <PropertyGroup>

--- a/src/OrchardCore/Directory.Build.targets
+++ b/src/OrchardCore/Directory.Build.targets
@@ -1,5 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <Import Project="..\OrchardCore.Build\OrchardCore.Commons.targets" />
+
   <PropertyGroup>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/OrchardCore.Admin.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/OrchardCore.Admin.Abstractions.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="$(MicrosoftAspNetCoreMvcAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCorePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
 
     <!-- Prevent package version downgrade errors, https://github.com/OrchardCMS/OrchardCore/issues/1535  -->
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/OrchardCore.Admin.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/OrchardCore.Admin.Abstractions.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
 
     <!-- Prevent package version downgrade errors, https://github.com/OrchardCMS/OrchardCore/issues/1535  -->
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/src/OrchardCore/OrchardCore.Application.Mvc.Targets/OrchardCore.Application.Mvc.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Mvc.Targets/OrchardCore.Application.Mvc.Targets.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IgnorePackageAssets>true</IgnorePackageAssets>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
   <!--

--- a/src/OrchardCore/OrchardCore.Application.Nancy.Targets/OrchardCore.Application.Nancy.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Nancy.Targets/OrchardCore.Application.Nancy.Targets.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IgnorePackageAssets>true</IgnorePackageAssets>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
   <!--

--- a/src/OrchardCore/OrchardCore.BackgroundTasks/OrchardCore.BackgroundTasks.csproj
+++ b/src/OrchardCore/OrchardCore.BackgroundTasks/OrchardCore.BackgroundTasks.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/OrchardCore.ContentManagement.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/OrchardCore.ContentManagement.Abstractions.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="$(MicrosoftAspNetCoreHtmlAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="$(MicrosoftAspNetCoreRoutingAbstractionsPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.ContentManagement/OrchardCore.ContentManagement.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement/OrchardCore.ContentManagement.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="$(MicrosoftAspNetCoreHtmlAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="$(MicrosoftAspNetCoreMvcDataAnnotationsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/OrchardCore.ContentTypes.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/OrchardCore.ContentTypes.Abstractions.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="YesSql.Core" Version="$(YesSqlVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="YesSql.Core" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Data/OrchardCore.Data.csproj
+++ b/src/OrchardCore/OrchardCore.Data/OrchardCore.Data.csproj
@@ -22,7 +22,7 @@
 
     <!-- Upgrade to a specific version of sqlite to allow for "-r winx64" to be used -->
     <!-- c.f. https://github.com/ericsink/SQLitePCL.raw/issues/194 -->
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="1.1.10-*" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Data/OrchardCore.Data.csproj
+++ b/src/OrchardCore/OrchardCore.Data/OrchardCore.Data.csproj
@@ -12,13 +12,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="YesSql.Provider.SqlServer" Version="$(YesSqlProvidersVersion)" />
-    <PackageReference Include="YesSql.Provider.MySql" Version="$(YesSqlProvidersVersion)" />
-    <PackageReference Include="YesSql.Provider.SqLite" Version="$(YesSqlProvidersVersion)" />
-    <PackageReference Include="YesSql.Provider.PostgreSql" Version="$(YesSqlProvidersVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="YesSql.Provider.SqlServer" />
+    <PackageReference Include="YesSql.Provider.MySql" />
+    <PackageReference Include="YesSql.Provider.SqLite" />
+    <PackageReference Include="YesSql.Provider.PostgreSql" />
 
     <!-- Upgrade to a specific version of sqlite to allow for "-r winx64" to be used -->
     <!-- c.f. https://github.com/ericsink/SQLitePCL.raw/issues/194 -->

--- a/src/OrchardCore/OrchardCore.DeferredTasks/OrchardCore.DeferredTasks.csproj
+++ b/src/OrchardCore/OrchardCore.DeferredTasks/OrchardCore.DeferredTasks.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(MicrosoftAspNetCoreHttpAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Deployment.Abstractions/OrchardCore.Deployment.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Deployment.Abstractions/OrchardCore.Deployment.Abstractions.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Deployment.Core/OrchardCore.Deployment.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Deployment.Core/OrchardCore.Deployment.Core.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCore.DisplayManagement.Liquid.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCore.DisplayManagement.Liquid.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
@@ -14,9 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="$(MicrosoftAspNetCoreHtmlAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="$(MicrosoftAspNetCoreMvcLocalizationPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
   </ItemGroup>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.1.1" />
+    <PackageReference Include="Castle.Core" />
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
   </ItemGroup>

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="$(MicrosoftExtensionsLocalizationPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Entities/OrchardCore.Entities.csproj
+++ b/src/OrchardCore/OrchardCore.Entities/OrchardCore.Entities.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Entities/OrchardCore.Entities.csproj
+++ b/src/OrchardCore/OrchardCore.Entities/OrchardCore.Entities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Environment.Cache.Abstractions/OrchardCore.Environment.Cache.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Cache.Abstractions/OrchardCore.Environment.Cache.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(MicrosoftExtensionsPrimitivesPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Environment.Cache/OrchardCore.Environment.Cache.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Cache/OrchardCore.Environment.Cache.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="$(MicrosoftAspNetCoreHttpAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Environment.Commands/OrchardCore.Environment.Commands.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Commands/OrchardCore.Environment.Commands.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/OrchardCore.Environment.Extensions.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions.Abstractions/OrchardCore.Environment.Extensions.Abstractions.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Environment.Extensions/OrchardCore.Environment.Extensions.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions/OrchardCore.Environment.Extensions.csproj
@@ -14,9 +14,9 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Environment.Navigation/OrchardCore.Environment.Navigation.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Navigation/OrchardCore.Environment.Navigation.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="$(MicrosoftAspNetCoreRoutingPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Environment.Shell.Abstractions/OrchardCore.Environment.Shell.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Shell.Abstractions/OrchardCore.Environment.Shell.Abstractions.csproj
@@ -10,11 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Environment.Shell/OrchardCore.Environment.Shell.csproj
+++ b/src/OrchardCore/OrchardCore.Environment.Shell/OrchardCore.Environment.Shell.csproj
@@ -14,13 +14,13 @@
 
   <ItemGroup>
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(MicrosoftExtensionsConfigurationJsonPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="$(MicrosoftExtensionsConfigurationXmlPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Feeds.Abstractions/OrchardCore.Feeds.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Feeds.Abstractions/OrchardCore.Feeds.Abstractions.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="$(MicrosoftAspNetCoreMvcAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Feeds.Core/OrchardCore.Feeds.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Feeds.Core/OrchardCore.Feeds.Core.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
+    <PackageReference Include="WindowsAzure.Storage" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.FileStorage.FileSystem/OrchardCore.FileStorage.FileSystem.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.FileSystem/OrchardCore.FileStorage.FileSystem.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.0.1" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Hosting.Console/OrchardCore.Hosting.Console.csproj
+++ b/src/OrchardCore/OrchardCore.Hosting.Console/OrchardCore.Hosting.Console.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="$(MicrosoftAspNetCoreHostingPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Liquid.Abstractions/OrchardCore.Liquid.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Liquid.Abstractions/OrchardCore.Liquid.Abstractions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluid.Core" Version="$(FluidCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
+    <PackageReference Include="Fluid.Core" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCore.Localization.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCore.Localization.Abstractions.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="$(MicrosoftAspNetCoreMvcLocalizationPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Localization" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Localization.Core/OrchardCore.Localization.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Localization.Core/OrchardCore.Localization.Core.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="$(MicrosoftExtensionsLocalizationPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Logging.NLog/OrchardCore.Logging.NLog.csproj
+++ b/src/OrchardCore/OrchardCore.Logging.NLog/OrchardCore.Logging.NLog.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.5.0-rc2" />
+    <PackageReference Include="NLog.Web.AspNetCore" />
 
     <!-- Used to fix conflicting referenced versions -->
     <PackageReference Include="System.Security.AccessControl" Version="4.4.0" />

--- a/src/OrchardCore/OrchardCore.Lucene.Abstractions/OrchardCore.Lucene.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Lucene.Abstractions/OrchardCore.Lucene.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="Lucene.Net" Version="$(LuceneNetVersion)" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Lucene.Net" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore/OrchardCore.Lucene.Core/OrchardCore.Lucene.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Lucene.Core/OrchardCore.Lucene.Core.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
-    <PackageReference Include="Lucene.Net.QueryParser" Version="$(LuceneNetVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="Lucene.Net.QueryParser" />
     <ProjectReference Include="..\OrchardCore.Lucene.Abstractions\OrchardCore.Lucene.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.Queries.Abstractions\OrchardCore.Queries.Abstractions.csproj" />
   </ItemGroup>

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/OrchardCore.Modules.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/OrchardCore.Modules.Abstractions.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="$(MicrosoftAspNetCoreRoutingPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftAspNetCoreHostingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(MicrosoftExtensionsConfigurationAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Modules/OrchardCore.Modules.csproj
+++ b/src/OrchardCore/OrchardCore.Modules/OrchardCore.Modules.csproj
@@ -11,14 +11,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="$(MicrosoftAspNetCoreHttpPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />    
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="$(MicrosoftExtensionsFileProvidersCompositePackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="$(MicrosoftExtensionsLocalizationPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />    
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Mvc.Abstractions/OrchardCore.Mvc.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Mvc.Abstractions/OrchardCore.Mvc.Abstractions.csproj
@@ -11,9 +11,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCorePackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="$(MicrosoftAspNetCoreMvcRazorPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Mvc.Core/OrchardCore.Mvc.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/OrchardCore.Mvc.Core.csproj
@@ -13,13 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(MicrosoftAspNetCoreMvcPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="$(MicrosoftAspNetCoreRoutingPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(MicrosoftExtensionsFileProvidersEmbeddedPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Nancy.Core/OrchardCore.Nancy.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Nancy.Core/OrchardCore.Nancy.Core.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="$(MicrosoftAspNetCoreOwinPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Owin" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Nancy.Core/OrchardCore.Nancy.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Nancy.Core/OrchardCore.Nancy.Core.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Owin" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
+    <PackageReference Include="Nancy" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.OpenId.Core.EntityFrameworkCore/OrchardCore.OpenId.Core.EntityFrameworkCore.csproj
+++ b/src/OrchardCore/OrchardCore.OpenId.Core.EntityFrameworkCore/OrchardCore.OpenId.Core.EntityFrameworkCore.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="$(OpenIddictVersion)" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.OpenId.Core/OrchardCore.OpenId.Core.csproj
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/OrchardCore.OpenId.Core.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenIddict.Core" Version="$(OpenIddictVersion)" />
+    <PackageReference Include="OpenIddict.Core" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Parser.Yaml/OrchardCore.Parser.Yaml.csproj
+++ b/src/OrchardCore/OrchardCore.Parser.Yaml/OrchardCore.Parser.Yaml.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
-    <PackageReference Include="YamlDotNet" Version="4.2.1" />
+    <PackageReference Include="YamlDotNet" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Parser.Yaml/OrchardCore.Parser.Yaml.csproj
+++ b/src/OrchardCore/OrchardCore.Parser.Yaml/OrchardCore.Parser.Yaml.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsConfigurationPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="$(MicrosoftExtensionsConfigurationFileExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" />
     <PackageReference Include="YamlDotNet" Version="4.2.1" />
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Queries.Abstractions/OrchardCore.Queries.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Queries.Abstractions/OrchardCore.Queries.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/OrchardCore.Recipes.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/OrchardCore.Recipes.Abstractions.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(MicrosoftExtensionsOptionsPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Recipes.Implementations/OrchardCore.Recipes.Implementations.csproj
+++ b/src/OrchardCore/OrchardCore.Recipes.Implementations/OrchardCore.Recipes.Implementations.csproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftExtensionsHostingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(MicrosoftExtensionsDependencyInjectionAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/OrchardCore.ResourceManagement.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/OrchardCore.ResourceManagement.Abstractions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="$(MicrosoftAspNetCoreMvcViewFeaturesPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="$(MicrosoftAspNetCoreRazorRuntimePackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Runtime" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Scripting.Abstractions/OrchardCore.Scripting.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Scripting.Abstractions/OrchardCore.Scripting.Abstractions.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(MicrosoftExtensionsFileProvidersAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Scripting.Core/OrchardCore.Scripting.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Scripting.Core/OrchardCore.Scripting.Core.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/OrchardCore.Scripting.JavaScript.csproj
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/OrchardCore.Scripting.JavaScript.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jint" Version="3.0.0-beta-1138" />
+    <PackageReference Include="Jint" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
   </ItemGroup>

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/OrchardCore.Scripting.JavaScript.csproj
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/OrchardCore.Scripting.JavaScript.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Jint" Version="3.0.0-beta-1138" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="$(MicrosoftExtensionsCachingAbstractionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Security.Abstractions/OrchardCore.Security.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Security.Abstractions/OrchardCore.Security.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="$(MicrosoftAspNetCoreIdentityPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Security/OrchardCore.Security.csproj
+++ b/src/OrchardCore/OrchardCore.Security/OrchardCore.Security.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Security/OrchardCore.Security.csproj
+++ b/src/OrchardCore/OrchardCore.Security/OrchardCore.Security.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="$(MicrosoftAspNetCoreAuthorizationPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
   <!-- Add a ".props" file in the package specific to the "Theme" module type -->

--- a/src/OrchardCore/OrchardCore.Users.Core/OrchardCore.Users.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Users.Core/OrchardCore.Users.Core.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="$(MicrosoftAspNetCoreIdentityPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="$(MicrosoftExtensionsLocalizationAbstractionsPackageVersion)" />
-    <PackageReference Include="YesSql.Core" Version="$(YesSqlVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="YesSql.Core" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/OrchardCore.Workflows.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/OrchardCore.Workflows.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/OrchardCore.XmlRpc.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/OrchardCore.XmlRpc.Abstractions.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
 
     <!-- Prevent package version downgrade errors, https://github.com/OrchardCMS/OrchardCore/issues/1535  -->
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" />
     <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/OrchardCore.XmlRpc.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/OrchardCore.XmlRpc.Abstractions.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="$(MicrosoftAspNetCoreMvcCorePackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
 
     <!-- Prevent package version downgrade errors, https://github.com/OrchardCMS/OrchardCore/issues/1535  -->
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -78,12 +78,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Moq" Version="4.7.99" />
-    <PackageReference Include="xunit" Version="$(XunitVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)" />
-    <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzers)" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="xunit.analyzers" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="$(DotNetXunitVersion)" />
   </ItemGroup>
 

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -91,4 +91,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <Import Project="..\..\src\OrchardCore.Build\OrchardCore.Commons.targets" />
+
 </Project>

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -80,7 +80,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit.analyzers" />

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -84,7 +84,7 @@
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualStudioVersion)" />
     <PackageReference Include="xunit.analyzers" Version="$(XunitAnalyzers)" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="$(XunitVersion)" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="$(DotNetXunitVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Uses an ItemGroup instead of a PropertyGroup

Assigns Version attributes automatically when a `<PackageReference Include="X" />` matches a `<PackageManagement Include="X" />` item.

The Version attribute is optional at that point. In this PR they are removed.

You don't need to hand-edit csproj Version attributes anymore. If you add a PackageReference that has the wrong version, then that version will be overridden.
