### PR TITLE
Fix the bug of storing ScriptTask

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ScriptTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ScriptTask.cs
@@ -32,15 +32,6 @@ namespace OrchardCore.Workflows.Activities
         }
 
         /// <summary>
-        /// A title describing the work done by the script.
-        /// </summary>
-        public string Title
-        {
-            get => GetProperty<String>();
-            set => SetProperty(value);
-        }
-
-        /// <summary>
         /// The script can call any available functions, including setOutcome().
         /// </summary>
         public WorkflowExpression<object> Script

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/ScriptTaskDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/ScriptTaskDisplay.cs
@@ -11,14 +11,12 @@ namespace OrchardCore.Workflows.Drivers
     {
         protected override void EditActivity(ScriptTask source, ScriptTaskViewModel model)
         {
-            model.Title = source.Title;
             model.AvailableOutcomes = string.Join(", ", source.AvailableOutcomes);
             model.Script = source.Script.Expression;
         }
 
         protected override void UpdateActivity(ScriptTaskViewModel model, ScriptTask activity)
         {
-            activity.Title = model.Title?.Trim()?? string.Empty;
             activity.AvailableOutcomes = model.AvailableOutcomes.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
             activity.Script = new WorkflowExpression<object>(model.Script);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/ScriptTaskDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/ScriptTaskDisplay.cs
@@ -18,7 +18,7 @@ namespace OrchardCore.Workflows.Drivers
 
         protected override void UpdateActivity(ScriptTaskViewModel model, ScriptTask activity)
         {
-            activity.Title = model.Title?.Trim();
+            activity.Title = model.Title?.Trim()?? string.Empty;
             activity.AvailableOutcomes = model.AvailableOutcomes.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).ToList();
             activity.Script = new WorkflowExpression<object>(model.Script);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/ViewModels/ScriptTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/ViewModels/ScriptTaskViewModel.cs
@@ -4,8 +4,6 @@ namespace OrchardCore.Workflows.ViewModels
 {
     public class ScriptTaskViewModel
     {
-        public string Title { get; set; }
-
         [Required]
         public string AvailableOutcomes { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/ScriptTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/ScriptTask.Fields.Design.cshtml
@@ -3,7 +3,3 @@
 <header>
     <h4><i class="fa fa-cog"></i>@Model.Activity.GetTitleOrDefault(() => T["Script"])</h4>
 </header>
-@if (!String.IsNullOrWhiteSpace(Model.Activity.Title))
-{
-    <span>@Model.Activity.Title</span>
-}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/ScriptTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/ScriptTask.Fields.Edit.cshtml
@@ -1,12 +1,6 @@
 @using OrchardCore.Workflows.ViewModels;
 @model ScriptTaskViewModel
 
-<fieldset class="form-group" asp-validation-class-for="Title">
-    <label asp-for="Title">@T["Title"] <span asp-validation-for="Title"></span></label>
-    <input asp-for="Title" class="form-control" autofocus />
-    <span class="hint">@T["Optionally specify a title that describes the script."]</span>
-</fieldset>
-
 <fieldset class="form-group" asp-validation-class-for="AvailableOutcomes">
     <label asp-for="AvailableOutcomes">@T["Available Outcomes"] <span asp-validation-for="AvailableOutcomes"></span></label>
     <input asp-for="AvailableOutcomes" class="form-control" />


### PR DESCRIPTION
Setting the Title of the ScriptTask to null raises an exception.

@sebastienros  @sfmskywalker  Is there any reason to have a Title for this specific Task, as all Tasks have a default Title and having two Title fields for ScriptTask seems a little strange.