### PR TITLE
Updating NodaTime to 2.4

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -24,7 +24,7 @@
     <PackageManagement Include="ncrontab" Version="3.3.0" />
     <PackageManagement Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="4.6.0" />
-    <PackageManagement Include="NodaTime" Version="2.3.0" />
+    <PackageManagement Include="NodaTime" Version="2.4.0" />
     <PackageManagement Include="OpenIddict" Version="2.0.0-rc3-final" />
     <PackageManagement Include="OpenIddict.Core" Version="2.0.0-rc3-final" />
     <PackageManagement Include="OpenIddict.EntityFrameworkCore" Version="2.0.0-rc3-final" />


### PR DESCRIPTION
Introduce a new netstandard2.0 target. This is the same code as the netstandard1.3 target - no BclDateTimeZone support, for example - but library authors are being encouraged to include a netstandard2.0 target as it reduces the indirect dependencies shown in Visual Studio when adding the package.