### PR TITLE
Fixing handling of updating content fields with empty values

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
@@ -213,7 +213,11 @@ namespace OrchardCore.Menu.Controllers
                 return View(model);
             }
 
-            menuItem.Merge(contentItem.Content, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
+            menuItem.Merge(contentItem.Content, new JsonMergeSettings
+            {
+                MergeArrayHandling = MergeArrayHandling.Replace,
+                MergeNullValueHandling = MergeNullValueHandling.Merge
+            });
 
             _session.Save(menu);
 


### PR DESCRIPTION
Fixes an issue that prevents the user from clearing out the contents of a content field attached to a menu item. The issue was caused due to the fact that `JObject.Merge` ignored null values by default.

Repro steps:

1. Attach the Text field to the MenuItem content type.
2. Add or edit a menu item of a Menu content item.
3. Enter a value on the text field and save the change.
4. Now edit the same menu item and clear out the contents of the text field and save the change.
5. Observe that the text field still has its original content as entered in step 3 (it's not empty).