### PR TITLE
Reset the loop variable after finishing the loop

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForEachTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForEachTask.cs
@@ -81,6 +81,7 @@ namespace OrchardCore.Workflows.Activities
             }
             else
             {
+                Index = 0;
                 return Outcomes("Done");
             }
         }


### PR DESCRIPTION
After finishing the execution of a loop, the loop Index remains equal to the index of the last item. It causes problem in case we have two inner loops where the inner loop must be re-run again. In such cases, the next runs of the loop starts from the index of the last time instead of fresh starting.