### PR TITLE
Package management cleanup

### DIFF
--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -36,7 +36,6 @@
     <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Elm" Version="0.2.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Identity.Service" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Hosting" Version="2.0.2" />
@@ -50,16 +49,8 @@
     <PackageManagement Include="Microsoft.AspNetCore.Http" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Abstractions" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.AzureKeyVault" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Core" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.IntegratedWebClient" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Mvc" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Specification.Tests" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity.Specification.Tests" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.JsonPatch" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.JsonPatch" Version="2.0.0" />
     <PackageManagement Include="Microsoft.AspNetCore.Localization" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Localization.Routing" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="2.0.2" />
@@ -80,9 +71,7 @@
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.NodeServices" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.AspNetCore.NodeServices.Sockets" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Owin" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Proxy" Version="0.3.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Razor.Language" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Razor" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Razor.Runtime" Version="2.0.2" />
@@ -99,7 +88,6 @@
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Session" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.SpaServices" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.2" />
@@ -118,8 +106,6 @@
     <PackageManagement Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
     <PackageManagement Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.7.0" />
     <PackageManagement Include="Microsoft.CodeAnalysis.Razor" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.CodeAnalysis.Razor.Workspaces" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.CodeAnalysis.Remote.Razor" Version="2.0.1" />
     <PackageManagement Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="2.7.0" />
     <PackageManagement Include="Microsoft.CSharp" Version="4.4.1" />
     <PackageManagement Include="Microsoft.Data.Sqlite.Core" Version="2.0.1" />
@@ -193,6 +179,5 @@
     <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
     <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.0.3" />
     <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGenerators.Mvc" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.Web.XdtExtensions" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -92,7 +92,7 @@
     <PackageManagement Include="Microsoft.AspNetCore.Rewrite" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Routing" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.2" />

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -1,11 +1,11 @@
 <Project>
   <ItemGroup>
     <PackageManagement Include="Libuv" Version="1.10.0" />
-    <PackageManagement Include="Microsoft.Application.Insights.AspNetCore" Version="2.2.1" />
+    <PackageManagement Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.2.1" />
     <PackageManagement Include="Microsoft.AspNetCore" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.All" Version="2.0.6" />
     <PackageManagement Include="Microsoft.AspNetCore.Antiforgery" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Application.Insights.Hosting.Startup" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Core" Version="2.0.2" />
@@ -19,52 +19,52 @@
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Twitter" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Authorization" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Authorization.Policy" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.AspNetCore.Azure.App.Services.Hosting.Startup" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Azure.App.Services.Integration" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Azure.App.Services.Site.Extension" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.AzureAppServices.SiteExtension" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Buffering" Version="0.2.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Cookie.Policy" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.CookiePolicy" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Cors" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Cryptography.Internal" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Cryptography.Key.Derivation" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.DataProtection.Azure.Storage" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.DataProtection" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.3.2" />
     <PackageManagement Include="Microsoft.AspNetCore.DataProtection.SystemWeb" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Elm" Version="0.2.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Entity.Framework.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Diagnostics.Identity.Service" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Hosting" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Hosting.Windows.Services" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Http.Extensions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Http.Features" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Http.Overrides" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.HttpOverrides" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Http" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Entity.Framework.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Abstractions" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Azure.Key.Vault" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.AzureKeyVault" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Core" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Entity.Framework.Core" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Integrated.WebClient" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.EntityFrameworkCore" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.IntegratedWebClient" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Mvc" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity.Service" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity.Service.Specification.Tests" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Identity.Specification.Tests" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.AspNetCore.Json.Patch" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.JsonPatch" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Localization" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Localization.Routing" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Middleware.Analysis" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.MiddlewareAnalysis" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Api.Explorer" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Cors" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="2.0.3" />
@@ -74,13 +74,13 @@
     <PackageManagement Include="Microsoft.AspNetCore.Mvc" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.Pages" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.AspNetCore.Mvc.Web.Api.Compat.Shim" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.AspNetCore.Node.Services" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.AspNetCore.Node.Services.Sockets" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.NodeServices" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.NodeServices.Sockets" Version="2.0.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Owin" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Proxy" Version="0.3.1" />
     <PackageManagement Include="Microsoft.AspNetCore.Razor.Language" Version="2.0.2" />
@@ -92,7 +92,7 @@
     <PackageManagement Include="Microsoft.AspNetCore.Rewrite" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Routing.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Routing" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Server.Http.Sys" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.Server.HttpSys" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.0.2" />
@@ -101,15 +101,15 @@
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.0.2" />
     <PackageManagement Include="Microsoft.AspNetCore.Session" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Spa.Services" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.AspNetCore.SpaServices" Version="2.0.3" />
     <PackageManagement Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Test.Host" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Web.Sockets" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNetCore.Web.Utilities" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.AspNet.Identity.AspNetCore.Compat" Version="0.3.1" />
