### PR TITLE
Add missing tests and project files cleanup.

### DIFF
--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\OrchardCore.Build\Dependencies.props" />
 
@@ -13,9 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\OrchardCore\OrchardCore.Hosting.Console\OrchardCore.Hosting.Console.csproj" />
+    <ProjectReference Include="..\OrchardCore\OrchardCore.Application.Cms.Targets\OrchardCore.Application.Cms.Targets.csproj" />
     <ProjectReference Include="..\OrchardCore\OrchardCore.Logging.NLog\OrchardCore.Logging.NLog.csproj" />
-    <ProjectReference Include="..\OrchardCore\OrchardCore.Application.Cms.Targets\OrchardCore.Application.Cms.Targets.csproj" PrivateAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
+<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\OrchardCore.Build\Dependencies.props" />
 
@@ -15,7 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore\OrchardCore.Hosting.Console\OrchardCore.Hosting.Console.csproj" />
     <ProjectReference Include="..\OrchardCore\OrchardCore.Logging.NLog\OrchardCore.Logging.NLog.csproj" />
-    <ProjectReference Include="..\OrchardCore\OrchardCore.Application.Cms.Targets\OrchardCore.Application.Cms.Targets.csproj" />
+    <ProjectReference Include="..\OrchardCore\OrchardCore.Application.Cms.Targets\OrchardCore.Application.Cms.Targets.csproj" PrivateAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/OrchardCore.Application.Pages.csproj
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/OrchardCore.Application.Pages.csproj
@@ -22,30 +22,6 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Update="Pages\Shared\_BarLayout.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Pages\Shared\_BazLayout.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Pages\Shared\_FooBarLayout.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Views\Shared\_BazLayout.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Views\Shared\_BarLayout.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Views\Shared\_FooBazLayout.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-    <Content Update="Views\Shared\_FooBarLayout.cshtml">
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-  </ItemGroup>
-
   <!-- Necessary as we reference the Project and not the Package -->
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Application.Cms.Targets\OrchardCore.Application.Cms.Targets.targets" />
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Application.Targets\OrchardCore.Application.Targets.targets" />

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -19,7 +19,7 @@ namespace OrchardCore.Tests.Extensions
         private static IApplicationContext ApplicationContext
             = new ModularApplicationContext(HostingEnvironment, new List<IModuleNamesProvider>()
             {
-                new AssemblyAttributeModuleNamesProvider(HostingEnvironment)
+                new ModuleNamesProvider()
             });
 
         private static IFeaturesProvider ModuleFeatureProvider =
@@ -60,6 +60,28 @@ namespace OrchardCore.Tests.Extensions
                 ThemeFeatureProvider,
                 new NullLogger<ExtensionManager>()
                 );
+        }
+
+        private class ModuleNamesProvider : IModuleNamesProvider
+        {
+            private readonly string[] _moduleNames;
+
+            public ModuleNamesProvider()
+            {
+                _moduleNames = new[]
+                {
+                    "BaseThemeSample",
+                    "BaseThemeSample2",
+                    "DerivedThemeSample",
+                    "DerivedThemeSample2",
+                    "ModuleSample"
+                };
+            }
+
+            public IEnumerable<string> GetModuleNames()
+            {
+                return _moduleNames;
+            }
         }
 
         [Fact]

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/ApplicationControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/ApplicationControllerTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -99,12 +101,11 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
         }
 
         [Theory]
