### PR TITLE
Fix OpenId readme to use correct step name

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/README.md
@@ -55,7 +55,7 @@ Available settings are:
 A sample of OpenID Connect Settings recipe step:
 ```
 {
-      "name": "openidsettings",
+      "name": "OpenIdServerSettings",
       "TestingModeEnabled": false,
       "AccessTokenFormat": "JWT", //JWT or Encrypted
       "Authority": "https://www.orchardproject.net",


### PR DESCRIPTION
In the OrchardCore.OpenID documentation, under the Authorization Server section the recipe is using an incorrect step name. It should be OpenIdServerSettings