### PR TITLE
Adding DefaultRequestHeaders is not thread safe.

### DIFF
--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/Extensions/HttpRequestExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/Extensions/HttpRequestExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -48,7 +49,7 @@ namespace OrchardCore.Apis.GraphQL.Client
                 Encoding.UTF8,
                 "application/json");
 
-            return client.PatchAsync(requestUri, content);
+            return HttpRequestExtensions.PatchAsync(client, requestUri, content);
         }
 
         /// <summary>
@@ -77,7 +78,8 @@ namespace OrchardCore.Apis.GraphQL.Client
                 RequestUri = new Uri(client.BaseAddress + requestUri),
                 Content = content
             };
-            client.DefaultRequestHeaders.ExpectContinue = false;
+
+            request.Headers.ExpectContinue = false;
             return client.SendAsync(request);
         }
 
@@ -146,11 +148,17 @@ namespace OrchardCore.Apis.GraphQL.Client
                 Encoding.UTF8,
                 "application/json");
 
-            client.DefaultRequestHeaders
-              .Accept
-              .Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = content;
 
-            return client.PostAsync(requestUri, content);
+            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/json"))
+            {
+                request.Headers
+                    .Accept
+                    .Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            }
+
+            return client.SendAsync(request);
         }
 
         public static Task<HttpResponseMessage> PostJsonAsync(
@@ -163,11 +171,17 @@ namespace OrchardCore.Apis.GraphQL.Client
                 Encoding.UTF8,
                 "application/json");
 
-            client.DefaultRequestHeaders
-              .Accept
-              .Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = content;
 
-            return client.PostAsync(requestUri, content);
+            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/json"))
+            {
+                request.Headers
+                    .Accept
+                    .Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            }
+
+            return client.SendAsync(request);
         }
 
         public static Task<HttpResponseMessage> PostJsonApiAsync(
@@ -180,11 +194,17 @@ namespace OrchardCore.Apis.GraphQL.Client
                 Encoding.UTF8,
                 "application/vnd.api+json");
 
-            client.DefaultRequestHeaders
-              .Accept
-              .Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = content;
 
-            return client.PostAsync(requestUri, content);
+            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/vnd.api+json"))
+            {
+                request.Headers
+                    .Accept
+                    .Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
+            }
+
+            return client.SendAsync(request);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/Extensions/HttpRequestExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/Extensions/HttpRequestExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -148,15 +147,12 @@ namespace OrchardCore.Apis.GraphQL.Client
                 Encoding.UTF8,
                 "application/json");
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
             request.Content = content;
 
-            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/json"))
-            {
-                request.Headers
-                    .Accept
-                    .Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            }
+            request.Headers
+                .Accept
+                .Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return client.SendAsync(request);
         }
@@ -171,15 +167,12 @@ namespace OrchardCore.Apis.GraphQL.Client
                 Encoding.UTF8,
                 "application/json");
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
             request.Content = content;
 
-            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/json"))
-            {
-                request.Headers
-                    .Accept
-                    .Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            }
+            request.Headers
+                .Accept
+                .Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return client.SendAsync(request);
         }
@@ -194,15 +187,12 @@ namespace OrchardCore.Apis.GraphQL.Client
                 Encoding.UTF8,
                 "application/vnd.api+json");
 
-            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
             request.Content = content;
 
-            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/vnd.api+json"))
-            {
-                request.Headers
-                    .Accept
-                    .Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
-            }
+            request.Headers
+                .Accept
+                .Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
 
             return client.SendAsync(request);
         }

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/OrchardCore.Apis.GraphQL.Client.csproj
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/OrchardCore.Apis.GraphQL.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,7 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
 
 </Project>

--- a/test/OrchardCore.Tests/Apis/Context/Extensions/HttpRequestExtensions.cs
+++ b/test/OrchardCore.Tests/Apis/Context/Extensions/HttpRequestExtensions.cs
@@ -49,7 +49,7 @@ namespace OrchardCore.Tests.Apis.Context
                 Encoding.UTF8,
                 "application/json");
 
-            return client.PatchAsync(requestUri, content);
+            return HttpRequestExtensions.PatchAsync(client, requestUri, content);
         }
 
         /// <summary>
@@ -78,7 +78,8 @@ namespace OrchardCore.Tests.Apis.Context
                 RequestUri = new Uri(client.BaseAddress + requestUri),
                 Content = content
             };
-            client.DefaultRequestHeaders.ExpectContinue = false;
+
+            request.Headers.ExpectContinue = false;
             return client.SendAsync(request);
         }
 
