### PR TITLE
Prevent issues caused by a not trimmed Stereotype

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/ContentTypeSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/ContentTypeSettingsDisplayDriver.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.ContentTypes.Editors
                 context.Builder.Draftable(model.Draftable);
                 context.Builder.Versionable(model.Versionable);
                 context.Builder.Securable(model.Securable);
-                context.Builder.Stereotype(model.Stereotype);
+                context.Builder.Stereotype(model.Stereotype?.Trim());
             }
 
             return Edit(contentTypeDefinition, context.Updater);


### PR DESCRIPTION
Enforces trimming the stereotype string entered in the admin.
I had issues with "CustomSettings" stereotype. When adding spaces at the start or end of the string the custom settings page was not shown.
Maybe it was causing issues with other stereotypes too.