### PR TITLE
Fixes exception in VS Studio Debugger when Inspecting Model in Razor View

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeDebugView.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeDebugView.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -27,7 +27,7 @@ namespace OrchardCore.DisplayManagement.Shapes
             get
             {
                 return _shape.Properties
-                    .Cast<DictionaryEntry>()
+                    .Cast<KeyValuePair<object,object>>()
                     .Select(entry => new KeyValuePairs(entry.Key, entry.Value))
                     .ToArray();
             }


### PR DESCRIPTION
The ShapeDebugView.Properties property uses non generic DictionaryEntry for casting dictionary items in linq expression instead of the generic KeyValuePair