### PR TITLE
Fixes BackgroundTaskService.Terminate().

### DIFF
--- a/src/OrchardCore/OrchardCore.BackgroundTasks/BackgroundTaskService.cs
+++ b/src/OrchardCore/OrchardCore.BackgroundTasks/BackgroundTaskService.cs
@@ -126,7 +126,9 @@ namespace OrchardCore.BackgroundTasks
         {
             lock (_states)
             {
-                foreach (var task in _states.Keys)
+                var tasks = _states.Keys.ToArray();
+
+                foreach (var task in tasks)
                 {
                     _states[task] = BackgroundTaskState.Stopped;
                 }

--- a/src/OrchardCore/OrchardCore.BackgroundTasks/BackgroundTasksStarter.cs
+++ b/src/OrchardCore/OrchardCore.BackgroundTasks/BackgroundTasksStarter.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using OrchardCore.Modules;
 
 namespace OrchardCore.BackgroundTasks
@@ -26,6 +26,8 @@ namespace OrchardCore.BackgroundTasks
 
         public Task TerminatedAsync()
         {
+            _backgroundService.Terminate();
+
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Maybe not so important but `BackgroundTaskService.Terminate()` was never called. Then, when executing the bg tasks dictionary keys needs to be allocated before being enumerated, otherwise it fails.