### PR TITLE
The settingStep raises an exception in case the property already exist.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/Recipes/SettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Recipes/SettingsStep.cs
@@ -86,7 +86,7 @@ namespace OrchardCore.Settings.Recipes
                         break;
 
                     default:
-                        site.Properties.Add(property);
+                        site.Properties[property.Name] = property.Value;
                         break;
                 }
             }            


### PR DESCRIPTION
The settingStep raises an exception in case the property already exists. It causes problem for non-setup recipes who want to change SiteSettings.