### PR TITLE
Adjusting build warnings

### DIFF
--- a/src/OrchardCore.Build/OrchardCore.Commons.targets
+++ b/src/OrchardCore.Build/OrchardCore.Commons.targets
@@ -2,13 +2,13 @@
 
   <Target Name="VerifyIncludeBuildOutputProperty" AfterTargets="BeforeCompile" BeforeTargets="CoreCompile">
     <PropertyGroup>
-      <_HasCompileItems Condition=" '@(Compile)' == '' ">false</_HasCompileItems>
-      <_HasCompileItems Condition=" '@(Compile)' != '' ">true</_HasCompileItems>
+      <_IsEmptyAssembly Condition=" '@(Compile)' == '' and  '@(EmbeddedResource)' == '' ">true</_IsEmptyAssembly>
     </PropertyGroup>
     
-    <Error Condition=" '$(_HasCompileItems)' == 'false' and '$(IncludeBuildOutput)' != 'false' " 
-           Text="Project contains no 'Compile' items. Set &lt;IncludeBuildOutput&gt;false&lt;/IncludeBuildOutput&gt; in $(MSBuildProjectFile)." 
-           File="$(MSBuildProjectFullPath)" />
+    <Warning Condition=" '$(_IsEmptyAssembly)' == 'true' and '$(IncludeBuildOutput)' != 'false' " 
+             Code="OC2001"
+             Text="Project contains no 'Compile' or 'EmbeddedResource' items. Set &lt;IncludeBuildOutput&gt;false&lt;/IncludeBuildOutput&gt; in $(MSBuildProjectFile)." 
+             File="$(MSBuildProjectFullPath)" />
   </Target>
 
   <Target Name="ApplyPackageManagement" BeforeTargets="CollectPackageReferences" DependsOnTargets="ApplyPackageManagementItems" />
@@ -19,6 +19,7 @@
       <_PackageManagementVersion>%(PackageManagement.Version)</_PackageManagementVersion>
     </PropertyGroup>
     <Warning Condition=" '%(PackageReference.Identity)' == '$(_PackageManagementIdentity)' and '%(PackageReference.Version)' == '$(_PackageManagementVersion)' "
+             Code="OC2002"
              Text="PackageReference %(PackageReference.Identity)@%(PackageReference.Version) Version attribute is not needed" 
              File="$(MSBuildProjectFullPath)" />
     <ItemGroup>
@@ -40,6 +41,7 @@
       <UnmanagedPackageReference Remove="@(UnmanagedPackageReference)" Condition=" $([System.String]::Copy('%(Identity)').StartsWith('System.')) " />
     </ItemGroup>
     <Warning Condition=" '@(UnmanagedPackageReference)' != '' "
+             Code="OC2003"
              Text="%(UnmanagedPackageReference.Identity)@%(UnmanagedPackageReference.Version) is an unmanaged PackageReference" 
              File="$(MSBuildProjectFullPath)" />
   </Target>


### PR DESCRIPTION
* Changes error to warning because it's not necessarily fatal
* Does not warn if assembly has no code but contains embedded resources
* Adds a message code to suppress with nowarn:OC2001 if needed
* Adds a message code to the other PackageReference warnings in the file