### PR TITLE
Prevent agency content from being all displayed inline.

### DIFF
--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Content.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Content.liquid
@@ -11,8 +11,6 @@
 
 <section>
   <div class="container">
-    <div class="row">
-        {{ Model.Content | shape_render }}
-    </div>
+      {{ Model.Content | shape_render }}
   </div>
 </section>


### PR DESCRIPTION
Using the agency recipe, the following in an html body part

    <p>Test1</p><p>Test2</p>

was displayed as

    Test1Test2

in place of

    Test1
    Test2

The following in a markdown body part

    # Test1
    # Test2

was displayed as

    Test1Test2

in place of

    Test1
    Test2

Applying this PR solves this little issue and doesn't seem to modify the other renderings.
But not sure so it's just to show the idea and need to be checked.