### PR TITLE
Culture testing

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
@@ -14,8 +14,6 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Environment.Shell\OrchardCore.Environment.Shell.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Localization.Abstractions\OrchardCore.Localization.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Localization.Core\OrchardCore.Localization.Core.csproj" />
-    <ProjectReference Include="..\OrchardCore.Features\OrchardCore.Features.csproj" />
-    <ProjectReference Include="..\OrchardCore.Settings\OrchardCore.Settings.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Manifest.cs
@@ -6,6 +6,5 @@ using OrchardCore.Modules.Manifest;
     Website = "http://orchardproject.net",
     Version = "2.0.0",
     Description = "The settings module creates site settings that other modules can contribute to.",
-    Category = "Configuration",
-    Dependencies = new[] { "OrchardCore.Localization" }
+    Category = "Configuration"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Migrations.cs
@@ -1,7 +1,7 @@
 using OrchardCore.Data.Migration;
 using OrchardCore.Localization.Indexes;
 
-namespace OrchardCore.Localization
+namespace OrchardCore.Settings
 {
     public class Migrations : DataMigration
     {
@@ -13,6 +13,5 @@ namespace OrchardCore.Localization
 
             return 1;
         }
-
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Startup.cs
@@ -1,12 +1,13 @@
 using System;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Liquid;
+using OrchardCore.Localization.Indexes;
 using OrchardCore.Localization.Services;
 using OrchardCore.Modules;
 using OrchardCore.Recipes;
@@ -15,6 +16,7 @@ using OrchardCore.Settings.Drivers;
 using OrchardCore.Settings.Recipes;
 using OrchardCore.Settings.Services;
 using OrchardCore.Setup.Events;
+using YesSql.Indexes;
 
 namespace OrchardCore.Settings
 {
@@ -40,9 +42,11 @@ namespace OrchardCore.Settings
             services.AddScoped<ILiquidTemplateEventHandler, SiteLiquidTemplateEventHandler>();
 
             services.AddScoped<ITimeZoneSelector, DefaultTimeZoneSelector>();
-            services.AddScoped<IRequestCultureProvider, DefaultRequestCultureProvider>();
             services.AddScoped<ICultureStore, CultureStore>();
             services.AddScoped<ICultureManager, CultureManager>();
+
+            services.AddScoped<IDataMigration, Migrations>();
+            services.AddSingleton<IIndexProvider, CultureIndexProvider>();
         }
 
         public override void Configure(IApplicationBuilder builder, IRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore/OrchardCore.Localization.Core/DefaultRequestCultureProvider.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/DefaultRequestCultureProvider.cs
@@ -3,15 +3,16 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Settings;
 
-namespace OrchardCore.Settings.Services
+namespace OrchardCore.Localization
 {
     public class DefaultRequestCultureProvider : RequestCultureProvider
     {
         public override Task<ProviderCultureResult> DetermineProviderCultureResult(HttpContext httpContext)
         {
             var siteService = httpContext.RequestServices.GetRequiredService<ISiteService>();
-            var siteCulture = siteService.GetSiteSettingsAsync().Result?.Culture != null ? siteService.GetSiteSettingsAsync().Result?.Culture : CultureInfo.InvariantCulture.Name;
+            var siteCulture = siteService.GetSiteSettingsAsync().Result?.Culture ?? CultureInfo.InvariantCulture.Name;
             return Task.FromResult(new ProviderCultureResult(siteCulture));
         }
     }

--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizerFactory.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizerFactory.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Globalization;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OrchardCore.Localization.Services;
@@ -12,25 +10,22 @@ namespace OrchardCore.Localization.PortableObject
     public class PortableObjectStringLocalizerFactory : IStringLocalizerFactory
     {
         private readonly ILocalizationManager _localizationManager;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ILocalCulture _localCulture;
         private readonly ILogger _logger;
 
         public PortableObjectStringLocalizerFactory(
             ILocalizationManager localizationManager,
-            IHttpContextAccessor httpContextAccessor,
+            ILocalCulture localCulture,
             ILogger<PortableObjectStringLocalizerFactory> logger)
         {
             _localizationManager = localizationManager;
-            _httpContextAccessor = httpContextAccessor;
+            _localCulture = localCulture;
             _logger = logger;
         }
 
         public IStringLocalizer Create(Type resourceSource)
         {
-            var culture = _httpContextAccessor.HttpContext.RequestServices
-                .GetRequiredService<ILocalCulture>().GetLocalCultureAsync().Result;
-
-            return new PortableObjectStringLocalizer(culture, resourceSource.FullName, _localizationManager, _logger);
+            return new PortableObjectStringLocalizer(_localCulture.GetLocalCultureAsync().Result, resourceSource.FullName, _localizationManager, _logger);
         }
 
         public IStringLocalizer Create(string baseName, string location)

--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizerFactory.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizerFactory.cs
@@ -1,25 +1,36 @@
 using System;
 using System.Globalization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OrchardCore.Localization.Services;
+using OrchardCore.Modules.Services;
 
 namespace OrchardCore.Localization.PortableObject
 {
     public class PortableObjectStringLocalizerFactory : IStringLocalizerFactory
     {
         private readonly ILocalizationManager _localizationManager;
+        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger _logger;
 
-        public PortableObjectStringLocalizerFactory(ILocalizationManager localizationManager, ILogger<PortableObjectStringLocalizerFactory> logger)
+        public PortableObjectStringLocalizerFactory(
+            ILocalizationManager localizationManager,
+            IHttpContextAccessor httpContextAccessor,
+            ILogger<PortableObjectStringLocalizerFactory> logger)
         {
             _localizationManager = localizationManager;
+            _httpContextAccessor = httpContextAccessor;
             _logger = logger;
         }
 
         public IStringLocalizer Create(Type resourceSource)
         {
-            return new PortableObjectStringLocalizer(CultureInfo.CurrentUICulture, resourceSource.FullName, _localizationManager, _logger);
+            var culture = _httpContextAccessor.HttpContext.RequestServices
+                .GetRequiredService<ILocalCulture>().GetLocalCultureAsync().Result;
+
+            return new PortableObjectStringLocalizer(culture, resourceSource.FullName, _localizationManager, _logger);
         }
 
         public IStringLocalizer Create(string baseName, string location)

--- a/src/OrchardCore/OrchardCore.Localization.Core/Services/CultureManager.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/Services/CultureManager.cs
@@ -3,10 +3,9 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Localization;
 using Microsoft.Extensions.Caching.Distributed;
 using OrchardCore.Localization.Models;
+using OrchardCore.Modules.Services;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Localization.Services
@@ -15,18 +14,18 @@ namespace OrchardCore.Localization.Services
     {
         private readonly ICultureStore _cultureStore;
         private readonly IDistributedCache _distributedCache;
-        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ILocalCulture _localCulture;
         private readonly ISiteService _siteService;
 
         public CultureManager(
             ICultureStore cultureStore,
             IDistributedCache distributedCache,
-            IHttpContextAccessor httpContextAccessor,
+            ILocalCulture localCulture,
             ISiteService siteService)
         {
             _cultureStore = cultureStore;
             _distributedCache = distributedCache;
-            _httpContextAccessor = httpContextAccessor;
+            _localCulture = localCulture;
             _siteService = siteService;
         }
 
@@ -81,7 +80,7 @@ namespace OrchardCore.Localization.Services
 
         public string GetCurrentCulture()
         {
-            return _httpContextAccessor.HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name ?? CultureInfo.CurrentCulture.Name;
+            return _localCulture.GetLocalCultureAsync().Result.Name;
         }
 
         public bool IsValidCulture(string cultureName)

--- a/src/OrchardCore/OrchardCore.Localization.Core/Services/CultureManager.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/Services/CultureManager.cs
@@ -81,7 +81,7 @@ namespace OrchardCore.Localization.Services
 
         public string GetCurrentCulture()
         {
-            return _httpContextAccessor.HttpContext.Features.Get<IRequestCultureFeature>().Provider != null ? _httpContextAccessor.HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name : CultureInfo.CurrentCulture.Name;
+            return _httpContextAccessor.HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture.Name ?? CultureInfo.CurrentCulture.Name;
         }
 
         public bool IsValidCulture(string cultureName)

--- a/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddSingleton<IClock, Clock>();
             services.AddScoped<ILocalClock, LocalClock>();
-            services.AddScoped<ILocalCulture, LocalCulture>();
+            services.AddSingleton<ILocalCulture, LocalCulture>();
 
             services.AddSingleton<IPoweredByMiddlewareOptions, PoweredByMiddlewareOptions>();
             services.AddTransient<IModularTenantRouteBuilder, ModularTenantRouteBuilder>();

--- a/src/OrchardCore/OrchardCore.Modules/Services/LocalCulture.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Services/LocalCulture.cs
@@ -8,25 +8,13 @@ namespace OrchardCore.Modules.Services
     public class LocalCulture : ILocalCulture
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private CultureInfo _culture;
 
         public LocalCulture(IHttpContextAccessor httpContextAccessor)
         {
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public async Task<CultureInfo> GetLocalCultureAsync()
-        {
-            // Caching the result per request
-            if (_culture == null)
-            {
-                _culture = await LoadLocalCultureAsync();
-            }
-
-            return _culture;
-        }
-
-        private Task<CultureInfo> LoadLocalCultureAsync()
+        public Task<CultureInfo> GetLocalCultureAsync()
         {
             return Task.FromResult(_httpContextAccessor.HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture ?? CultureInfo.CurrentCulture);
         }

--- a/src/OrchardCore/OrchardCore.Modules/Services/LocalCulture.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Services/LocalCulture.cs
@@ -1,7 +1,5 @@
-using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
 
@@ -30,7 +28,7 @@ namespace OrchardCore.Modules.Services
 
         private Task<CultureInfo> LoadLocalCultureAsync()
         {
-            return Task.FromResult(_httpContextAccessor.HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture);
+            return Task.FromResult(_httpContextAccessor.HttpContext.Features.Get<IRequestCultureFeature>()?.RequestCulture.Culture ?? CultureInfo.CurrentCulture);
         }
     }
 }


### PR DESCRIPTION
Some suggestions

- Migration for `CultureIndex` is done in `OC.Settings` so that it doesn't need a dependency on `OC.Localization`.

- As it is used we don't need to register `DefaultRequestCultureProvider`, and it is defined in `OC.Localization.Core` so that `OC.Localization` doesn't need to reference `OC.Settings`.

- In the startup of `OC.Localization`, use the new helpers `SetDefaultCulture`, `AddSupportedCultures` and `AddSupportedUICultures`.

- And other minor updates.

A few others to come, nothing has been tested yet ;)