### PR TITLE
CodeMirror LineWrapping in Edit Template

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Templates/wwwroot/templatepreview.edit.js
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/wwwroot/templatepreview.edit.js
@@ -18,9 +18,10 @@ function initializeTemplatePreview(nameElement, editorElement) {
 
     editor = CodeMirror.fromTextArea(editorElement, {
         lineNumbers: true,
+        lineWrapping: true,
         styleActiveLine: true,
         matchBrackets: true,
-        mode: { name: "liquid" },
+        mode: { name: "liquid" }
     });
 
     editor.on('change', function (cm) {


### PR DESCRIPTION
An easy way to prevent horizontal scrollbar in codemirror editor is to use the lineWrapping option: http://codemirror.net/doc/manual.html#option_lineWrapping

Fixes #1670 