### PR TITLE
Enable, fixe and improve the code tab extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,7 @@ markdown_extensions:
       template: 'default'
 
 # Page tree
-pages:
+nav:
     - About Orchard Core: index.md
     - Getting started:
         - Create a CMS Web application: docs/getting-started/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,8 @@ markdown_extensions:
   - markdown.extensions.footnotes
   - markdown.extensions.meta
 #  - markdown.extensions.nl2br
-#  - markdown_fenced_code_tabs
+  - markdown_fenced_code_tabs:
+      template: 'default'
 
 # Page tree
 pages:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-markdown-fenced-code-tabs
+mkdocs>=1.0
+markdown-fenced-code-tabs>=1.0

--- a/src/docs/css/code-tabs.css
+++ b/src/docs/css/code-tabs.css
@@ -3,17 +3,11 @@
 }
 
 .md-fenced-code-tabs {
-    box-sizing: border-box;
-    box-shadow: 0 2px 2px 0 rgba(0,0,0,.14), 0 1px 5px 0 rgba(0,0,0,.12), 0 3px 1px -2px rgba(0,0,0,.2);
-    max-width: 100%;
-    border-radius: .2rem;
-}
-
-.md-fenced-code-tabs {
     display: flex;
     position: relative;
     flex-wrap: wrap;
     width: 100%;
+    margin: 10px 0 20px 0;
 }
 
 .md-fenced-code-tabs input {
@@ -22,21 +16,37 @@
 }
 
 .md-fenced-code-tabs label {
-    width: auto;
+    display: block;
     cursor: pointer;
-    font-size: 1.28rem;
-    padding: 1.2rem 1.6rem;
+    font-weight: bold;
+    margin: 0 5px 5px 0;
+    padding: 5px 10px;
+    float: left;
+    background-color: #999;
+    color: #fff;
+    -moz-border-radius: 5px;
+    -webkit-border-radius: 5px;
+    border-radius: 5px;
+    -khtml-border-radius: 5px;
+}
+
+.md-fenced-code-tabs label:hover {
+    background-color: #777;
 }
 
 .md-fenced-code-tabs input:checked + label {
-    color: #03a9f4;
-    border-bottom: 2px solid #03a9f4;
+    background-color: #2980b9;
+}
+
+.md-fenced-code-tabs input:checked + label:hover {
+    background-color: #333;
 }
 
 .md-fenced-code-tabs .code-tabpanel {
     display: none;
     width: 100%;
     order: 99;
+    border: 1px solid #e1e4e5;
 }
 
 .md-fenced-code-tabs input:checked + label + .code-tabpanel {
@@ -47,6 +57,5 @@
 .md-fenced-code-tabs .codehilite {
     width: 100%;
     margin: 0px;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding: 5px;
 }


### PR DESCRIPTION
Hello! This PR includes:

- Bump of the mkdocs to version 1+ and fixe the warnings
- Enable the `markdown_fenced_code_tabs` extension and update its settings
- Improve the `code-tab.css`. The new style looks like

<img width="827" alt="capture d ecran 2018-11-14 a 06 09 26" src="https://user-images.githubusercontent.com/2587473/48461409-e0c62d80-e7d3-11e8-824a-6579ff4815a2.png">

Hope it helps 😉 