### PR TITLE
Use recipe display names in the admin UI.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -63,12 +63,12 @@ namespace OrchardCore.Recipes.Controllers
 
             var model = recipes.Select(recipe => new RecipeViewModel
             {
-                Name = recipe.Name,
+                Name = recipe.DisplayName,
                 FileName = recipe.RecipeFileInfo.Name,
                 BasePath = recipe.BasePath,
                 Tags = recipe.Tags,
                 IsSetupRecipe = recipe.IsSetupRecipe,
-                Feature = features.FirstOrDefault(f=>recipe.BasePath.Contains(f.Extension.SubPath))?.Name,
+                Feature = features.FirstOrDefault(f=>recipe.BasePath.Contains(f.Extension.SubPath))?.Name ?? "Application",
                 Description = recipe.Description
             }).ToArray();
 


### PR DESCRIPTION

- Use recipe display names in the admin UI

- Also, when a recipe is defined at the app level, right now it is not related to a feature, in this case in place of displaying the related feature name we display `Application`.

Note: The app module is under the virtual path `.Modules/YourAppName` but for performance we don't serve again all the application sub folders under this path. E.g we serve `/Views & /Pages`, but e.g not `/Recipes` because `ApplicationRecipeHarvester` existed, before we made the application a module.