-        //[InlineData("nonUrlString", false)]
-        //[InlineData("http://localhost http://localhost:8080 nonUrlString", false)]
+        [InlineData("nonUrlString", false)]
+        [InlineData("http://localhost http://localhost:8080 nonUrlString", false)]
         [InlineData("http://localhost http://localhost:8080", true)]
         public async Task RedirectUrisAreValid(string uris, bool expectValidModel)
         {
-
             var controller = new ApplicationController(
                 Mock.Of<IShapeFactory>(),
                 Mock.Of<ISiteService>(),
@@ -122,6 +123,12 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
             model.Type = OpenIddictConstants.ClientTypes.Public;
             model.AllowAuthorizationCodeFlow = true;
             model.RedirectUris = uris;
+
+            foreach (var validation in model.Validate(new ValidationContext(model)))
+            {
+                controller.ModelState.AddModelError(validation.MemberNames.First(), validation.ErrorMessage);
+            }
+
             var result = await controller.Create(model);
             if (expectValidModel)
             {

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/ApplicationControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/ApplicationControllerTests.cs
@@ -98,9 +98,9 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
             Assert.Equal(expectValidModel, controller.ModelState.IsValid);
         }
 
-        [Theory(Skip = "Multi uri is not implemented yet see https://github.com/OrchardCMS/OrchardCore/pull/2165")]
-        [InlineData("nonUrlString", false)]
-        [InlineData("http://localhost http://localhost:8080 nonUrlString", false)]
+        [Theory]
+        //[InlineData("nonUrlString", false)]
+        //[InlineData("http://localhost http://localhost:8080 nonUrlString", false)]
         [InlineData("http://localhost http://localhost:8080", true)]
         public async Task RedirectUrisAreValid(string uris, bool expectValidModel)
         {

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\src\OrchardCore.Build\Dependencies.props" />
 
@@ -45,13 +45,10 @@
   </ItemGroup>
 
   <!-- Necessary as we reference the Project and not the Package -->
-  <Import Project="..\..\src\OrchardCore\OrchardCore.Application.Targets\OrchardCore.Application.Targets.targets" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrchardCore.Cms.Web\OrchardCore.Cms.Web.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore.Modules\OrchardCore.OpenId\OrchardCore.OpenId.csproj" />
     <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Apis.GraphQL.Client\OrchardCore.Apis.GraphQL.Client.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Application.Targets\OrchardCore.Application.Targets.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\BaseThemeSample\BaseThemeSample.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\BaseThemeSample2\BaseThemeSample2.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\DerivedThemeSample\DerivedThemeSample.csproj" />
@@ -60,19 +57,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\OrchardCore.Modules\OrchardCore.Liquid\OrchardCore.Liquid.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore.Modules\OrchardCore.Queries\OrchardCore.Queries.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore.Modules\OrchardCore.Users\OrchardCore.Users.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore.Modules\OrchardCore.Workflows\OrchardCore.Workflows.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.ContentManagement\OrchardCore.ContentManagement.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Data\OrchardCore.Data.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Hosting.Console\OrchardCore.Hosting.Console.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Localization.Abstractions\OrchardCore.Localization.Abstractions.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Localization.Core\OrchardCore.Localization.Core.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Recipes.Core\OrchardCore.Recipes.Core.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Scripting.JavaScript\OrchardCore.Scripting.JavaScript.csproj" />
-    <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -44,9 +44,6 @@
     <EmbeddedResource Include="Localization\PoFiles\SimpleEntry.po" />
   </ItemGroup>
 
-  <!-- 'OrchardCore.Tests' needs to be a modular Application (see the related import at the end).
-       So that the testing modules and those referenced by 'OrchardCore.Cms.Web' are discovered. -->
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrchardCore.Cms.Web\OrchardCore.Cms.Web.csproj" />
     <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Apis.GraphQL.Client\OrchardCore.Apis.GraphQL.Client.csproj" />
@@ -76,9 +73,6 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <!-- Necessary as we reference the Project (here indirectly) and not the Package (directly
-       or with all transitive package references using the 'PrivateAssets="none"' metadata). -->
-  <Import Project="..\..\src\OrchardCore\OrchardCore.Application.Targets\OrchardCore.Application.Targets.targets" />
   <Import Project="..\..\src\OrchardCore.Build\OrchardCore.Commons.targets" />
 
 </Project>

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -44,19 +44,18 @@
     <EmbeddedResource Include="Localization\PoFiles\SimpleEntry.po" />
   </ItemGroup>
 
-  <!-- Necessary as we reference the Project and not the Package -->
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrchardCore.Cms.Web\OrchardCore.Cms.Web.csproj" />
     <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Apis.GraphQL.Client\OrchardCore.Apis.GraphQL.Client.csproj" />
+  </ItemGroup>
+
+  <!-- Acts as an Application (see the related import at the end) composed of the following Modules. -->
+  <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Tests.Modules\BaseThemeSample\BaseThemeSample.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\BaseThemeSample2\BaseThemeSample2.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\DerivedThemeSample\DerivedThemeSample.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\DerivedThemeSample2\DerivedThemeSample2.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\ModuleSample\ModuleSample.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
   </ItemGroup>
 
   <ItemGroup>
@@ -75,6 +74,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <!-- Necessary as we reference the Project through 'OrchardCore.Cms.Web' but not the Package directly. -->
+  <Import Project="..\..\src\OrchardCore\OrchardCore.Application.Targets\OrchardCore.Application.Targets.targets" />
   <Import Project="..\..\src\OrchardCore.Build\OrchardCore.Commons.targets" />
 
 </Project>

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -44,12 +44,14 @@
     <EmbeddedResource Include="Localization\PoFiles\SimpleEntry.po" />
   </ItemGroup>
 
+  <!-- 'OrchardCore.Tests' needs to be a modular Application (see the related import at the end).
+       So that the testing modules and those referenced by 'OrchardCore.Cms.Web' are discovered. -->
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrchardCore.Cms.Web\OrchardCore.Cms.Web.csproj" />
     <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Apis.GraphQL.Client\OrchardCore.Apis.GraphQL.Client.csproj" />
   </ItemGroup>
 
-  <!-- Acts as an Application (see the related import at the end) composed of the following Modules. -->
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Tests.Modules\BaseThemeSample\BaseThemeSample.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\BaseThemeSample2\BaseThemeSample2.csproj" />
@@ -74,7 +76,8 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
-  <!-- Necessary as we reference the Project through 'OrchardCore.Cms.Web' but not the Package directly. -->
+  <!-- Necessary as we reference the Project (here indirectly) and not the Package (directly
+       or with all transitive package references using the 'PrivateAssets="none"' metadata). -->
   <Import Project="..\..\src\OrchardCore\OrchardCore.Application.Targets\OrchardCore.Application.Targets.targets" />
   <Import Project="..\..\src\OrchardCore.Build\OrchardCore.Commons.targets" />
 


### PR DESCRIPTION
- Some project files cleanup.

- @PinpointTownes i think that now we can run the `RedirectUrisAreValid()` test which was waiting for #2165. It works but only if the provided uris are valid, otherwise `ApplicationController.Create()` fails in place of adding a model state error. Here i prefer to let you see what is better to do. So, right now i just commented the 2 `InlineData` which contain an invalid uri.

- @sebastienros next step is to fix the intermittent issue on AppVeyor. As you said, maybe due to a timing issue related to lucene indexing. I will dig into it but i have no obvious solution at the moment.