### PR TITLE
Bugfix for #1709 - All Workflow Instances are shown for all workflow definitions, instead of just the instances for the selected definition

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -18,6 +18,7 @@ using OrchardCore.Settings;
 using OrchardCore.Workflows.Helpers;
 using OrchardCore.Workflows.Models;
 using OrchardCore.Workflows.Services;
+using OrchardCore.Workflows.Specifications;
 using OrchardCore.Workflows.ViewModels;
 
 namespace OrchardCore.Workflows.Controllers
@@ -77,9 +78,10 @@ namespace OrchardCore.Workflows.Controllers
 
             var workflowType = await _workflowTypeStore.GetAsync(workflowTypeId);
             var siteSettings = await _siteService.GetSiteSettingsAsync();
-            var count = await _workflowStore.CountAsync();
+            var specification = new ManyWorkflowsByTypeSpecification(workflowType.WorkflowTypeId);
+            var count = await _workflowStore.CountAsync(specification);
             var pager = new Pager(pagerParameters, siteSettings.PageSize);
-            var records = await _workflowStore.ListAsync(pager.GetStartIndex(), pager.PageSize);
+            var records = await _workflowStore.ListAsync(specification, pager.GetStartIndex(), pager.PageSize);
             var pagerShape = (await New.Pager(pager)).TotalItemCount(count);
 
             var viewModel = new WorkflowIndexViewModel

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Controllers/HttpWorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Controllers/HttpWorkflowController.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using OrchardCore.Workflows.Http.Activities;
 using OrchardCore.Workflows.Http.Models;
 using OrchardCore.Workflows.Services;
