### PR TITLE
Try to fix a graphQL unit test.

### DIFF
--- a/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.Apis.Context
     public class SiteContext : IDisposable
     {
         public static OrchardTestFixture<SiteStartup> Site { get; }
-        public static HttpClient DefaultTenantClient { get; private set; }
+        public static HttpClient DefaultTenantClient;
 
         public HttpClient Client { get; private set; }
         public OrchardGraphQLClient GraphQLClient { get; private set; }
@@ -20,7 +20,6 @@ namespace OrchardCore.Tests.Apis.Context
         static SiteContext()
         {
             Site = new OrchardTestFixture<SiteStartup>();
-            DefaultTenantClient = Site.CreateClient();
         }
 
         public virtual async Task InitializeAsync()
@@ -30,6 +29,10 @@ namespace OrchardCore.Tests.Apis.Context
             await semaphoreSlim.WaitAsync();
             try
             {
+                if (DefaultTenantClient == null)
+                {
+                    DefaultTenantClient = Site.CreateClient();
+                }
 
                 var createModel = new Tenants.ViewModels.CreateApiViewModel
                 {


### PR DESCRIPTION

Working on #2247 in my last commits i noticed a failing unit test `ShouldListBlogPostWhenCallingAQuery`, and i just saw the same for #2638.

The issues that I had already seen were mainly due to the concurrent usage of httpClient, so because we use a semaphore in tests that's ok. But, there was an issue when calling some methods in the constructor.

I don't remember exactly how testing classes are activated, but i had an issue when waiting for an async method to complete in the constructor. And `Site.CreateClient()` has internally the same kind of code.

Hmm, maybe this was just due to the time this method take to complete. But not calling `Site.CreateClient()` in the constructor seems to solve the issue, but not sure, if it is intermittent.

I will first see if all unit tests pass on this PR.