### PR TITLE
Setting logout permission on a application when server-endpoint allow…

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -339,6 +339,17 @@ namespace OrchardCore.OpenId.Controllers
                 descriptor.ClientSecret = null;
             }
 
+            var openIdServerSettings = await GetServerSettingsAsync();
+
+            if (openIdServerSettings.EnableLogoutEndpoint)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Logout);
+            }
+
             if (model.AllowAuthorizationCodeFlow)
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -167,8 +167,6 @@ namespace OrchardCore.OpenId.Controllers
                 Type = model.Type
             };
 
-            var openIdServerSettings = await GetServerSettingsAsync();
-
             if (model.AllowLogoutEndpoint)
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -169,7 +169,7 @@ namespace OrchardCore.OpenId.Controllers
 
             var openIdServerSettings = await GetServerSettingsAsync();
 
-            if (openIdServerSettings.EnableLogoutEndpoint)
+            if (model.AllowLogoutEndpoint)
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
             }
@@ -252,6 +252,7 @@ namespace OrchardCore.OpenId.Controllers
                 AllowImplicitFlow = await HasPermissionAsync(OpenIddictConstants.Permissions.GrantTypes.Implicit),
                 AllowPasswordFlow = await HasPermissionAsync(OpenIddictConstants.Permissions.GrantTypes.Password),
                 AllowRefreshTokenFlow = await HasPermissionAsync(OpenIddictConstants.Permissions.GrantTypes.RefreshToken),
+                AllowLogoutEndpoint = await HasPermissionAsync(OpenIddictConstants.Permissions.Endpoints.Logout),
                 ClientId = await _applicationManager.GetClientIdAsync(application),
                 ConsentType = await _applicationManager.GetConsentTypeAsync(application),
                 DisplayName = await _applicationManager.GetDisplayNameAsync(application),
@@ -350,9 +351,7 @@ namespace OrchardCore.OpenId.Controllers
                 descriptor.ClientSecret = null;
             }
 
-            var openIdServerSettings = await GetServerSettingsAsync();
-
-            if (openIdServerSettings.EnableLogoutEndpoint)
+            if (model.AllowLogoutEndpoint)
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
             }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -167,6 +167,17 @@ namespace OrchardCore.OpenId.Controllers
                 Type = model.Type
             };
 
+            var openIdServerSettings = await GetServerSettingsAsync();
+
+            if (openIdServerSettings.EnableLogoutEndpoint)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Logout);
+            }
+
             if (model.AllowAuthorizationCodeFlow)
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -64,6 +64,10 @@ namespace OrchardCore.OpenId.Recipes
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Authorization);
             }
