### PR TITLE
HTTP Response Activity

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRedirectTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRedirectTask.cs
@@ -15,8 +15,8 @@ namespace OrchardCore.Workflows.Http.Activities
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
 
         public HttpRedirectTask(
-            IStringLocalizer<HttpRedirectTask> localizer, 
-            IHttpContextAccessor httpContextAccessor, 
+            IStringLocalizer<HttpRedirectTask> localizer,
+            IHttpContextAccessor httpContextAccessor,
             IWorkflowExpressionEvaluator expressionEvaluator
         )
         {
@@ -52,6 +52,8 @@ namespace OrchardCore.Workflows.Http.Activities
             var location = await _expressionEvaluator.EvaluateAsync(Location, workflowContext);
 
             _httpContextAccessor.HttpContext.Response.Redirect(location, Permanent);
+            _httpContextAccessor.HttpContext.Items[WorkflowHttpResult.Instance] = WorkflowHttpResult.Instance;
+
             return Outcomes("Done");
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestTask.cs
@@ -19,7 +19,7 @@ namespace OrchardCore.Workflows.Http.Activities
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
 
         public HttpRequestTask(
-            IStringLocalizer<HttpRequestTask> localizer, 
+            IStringLocalizer<HttpRequestTask> localizer,
             IHttpContextAccessor httpContextAccessor,
             IWorkflowExpressionEvaluator expressionEvaluator
         )
@@ -153,6 +153,7 @@ namespace OrchardCore.Workflows.Http.Activities
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
+            // TODO: Refactor this to using HttpClientFactory.
             using (var httpClient = new HttpClient())
             {
                 var headersText = await _expressionEvaluator.EvaluateAsync(Headers, workflowContext);

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Primitives;
+using OrchardCore.Workflows.Abstractions.Models;
+using OrchardCore.Workflows.Activities;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Services;
+
+namespace OrchardCore.Workflows.Http.Activities
+{
+    public class HttpResponseTask : TaskActivity
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
+
+        public HttpResponseTask(
+            IStringLocalizer<HttpResponseTask> localizer,
+            IHttpContextAccessor httpContextAccessor,
+            IWorkflowExpressionEvaluator expressionEvaluator
+        )
+        {
+            T = localizer;
+            _httpContextAccessor = httpContextAccessor;
+            _expressionEvaluator = expressionEvaluator;
+        }
+
+        private IStringLocalizer T { get; }
+
+        public override string Name => nameof(HttpResponseTask);
+        public override LocalizedString Category => T["HTTP"];
+
+        public WorkflowExpression<string> Content
+        {
+            get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+
+        public HttpStatusCode HttpStatusCode
+        {
+            get => GetProperty(() => HttpStatusCode.OK);
+            set => SetProperty(value);
+        }
+
+        public WorkflowExpression<string> Headers
+        {
+            get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+
+        public WorkflowExpression<string> ContentType
+        {
+            get => GetProperty(() => new WorkflowExpression<string>("application/json"));
+            set => SetProperty(value);
+        }
+
+        public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            return Outcomes(T["Done"]);
+        }
+
+        public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            var headersString = await _expressionEvaluator.EvaluateAsync(Headers, workflowContext);
+            var content = await _expressionEvaluator.EvaluateAsync(Content, workflowContext);
+            var contentType = await _expressionEvaluator.EvaluateAsync(ContentType, workflowContext);
+            var headers = ParseHeaders(headersString);
+            var response = _httpContextAccessor.HttpContext.Response;
+
+            response.StatusCode = (int)HttpStatusCode;
+
+            foreach (var header in headers)
+            {
+                response.Headers.Add(header);
+            }
+
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                response.Body = new MemoryStream(Encoding.UTF8.GetBytes(content));
+            }
+
+            if (!string.IsNullOrWhiteSpace(contentType))
+            {
+                response.ContentType = contentType;
+            }
+
+            return Outcomes("Done");
+        }
+
+        private IEnumerable<KeyValuePair<string, StringValues>> ParseHeaders(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                return Enumerable.Empty<KeyValuePair<string, StringValues>>();
+
+            return
+                from header in text.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim())
+                let pair = header.Split(new[] { ':' })
+                where pair.Length == 2
+                select new KeyValuePair<string, StringValues>(pair[0], pair[1]);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
@@ -42,9 +42,9 @@ namespace OrchardCore.Workflows.Http.Activities
             set => SetProperty(value);
         }
 
-        public HttpStatusCode HttpStatusCode
+        public int HttpStatusCode
         {
-            get => GetProperty(() => HttpStatusCode.OK);
+            get => GetProperty(() => 200);
             set => SetProperty(value);
         }
 
@@ -73,16 +73,11 @@ namespace OrchardCore.Workflows.Http.Activities
             var headers = ParseHeaders(headersString);
             var response = _httpContextAccessor.HttpContext.Response;
 
-            response.StatusCode = (int)HttpStatusCode;
+            response.StatusCode = HttpStatusCode;
 
             foreach (var header in headers)
             {
                 response.Headers.Add(header);
-            }
-
-            if (!string.IsNullOrWhiteSpace(content))
-            {
-                response.Body = new MemoryStream(Encoding.UTF8.GetBytes(content));
             }
 
             if (!string.IsNullOrWhiteSpace(contentType))
@@ -90,6 +85,12 @@ namespace OrchardCore.Workflows.Http.Activities
                 response.ContentType = contentType;
             }
 
