### PR TITLE
Added null check to content item when indexing

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexingService.cs
@@ -104,6 +104,12 @@ namespace OrchardCore.Lucene
                         if (task.Type == IndexingTaskTypes.Update)
                         {
                             var contentItem = await contentManager.GetAsync(task.ContentItemId);
+
+                            if (contentItem == null)
+                            {
+                                continue;
+                            }
+
                             var context = new BuildIndexContext(new DocumentIndex(task.ContentItemId), contentItem, contentItem.ContentType);
 
                             // Update the document from the index if its lastIndexId is smaller than the current task id. 


### PR DESCRIPTION
Fixes issue with rebuild / resetting the index when you have a unpublished content item

See #1800