### PR TITLE
Little fixes in dynamic cache

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/README.md
@@ -89,7 +89,7 @@ Sometimes you may want to vary by a known value that is not an available context
 For example: You may wish to cache all your blog posts so that you can quickly display lists of your posts throughout your site. If the cache ID for the cache block was `blog-post`, you can use a known value as a context to vary the cache item for each blog post. In this case, you could use the Content Item ID as a context:
 
 ```
-{% cache "blog-post-summary", vary_by: Model.ContentItemId %}
+{% cache "blog-post-summary", vary_by: Model.ContentItem.ContentItemId %}
     ...
 {% endcache %}
 ```

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Cache/ITagCache.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Cache/ITagCache.cs
@@ -7,6 +7,7 @@ namespace OrchardCore.Environment.Cache
     {
         void Tag(string key, params string[] tags);
         IEnumerable<string> GetTaggedItems(string tag);
+        bool IsItemTagged(string tag, string item);
         Task RemoveTagAsync(string tag);
     }
 

--- a/src/OrchardCore/OrchardCore.Infrastructure/Cache/DefaultTagCache.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Cache/DefaultTagCache.cs
@@ -62,6 +62,11 @@ namespace OrchardCore.Environment.Cache
             return Enumerable.Empty<string>();
         }
 
+        public bool IsItemTagged(string tag, string item)
+        {
+            return _dictionary.TryGetValue(tag, out var set) && set.Contains(item);
+        }
+
         public Task RemoveTagAsync(string tag)
         {
             HashSet<string> set;


### PR DESCRIPTION
Working on a distributed cache with 2 instances of the same application.

- An instance can get a cached value before having tagged items locally. So the related tags will not invalidate the cache locally, and then in my case will not update the distributed cache. So i created `IsItemTagged(tag, item)` to check if items need to be tagged locally.

- When using known values variations, the key of the cached value returned by `GetCacheKey()` doesn't only rely on the `CacheId`. So, to compute the right cache key we need the actual cache context, not the one retrieved from the cache (the context is also cached).

Fixes #2432.