### PR TITLE
Fixes razor pages using [FromRoute] attribute.

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularFolderRouteModelConvention.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace OrchardCore.Mvc.RazorPages
@@ -29,24 +30,31 @@ namespace OrchardCore.Mvc.RazorPages
             }
 
             var fileName = pageName.Substring(fileIndex + 1);
+            var subpath = _folderPath + '/' + fileName;
 
-            if (pageName.EndsWith('/' + _folderPath + '/' + fileName))
+            if (pageName.EndsWith('/' + subpath))
             {
-                foreach (var selector in model.Selectors)
+                var selectors = model.Selectors.ToArray();
+
+                foreach (var selector in selectors)
                 {
                     selector.AttributeRouteModel.SuppressLinkGeneration = true;
-                }
+                    var pageTemplate = selector.AttributeRouteModel.Template;
 
-                var template = _route.Length > 0 ? _route + '/' + fileName : fileName;
-
-                model.Selectors.Add(new SelectorModel
-                {
-                    AttributeRouteModel = new AttributeRouteModel
+                    if (pageTemplate.StartsWith(subpath + '/'))
                     {
-                        Template = template,
-                        Name = template.Replace('/', '.')
+                        var template = pageTemplate.Replace(_folderPath, _route).TrimStart('/');
+
+                        model.Selectors.Add(new SelectorModel
+                        {
+                            AttributeRouteModel = new AttributeRouteModel
+                            {
+                                Template = template,
+                                Name = template.Replace('/', '.')
+                            }
+                        });
                     }
-                });
+                }
             }
         }
     }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRouteModelConvention.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageRouteModelConvention.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 namespace OrchardCore.Mvc.RazorPages
@@ -24,19 +25,27 @@ namespace OrchardCore.Mvc.RazorPages
 
             if (pageName.EndsWith('/' + _pageName))
             {
-                foreach (var selector in model.Selectors)
+                var selectors = model.Selectors.ToArray();
+
+                foreach (var selector in selectors)
                 {
                     selector.AttributeRouteModel.SuppressLinkGeneration = true;
-                }
+                    var pageTemplate = selector.AttributeRouteModel.Template;
 
-                model.Selectors.Add(new SelectorModel
-                {
-                    AttributeRouteModel = new AttributeRouteModel
+                    if (pageTemplate.StartsWith(_pageName + '/'))
                     {
-                        Template = _route,
-                        Name = _route.Replace('/', '.')
+                        var template = pageTemplate.Replace(_pageName, _route).TrimStart('/');
+
+                        model.Selectors.Add(new SelectorModel
+                        {
+                            AttributeRouteModel = new AttributeRouteModel
+                            {
+                                Template = template,
+                                Name = template.Replace('/', '.')
+                            }
+                        });
                     }
-                });
+                }
             }
         }
     }


### PR DESCRIPTION
For an application or a module razor page and can be updated at runtime.

- Then, e.g with the demo module with the same `[FromRoute]`, okay it was working for.

      "https://localhost:44300/orchardcore.demo/hello"
      "https://localhost:44300/orchardcore.demo/hello/bar"

- **Then because we are doing this** which defines new routes.

      options.Conventions.AddModularFolderRoute("/OrchardCore.Demo/Pages", "Demo");
      options.Conventions.AddModularPageRoute("/OrchardCore.Demo/Pages/Hello", "Hello");

- Okay, it was also working for.

      "https://localhost:44300/hello"
      "https://localhost:44300/demo/hello"

- But it was not working for.

      "https://localhost:44300/hello/bar"
      "https://localhost:44300/demo/hello/bar"

So, i also needed to update our page route and folder conventions