### PR TITLE
Removing restriction which activities are startable.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentEvent.cs
@@ -15,8 +15,6 @@ namespace OrchardCore.Contents.Workflows.Activities
         {
         }
 
-        public override bool CanStartWorkflow => true;
-
         public IList<string> ContentTypeFilter
         {
             get => GetProperty<IList<string>>(defaultValue: () => new List<string>());

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/ActivityController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/ActivityController.cs
@@ -19,7 +19,6 @@ namespace OrchardCore.Workflows.Controllers
     [Admin]
     public class ActivityController : Controller, IUpdateModel
     {
-        private readonly ISiteService _siteService;
         private readonly ISession _session;
         private readonly IActivityLibrary _activityLibrary;
         private readonly IWorkflowManager _workflowManager;
@@ -34,7 +33,6 @@ namespace OrchardCore.Workflows.Controllers
 
         public ActivityController
         (
-            ISiteService siteService,
             ISession session,
             IActivityLibrary activityLibrary,
             IWorkflowManager workflowManager,
@@ -47,7 +45,6 @@ namespace OrchardCore.Workflows.Controllers
             IHtmlLocalizer<ActivityController> h
         )
         {
-            _siteService = siteService;
             _session = session;
             _activityLibrary = activityLibrary;
             _workflowManager = workflowManager;
@@ -69,7 +66,6 @@ namespace OrchardCore.Workflows.Controllers
             }
 
             var activity = _activityLibrary.InstantiateActivity(activityName);
-            var workflowType = await _session.GetAsync<WorkflowType>(workflowTypeId);
             var activityId = _activityIdGenerator.GenerateUniqueId(new ActivityRecord());
             var activityEditor = await _activityDisplayManager.BuildEditorAsync(activity, this, isNew: true);
 
@@ -180,8 +176,8 @@ namespace OrchardCore.Workflows.Controllers
             _session.Save(workflowType);
             _notifier.Success(H["Activity updated successfully"]);
 
-            return Url.IsLocalUrl(model.ReturnUrl) 
-                ? (IActionResult)Redirect(model.ReturnUrl) 
+            return Url.IsLocalUrl(model.ReturnUrl)
+                ? (IActionResult)Redirect(model.ReturnUrl)
                 : RedirectToAction("Edit", "WorkflowType", new { id = model.WorkflowTypeId });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/ActivityLibrary.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/ActivityLibrary.cs
@@ -12,7 +12,6 @@ namespace OrchardCore.Workflows.Services
 {
     public class ActivityLibrary : IActivityLibrary
     {
-        private readonly IOptions<WorkflowOptions> _workflowOptions;
         private readonly Lazy<IDictionary<string, IActivity>> _activityDictionary;
         private readonly Lazy<IList<LocalizedString>> _activityCategories;
         private readonly IServiceProvider _serviceProvider;
@@ -20,7 +19,6 @@ namespace OrchardCore.Workflows.Services
 
         public ActivityLibrary(IOptions<WorkflowOptions> workflowOptions, IServiceProvider serviceProvider, ILogger<ActivityLibrary> logger)
         {
-            _workflowOptions = workflowOptions;
             _activityDictionary = new Lazy<IDictionary<string, IActivity>>(() => workflowOptions.Value.ActivityTypes.Select(x => serviceProvider.CreateInstance<IActivity>(x)).OrderBy(x => x.Name).ToDictionary(x => x.Name));
             _activityCategories = new Lazy<IList<LocalizedString>>(() => _activityDictionary.Value.Values.OrderBy(x => x.Category.Value).Select(x => x.Category).Distinct(new LocalizedStringComparer()).ToList());
             _serviceProvider = serviceProvider;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Activity.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Activity.Design.cshtml
@@ -5,8 +5,7 @@
     var activity = (IActivity)Model.Activity;
     var activityEvent = activity as IEvent;
     var isEvent = activityEvent != null;
-    var canStart = activity.CanStartWorkflow;
-    var isStart = canStart && activityRecord.IsStart;
+    var isStart = activityRecord.IsStart;
     var cssClass = isStart ? "activity-start" : isEvent ? "activity-event" : "activity-task";
     var hasEditor = activity.HasEditor;
     var activityType = isEvent ? "Event" : "Task";
@@ -23,10 +22,7 @@
         </div>
     }
     <div class="activity-commands">
-        @if (canStart)
-        {
-            <a class="btn btn-outline-secondary activity-start-action" href="#" data-toggle="button" title="@T["Startup task"]"><i class="fa fa-power-off"></i></a>
-        }
+        <a class="btn btn-outline-secondary activity-start-action" href="#" data-toggle="button" title="@T["Startup task"]"><i class="fa fa-power-off"></i></a>
         @if (hasEditor)
         {
             <a class="btn btn-primary activity-edit-action" asp-action="Edit" asp-controller="Activity" asp-route-workflowtypeid="@Model.WorkflowTypeId" asp-route-activityid="@activityRecord.ActivityId" asp-route-returnurl="@Model.ReturnUrl" data-persist-workflow="true" title="@T["Edit"]"><i class="fa fa-pencil"></i></a>

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/Activity.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/Activity.cs
@@ -17,7 +17,6 @@ namespace OrchardCore.Workflows.Activities
         public abstract string Name { get; }
         public abstract LocalizedString Category { get; }
         public virtual bool HasEditor => true;
-        public virtual bool CanStartWorkflow => false;
 
         public abstract IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext);
 
@@ -124,13 +123,13 @@ namespace OrchardCore.Workflows.Activities
         protected virtual T GetProperty<T>(Func<T> defaultValue = null, [CallerMemberName]string name = null)
         {
             var item = Properties[name];
-            return item != null ? item.ToObject<T>() : defaultValue != null ? defaultValue() : default(T);
+            return item != null ? item.ToObject<T>() : defaultValue != null ? defaultValue() : default;
         }
 
         protected virtual T GetProperty<T>(Type type, Func<T> defaultValue = null, [CallerMemberName]string name = null)
         {
             var item = Properties[name];
-            return item != null ? (T)item.ToObject(type) : defaultValue != null ? defaultValue() : default(T);
+            return item != null ? (T)item.ToObject(type) : defaultValue != null ? defaultValue() : default;
         }
 
         protected virtual void SetProperty(object value, [CallerMemberName]string name = null)

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/EventActivity.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/EventActivity.cs
@@ -4,8 +4,6 @@ namespace OrchardCore.Workflows.Activities
 {
     public abstract class EventActivity : Activity, IEvent
     {
-        public override bool CanStartWorkflow => true;
-
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
             // Halt the workflow to wait for the event to occur.

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/IActivity.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/IActivity.cs
@@ -17,11 +17,6 @@ namespace OrchardCore.Workflows.Activities
         bool HasEditor { get; }
 
         /// <summary>
-        /// Returns a value whether the event can cause a workflow to start.
-        /// </summary>
-        bool CanStartWorkflow { get; }
-
-        /// <summary>
         /// List of possible outcomes when the activity is executed.
         /// </summary>
         IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext);

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Helpers/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Helpers/ServiceCollectionExtensions.cs
@@ -10,10 +10,6 @@ namespace OrchardCore.Workflows.Helpers
         public static void AddActivity<TActivity, TDriver>(this IServiceCollection services) where TActivity : class, IActivity where TDriver : class, IDisplayDriver<IActivity>
         {
             services.Configure<WorkflowOptions>(options => options.RegisterActivity<TActivity, TDriver>());
-
-            // Note to @sebros: Uncomment the next two lines to register activities and drivers with the service container (and uncomment the line above).
-            //services.AddScoped<IActivity, TActivity>();
-            //services.AddScoped<IDisplayDriver<IActivity>, TDriver>();
         }
     }
 }


### PR DESCRIPTION
This PR removes the restriction of which activities can be used as the starting activity of a workflow. This used to be Event activities only, but now also Task activities can be the starting point. This is useful in scenarios where you would have a specific workflow type that you want to execute.

See #1819

