### PR TITLE
Adds support for caching antiforgery token markup

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/AntiForgeryDynamicCacheService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/AntiForgeryDynamicCacheService.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using OrchardCore.DynamicCache.Services;
+using OrchardCore.Environment.Cache;
+
+namespace OrchardCore.DynamicCache
+{
+    public class AntiForgeryDynamicCacheService : IDynamicCacheService
+    {
+        private const string Placeholder = "#{AntiForgeryToken}";
+
+        private readonly IDynamicCacheService _dynamicCacheService;
+        private readonly Regex _tagRegex;
+        private readonly Lazy<string> _tagFactory; // This ensures that we only generate the markup once per request
+
+        public AntiForgeryDynamicCacheService(
+            IDynamicCacheService dynamicCacheService, 
+            IAntiforgery antiforgery,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _dynamicCacheService = dynamicCacheService;
+
+            _tagRegex = new Regex("<input name=\"__RequestVerificationToken\" type=\"hidden\" value=\"[^\"]*\" />");
+            _tagFactory = new Lazy<string>(() =>
+            {
+                var htmlContent = antiforgery.GetHtml(httpContextAccessor.HttpContext);
+
+                using (var writer = new StringWriter())
+                {
+                    htmlContent.WriteTo(writer, HtmlEncoder.Default);
+                    return writer.ToString();
+                }
+            });
+        }
+
+        public async Task<string> GetCachedValueAsync(CacheContext context)
+        {
+            var cachedValue = await _dynamicCacheService.GetCachedValueAsync(context);
+
+            return ReplacePlaceholderWithTag(cachedValue);
+        }
+
+        public async Task SetCachedValueAsync(CacheContext context, string value)
+        {
+            await _dynamicCacheService.SetCachedValueAsync(context, ReplaceTagWithPlaceholder(value));
+        }
+
+        private string ReplaceTagWithPlaceholder(string value)
+        {
+            return _tagRegex.Replace(value, Placeholder);
+        }
+
+        private string ReplacePlaceholderWithTag(string value)
+        {
+            // Don't bother if this was a cache miss or if there's no placeholders to be replaced
+            if (value != null && value.Contains(Placeholder))
+            {
+                value = value.Replace(Placeholder, _tagFactory.Value);
+            }
+
+            return value;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/AntiForgeryStartup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/AntiForgeryStartup.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using OrchardCore.DynamicCache.Services;
+using OrchardCore.Modules;
+
+namespace OrchardCore.DynamicCache
+{
+    [Feature(FeatureName)]
+    public class AntiforgeryStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.RemoveAll<IDynamicCacheService>();
+            services.AddScoped<IDynamicCacheService>(sp => new AntiForgeryDynamicCacheService(
+                sp.GetRequiredService<DefaultDynamicCacheService>(),
+                sp.GetRequiredService<IAntiforgery>(),
+                sp.GetRequiredService<IHttpContextAccessor>()
+            ));
+        }
+
+        internal const string FeatureName = "OrchardCore.DynamicCache.Antiforgery";
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/AntiForgeryStartup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/AntiForgeryStartup.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.DynamicCache
         public override void ConfigureServices(IServiceCollection services)
         {
             services.RemoveAll<IDynamicCacheService>();
-            services.AddScoped<IDynamicCacheService>(sp => new AntiForgeryDynamicCacheService(
+            services.AddScoped<IDynamicCacheService>(sp => new AntiforgeryDynamicCacheService(
                 sp.GetRequiredService<DefaultDynamicCacheService>(),
                 sp.GetRequiredService<IAntiforgery>(),
                 sp.GetRequiredService<IHttpContextAccessor>()

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/Manifest.cs
@@ -1,3 +1,4 @@
+using OrchardCore.DynamicCache;
 using OrchardCore.Modules.Manifest;
 
 [assembly: Module(
@@ -7,4 +8,19 @@ using OrchardCore.Modules.Manifest;
     Version = "2.0.0",
     Description = "Dynamic Cache.",
     Category = "Performance"
+)]
+
+[assembly: Feature(
+    Id = Startup.FeatureName,
+    Name = "Dynamic Cache",
+    Category = "Performance",
+    Description = "Dynamic Cache."
+)]
+
+[assembly: Feature(
+    Id = AntiforgeryStartup.FeatureName,
+    Name = "Dynamic Cache For Antiforgery Tokens",
+    Category = "Performance",
+    Description = "Adds support for antiforgery tokens to be cached with the Dynamic Cache",
+    Dependencies = new[] { "OrchardCore.DynamicCache" }
 )]

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/Startup.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.DynamicCache
     /// <summary>
     /// These services are registered on the tenant service collection
     /// </summary>
+    [Feature(FeatureName)]
     public class Startup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)
@@ -23,8 +24,10 @@ namespace OrchardCore.DynamicCache
             services.AddScoped<IShapeDisplayEvents, DynamicCacheShapeDisplayEvents>();
 
             services.AddShapeAttributes<CachedShapeWrapperShapes>();
-            
+
             services.AddSingleton<IDynamicCache, DefaultDynamicCache>();
         }
+
+        internal const string FeatureName = "OrchardCore.DynamicCache";
     }
 }


### PR DESCRIPTION
Antiforgery tokens will work seamlessly with cached markup if the user has this feature enabled.

**How does it work?**
Markup is intercepted immediately before it is cached- if an aft tag is found, it is replaced with a fixed placeholder string.

Markup is also intercepted immediately after is is retrieved from the cache. If the fixed placeholder string is found, we'll replace it with a valid aft tag.

**Why is is in its own feature?**
There's a nominal perf hit incurred when replacing placeholders/tags. The feature allows users to choose whether or not they need to incur this hit.