### PR TITLE
Don't use the Plural extension if Localization is not enabled.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
@@ -1,5 +1,7 @@
 @model WorkflowTypeIndexViewModel
+@using System.Collections.Generic
 @using OrchardCore.Workflows.ViewModels;
+@inject IEnumerable<OrchardCore.Localization.IPluralRuleProvider> PluralRuleProviders;
 
 <h1>@RenderTitleSegments(T["Manage Workflow Types"])</h1>
 
@@ -52,7 +54,14 @@
                             }
                             @if (entry.WorkflowCount > 0)
                             {
+                                if (PluralRuleProviders.Any())
+                                {
                                 <a asp-action="Index" asp-controller="Workflow" asp-route-workflowtypeid="@entry.WorkflowType.Id" class="badge badge-info">@T.Plural(entry.WorkflowCount, "1 instance", "{0} instances", entry.WorkflowCount)</a>
+                                }
+                                else
+                                {
+                                <a asp-action="Index" asp-controller="Workflow" asp-route-workflowtypeid="@entry.WorkflowType.Id" class="badge badge-info">@T["Instances"] @entry.WorkflowCount</a>
+                                }
                             }
                         </div>
                     </div>


### PR DESCRIPTION
Just to show what happens and a possible workaround.

So, the `WorkFlows` index view uses the `Plural ViewLocalizerExtensions` so that when there are multiple instances of a workflow, and when `OC.Localization` is enabled, the following is displayed which is good.

![wf1](https://user-images.githubusercontent.com/8586360/43234080-47a6d088-907a-11e8-8390-52de80c29480.png)

But if `OC.Localization` is not enabled, the following is displayed which is wrong.

![wf2](https://user-images.githubusercontent.com/8586360/43234143-aa7ede8a-907a-11e8-9bd5-1d76e971fd47.png)

Here, by checking if there is no `IPluralRuleProvider`, we fallback to the following.

![wf3](https://user-images.githubusercontent.com/8586360/43234133-96e10984-907a-11e8-9a49-67dc5e8ee9f2.png)

