### PR TITLE
Run recipe and non recipe migrations in the same scope.

### DIFF
--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -39,12 +39,12 @@ namespace OrchardCore.Recipes.Services
             IRecipeResultStore recipeResultStore,
             IApplicationLifetime applicationLifetime,
             ShellSettings shellSettings,
-            IShellHost orchardHost,
+            IShellHost shellHost,
             ILogger<RecipeExecutor> logger,
             IStringLocalizer<RecipeExecutor> localizer)
         {
             _httpContextAccessor = httpContextAccessor;
-            _shellHost = orchardHost;
+            _shellHost = shellHost;
             _shellSettings = shellSettings;
             _applicationLifetime = applicationLifetime;
             _recipeEventHandlers = recipeEventHandlers;


### PR DESCRIPTION
**Repro**

- From the last dev, in the blog recipe file remove the `FileContentDefinition` feature.
- Run a setup using this blog recipe, it fails.

**Suggested solution**

- Execute recipe and non recipe migrations in the same scope, so the same session, transaction.

Maybe related to the #2709 issue.