### PR TITLE
Prevent hosting 'IStartupFilter' to add middlewares to the tenant pipeline.

### DIFF
--- a/src/OrchardCore/OrchardCore.Environment.Shell.Abstractions/Builders/Extensions/ServiceProviderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Shell.Abstractions/Builders/Extensions/ServiceProviderExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
 
 namespace OrchardCore.Environment.Shell.Builders
 {
@@ -18,6 +19,12 @@ namespace OrchardCore.Environment.Shell.Builders
 
             foreach (var services in servicesByType)
             {
+                // Prevent hosting 'IStartupFilter' to re-add middlewares to the tenant pipeline.
+                if (services.First().ServiceType == typeof(IStartupFilter))
+                {
+                    continue;
+                }
+
                 // if only one service of a given type
                 if (services.Count() == 1)
                 {
@@ -31,7 +38,7 @@ namespace OrchardCore.Environment.Shell.Builders
                         {
                             // There is no Func based way to register an open-generic type, instead of
                             // tenantServiceCollection.AddSingleton(typeof(IEnumerable<>), typeof(List<>));
-                            // Right now, we regsiter them as singleton per cloned scope even though it's wrong
+                            // Right now, we register them as singleton per cloned scope even though it's wrong
                             // but in the actual examples it won't matter.
                             clonedCollection.AddSingleton(service.ServiceType, service.ImplementationType);
                         }

--- a/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
@@ -202,18 +202,18 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 if (startupFilterType != null)
                 {
-                    // Remove the data protection startup filter registered at the host level.
-                    // Knowing that a host singleton is cloned through an implementation instance.
-                    var descriptor = services.FirstOrDefault(s => s.ServiceType == typeof(IStartupFilter) &&
-                        s.ImplementationInstance?.GetType() == startupFilterType);
+                    // Remove any previously registered data protection startup filters.
+                    var descriptors = services.Where(s => s.ServiceType == typeof(IStartupFilter) &&
+                        (s.ImplementationInstance?.GetType() == startupFilterType ||
+                        s.ImplementationType == startupFilterType)).ToArray();
 
-                    if (descriptor != null)
+                    foreach (var descriptor in descriptors)
                     {
                         services.Remove(descriptor);
                     }
                 }
 
-                // Remove options setups registered at the host level.
+                // Remove any previously registered options setups.
                 services.RemoveAll<IConfigureOptions<KeyManagementOptions>>();
                 services.RemoveAll<IConfigureOptions<DataProtectionOptions>>();
 


### PR DESCRIPTION
Try to fix #2074.

- So the idea is to not clone hosting startup filters services to the tenant container. So that they don't re-add middlewares in the tenant pipeline, see comments in the related issue.

- We were already removing the data protection startup filter registered at the host level and cloned by using an **implementation instance**. Here, we don't need it anymore but the little side effect is that another  DP startup filter is now pre-registered by another helper in the tenant context and so by providing an **implementation type**. I updated the code to also check the implementation type.