### PR TITLE
Fixes delete lucene index.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
@@ -73,6 +73,7 @@ namespace OrchardCore.Lucene
                 if (_indexPools.TryRemove(indexName, out var pool))
                 {
                     pool.MakeDirty();
+                    pool.Release();
                 }
             });
         }
@@ -140,6 +141,7 @@ namespace OrchardCore.Lucene
                 if (_indexPools.TryRemove(indexName, out var pool))
                 {
                     pool.MakeDirty();
+                    pool.Release();
                 }
             });
         }


### PR DESCRIPTION
@sebastienros 

Trying lucene distributed commands with 2 instances on a shared file system, one issue i had is after deleting an index there were some remaining files. But just saw that it is the same with only one instance.

**Repro after a blog setup**

- Go to lucene queries and do a `Match All` query.
- Go to lucene indices and do a `Reset` index and wait.
- Do a `Delete` index, but there are some remaining `*.cfs` files.

**Analyse**

In the 1st step a reader is created and put in the cache dico.

In the 2nd step there are some delete and store documents which remove the reader from the cache dico and mark it as dirty so that if the reader is currently used in an using block it will be disposed. But if the reader is not in an using block, it is removed from the dico but not disposed.

Then in the 3rd step, because the reader is no more in the cache dico we can't dispose it.

**Fix**

When deleting / storing documents we still remove the reader from the dico and mark it as dirty, but we also do a `Release()` on it. This because `Release()` will dispose the reader if it is not in use.