### PR TITLE
Async nav provider

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/AdminMenu.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.ContentTypes {
     public class AdminMenu : INavigationProvider {
@@ -12,11 +13,11 @@ namespace OrchardCore.ContentTypes {
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder.Add(T["Content Definition"], "2", contentDefinition => contentDefinition
@@ -31,6 +32,8 @@ namespace OrchardCore.ContentTypes {
                         .Permission(Permissions.ViewContentTypes)
                         .LocalNav())
                     );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
@@ -1,11 +1,11 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.Environment.Navigation;
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace OrchardCore.Contents
 {
@@ -26,11 +26,11 @@ namespace OrchardCore.Contents
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             var contentTypeDefinitions = _contentDefinitionManager.ListTypeDefinitions().OrderBy(d => d.Name);
@@ -63,7 +63,12 @@ namespace OrchardCore.Contents
                                 );
                     }
                 });
+
+
+
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.CustomSettings.Services;
 using OrchardCore.Environment.Navigation;
@@ -19,11 +20,11 @@ namespace OrchardCore.CustomSettings
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             foreach (var type in _customSettingsService.GetSettingsTypes())
@@ -38,6 +39,8 @@ namespace OrchardCore.CustomSettings
                                 .LocalNav()
                             )));
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Demo/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/AdminMenu.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Demo
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Demo
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -38,6 +39,9 @@ namespace OrchardCore.Demo
                         .Add(T["This is Menu Item 3.2"])
                     )
                 );
+
+            return Task.CompletedTask;
+
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/AdminMenu.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Deployment.Remote
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Deployment.Remote
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -35,6 +36,8 @@ namespace OrchardCore.Deployment.Remote
                         )
                     )
                 );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/AdminMenu.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Deployment
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Deployment
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -35,6 +36,8 @@ namespace OrchardCore.Deployment
                         )
                     )
                 );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Email.Drivers;
 using OrchardCore.Environment.Navigation;
@@ -14,10 +15,10 @@ namespace OrchardCore.Email
             T = localizer;
         }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
-                return;
+                return Task.CompletedTask;
 
             builder
                 .Add(T["Configuration"], configuration => configuration
@@ -27,6 +28,8 @@ namespace OrchardCore.Email
                           .Permission(Permissions.ManageEmailSettings)
                           .LocalNav()
                 )));
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Features/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/AdminMenu.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Features
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Features
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -29,6 +30,8 @@ namespace OrchardCore.Features
                         .LocalNav()
                     )
                 );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Forms.Drivers;
@@ -14,11 +15,11 @@ namespace OrchardCore.Forms
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -28,6 +29,8 @@ namespace OrchardCore.Forms
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = NoCaptchaSettingsDisplay.GroupId })
                             .LocalNav()
                         )));
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Https/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Https/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 
@@ -13,11 +14,11 @@ namespace OrchardCore.Https
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -28,6 +29,8 @@ namespace OrchardCore.Https
                             .LocalNav()
                         ))
                 );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Layers.Drivers;
@@ -14,11 +15,11 @@ namespace OrchardCore.Layers
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -35,6 +36,8 @@ namespace OrchardCore.Layers
                         .Action("Index", "Admin", new { area = "OrchardCore.Layers" })
                         .LocalNav()
                     ));
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/AdminMenu.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Lucene
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Lucene
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -39,6 +40,7 @@ namespace OrchardCore.Lucene
                             .LocalNav()
                         )));
 
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 
@@ -13,11 +14,11 @@ namespace OrchardCore.Media
 
         public IStringLocalizer S { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -27,6 +28,8 @@ namespace OrchardCore.Media
                         .Action("Index", "Admin", new { area = "OrchardCore.Media" })
                         .LocalNav()
                     ));
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/NavigationShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/NavigationShapes.cs
@@ -40,7 +40,7 @@ namespace OrchardCore.Navigation
                     var navigationManager = context.ServiceProvider.GetRequiredService<INavigationManager>();
                     var shapeFactory = context.ServiceProvider.GetRequiredService<IShapeFactory>();
                     var httpContextAccessor = context.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
