### PR TITLE
Fixes LocalClock async api.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/Services/DefaultTimeZoneSelector.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Services/DefaultTimeZoneSelector.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.Settings.Services
             return Task.FromResult(new TimeZoneSelectorResult
             {
                 Priority = 0,
-                TimeZoneId = () => _siteService.GetSiteSettingsAsync().ContinueWith(x => x.Result?.TimeZoneId)
+                TimeZoneId = async () => (await _siteService.GetSiteSettingsAsync())?.TimeZoneId
             });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Users/TimeZone/Services/UserTimeZoneSelector.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/TimeZone/Services/UserTimeZoneSelector.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.Users.TimeZone.Services
             return Task.FromResult(new TimeZoneSelectorResult
             {
                 Priority = 100,
-                TimeZoneId = () => _userTimeZoneService.GetUserTimeZoneAsync().ContinueWith(x => x.Result?.TimeZoneId)
+                TimeZoneId = async () => (await _userTimeZoneService.GetUserTimeZoneAsync())?.TimeZoneId
             });
         }
     }

--- a/src/OrchardCore/OrchardCore.Modules/Services/LocalClock.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Services/LocalClock.cs
@@ -2,17 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NodaTime;
-using OrchardCore.Modules;
 
 namespace OrchardCore.Modules
 {
     public class LocalClock : ILocalClock
     {
-        private static readonly Task<ITimeZone> Empty = Task.FromResult<ITimeZone>(null);
-
         private readonly IEnumerable<ITimeZoneSelector> _timeZoneSelectors;
         private readonly IClock _clock;
-        private Task<ITimeZone> _timeZone = Empty;
+        private ITimeZone _timeZone;
 
         public LocalClock(IEnumerable<ITimeZoneSelector> timeZoneSelectors, IClock clock)
         {
@@ -24,39 +21,40 @@ namespace OrchardCore.Modules
         {
             get
             {
-                return GetLocalTimeZoneAsync().ContinueWith(x => _clock.ConvertToTimeZone(_clock.UtcNow, x.Result));
+                return GetLocalNowAsync();
             }
         }
 
-        public Task<ITimeZone> GetLocalTimeZoneAsync()
+        public async Task<DateTimeOffset> GetLocalNowAsync()
+        {
+            return _clock.ConvertToTimeZone(_clock.UtcNow, await GetLocalTimeZoneAsync());
+        }
+
+        public async Task<ITimeZone> GetLocalTimeZoneAsync()
         {
             // Caching the result per request
-            if (_timeZone == Empty)
+            if (_timeZone == null)
             {
-                _timeZone = LoadLocalTimeZoneAsync();
+                _timeZone = await LoadLocalTimeZoneAsync();
             }
 
             return _timeZone;
         }
 
-        public Task<DateTimeOffset> ConvertToLocalAsync(DateTimeOffset dateTimeOffSet)
+        public async Task<DateTimeOffset> ConvertToLocalAsync(DateTimeOffset dateTimeOffSet)
         {
-            return GetLocalTimeZoneAsync().ContinueWith(localTimeZone =>
-            {
-                var dateTimeZone = ((TimeZone)localTimeZone.Result).DateTimeZone;
-                var offsetDateTime = OffsetDateTime.FromDateTimeOffset(dateTimeOffSet);
-                return offsetDateTime.InZone(dateTimeZone).ToDateTimeOffset();
-            });
+            var localTimeZone = await GetLocalTimeZoneAsync();
+            var dateTimeZone = ((TimeZone)localTimeZone).DateTimeZone;
+            var offsetDateTime = OffsetDateTime.FromDateTimeOffset(dateTimeOffSet);
+            return offsetDateTime.InZone(dateTimeZone).ToDateTimeOffset();
         }
 
-        public Task<DateTime> ConvertToUtcAsync(DateTime dateTime)
+        public async Task<DateTime> ConvertToUtcAsync(DateTime dateTime)
         {
-            return GetLocalTimeZoneAsync().ContinueWith(localTimeZone =>
-            {
-                var dateTimeZone = ((TimeZone)localTimeZone.Result).DateTimeZone;
-                var localDate = LocalDateTime.FromDateTime(dateTime);
-                return dateTimeZone.AtStrictly(localDate).ToDateTimeUtc();
-            });
+            var localTimeZone = await GetLocalTimeZoneAsync();
+            var dateTimeZone = ((TimeZone)localTimeZone).DateTimeZone;
+            var localDate = LocalDateTime.FromDateTime(dateTime);
+            return dateTimeZone.AtStrictly(localDate).ToDateTimeUtc();
         }
 
         private async Task<ITimeZone> LoadLocalTimeZoneAsync()

--- a/src/OrchardCore/OrchardCore.Modules/Services/LocalClock.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Services/LocalClock.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Modules
             }
         }
 
-        public async Task<DateTimeOffset> GetLocalNowAsync()
+        private async Task<DateTimeOffset> GetLocalNowAsync()
         {
             return _clock.ConvertToTimeZone(_clock.UtcNow, await GetLocalTimeZoneAsync());
         }


### PR DESCRIPTION
Hi @Skrypt 

Doing a benchmark with 100 concurent requests the site was not responding e.g for a minute. This when displaying a blog post which uses the `DateTime` shape which uses the local clock service.

This pr fixed the issue.

@Skrypt and @sebastienros please review to see if i didn't do any obvious mistakes.