### PR TITLE
Al 2540 menu dynamic parts and fields

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
@@ -2,8 +2,11 @@ using System;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Display;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.Menu.Models;
 
 namespace OrchardCore.Menu
@@ -32,6 +35,8 @@ namespace OrchardCore.Menu
                     var shapeFactory = context.ServiceProvider.GetRequiredService<IShapeFactory>();
                     var contentManager = context.ServiceProvider.GetRequiredService<IContentManager>();
                     var aliasManager = context.ServiceProvider.GetRequiredService<IContentAliasManager>();
+                    var displayManager = context.ServiceProvider.GetRequiredService<IContentItemDisplayManager>();
+                    var updateModelAccessor = context.ServiceProvider.GetRequiredService<IUpdateModelAccessor>();
 
                     string contentItemId = menu.Alias != null
                         ? await aliasManager.GetContentItemIdAsync(menu.Alias)
@@ -84,6 +89,11 @@ namespace OrchardCore.Menu
                         menu.Add(shape);
                     }
 
+                    // if parts are dynamically added to the Menu content item, they will be retrieved here through the built display shape properties
+                    var displayShape = await displayManager.BuildDisplayAsync(menuContentItem, updateModelAccessor.ModelUpdater, context.ShapeMetadata.DisplayType) as dynamic;
+                    foreach (var prop in (displayShape as Composite).Properties) {
+                        (menu as Composite).Properties.Add(prop);
+                    }
                 });
 
             builder.Describe("MenuItem")

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/Menu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/Menu.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     // By using a tag builder, sub items can alter the
     // menu element. Note how Display is called on the menu
     // items before the tag is actually rendered.
@@ -13,4 +13,9 @@
 
 <nav>
     @tag
+
+    @if (Model.Content != null)
+    {   
+        @await DisplayAsync(Model.Content)
+    }
 </nav>

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Menu.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Menu.liquid
@@ -4,4 +4,5 @@
         {{ item | shape_render }}
         {% endfor %}
     </ul>
+    {{ Model.Content | shape_render }}
 </div>

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Menu.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Menu.liquid
@@ -4,4 +4,5 @@
         {{ item | shape_render }}
         {% endfor %}
     </ul>
+    {{ Model.Content | shape_render }}
 </div>

--- a/src/OrchardCore.Themes/TheTheme/Views/Menu.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Menu.cshtml
@@ -13,3 +13,8 @@
 }
 
 @tag
+
+@if (Model.Content != null)
+{   
+    @await DisplayAsync(Model.Content)
+}


### PR DESCRIPTION
Fixes #2540 

### 1st Commit
Get Menu module's IShapeTableProvider implementation, during the OnProcessing hook, to request the IContentItemDisplayManager and IUpdateModelAccessor using the Service Locator pattern. 

*Note: ^ Not ideal, but this same approach is used by the OrchardCore.Contents Shapes class during the OnProcessing event. IContentItemDisplayManager can't be injected eagerly in the ShapeTableProvider constructor due to a circular reference (the base class for the default implementation of IContentItemDisplayManager has a service locator dependency on IShapeTableProvider). This circular dependency isn't ideal, but it already existed in the OrchardCore.Contents Shapes class, and therefore seems to be the way this sort of thing is already being achieved elsewhere across the code base.*

During the Menu shape's OnProcessing event, call BuildDisplay to get ContentDisplayManager to build the entire shape properly. Then add the properties from the returned display shape to the Menu shape.

### 2nd Commit
Now all Menu parts and fields can be rendered in the Menu template. We most likely just want to default to rendering the Content zone content in the default Menu templates for the standard themes (or render nothing there if the zone doesn't exist on the Menu shape).

