### PR TITLE
Disabled autocomplete in OpenId ClientSecret textbox

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
@@ -30,7 +30,7 @@
     <div class="form-group" asp-validation-class-for="ClientSecret">
         <label asp-for="ClientSecret">@T["Client Secret"]</label>
         <span asp-validation-for="ClientSecret" class="text-danger"></span>
-        <input asp-for="ClientSecret" class="form-control" autofocus />
+        <input asp-for="ClientSecret" class="form-control" autofocus autocomplete="off" />
     </div>
 
     <h3>Flows</h3>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
@@ -41,7 +41,7 @@
         <div class="form-group" asp-validation-class-for="ClientSecret">
             <label asp-for="ClientSecret">@T["Client Secret"]</label>
             <span asp-validation-for="ClientSecret" class="text-danger"></span>
-            <input asp-for="ClientSecret" class="form-control" autofocus />
+            <input asp-for="ClientSecret" class="form-control" autofocus autocomplete="off" />
         </div>
     </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdClientSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdClientSettings.Edit.cshtml
@@ -129,7 +129,7 @@
 
 <fieldset class="form-group collapse" asp-validation-class-for="ClientSecret">
     <label>@T["Client Secret"] <span asp-validation-for="ClientSecret"></span></label>
-    <input asp-for="ClientSecret" class="form-control" type="password" />
+    <input asp-for="ClientSecret" class="form-control" type="password" autocomplete="off" />
     <span class="hint">@T["set client secret."]</span>
 </fieldset>
 


### PR DESCRIPTION
Also: I noticed that the ClientSecret field on the OpenIdClientSettings is type=Password.  But the same field on the Application settings is not.  It's an equally critical field in both places, so I feel like they should be all one or the other.  Not mixed up like it is now.
My 2 cents: It doesn't make sense to set it as a password field, because it's stored in plaintext in the db, and  anyone with admin permission to view that page should be safe to view/edit those secrets.  And not being able to view the secret (if its hid by asteriskes) would make debugging auth problems more difficult for admins.