### PR TITLE
Placement documentation

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/README.md
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/README.md
@@ -62,6 +62,10 @@ be `Address.City`.
 
 ## Shapes
 
+### What is a shape?
+
+Everything you need to know about Shapes is in [this video](https://youtu.be/gKLjtCIs4GU).
+
 ### Tag Helpers
 
 #### Manipulating shape metadata

--- a/src/OrchardCore/OrchardCore.DisplayManagement/README.md
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/README.md
@@ -42,7 +42,7 @@ Placement information consists of:
   "TextField": [
     {
 		"display-type": "Detail",
-		"differentiator": "Article.MyTextField",
+		"differentiator": "Article-MyTextField",
 
 		"place": "Content",
 		"alternates": [ "TextField_Title" ],

--- a/src/OrchardCore/OrchardCore.DisplayManagement/README.md
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/README.md
@@ -131,17 +131,4 @@ Tag helper example:
 
 ## Shape differentiators
 
-The differentiator uniquely identifies a shape in a zone. When rendering a content item, the shape has a `Content` property that contains
-all the shapes provided by content display drivers, including the ones for content parts and content fields.
-
-Differentiators can be used to configure the placement information, or to access specific shapes in a zone using these template helpers:
-
-### Content Part differentiator
-
-If the shape type is the same as the content part name, the shape will be named `[PartName]`, e.g. `HtmlBodyPart`, `Services`.
-If the shape type is different than the content part name, it will be `[PartName]-[ShapeType]`, e.g. `ListPart-ListPartFeed`
-
-### Content Field differentiator
-
-If the shape type is the same as the content field name, the shape will be named `[PartName]-[FieldName]`, e.g. `HtmlBodyPart-Description`, `Services-Image`.
-If the shape type is different than the content field name, it will be `[PartName]-[FieldName]-[ShapeType]`, e.g. `HtmlBodyPart-Description-CustomFieldSummary`, `Services-Image-ImageFieldSummary`
+You can find information  about shape differenciators in the [Templates documentation](../../OrchardCore.Modules/OrchardCore.Templates/README/#content-field-differentiator)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/README.md
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/README.md
@@ -131,4 +131,4 @@ Tag helper example:
 
 ## Shape differentiators
 
-You can find information  about shape differenciators in the [Templates documentation](../../OrchardCore.Modules/OrchardCore.Templates/README/#content-field-differentiator)
+You can find information about shape differenciators in the [Templates documentation](../../OrchardCore.Modules/OrchardCore.Templates/README/#content-field-differentiator)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/README.md
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/README.md
@@ -6,8 +6,7 @@ Any extension can contain an optional `placement.json` file providing custom pla
 
 ### Format
 
-A `placement.json` file contains an object whose properties are shape names. Each of these properties is an array of 
-placement rules.
+A `placement.json` file contains an object whose properties are shape names. Each of these properties is an array of placement rules.
 
 In the following example, we describe the placement for the `TextField` and `Parts_Contents_Publish` shapes.
 
@@ -38,10 +37,9 @@ Placement information consists of:
 - `wrappers` (Optional): An array of shape types to use as wrappers for the current shape.
 - `shape` (Optional): A substitution shape type.
 
-
 ```json
 {
-  "TextField": [ 
+  "TextField": [
     {
 		"display-type": "Detail",
 		"differentiator": "Article.MyTextField",
@@ -126,3 +124,20 @@ Tag helper example:
 ```
 3 days ago
 ```
+
+## Shape differentiators
+
+The differentiator uniquely identifies a shape in a zone. When rendering a content item, the shape has a `Content` property that contains
+all the shapes provided by content display drivers, including the ones for content parts and content fields.
+
+Differentiators can be used to configure the placement information, or to access specific shapes in a zone using these template helpers:
+
+### Content Part differentiator
+
+If the shape type is the same as the content part name, the shape will be named `[PartName]`, e.g. `HtmlBodyPart`, `Services`.
+If the shape type is different than the content part name, it will be `[PartName]-[ShapeType]`, e.g. `ListPart-ListPartFeed`
+
+### Content Field differentiator
+
+If the shape type is the same as the content field name, the shape will be named `[PartName]-[FieldName]`, e.g. `HtmlBodyPart-Description`, `Services-Image`.
+If the shape type is different than the content field name, it will be `[PartName]-[FieldName]-[ShapeType]`, e.g. `HtmlBodyPart-Description-CustomFieldSummary`, `Services-Image-ImageFieldSummary`


### PR DESCRIPTION
Copy the differentiators documentation into http://orchardcore.readthedocs.io/en/dev/OrchardCore.Modules/OrchardCore.Templates/README/#content-field-differentiator to the placement page.

Fixes #1382