### PR TITLE
Fixing that generated Alias would not be persisted

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Fluid;
 using OrchardCore.Alias.Models;
 using OrchardCore.Alias.Settings;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Environment.Cache;
@@ -47,6 +48,7 @@ namespace OrchardCore.Alias.Handlers
                 templateContext.SetValue("ContentItem", part.ContentItem);
 
                 part.Alias = await _liquidTemplateManager.RenderAsync(pattern, templateContext);
+                part.Apply();
             }
         }
 

--- a/test/Functional/setup.test.js
+++ b/test/Functional/setup.test.js
@@ -10,7 +10,7 @@ const basePath = "http://localhost:5000";
 // e.g., npm test --debug
 // In debug mode we show the editor, slow down operations, and increase the timeout for each test
 let debug = process.env.npm_config_debug || false;
-jest.setTimeout(debug ? 60000 : 15000);
+jest.setTimeout(debug ? 60000 : 30000);
 
 beforeAll(async () => {
 


### PR DESCRIPTION
This PR fixes an issue where the generated alias would not be persisted due to a missing call to `part.Apply()`.