### PR TITLE
If the setup fails, revert back the tenant to the Uninitialized state.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Data;
 using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Models;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Setup.Services;
 using OrchardCore.Setup.ViewModels;
@@ -142,6 +143,8 @@ namespace OrchardCore.Setup.Controllers
                 {
                     ModelState.AddModelError(error.Key, error.Value);
                 }
+
+                _shellSettings.State = TenantState.Uninitialized;
 
                 return View(model);
             }


### PR DESCRIPTION
If the setup fails and return back to the setup form, when you re-submit the form you get.

    The requested tenant is currently initializing.

So, here in this case we revert back the tenant state to `TenantState.Uninitialized`.