+            if (!string.IsNullOrWhiteSpace(content))
+            {
+                await response.WriteAsync(content);
+            }
+
+            _httpContextAccessor.HttpContext.Items[WorkflowHttpResult.Instance] = WorkflowHttpResult.Instance;
             return Outcomes("Done");
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Controllers/HttpWorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Controllers/HttpWorkflowController.cs
@@ -185,7 +185,7 @@ namespace OrchardCore.Workflows.Http.Controllers
         /// </summary>
         private IActionResult GetWorkflowActionResult()
         {
-            if (Response.StatusCode != 0 && Response.StatusCode != (int)HttpStatusCode.OK)
+            if (HttpContext.Items.ContainsKey(WorkflowHttpResult.Instance))
             {
                 return new EmptyResult();
             }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Drivers/HttpResponseTaskDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Drivers/HttpResponseTaskDisplay.cs
@@ -1,0 +1,26 @@
+using OrchardCore.Workflows.Display;
+using OrchardCore.Workflows.Http.Activities;
+using OrchardCore.Workflows.Http.ViewModels;
+using OrchardCore.Workflows.Models;
+
+namespace OrchardCore.Workflows.Http.Drivers
+{
+    public class HttpResponseTaskDisplay : ActivityDisplayDriver<HttpResponseTask, HttpResponseTaskViewModel>
+    {
+        protected override void EditActivity(HttpResponseTask activity, HttpResponseTaskViewModel model)
+        {
+            model.HttpStatusCode = activity.HttpStatusCode;
+            model.Content = activity.Content.Expression;
+            model.ContentType = activity.ContentType.Expression;
+            model.Headers = activity.Headers.Expression;
+        }
+
+        protected override void UpdateActivity(HttpResponseTaskViewModel model, HttpResponseTask activity)
+        {
+            activity.HttpStatusCode = model.HttpStatusCode;
+            activity.Content = new WorkflowExpression<string>(model.Content);
+            activity.ContentType = new WorkflowExpression<string>(model.ContentType?.Trim());
+            activity.Headers = new WorkflowExpression<string>(model.Headers?.Trim());
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Startup.cs
@@ -45,6 +45,7 @@ namespace OrchardCore.Workflows.Http
             services.AddActivity<HttpRequestFilterEvent, HttpRequestFilterEventDisplay>();
             services.AddActivity<HttpRedirectTask, HttpRedirectTaskDisplay>();
             services.AddActivity<HttpRequestTask, HttpRequestTaskDisplay>();
+            services.AddActivity<HttpResponseTask, HttpResponseTaskDisplay>();
             services.AddActivity<SignalEvent, SignalEventDisplay>();
 
             services.AddScoped<ILiquidTemplateEventHandler, SignalLiquidTemplateHandler>();

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/ViewModels/HttpResponseTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/ViewModels/HttpResponseTaskViewModel.cs
@@ -4,7 +4,7 @@ namespace OrchardCore.Workflows.Http.ViewModels
 {
     public class HttpResponseTaskViewModel
     {
-        public HttpStatusCode HttpStatusCode { get; set; }
+        public int HttpStatusCode { get; set; }
         public string Headers { get; set; }
         public string Content { get; set; }
         public string ContentType { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/ViewModels/HttpResponseTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/ViewModels/HttpResponseTaskViewModel.cs
@@ -1,0 +1,12 @@
+using System.Net;
+
+namespace OrchardCore.Workflows.Http.ViewModels
+{
+    public class HttpResponseTaskViewModel
+    {
+        public HttpStatusCode HttpStatusCode { get; set; }
+        public string Headers { get; set; }
+        public string Content { get; set; }
+        public string ContentType { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/WorkflowHttpResult.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/WorkflowHttpResult.cs
@@ -1,0 +1,7 @@
+namespace OrchardCore.Workflows.Http
+{
+    public class WorkflowHttpResult
+    {
+        public static readonly WorkflowHttpResult Instance = new WorkflowHttpResult();
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Design.cshtml
@@ -3,4 +3,4 @@
 <header>
     <h4><i class="fa fa-globe"></i>@Model.Activity.GetTitleOrDefault(() => T["HTTP Response"])</h4>
 </header>
-<span>@T["<em>{0} {1}</em>", Model.Activity.HttpMethod, Model.Activity.Url]</span>
+<span>@T["<em>HTTP {0}</em>", Model.Activity.HttpStatusCode]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Design.cshtml
@@ -1,0 +1,6 @@
+@model ActivityViewModel<HttpResponseTask>
+@using OrchardCore.Workflows.Http.Activities
+<header>
+    <h4><i class="fa fa-globe"></i>@Model.Activity.GetTitleOrDefault(() => T["HTTP Response"])</h4>
+</header>
+<span>@T["<em>{0} {1}</em>", Model.Activity.HttpMethod, Model.Activity.Url]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
@@ -48,6 +48,6 @@
             mode: { name: "liquid" },
         };
         CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Headers)'), codeMirrorOptions);
-        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Body)'), codeMirrorOptions);
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Content)'), codeMirrorOptions);
 });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
@@ -1,0 +1,53 @@
+@using OrchardCore.Workflows.Http.ViewModels;
+@model HttpResponseTaskViewModel
+
+<fieldset class="form-group" asp-validation-class-for="HttpStatusCode">
+    <label asp-for="HttpStatusCode">@T["HTTP Status Code"] <span asp-validation-for="HttpStatusCode"></span></label>
+    <input type="text" asp-for="HttpStatusCode" class="form-control" />
+    <span class="hint">@T["The HTTP Status Code to send back. <a href=\"https://en.wikipedia.org/wiki/List_of_HTTP_status_codes\" target=\"_blank\">Click here</a> for a complete list."]</span>
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="ContentType">
+    <label asp-for="ContentType">@T["Content Type"] <span asp-validation-for="ContentType"></span></label>
+    <select asp-for="ContentType" class="form-control">
+        <option>text/plain</option>
+        <option>application/x-www-form-urlencoded</option>
+        <option>application/json</option>
+        <option>application/xml</option>
+    </select>
+    <span class="hint">@T["The content type of the response body."]</span>
+</fieldset>
+
+@*TODO: Only display Content field when appropriate for the selected HTTP status code.*@
+<fieldset class="form-group" asp-validation-class-for="Content">
+    <label asp-for="Content">@T["Content"] <span asp-validation-for="Content"></span></label>
+    <textarea asp-for="Content"></textarea>
+    <span class="hint">@T["The body to send back. With Liquid support."]</span>
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="Headers">
+    <label asp-for="Headers">@T["Headers"] <span asp-validation-for="Headers"></span></label>
+    <textarea asp-for="Headers"></textarea>
+    <span class="hint">@T["Provide additional HTTP response headers. Enter one key/value pair per line. For example: \"X-MyHeader: Foo\". With Liquid support."]</span>
+</fieldset>
+
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.min.js" depends-on="admin" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/javascript/javascript.min.js" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/mode/simple.min.js" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/mode/multiplex.min.js" at="Foot"></script>
+<script asp-src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/xml/xml.min.js" at="Foot"></script>
+
+<script asp-src="/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+
+<script at="Foot">
+    $(function () {
+        var codeMirrorOptions = {
+            lineNumbers: true,
+            styleActiveLine: true,
+            matchBrackets: true,
+            mode: { name: "liquid" },
+        };
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Headers)'), codeMirrorOptions);
+        CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Body)'), codeMirrorOptions);
+});
+</script>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+<h4 class="card-title"><i class="fa fa-globe"></i>@T["HTTP Response"]</h4>
+<p>@T["Write a HTTP response."]</p>


### PR DESCRIPTION
The HTTP Response Activity enables workflow users to control the HTTP response being sent back to the client, thus allowing full request/response workflows.

![image](https://user-images.githubusercontent.com/938393/44355674-84da5a00-a4ad-11e8-8fbf-85d114cae24a.png)

The HTTP Response Task editor:
![image](https://user-images.githubusercontent.com/938393/44355721-a0ddfb80-a4ad-11e8-9970-3a88b995d40c.png)

A sample request/response via Postman:
![image](https://user-images.githubusercontent.com/938393/44355751-bce19d00-a4ad-11e8-9ad4-e824139e9a3d.png)

![image](https://user-images.githubusercontent.com/938393/44355835-f2868600-a4ad-11e8-8bc6-9034e190c4b4.png)

Fixes #1724 