### PR TITLE
Duplicate data protection startup filters per tenant.

### DIFF
--- a/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
@@ -213,8 +213,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                 }
 
-                // Remove the 'KeyManagementOptionsSetup' registered at the host level.
+                // Remove options setups registered at the host level.
                 services.RemoveAll<IConfigureOptions<KeyManagementOptions>>();
+                services.RemoveAll<IConfigureOptions<DataProtectionOptions>>();
 
                 services.Add(collection);
             });

--- a/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -190,11 +191,32 @@ namespace Microsoft.Extensions.DependencyInjection
                 // rely on IDataProtector/IDataProtectionProvider automatically get an isolated instance that
                 // manages its own key ring and doesn't allow decrypting payloads encrypted by another tenant.
                 // By default, the key ring is stored in the tenant directory of the configured App_Data path.
-                services.Add(new ServiceCollection()
+                var collection = new ServiceCollection()
                     .AddDataProtection()
                     .PersistKeysToFileSystem(directory)
                     .SetApplicationName(settings.Name)
-                    .Services);
+                    .Services;
+
+                // Retrieve the implementation type of the newly startup filter registered as a singleton
+                var startupFilterType = collection.FirstOrDefault(s => s.ServiceType == typeof(IStartupFilter))?.ImplementationType;
+
+                if (startupFilterType != null)
+                {
+                    // Remove the data protection startup filter registered at the host level.
+                    // Knowing that a host singleton is cloned through an implementation instance.
+                    var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(IStartupFilter) &&
+                        s.ImplementationInstance?.GetType() == startupFilterType);
+
+                    if (descriptor != null)
+                    {
+                        services.Remove(descriptor);
+                    }
+                }
+
+                // Remove the 'KeyManagementOptionsSetup' registered at the host level.
+                services.RemoveAll<IConfigureOptions<KeyManagementOptions>>();
+
+                services.Add(collection);
             });
         }
     }


### PR DESCRIPTION
Working around the tenant pipeline, i could see a data protection startup filter duplicate per tenant.

![startupfilters1](https://user-images.githubusercontent.com/8586360/42479691-54602128-83da-11e8-8227-0ebfa9f4150a.png)

And some duplicates in some options collections.

![startupfilters2](https://user-images.githubusercontent.com/8586360/42479714-70c7d360-83da-11e8-8881-1ae129f00378.png)

In the startup of the data protection module, we re-register all data protection services  to be tenant-aware (by using a new `ServiceCollection`). It's not a problem for most of the services which will be resolved by using the last registration. But when services are resolved through an `IEnumerable` we get duplicates. This is the case for the `DataProtectionStartupFilter`, `IConfigureOptions<KeyManagementOptions>` and `IConfigureOptions<DataProtectionOptions>`.


So, applying this PR we now have only one data protection startup filter per tenant.

![startupfilters3](https://user-images.githubusercontent.com/8586360/42479752-9d644cd2-83da-11e8-8121-193937af5e63.png)

and no more duplicates in options collections.

![startupfilters4](https://user-images.githubusercontent.com/8586360/42479759-a2b1fe0a-83da-11e8-9e12-3fd3a493cfb7.png)

