### PR TITLE
Migrate to OpenIddict 2.0 RTM

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -25,9 +25,9 @@
     <PackageManagement Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="4.7.0" />
     <PackageManagement Include="NodaTime" Version="2.4.0" />
-    <PackageManagement Include="OpenIddict" Version="2.0.0-rtm-1116" />
-    <PackageManagement Include="OpenIddict.Core" Version="2.0.0-rtm-1116" />
-    <PackageManagement Include="OpenIddict.EntityFrameworkCore" Version="2.0.0-rtm-1116" />
+    <PackageManagement Include="OpenIddict" Version="2.0.0" />
+    <PackageManagement Include="OpenIddict.Core" Version="2.0.0" />
+    <PackageManagement Include="OpenIddict.EntityFrameworkCore" Version="2.0.0" />
     <PackageManagement Include="Serilog" Version="2.7.1" />
     <PackageManagement Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageManagement Include="Serilog.Settings.Configuration" Version="2.6.1" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.OpenId.Tasks
             {
                 await serviceProvider.GetRequiredService<IOpenIdAuthorizationManager>().PruneAsync(cancellationToken);
             }
-            catch (OpenIddictException exception) when (exception.Reason == OpenIddictConstants.Exceptions.ConcurrencyError)
+            catch (OpenIddictExceptions.ConcurrencyException exception)
             {
                 _logger.LogDebug(exception, "A concurrency error occurred while pruning authorizations from the database.");
             }
@@ -50,7 +50,7 @@ namespace OrchardCore.OpenId.Tasks
             {
                 await serviceProvider.GetRequiredService<IOpenIdTokenManager>().PruneAsync(cancellationToken);
             }
-            catch (OpenIddictException exception) when (exception.Reason == OpenIddictConstants.Exceptions.ConcurrencyError)
+            catch (OpenIddictExceptions.ConcurrencyException exception)
             {
                 _logger.LogDebug(exception, "A concurrency error occurred while pruning tokens from the database.");
             }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdApplicationManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdApplicationManager.cs
@@ -17,10 +17,11 @@ namespace OrchardCore.OpenId.Services.Managers
         IOpenIdApplicationManager where TApplication : class
     {
         public OpenIdApplicationManager(
+            IOpenIddictApplicationCache<TApplication> cache,
             IOpenIddictApplicationStoreResolver resolver,
             ILogger<OpenIdApplicationManager<TApplication>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options)
-            : base(resolver, logger, options)
+            : base(cache, resolver, logger, options)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdAuthorizationManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdAuthorizationManager.cs
@@ -14,10 +14,11 @@ namespace OrchardCore.OpenId.Services.Managers
         IOpenIdAuthorizationManager where TAuthorization : class
     {
         public OpenIdAuthorizationManager(
+            IOpenIddictAuthorizationCache<TAuthorization> cache,
             IOpenIddictAuthorizationStoreResolver resolver,
             ILogger<OpenIddictAuthorizationManager<TAuthorization>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options)
-            : base(resolver, logger, options)
+            : base(cache, resolver, logger, options)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdScopeManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdScopeManager.cs
@@ -13,10 +13,11 @@ namespace OrchardCore.OpenId.Services.Managers
     public class OpenIdScopeManager<TScope> : OpenIddictScopeManager<TScope>, IOpenIdScopeManager where TScope : class
     {
         public OpenIdScopeManager(
+            IOpenIddictScopeCache<TScope> cache,
             IOpenIddictScopeStoreResolver resolver,
             ILogger<OpenIddictScopeManager<TScope>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options)
-            : base(resolver, logger, options)
+            : base(cache, resolver, logger, options)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdTokenManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdTokenManager.cs
@@ -13,10 +13,11 @@ namespace OrchardCore.OpenId.Services.Managers
     public class OpenIdTokenManager<TToken> : OpenIddictTokenManager<TToken>, IOpenIdTokenManager where TToken : class
     {
         public OpenIdTokenManager(
+            IOpenIddictTokenCache<TToken> cache,
             IOpenIddictTokenStoreResolver resolver,
             ILogger<OpenIddictTokenManager<TToken>> logger,
             IOptionsMonitor<OpenIddictCoreOptions> options)
-            : base(resolver, logger, options)
+            : base(cache, resolver, logger, options)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
@@ -571,7 +571,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
         /// whose result returns the token type associated with the specified token.
         /// </returns>
-        public virtual ValueTask<string> GetTokenTypeAsync(TToken token, CancellationToken cancellationToken)
+        public virtual ValueTask<string> GetTypeAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
             {
@@ -910,7 +910,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <returns>
         /// A <see cref="Task"/> that can be used to monitor the asynchronous operation.
         /// </returns>
-        public virtual Task SetTokenTypeAsync(TToken token, string type, CancellationToken cancellationToken)
+        public virtual Task SetTypeAsync(TToken token, string type, CancellationToken cancellationToken)
         {
             if (token == null)
             {


### PR DESCRIPTION
This PR updates the OpenID module to use OpenIddict 2.0 RTM, which includes the fix for the vulnerability reported last week.