### PR TITLE
Update setup and tenant views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,5 +189,5 @@ node_modules/
 wwwroot
 !src/OrchardCore.Modules/**/wwwroot
 !src/OrchardCore.Themes/**/wwwroot
-!src/Templates/**/wwwroot
+!src/Templates/**/content/**
 .template.config/

--- a/src/OrchardCore.Modules/OrchardCore.Setup/Assets/js/setup.js
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Assets/js/setup.js
@@ -6,7 +6,7 @@ $(function () {
         toggleConnectionStringAndPrefix();
     });
 
-    // Refresh the description hide the connection string when a provider is selected
+    // Refresh the recipe description
     $("#recipes div a").on('click', function () {
         refreshDescription($(this));
     });

--- a/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
@@ -143,23 +143,12 @@
         <div class="row">
             <div class="form-group col-md-6">
                 <label asp-for="DatabaseProvider">@T["What type of database to use?"]</label>
-                @if (Model.DatabaseConfigurationPreset)
-                {
-                    var provider = Model.DatabaseProviders.FirstOrDefault(p => p.Value == Model.DatabaseProvider);
-
-                    <select asp-for="DatabaseProvider" class="form-control" required readonly>
+                <select asp-for="DatabaseProvider" class="form-control" required>
+                    @foreach (var provider in Model.DatabaseProviders)
+                    {
                         <option value="@provider.Value" data-connection-string="@provider.HasConnectionString" data-table-prefix="@provider.HasTablePrefix">@provider.Name</option>
-                    </select>
-                }
-                else
-                {
-                    <select asp-for="DatabaseProvider" class="form-control" required>
-                        @foreach (var provider in Model.DatabaseProviders)
-                        {
-                            <option value="@provider.Value" data-connection-string="@provider.HasConnectionString" data-table-prefix="@provider.HasTablePrefix">@provider.Name</option>
-                        }
-                    </select>
-                }
+                    }
+                </select>
                 <span asp-validation-for="DatabaseProvider" class="text-danger"></span>
             </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Edit.cshtml
@@ -41,11 +41,11 @@
                     <option value="" data-connection-string="false">@T["None"]</option>
                     @foreach (var provider in DatabaseProviders)
                     {
-                        <option value="@provider.Value" data-connection-string="@provider.HasConnectionString.ToString().ToLower()">@provider.Name</option>
+                        <option value="@provider.Value" data-connection-string="@provider.HasConnectionString.ToString().ToLower()" data-table-prefix="@provider.HasTablePrefix.ToString().ToLower()">@provider.Name</option>
                     }
                 </select>
             </div>
-            <div class="form-group col-md-6" asp-validation-class-for="TablePrefix">
+            <div class="form-group col-md-6 tablePrefix" asp-validation-class-for="TablePrefix">
                 <label asp-for="TablePrefix">@T["Table Prefix"]</label>
                 <span asp-validation-for="TablePrefix" class="text-danger"></span>
                 <input asp-for="TablePrefix" class="form-control" />


### PR DESCRIPTION
Related to my last comment in #1940. Here i copied the last part of this comment.

- You are totally right, we now have the following pattern where `Part A` is useless.

      if (!Model.DatabaseConfigurationPreset)
      {
          ...
          if (Model.DatabaseConfigurationPreset)
          {
              // Part A
          }
          else
          {
              // Part B
          }

- I also saw a bad comment in `setup.js`.

- Finally, when **editing a tenant** the connection string is shown / hidden based on the selected provider, **but not the prefix** (it works when **creating a tenant**).