-                    var menuItems = navigationManager.BuildMenu(menuName, context.DisplayContext.ViewContext);
+                    var menuItems = await navigationManager.BuildMenuAsync(menuName, context.DisplayContext.ViewContext);
                     var httpContext = httpContextAccessor.HttpContext;
 
                     if (httpContext != null)

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/README.md
@@ -122,7 +122,7 @@ public class MainMenu : INavigationProvider
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public async Task BuildNavigation(string name, NavigationBuilder builder)
         {
             //Only interact with the "main" navigation menu here.
             if (!String.Equals(name, "main", StringComparison.OrdinalIgnoreCase))

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/AdminMenu.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Environment.Shell.Descriptor.Models;
@@ -21,11 +22,11 @@ namespace OrchardCore.OpenId
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder.Add(T["OpenID Connect"], "15", category =>
@@ -81,6 +82,8 @@ namespace OrchardCore.OpenId
                     });
                 }
             });
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/AdminMenu.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Queries
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Queries
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder.Add(T["Content"], content => content
@@ -25,7 +26,9 @@ namespace OrchardCore.Queries
                     .Action("Index", "Admin", new { area = "OrchardCore.Queries" })
                     .Permission(Permissions.ManageQueries)
                     .LocalNav())
-                );            
+                );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/AdminMenu.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Queries.Sql
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Queries.Sql
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -28,6 +29,9 @@ namespace OrchardCore.Queries.Sql
                             .Action("Query", "Admin", new { area = "OrchardCore.Queries" })
                             .Permission(Permissions.ManageSqlQueries)
                             .LocalNav())));
+
+
+            return Task.CompletedTask;
 
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using OrchardCore.Security;
@@ -15,11 +16,11 @@ namespace OrchardCore.Recipes
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder.Add(T["Configuration"], configuration => configuration
@@ -29,6 +30,8 @@ namespace OrchardCore.Recipes
                     .Action("Index", "Admin", new { area = "OrchardCore.Recipes" })
                     .LocalNav())
                 );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/AdminMenu.cs
@@ -1,6 +1,7 @@
+using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
-using System;
 
 namespace OrchardCore.Roles
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Roles
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -28,6 +29,8 @@ namespace OrchardCore.Roles
                             .Permission(Permissions.ManageRoles)
                             .LocalNav()
                         )));
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 
@@ -13,11 +14,11 @@ namespace OrchardCore.Settings
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder.Add(T["Configuration"], configuration => configuration
@@ -29,6 +30,8 @@ namespace OrchardCore.Settings
                     )
                 )
             );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/AdminMenu.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Templates
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Templates
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -28,6 +29,8 @@ namespace OrchardCore.Templates
                         .LocalNav()
                     )
                 );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/AdminMenu.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
 using OrchardCore.Environment.Shell;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Tenants
 {
@@ -17,17 +18,17 @@ namespace OrchardCore.Tenants
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             // Don't add the menu item on non-default tenants
             if (_shellSettings.Name != ShellHelper.DefaultShellName)
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -39,6 +40,8 @@ namespace OrchardCore.Tenants
                         .LocalNav()
                     )
                 );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Themes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/AdminMenu.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 using System;
+using System.Threading.Tasks;
 
 namespace OrchardCore.Themes
 {
@@ -13,11 +14,11 @@ namespace OrchardCore.Themes
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -30,6 +31,8 @@ namespace OrchardCore.Themes
                         .LocalNav()
                     )
                 );
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/AdminMenu.cs
@@ -1,8 +1,9 @@
+using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
-using System;
-using OrchardCore.Users.Drivers;
 using OrchardCore.Modules;
+using OrchardCore.Users.Drivers;
 
 namespace OrchardCore.Users
 {
@@ -15,11 +16,11 @@ namespace OrchardCore.Users
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -30,9 +31,11 @@ namespace OrchardCore.Users
                             .Permission(Permissions.ManageUsers)
                             .LocalNav()
                          )));
