### PR TITLE
Incorrect using in code generation templates for modules 

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Manifest.cs
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Manifest.cs
@@ -1,4 +1,4 @@
-using OrchardCore.Modules.Cms.Manifest;
+using OrchardCore.Modules.Manifest;
 
 [assembly: Module(
     Name = "OrchardCore.Templates.Module",

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/Manifest.cs
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/Manifest.cs
@@ -1,4 +1,4 @@
-using OrchardCore.Modules.Mvc.Manifest;
+using OrchardCore.Modules.Manifest;
 
 [assembly: Module(
     Name = "OrchardCore.Templates.Mvc.Module",


### PR DESCRIPTION
Fix wrong using reference in Manifest.cs in both the CMS and MVC module templates. resolves #2802 