### PR TITLE
Media step must override existing file instead of raising exception

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Recipes/MediaStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Recipes/MediaStep.cs
@@ -32,13 +32,13 @@ namespace OrchardCore.Media.Recipes
 
             var model = context.Step.ToObject<MediaStepModel>();
 
-            foreach(JObject item in model.Files)
+            foreach (JObject item in model.Files)
             {
                 var file = item.ToObject<MediaStepFile>();
                 using (var stream = new MemoryStream(Convert.FromBase64String(file.Base64)))
                 {
-                    await _mediaFileStore.CreateFileFromStream(file.Path, stream);
-                }                    
+                    await _mediaFileStore.CreateFileFromStream(file.Path, stream, true);
+                }
             }
         }
     }


### PR DESCRIPTION
By running the media-step, it must override existing file instead of raising exception