+            if (model.AllowRefreshTokenFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
+            }
             if (model.AllowAuthorizationCodeFlow || model.AllowClientCredentialsFlow ||
                 model.AllowPasswordFlow || model.AllowRefreshTokenFlow)
             {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
@@ -22,6 +22,7 @@ namespace OrchardCore.OpenId.ViewModels
         public bool AllowAuthorizationCodeFlow { get; set; }
         public bool AllowRefreshTokenFlow { get; set; }
         public bool AllowImplicitFlow { get; set; }
+        public bool AllowLogoutEndpoint { get; set; }
 
         public class RoleEntry
         {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
@@ -26,6 +26,7 @@ namespace OrchardCore.OpenId.ViewModels
         public bool AllowAuthorizationCodeFlow { get; set; }
         public bool AllowRefreshTokenFlow { get; set; }
         public bool AllowImplicitFlow { get; set; }
+        public bool AllowLogoutEndpoint { get; set; }
 
         public class RoleEntry
         {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
@@ -2,7 +2,7 @@
 @using OpenIddict.Abstractions;
 @using OrchardCore.OpenId.ViewModels;
 @using OrchardCore.OpenId.Settings;
-@{ 
+@{
     var settings = ViewData[nameof(OpenIdServerSettings)] as OpenIdServerSettings;
 }
 <h1>@RenderTitleSegments(T["Create a new application"])</h1>
@@ -95,60 +95,61 @@
             <span asp-validation-for="RedirectUris" class="text-danger">@T["The Redirect Uri is required."]</span>
             <input asp-for="RedirectUris" class="form-control" autofocus />
         </div>
-        <div class="form-check">
-            <div asp-validation-class-for="AllowLogoutEndpoint">
-                <label class="form-check-label">
-                    <input asp-for="AllowLogoutEndpoint" type="checkbox" data-toggle="collapse" data-target="#postLogoutRedirectUrisGroup" class="form-check-input" checked="@Model.AllowLogoutEndpoint" />
-                    @T["Enable Logout Endpoint"]
-                </label>
-            </div>
-        </div>
-            <div class="form-group collapse" id="postLogoutRedirectUrisGroup" name="postLogoutRedirectUrisGroup">
-                <div asp-validation-class-for="PostLogoutRedirectUris">
+        <fieldset class="form-group collapse" id="AllowLogoutEndpointFieldSet">
+            <fieldset class="form-group">
+                <div class="form-check">
+                    <label class="form-check-label">
+                        <input asp-for="AllowLogoutEndpoint" type="checkbox" data-toggle="collapse" data-target="#postLogoutRedirectUris" class="form-check-input" checked="@Model.AllowLogoutEndpoint" />
+                        @T["Allow Logout Endpoint"]
+                    </label>
+                </div>
+            </fieldset>
+            <div class="form-group collapse" id="postLogoutRedirectUris" name="postLogoutRedirectUris">
+                <div class="form-group" asp-validation-class-for="PostLogoutRedirectUris">
                     <label asp-for="PostLogoutRedirectUris">@T["Logout Redirect Uri"]</label>
                     <span asp-validation-for="PostLogoutRedirectUris" class="text-danger">@T["The Logout Redirect Uri is required."]</span>
                     <input asp-for="PostLogoutRedirectUris" class="form-control" autofocus />
                 </div>
             </div>
-
-            <div class="form-group" asp-validation-class-for="ConsentType">
-                <label asp-for="ConsentType">@T["Consent type"]</label>
-                <select asp-for="ConsentType" class="form-control">
-                    <option value="@OpenIddictConstants.ConsentTypes.Explicit">@T["Explicit consent"]</option>
-                    <option value="@OpenIddictConstants.ConsentTypes.Implicit">@T["Implicit consent"]</option>
-                    <option value="@OpenIddictConstants.ConsentTypes.External">@T["External consent"]</option>
-                </select>
-                <div class="hint">
-                    @T["The consent type affects the way authorization requests are handled."]
-                    <ul>
-                        <li>When the consent is explicit, the authorization request must be approved by the end user. <strong>This is the recommended option.</strong></li>
-                        <li>When the consent is implicit, the authorization request is assumed to be pre-approved and no consent form is displayed.</li>
-                        <li>When the consent is external, the authorization request is rejected unless a pre-existing authorization (granted programatically) already exists.</li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-
-        <div class="form-group collapse" id="RoleGroup" name="RoleGroup">
-            <h6>@T["Client Credentials Roles"]</h6>
-            @for (var i = 0; i < Model.RoleEntries.Count; i++)
-            {
-                <div class="form-check">
-                    <label class="form-check-label" asp-for="RoleEntries[i].Selected">
-                        <input class="form-check-input" type="checkbox" asp-for="RoleEntries[i].Selected" />
-                        <input type="hidden" asp-for="RoleEntries[i].Name" />
-                        @Model.RoleEntries[i].Name
-                    </label>
-                </div>
-            }
-        </div>
-
-        <fieldset>
-            <div class="form-group">
-                <button class="btn btn-primary" type="submit">@T["Save"]</button>
-                <a class="btn btn-secondary" asp-route-action="Index">@T["Cancel"]</a>
-            </div>
         </fieldset>
+        <div class="form-group" asp-validation-class-for="ConsentType">
+            <label asp-for="ConsentType">@T["Consent type"]</label>
+            <select asp-for="ConsentType" class="form-control">
+                <option value="@OpenIddictConstants.ConsentTypes.Explicit">@T["Explicit consent"]</option>
+                <option value="@OpenIddictConstants.ConsentTypes.Implicit">@T["Implicit consent"]</option>
+                <option value="@OpenIddictConstants.ConsentTypes.External">@T["External consent"]</option>
+            </select>
+            <div class="hint">
+                @T["The consent type affects the way authorization requests are handled."]
+                <ul>
+                    <li>When the consent is explicit, the authorization request must be approved by the end user. <strong>This is the recommended option.</strong></li>
+                    <li>When the consent is implicit, the authorization request is assumed to be pre-approved and no consent form is displayed.</li>
+                    <li>When the consent is external, the authorization request is rejected unless a pre-existing authorization (granted programatically) already exists.</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <div class="form-group collapse" id="RoleGroup" name="RoleGroup">
+        <h6>@T["Client Credentials Roles"]</h6>
+        @for (var i = 0; i < Model.RoleEntries.Count; i++)
+        {
+            <div class="form-check">
+                <label class="form-check-label" asp-for="RoleEntries[i].Selected">
+                    <input class="form-check-input" type="checkbox" asp-for="RoleEntries[i].Selected" />
+                    <input type="hidden" asp-for="RoleEntries[i].Name" />
+                    @Model.RoleEntries[i].Name
+                </label>
+            </div>
+        }
+    </div>
+
+    <fieldset>
+        <div class="form-group">
+            <button class="btn btn-primary" type="submit">@T["Save"]</button>
+            <a class="btn btn-secondary" asp-route-action="Index">@T["Cancel"]</a>
+        </div>
+    </fieldset>
 </form>
 <script at="Foot" type="text/javascript">
     //<![CDATA[
@@ -157,8 +158,6 @@
         refreshClientSecret('@OpenIddictConstants.ClientTypes.Confidential');
         refreshFlows();
         refreshOfflineAccessTip(false);
-        refreshEnableLogoutEndpointVisibility();
-
 
         function refreshForbiddenFlows() {
             @if (settings == null)
@@ -169,7 +168,6 @@
                     $("#AllowPasswordFlowFieldSet").collapse("show");
                     $("#AllowClientCredentialsFlowFieldSet").collapse("show");
                     $("#AllowRefreshTokenFlowFieldSet").collapse("show");
-                    $("#AllowLogoutEndpointFieldSet").collapse("show");
                 </text>
 
             }
@@ -216,13 +214,12 @@
                         $("#AllowRefreshTokenFlowFieldSet").collapse("hide");
                         $("#AllowRefreshTokenFlow").prop("checked", false);
                     }
-
                     if (@(settings.EnableLogoutEndpoint.ToString().ToLower()) == true) {
                         $("#AllowLogoutEndpointFieldSet").collapse("show");
                     }
                     else {
                         $("#AllowLogoutEndpointFieldSet").collapse("hide");
-                        $("#AllowLogoutEndpoint").prop("checked", false);
+                        $("#AllowLogoutEndpointFieldSet").prop("checked", false);
                     }
                 </text>
             }
@@ -302,28 +299,25 @@
                 refreshOfflineAccessTip();
             }
         }
