### PR TITLE
Renamed Image part to ImagePart to fix conflict with Image content type.

### DIFF
--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -410,8 +410,8 @@
           },
           "ContentTypePartDefinitionRecords": [
             {
-              "PartName": "Image",
-              "Name": "Image",
+              "PartName": "ImagePart",
+              "Name": "ImagePart",
               "Settings": {
                 "Position": "0"
               }
@@ -452,8 +452,8 @@
           },
           "ContentTypePartDefinitionRecords": [
             {
-              "PartName": "Image",
-              "Name": "Image",
+              "PartName": "ImagePart",
+              "Name": "ImagePart",
               "Settings": {
                 "Position": "0"
               }
@@ -614,7 +614,7 @@
           ]
         },
         {
-          "Name": "Image",
+          "Name": "ImagePart",
           "Settings": {
             "Attachable": true
           },
@@ -635,7 +635,7 @@
                 "Editor": null,
                 "Position": "0",
                 "Multiple": false,
-                "Required":  true
+                "Required": true
               }
             },
             {


### PR DESCRIPTION
This is my proposed fix for the Image graphql query in the Blog recipe not currently working since there are multiple types called 'Image'.

This changes the name of the 'Image' part to 'ImagePart' which solves the naming conflict and also is more consistent with other part naming. 