### PR TITLE
Fixing workflow counting issues

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -77,9 +77,9 @@ namespace OrchardCore.Workflows.Controllers
 
             var workflowType = await _workflowTypeStore.GetAsync(workflowTypeId);
             var siteSettings = await _siteService.GetSiteSettingsAsync();
-            var count = await _workflowStore.CountAsync();
+            var count = await _workflowStore.CountAsync(workflowType.WorkflowTypeId);
             var pager = new Pager(pagerParameters, siteSettings.PageSize);
-            var records = await _workflowStore.ListAsync(pager.GetStartIndex(), pager.PageSize);
+            var records = await _workflowStore.ListAsync(workflowType.WorkflowTypeId, pager.GetStartIndex(), pager.PageSize);
             var pagerShape = (await New.Pager(pager)).TotalItemCount(count);
 
             var viewModel = new WorkflowIndexViewModel

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
@@ -123,7 +123,10 @@ namespace OrchardCore.Workflows.Controllers
                 .ListAsync();
 
             var workflowTypeIds = workflowTypes.Select(x => x.WorkflowTypeId).ToList();
-            var workflowGroups = (await _session.QueryIndex<WorkflowIndex>(x => x.WorkflowTypeId.IsIn(workflowTypeIds)).ListAsync()).GroupBy(x => x.WorkflowTypeId).ToDictionary(x => x.Key);
+            var workflowGroups = (await _session.QueryIndex<WorkflowIndex>(x => x.WorkflowTypeId.IsIn(workflowTypeIds))
+                .ListAsync())
+                .GroupBy(x => x.WorkflowTypeId)
+                .ToDictionary(x => x.Key);
 
             // Maintain previous route data when generating page links.
             var routeData = new RouteData();

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowStore.cs
@@ -23,14 +23,25 @@ namespace OrchardCore.Workflows.Services
             _logger = logger;
         }
 
-        public Task<int> CountAsync()
+        private IQuery<Workflow, WorkflowIndex> FilterByWorkflowTypeId(IQuery<Workflow, WorkflowIndex> query, string workflowTypeId)
         {
-            return _session.Query<Workflow>().CountAsync();
+            if (workflowTypeId != null)
+            {
+                query = query.Where(x => x.WorkflowTypeId == workflowTypeId);
+            }
+
+            return query;
         }
 
-        public Task<IEnumerable<Workflow>> ListAsync(int? skip = null, int? take = null)
+        public Task<int> CountAsync(string workflowTypeId = null)
         {
-            var query = (IQuery<Workflow>)_session.Query<Workflow, WorkflowIndex>().OrderByDescending(x => x.CreatedUtc);
+            return FilterByWorkflowTypeId(_session.Query<Workflow, WorkflowIndex>(), workflowTypeId).CountAsync();
+        }
+
+        public Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId = null, int? skip = null, int? take = null)
+        {
+            var query = (IQuery<Workflow>)FilterByWorkflowTypeId(_session.Query<Workflow, WorkflowIndex>(), workflowTypeId)
+                .OrderByDescending(x => x.CreatedUtc);
 
             if (skip != null)
             {
@@ -41,7 +52,7 @@ namespace OrchardCore.Workflows.Services
             {
                 query = query.Take(take.Value);
             }
-            
+
             return query.ListAsync();
         }
 

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowStore.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowStore.cs
@@ -6,8 +6,8 @@ namespace OrchardCore.Workflows.Services
 {
     public interface IWorkflowStore
     {
-        Task<int> CountAsync();
-        Task<IEnumerable<Workflow>> ListAsync(int? skip = null, int? take = null);
+        Task<int> CountAsync(string workflowTypeId = null);
+        Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId = null, int? skip = null, int? take = null);
         Task<IEnumerable<Workflow>> ListAsync(IEnumerable<string> workflowTypeIds);
         Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId, IEnumerable<string> blockingActivityIds);
         Task<IEnumerable<Workflow>> ListAsync(string activityName, string correlationId = null);


### PR DESCRIPTION
Fixes #1709

There's an issue with the `T.Plural` method which causes to always display "1 instances". I'll look into that separately.