### PR TITLE
Rename Layers to Zones

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Layers
             builder
                 .Add(T["Configuration"], configuration => configuration
                     .Add(T["Settings"], settings => settings
-                        .Add(T["Layers"], T["Layers"], layers => layers
+                        .Add(T["Zones"], T["Zones"], zones => zones
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = LayerSiteSettingsDisplayDriver.GroupId })
                             .Permission(Permissions.ManageLayers)
                             .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerSiteSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerSiteSettingsDisplayDriver.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Layers.Drivers
 {
     public class LayerSiteSettingsDisplayDriver : SectionDisplayDriver<ISite, LayerSettings>
     {
-        public const string GroupId = "layers";
+        public const string GroupId = "zones";
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IAuthorizationService _authorizationService;
 


### PR DESCRIPTION
Fixes #2843.   Made the following changes to rename Layers to Zones:
- Changed menu item text from Layers to Zones in AdminMenu, renamed layers lambda parameter to zones.
- Changed layers to zones for GroupId constant in LayerSiteSettingsDisplayDriver
- Verified that the menu Item was correctly shown under configuration -> settings -> zones
- Verified that the URL was /admin/settings/zones

![image](https://user-images.githubusercontent.com/26497457/49967325-2156bb00-fee8-11e8-8456-3da4a84f8193.png)

@agriffard  I am not sure how deep you want the rename to go.  For instance should LayerSiteSettingsDisplayDriver be renamed to ZoneSiteSiteSettingsDisplayDriver?  Should LayerSettings.Edit.cshtml be renamed to ZoneSettings.Edit.cshtml?
