### PR TITLE
Update OC.Azure.Media Startup.cs

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Startup.cs
@@ -23,6 +23,8 @@ namespace OrchardCore.Media.Azure
             _logger = logger;
         }
 
+        public override int Order => 10;
+
         public override void ConfigureServices(IServiceCollection services)
         {
             services.Configure<MediaBlobStorageOptions>(_configuration.GetSection("Modules:OrchardCore.Media.Azure"));


### PR DESCRIPTION
Need to run after `OC.Media` to replace the `IMediaFileStore` service. So maybe better to rely on the startup order in place of the feature names ordering.