### PR TITLE
Al 2422 Make sure that vueElementId is unique on the page

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
@@ -13,7 +13,7 @@
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
     var fieldName = Model.PartFieldDefinition.Name;
     var tenantPath = string.IsNullOrEmpty(ShellSettings.RequestUrlPrefix) ? string.Empty : "/" + ShellSettings.RequestUrlPrefix;
-    var vueElementId = $"ContentPicker_{partName}_{fieldName}";
+    var vueElementId = $"ContentPicker_{partName}_{fieldName}_{Guid.NewGuid()}";
     var multiple = settings.Multiple.ToString().ToLowerInvariant();
 }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
@@ -13,7 +13,7 @@
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
     var fieldName = Model.PartFieldDefinition.Name;
     var tenantPath = string.IsNullOrEmpty(ShellSettings.RequestUrlPrefix) ? string.Empty : "/" + ShellSettings.RequestUrlPrefix;
-    var vueElementId = $"ContentPicker_{partName}_{fieldName}_{Guid.NewGuid()}";
+    var vueElementId = $"ContentPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
     var multiple = settings.Multiple.ToString().ToLowerInvariant();
 }
 


### PR DESCRIPTION
fixes #2422 

Make sure that vueElementId includes `Guid.NewGuid()`, so that we can be sure it is unique on the page, no matter how many content pickers are rendered