### PR TITLE
Fixes lucene issue e.g on a blog setup.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneAnalyzerManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneAnalyzerManager.cs
@@ -1,24 +1,26 @@
 using System;
 using System.Collections.Generic;
 using Lucene.Net.Analysis;
+using Microsoft.Extensions.Options;
 
 namespace OrchardCore.Lucene.Services
 {
     /// <summary>
-    /// Coordinates <see cref="ILuceneAnalyzerProvider"/> implementations
+    /// Coordinates <see cref="ILuceneAnalyzer"/> implementations provided by <see cref="LuceneOptions"/>
     /// to return the list of all available <see cref="ILuceneAnalyzer"/> objects.
     /// </summary>
     public class LuceneAnalyzerManager
     {
-        /// <summary>
-        /// We lock this dictionary on <see cref="RegisterAnalyzer"/> and <see cref="RemoveAnalyzer"/> only
-        /// as we assume it can only be changed on application startup and is readonly at runtime.
-        /// </summary>
         private readonly Dictionary<string, ILuceneAnalyzer> _analyzers;
 
-        public LuceneAnalyzerManager()
+        public LuceneAnalyzerManager(IOptions<LuceneOptions> options)
         {
             _analyzers = new Dictionary<string, ILuceneAnalyzer>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var analyzer in options.Value.Analyzers)
+            {
+                _analyzers[analyzer.Name] = analyzer;
+            }
         }
 
         public IEnumerable<ILuceneAnalyzer> GetAnalyzers()
@@ -34,30 +36,6 @@ namespace OrchardCore.Lucene.Services
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Registers a named lucene analyzer.
-        /// This method can only be called during initilization of the application.
-        /// </summary>
-        public void RegisterAnalyzer(ILuceneAnalyzer analyzer)
-        {
-            lock (_analyzers)
-            {
-                _analyzers[analyzer.Name] = analyzer;
-            }
-        }
-
-        /// <summary>
-        /// Removes a named lucene analyzer.
-        /// This method can only be called during initilization of the application.
-        /// </summary>
-        public void RemoveAnalyzer(string name)
-        {
-            lock (_analyzers)
-            {
-                _analyzers.Remove(name);
-            }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
@@ -38,6 +38,10 @@ namespace OrchardCore.Lucene
             services.AddSingleton<LuceneIndexManager>();
             services.AddSingleton<LuceneAnalyzerManager>();
 
+            services.Configure<LuceneOptions>(o =>
+                o.Analyzers.Add(new LuceneAnalyzer(LuceneSettings.StandardAnalyzer,
+                    new StandardAnalyzer(LuceneSettings.DefaultVersion))));
+
             services.AddScoped<IDisplayDriver<ISite>, LuceneSiteSettingsDisplayDriver>();
             services.AddScoped<IDisplayDriver<Query>, LuceneQueryDisplayDriver>();
 
@@ -72,9 +76,6 @@ namespace OrchardCore.Lucene
                 template: "api/lucene/documents",
                 defaults: new { controller = "Api", action = "Documents" }
             );
-
-            var luceneAnalyzerManager = serviceProvider.GetRequiredService<LuceneAnalyzerManager>();
-            luceneAnalyzerManager.RegisterAnalyzer(new LuceneAnalyzer(LuceneSettings.StandardAnalyzer, new StandardAnalyzer(LuceneSettings.DefaultVersion)));
         }
     }
 

--- a/src/OrchardCore/OrchardCore.Lucene.Abstractions/ILuceneAnalyzer.cs
+++ b/src/OrchardCore/OrchardCore.Lucene.Abstractions/ILuceneAnalyzer.cs
@@ -1,6 +1,6 @@
 using Lucene.Net.Analysis;
 
-namespace OrchardCore.Lucene.Services
+namespace OrchardCore.Lucene
 {
     /// <summary>
     /// Represents an <see cref="Analyzer"/> instance that is available in the system.

--- a/src/OrchardCore/OrchardCore.Lucene.Abstractions/LuceneOptions.cs
+++ b/src/OrchardCore/OrchardCore.Lucene.Abstractions/LuceneOptions.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace OrchardCore.Lucene
+{
+    public class LuceneOptions
+    {
+        public IList<ILuceneAnalyzer> Analyzers { get; } = new List<ILuceneAnalyzer>();
+    }
+}


### PR DESCRIPTION
Here a suggested change to fix lucene issues we now have e.g on a blog setup.

The problem is when doing a setup, recipe steps are not called in the context of a request, so modules `Configure()` are not called and e.g the default lucene analyzer is not registered.

@Jetski5822 also had this issue when doing a tenant setup through graphql and fixed it, see #1689.

But more globally, i think that modules `Configure()` should only configure the tenant pipeline, not other things. Otherwise if they are not called the tenant state may not be consistent.

So, here i suggest another way to fix this issue by using an `IOptions<LuceneOptions>`.

- If ok, let me know if we need other lucene options.

- Then maybe do the same in other startup `Configure()`, here or in another PR, let me know.


