### PR TITLE
Update templates project files.

### DIFF
--- a/src/Templates/OrchardCore.Templates.Cms.Web/OrchardCore.Templates.Cms.Web.csproj
+++ b/src/Templates/OrchardCore.Templates.Cms.Web/OrchardCore.Templates.Cms.Web.csproj
@@ -3,12 +3,13 @@
   <Import Project="..\..\OrchardCore.Build\Dependencies.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PreserveCompilationContext>true</PreserveCompilationContext>
-    <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
-    <MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Hosting.Console\OrchardCore.Hosting.Console.csproj" />
@@ -17,11 +18,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <!-- Necessary as we reference the Project and not the Package -->

--- a/src/Templates/OrchardCore.Templates.Module/OrchardCore.Templates.Module.csproj
+++ b/src/Templates/OrchardCore.Templates.Module/OrchardCore.Templates.Module.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Templates/OrchardCore.Templates.Module/OrchardCore.Templates.Module.csproj
+++ b/src/Templates/OrchardCore.Templates.Module/OrchardCore.Templates.Module.csproj
@@ -1,4 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+
+  <!-- Necessary as we reference the Project and not the Package -->
+  <Import Project="..\..\OrchardCore.Modules\Directory.Build.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -17,5 +20,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>
-  
+
+  <!-- Necessary as we reference the Project and not the Package -->
+  <Import Project="..\..\OrchardCore.Modules\Directory.Build.targets" />
+
 </Project>

--- a/src/Templates/OrchardCore.Templates.Theme/OrchardCore.Templates.Theme.csproj
+++ b/src/Templates/OrchardCore.Templates.Theme/OrchardCore.Templates.Theme.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Templates/OrchardCore.Templates.Theme/OrchardCore.Templates.Theme.csproj
+++ b/src/Templates/OrchardCore.Templates.Theme/OrchardCore.Templates.Theme.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
+  <!-- Necessary as we reference the Project and not the Package -->
+  <Import Project="..\..\OrchardCore.Themes\Directory.Build.props" />
+
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
@@ -14,5 +17,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" />
   </ItemGroup>
+
+  <!-- Necessary as we reference the Project and not the Package -->
+  <Import Project="..\..\OrchardCore.Themes\Directory.Build.targets" />
 
 </Project>


### PR DESCRIPTION
I began to update the templates project files based on the last change.

One question, when a module / theme template is used, where the generated project will be generated? If they are outputed in `OC.Modules` or `OC.Themes` that's ok.

This because to build correctly a module / theme when using project references we need the `Directory.Build.props` and `Directory.Build.targets` files which are in these folders.

Otherwise we would need to import explicitly these files in the module / theme template project files.

Let me know, easy to do.