### PR TITLE
Problem: ExpandoObject could not be converted to IContent (ContentItem)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
+using Newtonsoft.Json;
 using OrchardCore.ContentManagement;
 using OrchardCore.Workflows.Abstractions.Models;
 using OrchardCore.Workflows.Activities;
@@ -48,7 +49,10 @@ namespace OrchardCore.Contents.Workflows.Activities
             // Try and evaluate a content item from the Content expression, if provided.
             if (!string.IsNullOrWhiteSpace(Content.Expression))
             {
-                return await ScriptEvaluator.EvaluateAsync(Content, workflowContext);
+                var expression = new WorkflowExpression<object> { Expression = Content.Expression };
+                var contentItemJson = JsonConvert.SerializeObject(await ScriptEvaluator.EvaluateAsync(expression, workflowContext));
+                var res = JsonConvert.DeserializeObject<ContentItem>(contentItemJson);
+                return res;
             }
 
             // If no expression was provided, see if the content item was provided as an input or as a property using the "Content" key.

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestTask.cs
@@ -172,7 +172,7 @@ namespace OrchardCore.Workflows.Http.Activities
                 {
                     var body = await _expressionEvaluator.EvaluateAsync(Body, workflowContext);
                     var contentType = await _expressionEvaluator.EvaluateAsync(ContentType, workflowContext);
-                    var content = new StringContent(body, Encoding.UTF8, contentType);
+                    request.Content = new StringContent(body, Encoding.UTF8, contentType);
                 }
 
                 var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseContentRead);


### PR DESCRIPTION
https://github.com/OrchardCMS/OrchardCore/issues/2226

Problem: ExpandoObject could not be converted to IContent (ContentItem)
Solution: Using JsonConvert to to deserialize the Json into ContentItem