### PR TITLE
Fixing and improving Liquid support for workflows and content events

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using Newtonsoft.Json;
 using OrchardCore.ContentManagement;
+using OrchardCore.Contents.Workflows.Handlers;
 using OrchardCore.Workflows.Abstractions.Models;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Helpers;
@@ -26,7 +27,7 @@ namespace OrchardCore.Contents.Workflows.Activities
         public override LocalizedString Category => T["Content"];
 
         /// <summary>
-        /// An expression that evaluates to either a <see cref="IContent"/> item.
+        /// An expression that evaluates to an <see cref="IContent"/> item.
         /// </summary>
         public WorkflowExpression<IContent> Content
         {
@@ -55,8 +56,9 @@ namespace OrchardCore.Contents.Workflows.Activities
                 return res;
             }
 
-            // If no expression was provided, see if the content item was provided as an input or as a property using the "Content" key.
-            var content = workflowContext.Input.GetValue<IContent>("Content") ?? workflowContext.Properties.GetValue<IContent>("Content");
+            // If no expression was provided, see if the content item was provided as an input or as a property.
+            var content = workflowContext.Input.GetValue<IContent>(ContentsHandler.ContentItemInputKey)
+                ?? workflowContext.Properties.GetValue<IContent>(ContentsHandler.ContentItemInputKey);
 
             if (content != null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/CreateContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/CreateContentTask.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Localization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
+using OrchardCore.Contents.Workflows.Handlers;
 using OrchardCore.Workflows.Abstractions.Models;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Models;
@@ -15,7 +16,7 @@ namespace OrchardCore.Contents.Workflows.Activities
     {
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
 
-        public CreateContentTask(IContentManager contentManager, IWorkflowExpressionEvaluator expressionEvaluator, IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<CreateContentTask> localizer) 
+        public CreateContentTask(IContentManager contentManager, IWorkflowExpressionEvaluator expressionEvaluator, IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<CreateContentTask> localizer)
             : base(contentManager, scriptEvaluator, localizer)
         {
             _expressionEvaluator = expressionEvaluator;
@@ -69,7 +70,7 @@ namespace OrchardCore.Contents.Workflows.Activities
 
             workflowContext.LastResult = contentItem;
             workflowContext.CorrelationId = contentItem.ContentItemId;
-            workflowContext.Properties["Content"] = contentItem;
+            workflowContext.Properties[ContentsHandler.ContentItemInputKey] = contentItem;
 
             return Outcomes("Done");
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Handlers/ContentsHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Handlers/ContentsHandler.cs
@@ -17,24 +17,24 @@ namespace OrchardCore.Contents.Workflows.Handlers
             _workflowManager = workflowManager;
         }
 
-        public override async Task CreatedAsync(CreateContentContext context)
+        public override Task CreatedAsync(CreateContentContext context)
         {
-            await TriggerWorkflowEventAsync(nameof(ContentCreatedEvent), context.ContentItem);
+            return TriggerWorkflowEventAsync(nameof(ContentCreatedEvent), context.ContentItem);
         }
 
-        public override async Task PublishedAsync(PublishContentContext context)
+        public override Task PublishedAsync(PublishContentContext context)
         {
-            await TriggerWorkflowEventAsync(nameof(ContentPublishedEvent), context.ContentItem);
+            return TriggerWorkflowEventAsync(nameof(ContentPublishedEvent), context.ContentItem);
         }
 
-        public override async Task RemovedAsync(RemoveContentContext context)
+        public override Task RemovedAsync(RemoveContentContext context)
         {
-            await TriggerWorkflowEventAsync(nameof(ContentDeletedEvent), context.ContentItem);
+            return TriggerWorkflowEventAsync(nameof(ContentDeletedEvent), context.ContentItem);
         }
 
-        private async Task TriggerWorkflowEventAsync(string name, ContentItem contentItem)
+        private Task TriggerWorkflowEventAsync(string name, ContentItem contentItem)
         {
-            await _workflowManager.TriggerEventAsync(name,
+            return _workflowManager.TriggerEventAsync(name,
                 input: new { ContentItem = contentItem },
                 correlationId: contentItem.ContentItemId
             );

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Handlers/ContentsHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Handlers/ContentsHandler.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.Contents.Workflows.Activities;
 using OrchardCore.Workflows.Services;
@@ -7,6 +8,8 @@ namespace OrchardCore.Contents.Workflows.Handlers
 {
     public class ContentsHandler : ContentHandlerBase
     {
+        public const string ContentItemInputKey = "ContentItem";
+
         private readonly IWorkflowManager _workflowManager;
 
         public ContentsHandler(IWorkflowManager workflowManager)
@@ -16,17 +19,25 @@ namespace OrchardCore.Contents.Workflows.Handlers
 
         public override async Task CreatedAsync(CreateContentContext context)
         {
-            await _workflowManager.TriggerEventAsync(nameof(ContentCreatedEvent), new { Content = context.ContentItem }, context.ContentItem.ContentItemId);
+            await TriggerWorkflowEventAsync(nameof(ContentCreatedEvent), context.ContentItem);
         }
 
-        public override Task PublishedAsync(PublishContentContext context)
+        public override async Task PublishedAsync(PublishContentContext context)
         {
-            return _workflowManager.TriggerEventAsync(nameof(ContentPublishedEvent), new { Content = context.ContentItem }, context.ContentItem.ContentItemId);
+            await TriggerWorkflowEventAsync(nameof(ContentPublishedEvent), context.ContentItem);
         }
 
-        public override Task RemovedAsync(RemoveContentContext context)
+        public override async Task RemovedAsync(RemoveContentContext context)
         {
-            return _workflowManager.TriggerEventAsync(nameof(ContentDeletedEvent), new { Content = context.ContentItem }, context.ContentItem.ContentItemId);
+            await TriggerWorkflowEventAsync(nameof(ContentDeletedEvent), context.ContentItem);
+        }
+
+        private async Task TriggerWorkflowEventAsync(string name, ContentItem contentItem)
+        {
+            await _workflowManager.TriggerEventAsync(name,
+                input: new { ContentItem = contentItem },
+                correlationId: contentItem.ContentItemId
+            );
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Expressions/LiquidWorkflowExpressionEvaluator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Expressions/LiquidWorkflowExpressionEvaluator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fluid;
+using Fluid.Values;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -57,29 +58,11 @@ namespace OrchardCore.Workflows.Expressions
             var services = _serviceProvider;
 
             // Set WorkflowContext as the model.
+            context.MemberAccessStrategy.Register<LiquidPropertyAccessor, FluidValue>((obj, name) => obj.GetValueAsync(name));
             context.MemberAccessStrategy.Register<WorkflowExecutionContext>();
-            context.SetValue(nameof(WorkflowExecutionContext), workflowContext);
-            context.SetValue("CorrelationId", workflowContext.CorrelationId);
-
-            // TODO: Add Liquid filters to easily access values from Input and Properties.
-            context.SetValue("Input", workflowContext.Input);
-            context.SetValue("Properties", workflowContext.Properties);
-
-            // TODO: For now, simply add each Input and Property to the context, with the risk of overwriting items with the same key.
-            // Add workflow input.
-            foreach (var item in workflowContext.Input)
-            {
-                context.SetValue(item.Key, item.Value);
-            }
-
-            // Add workflow properties.
-            foreach (var item in workflowContext.Properties)
-            {
-                context.SetValue(item.Key, item.Value);
-            }
-
-            // Add LastResult.
-            context.SetValue("LastResult", workflowContext.LastResult);
+            context.MemberAccessStrategy.Register<WorkflowExecutionContext, LiquidPropertyAccessor>("Input", obj => new LiquidPropertyAccessor(name => ToFluidValue(obj.Input, name)));
+            context.MemberAccessStrategy.Register<WorkflowExecutionContext, LiquidPropertyAccessor>("Properties", obj => new LiquidPropertyAccessor(name => ToFluidValue(obj.Properties, name)));
+            context.SetValue("Workflow", workflowContext);
 
             // Add services.
             context.AmbientValues.Add("Services", services);
@@ -101,7 +84,7 @@ namespace OrchardCore.Workflows.Expressions
             var localizer = services.GetRequiredService<IViewLocalizer>();
             context.AmbientValues.Add("ViewLocalizer", localizer);
 
-            // TODO: Extract the request culture
+            // TODO: Extract the request culture.
 
             // Give modules a chance to add more things to the template context.
             foreach (var handler in services.GetServices<ILiquidTemplateEventHandler>())
@@ -110,6 +93,14 @@ namespace OrchardCore.Workflows.Expressions
             }
 
             return context;
+        }
+
+        private Task<FluidValue> ToFluidValue(IDictionary<string, object> dictionary, string key)
+        {
+            if (!dictionary.ContainsKey(key))
+                return Task.FromResult(default(FluidValue));
+
+            return Task.FromResult(FluidValue.Create(dictionary[key]));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Expressions/LiquidWorkflowExpressionEvaluator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Expressions/LiquidWorkflowExpressionEvaluator.cs
@@ -61,6 +61,7 @@ namespace OrchardCore.Workflows.Expressions
             context.MemberAccessStrategy.Register<LiquidPropertyAccessor, FluidValue>((obj, name) => obj.GetValueAsync(name));
             context.MemberAccessStrategy.Register<WorkflowExecutionContext>();
             context.MemberAccessStrategy.Register<WorkflowExecutionContext, LiquidPropertyAccessor>("Input", obj => new LiquidPropertyAccessor(name => ToFluidValue(obj.Input, name)));
+            context.MemberAccessStrategy.Register<WorkflowExecutionContext, LiquidPropertyAccessor>("Output", obj => new LiquidPropertyAccessor(name => ToFluidValue(obj.Output, name)));
             context.MemberAccessStrategy.Register<WorkflowExecutionContext, LiquidPropertyAccessor>("Properties", obj => new LiquidPropertyAccessor(name => ToFluidValue(obj.Properties, name)));
             context.SetValue("Workflow", workflowContext);
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/README.md
@@ -148,9 +148,29 @@ The following Liquid tags, properties and filters are available by default to an
 
 | Expression | Type | Description | Example |
 | ---------- | ---- | ----------- | ------- |
-| CorrelationId | Property | Returns the correlation value of the workflow instance. | `{{ CorrelationId }}` |
-| Input | Property | Returns the Input dictionary. | `{{ Input["Foo"] }}` |
-| Properties | Property | Returns the Properties dictionary. | `{{ Properties["Foo"] }}` |
+| Workflow.CorrelationId | Property | Returns the correlation value of the workflow instance. | `{{ Workflow.CorrelationId }}` |
+| Workflow.Input | Property | Returns the Input dictionary. | `{{ Workflow.Input["ContentItem"] }}` |
+| Workflow.Output | Property | Returns the Output dictionary. | `{{ Workflow.Output["SomeResult"] }}` |
+| Workflow.Properties | Property | Returns the Properties dictionary. | `{{ Workflow.Properties["Foo"] }}` |
+
+Instead of using the indexer syntax on the three workflow dictionaries `Input`, `Output` and `Properties`, you cal also use dot notation, e.g.:
+
+```liquid
+{{ Workflow.Input.ContentItem }}
+```
+
+### Liquid Expressions and ContentItem Events
+
+When handling content related events using a workflow, the content item in question is made available to the workflow via the `Input` dictionary.
+For example, if you have a workflow that starts with the **Content Created Event** activity, you can send an email or make an HTTP request whereand reference the content item from fieldsliquid-ebabled fields as follows:
+
+```liquid
+{{ Workflow.Input.ContentItem | display_url }}
+{{ Workflow.Input.ContentItem | display_text }}
+{{ Workflow.Input.ContentItem.Content.TitlePart.Title }}
+```
+
+For more examples of supported content item filters, see documention on [Liquid ](https://orchardcore.readthedocs.io/en/latest/OrchardCore.Modules/OrchardCore.Liquid/README/).
 
 ## Activities out of the box
 

--- a/src/OrchardCore/OrchardCore.Liquid.Abstractions/LiquidPropertyAccessor.cs
+++ b/src/OrchardCore/OrchardCore.Liquid.Abstractions/LiquidPropertyAccessor.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Liquid
 {
     /// <summary>
     /// Can be used to provide a factory to return a value based on a property name 
-    /// that is unkown at registration time. 
+    /// that is unknown at registration time. 
     /// 
     /// e.g. {{ LiquidPropertyAccessor.MyPropertyName }} (MyPropertyName will be passed as the identifier argument to the factory)
     /// </summary>


### PR DESCRIPTION
Fixes the issue described in #2317 by scoping workflow input within a "Workflow" liquid variable, while also providing easy access to workflow input from liquid templates.

This allows the user to access content items from liquid templates when responding to content-related events such as "ContentItemCreated".

Examples:

**Access the WorkflowExecutionContext object itself**
```liquid
{{ Workflow }}
```

**Access a public property on the WorkflowExecutionContext**

```liquid
{{ Workflow.WorkflowId }}
{{ Workflow.CorrelationId }}
{{ Workflow.Status }}
{{ Workflow.Input }}
{{ Workflow.Output }}
{{ Workflow.Properties }}
```

**Access items from the Input dictionary**
```liquid
{{ Workflow.Input.ContentItem }}
```

And because the ContentItem object is of type `ContentItem`, you can apply all of its liquid filters described in the documentation in section [Content Item Filters](https://orchardcore.readthedocs.io/en/latest/OrchardCore.Modules/OrchardCore.Liquid/README/): 

**Apply content item filters**
```liquid
{{ Workflow.Input.ContentItem | display_text }}
{{ Workflow.Input.ContentItem | display_url }}
```