### PR TITLE
Use TryAddEnumerable to register IdGeneratorMethod.

### DIFF
--- a/src/OrchardCore/OrchardCore.Entities/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Entities/ServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Entities
         public static IServiceCollection AddIdGeneration(this IServiceCollection services)
         {
             services.TryAddSingleton<IIdGenerator, DefaultIdGenerator>();
-            services.TryAddSingleton<IGlobalMethodProvider, IdGeneratorMethod>();
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<IGlobalMethodProvider, IdGeneratorMethod>());
             return services;
         }
     }


### PR DESCRIPTION
Fixes #2136 

So that we can still call `AddIdGeneration()` multiple times. But if other `IGlobalMethodProvider` are registered before these calls, the `IdGeneratorMethod` is still registered, once but still registered.