### PR TITLE
Remove the dependency of OpenId on the Users and Roles modules

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Manifest.cs
@@ -39,9 +39,7 @@ using OrchardCore.OpenId;
     Dependencies = new[]
     {
         OpenIdConstants.Features.Core,
-        OpenIdConstants.Features.Management,
-        "OrchardCore.Users",
-        "OrchardCore.Roles"
+        OpenIdConstants.Features.Management
     }
 )]
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -16,15 +16,15 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.OpenId.Core\OrchardCore.OpenId.Core.csproj" />
-    <ProjectReference Include="..\OrchardCore.Roles\OrchardCore.Roles.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Users.Abstractions\OrchardCore.Users.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.Settings\OrchardCore.Settings.csproj" />
-    <ProjectReference Include="..\OrchardCore.Users\OrchardCore.Users.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" />
     <PackageReference Include="OpenIddict" />
   </ItemGroup>
 


### PR DESCRIPTION
Looking to break the hard dependency on the Users and Roles module and find another means to ensure that a user and role provider is enabled for this feature to work as an identity server.