### PR TITLE
CreatedUtc Datetime Editor

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/DateEditorDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/DateEditorDriver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
@@ -7,16 +7,19 @@ using OrchardCore.Contents.Models;
 using OrchardCore.Contents.ViewModels;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Modules;
 
 namespace OrchardCore.Contents.Drivers
 {
     public class DateEditorDriver : ContentPartDisplayDriver<CommonPart>
     {
         private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly ILocalClock _localClock;
 
-        public DateEditorDriver(IContentDefinitionManager contentDefinitionManager)
+        public DateEditorDriver(IContentDefinitionManager contentDefinitionManager, ILocalClock localClock)
         {
             _contentDefinitionManager = contentDefinitionManager;
+            _localClock = localClock;
         }
 
         public override IDisplayResult Edit(CommonPart part)
@@ -25,9 +28,9 @@ namespace OrchardCore.Contents.Drivers
 
             if (settings.DisplayDateEditor)
             {
-                return Initialize<DateEditorViewModel>("CommonPart_Edit__Date", model =>
+                return Initialize<DateEditorViewModel>("CommonPart_Edit__Date", async model =>
                 {
-                    model.CreatedUtc = part.ContentItem.CreatedUtc;
+                    model.CreatedUtc = part.ContentItem.CreatedUtc.Value == null ? (DateTime?)null : (await _localClock.ConvertToLocalAsync(part.ContentItem.CreatedUtc.Value)).DateTime;
                 });
             }
 
@@ -43,7 +46,14 @@ namespace OrchardCore.Contents.Drivers
                 var model = new DateEditorViewModel();
                 await updater.TryUpdateModelAsync(model, Prefix);
 
-                part.ContentItem.CreatedUtc = model.CreatedUtc;
+                if (model.CreatedUtc == null)
+                {
+                    part.ContentItem.CreatedUtc = null;
+                }
+                else
+                {
+                    part.ContentItem.CreatedUtc = await _localClock.ConvertToUtcAsync(model.CreatedUtc.Value);
+                }
             }
 
             return Edit(part);

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/DateEditorDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/DateEditorDriver.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Contents.Drivers
             {
                 return Initialize<DateEditorViewModel>("CommonPart_Edit__Date", async model =>
                 {
-                    model.CreatedUtc = part.ContentItem.CreatedUtc.Value == null ? (DateTime?)null : (await _localClock.ConvertToLocalAsync(part.ContentItem.CreatedUtc.Value)).DateTime;
+                    model.LocalDateTime = part.ContentItem.CreatedUtc.Value == null ? (DateTime?)null : (await _localClock.ConvertToLocalAsync(part.ContentItem.CreatedUtc.Value)).DateTime;
                 });
             }
 
@@ -46,13 +46,13 @@ namespace OrchardCore.Contents.Drivers
                 var model = new DateEditorViewModel();
                 await updater.TryUpdateModelAsync(model, Prefix);
 
-                if (model.CreatedUtc == null)
+                if (model.LocalDateTime == null)
                 {
                     part.ContentItem.CreatedUtc = null;
                 }
                 else
                 {
-                    part.ContentItem.CreatedUtc = await _localClock.ConvertToUtcAsync(model.CreatedUtc.Value);
+                    part.ContentItem.CreatedUtc = await _localClock.ConvertToUtcAsync(model.LocalDateTime.Value);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/ViewModels/DateEditorViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/ViewModels/DateEditorViewModel.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 
 namespace OrchardCore.Contents.ViewModels
 {
     public class DateEditorViewModel
     {
-        public DateTime? CreatedUtc { get; set; }
+        public DateTime? LocalDateTime { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/CommonPart-Date.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/CommonPart-Date.Edit.cshtml
@@ -4,7 +4,7 @@
 <fieldset class="form-group" asp-validation-class-for="CreatedUtc">
     <div class="row col-md-6 col-lg-3">
         <label asp-for="CreatedUtc">@T["Created"] <span asp-validation-for="CreatedUtc"></span></label>
-        <input asp-for="CreatedUtc" class="form-control" step="1" type="datetime-local" />
+        <input asp-for="CreatedUtc" class="form-control" type="datetime-local" />
     </div>
     <span class="hint">@T["The date when the content item was created or first published."]</span>
 </fieldset>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/CommonPart-Date.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/CommonPart-Date.Edit.cshtml
@@ -2,9 +2,9 @@
 @model DateEditorViewModel
 
 <fieldset class="form-group" asp-validation-class-for="CreatedUtc">
-    <div class="row col-sm-12 col-md-6 col-lg-3">
+    <div class="row col-md-6 col-lg-3">
         <label asp-for="CreatedUtc">@T["Created"] <span asp-validation-for="CreatedUtc"></span></label>
         <input asp-for="CreatedUtc" class="form-control" step="1" type="datetime-local" />
-        <span class="hint">@T["The date when the content item was created or first published."]</span>
     </div>
+    <span class="hint">@T["The date when the content item was created or first published."]</span>
 </fieldset>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/CommonPart-Date.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/CommonPart-Date.Edit.cshtml
@@ -1,8 +1,10 @@
-﻿@using OrchardCore.Contents.ViewModels;
+@using OrchardCore.Contents.ViewModels;
 @model DateEditorViewModel
 
 <fieldset class="form-group" asp-validation-class-for="CreatedUtc">
-    <label asp-for="CreatedUtc">@T["Created"] <span asp-validation-for="CreatedUtc"></span></label>
-    <input asp-for="CreatedUtc" class="form-control" />
-    <span class="hint">@T["The date when the content item was created or first published."]</span>
+    <div class="row col-sm-12 col-md-6 col-lg-3">
+        <label asp-for="CreatedUtc">@T["Created"] <span asp-validation-for="CreatedUtc"></span></label>
+        <input asp-for="CreatedUtc" class="form-control" step="1" type="datetime-local" />
+        <span class="hint">@T["The date when the content item was created or first published."]</span>
+    </div>
 </fieldset>

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Content-BlogPost.Summary.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Content-BlogPost.Summary.liquid
@@ -8,7 +8,7 @@
         </h3>
     {% enda %}
     <p class="post-meta">
-        {% assign format = "MMMM dd, yyyy" | t %}
+        {% assign format = "MMMM dd, yyyy HH:mm" | t %}
         {% assign dateTime = "DateTime" | shape_new: utc: Model.ContentItem.CreatedUtc, format: format | shape_stringify %}
         {{ "Posted by" | t }} <a href="#">{{ Model.ContentItem.Owner }}</a> {{ "on {0}" | t: dateTime | raw }}
     </p>

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Content-BlogPost.Summary.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Content-BlogPost.Summary.liquid
@@ -8,7 +8,7 @@
         </h3>
     {% enda %}
     <p class="post-meta">
-        {% assign format = "MMMM dd, yyyy HH:mm" | t %}
+        {% assign format = "MMMM dd, yyyy" | t %}
         {% assign dateTime = "DateTime" | shape_new: utc: Model.ContentItem.CreatedUtc, format: format | shape_stringify %}
         {{ "Posted by" | t }} <a href="#">{{ Model.ContentItem.Owner }}</a> {{ "on {0}" | t: dateTime | raw }}
     </p>


### PR DESCRIPTION
Change the editor for the createdUtc property in CommonPart-Date.Edit.cshtml

Use input type="datetime-local" by default

Will propably need some work to store it as utc and use the timezone setting like in the DateTimeField.

Fixes #525 