### PR TITLE
Make ShellHost IDisposable.

### DIFF
--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -413,11 +413,6 @@ namespace OrchardCore.Environment.Shell
         {
             var shells = _shellContexts?.Values.ToArray();
 
-            if (shells == null || shells.Length == 0)
-            {
-                return;
-            }
-
             foreach (var shell in shells)
             {
                 shell.Dispose();

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -409,7 +409,6 @@ namespace OrchardCore.Environment.Shell
                 shellSettings.State == TenantState.Initializing;
         }
 
-
         public void Dispose()
         {
             var shells = _shellContexts?.Values.ToArray();

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.Environment.Shell
     /// tenant is removed, but are necessary to match an incoming request, even if they are not initialized.
     /// Each <see cref="ShellContext"/> is activated (its service provider is built) on the first request.
     /// </summary>
-    public class ShellHost : IShellHost, IShellDescriptorManagerEventHandler
+    public class ShellHost : IShellHost, IShellDescriptorManagerEventHandler, IDisposable
     {
         private readonly IShellSettingsManager _shellSettingsManager;
         private readonly IShellContextFactory _shellContextFactory;
@@ -407,6 +407,26 @@ namespace OrchardCore.Environment.Shell
                 shellSettings.State == TenantState.Running ||
                 shellSettings.State == TenantState.Uninitialized ||
                 shellSettings.State == TenantState.Initializing;
+        }
+
+
+        public void Dispose()
+        {
+            var shells = _shellContexts?.Values.ToArray();
+
+            if (shells == null || shells.Length == 0)
+            {
+                return;
+            }
+
+            foreach (var shell in shells)
+            {
+                if (shell.ServiceProvider != null)
+                {
+                    shell.Dispose();
+                    Console.WriteLine($"Disposed {shell.Settings.Name}");
+                }
+            }
         }
     }
 }

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -421,11 +421,7 @@ namespace OrchardCore.Environment.Shell
 
             foreach (var shell in shells)
             {
-                if (shell.ServiceProvider != null)
-                {
-                    shell.Dispose();
-                    Console.WriteLine($"Disposed {shell.Settings.Name}");
-                }
+                shell.Dispose();
             }
         }
     }


### PR DESCRIPTION
Dispose the shells via shellHost when the application shut down. IDisposable services are naturally disposed when out of scope, but not tenant singletons which are held by the related shell contexts service providers.

I saw this when using a tenant singleton which hold a redis connection multiplexer. Then, i checked that, with this change, the tenant singleton (which is IDisposable) `Dispose()` was called.

