### PR TITLE
Adds alternate and wrapper attributes to the BaseShapeTagHelper.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -403,10 +403,21 @@ Sets the type of a shape.
 
 Input
 ```liquid
-{% shape_type my_shape "Summary" %}
+{% shape_type my_shape "MyType" %}
 ```
 
 Whenever the type is changed, it is recommended to clear the shape alternates before using the `shape_clear_alternates` tag.
+
+### shape_display_type
+
+Sets the display type of a shape.
+
+Input
+```liquid
+{% shape_display_type my_shape "Summary" %}
+```
+
+Whenever the display type is changed, it is recommended to clear the shape alternates before.
 
 ### shape_position
 
@@ -468,6 +479,11 @@ Input
 ```liquid
 {% shape "menu", alias: "alias:main-menu", cache_id: "main-menu", cache_duration: "00:05:00", cache_tag: "alias:main-menu" %}
 ```
+When using the shape tag a specific wrapper and / or alternate can be specified.
+
+```liquid
+{% shape "menu", alias: "alias:main-menu", alternate: "Menu_Footer" %}
+```
 
 ### zone
 
@@ -508,7 +524,7 @@ Invokes the `style` tag helper from the **Orchard.ResourceManagement** package.
 
 ### a
 
-Invokes the `a` tag helper from the MVC package.
+Invokes the `a` content link tag helper from the **OrchardCore.Contents** package.
 
 ### antiforgerytoken
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -53,9 +53,10 @@ namespace OrchardCore.DisplayManagement.Liquid
             Factory.RegisterTag<ClearAttributesTag>("shape_clear_attributes");
             Factory.RegisterTag<AddAttributesTag>("shape_add_attributes");
             Factory.RegisterTag<ShapeTypeTag>("shape_type");
+            Factory.RegisterTag<ShapeDisplayTypeTag>("shape_display_type");
             Factory.RegisterTag<ShapePositionTag>("shape_position");
             Factory.RegisterTag<ShapeTabTag>("shape_tab");
-            Factory.RegisterTag<RemoveItemTag>("shape_remove_item");
+            Factory.RegisterTag<ShapeRemoveItemTag>("shape_remove_item");
             Factory.RegisterTag<ShapePagerTag>("shape_pager");
 
             Factory.RegisterTag<HelperTag>("helper");

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeDisplayTypeTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeDisplayTypeTag.cs
@@ -4,20 +4,19 @@ using System.Threading.Tasks;
 using Fluid;
 using Fluid.Ast;
 using OrchardCore.DisplayManagement.Liquid.Ast;
-using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.DisplayManagement.Liquid.Tags
 {
-    public class RemoveItemTag : ExpressionArgumentsTag
+    public class ShapeDisplayTypeTag : ExpressionArgumentsTag
     {
         public override async Task<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, Expression expression, FilterArgument[] args)
         {
             var objectValue = (await expression.EvaluateAsync(context)).ToObjectValue();
 
-            if (objectValue is Shape shape && shape.Items != null)
+            if (objectValue is IShape shape)
             {
                 var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
-                shape.Remove(arguments["item"].Or(arguments.At(0)).ToStringValue());
+                shape.Metadata.DisplayType = arguments["type"].Or(arguments.At(0)).ToStringValue();
             }
 
             return Completion.Normal;

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeRemoveItemTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeRemoveItemTag.cs
@@ -4,19 +4,20 @@ using System.Threading.Tasks;
 using Fluid;
 using Fluid.Ast;
 using OrchardCore.DisplayManagement.Liquid.Ast;
+using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.DisplayManagement.Liquid.Tags
 {
-    public class DisplayTypeTag : ExpressionArgumentsTag
+    public class ShapeRemoveItemTag : ExpressionArgumentsTag
     {
         public override async Task<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, Expression expression, FilterArgument[] args)
         {
             var objectValue = (await expression.EvaluateAsync(context)).ToObjectValue();
 
-            if (objectValue is IShape shape)
+            if (objectValue is Shape shape && shape.Items != null)
             {
                 var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
-                shape.Metadata.DisplayType = arguments["type"].Or(arguments.At(0)).ToStringValue();
+                shape.Remove(arguments["item"].Or(arguments.At(0)).ToStringValue());
             }
 
             return Completion.Normal;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using OrchardCore.DisplayManagement.Implementation;
-using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.DisplayManagement.TagHelpers
 {
@@ -84,7 +83,17 @@ namespace OrchardCore.DisplayManagement.TagHelpers
             {
                 shape.Id = Convert.ToString(output.Attributes["id"].Value);
             }
-            
+
+            if (output.Attributes.ContainsName("alternate"))
+            {
+                shape.Metadata.Alternates.Add(Convert.ToString(output.Attributes["alternate"].Value));
+            }
+
+            if (output.Attributes.ContainsName("wrapper"))
+            {
+                shape.Metadata.Wrappers.Add(Convert.ToString(output.Attributes["wrapper"].Value));
+            }
+
             tagHelperContext.Items.Add(typeof(IShape), shape);
 
             if (!string.IsNullOrWhiteSpace(Cache))


### PR DESCRIPTION
So that you can use e.g in liquid.

    {% shape "menu", alias: "alias:main-menu", alternate:"Menu_Footer" %}

See related comments on gitter, @d-miles can you try it on your side if you can fork this branch.

Also, the `DisplayTypeTag` was implemented but not registered. Renamed to `ShapeDisplayTypeTag`.