+using OrchardCore.Workflows.Specifications;
 
 namespace OrchardCore.Workflows.Http.Controllers
 {
@@ -122,7 +123,7 @@ namespace OrchardCore.Workflows.Http.Controllers
             else
             {
                 // Otherwise, we need to resume a halted workflow.
-                var workflow = (await _workflowStore.ListAsync(workflowType.WorkflowTypeId, new[] { startActivity.ActivityId })).FirstOrDefault();
+                var workflow = await _workflowStore.GetAsync(new ManyWorkflowsBlockedByActivitiesAndByTypeSpecification(workflowType.WorkflowTypeId, new[] { startActivity.ActivityId }));
 
                 if (workflow == null)
                 {
@@ -156,7 +157,7 @@ namespace OrchardCore.Workflows.Http.Controllers
             // If a specific workflow was provided, then resume that workflow.
             if (!String.IsNullOrWhiteSpace(payload.WorkflowId))
             {
-                var workflow = await _workflowStore.GetAsync(payload.WorkflowId);
+                var workflow = await _workflowStore.GetAsync(new SingleWorkflowSpecification(payload.WorkflowId));
                 var signalActivities = workflow?.BlockingActivities.Where(x => x.Name == SignalEvent.EventName).ToList();
 
                 if (signalActivities == null)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Startup.cs
@@ -19,6 +19,7 @@ using OrchardCore.Workflows.Http.Services;
 using OrchardCore.Workflows.Http.WorkflowContextProviders;
 using OrchardCore.Workflows.Models;
 using OrchardCore.Workflows.Services;
+using OrchardCore.Workflows.Specifications;
 
 namespace OrchardCore.Workflows.Http
 {
@@ -63,7 +64,7 @@ namespace OrchardCore.Workflows.Http
             var workflowTypeStore = serviceProvider.GetRequiredService<IWorkflowTypeStore>();
             var workflowStore = serviceProvider.GetRequiredService<IWorkflowStore>();
             var workflowTypeDictionary = workflowTypeStore.ListAsync().GetAwaiter().GetResult().ToDictionary(x => x.WorkflowTypeId);
-            var workflowDictionary = workflowStore.ListAsync().GetAwaiter().GetResult().ToDictionary(x => x.Id);
+            var workflowDictionary = workflowStore.ListAsync(new AllWorkflowsSpecification()).GetAwaiter().GetResult().ToDictionary(x => x.Id);
 
             ConfigureWorkflowRouteEntries(serviceProvider, workflowTypeDictionary, workflowDictionary);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Indexes/WorkflowIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Indexes/WorkflowIndexProvider.cs
@@ -9,17 +9,15 @@ namespace OrchardCore.Workflows.Indexes
     {
         public string WorkflowTypeId { get; set; }
         public string WorkflowId { get; set; }
+        public string WorkflowCorrelationId { get; set; }
         public DateTime CreatedUtc { get; set; }
     }
 
-    public class WorkflowBlockingActivitiesIndex : MapIndex
+    public class WorkflowBlockingActivitiesIndex : WorkflowIndex
     {
         public string ActivityId { get; set; }
         public string ActivityName { get; set; }
         public bool ActivityIsStart { get; set; }
-        public string WorkflowTypeId { get; set; }
-        public string WorkflowId { get; set; }
-        public string WorkflowCorrelationId { get; set; }
     }
 
     public class WorkflowIndexProvider : IndexProvider<Workflow>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
@@ -26,6 +26,7 @@ namespace OrchardCore.Workflows
             SchemaBuilder.CreateMapIndexTable(nameof(WorkflowIndex), table => table
                 .Column<string>("WorkflowTypeId")
                 .Column<string>("WorkflowId")
+                .Column<string>("WorkflowCorrelationId")
                 .Column<DateTime>("CreatedUtc")
             );
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowManager.cs
@@ -10,6 +10,7 @@ using OrchardCore.Modules;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Helpers;
 using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Specifications;
 
 namespace OrchardCore.Workflows.Services
 {
@@ -122,7 +123,7 @@ namespace OrchardCore.Workflows.Services
             var workflowTypesToStart = await _workflowTypeStore.GetByStartActivityAsync(name);
 
             // And any workflow halted on this kind of activity for the specified target.
-            var haltedWorkflows = await _workflowStore.ListAsync(name, correlationId);
+            var haltedWorkflows = await _workflowStore.ListPendingWorkflowsAsync(name, correlationId);
 
             // If no workflow matches the event, do nothing.
             if (!workflowTypesToStart.Any() && !haltedWorkflows.Any())

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/AllWorkflowsSpecification.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/AllWorkflowsSpecification.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Linq.Expressions;
+using OrchardCore.Workflows.Indexes;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public class AllWorkflowsSpecification : Specification<WorkflowIndex>
+    {
+        public override Expression<Func<WorkflowIndex, object>> OrderByDescendingExpression => x => x.CreatedUtc;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsBlockedByActivitiesAndByTypeSpecification.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsBlockedByActivitiesAndByTypeSpecification.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using OrchardCore.Workflows.Indexes;
+using YesSql.Services;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public class ManyWorkflowsBlockedByActivitiesAndByTypeSpecification : Specification<WorkflowBlockingActivitiesIndex>
+    {
+        private readonly string _workflowTypeId;
+        private readonly IEnumerable<string> _blockingActivityIds;
+
+        public ManyWorkflowsBlockedByActivitiesAndByTypeSpecification(string workflowTypeId, IEnumerable<string> blockingActivityIds)
+        {
+            _workflowTypeId = workflowTypeId;
+            _blockingActivityIds = blockingActivityIds.ToList();
+        }
+
+        public override Expression<Func<WorkflowBlockingActivitiesIndex, bool>> PredicateExpression => index =>
+            index.WorkflowTypeId == _workflowTypeId &&
+            index.ActivityId.IsIn(_blockingActivityIds);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsBlockedByActivityNameAndByTypeSpecification.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsBlockedByActivityNameAndByTypeSpecification.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Linq.Expressions;
+using OrchardCore.Workflows.Indexes;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public class ManyWorkflowsBlockedByActivityNameAndByTypeSpecification : Specification<WorkflowBlockingActivitiesIndex>
+    {
+        private readonly string _workflowTypeId;
+        private readonly string _activityName;
+        private readonly string _correlationId;
+
+        public ManyWorkflowsBlockedByActivityNameAndByTypeSpecification(string workflowTypeId, string activityName, string correlationId = null)
+        {
+            _workflowTypeId = workflowTypeId;
+            _activityName = activityName;
+            _correlationId = correlationId;
+        }
+
+        public override Expression<Func<WorkflowBlockingActivitiesIndex, bool>> PredicateExpression => index =>
+            index.WorkflowTypeId == _workflowTypeId &&
+            index.ActivityName == _activityName &&
+            index.WorkflowCorrelationId == (_correlationId ?? "");
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsBlockedByActivityNameSpecification.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsBlockedByActivityNameSpecification.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Linq.Expressions;
+using OrchardCore.Workflows.Indexes;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public class ManyWorkflowsBlockedByActivityNameSpecification : Specification<WorkflowBlockingActivitiesIndex>
+    {
+        private readonly string _activityName;
+        private readonly string _correlationId;
+
+        public ManyWorkflowsBlockedByActivityNameSpecification(string activityName, string correlationId = null)
+        {
+            _activityName = activityName;
+            _correlationId = correlationId;
+        }
+
+        public override Expression<Func<WorkflowBlockingActivitiesIndex, bool>> PredicateExpression => index =>
+            index.ActivityName == _activityName &&
+            index.WorkflowCorrelationId == (_correlationId ?? "");
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsByTypeSpecification.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsByTypeSpecification.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Linq.Expressions;
+using OrchardCore.Workflows.Indexes;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public class ManyWorkflowsByTypeSpecification : Specification<WorkflowIndex>
+    {
+        private readonly string _workflowTypeId;
+
+        public ManyWorkflowsByTypeSpecification(string workflowTypeId)
+        {
+            _workflowTypeId = workflowTypeId;
+        }
+
+        public override Expression<Func<WorkflowIndex, bool>> PredicateExpression => index => index.WorkflowTypeId == _workflowTypeId;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsByTypesSpecification.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsByTypesSpecification.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using OrchardCore.Workflows.Indexes;
+using YesSql.Services;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public class ManyWorkflowsByTypesSpecification : Specification<WorkflowIndex>
+    {
+        private readonly IEnumerable<string> _workflowTypeIds;
+
+        public ManyWorkflowsByTypesSpecification(IEnumerable<string> workflowTypeIds)
+        {
+            _workflowTypeIds = workflowTypeIds.ToList();
+        }
+
+        public override Expression<Func<WorkflowIndex, bool>> PredicateExpression => index => index.WorkflowTypeId.IsIn(_workflowTypeIds);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsSpecification.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/ManyWorkflowsSpecification.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using OrchardCore.Workflows.Indexes;
+using YesSql.Services;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public class ManyWorkflowsSpecification : Specification<WorkflowIndex>
+    {
+        private readonly IEnumerable<string> _workflowIds;
+
+        public ManyWorkflowsSpecification(IEnumerable<string> workflowIds)
+        {
+            _workflowIds = workflowIds.ToList();
+        }
+
+        public override Expression<Func<WorkflowIndex, bool>> PredicateExpression => index => index.WorkflowId.IsIn(_workflowIds);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/SingleWorkflowSpecification.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Specifications/SingleWorkflowSpecification.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Linq.Expressions;
+using OrchardCore.Workflows.Indexes;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public class SingleWorkflowSpecification : Specification<WorkflowIndex>
+    {
+        private readonly string _workflowId;
+
+        public SingleWorkflowSpecification(string workflowId)
+        {
+            _workflowId = workflowId;
+        }
+
+        public override Expression<Func<WorkflowIndex, bool>> PredicateExpression => index => index.WorkflowId == _workflowId;
+    }
+}

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/OrchardCore.Workflows.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/OrchardCore.Workflows.Abstractions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\OrchardCore.Entities.DisplayManagement\OrchardCore.Entities.DisplayManagement.csproj" />
     <ProjectReference Include="..\OrchardCore.Entities\OrchardCore.Entities.csproj" />

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowStore.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowStore.cs
@@ -1,21 +1,19 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Specifications;
+using YesSql.Indexes;
 
 namespace OrchardCore.Workflows.Services
 {
     public interface IWorkflowStore
     {
         Task<int> CountAsync();
-        Task<IEnumerable<Workflow>> ListAsync(int? skip = null, int? take = null);
-        Task<IEnumerable<Workflow>> ListAsync(IEnumerable<string> workflowTypeIds);
-        Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId, IEnumerable<string> blockingActivityIds);
-        Task<IEnumerable<Workflow>> ListAsync(string activityName, string correlationId = null);
-        Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId, string activityName, string correlationId = null);
+        Task<int> CountAsync<TIndex>(Specification<TIndex> specification) where TIndex : class, IIndex;
+        Task<IEnumerable<Workflow>> ListAsync<TIndex>(Specification<TIndex> specification, int? skip = null, int? take = null) where TIndex : class, IIndex;
+        Task<IEnumerable<Workflow>> ListPendingWorkflowsAsync(string activityName, string correlationId = null);
         Task<Workflow> GetAsync(int id);
-        Task<Workflow> GetAsync(string uid);
-        Task<IEnumerable<Workflow>> GetAsync(IEnumerable<int> ids);
-        Task<IEnumerable<Workflow>> GetAsync(IEnumerable<string> uids);
+        Task<Workflow> GetAsync<TIndex>(Specification<TIndex> specification) where TIndex : class, IIndex;
         Task SaveAsync(Workflow workflow);
         Task DeleteAsync(Workflow workflow);
     }

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Specifications/Specification.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Specifications/Specification.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Linq.Expressions;
+
+namespace OrchardCore.Workflows.Specifications
+{
+    public abstract class Specification<T>
+    {
+        public virtual Expression<Func<T, bool>> PredicateExpression { get; }
+        public virtual Expression<Func<T, object>> OrderByExpression { get; }
+        public virtual Expression<Func<T, object>> OrderByDescendingExpression { get; }
+    }
+}


### PR DESCRIPTION
As part of the fix, I refactored the `IWorkflowStore` service a bit to decrease the number of overloads on `ListAsync` with all sorts of variations on what filter parameters it accepted. Using the Specification pattern, not only are queries now extensible, they are also reusable. This is useful for example the `ListAsync` and `CountAsync` operations where I want to apply the same predicate.

e.g.

```csharp
var pager = new Pager(pagerParameters, siteSettings.PageSize);

// The "specification", i.e. predicate.
var specification = new ManyWorkflowsByTypeSpecification(workflowType.WorkflowTypeId);

// Retrieve a list of workflows that match the provided predicate.
var records = await _workflowStore.ListAsync(specification, pager.GetStartIndex(), pager.PageSize);

// Count the total number of workflows that match the provided predicate.
var count = await _workflowStore.CountAsync(specification);

var pagerShape = (await New.Pager(pager)).TotalItemCount(count);
```

In case one wonders "why not just use predicate expressions directly?", there's a nice article about the specification pattern here: https://enterprisecraftsmanship.com/2016/02/08/specification-pattern-c-implementation/

I'm open to applying other solutions that are less involved and require less file changes, but personally I think it's quite neat.

Fixes #1709