### PR TITLE
Issue 2799 - link tags should self close

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -34,12 +34,15 @@ namespace OrchardCore.ResourceManagement
             CdnMode = options.UseCdn;
             DebugMode = options.DebugMode;
             Culture = options.Culture;
+            SelfClosing = options.SelfClosing;
         }
 
         public bool HasAttributes
         {
             get { return _attributes != null && _attributes.Any(a => a.Value != null); }
         }
+
+        public bool SelfClosing { get; set; }
 
         /// <summary>
         /// The resource will be displayed in the head of the page
@@ -78,6 +81,16 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
+        public RequireSettings IsSelfClosing()
+        {
+            return IsSelfClosing(true);
+        }
+
+        public RequireSettings IsSelfClosing(bool selfClosing)
+        {
+            SelfClosing |= selfClosing;
+            return this;
+        }
         public RequireSettings UseDebugMode()
         {
             return UseDebugMode(true);
@@ -182,6 +195,7 @@ namespace OrchardCore.ResourceManagement
                 .WithBasePath(BasePath).WithBasePath(other.BasePath)
                 .UseCdn(CdnMode).UseCdn(other.CdnMode)
                 .UseDebugMode(DebugMode).UseDebugMode(other.DebugMode)
+                .IsSelfClosing(SelfClosing).IsSelfClosing(other.SelfClosing)
                 .UseCulture(Culture).UseCulture(other.Culture)
                 .UseCondition(Condition).UseCondition(other.Condition)
                 .UseVersion(Version).UseVersion(other.Version)

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -34,16 +34,13 @@ namespace OrchardCore.ResourceManagement
             CdnMode = options.UseCdn;
             DebugMode = options.DebugMode;
             Culture = options.Culture;
-            SelfClosing = options.SelfClosing;
         }
 
         public bool HasAttributes
         {
             get { return _attributes != null && _attributes.Any(a => a.Value != null); }
         }
-
-        public bool SelfClosing { get; set; }
-
+        
         /// <summary>
         /// The resource will be displayed in the head of the page
         /// </summary>
@@ -81,16 +78,6 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
-        public RequireSettings IsSelfClosing()
-        {
-            return IsSelfClosing(true);
-        }
-
-        public RequireSettings IsSelfClosing(bool selfClosing)
-        {
-            SelfClosing |= selfClosing;
-            return this;
-        }
         public RequireSettings UseDebugMode()
         {
             return UseDebugMode(true);
@@ -195,7 +182,6 @@ namespace OrchardCore.ResourceManagement
                 .WithBasePath(BasePath).WithBasePath(other.BasePath)
                 .UseCdn(CdnMode).UseCdn(other.CdnMode)
                 .UseDebugMode(DebugMode).UseDebugMode(other.DebugMode)
-                .IsSelfClosing(SelfClosing).IsSelfClosing(other.SelfClosing)
                 .UseCulture(Culture).UseCulture(other.Culture)
                 .UseCondition(Condition).UseCondition(other.Condition)
                 .UseVersion(Version).UseVersion(other.Version)

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -23,7 +23,8 @@ namespace OrchardCore.ResourceManagement
         };
         private static readonly Dictionary<string, TagRenderMode> _fileTagRenderModes = new Dictionary<string, TagRenderMode> {
             { "script", TagRenderMode.Normal },
-            { "link", TagRenderMode.SelfClosing }
+            { "link", TagRenderMode.SelfClosing },
+            { "stylesheet", TagRenderMode.SelfClosing }
         };
         
         private string _basePath;
@@ -216,11 +217,10 @@ namespace OrchardCore.ResourceManagement
                 url = url.Substring(1);
             }
 
-            var tagBuilder = new TagBuilder(TagName);
-            if (settings.SelfClosing)
+            var tagBuilder = new TagBuilder(TagName)
             {
-                tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
-            }
+                TagRenderMode = TagRenderMode
+            };
 
             if (!String.IsNullOrEmpty(CdnIntegrity) && url != null && url == UrlCdn)
             {

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -217,6 +217,10 @@ namespace OrchardCore.ResourceManagement
             }
 
             var tagBuilder = new TagBuilder(TagName);
+            if (settings.SelfClosing)
+            {
+                tagBuilder.TagRenderMode = TagRenderMode.SelfClosing;
+            }
 
             if (!String.IsNullOrEmpty(CdnIntegrity) && url != null && url == UrlCdn)
             {

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
@@ -7,7 +7,5 @@ namespace OrchardCore.ResourceManagement
         public bool DebugMode { get; set; } = false;
 
         public string Culture { get; set; }
-
-        public bool SelfClosing { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
@@ -7,5 +7,7 @@ namespace OrchardCore.ResourceManagement
         public bool DebugMode { get; set; } = false;
 
         public string Culture { get; set; }
+
+        public bool SelfClosing { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -39,13 +39,12 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-
             if (String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
             {
                 // Include custom script
-
                 var setting = _resourceManager.Include("stylesheet", Src, DebugSrc);
-
+                setting.IsSelfClosing();
+                
                 if (At != ResourceLocation.Unspecified)
                 {
                     setting.AtLocation(At);
@@ -75,6 +74,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 // Resource required
 
                 var setting = _resourceManager.RegisterResource("stylesheet", Name);
+                setting.IsSelfClosing();
 
                 if (At != ResourceLocation.Unspecified)
                 {
@@ -140,6 +140,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 // Also include the style
 
                 var setting = _resourceManager.RegisterResource("stylesheet", Name);
+                setting.IsSelfClosing();
 
                 if (At != ResourceLocation.Unspecified)
                 {
@@ -170,7 +171,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.UseCulture(Culture);
                 }
             }
-
+            
             output.TagName = null;
         }
     }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -43,8 +43,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
             {
                 // Include custom script
                 var setting = _resourceManager.Include("stylesheet", Src, DebugSrc);
-                setting.IsSelfClosing();
-                
+
                 if (At != ResourceLocation.Unspecified)
                 {
                     setting.AtLocation(At);
@@ -74,7 +73,6 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 // Resource required
 
                 var setting = _resourceManager.RegisterResource("stylesheet", Name);
-                setting.IsSelfClosing();
 
                 if (At != ResourceLocation.Unspecified)
                 {
@@ -140,7 +138,6 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 // Also include the style
 
                 var setting = _resourceManager.RegisterResource("stylesheet", Name);
-                setting.IsSelfClosing();
 
                 if (At != ResourceLocation.Unspecified)
                 {


### PR DESCRIPTION
- The TagBuilder needs to be created with the RenderMode set to SelfClosing.
- To allow this to pass through to the ResourceDefinition via the settings, we need a new RequireSetting property called SelfClosing.

Fixes #2799