-        function refreshEnableLogoutEndpointVisibility() {
-            var allowLogoutEndpoint = $("#AllowLogoutEndpoint");
-
-            if ($("AllowLogoutEndpoint").prop('checked') ) {
-                allowLogoutEndpoint.removeAttr("disabled");
-            }
-            else {
-                allowLogoutEndpoint.attr('disabled', true);
-                allowLogoutEndpoint.prop("checked", false);
-            }
-        }
         function refreshRedirectSettings() {
-            refreshEnableLogoutEndpointVisibility();
             var redirectSection = $("#RedirectSection");
             var skipConsent = $("#SkipConsent");
+            var postLogoutRedirecUris = $("#postLogoutRedirectUris")
 
             if ($("#AllowImplicitFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked')) {
                 redirectSection.collapse("show");
+                if ($("#AllowLogoutEndpoint").prop('checked')) {
+                    postLogoutRedirecUris.collapse("show");
+                }
+                else {
+                    postLogoutRedirecUris.collapse("hide");
+                }
             }
             else {
                 skipConsent.prop("checked", false);
                 redirectSection.collapse("hide");
+                $("#AllowLogoutEndpoint").prop('checked', false);
+                postLogoutRedirecUris.collapse("hide");
             }
         }
     };

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
@@ -95,49 +95,60 @@
             <span asp-validation-for="RedirectUris" class="text-danger">@T["The Redirect Uri is required."]</span>
             <input asp-for="RedirectUris" class="form-control" autofocus />
         </div>
