### PR TITLE
Fixing ValidateFormTask

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormTask.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Localization;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.Workflows.Abstractions.Models;
@@ -43,7 +42,8 @@ namespace OrchardCore.Forms.Workflows.Activities
                 throw new InvalidOperationException("Cannot add model validation errors when there's no Updater present.");
             }
 
-            var outcome = updater.ModelState.ValidationState == ModelValidationState.Invalid ? "Invalid" : "Valid";
+            var isValid = updater.ModelState.ErrorCount == 0;
+            var outcome = isValid ? "Valid" : "Invalid";
             return Outcomes(outcome);
         }
     }


### PR DESCRIPTION
This PR fixes an issue with the `ValidateFormTask` activity where it would always return a Valid outcome, even if there are model state errors. The issue is that `ModelState.ValidationState` is always `Unvalidated`, even after adding model state errors. I suspect there must be some sort of "validate model state" method somewhere that updates the ValidationState, but I have yet to find it. In any case, the change I applied uses the expected logic (invalid if more than one error).