### PR TITLE
Fixes 404 when previewing template in tenant

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -54,15 +54,17 @@ namespace OrchardCore.Templates.Controllers
 
             var alias = Request.Form["Alias"].ToString();
 
-            string contentItemId;
-            if (string.IsNullOrEmpty(alias) || alias == "/")
+            string contentItemId = string.Empty;
+
+            if (string.IsNullOrEmpty(alias) == false && alias != "/")
             {
-                var homeRoute = (await _siteService.GetSiteSettingsAsync()).HomeRoute;
-                contentItemId = homeRoute["contentItemId"]?.ToString();
+                contentItemId = await _contentAliasManager.GetContentItemIdAsync("slug:" + alias);                
             }
-            else
+
+            if (string.IsNullOrEmpty(contentItemId))
             {
-                contentItemId = await _contentAliasManager.GetContentItemIdAsync("slug:" + alias);
+                    var homeRoute = (await _siteService.GetSiteSettingsAsync()).HomeRoute;
+                    contentItemId = homeRoute["contentItemId"]?.ToString();
             }
 
             if (string.IsNullOrEmpty(contentItemId))


### PR DESCRIPTION
Fixes #2366

This fixes the issue.
It's the simplest solution I found. It works.
The issue is caused because we are assuming the "alias" passed when in the homepage will always be "/".
But when in a tenant the alias passed is "/tenant1/", so the "if" clause fails.
Maybe a more exhaustive approach is to compute on the view  a variable "isHomePath" and pass it to the controller. This will involve more code, maybe resorting to use "Request.PathBase" ?
So I though that maybe this approach is good enough.
cc @sebastienros 