-    <PackageManagement Include="Microsoft.AspNet.Identity.Entity.Framework" Version="2.2.1" />
-    <PackageManagement Include="Microsoft.AspNet.Web.Api.Client" Version="5.2.4" />
-    <PackageManagement Include="Microsoft.Azure.Key.Vault" Version="2.3.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.TestHost" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.WebSockets" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNetCore.WebUtilities" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.AspNet.Identity.AspNetCoreCompat" Version="0.3.1" />
+    <PackageManagement Include="Microsoft.AspNet.Identity.EntityFramework" Version="2.2.1" />
+    <PackageManagement Include="Microsoft.AspNet.WebApi.Client" Version="5.2.4" />
+    <PackageManagement Include="Microsoft.Azure.KeyVault" Version="2.3.2" />
     <PackageManagement Include="Microsoft.Build" Version="15.6.82" />
     <PackageManagement Include="Microsoft.Build.Runtime" Version="15.6.82" />
     <PackageManagement Include="Microsoft.Build.Tasks.Core" Version="15.6.82" />
@@ -125,38 +125,38 @@
     <PackageManagement Include="Microsoft.Data.Sqlite.Core" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Data.Sqlite" Version="2.0.1" />
     <PackageManagement Include="Microsoft.DotNet.Watcher.Tools" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Design" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.In.Memory" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Relational.Design.Specification.Tests" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Relational" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Relational.Specification.Tests" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Specification.Tests" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Sqlite.Core" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Sqlite" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Sql.Server" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Tools.Dot.Net" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.Entity.Framework.Core.Tools" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Relational" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Relational.Specification.Tests" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Specification.Tests" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.2" />
     <PackageManagement Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Caching.Memory" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Caching.Redis" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Caching.Sql.Config.Tools" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Caching.Sql.Server" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Caching.SqlConfig.Tools" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Caching.SqlServer" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Configuration.Environment.Variables" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration.Ini" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Configuration.User.Secrets" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Configuration.Xml" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageManagement Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
     <PackageManagement Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
-    <PackageManagement Include="Microsoft.Extensions.Diagnostic.Adapter" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.DiagnosticAdapter" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.FileProviders.Abstractions" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.FileProviders.Composite" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.0.1" />
@@ -168,31 +168,31 @@
     <PackageManagement Include="Microsoft.Extensions.Localization.Abstractions" Version="2.0.2" />
     <PackageManagement Include="Microsoft.Extensions.Localization" Version="2.0.2" />
     <PackageManagement Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Logging.Azure.App.Services" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.AzureAppServices" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Logging.Configuration" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Logging.Console" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Logging.Debug" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Logging.Event.Source" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.EventSource" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Logging" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Logging.Trace.Source" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Object.Pool" Version="2.0.0" />
+    <PackageManagement Include="Microsoft.Extensions.Logging.TraceSource" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.ObjectPool" Version="2.0.0" />
     <PackageManagement Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Options" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
-    <PackageManagement Include="Microsoft.Extensions.Secret.Manager.Tools" Version="2.0.1" />
-    <PackageManagement Include="Microsoft.Extensions.Web.Encoders" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.Extensions.WebEncoders" Version="2.0.1" />
     <PackageManagement Include="Microsoft.Net.Http.Headers" Version="2.0.2" />
     <PackageManagement Include="Microsoft.Owin.Security.Interop" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Browser.Link" Version="2.0.2" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Contracts" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Core" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Design" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Entity.Framework.Core" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Templating" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Tools" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generation.Utils" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.VisualStudio.Web.Code.Generators.Mvc" Version="2.0.3" />
-    <PackageManagement Include="Microsoft.Web.Xdt.Extensions" Version="2.0.1" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.2" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Contracts" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Core" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Templating" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGenerators.Mvc" Version="2.0.3" />
+    <PackageManagement Include="Microsoft.Web.XdtExtensions" Version="2.0.1" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -21,9 +21,8 @@
     <PackageManagement Include="xunit" Version="2.3.0-beta2-build3683" />
     <PackageManagement Include="xunit.runner.visualstudio" Version="2.3.0-beta2-build1317" />
     <PackageManagement Include="Fluid.Core" Version="1.0.0-beta-9442" />
-    <PackageManagement Include="YesSql" Version="2.0.0-beta-1194" />
+    <PackageManagement Include="YesSql.Abstractions" Version="2.0.0-beta-1194" />
     <PackageManagement Include="YesSql.Core" Version="2.0.0-beta-1194" />
-    <PackageManagement Include="YesSql.Providers" Version="1.0.0-beta-1194" />
     <PackageManagement Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1194" />
     <PackageManagement Include="YesSql.Provider.SqLite" Version="1.0.0-beta-1194" />
     <PackageManagement Include="YesSql.Provider.MySql" Version="1.0.0-beta-1194" />


### PR DESCRIPTION
Some package name verification found that for a lot of names for transitive references had incorrect dots. It's not a restore or build error because they're not currently used - but this change corrects them in case they are added in the future.