@@ -147,14 +148,17 @@ namespace OrchardCore.Tests.Apis.Context
                 Encoding.UTF8,
                 "application/json");
 
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = content;
+
             if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/json"))
             {
-                client.DefaultRequestHeaders
-                  .Accept
-                  .Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                request.Headers
+                    .Accept
+                    .Add(new MediaTypeWithQualityHeaderValue("application/json"));
             }
 
-            return client.PostAsync(requestUri, content);
+            return client.SendAsync(request);
         }
 
         public static Task<HttpResponseMessage> PostJsonAsync(
@@ -167,14 +171,17 @@ namespace OrchardCore.Tests.Apis.Context
                 Encoding.UTF8,
                 "application/json");
 
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = content;
+
             if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/json"))
             {
-                client.DefaultRequestHeaders
-                  .Accept
-                  .Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                request.Headers
+                    .Accept
+                    .Add(new MediaTypeWithQualityHeaderValue("application/json"));
             }
 
-            return client.PostAsync(requestUri, content);
+            return client.SendAsync(request);
         }
 
         public static Task<HttpResponseMessage> PostJsonApiAsync(
@@ -187,11 +194,17 @@ namespace OrchardCore.Tests.Apis.Context
                 Encoding.UTF8,
                 "application/vnd.api+json");
 
-            client.DefaultRequestHeaders
-              .Accept
-              .Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
+            var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
+            request.Content = content;
 
-            return client.PostAsync(requestUri, content);
+            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/vnd.api+json"))
+            {
+                request.Headers
+                    .Accept
+                    .Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
+            }
+
+            return client.SendAsync(request);
         }
     }
 }

--- a/test/OrchardCore.Tests/Apis/Context/Extensions/HttpRequestExtensions.cs
+++ b/test/OrchardCore.Tests/Apis/Context/Extensions/HttpRequestExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -151,12 +150,9 @@ namespace OrchardCore.Tests.Apis.Context
             var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
             request.Content = content;
 
-            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/json"))
-            {
-                request.Headers
-                    .Accept
-                    .Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            }
+            request.Headers
+                .Accept
+                .Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return client.SendAsync(request);
         }
@@ -174,12 +170,9 @@ namespace OrchardCore.Tests.Apis.Context
             var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
             request.Content = content;
 
-            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/json"))
-            {
-                request.Headers
-                    .Accept
-                    .Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            }
+            request.Headers
+                .Accept
+                .Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return client.SendAsync(request);
         }
@@ -197,12 +190,9 @@ namespace OrchardCore.Tests.Apis.Context
             var request = new HttpRequestMessage(HttpMethod.Post, requestUri);
             request.Content = content;
 
-            if (!client.DefaultRequestHeaders.Accept.Any(x => x.MediaType == "application/vnd.api+json"))
-            {
-                request.Headers
-                    .Accept
-                    .Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
-            }
+            request.Headers
+                .Accept
+                .Add(new MediaTypeWithQualityHeaderValue("application/vnd.api+json"));
 
             return client.SendAsync(request);
         }


### PR DESCRIPTION
**Issue**

- Because graphql tests are now done in parallel, on AppVeyor i saw another issue when trying to update the client default headers and saying `An item with the same key has already been added`.

- In fact `HttpClient` can be used concurrently unless for updating its `DefaultRequestHeaders` which is not thread safe. There is an [open issue](https://github.com/dotnet/corefx/issues/23544) saying.

    > Both changing DefaultRequestHeaders per request and concurrently making requests from a shared HttpClient will end very badly.

**Solutions**

- Now i remember that i also had this issue, then my 1st solution was to not use a shared `DefaultTenantClient` but to always create a new one. But in this case i needed to reuse a semaphore because the web factory create a `TestServer` on the 1st client creation and this is not thread safe.

- But i saw that in fact we update the client `DefaultRequestHeaders` in our own `HttpRequestExtensions`. So another solution would be to not do that and let people initializing the `HttpClient` they want to use concurrently afterwards, maybe with some other helpers.

- **Finally**, here i opted to not add an header to the `HttpClient.DefaultRequestHeaders` but to the new `HttpRequestMessage.Headers` created for this request. Maybe not the optimal solution, please review. The compromise is to check if not already in the `DefaultRequestHeaders`, as already done in one `HttpRequestExtensions` in `OC.Tests`, but not in the original version in `OC.Apis.GraphQL.Client`.

**Update**: Removed the default headers checking as it is longer than just adding an header, but this on the headers of the new httpRequestMessage.