+
+            return Task.CompletedTask;
         }
     }
-    
+
     [Feature("OrchardCore.Users.Registration")]
     public class RegistrationAdminMenu : INavigationProvider
     {
@@ -43,11 +46,11 @@ namespace OrchardCore.Users
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -58,6 +61,8 @@ namespace OrchardCore.Users
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = RegistrationSettingsDisplayDriver.GroupId })
                             .LocalNav()
                         )));
+
+            return Task.CompletedTask;
         }
     }
 
@@ -71,11 +76,11 @@ namespace OrchardCore.Users
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder
@@ -86,6 +91,8 @@ namespace OrchardCore.Users
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = ResetPasswordSettingsDisplayDriver.GroupId })
                             .LocalNav()
                         )));
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/AdminMenu.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Environment.Navigation;
 
@@ -13,17 +14,19 @@ namespace OrchardCore.Workflows
 
         public IStringLocalizer T { get; set; }
 
-        public void BuildNavigation(string name, NavigationBuilder builder)
+        public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (!string.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return;
+                return Task.CompletedTask;
             }
 
             builder.Add(T["Workflows"], "5", workflow => workflow
                 .AddClass("workflows").Id("workflows").Action("Index", "WorkflowType", new { area = "OrchardCore.Workflows" })
                     .Permission(Permissions.ManageWorkflows)
                     .LocalNav());
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Environment.Navigation/INavigationManager.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Navigation/INavigationManager.cs
@@ -1,10 +1,11 @@
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 
 namespace OrchardCore.Environment.Navigation
 {
     public interface INavigationManager
     {
-        IEnumerable<MenuItem> BuildMenu(string name, ActionContext context);
+        Task<IEnumerable<MenuItem>> BuildMenuAsync(string name, ActionContext context);
     }
 }

--- a/src/OrchardCore/OrchardCore.Environment.Navigation/INavigationProvider.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Navigation/INavigationProvider.cs
@@ -1,7 +1,9 @@
+using System.Threading.Tasks;
+
 namespace OrchardCore.Environment.Navigation
 {
     public interface INavigationProvider
     {
-        void BuildNavigation(string name, NavigationBuilder builder);
+        Task BuildNavigationAsync(string name, NavigationBuilder builder);
     }
 }

--- a/src/OrchardCore/OrchardCore.Environment.Navigation/NavigationManager.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Navigation/NavigationManager.cs
@@ -39,7 +39,7 @@ namespace OrchardCore.Environment.Navigation
             _authorizationService = authorizationService;
         }
 
-        public IEnumerable<MenuItem> BuildMenu(string name, ActionContext actionContext)
+        public async Task<IEnumerable<MenuItem>> BuildMenuAsync(string name, ActionContext actionContext)
         {
             var builder = new NavigationBuilder();
 
@@ -49,7 +49,7 @@ namespace OrchardCore.Environment.Navigation
             {
                 try
                 {
-                    navigationProvider.BuildNavigationAsync(name, builder);
+                    await navigationProvider.BuildNavigationAsync(name, builder);
                 }
                 catch (Exception e)
                 {

--- a/src/OrchardCore/OrchardCore.Environment.Navigation/NavigationManager.cs
+++ b/src/OrchardCore/OrchardCore.Environment.Navigation/NavigationManager.cs
@@ -49,7 +49,7 @@ namespace OrchardCore.Environment.Navigation
             {
                 try
                 {
-                    navigationProvider.BuildNavigation(name, builder);
+                    navigationProvider.BuildNavigationAsync(name, builder);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Fixes #2342
I made a separate PR to make easier to fix possible issues.
INavigationProvider is now async. So you can "await" AdminMenus.
Right now all of them are sill running synchronously though, because there is nothing to await on them. 
Please take a look to see if it's OK to use " return Task.CompletedTask" as a way to avoid CS1998 compilation errors.
It works OK for me.
And NavigationManager seems to handle correctly exceptions raised from AdminMenus.

