### PR TITLE
Made SectionDisplayDrivers Update call EditAsync to fix null issue

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Demo/Drivers/UserProfileDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Drivers/UserProfileDisplayDriver.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.Demo.Drivers
             }).Location("Content:2");
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(UserProfile profile, IUpdateModel updater, BuildEditorContext context)
+        public override async Task<IDisplayResult> UpdateAsync(UserProfile profile, BuildEditorContext context)
         {
             var model = new EditUserProfileViewModel();
 
@@ -30,7 +30,7 @@ namespace OrchardCore.Demo.Drivers
                 profile.Name = model.Name;
             }
 
-            return Edit(profile);
+            return Edit(profile, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/NoCaptchaSettingsDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/NoCaptchaSettingsDisplay.cs
@@ -33,13 +33,13 @@ namespace OrchardCore.Forms.Drivers
                 .OnGroup(GroupId);
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(NoCaptchaSettings section, IUpdateModel updater, string groupId)
+        public override async Task<IDisplayResult> UpdateAsync(NoCaptchaSettings section, BuildEditorContext context)
         {
-            if (groupId == GroupId)
+            if (context.GroupId == GroupId)
             {
                 var model = new NoCaptchaSettingsViewModel();
 
-                if (await updater.TryUpdateModelAsync(model, Prefix))
+                if (await context.Updater.TryUpdateModelAsync(model, Prefix))
                 {
 
                     section.SiteKey = model.SiteKey?.Trim();
@@ -50,7 +50,7 @@ namespace OrchardCore.Forms.Drivers
                 }
             }
 
-            return Edit(section);
+            return await EditAsync(section, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Https/Drivers/HttpsSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Https/Drivers/HttpsSettingsDisplayDriver.cs
@@ -57,13 +57,13 @@ namespace OrchardCore.Https.Drivers {
             }).Location("Content:2").OnGroup(SettingsGroupId);
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(HttpsSettings settings, IUpdateModel updater, string groupId)
+        public override async Task<IDisplayResult> UpdateAsync(HttpsSettings settings, BuildEditorContext context)
         {
-            if (groupId == SettingsGroupId)
+            if (context.GroupId == SettingsGroupId)
             {
                 var model = new HttpsSettingsViewModel();
 
-                await updater.TryUpdateModelAsync(model, Prefix);
+                await context.Updater.TryUpdateModelAsync(model, Prefix);
 
                 settings.RequireHttps = model.RequireHttps;
                 settings.RequireHttpsPermanent = model.RequireHttpsPermanent;
@@ -76,7 +76,7 @@ namespace OrchardCore.Https.Drivers {
                 _memoryCache.Set(entry.Key, entry, new MemoryCacheEntryOptions { Priority = CacheItemPriority.NeverRemove });
             }
 
-            return Edit(settings);
+            return await EditAsync(settings, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Drivers/LuceneSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Drivers/LuceneSettingsDisplayDriver.cs
@@ -28,19 +28,19 @@ namespace OrchardCore.Lucene.Drivers
                 }).Location("Content:2").OnGroup("search");
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(LuceneSettings section, IUpdateModel updater, string groupId)
+        public override async Task<IDisplayResult> UpdateAsync(LuceneSettings section,  BuildEditorContext context)
         {
-            if (groupId == "search")
+            if (context.GroupId == "search")
             {
                 var model = new LuceneSettingsViewModel();
 
-                await updater.TryUpdateModelAsync(model, Prefix);
+                await context.Updater.TryUpdateModelAsync(model, Prefix);
 
                 section.SearchIndex = model.SearchIndex;
                 section.DefaultSearchFields = model.SearchFields?.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
             }
 
-            return Edit(section);
+            return await EditAsync(section, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdClientSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdClientSettingsDisplayDriver.cs
@@ -103,7 +103,7 @@ namespace OrchardCore.OpenId.Drivers
             }).Location("Content:2").OnGroup(SettingsGroupId);
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(OpenIdClientSettings settings, IUpdateModel updater, string groupId)
+        public override async Task<IDisplayResult> UpdateAsync(OpenIdClientSettings settings, BuildEditorContext context)
         {
             var user = _httpContextAccessor.HttpContext?.User;
             if (user == null || !await _authorizationService.AuthorizeAsync(user, Permissions.ManageClientSettings))
@@ -111,11 +111,11 @@ namespace OrchardCore.OpenId.Drivers
                 return null;
             }
 
-            if (groupId == SettingsGroupId)
+            if (context.GroupId == SettingsGroupId)
             {
                 var previousClientSecret = settings.ClientSecret;
                 var model = new OpenIdClientSettingsViewModel();
-                await updater.TryUpdateModelAsync(model, Prefix);
+                await context.Updater.TryUpdateModelAsync(model, Prefix);
 
                 model.Scopes = model.Scopes ?? string.Empty;
 
@@ -184,18 +184,18 @@ namespace OrchardCore.OpenId.Drivers
                     if (result != ValidationResult.Success)
                     {
                         var key = result.MemberNames.FirstOrDefault() ?? string.Empty;
-                        updater.ModelState.AddModelError(key, result.ErrorMessage);
+                        context.Updater.ModelState.AddModelError(key, result.ErrorMessage);
                     }
                 }
 
                 // If the settings are valid, reload the current tenant.
-                if (updater.ModelState.IsValid)
+                if (context.Updater.ModelState.IsValid)
                 {
                     _shellHost.ReloadShellContext(_shellSettings);
                 }
             }
 
-            return Edit(settings);
+            return await EditAsync(settings, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdServerSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdServerSettingsDisplayDriver.cs
@@ -94,7 +94,7 @@ namespace OrchardCore.OpenId.Drivers
             }).Location("Content:2").OnGroup(SettingsGroupId);
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(OpenIdServerSettings settings, IUpdateModel updater, string groupId)
+        public override async Task<IDisplayResult> UpdateAsync(OpenIdServerSettings settings,  BuildEditorContext context)
         {
             var user = _httpContextAccessor.HttpContext?.User;
             if (user == null || !await _authorizationService.AuthorizeAsync(user, Permissions.ManageServerSettings))
@@ -102,10 +102,10 @@ namespace OrchardCore.OpenId.Drivers
                 return null;
             }
 
-            if (groupId == SettingsGroupId)
+            if (context.GroupId == SettingsGroupId)
             {
                 var model = new OpenIdServerSettingsViewModel();
-                await updater.TryUpdateModelAsync(model, Prefix);
+                await context.Updater.TryUpdateModelAsync(model, Prefix);
 
                 settings.TestingModeEnabled = model.TestingModeEnabled;
                 settings.AccessTokenFormat = model.AccessTokenFormat;
@@ -129,18 +129,18 @@ namespace OrchardCore.OpenId.Drivers
                     if (result != ValidationResult.Success)
                     {
                         var key = result.MemberNames.FirstOrDefault() ?? string.Empty;
-                        updater.ModelState.AddModelError(key, result.ErrorMessage);
+                        context.Updater.ModelState.AddModelError(key, result.ErrorMessage);
                     }
                 }
 
                 // If the settings are valid, reload the current tenant.
-                if (updater.ModelState.IsValid)
+                if (context.Updater.ModelState.IsValid)
                 {
                     _shellHost.ReloadShellContext(_shellSettings);
                 }
             }
 
