### PR TITLE
Adding File Content Definition feature.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Manifest.cs
@@ -4,12 +4,25 @@ using OrchardCore.Modules.Manifest;
     Name = "Contents",
     Author = "The Orchard Team",
     Website = "http://orchardproject.net",
-    Version = "2.0.0",
+    Version = "2.0.0"
+)]
+
+[assembly: Feature(
+    Id = "OrchardCore.Contents",
+    Name = "Contents",
     Description = "The contents module enables the edition and rendering of content items.",
-    Dependencies = new []
+    Dependencies = new[]
     {
         "OrchardCore.Settings",
         "OrchardCore.Liquid"
     },
+    Category = "Content Management"
+)]
+
+[assembly:Feature(
+    Id = "OrchardCore.Contents.FileContentDefinition",
+    Name = "File Content Definition",
+    Description = "Stores Content Definition in a local file.",
+    Dependencies = new[] { "OrchardCore.Contents" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -147,4 +147,13 @@ namespace OrchardCore.Contents
             services.AddScoped<IDisplayDriver<DeploymentStep>, ContentDeploymentStepDriver>();
         }
     }
+
+    [Feature("OrchardCore.Contents.FileContentDefinition")]
+    public class FileContentDefinitionStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddFileContentDefinitionStore();
+        }
+    }
 }

--- a/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
@@ -41,6 +41,7 @@
         "OrchardCore.ContentFields",
         "OrchardCore.ContentPreview",
         "OrchardCore.Contents",
+        "OrchardCore.Contents.FileContentDefinition",
         "OrchardCore.ContentTypes",
         "OrchardCore.CustomSettings",
         "OrchardCore.Deployment",

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -41,6 +41,7 @@
         "OrchardCore.ContentFields",
         "OrchardCore.ContentPreview",
         "OrchardCore.Contents",
+        "OrchardCore.Contents.FileContentDefinition",
         "OrchardCore.ContentTypes",
         "OrchardCore.CustomSettings",
         "OrchardCore.Deployment",

--- a/src/OrchardCore.Themes/TheTheme/Recipes/empty.recipe.json
+++ b/src/OrchardCore.Themes/TheTheme/Recipes/empty.recipe.json
@@ -40,6 +40,7 @@
         "OrchardCore.ContentFields",
         "OrchardCore.ContentPreview",
         "OrchardCore.Contents",
