### PR TITLE
Little fixes related to Lucene.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Query.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Query.cshtml
@@ -55,6 +55,8 @@
 
 @if (Model.Documents.Any())
 {
+    var fieldNames = Model.Documents.SelectMany(d => d.Fields.Select(f => f.Name)).Distinct();
+
     <div class="form-group">
         <a href="@Url.Action("Create", "Admin", new { area = "OrchardCore.Queries", id = "Lucene", query = Model.DecodedQuery })" class="btn btn-success">@T["Create"]</a>
     </div>
@@ -63,9 +65,9 @@
         <thead>
             <tr>
                 <th>#</th>
-                @foreach (var field in Model.Documents.First())
+                @foreach (var name in fieldNames)
                 {
-                <th>@field.Name</th>
+                <th>@name</th>
                 }
             </tr>
         </thead>
@@ -75,9 +77,9 @@
             {
             <tr>
                 <th scope="row">@(row++)</th>
-                @foreach (var field in document)
+                @foreach (var name in fieldNames)
                 {
-                    <td>@field.GetStringValue()</td>
+                    <td>@(document.GetField(name)?.GetStringValue() ?? String.Empty)</td>
                 }
             </tr>
             }

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentsHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentsHandler.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.ContentManagement.Handlers
             return Task.CompletedTask;
         }
 
-        public override Task PublishedAsync(PublishContentContext context)
+        public override Task PublishingAsync(PublishContentContext context)
         {
             var utcNow = _clock.UtcNow;
 


### PR DESCRIPTION
When `PublishedAsync()` are executed (in a reverse order), `LuceneIndexingContentHandler` runs before `UpdateContentsHandler` which updates `PublishedUtc`. So, when `DefaultContentIndexHandler` executes `BuildIndexAsync()`, the value of this property may be the previous one or null.

- So, here, without reconsidering the handlers ordering, in `UpdateContentsHandler` i just renamed `PublishedAsync()` to `PublishingAsync()` so that it updates `PublishedUtc` before, knowing that if the publishing is cancelled the content item updates will not be persisted.

---

When displaying the result of a lucene query through the admin, because all documents don't have the same list of fields, the resulting table is not correctly rendered.

![query1](https://user-images.githubusercontent.com/8586360/43052840-6d8b39ae-8e29-11e8-9af3-5e18976b3e4d.png)

So, here we resolve all possible field names, then for each document we try to get all all of them.

![query2](https://user-images.githubusercontent.com/8586360/43052852-83009054-8e29-11e8-8f4b-6fd822f52d09.png)