-        <div asp-validation-class-for="PostLogoutRedirectUris">
-            <label asp-for="PostLogoutRedirectUris">@T["Logout Redirect Uri"]</label>
-            <span asp-validation-for="PostLogoutRedirectUris" class="text-danger">@T["The Logout Redirect Uri is required."]</span>
-            <input asp-for="PostLogoutRedirectUris" class="form-control" autofocus />
-        </div>
-        <div class="form-group" asp-validation-class-for="ConsentType">
-            <label asp-for="ConsentType">@T["Consent type"]</label>
-            <select asp-for="ConsentType" class="form-control">
-                <option value="@OpenIddictConstants.ConsentTypes.Explicit">@T["Explicit consent"]</option>
-                <option value="@OpenIddictConstants.ConsentTypes.Implicit">@T["Implicit consent"]</option>
-                <option value="@OpenIddictConstants.ConsentTypes.External">@T["External consent"]</option>
-            </select>
-            <div class="hint">
-                @T["The consent type affects the way authorization requests are handled."]
-                <ul>
-                    <li>When the consent is explicit, the authorization request must be approved by the end user. <strong>This is the recommended option.</strong></li>
-                    <li>When the consent is implicit, the authorization request is assumed to be pre-approved and no consent form is displayed.</li>
-                    <li>When the consent is external, the authorization request is rejected unless a pre-existing authorization (granted programatically) already exists.</li>
-                </ul>
-            </div>
-        </div>
-    </div>
-
-    <div class="form-group collapse" id="RoleGroup" name="RoleGroup">
-        <h6>@T["Client Credentials Roles"]</h6>
-        @for (var i = 0; i < Model.RoleEntries.Count; i++)
-        {
-            <div class="form-check">
-                <label class="form-check-label" asp-for="RoleEntries[i].Selected">
-                    <input class="form-check-input" type="checkbox" asp-for="RoleEntries[i].Selected" />
-                    <input type="hidden" asp-for="RoleEntries[i].Name" />
-                    @Model.RoleEntries[i].Name
+        <div class="form-check">
+            <div asp-validation-class-for="AllowLogoutEndpoint">
+                <label class="form-check-label">
+                    <input asp-for="AllowLogoutEndpoint" type="checkbox" data-toggle="collapse" data-target="#postLogoutRedirectUrisGroup" class="form-check-input" checked="@Model.AllowLogoutEndpoint" />
+                    @T["Enable Logout Endpoint"]
                 </label>
             </div>
-        }
-    </div>
-
-    <fieldset>
-        <div class="form-group">
-            <button class="btn btn-primary" type="submit">@T["Save"]</button>
-            <a class="btn btn-secondary" asp-route-action="Index">@T["Cancel"]</a>
         </div>