+        "OrchardCore.Contents.FileContentDefinition",
         "OrchardCore.ContentTypes",
         "OrchardCore.CustomSettings",
         "OrchardCore.Deployment",

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentDefinitionStore.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentDefinitionStore.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using OrchardCore.ContentManagement.Metadata.Records;
+
+namespace OrchardCore.ContentManagement
+{
+    public interface IContentDefinitionStore
+    {
+        Task<ContentDefinitionRecord> LoadContentDefinitionAsync();
+
+        Task SaveContentDefinitionAsync(ContentDefinitionRecord contentDefinitionRecord);
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Records/ContentDefinitionRecord.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Records/ContentDefinitionRecord.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace OrchardCore.ContentManagement.Metadata.Records
 {

--- a/src/OrchardCore/OrchardCore.ContentManagement/ContentDefinitionManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ContentDefinitionManager.cs
@@ -3,11 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
-using OrchardCore.ContentManagement.Metadata.Records;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentManagement.Metadata.Records;
 using OrchardCore.Environment.Cache;
-using YesSql;
 
 namespace OrchardCore.ContentManagement
 {
@@ -15,47 +14,24 @@ namespace OrchardCore.ContentManagement
     {
         private const string TypeHashCacheKey = "ContentDefinitionManager:Serial";
 
-        private readonly ISession _session;
         private ContentDefinitionRecord _contentDefinitionRecord;
         private readonly IMemoryCache _memoryCache;
         private readonly ISignal _signal;
-
+        private readonly IContentDefinitionStore _contentDefinitionStore;
         private readonly ConcurrentDictionary<string, ContentTypeDefinition> _typeDefinitions;
         private readonly ConcurrentDictionary<string, ContentPartDefinition> _partDefinitions;
 
         public ContentDefinitionManager(
-            ISession session,
             IMemoryCache memoryCache,
-            ISignal signal)
+            ISignal signal,
+            IContentDefinitionStore contentDefinitionStore)
         {
             _signal = signal;
+            _contentDefinitionStore = contentDefinitionStore;
             _memoryCache = memoryCache;
-            _session = session;
 
             _typeDefinitions = _memoryCache.GetOrCreate("TypeDefinitions", entry => new ConcurrentDictionary<string, ContentTypeDefinition>());
             _partDefinitions = _memoryCache.GetOrCreate("PartDefinitions", entry => new ConcurrentDictionary<string, ContentPartDefinition>());
-        }
-
-        private ContentDefinitionRecord GetContentDefinitionRecord()
-        {
-            // cache in the current work context
-            if (_contentDefinitionRecord != null)
-            {
-                return _contentDefinitionRecord;
-            }
-
-            _contentDefinitionRecord = _session
-                .Query<ContentDefinitionRecord>()
-                .FirstOrDefaultAsync()
-                .GetAwaiter().GetResult();
-
-            if (_contentDefinitionRecord == null)
-            {
-                _contentDefinitionRecord = new ContentDefinitionRecord();
-                UpdateContentDefinitionRecord();
-            }
-
-            return _contentDefinitionRecord;
         }
 
         public ContentTypeDefinition GetTypeDefinition(string name)
@@ -284,20 +260,9 @@ namespace OrchardCore.ContentManagement
             return source == null ? null : new ContentFieldDefinition(source.Name);
         }
 
-        private void UpdateContentDefinitionRecord()
-        {
-            _contentDefinitionRecord.Serial++;
-            _session.Save(_contentDefinitionRecord);
-            _signal.SignalToken(TypeHashCacheKey);
-
-            // Release cached values
-            _typeDefinitions.Clear();
-            _partDefinitions.Clear();
-        }
-
         public Task<int> GetTypesHashAsync()
         {
-            // The serial number is store in local cache in order to prevent
+            // The serial number is stored in local cache in order to prevent
             // loading the record if it's not necessary
 
             int serial;
@@ -312,5 +277,29 @@ namespace OrchardCore.ContentManagement
 
             return Task.FromResult(serial);
         }
+
+        private ContentDefinitionRecord GetContentDefinitionRecord()
+        {
+            if (_contentDefinitionRecord != null)
+            {
+                return _contentDefinitionRecord;
+            }
+
+            return _contentDefinitionRecord = _contentDefinitionStore.LoadContentDefinitionAsync().GetAwaiter().GetResult();
+        }
+
+        private void UpdateContentDefinitionRecord()
+        {
+            _contentDefinitionRecord.Serial++;
+            _contentDefinitionStore.SaveContentDefinitionAsync(_contentDefinitionRecord).GetAwaiter().GetResult();
+
+            _signal.SignalToken(TypeHashCacheKey);
+
+
+            // Release cached values
+            _typeDefinitions.Clear();
+            _partDefinitions.Clear();
+        }
+
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement/DatabaseContentDefinitionStore.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DatabaseContentDefinitionStore.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using OrchardCore.ContentManagement.Metadata.Records;
+using YesSql;
+
+namespace OrchardCore.ContentManagement
+{
+    public class DatabaseContentDefinitionStore : IContentDefinitionStore
+    {
+        private readonly ISession _session;
+
+        public DatabaseContentDefinitionStore(ISession session)
+        {
+            _session = session;
+        }
+
+        public async Task<ContentDefinitionRecord> LoadContentDefinitionAsync()
+        {
+            var contentDefinitionRecord = await _session
+                .Query<ContentDefinitionRecord>()
+                .FirstOrDefaultAsync();
+
+            if (contentDefinitionRecord == null)
+            {
+                contentDefinitionRecord = new ContentDefinitionRecord();
+                await SaveContentDefinitionAsync(contentDefinitionRecord);
+            }
+
+            return contentDefinitionRecord;
+        }
+
+        public Task SaveContentDefinitionAsync(ContentDefinitionRecord contentDefinitionRecord)
+        {
+            _session.Save(contentDefinitionRecord);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
@@ -1,0 +1,60 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using OrchardCore.ContentManagement.Metadata.Records;
+using OrchardCore.Environment.Shell;
+
+namespace OrchardCore.ContentManagement
+{
+    public class FileContentDefinitionStore : IContentDefinitionStore
+    {
+        private readonly IOptions<ShellOptions> _shellOptions;
+        private readonly ShellSettings _shellSettings;
+
+        public FileContentDefinitionStore(IOptions<ShellOptions> shellOptions, ShellSettings shellSettings)
+        {
+            _shellOptions = shellOptions;
+            _shellSettings = shellSettings;
+        }
+
+        public Task<ContentDefinitionRecord> LoadContentDefinitionAsync()
+        {
+            
+            ContentDefinitionRecord result;
+
+            if (!File.Exists(Filename))
+            {
+                result = new ContentDefinitionRecord();
+            }
+            else
+            {
+                using (var file = File.OpenText(Filename))
+                {
+                    var serializer = new JsonSerializer();
+                    result = (ContentDefinitionRecord)serializer.Deserialize(file, typeof(ContentDefinitionRecord));
+                }
+            }
+
+            return Task.FromResult(result);
+        }
+
+        public Task SaveContentDefinitionAsync(ContentDefinitionRecord contentDefinitionRecord)
+        {
+            using (var file = File.CreateText(Filename))
+            {
+                var serializer = new JsonSerializer();
+                serializer.Formatting = Formatting.Indented;
+                serializer.Serialize(file, contentDefinitionRecord);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private string Filename => Path.Combine(
+                _shellOptions.Value.ShellsApplicationDataPath,
+                _shellOptions.Value.ShellsContainerName,
+                _shellSettings.Name, "ContentDefinition.json");
+
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ namespace OrchardCore.ContentManagement
         {
             services.AddScoped<ICacheContextProvider, ContentDefinitionCacheContextProvider>();
             services.TryAddScoped<IContentDefinitionManager, ContentDefinitionManager>();
+            services.TryAddScoped<IContentDefinitionStore, DatabaseContentDefinitionStore>();
             services.TryAddScoped<IContentManager, DefaultContentManager>();
             services.TryAddScoped<IContentManagerSession, DefaultContentManagerSession>();
             services.AddSingleton<IIndexProvider, ContentItemIndexProvider>();
@@ -28,6 +29,14 @@ namespace OrchardCore.ContentManagement
 
             services.AddSingleton<IContentItemIdGenerator, DefaultContentItemIdGenerator>();
             services.AddScoped<IContentAliasManager, ContentAliasManager>();
+
+            return services;
+        }
+
+        public static IServiceCollection AddFileContentDefinitionStore(this IServiceCollection services)
+        {
+            services.RemoveAll<IContentDefinitionStore>();
+            services.TryAddScoped<IContentDefinitionStore, FileContentDefinitionStore>();
 
             return services;
         }

--- a/src/Templates/OrchardCore.Cms.Templates/content/OrchardCore.Templates.Theme/Recipes/Theme.recipe.json
+++ b/src/Templates/OrchardCore.Cms.Templates/content/OrchardCore.Templates.Theme/Recipes/Theme.recipe.json
@@ -42,6 +42,7 @@
         "OrchardCore.ContentFields",
         "OrchardCore.ContentPreview",
         "OrchardCore.Contents",
+        "OrchardCore.Contents.FileContentDefinition",
         "OrchardCore.ContentTypes",
         "OrchardCore.CustomSettings",
         "OrchardCore.Deployment",

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/Recipes/pages.recipe.json
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/Recipes/pages.recipe.json
@@ -40,6 +40,7 @@
         "OrchardCore.ContentFields",
         "OrchardCore.ContentPreview",
         "OrchardCore.Contents",
+        "OrchardCore.Contents.FileContentDefinition",
         "OrchardCore.ContentTypes",
         "OrchardCore.CustomSettings",
         "OrchardCore.Deployment",


### PR DESCRIPTION
Right now as a feature, to allow for smooth transition. Enabled by default in recipes for new sites to use it.

For users who want to use it on existing sites, 
- Export the Content Definition to a file. 
- Copy the recipe in `App_Data\Sites\[SITENAME]\ContentDefinition.json`. 
- Edit the file and change `ContentTypes` to `ContentTypeDefinitionRecords`, and `ContentParts` to `ContentPartDefinitionRecords`
- Enable the `File Content Definition Feature`

Once everyone who cares has migrated, we'll make it the default by removing this feature, and creating a new one for the Database implementation.