### PR TITLE
Fix template resolving.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/README.md
@@ -138,7 +138,7 @@ When using shape tag helpers, the following attributes can be used:
 
 For example, to cache the menu shape in a liquid template, you would use this markup:
 
-`{% shape "menu", alias: "alias:main-menu", cache_id: "main-menu", cache_expires_after: "00:05:00", cache_tag: "alias:main-menu" %}`
+`{% shape "Menu", alias: "alias:main-menu", cache_id: "main-menu", cache_expires_after: "00:05:00", cache_tag: "alias:main-menu" %}`
 
 ### Liquid cache block
 The liquid `cache` block can be used to cache sections of markup. `cache` blocks can be nested.

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -525,13 +525,13 @@ Renders a specific named tag with its properties
 Input
 
 ```liquid
-{% shape "menu", alias: "alias:main-menu", cache_id: "main-menu", cache_expires_after: "00:05:00", cache_tag: "alias:main-menu" %}
+{% shape "Menu", alias: "alias:main-menu", cache_id: "main-menu", cache_expires_after: "00:05:00", cache_tag: "alias:main-menu" %}
 ```
 
 When using the shape tag a specific wrapper and / or alternate can be specified.
 
 ```liquid
-{% shape "menu", alias: "alias:main-menu", alternate: "Menu_Footer" %}
+{% shape "Menu", alias: "alias:main-menu", alternate: "Menu_Footer" %}
 ```
 
 ### `zone`

--- a/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Menu
         public void Discover(ShapeTableBuilder builder)
         {
             builder.Describe("Menu")
-                .OnProcessing(async context =>
+                .OnDisplaying(async context =>
                 {
                     dynamic menu = context.Shape;
                     string identifier = menu.ContentItemId ?? menu.Alias;

--- a/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Menu
         public void Discover(ShapeTableBuilder builder)
         {
             builder.Describe("Menu")
-                .OnDisplaying(async context =>
+                .OnProcessing(async context =>
                 {
                     dynamic menu = context.Shape;
                     string identifier = menu.ContentItemId ?? menu.Alias;

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Services/TemplatesShapeBindingResolver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Services/TemplatesShapeBindingResolver.cs
@@ -65,7 +65,7 @@ namespace OrchardCore.Templates.Services
         {
             return new ShapeBinding()
             {
-                ShapeDescriptor = new ShapeDescriptor() { ShapeType = shapeType },
+                ShapeDescriptor = null,
                 BindingName = shapeType,
                 BindingSource = shapeType,
                 BindingAsync = async displayContext =>

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
@@ -39,7 +39,7 @@
             <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
                 Menu <i class="fa fa-bars"></i>
             </button>
-            {% shape "menu", alias: "alias:main-menu", cache_id: "main-menu", cache_tag: "alias:main-menu" %}
+            {% shape "Menu", alias: "alias:main-menu", cache_id: "main-menu", cache_tag: "alias:main-menu" %}
         </div>
     </nav>
     {% render_section "Header", required: false %}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -44,7 +44,7 @@
                 <span class="sr-only">{{ "Toggle navigation" | t }}</span>
                 {{ "Menu" | t }} <i class="fa fa-bars"></i>
             </button>
-            {% shape "menu", alias: "alias:main-menu", cache_id: "main-menu", cache_duration: "00:05:00", cache_tag: "alias:main-menu" %}
+            {% shape "Menu", alias: "alias:main-menu", cache_id: "main-menu", cache_duration: "00:05:00", cache_tag: "alias:main-menu" %}
         </div>
     </nav>
     {% render_section "Header", required: false %}

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
@@ -191,20 +191,17 @@ namespace OrchardCore.DisplayManagement.Implementation
             ShapeBinding resolved = null;
             foreach (var shapeAlternate in shapeAlternates.Reverse())
             {
-                if (resolved == null)
+                foreach (var shapeBindingResolver in _shapeBindingResolvers)
                 {
-                    foreach (var shapeBindingResolver in _shapeBindingResolvers)
+                    if (shapeBindingResolver.TryGetDescriptorBinding(shapeAlternate, out resolved))
                     {
-                        if (shapeBindingResolver.TryGetDescriptorBinding(shapeAlternate, out resolved))
+                        if (resolved.ShapeDescriptor != null)
                         {
-                            if (resolved.ShapeDescriptor != null)
-                            {
-                                shapeBinding = resolved;
-                                return true;
-                            }
-
-                            break;
+                            shapeBinding = resolved;
+                            return true;
                         }
+
+                        break;
                     }
                 }
 

--- a/src/Templates/OrchardCore.Cms.Templates/content/OrchardCore.Templates.Theme/Views/Layout.liquid
+++ b/src/Templates/OrchardCore.Cms.Templates/content/OrchardCore.Templates.Theme/Views/Layout.liquid
@@ -28,7 +28,7 @@
             </button>
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <div class="navbar-nav-scroll">
-                    {% shape "menu", alias: "alias:main-menu", cache_id: "main-menu", cache_duration: "00:05:00", cache_tag: "alias:main-menu" %}
+                    {% shape "Menu", alias: "alias:main-menu", cache_id: "main-menu", cache_duration: "00:05:00", cache_tag: "alias:main-menu" %}
                 </div>
                 {% render_section "Menu", required: false %}
             </div>


### PR DESCRIPTION
Fixes #2631. Here the suggestion.

See my comments in #2631 where the main point is that `TemplatesShapeBindingResolver` create an incomplete `ShapeDescriptor`, so some of its events as `ProcessingAsync()` may not be called.

- So, for a database template, here the idea is to retrieve the shape descriptor from the same alternate or base shape type defined in the shape table.

- One limitation that i thought i had was to forbid to add alternates in `OnProcessing()` but instead in `OnDisplaying()`, as i did in `MenuShapes.cs`. Otherwise how can we take into account these alternates before calling `ProcessingAsync()`.

      // now find the actual binding to render, taking alternates into account
      if (TryGetDescriptorBinding(..., shapeMetadata.Alternates, shapeTable, out actualBinding))
      {
          ... await shapeBinding.ShapeDescriptor.ProcessingAsync.InvokeAsync(...);

    But wait wait wait, with the current implementation i tried to use a `Menu-MainMenu.liquid` template file and it was not working. So, the above rule also apply to tempate files.

- There is another place where an alternate is added through `OnProcessing()`, in `Shapes.cs` for the `ContentItem` shape. I didn't try anything yet for this one.