### PR TITLE
Fixes preview window scrolling position.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -82,8 +82,8 @@
 
     iframe.onload = function () {
         if (previewRendering) {
-            $(this.contentWindow).scrollTop(scrollTop);
             this.style.display = 'block';
+            $(this.contentWindow).scrollTop(scrollTop);
 
             if (iframe2 && iframe2.contentWindow) {
                 iframe2.style.display = 'none';
@@ -127,8 +127,8 @@
                         // Then, we use 2 frames to cancel the flicker that this deferring causes.
 
                         scrollTop = $(iframe.contentWindow).scrollTop();
-                        $(iframe2.contentWindow).scrollTop(scrollTop);
                         iframe2.style.display = 'block';
+                        $(iframe2.contentWindow).scrollTop(scrollTop);
 
                         iframe.style.display = 'none';
                         iframe.contentWindow.document.open();

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -85,8 +85,8 @@
 
     iframe.onload = function () {
         if (previewRendering) {
-            $(this.contentWindow).scrollTop(scrollTop);
             this.style.display = 'block';
+            $(this.contentWindow).scrollTop(scrollTop);
 
             if (iframe2 && iframe2.contentWindow) {
                 iframe2.style.display = 'none';
@@ -138,8 +138,8 @@
                         // Then, we use 2 frames to cancel the flicker that this deferring causes.
 
                         scrollTop = $(iframe.contentWindow).scrollTop();
-                        $(iframe2.contentWindow).scrollTop(scrollTop);
                         iframe2.style.display = 'block';
+                        $(iframe2.contentWindow).scrollTop(scrollTop);
 
                         iframe.style.display = 'none';
                         iframe.contentWindow.document.open();


### PR DESCRIPTION
Fixes #2091.

So, now when previewing an item, on each update the preview window doesn't keep its scrolling position and go up to the top, which was not the case before.

@Skrypt i think i found the issue, at some point to `Fix preview not scrolling on Safari` in 60ce546 you have used the `display` style in place of the `visibility`. The little problem is that a frame loses its scrolling position when setting `display = none`, and then setting the position again in this mode has no effect.

I needed to set the scrolling position after switching from `display= none` to `display = block`, not before.