### PR TITLE
Update Modules documentation

### DIFF
--- a/src/OrchardCore/OrchardCore.Modules/README.md
+++ b/src/OrchardCore/OrchardCore.Modules/README.md
@@ -4,118 +4,76 @@ The library Orchard Core Modules provides a mechanism to have a self-contained m
 
 ## Getting started
 
-First, create a brand new web application.
+In Visual Studio, create a new web application.
 
-Install OrchardCore.Application.Cms.Targets into the project by managing the project NuGet packages.
+Install `OrchardCore.Application.Cms.Targets` into the project by managing the project NuGet packages.
 
-Within this new application we are initially going to focus on `Startup.cs`.
-
-Okay so first, let's open up `Startup.cs`.
-
-Within the `ConfigureServices` method, add this line:
+Next, within `Startup.cs`, modify the `ConfigureServices` method, add this line:
 
 ```csharp
-services.AddOrchardCms(); 
+services.AddOrchardCms();
 ```
 
-Next, at the end of the `Configure` method, replace this block: 
+Next, at the end of the `Configure` method, replace this block:
 
 ```csharp
-app.Run(async (context) => 
+app.Run(async (context) =>
 {
-    await context.Response.WriteAsync("Hello World!"); 
+    await context.Response.WriteAsync("Hello World!");
 });
 ```
 
-with this line: 
+with this line:
 
 ```csharp
 app.UseOrchardCore();
 ```
 
-That's it. Erm, wait, what? Okay so right now you must be thinking, well what the hell does this do? Good question.
+## Additional frameworks
 
-`AddModuleServices` will add the container middleware to your application pipeline; this means, in short, that it will look for a folder called `Modules` within your application, for all folders that contain the manifest file `Module.txt`. If you looked on the file system it would look like this:
-
-```
-MyNewWebApplication
-  \ Modules
-    \ Module1
-    \ Module2
-```
-
-Once it has found that manifest file, and said file is valid, it will then look for all classes that inherit from `StartupBase`, instantiate them and then call the methods on here. An example of one is:
-
-```csharp
-public class Startup : StartupBase
-{
-    public override void ConfigureServices(IServiceCollection services)
-    {
-        services.AddScoped<ISomeInterface, SomeImplementedClass>();
-    }
-}
-```
-
-By doing this you allow your modules to be self-contained, completely decoupled from the Hosting application.
-
-!!! note
-    If you drop a new module in, then you will need to restart the application for it to be found.
-
-## Add Extra Locations
-By default module discovery is linked to the `Modules` folder. This however can be extended.
-
-Within the `Startup.cs` file in your host, within the `ConfigureServices` method, add:
-
-```csharp
-services.AddExtensionLocation("SomeOtherFolderToLookIn");
-```
-
-## Add Extra Manifest filenames
-By default the module manifest file is `Module.txt`. This however can be extended.
-
-Within the `Startup.cs` file in your host, within the `ConfigureServices` method, add:
-
-```csharp
-services.AddManifestDefinition("ManifestMe.txt", "module");
-```
-
-## Additional framework
 You can add your favourite application framework to the pipeline, easily. The below implementations are designed to work side by side, so if you want Asp.Net Mvc and Nancy within your pipeline, just add both.
 
 The modular framework wrappers below are designed to work directly with the modular application framework, so avoid just adding the raw framework and expect it to just work.
 
 ### Asp.Net Mvc
-Within your hosting application add a reference to `OrchardCore.Mvc.Core`.
 
-Next, within `Startup.cs` modify the method `AddModuleServices` to look like this:
+Install `OrchardCore.Application.Mvc.Targets` into the project by managing the project NuGet packages.
+
+Next, within `Startup.cs`, modify the method `ConfigureServices` to look like this:
 
 ```csharp
-services.AddModuleServices(configure => configure
-    .AddMvcModules(services.BuildServiceProvider())
-    .AddConfiguration(Configuration)
-);
+            // Add ASP.NET MVC and support for modules
+            services
+                .AddOrchardCore()
+                .AddMvc()
+                ;
 ```
 
-!!! note 
-    Note the addition of `.AddMvcModules(services.BuildServiceProvider())`
+!!! note
+    Note the addition of `.AddMvc()`
 
-That's it, done. Asp.Net Mvc is now part of your pipeline.
+Asp.Net Mvc is now part of your pipeline.
+
+You can find an sample application here: [OrchardCore.Mvc.Web](..\..\OrchardCore.Mvc.Web\Startup.cs)
 
 ### NancyFx
-Within your hosting application add a reference to `OrchardCore.Nancy.Core`
 
-Next, within `Startup.cs` modify the method `Configure` to look like this:
+Install `OrchardCore.Application.Nancy.Targets` into the project by managing the project NuGet packages.
+
+Next, within `Startup.cs`, modify the method `ConfigureServices` to look like this:
 
 ```csharp
-app.UseModules(modules => modules
-    .UseNancyModules()
+            // Add Nancy and support for modules
+            services
+                .AddOrchardCore()
+                .AddNancy()
+                ;
 );
 ```
 
-!!! note 
-    Note the addition of `.UseNancyModules()`
+!!! note
+    Note the addition of `.AddNancy()`
 
-That's it, done. NancyFx is now part of your pipeline. What this means is that Nancy modules will be automatically discovered.
+NancyFx is now part of your pipeline. What this means is that Nancy modules will be automatically discovered.
 
-!!! note 
-    There is no need to register a Nancy Module within its own Startup class.
+You can find an sample application here: [OrchardCore.Nancy.Web](..\..\OrchardCore.Nancy.Web\Startup.cs)


### PR DESCRIPTION
Remove explanations about Module.txt and builder extension methods that do not exist anymore.
Update code samples about OrchardCore.Mvc.Web and OrchardCore.Nancy.Web

Fixes #1908