### PR TITLE
Validate OpenIdServerSettings before registering OpenId server

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
@@ -123,6 +123,11 @@ namespace OrchardCore.OpenId.Configuration
                 options.AccessTokenHandler = new JwtSecurityTokenHandler();
             }
 
+            if (!settings.EnableAuthorizationEndpoint && !settings.EnableTokenEndpoint && !settings.EnableLogoutEndpoint && !settings.EnableUserInfoEndpoint)
+            {
+                // Work around for Openiddict that throws an exception when no flows are selected
+                settings.EnableAuthorizationEndpoint = true;
+            }
             if (settings.EnableAuthorizationEndpoint)
             {
                 options.AuthorizationEndpointPath = "/connect/authorize";

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -411,8 +411,6 @@ namespace OrchardCore.OpenId.Controllers
             var principal = await _signInManager.CreateUserPrincipalAsync(user);
             var identity = (ClaimsIdentity) principal.Identity;
 
-            identity.AddClaim(new Claim("TrivestId", "Contoso"));
-
             // Note: while ASP.NET Core Identity uses the legacy WS-Federation claims (exposed by the ClaimTypes class),
             // OpenIddict uses the newer JWT claims defined by the OpenID Connect specification. To ensure the mandatory
             // subject claim is correctly populated (and avoid an InvalidOperationException), it's manually added here.

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -411,6 +411,8 @@ namespace OrchardCore.OpenId.Controllers
             var principal = await _signInManager.CreateUserPrincipalAsync(user);
             var identity = (ClaimsIdentity) principal.Identity;
 
+            identity.AddClaim(new Claim("TrivestId", "Contoso"));
+
             // Note: while ASP.NET Core Identity uses the legacy WS-Federation claims (exposed by the ClaimTypes class),
             // OpenIddict uses the newer JWT claims defined by the OpenID Connect specification. To ensure the mandatory
             // subject claim is correctly populated (and avoid an InvalidOperationException), it's manually added here.

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdServerSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdServerSettingsViewModel.cs
@@ -25,6 +25,17 @@ namespace OrchardCore.OpenId.ViewModels
         public bool AllowImplicitFlow { get; set; }
         public bool UseRollingTokens { get; set; }
 
+        [Newtonsoft.Json.JsonIgnore]
+        public EndpointInfo Endpoints { get; set; }
+
+        public class EndpointInfo
+        {
+            public string TokenEndpointPath { get; set; }
+            public string AuthorizationEndpointPath { get; set; }
+            public string LogoutEndpointPath { get; set; }
+            public string UserinfoEndpointPath { get; set; }
+        }
+
         public class CertificateInfo
         {
             public string FriendlyName { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdServerSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdServerSettings.Edit.cshtml
@@ -2,9 +2,6 @@
 @using OrchardCore.OpenId.Settings;
 @using System.Security.Cryptography.X509Certificates
 @model OpenIdServerSettingsViewModel
-@inject Microsoft.Extensions.Options.IOptionsMonitor<OpenIddict.Server.OpenIddictServerOptions> OpenIddictServerOptionsMonitor
-
-@{ var OpenIddictServerOptions = OpenIddictServerOptionsMonitor.Get(OpenIddict.Server.OpenIddictServerDefaults.AuthenticationScheme); }
 
 <p class="alert alert-warning">@T["The current tenant will be reloaded when the settings are saved."]</p>
 
@@ -84,7 +81,10 @@
             @T["Enable Token Endpoint"]
         </label>
     </div>
-    <span class="hint">@T["Enables action {0}", OpenIddictServerOptions.TokenEndpointPath]</span>
+    @if (!String.IsNullOrWhiteSpace(Model.Endpoints.TokenEndpointPath))
+    {
+        <span class="hint">@T["Enables action {0}", Model.Endpoints.TokenEndpointPath]</span>
+    }
 </fieldset>
 
 <fieldset class="form-group" asp-validation-class-for="EnableAuthorizationEndpoint">
@@ -94,7 +94,10 @@
             @T["Enable Authorization Endpoint"]
         </label>
     </div>
-    <span class="hint">@T["Enables action {0}", OpenIddictServerOptions.AuthorizationEndpointPath]</span>
+    @if (!String.IsNullOrWhiteSpace(Model.Endpoints.AuthorizationEndpointPath))
+    {
+        <span class="hint">@T["Enables action {0}", Model.Endpoints.AuthorizationEndpointPath]</span>
+    }
 </fieldset>
 
 <fieldset class="form-group" asp-validation-class-for="EnableLogoutEndpoint">
@@ -104,7 +107,10 @@
             @T["Enable Logout Endpoint"]
         </label>
     </div>
-    <span class="hint">@T["Enables action {0}", OpenIddictServerOptions.LogoutEndpointPath]</span>
+    @if (!String.IsNullOrWhiteSpace(Model.Endpoints.LogoutEndpointPath))
+    {
+        <span class="hint">@T["Enables action {0}", Model.Endpoints.LogoutEndpointPath]</span>
+    }
 </fieldset>
 
 <fieldset class="form-group" asp-validation-class-for="EnableUserInfoEndpoint">
@@ -114,7 +120,10 @@
             @T["Enable User Info Endpoint"]
         </label>
     </div>
-    <span class="hint">@T["Enables action {0}", OpenIddictServerOptions.UserinfoEndpointPath]</span>
+    @if (!String.IsNullOrWhiteSpace(Model.Endpoints.UserinfoEndpointPath))
+    {
+        <span class="hint">@T["Enables action {0}", Model.Endpoints.UserinfoEndpointPath]</span>
+    }
 </fieldset>
 
 <h3>Flows</h3>


### PR DESCRIPTION
Validated OpenIdServerSettings before starting the OpenId server, so that it does not throw exceptions.

Described in issue https://github.com/OrchardCMS/OrchardCore/issues/2414