### PR TITLE
Order exported type for content export step as discussed in issue #2491

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,4 +192,3 @@ wwwroot
 !src/Templates/**/content/**
 .template.config/
 /OrchardCore.sln.GhostDoc.xml
-/src/Templates/OrchardCore.Cms.Templates/content

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ wwwroot
 !src/Templates/**/content/**
 .template.config/
 /OrchardCore.sln.GhostDoc.xml
+/src/Templates/OrchardCore.Cms.Templates/content

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentDeploymentStep.Fields.Edit.cshtml
@@ -16,7 +16,7 @@
     <div class="row">
         <div class="col-sm">
             <ul class="list-group">
-                @foreach (var contentTypeDefinition in ContentDefinitionManager.ListTypeDefinitions())
+                @foreach (var contentTypeDefinition in ContentDefinitionManager.ListTypeDefinitions().OrderBy(i => i.Name))
                 {
                     var name = contentTypeDefinition.Name;
                     var checkd = contentTypes?.Contains(name);

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Recipes/SettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Recipes/SettingsStep.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Routing;
 using Newtonsoft.Json.Linq;
@@ -46,7 +47,7 @@ namespace OrchardCore.Settings.Recipes
                         break;
 
                     case "SupportedCultures":
-                        site.SupportedCultures = property.Value<string[]>();
+                        site.SupportedCultures = property.Value.ToObject<string[]>();
                         break;
 
                     case "MaxPagedCount":

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Recipes/SettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Recipes/SettingsStep.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Routing;
 using Newtonsoft.Json.Linq;


### PR DESCRIPTION
For issue #2491, ordering contenttype in content deployment step