### PR TITLE
Allow to pre-configure tenant StaticFileOptions.

### DIFF
--- a/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Modules/Extensions/ServiceCollectionExtensions.cs
@@ -118,11 +118,11 @@ namespace Microsoft.Extensions.DependencyInjection
                     fileProvider = new ModuleEmbeddedStaticFileProvider(env);
                 }
 
-                app.UseStaticFiles(new StaticFileOptions
-                {
-                    RequestPath = "",
-                    FileProvider = fileProvider
-                });
+                var options = serviceProvider.GetRequiredService<IOptions<StaticFileOptions>>().Value;
+
+                options.RequestPath = "";
+                options.FileProvider = fileProvider;
+                app.UseStaticFiles(options);
             });
         }
 


### PR DESCRIPTION
Fixes #2144.

This way, a module can pre-configure the options, e.g by specifying a `ContentTypeProvider`.

    services.Configure<StaticFileOptions>(options =>
    {
        var provider = options.ContentTypeProvider as FileExtensionContentTypeProvider ??
            new FileExtensionContentTypeProvider();

        provider.Mappings[".wasm"] = "application/wasm";
        provider.Mappings[".dll"] = "application/dll";
        options.ContentTypeProvider = provider;
    });