### PR TITLE
Fixing ContentDefinitionDeploymentStepDriver

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Deployment/ContentDefinitionDeploymentStepDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Deployment/ContentDefinitionDeploymentStepDriver.cs
@@ -10,14 +10,14 @@ namespace OrchardCore.ContentTypes.Deployment
         {
             return
                 Combine(
-                    Copy("ContentDefinitionDeploymentStep_Fields_Summary", step).Location("Summary", "Content"),
-                    Copy("ContentDefinitionDeploymentStep_Fields_Thumbnail", step).Location("Thumbnail", "Content")
+                    View("ContentDefinitionDeploymentStep_Fields_Summary", step).Location("Summary", "Content"),
+                    View("ContentDefinitionDeploymentStep_Fields_Thumbnail", step).Location("Thumbnail", "Content")
                 );
         }
 
         public override IDisplayResult Edit(ContentDefinitionDeploymentStep step)
         {
-            return Copy("ContentDefinitionDeploymentStep_Fields_Edit", step).Location("Content");
+            return View("ContentDefinitionDeploymentStep_Fields_Edit", step).Location("Content");
         }
     }
 }


### PR DESCRIPTION
I don't know what the `Copy` function is for, but other deployment step drivers aren't using it and they work correctly (and now the Content Definition Deployment Step does too :))

Fixes #1805 