-    </fieldset>
+            <div class="form-group collapse" id="postLogoutRedirectUrisGroup" name="postLogoutRedirectUrisGroup">
+                <div asp-validation-class-for="PostLogoutRedirectUris">
+                    <label asp-for="PostLogoutRedirectUris">@T["Logout Redirect Uri"]</label>
+                    <span asp-validation-for="PostLogoutRedirectUris" class="text-danger">@T["The Logout Redirect Uri is required."]</span>
+                    <input asp-for="PostLogoutRedirectUris" class="form-control" autofocus />
+                </div>
+            </div>
+
+            <div class="form-group" asp-validation-class-for="ConsentType">
+                <label asp-for="ConsentType">@T["Consent type"]</label>
+                <select asp-for="ConsentType" class="form-control">
+                    <option value="@OpenIddictConstants.ConsentTypes.Explicit">@T["Explicit consent"]</option>
+                    <option value="@OpenIddictConstants.ConsentTypes.Implicit">@T["Implicit consent"]</option>
+                    <option value="@OpenIddictConstants.ConsentTypes.External">@T["External consent"]</option>
+                </select>
+                <div class="hint">
+                    @T["The consent type affects the way authorization requests are handled."]
+                    <ul>
+                        <li>When the consent is explicit, the authorization request must be approved by the end user. <strong>This is the recommended option.</strong></li>
+                        <li>When the consent is implicit, the authorization request is assumed to be pre-approved and no consent form is displayed.</li>
+                        <li>When the consent is external, the authorization request is rejected unless a pre-existing authorization (granted programatically) already exists.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="form-group collapse" id="RoleGroup" name="RoleGroup">
+            <h6>@T["Client Credentials Roles"]</h6>
+            @for (var i = 0; i < Model.RoleEntries.Count; i++)
+            {
+                <div class="form-check">
+                    <label class="form-check-label" asp-for="RoleEntries[i].Selected">
+                        <input class="form-check-input" type="checkbox" asp-for="RoleEntries[i].Selected" />
+                        <input type="hidden" asp-for="RoleEntries[i].Name" />
+                        @Model.RoleEntries[i].Name
+                    </label>
+                </div>
+            }
+        </div>
+
+        <fieldset>
+            <div class="form-group">
+                <button class="btn btn-primary" type="submit">@T["Save"]</button>
+                <a class="btn btn-secondary" asp-route-action="Index">@T["Cancel"]</a>
+            </div>
+        </fieldset>
 </form>
 <script at="Foot" type="text/javascript">
     //<![CDATA[
@@ -146,6 +157,8 @@
         refreshClientSecret('@OpenIddictConstants.ClientTypes.Confidential');
         refreshFlows();
         refreshOfflineAccessTip(false);
+        refreshEnableLogoutEndpointVisibility();
+
 
         function refreshForbiddenFlows() {
             @if (settings == null)
@@ -156,6 +169,7 @@
                     $("#AllowPasswordFlowFieldSet").collapse("show");
                     $("#AllowClientCredentialsFlowFieldSet").collapse("show");
                     $("#AllowRefreshTokenFlowFieldSet").collapse("show");
+                    $("#AllowLogoutEndpointFieldSet").collapse("show");
                 </text>
 
             }
@@ -201,6 +215,14 @@
                     else {
                         $("#AllowRefreshTokenFlowFieldSet").collapse("hide");
                         $("#AllowRefreshTokenFlow").prop("checked", false);
+                    }
+
+                    if (@(settings.EnableLogoutEndpoint.ToString().ToLower()) == true) {
+                        $("#AllowLogoutEndpointFieldSet").collapse("show");
+                    }
+                    else {
+                        $("#AllowLogoutEndpointFieldSet").collapse("hide");
+                        $("#AllowLogoutEndpoint").prop("checked", false);
                     }
                 </text>
             }
@@ -280,7 +302,19 @@
                 refreshOfflineAccessTip();
             }
         }
