### PR TITLE
Add BagPart GraphQL paging

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/GraphQL/BagPartQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/GraphQL/BagPartQueryObjectType.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
 using GraphQL.Types;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.GraphQL.Queries.Types;
 using OrchardCore.Flows.Models;
 
@@ -10,10 +13,11 @@ namespace OrchardCore.Flows.GraphQL
         {
             Name = "BagPart";
 
-            Field<ListGraphType<ContentItemInterface>>(
-                "items",
-                "The items.",
-                resolve: context => context.Source.ContentItems);
+            Field<ListGraphType<ContentItemInterface>, IEnumerable<ContentItem>>()
+                .Name("contentItems")
+                .Description("the content items")
+                .PagingArguments()
+                .Resolve(x => x.Page(x.Source.ContentItems));
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Extensions/ResolveFieldContextExtensions.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Apis.GraphQL
                 .Argument<IntGraphType, int>("skip", "the number of elements to skip", 0);
         }
 
-        public static IEnumerable<string> Page<T>(this ResolveFieldContext<T> context, IEnumerable<string> source)
+        public static IEnumerable<TSource> Page<T, TSource>(this ResolveFieldContext<T> context, IEnumerable<TSource> source)
         {
             var skip = context.GetArgument<int>("skip");
             var first = context.GetArgument<int>("first");


### PR DESCRIPTION
Adding `first`, `last`, and `skip` support for BagPart ContentItems in GraphQL.

Changed _items_ to _contentItems_ in BagPart to make it consistent with its `ContentItems` property as well as the ContentPickerField.

Changed the signature of the `Page` Extension Method to make it more generic so it would work with the original `string` type as well as `ContentItem` type.

Tested BagPart(portfolio), ContentPickerField(related), and MediaField(images) for The Agency Theme Landing Page to make sure paging works correctly. All works well.

```GraphQL
{
  landingPage {
    portfolio {
      contentItems(skip: 1, first: 2) {
        displayText
      }
    }
    related {
      contentItems(last: 1) {
        displayText
      }
    }
    images {
      urls(skip: 1, last: 1)
      paths(first: 3)
    }
  }
}
```

```JSON
{
  "data": {
    "landingPage": [
      {
        "portfolio": {
          "contentItems": [
            {
              "displayText": "Explore"
            },
            {
              "displayText": "Finish"
            }
          ]
        },
        "related": {
          "contentItems": [
            {
              "displayText": "Page 2"
            }
          ]
        },
        "images": {
          "urls": [
            "/media/team/3.jpg"
          ],
          "paths": [
            "team/1.jpg",
            "team/2.jpg",
            "team/3.jpg"
          ]
        }
      }
    ]
  }
}
```