### PR TITLE
Allow different module loading strategies trough an IModuleNamesProvider

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewOptionsSetup.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewOptionsSetup.cs
@@ -1,20 +1,24 @@
 using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
+using OrchardCore.Modules;
 
 namespace OrchardCore.DisplayManagement.Liquid
 {
     public class LiquidViewOptionsSetup : IConfigureOptions<LiquidViewOptions>
     {
         private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IApplicationContext _applicationContext;
 
         /// <summary>
         /// Initializes a new instance of <see cref="LiquidViewOptions"/>.
         /// </summary>
         /// <param name="hostingEnvironment"><see cref="IHostingEnvironment"/> for the application.</param>
-        public LiquidViewOptionsSetup(IHostingEnvironment hostingEnvironment)
+        /// <param name="applicationContext"><see cref="IApplicationContext"/> for the application.</param>
+        public LiquidViewOptionsSetup(IHostingEnvironment hostingEnvironment, IApplicationContext applicationContext)
         {
             _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));
+            _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
         }
 
         public void Configure(LiquidViewOptions options)
@@ -25,7 +29,7 @@ namespace OrchardCore.DisplayManagement.Liquid
 
                 if (_hostingEnvironment.IsDevelopment())
                 {
-                    options.FileProviders.Insert(0, new ModuleProjectLiquidFileProvider(_hostingEnvironment));
+                    options.FileProviders.Insert(0, new ModuleProjectLiquidFileProvider(_applicationContext));
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ModuleProjectLiquidFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ModuleProjectLiquidFileProvider.cs
@@ -17,9 +17,9 @@ namespace OrchardCore.DisplayManagement.Liquid
     public class ModuleProjectLiquidFileProvider : IFileProvider
     {
         private static Dictionary<string, string> _paths;
-        private static object _synLock = new object();
+        private static readonly object _synLock = new object();
 
-        public ModuleProjectLiquidFileProvider(IHostingEnvironment environment)
+        public ModuleProjectLiquidFileProvider(IApplicationContext applicationContext)
         {
             if (_paths != null)
             {
@@ -33,12 +33,10 @@ namespace OrchardCore.DisplayManagement.Liquid
                     if (_paths == null)
                     {
                         var assets = new List<Asset>();
-                        var application = environment.GetApplication();
+                        var application = applicationContext.Application;
 
-                        foreach (var name in application.ModuleNames)
+                        foreach (var module in application.Modules)
                         {
-                            var module = environment.GetModule(name);
-
                             if (module.Assembly == null || Path.GetDirectoryName(module.Assembly.Location)
                                 != Path.GetDirectoryName(application.Assembly.Location))
                             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ModuleProjectLiquidFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ModuleProjectLiquidFileProvider.cs
@@ -30,25 +30,22 @@ namespace OrchardCore.DisplayManagement.Liquid
             {
                 if (_paths == null)
                 {
-                    if (_paths == null)
+                    var assets = new List<Asset>();
+                    var application = applicationContext.Application;
+
+                    foreach (var module in application.Modules)
                     {
-                        var assets = new List<Asset>();
-                        var application = applicationContext.Application;
-
-                        foreach (var module in application.Modules)
+                        if (module.Assembly == null || Path.GetDirectoryName(module.Assembly.Location)
+                            != Path.GetDirectoryName(application.Assembly.Location))
                         {
-                            if (module.Assembly == null || Path.GetDirectoryName(module.Assembly.Location)
-                                != Path.GetDirectoryName(application.Assembly.Location))
-                            {
-                                continue;
-                            }
-
-                            assets.AddRange(module.Assets.Where(a => a.ModuleAssetPath
-                                .EndsWith(".liquid", StringComparison.Ordinal)));
+                            continue;
                         }
 
-                        _paths = assets.ToDictionary(a => a.ModuleAssetPath, a => a.ProjectAssetPath);
+                        assets.AddRange(module.Assets.Where(a => a.ModuleAssetPath
+                            .EndsWith(".liquid", StringComparison.Ordinal)));
                     }
+
+                    _paths = assets.ToDictionary(a => a.ModuleAssetPath, a => a.ProjectAssetPath);
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore.Environment.Extensions/ExtensionManager.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions/ExtensionManager.cs
@@ -16,7 +16,6 @@ namespace OrchardCore.Environment.Extensions
 {
     public class ExtensionManager : IExtensionManager
     {
-        private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IApplicationContext _applicationContext;
 
         private readonly IEnumerable<IExtensionDependencyStrategy> _extensionDependencyStrategies;
@@ -29,19 +28,19 @@ namespace OrchardCore.Environment.Extensions
         private IDictionary<string, FeatureEntry> _features;
         private IFeatureInfo[] _featureInfos;
 
-        private ConcurrentDictionary<string, Lazy<IEnumerable<IFeatureInfo>>> _featureDependencies
+        private readonly ConcurrentDictionary<string, Lazy<IEnumerable<IFeatureInfo>>> _featureDependencies
             = new ConcurrentDictionary<string, Lazy<IEnumerable<IFeatureInfo>>>();
 
-        private ConcurrentDictionary<string, Lazy<IEnumerable<IFeatureInfo>>> _dependentFeatures
+        private readonly ConcurrentDictionary<string, Lazy<IEnumerable<IFeatureInfo>>> _dependentFeatures
             = new ConcurrentDictionary<string, Lazy<IEnumerable<IFeatureInfo>>>();
 
-        private static Func<IFeatureInfo, IFeatureInfo[], IFeatureInfo[]> GetDependentFeaturesFunc =
+        private static readonly Func<IFeatureInfo, IFeatureInfo[], IFeatureInfo[]> GetDependentFeaturesFunc =
             new Func<IFeatureInfo, IFeatureInfo[], IFeatureInfo[]>(
                 (currentFeature, fs) => fs
                     .Where(f => f.Dependencies.Any(dep => dep == currentFeature.Id))
                     .ToArray());
 
-        private static Func<IFeatureInfo, IFeatureInfo[], IFeatureInfo[]> GetFeatureDependenciesFunc =
+        private static readonly Func<IFeatureInfo, IFeatureInfo[], IFeatureInfo[]> GetFeatureDependenciesFunc =
             new Func<IFeatureInfo, IFeatureInfo[], IFeatureInfo[]>(
                 (currentFeature, fs) => fs
                     .Where(f => currentFeature.Dependencies.Any(dep => dep == f.Id))
@@ -51,7 +50,6 @@ namespace OrchardCore.Environment.Extensions
         private static object InitializationSyncLock = new object();
 
         public ExtensionManager(
-            IHostingEnvironment hostingEnvironment,
             IApplicationContext applicationContext,
             IEnumerable<IExtensionDependencyStrategy> extensionDependencyStrategies,
             IEnumerable<IExtensionPriorityStrategy> extensionPriorityStrategies,
@@ -59,7 +57,6 @@ namespace OrchardCore.Environment.Extensions
             IFeaturesProvider featuresProvider,
             ILogger<ExtensionManager> logger)
         {
-            _hostingEnvironment = hostingEnvironment;
             _applicationContext = applicationContext;
             _extensionDependencyStrategies = extensionDependencyStrategies;
             _extensionPriorityStrategies = extensionPriorityStrategies;

--- a/src/OrchardCore/OrchardCore.Environment.Extensions/ExtensionManager.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Extensions/ExtensionManager.cs
@@ -17,6 +17,7 @@ namespace OrchardCore.Environment.Extensions
     public class ExtensionManager : IExtensionManager
     {
         private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IApplicationContext _applicationContext;
 
         private readonly IEnumerable<IExtensionDependencyStrategy> _extensionDependencyStrategies;
         private readonly IEnumerable<IExtensionPriorityStrategy> _extensionPriorityStrategies;
@@ -51,6 +52,7 @@ namespace OrchardCore.Environment.Extensions
 
         public ExtensionManager(
             IHostingEnvironment hostingEnvironment,
+            IApplicationContext applicationContext,
             IEnumerable<IExtensionDependencyStrategy> extensionDependencyStrategies,
             IEnumerable<IExtensionPriorityStrategy> extensionPriorityStrategies,
             ITypeFeatureProvider typeFeatureProvider,
@@ -58,6 +60,7 @@ namespace OrchardCore.Environment.Extensions
             ILogger<ExtensionManager> logger)
         {
             _hostingEnvironment = hostingEnvironment;
+            _applicationContext = applicationContext;
             _extensionDependencyStrategies = extensionDependencyStrategies;
             _extensionPriorityStrategies = extensionPriorityStrategies;
             _typeFeatureProvider = typeFeatureProvider;
@@ -238,14 +241,12 @@ namespace OrchardCore.Environment.Extensions
                     return;
                 }
 
-                var moduleNames = _hostingEnvironment.GetApplication().ModuleNames;
+                var modules = _applicationContext.Application.Modules;
                 var loadedExtensions = new ConcurrentDictionary<string, ExtensionEntry>();
 
                 // Load all extensions in parallel
-                Parallel.ForEach(moduleNames, new ParallelOptions { MaxDegreeOfParallelism = 8 }, (name) =>
+                Parallel.ForEach(modules, new ParallelOptions { MaxDegreeOfParallelism = 8 }, (module) =>
                 {
-                    var module = _hostingEnvironment.GetModule(name);
-
                     if (!module.ModuleInfo.Exists)
                     {
                         return;

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/Application.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/Application.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
+
+namespace OrchardCore.Modules
+{
+    public class Application
+    {
+        private readonly Dictionary<string, List<Module>> _modulesByName;
+        private readonly List<Module> _modules;
+
+        public static readonly string ModulesPath = ".Modules";
+        public static readonly string ModuleName = "Application";
+        public static readonly string ModulesRoot = ModulesPath + "/";
+
+        public Application(IHostingEnvironment environment, IEnumerable<Module> modules)
+        {
+            Name = environment.ApplicationName;
+            Path = environment.ContentRootPath;
+            Root = Path + '/';
+            ModulePath = ModulesRoot + Name;
+            ModuleRoot = ModulePath + '/';
+
+            Assembly = Assembly.Load(new AssemblyName(Name));
+
+            _modules = new List<Module>(modules);
+            _modulesByName = _modules.GroupBy(x => x.Name).ToDictionary(x => x.Key, x => x.ToList());
+        }
+
+        public string Name { get; }
+        public string Path { get; }
+        public string Root { get; }
+        public string ModulePath { get; }
+        public string ModuleRoot { get; }
+        public Assembly Assembly { get; }
+        public IEnumerable<Module> Modules => _modules;
+
+        public Module GetModule(string name)
+        {
+            if (!_modulesByName.TryGetValue(name, out var modules) || modules.Count == 0)
+            {
+                return new Module(string.Empty);
+            }
+
+            return modules[modules.Count - 1];
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/AssemblyAttributeModuleNamesProvider.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/AssemblyAttributeModuleNamesProvider.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
+using OrchardCore.Modules.Manifest;
+
+namespace OrchardCore.Modules
+{
+    public class AssemblyAttributeModuleNamesProvider : IModuleNamesProvider
+    {
+        private readonly List<string> _moduleNames;
+
+        public AssemblyAttributeModuleNamesProvider(IHostingEnvironment hostingEnvironment)
+        {
+            var assembly = Assembly.Load(new AssemblyName(hostingEnvironment.ApplicationName));
+            _moduleNames = assembly.GetCustomAttributes<ModuleNameAttribute>().Select(m => m.Name).ToList();
+        }
+
+        public IEnumerable<string> GetModuleNames()
+        {
+            return _moduleNames;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/Asset.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/Asset.cs
@@ -1,0 +1,25 @@
+namespace OrchardCore.Modules
+{
+    public class Asset
+    {
+        public Asset(string asset)
+        {
+            asset = asset.Replace('\\', '/');
+            var index = asset.IndexOf('|');
+
+            if (index == -1)
+            {
+                ModuleAssetPath = string.Empty;
+                ProjectAssetPath = string.Empty;
+            }
+            else
+            {
+                ModuleAssetPath = asset.Substring(0, index);
+                ProjectAssetPath = asset.Substring(index + 1);
+            }
+        }
+
+        public string ModuleAssetPath { get; }
+        public string ProjectAssetPath { get; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/IModuleNamesProvider.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/IModuleNamesProvider.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace OrchardCore.Modules
+{
+    public interface IModuleNamesProvider
+    {
+        IEnumerable<string> GetModuleNames();
+    }
+}

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/ModularApplicationContext.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/ModularApplicationContext.cs
@@ -1,236 +1,62 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.FileProviders.Embedded;
-using OrchardCore.Modules.Manifest;
 
 namespace OrchardCore.Modules
 {
-    public static class ModularApplicationContext
+    public interface IApplicationContext
     {
-        private static Application _application;
-        private static readonly IDictionary<string, Module> _modules = new Dictionary<string, Module>();
-        private static readonly object _synLock = new object();
+        Application Application { get; }
+    }
 
-        public static Application GetApplication(this IHostingEnvironment environment)
+    public class ModularApplicationContext : IApplicationContext
+    {
+        private readonly IHostingEnvironment _environment;
+        private readonly IEnumerable<IModuleNamesProvider> _moduleNamesProviders;
+        private Application _application;
+        private static readonly object _initLock = new object();
+
+        public ModularApplicationContext(IHostingEnvironment environment, IEnumerable<IModuleNamesProvider> moduleNamesProviders)
+        {
+            _environment = environment;
+            _moduleNamesProviders = moduleNamesProviders;
+        }
+
+        public Application Application
+        {
+            get
+            {
+                EnsureInitialized();
+                return _application;
+            }
+        }
+
+        private void EnsureInitialized()
         {
             if (_application == null)
             {
-                lock (_synLock)
+                lock (_initLock)
                 {
                     if (_application == null)
                     {
-                        _application = new Application(environment);
+                        _application = new Application(_environment, GetModules());
                     }
                 }
             }
-
-            return _application;
         }
 
-        public static Module GetModule(this IHostingEnvironment environment, string name)
+        private IEnumerable<Module> GetModules()
         {
-            if (!_modules.TryGetValue(name, out var module))
-            {
-                if (!environment.GetApplication().ModuleNames.Contains(name, StringComparer.Ordinal))
-                {
-                    return new Module(string.Empty);
-                }
+            var modules = new List<Module>();
+            modules.Add(new Module(_environment.ApplicationName, true));
 
-                lock (_synLock)
-                {
-                    if (!_modules.TryGetValue(name, out module))
-                    {
-                        _modules[name] = module = new Module(name, name == environment.ApplicationName);
-                    }
-                }
+            foreach (var provider in _moduleNamesProviders)
+            {
+                modules.AddRange(provider.GetModuleNames().Select(name => new Module(name, name == _environment.ApplicationName)));
             }
 
-            return module;
+            return modules;
         }
-    }
-
-    public class Application
-    {
-        public const string ModulesPath = ".Modules";
-        public const string ModuleName = "Application";
-        public static string ModulesRoot = ModulesPath + "/";
-
-        public Application(IHostingEnvironment environment)
-        {
-            Name = environment.ApplicationName;
-            Path = environment.ContentRootPath;
-            Root = Path + '/';
-
-            Assembly = Assembly.Load(new AssemblyName(Name));
-
-            var moduleNames = Assembly.GetCustomAttributes<ModuleNameAttribute>()
-                .Select(m => m.Name).ToList();
-
-            moduleNames.Add(Name);
-            ModuleNames = moduleNames;
-
-            ModulePath = ModulesRoot + Name;
-            ModuleRoot = ModulePath + '/';
-        }
-
-        public string Name { get; }
-        public string Path { get; }
-        public string Root { get; }
-        public Assembly Assembly { get; }
-        public IEnumerable<string> ModuleNames { get; }
-        public string ModulePath { get; }
-        public string ModuleRoot { get; }
-    }
-
-    public class Module
-    {
-        public const string WebRootPath = "wwwroot";
-        public static string WebRoot = WebRootPath + "/";
-
-        private readonly string _baseNamespace;
-        private readonly DateTimeOffset _lastModified;
-        private readonly IDictionary<string, IFileInfo> _fileInfos = new Dictionary<string, IFileInfo>();
-
-        public Module(string name, bool isApplication = false)
-        {
-            if (!string.IsNullOrWhiteSpace(name))
-            {
-                Name = name;
-                SubPath = Application.ModulesRoot + Name;
-                Root = SubPath + '/';
-
-                Assembly = Assembly.Load(new AssemblyName(name));
-
-                Assets = Assembly.GetCustomAttributes<ModuleAssetAttribute>()
-                    .Select(a => new Asset(a.Asset)).ToArray();
-
-                AssetPaths = Assets.Select(a => a.ModuleAssetPath).ToArray();
-
-                var moduleInfos = Assembly.GetCustomAttributes<ModuleAttribute>();
-
-                ModuleInfo =
-                    moduleInfos.Where(f => !(f is ModuleMarkerAttribute)).FirstOrDefault() ??
-                    moduleInfos.Where(f => f is ModuleMarkerAttribute).FirstOrDefault() ??
-                    new ModuleAttribute { Name = Name };
-
-                var features = Assembly.GetCustomAttributes<Manifest.FeatureAttribute>()
-                    .Where(f => !(f is ModuleAttribute)).ToList();
-
-                ModuleInfo.Id = Name;
-
-                if (isApplication)
-                {
-                    ModuleInfo.Name = Application.ModuleName;
-                    ModuleInfo.Description = "Provides core features defined at the application level";
-                    ModuleInfo.Priority = int.MinValue.ToString();
-                    ModuleInfo.Category = "Application";
-                    ModuleInfo.DefaultTenantOnly = true;
-
-                    if (features.Any())
-                    {
-                        features.Insert(0, new Manifest.FeatureAttribute()
-                        {
-                            Id = ModuleInfo.Id,
-                            Name = ModuleInfo.Name,
-                            Description = ModuleInfo.Description,
-                            Priority = ModuleInfo.Priority,
-                            Category = ModuleInfo.Category
-                        });
-                    }
-                }
-
-                ModuleInfo.Features.AddRange(features);
-            }
-            else
-            {
-                Name = Root = SubPath = String.Empty;
-                Assets = Enumerable.Empty<Asset>();
-                AssetPaths = Enumerable.Empty<string>();
-                ModuleInfo = new ModuleAttribute();
-            }
-
-            _baseNamespace = Name + '.';
-            _lastModified = DateTimeOffset.UtcNow;
-
-            if (!string.IsNullOrEmpty(Assembly?.Location))
-            {
-                try
-                {
-                    _lastModified = File.GetLastWriteTimeUtc(Assembly.Location);
-                }
-                catch (PathTooLongException)
-                {
-                }
-                catch (UnauthorizedAccessException)
-                {
-                }
-            }
-        }
-
-        public string Name { get; }
-        public string Root { get; }
-        public string SubPath { get; }
-        public Assembly Assembly { get; }
-        public IEnumerable<Asset> Assets { get; }
-        public IEnumerable<string> AssetPaths { get; }
-        public ModuleAttribute ModuleInfo { get; }
-
-        public IFileInfo GetFileInfo(string subpath)
-        {
-            if (!_fileInfos.TryGetValue(subpath, out var fileInfo))
-            {
-                if (!AssetPaths.Contains(Root + subpath, StringComparer.Ordinal))
-                {
-                    return new NotFoundFileInfo(subpath);
-                }
-
-                lock (_fileInfos)
-                {
-                    if (!_fileInfos.TryGetValue(subpath, out fileInfo))
-                    {
-                        var resourcePath = _baseNamespace + subpath.Replace('/', '>');
-                        var fileName = Path.GetFileName(subpath);
-
-                        if (Assembly.GetManifestResourceInfo(resourcePath) == null)
-                        {
-                            return new NotFoundFileInfo(fileName);
-                        }
-
-                        _fileInfos[subpath] = fileInfo = new EmbeddedResourceFileInfo(
-                            Assembly, resourcePath, fileName, _lastModified);
-                    }
-                }
-            }
-
-            return fileInfo;
-        }
-    }
-
-    public class Asset
-    {
-        public Asset(string asset)
-        {
-            asset = asset.Replace('\\', '/');
-            var index = asset.IndexOf('|');
-
-            if (index == -1)
-            {
-                ModuleAssetPath = string.Empty;
-                ProjectAssetPath = string.Empty;
-            }
-            else
-            {
-                ModuleAssetPath = asset.Substring(0, index);
-                ProjectAssetPath = asset.Substring(index + 1);
-            }
-        }
-
-        public string ModuleAssetPath { get; }
-        public string ProjectAssetPath { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/Module.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/Module.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Embedded;
+using OrchardCore.Modules.Manifest;
+
+namespace OrchardCore.Modules
+{
+    public class Module
+    {
+        public const string WebRootPath = "wwwroot";
+        public static string WebRoot = WebRootPath + "/";
+
+        private readonly string _baseNamespace;
+        private readonly DateTimeOffset _lastModified;
+        private readonly IDictionary<string, IFileInfo> _fileInfos = new Dictionary<string, IFileInfo>();
+
+        public Module(string name, bool isApplication = false)
+        {
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                Name = name;
+                SubPath = Application.ModulesRoot + Name;
+                Root = SubPath + '/';
+
+                Assembly = Assembly.Load(new AssemblyName(name));
+
+                Assets = Assembly.GetCustomAttributes<ModuleAssetAttribute>()
+                    .Select(a => new Asset(a.Asset)).ToArray();
+
+                AssetPaths = Assets.Select(a => a.ModuleAssetPath).ToArray();
+
+                var moduleInfos = Assembly.GetCustomAttributes<ModuleAttribute>();
+
+                ModuleInfo =
+                    moduleInfos.Where(f => !(f is ModuleMarkerAttribute)).FirstOrDefault() ??
+                    moduleInfos.Where(f => f is ModuleMarkerAttribute).FirstOrDefault() ??
+                    new ModuleAttribute { Name = Name };
+
+                var features = Assembly.GetCustomAttributes<Manifest.FeatureAttribute>()
+                    .Where(f => !(f is ModuleAttribute)).ToList();
+
+                ModuleInfo.Id = Name;
+
+                if (isApplication)
+                {
+                    ModuleInfo.Name = Application.ModuleName;
+                    ModuleInfo.Description = "Provides core features defined at the application level";
+                    ModuleInfo.Priority = int.MinValue.ToString();
+                    ModuleInfo.Category = "Application";
+                    ModuleInfo.DefaultTenantOnly = true;
+
+                    if (features.Any())
+                    {
+                        features.Insert(0, new Manifest.FeatureAttribute()
+                        {
+                            Id = ModuleInfo.Id,
+                            Name = ModuleInfo.Name,
+                            Description = ModuleInfo.Description,
+                            Priority = ModuleInfo.Priority,
+                            Category = ModuleInfo.Category
+                        });
+                    }
+                }
+
+                ModuleInfo.Features.AddRange(features);
+            }
+            else
+            {
+                Name = Root = SubPath = String.Empty;
+                Assets = Enumerable.Empty<Asset>();
+                AssetPaths = Enumerable.Empty<string>();
+                ModuleInfo = new ModuleAttribute();
+            }
+
+            _baseNamespace = Name + '.';
+            _lastModified = DateTimeOffset.UtcNow;
+
+            if (!string.IsNullOrEmpty(Assembly?.Location))
+            {
+                try
+                {
+                    _lastModified = File.GetLastWriteTimeUtc(Assembly.Location);
+                }
+                catch (PathTooLongException)
+                {
+                }
+                catch (UnauthorizedAccessException)
+                {
+                }
+            }
+        }
+
+        public string Name { get; }
+        public string Root { get; }
+        public string SubPath { get; }
+        public Assembly Assembly { get; }
+        public IEnumerable<Asset> Assets { get; }
+        public IEnumerable<string> AssetPaths { get; }
+        public ModuleAttribute ModuleInfo { get; }
+
+        public IFileInfo GetFileInfo(string subpath)
+        {
+            if (!_fileInfos.TryGetValue(subpath, out var fileInfo))
+            {
+                if (!AssetPaths.Contains(Root + subpath, StringComparer.Ordinal))
+                {
+                    return new NotFoundFileInfo(subpath);
+                }
+
+                lock (_fileInfos)
+                {
+                    if (!_fileInfos.TryGetValue(subpath, out fileInfo))
+                    {
+                        var resourcePath = _baseNamespace + subpath.Replace('/', '>');
+                        var fileName = Path.GetFileName(subpath);
+
+                        if (Assembly.GetManifestResourceInfo(resourcePath) == null)
+                        {
+                            return new NotFoundFileInfo(fileName);
+                        }
+
+                        _fileInfos[subpath] = fileInfo = new EmbeddedResourceFileInfo(
+                            Assembly, resourcePath, fileName, _lastModified);
+                    }
+                }
+            }
+
+            return fileInfo;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/ModuleEmbeddedFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/ModuleEmbeddedFileProvider.cs
@@ -17,14 +17,14 @@ namespace OrchardCore.Modules
     /// </summary>
     public class ModuleEmbeddedFileProvider : IFileProvider
     {
-        private readonly IHostingEnvironment _environment;
+        private readonly IApplicationContext _applicationContext;
 
-        public ModuleEmbeddedFileProvider(IHostingEnvironment hostingEnvironment)
+        public ModuleEmbeddedFileProvider(IApplicationContext applicationContext)
         {
-            _environment = hostingEnvironment;
+            _applicationContext = applicationContext;
         }
 
-        private Application Application => _environment.GetApplication();
+        private Application Application => _applicationContext.Application;
 
         public IDirectoryContents GetDirectoryContents(string subpath)
         {
@@ -43,8 +43,8 @@ namespace OrchardCore.Modules
             }
             else if (folder == Application.ModulesPath)
             {
-                entries.AddRange(Application.ModuleNames
-                    .Select(n => new EmbeddedDirectoryInfo(n)));
+                entries.AddRange(Application.Modules
+                    .Select(n => new EmbeddedDirectoryInfo(n.Name)));
             }
             else if (folder == Application.ModulePath)
             {
@@ -64,7 +64,7 @@ namespace OrchardCore.Modules
                 var path = folder.Substring(Application.ModulesRoot.Length);
                 var index = path.IndexOf('/');
                 var name = index == -1 ? path : path.Substring(0, index);
-                var assetPaths = _environment.GetModule(name).AssetPaths;
+                var assetPaths = Application.GetModule(name).AssetPaths;
                 var folders = new HashSet<string>(StringComparer.Ordinal);
                 var folderSlash = folder + '/';
 
@@ -113,7 +113,7 @@ namespace OrchardCore.Modules
                 {
                     var module = path.Substring(0, index);
                     var fileSubPath = path.Substring(index + 1);
-                    return _environment.GetModule(module).GetFileInfo(fileSubPath);
+                    return Application.GetModule(module).GetFileInfo(fileSubPath);
                 }
             }
 

--- a/src/OrchardCore/OrchardCore.Modules.Abstractions/ModuleEmbeddedStaticFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Modules.Abstractions/ModuleEmbeddedStaticFileProvider.cs
@@ -13,11 +13,11 @@ namespace OrchardCore.Modules
     /// </summary>
     public class ModuleEmbeddedStaticFileProvider : IFileProvider
     {
-        private readonly IHostingEnvironment _environment;
+        private readonly IApplicationContext _applicationContext;
 
-        public ModuleEmbeddedStaticFileProvider(IHostingEnvironment environment)
+        public ModuleEmbeddedStaticFileProvider(IApplicationContext applicationContext)
         {
-            _environment = environment;
+            _applicationContext = applicationContext;
         }
 
         public IDirectoryContents GetDirectoryContents(string subpath)
@@ -38,18 +38,19 @@ namespace OrchardCore.Modules
 
             if (index != -1)
             {
+                var application = _applicationContext.Application;
                 var module = path.Substring(0, index);
 
-                if (_environment.GetApplication().ModuleNames.Contains(module))
+                if (application.Modules.Any(m=> m.Name == module))
                 {
                     var fileSubPath = Module.WebRoot + path.Substring(index + 1);
 
-                    if (module != _environment.GetApplication().Name)
+                    if (module != application.Name)
                     {
-                        return _environment.GetModule(module).GetFileInfo(fileSubPath);
+                        return application.GetModule(module).GetFileInfo(fileSubPath);
                     }
 
-                    fileSubPath = _environment.GetApplication().Root + fileSubPath;
+                    fileSubPath = application.Root + fileSubPath;
                     return new PhysicalFileInfo(new FileInfo(fileSubPath));
                 }
             }

--- a/src/OrchardCore/OrchardCore.Modules/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Extensions/ApplicationBuilderExtensions.cs
@@ -14,9 +14,10 @@ namespace Microsoft.AspNetCore.Builder
         public static IApplicationBuilder UseOrchardCore(this IApplicationBuilder app, Action<IApplicationBuilder> configure = null)
         {
             var env = app.ApplicationServices.GetRequiredService<IHostingEnvironment>();
+            var appContext = app.ApplicationServices.GetRequiredService<IApplicationContext>();
 
             env.ContentRootFileProvider = new CompositeFileProvider(
-                new ModuleEmbeddedFileProvider(env),
+                new ModuleEmbeddedFileProvider(appContext),
                 env.ContentRootFileProvider);
 
             app.UseMiddleware<PoweredByMiddleware>();

--- a/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
@@ -87,6 +87,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void AddExtensionServices(OrchardCoreBuilder builder)
         {
+            builder.ApplicationServices.AddSingleton<IModuleNamesProvider, AssemblyAttributeModuleNamesProvider>();
+            builder.ApplicationServices.AddSingleton<IApplicationContext, ModularApplicationContext>();
+            
             builder.ApplicationServices.AddExtensionManagerHost();
 
             builder.ConfigureServices(services =>
@@ -103,18 +106,19 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Configure((app, routes, serviceProvider) =>
             {
                 var env = serviceProvider.GetRequiredService<IHostingEnvironment>();
+                var appContext = serviceProvider.GetRequiredService<IApplicationContext>();
 
                 IFileProvider fileProvider;
                 if (env.IsDevelopment())
                 {
                     var fileProviders = new List<IFileProvider>();
-                    fileProviders.Add(new ModuleProjectStaticFileProvider(env));
-                    fileProviders.Add(new ModuleEmbeddedStaticFileProvider(env));
+                    fileProviders.Add(new ModuleProjectStaticFileProvider(appContext));
+                    fileProviders.Add(new ModuleEmbeddedStaticFileProvider(appContext));
                     fileProvider = new CompositeFileProvider(fileProviders);
                 }
                 else
                 {
-                    fileProvider = new ModuleEmbeddedStaticFileProvider(env);
+                    fileProvider = new ModuleEmbeddedStaticFileProvider(appContext);
                 }
 
                 app.UseStaticFiles(new StaticFileOptions

--- a/src/OrchardCore/OrchardCore.Mvc.Core/ModularRazorViewEngineOptionsSetup.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/ModularRazorViewEngineOptionsSetup.cs
@@ -9,10 +9,12 @@ namespace OrchardCore.Mvc
     public class ModularRazorViewEngineOptionsSetup : IConfigureOptions<RazorViewEngineOptions>
     {
         private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IApplicationContext _applicationContext;
 
-        public ModularRazorViewEngineOptionsSetup(IHostingEnvironment hostingEnvironment)
+        public ModularRazorViewEngineOptionsSetup(IHostingEnvironment hostingEnvironment, IApplicationContext applicationContext)
         {
             _hostingEnvironment = hostingEnvironment;
+            _applicationContext = applicationContext;
         }
 
         public void Configure(RazorViewEngineOptions options)
@@ -23,13 +25,13 @@ namespace OrchardCore.Mvc
             {
                 if (options.FileProviders[i] == _hostingEnvironment.ContentRootFileProvider)
                 {
-                    options.FileProviders[i] = new ModuleEmbeddedFileProvider(_hostingEnvironment);
+                    options.FileProviders[i] = new ModuleEmbeddedFileProvider(_applicationContext);
                 }
             }
 
             if (_hostingEnvironment.IsDevelopment())
             {
-                options.FileProviders.Insert(0, new ModuleProjectRazorFileProvider(_hostingEnvironment));
+                options.FileProviders.Insert(0, new ModuleProjectRazorFileProvider(_applicationContext));
             }
         }
     }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -17,9 +17,9 @@ namespace OrchardCore.Mvc
     public class ModuleProjectRazorFileProvider : IFileProvider
     {
         private static Dictionary<string, string> _paths;
-        private static object _synLock = new object();
+        private static readonly object _synLock = new object();
 
-        public ModuleProjectRazorFileProvider(IHostingEnvironment environment)
+        public ModuleProjectRazorFileProvider(IApplicationContext applicationContext)
         {
             if (_paths != null)
             {
@@ -31,12 +31,10 @@ namespace OrchardCore.Mvc
                 if (_paths == null)
                 {
                     var assets = new List<Asset>();
-                    var application = environment.GetApplication();
+                    var application = applicationContext.Application;
 
-                    foreach (var name in application.ModuleNames)
+                    foreach (var module in application.Modules)
                     {
-                        var module = environment.GetModule(name);
-
                         if (module.Assembly == null || Path.GetDirectoryName(module.Assembly.Location)
                             != Path.GetDirectoryName(application.Assembly.Location))
                         {

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/DefaultModularPageRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/DefaultModularPageRouteModelConvention.cs
@@ -9,11 +9,11 @@ namespace OrchardCore.Mvc.RazorPages
 {
     public class DefaultModularPageRouteModelConvention : IPageRouteModelConvention
     {
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IApplicationContext _applicationContext;
 
-        public DefaultModularPageRouteModelConvention(IHostingEnvironment hostingEnvironment)
+        public DefaultModularPageRouteModelConvention(IApplicationContext applicationContext)
         {
-            _hostingEnvironment = hostingEnvironment;
+            _applicationContext = applicationContext;
         }
 
         public void Apply(PageRouteModel model)
@@ -51,7 +51,7 @@ namespace OrchardCore.Mvc.RazorPages
                         }
                     });
 
-                    var name = _hostingEnvironment.GetModule(module).ModuleInfo.Name;
+                    var name = _applicationContext.Application.GetModule(module).ModuleInfo.Name;
 
                     if (!String.IsNullOrWhiteSpace(name))
                     {

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRazorPagesOptionsSetup.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRazorPagesOptionsSetup.cs
@@ -1,22 +1,23 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
+using OrchardCore.Modules;
 
 namespace OrchardCore.Mvc.RazorPages
 {
     public class ModularPageRazorPagesOptionsSetup : IConfigureOptions<RazorPagesOptions>
     {
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IApplicationContext _applicationContext;
 
-        public ModularPageRazorPagesOptionsSetup(IHostingEnvironment hostingEnvironment)
+        public ModularPageRazorPagesOptionsSetup(IApplicationContext applicationContext)
         {
-            _hostingEnvironment = hostingEnvironment;
+            _applicationContext = applicationContext;
         }
 
         public void Configure(RazorPagesOptions options)
         {
             options.RootDirectory = "/";
-            options.Conventions.Add(new DefaultModularPageRouteModelConvention(_hostingEnvironment));
+            options.Conventions.Add(new DefaultModularPageRouteModelConvention(_applicationContext));
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/SharedViewCompilerProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/SharedViewCompilerProvider.cs
@@ -21,6 +21,7 @@ namespace OrchardCore.Mvc
     public class SharedViewCompilerProvider : IViewCompilerProvider
     {
         private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly IApplicationContext _applicationContext;
         private readonly IEnumerable<IApplicationFeatureProvider<ViewsFeature>> _viewsFeatureProviders;
 
         private readonly RazorProjectEngine _razorProjectEngine;
@@ -37,6 +38,7 @@ namespace OrchardCore.Mvc
 
         public SharedViewCompilerProvider(
             IHostingEnvironment hostingEnvironment,
+            IApplicationContext applicationContext,
             IEnumerable<IApplicationFeatureProvider<ViewsFeature>> viewsFeatureProviders,
             ApplicationPartManager applicationPartManager,
             RazorProjectEngine razorProjectEngine,
@@ -46,6 +48,7 @@ namespace OrchardCore.Mvc
             ILoggerFactory loggerFactory)
         {
             _hostingEnvironment = hostingEnvironment;
+            _applicationContext = applicationContext;
             _viewsFeatureProviders = viewsFeatureProviders;
             _applicationPartManager = applicationPartManager;
             _razorProjectEngine = razorProjectEngine;
@@ -100,13 +103,11 @@ namespace OrchardCore.Mvc
 
             if (!_hostingEnvironment.IsDevelopment())
             {
-                var moduleNames = _hostingEnvironment.GetApplication().ModuleNames;
+                var modules = _applicationContext.Application.Modules;
                 var moduleFeature = new ViewsFeature();
 
-                foreach (var name in moduleNames)
+                foreach (var module in modules)
                 {
-                    var module = _hostingEnvironment.GetModule(name);
-
                     var precompiledAssemblyPath = Path.Combine(Path.GetDirectoryName(module.Assembly.Location),
                         module.Assembly.GetName().Name + ".Views.dll");
 

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -35,7 +35,6 @@ namespace OrchardCore.Tests.Extensions
         public ExtensionManagerTests()
         {
             ModuleScopedExtensionManager = new ExtensionManager(
-                HostingEnvironment,
                 ApplicationContext,
                 new[] { new ExtensionDependencyStrategy() },
                 new[] { new ExtensionPriorityStrategy() },
@@ -45,7 +44,6 @@ namespace OrchardCore.Tests.Extensions
                 );
 
             ThemeScopedExtensionManager = new ExtensionManager(
-                HostingEnvironment,
                 ApplicationContext,
                 new[] { new ExtensionDependencyStrategy() },
                 new[] { new ExtensionPriorityStrategy() },
@@ -55,7 +53,6 @@ namespace OrchardCore.Tests.Extensions
                 );
 
             ModuleThemeScopedExtensionManager = new ExtensionManager(
-                HostingEnvironment,
                 ApplicationContext,
                 new IExtensionDependencyStrategy[] { new ExtensionDependencyStrategy(), new ThemeExtensionDependencyStrategy() },
                 new[] { new ExtensionPriorityStrategy() },

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using OrchardCore.DisplayManagement.Events;
 using OrchardCore.DisplayManagement.Extensions;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Extensions.Features;
+using OrchardCore.Modules;
 using OrchardCore.Tests.Stubs;
 using Xunit;
 
@@ -13,6 +15,12 @@ namespace OrchardCore.Tests.Extensions
     {
         private static IHostingEnvironment HostingEnvironment
             = new StubHostingEnvironment();
+
+        private static IApplicationContext ApplicationContext
+            = new ModularApplicationContext(HostingEnvironment, new List<IModuleNamesProvider>()
+            {
+                new AssemblyAttributeModuleNamesProvider(HostingEnvironment)
+            });
 
         private static IFeaturesProvider ModuleFeatureProvider =
             new FeaturesProvider(new[] { new ThemeFeatureBuilderEvents() }, new NullLogger<FeaturesProvider>());
@@ -28,6 +36,7 @@ namespace OrchardCore.Tests.Extensions
         {
             ModuleScopedExtensionManager = new ExtensionManager(
                 HostingEnvironment,
+                ApplicationContext,
                 new[] { new ExtensionDependencyStrategy() },
                 new[] { new ExtensionPriorityStrategy() },
                 new TypeFeatureProvider(),
@@ -37,6 +46,7 @@ namespace OrchardCore.Tests.Extensions
 
             ThemeScopedExtensionManager = new ExtensionManager(
                 HostingEnvironment,
+                ApplicationContext,
                 new[] { new ExtensionDependencyStrategy() },
                 new[] { new ExtensionPriorityStrategy() },
                 new TypeFeatureProvider(),
@@ -46,6 +56,7 @@ namespace OrchardCore.Tests.Extensions
 
             ModuleThemeScopedExtensionManager = new ExtensionManager(
                 HostingEnvironment,
+                ApplicationContext,
                 new IExtensionDependencyStrategy[] { new ExtensionDependencyStrategy(), new ThemeExtensionDependencyStrategy() },
                 new[] { new ExtensionPriorityStrategy() },
                 new TypeFeatureProvider(),


### PR DESCRIPTION
Currently, module discovery and loading is only done trough a build task and/or the use of the ModuleNameAttribute.

We would like to load modules using a different strategy, e.g. from a list of modules in a json file or database.

This is not possible at the moment, because of the hard-coded assembly loading / module discovery inside 'Application': https://github.com/OrchardCMS/OrchardCore/blob/dev/src/OrchardCore/OrchardCore.Modules.Abstractions/ModularApplicationContext.cs#L71

Building on top of this, we're working on a nuget gallery feature, allowing to install modules at runtime from nuget feeds.

---

I've made the following changes, which allows to inject custom 'IModuleNamesProvider' instances.

Please review if I'm on right track and if this (or something alike) can be included before RTM.

- Introduce IApplicationContext replacing IHostingEnvironment.GetApplication()
- Introduce IModuleNamesProvider with a default implementation (AssemblyAttributeModuleNamesProvider) using ModuleNameAttribute
- Replace all occurrences of IHostingEnvironment.GetApplication()/GetModule() with IApplicationContext