### PR TITLE
Let the application acting as a super theme for shapes rendering.

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Extensions;
 using OrchardCore.Environment.Extensions;
@@ -19,6 +20,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
     {
         private static ConcurrentDictionary<string, FeatureShapeDescriptor> _shapeDescriptors = new ConcurrentDictionary<string, FeatureShapeDescriptor>();
 
+        private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IEnumerable<IShapeTableProvider> _bindingStrategies;
         private readonly IShellFeaturesManager _shellFeaturesManager;
         private readonly IExtensionManager _extensionManager;
@@ -28,6 +30,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
         private readonly IMemoryCache _memoryCache;
 
         public DefaultShapeTableManager(
+            IHostingEnvironment hostingEnvironment,
             IEnumerable<IShapeTableProvider> bindingStrategies,
             IShellFeaturesManager shellFeaturesManager,
             IExtensionManager extensionManager,
@@ -35,6 +38,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
             ILogger<DefaultShapeTableManager> logger,
             IMemoryCache memoryCache)
         {
+            _hostingEnvironment = hostingEnvironment;
             _bindingStrategies = bindingStrategies;
             _shellFeaturesManager = shellFeaturesManager;
             _extensionManager = extensionManager;
@@ -78,6 +82,12 @@ namespace OrchardCore.DisplayManagement.Descriptors
                     .GetResult()
                     .Select(f => f.Id)
                     .ToList();
+
+                // let the application acting as a super theme for shapes rendering.
+                if (enabledAndOrderedFeatureIds.Remove(_hostingEnvironment.ApplicationName))
+                {
+                    enabledAndOrderedFeatureIds.Add(_hostingEnvironment.ApplicationName);
+                }
 
                 var descriptors = _shapeDescriptors
                     .Where(sd => enabledAndOrderedFeatureIds.Contains(sd.Value.Feature.Id))

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Extensions;
@@ -20,7 +20,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
     {
         private static ConcurrentDictionary<string, FeatureShapeDescriptor> _shapeDescriptors = new ConcurrentDictionary<string, FeatureShapeDescriptor>();
 
-        private readonly string _applicationName;
+        private readonly IHostingEnvironment _hostingEnvironment;
         private readonly IEnumerable<IShapeTableProvider> _bindingStrategies;
         private readonly IShellFeaturesManager _shellFeaturesManager;
         private readonly IExtensionManager _extensionManager;
@@ -30,6 +30,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
         private readonly IMemoryCache _memoryCache;
 
         public DefaultShapeTableManager(
+            IHostingEnvironment hostingEnvironment,
             IEnumerable<IShapeTableProvider> bindingStrategies,
             IShellFeaturesManager shellFeaturesManager,
             IExtensionManager extensionManager,
@@ -37,7 +38,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
             ILogger<DefaultShapeTableManager> logger,
             IMemoryCache memoryCache)
         {
-            _applicationName = Assembly.GetEntryAssembly().GetName().Name;
+            _hostingEnvironment = hostingEnvironment;
             _bindingStrategies = bindingStrategies;
             _shellFeaturesManager = shellFeaturesManager;
             _extensionManager = extensionManager;
@@ -83,9 +84,9 @@ namespace OrchardCore.DisplayManagement.Descriptors
                     .ToList();
 
                 // let the application acting as a super theme for shapes rendering.
-                if (enabledAndOrderedFeatureIds.Remove(_applicationName))
+                if (enabledAndOrderedFeatureIds.Remove(_hostingEnvironment.ApplicationName))
                 {
-                    enabledAndOrderedFeatureIds.Add(_applicationName);
+                    enabledAndOrderedFeatureIds.Add(_hostingEnvironment.ApplicationName);
                 }
 
                 var descriptors = _shapeDescriptors

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -2,8 +2,8 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Extensions;
 using OrchardCore.Environment.Extensions;
@@ -20,7 +20,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
     {
         private static ConcurrentDictionary<string, FeatureShapeDescriptor> _shapeDescriptors = new ConcurrentDictionary<string, FeatureShapeDescriptor>();
 
-        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly string _applicationName;
         private readonly IEnumerable<IShapeTableProvider> _bindingStrategies;
         private readonly IShellFeaturesManager _shellFeaturesManager;
         private readonly IExtensionManager _extensionManager;
@@ -30,7 +30,6 @@ namespace OrchardCore.DisplayManagement.Descriptors
         private readonly IMemoryCache _memoryCache;
 
         public DefaultShapeTableManager(
-            IHostingEnvironment hostingEnvironment,
             IEnumerable<IShapeTableProvider> bindingStrategies,
             IShellFeaturesManager shellFeaturesManager,
             IExtensionManager extensionManager,
@@ -38,7 +37,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
             ILogger<DefaultShapeTableManager> logger,
             IMemoryCache memoryCache)
         {
-            _hostingEnvironment = hostingEnvironment;
+            _applicationName = Assembly.GetEntryAssembly().GetName().Name;
             _bindingStrategies = bindingStrategies;
             _shellFeaturesManager = shellFeaturesManager;
             _extensionManager = extensionManager;
@@ -84,9 +83,9 @@ namespace OrchardCore.DisplayManagement.Descriptors
                     .ToList();
 
                 // let the application acting as a super theme for shapes rendering.
-                if (enabledAndOrderedFeatureIds.Remove(_hostingEnvironment.ApplicationName))
+                if (enabledAndOrderedFeatureIds.Remove(_applicationName))
                 {
-                    enabledAndOrderedFeatureIds.Add(_hostingEnvironment.ApplicationName);
+                    enabledAndOrderedFeatureIds.Add(_applicationName);
                 }
 
                 var descriptors = _shapeDescriptors

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
@@ -16,6 +17,7 @@ using OrchardCore.Environment.Extensions.Loaders;
 using OrchardCore.Environment.Extensions.Manifests;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Modules.Manifest;
+using OrchardCore.Tests.Stubs;
 using Xunit;
 
 namespace OrchardCore.Tests.DisplayManagement.Decriptors
@@ -145,6 +147,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
             serviceCollection.AddScoped<IShellFeaturesManager, TestShellFeaturesManager>();
             serviceCollection.AddScoped<IShapeTableManager, DefaultShapeTableManager>();
             serviceCollection.AddSingleton<ITypeFeatureProvider, TypeFeatureProvider>();
+            serviceCollection.AddSingleton<IHostingEnvironment>(new StubHostingEnvironment());
 
             var testFeatureExtensionInfo = new TestModuleExtensionInfo("Testing");
             var theme1FeatureExtensionInfo = new TestThemeExtensionInfo("Theme1");


### PR DESCRIPTION
- At the app level we can already define controller / views.

- Here, the app acts as a theme for shape rendering by moving the app module at the end of the list of ordered features, but only for shape rendering.

- Note: The app will not be able, as a regular theme, to override a module controller view. But it is doable by adapting a little `ThemeAwareViewLocationExpanderProvider`, but not sure it's good to do that.

Sorry, maybe i didn't think yet about some possible side effects, but here the idea.