+        function refreshEnableLogoutEndpointVisibility() {
+            var allowLogoutEndpoint = $("#AllowLogoutEndpoint");
+
+            if ($("AllowLogoutEndpoint").prop('checked') ) {
+                allowLogoutEndpoint.removeAttr("disabled");
+            }
+            else {
+                allowLogoutEndpoint.attr('disabled', true);
+                allowLogoutEndpoint.prop("checked", false);
+            }
+        }
         function refreshRedirectSettings() {
+            refreshEnableLogoutEndpointVisibility();
             var redirectSection = $("#RedirectSection");
             var skipConsent = $("#SkipConsent");
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
@@ -107,11 +107,25 @@
             <span asp-validation-for="RedirectUris" class="text-danger">@T["The Redirect Uri is required."]</span>
             <input asp-for="RedirectUris" class="form-control" autofocus />
         </div>
-        <div asp-validation-class-for="PostLogoutRedirectUris">
-            <label asp-for="PostLogoutRedirectUris">@T["Logout Redirect Uri"]</label>
-            <span asp-validation-for="PostLogoutRedirectUris" class="text-danger">@T["The Logout Redirect Uri is required."]</span>
-            <input asp-for="PostLogoutRedirectUris" class="form-control" autofocus />
-        </div>
+
+
+        <fieldset class="form-group collapse" id="AllowLogoutEndpointFieldSet">
+            <fieldset class="form-group">
+                <div class="form-check">
+                    <label class="form-check-label">
+                        <input asp-for="AllowLogoutEndpoint" type="checkbox" data-toggle="collapse" data-target="#postLogoutRedirectUris" class="form-check-input" checked="@Model.AllowLogoutEndpoint" />
+                        @T["Allow Logout Endpoint"]
+                    </label>
+                </div>
+            </fieldset>
+            <div class="form-group collapse" id="postLogoutRedirectUris" name="postLogoutRedirectUris">
+                <div class="form-group" asp-validation-class-for="PostLogoutRedirectUris">
+                    <label asp-for="PostLogoutRedirectUris">@T["Logout Redirect Uri"]</label>
+                    <span asp-validation-for="PostLogoutRedirectUris" class="text-danger">@T["The Logout Redirect Uri is required."]</span>
+                    <input asp-for="PostLogoutRedirectUris" class="form-control" autofocus />
+                </div>
+            </div>
+        </fieldset>
         <div class="form-group" asp-validation-class-for="ConsentType">
             <label asp-for="ConsentType">@T["Consent type"]</label>
             <select asp-for="ConsentType" class="form-control">
@@ -168,6 +182,7 @@
                     $("#AllowPasswordFlowFieldSet").collapse("show");
                     $("#AllowClientCredentialsFlowFieldSet").collapse("show");
                     $("#AllowRefreshTokenFlowFieldSet").collapse("show");
+                    $("#AllowLogoutEndpointFieldSet").collapse("show");
                 </text>
 
             }
@@ -213,6 +228,14 @@
                     else {
                         $("#AllowRefreshTokenFlowFieldSet").collapse("hide");
                         $("#AllowRefreshTokenFlow").prop("checked", false);
+                    }
+
+                    if (@(settings.EnableLogoutEndpoint.ToString().ToLower()) == true) {
+                        $("#AllowLogoutEndpointFieldSet").collapse("show");
+                    }
+                    else {
+                        $("#AllowLogoutEndpointFieldSet").collapse("hide");
+                        $("#AllowLogoutEndpointFieldSet").prop("checked", false);
                     }
                 </text>
             }
@@ -293,13 +316,22 @@
         function refreshRedirectSettings() {
             var redirectSection = $("#RedirectSection");
             var skipConsent = $("#SkipConsent");
+            var postLogoutRedirecUris = $("#postLogoutRedirectUris")
 
             if ($("#AllowImplicitFlow").prop('checked') || $("#AllowAuthorizationCodeFlow").prop('checked')) {
                 redirectSection.collapse("show");
+                if ($("#AllowLogoutEndpoint").prop('checked')) {
+                    postLogoutRedirecUris.collapse("show");
+                }
+                else {
+                    postLogoutRedirecUris.collapse("hide");
+                }
             }
             else {
                 skipConsent.prop("checked", false);
                 redirectSection.collapse("hide");
+                $("#AllowLogoutEndpoint").prop('checked', false);
+                postLogoutRedirecUris.collapse("hide");
             }
         }
     };


### PR DESCRIPTION
Setting logout permission on a application when serverendpoint allows logout.

When not setting this permission, OpenIddict.Server.OpenIddictServerProviderValidateLogoutRequest will return false.

The user will get an error "invalid_request The specified 'post_logout_redirect_url' parameter is invalid."
While the parameter is valid, but a permission is missing, which cannot be set in the application UI of OrchardCore
