### PR TITLE
Fixes caching with known values variations.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/Services/DefaultDynamicCacheService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/Services/DefaultDynamicCacheService.cs
@@ -28,14 +28,14 @@ namespace OrchardCore.DynamicCache.Services
 
         public async Task<string> GetCachedValueAsync(CacheContext context)
         {
-            context = await GetCachedContextAsync(context.CacheId);
+            var cacheKey = await GetCacheKey(context);
+
+            context = await GetCachedContextAsync(cacheKey);
             if (context == null)
             {
                 // We don't know the context, so we must treat this as a cache miss
                 return null;
             }
-            
-            var cacheKey = await GetCacheKey(context);
 
             var content = await GetCachedStringAsync(cacheKey);
 
@@ -51,7 +51,7 @@ namespace OrchardCore.DynamicCache.Services
             
             await Task.WhenAll(
                 SetCachedValueAsync(cacheKey, value, context),
-                SetCachedValueAsync(GetCacheContextCacheKey(context.CacheId), esi, context)
+                SetCachedValueAsync(GetCacheContextCacheKey(cacheKey), esi, context)
             );
         }
         
@@ -99,9 +99,9 @@ namespace OrchardCore.DynamicCache.Services
             return key;
         }
 
-        private string GetCacheContextCacheKey(string cacheId)
+        private string GetCacheContextCacheKey(string cacheKey)
         {
-            return "cachecontext-" + cacheId;
+            return "cachecontext-" + cacheKey;
         }
 
         private async Task<string> GetCachedStringAsync(string cacheKey)
@@ -120,9 +120,9 @@ namespace OrchardCore.DynamicCache.Services
             return Encoding.UTF8.GetString(bytes);
         }
 
-        private async Task<CacheContext> GetCachedContextAsync(string cacheId)
+        private async Task<CacheContext> GetCachedContextAsync(string cacheKey)
         {
-            var cachedValue = await GetCachedStringAsync(GetCacheContextCacheKey(cacheId));
+            var cachedValue = await GetCachedStringAsync(GetCacheContextCacheKey(cacheKey));
 
             if (cachedValue == null)
             {


### PR DESCRIPTION
Repro

- After a blog setup, create 2 articles.

- Create a `Content__Article` template through the UI and add the following.

      {% cache "Article", vary_by: Model.ContentItem.ContentItemId %}
          <h3>Cache testing: {{ "now" | date: "%Y-%m-%d %H:%M:%S" }}</h3>
      {% endcache %}

- Then, when rendering the 2 articles, you will see that it doesn't vary by `ContentItemId`.

Fixes #2432.