### PR TITLE
Fixes #2671 - increment MenuItem.Level property for each layer of MenuItems

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/MenuShapes.cs
@@ -108,7 +108,7 @@ namespace OrchardCore.Menu
                             var shape = await shapeFactory.CreateAsync("MenuItem", Arguments.From(new
                             {
                                 ContentItem = contentItem,
-                                Level = 0,
+                                Level = level + 1,
                                 Menu = menu,
                                 Differentiator = differentiator
                             }));


### PR DESCRIPTION
Made the change, tested against a custom theme, alternates resolve properly using the `__level_x` naming convention and the `.Level` property is available in the `.liquid` templates. 

Code looks OK. I commend this PR to the house...