-            return Edit(settings);
+            return await EditAsync(settings, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
@@ -74,7 +74,7 @@ namespace OrchardCore.OpenId.Drivers
             }).Location("Content:2").OnGroup(SettingsGroupId);
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(OpenIdValidationSettings settings, IUpdateModel updater, string groupId)
+        public override async Task<IDisplayResult> UpdateAsync(OpenIdValidationSettings settings, BuildEditorContext context)
         {
             var user = _httpContextAccessor.HttpContext?.User;
             if (user == null || !await _authorizationService.AuthorizeAsync(user, Permissions.ManageValidationSettings))
@@ -82,11 +82,11 @@ namespace OrchardCore.OpenId.Drivers
                 return null;
             }
 
-            if (groupId == SettingsGroupId)
+            if (context.GroupId == SettingsGroupId)
             {
                 var model = new OpenIdValidationSettingsViewModel();
 
-                await updater.TryUpdateModelAsync(model, Prefix);
+                await context.Updater.TryUpdateModelAsync(model, Prefix);
 
                 settings.Authority = model.Authority?.Trim();
                 settings.Audience = model.Audience?.Trim();
@@ -97,18 +97,18 @@ namespace OrchardCore.OpenId.Drivers
                     if (result != ValidationResult.Success)
                     {
                         var key = result.MemberNames.FirstOrDefault() ?? string.Empty;
-                        updater.ModelState.AddModelError(key, result.ErrorMessage);
+                        context.Updater.ModelState.AddModelError(key, result.ErrorMessage);
                     }
                 }
 
                 // If the settings are valid, reload the current tenant.
-                if (updater.ModelState.IsValid)
+                if (context.Updater.ModelState.IsValid)
                 {
                     _shellHost.ReloadShellContext(_shellSettings);
                 }
             }
 
-            return Edit(settings);
+            return await EditAsync(settings, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Entities.DisplayManagement;
@@ -21,13 +22,13 @@ namespace OrchardCore.Users.Drivers
             }).Location("Content:5").OnGroup(GroupId);
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(RegistrationSettings section, IUpdateModel updater, string groupId)
+        public override async Task<IDisplayResult> UpdateAsync(RegistrationSettings section, BuildEditorContext context)
         {
-            if (groupId == GroupId)
+            if (context.GroupId == GroupId)
             {
-                await updater.TryUpdateModelAsync(section, Prefix);
+                await context.Updater.TryUpdateModelAsync(section, Prefix);
             }
-            return Edit(section);
+            return await EditAsync(section, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/ResetPasswordSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/ResetPasswordSettingsDisplayDriver.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Entities.DisplayManagement;
@@ -20,13 +21,13 @@ namespace OrchardCore.Users.Drivers
             }).Location("Content:5").OnGroup(GroupId);
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(ResetPasswordSettings section, IUpdateModel updater, string groupId)
+        public override async Task<IDisplayResult> UpdateAsync(ResetPasswordSettings section, BuildEditorContext context)
         {
-            if (groupId == GroupId)
+            if (context.GroupId == GroupId)
             {
-                await updater.TryUpdateModelAsync(section, Prefix);
+                await context.Updater.TryUpdateModelAsync(section, Prefix);
             }
-            return Edit(section);
+            return await EditAsync(section, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/TimeZone/Drivers/UserTimeZoneDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/TimeZone/Drivers/UserTimeZoneDisplayDriver.cs
@@ -42,7 +42,7 @@ namespace OrchardCore.Users.TimeZone.Drivers
                 await _userTimeZoneService.UpdateUserTimeZoneAsync(user);
             }            
 
-            return Edit(userTimeZone, context);
+            return await EditAsync(userTimeZone, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/ActivityMetadataDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/ActivityMetadataDisplay.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.Workflows.Drivers
                 section.Title = viewModel.Title?.Trim();
             }
 
-            return Edit(section, context);
+            return await EditAsync(section, context);
         }
     }
 }


### PR DESCRIPTION
As a result of https://github.com/OrchardCMS/OrchardCore/pull/2098 some SectionDisplayDrivers for site settings are broken, they refuse to store the settings.

This fixes the issue.
