### PR TITLE
Fixes #1750

### DIFF
--- a/src/OrchardCore.Cms.Web/Properties/launchSettings.json
+++ b/src/OrchardCore.Cms.Web/Properties/launchSettings.json
@@ -16,9 +16,9 @@
       }
     },
     "web": {
-      "commandName": "web",
+      "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "http://localhost:5000",
+      "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
I also changed launchUrl to applicationUrl because in case of a launchUrl you can't change the port number.
When you create a new web app the default settings for this profile is:
```
"WebApplication1": {
      "commandName": "Project",
      "launchBrowser": true,
      "environmentVariables": {
        "ASPNETCORE_ENVIRONMENT": "Development"
      },
      "applicationUrl": "http://localhost:6346/"
    }
```
So I assume this is the recommended.