### PR TITLE
set order to explicitly  override default configuration

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/Startup.cs
@@ -64,5 +64,8 @@ namespace OrchardCore.DataProtection.Azure
                 throw;
             }
         }
+
+        // Assume that this module will override default configuration, so set the Order to a value above the default.
+        public override int Order => 10;
     }
 }


### PR DESCRIPTION
Fixed #1984 .
set order to explicitly  override default configuration for DataProtection