### PR TITLE
Fix incorrect selection of content type node on blog recipe

### DIFF
--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -943,6 +943,7 @@
                     "Href": null,
                     "Url": null,
                     "Position": null,
+                    "SelectionPriority": -50,
                     "LinkToFirstChild": true,
                     "LocalNav": false,
                     "Culture": null,


### PR DESCRIPTION
When the user clicks on a content type, and the page reloads, the link selected is not the one that the user clicked on, but the parent link "Content Items". 
We introduced the "SelectionPriority" property to fix these issues, but I don't added to the blog recipe.

![fix-selection-priority](https://user-images.githubusercontent.com/2589629/49038720-06810880-f1be-11e8-9c8b-3280f0549127.gif)
