### PR TITLE
Better place to revert to the initial state if the setup fails.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Data;
 using OrchardCore.Environment.Shell;
-using OrchardCore.Environment.Shell.Models;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Setup.Services;
 using OrchardCore.Setup.ViewModels;
@@ -143,8 +142,6 @@ namespace OrchardCore.Setup.Controllers
                 {
                     ModelState.AddModelError(error.Key, error.Value);
                 }
-
-                _shellSettings.State = TenantState.Uninitialized;
 
                 return View(model);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Setup/Services/SetupService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Services/SetupService.cs
@@ -63,12 +63,19 @@ namespace OrchardCore.Setup.Services
             return _recipes;
         }
 
-        public Task<string> SetupAsync(SetupContext context)
+        public async Task<string> SetupAsync(SetupContext context)
         {
             var initialState = _shellSettings.State;
             try
             {
-                return SetupInternalAsync(context);
+                var executionId = await SetupInternalAsync(context);
+
+                if (context.Errors.Any())
+                {
+                    _shellSettings.State = initialState;
+                }
+
+                return executionId;
             }
             catch
             {


### PR DESCRIPTION
So that if `SetupAsync()` is called from other places, the caller don't have to revert back the tenant state if there are setup errors. E.g as done through graphql in `CreateTenantMutation`, see #1689.