### PR TITLE
Al facilitate nested subfolder templates

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/BasicShapeTemplateHarvester.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/BasicShapeTemplateHarvester.cs
@@ -31,6 +31,8 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
             }
         }
 
+        public bool InDepth => false;
+
         static string Adjust(string subPath, string fileName, string displayType)
         {
             var leader = "";

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/BasicShapeTemplateHarvester.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/BasicShapeTemplateHarvester.cs
@@ -4,7 +4,7 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
 {
     public class BasicShapeTemplateHarvester : IShapeTemplateHarvester
     {
-        public IEnumerable<string> SubPaths()
+        public virtual IEnumerable<string> SubPaths()
         {
             return new[] { "Views", "Views/Items", "Views/Parts", "Views/Fields", "Views/Elements" };
         }
@@ -31,19 +31,16 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
             }
         }
 
-        public bool InDepth => false;
+        public virtual bool InDepth => false;
 
-        static string Adjust(string subPath, string fileName, string displayType)
+        protected virtual string leader(string subPath) => 
+            (subPath.StartsWith("Views/") && subPath != "Views/Items") ? subPath.Substring("Views/".Length) + "_" : "";
+
+        string Adjust(string subPath, string fileName, string displayType)
         {
-            var leader = "";
-            if (subPath.StartsWith("Views/") && subPath != "Views/Items")
-            {
-                leader = subPath.Substring("Views/".Length) + "_";
-            }
-
             // canonical shape type names must not have - or . to be compatible
             // with display and shape api calls)))
-            var shapeType = leader + fileName.Replace("--", "__").Replace("-", "__").Replace('.', '_');
+            var shapeType = leader(subPath) + fileName.Replace("--", "__").Replace("-", "__").Replace('.', '_');
 
             if (string.IsNullOrEmpty(displayType))
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/IShapeTemplateHarvester.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/IShapeTemplateHarvester.cs
@@ -10,5 +10,6 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
     {
         IEnumerable<string> SubPaths();
         IEnumerable<HarvestShapeHit> HarvestShape(HarvestShapeInfo info);
+        bool InDepth { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
@@ -93,7 +93,7 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
                     var filePaths = _fileProviderAccessor.FileProvider.GetViewFilePaths(
                         PathExtensions.Combine(extensionDescriptor.SubPath, subPath), 
                         _viewEnginesByExtension.Keys.ToArray(),
-                        inViewsFolder: true, inDepth: false).ToArray();
+                        inViewsFolder: true, inDepth: harvesterInfo.harvester.InDepth).ToArray();
 
                     return new { harvesterInfo.harvester, subPath, filePaths };
                 }))


### PR DESCRIPTION
Related to #2640 

### Problem
Templates in the views folder can quickly stack up and become difficult to manage without the ability to group them into nested subdirectories.

### Solution
#### 1st Commit
Don't hardcode `InDepth` to false in `ShapeTemplateBindingStrategy.cs`. Instead make`IShapeTemplateHarvester` expressive enough to say whether or not it points to view directories that contain nested subdirectories.

#### 2nd Commit
Not essential, but provide some overridable extension points on `BasicShapeTemplateHarvester`, to make it far easier to define new harvesters (avoiding having to rewrite error-prone code, such as that found in the `Adjust` method).

Together these changes make it simple for developers to extend the existing shape template harvester functionality, like this:

```
    public class NestedShapeTemplateHarvester : BasicShapeTemplateHarvester
    {
        public override IEnumerable<string> SubPaths() => new[] { "Views/Nested" };
        public override bool InDepth => true;
        protected override string leader(string _) => "";
    }
```
^ Haven't include the above in the PR, but could do..?
