### PR TITLE
Expose Lucene sort field type in order to respect numerics

### DIFF
--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/Snippets/recentBlogPosts.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/Snippets/recentBlogPosts.json
@@ -1,0 +1,12 @@
+{
+  "query": {
+    "term": { "Content.ContentItem.ContentType": "BlogPost" }
+  },
+  "sort": {
+    "Content.ContentItem.CreatedUtc": {
+      "order": "desc",
+      "fieldType": "double"
+    }
+  },
+  "size": 3
+}

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -860,7 +860,7 @@
           "Source": "Lucene",
           "Name": "RecentBlogPosts",
           "Index": "Search",
-          "Template": "[js:base64('ew0KICAicXVlcnkiOiB7DQogICAgInRlcm0iIDogeyAiQ29udGVudC5Db250ZW50SXRlbS5Db250ZW50VHlwZSIgOiAiQmxvZ1Bvc3QiIH0gDQogIH0sDQogICJzb3J0IjogeyAiQ29udGVudC5Db250ZW50SXRlbS5DcmVhdGVkVXRjIjogeyAib3JkZXIiOiAiZGVzYyIgfSB9LA0KICAic2l6ZSI6IDMNCn0=')]",
+          "Template": "[js:base64('ewogICJxdWVyeSI6IHsKICAgICJ0ZXJtIiA6IHsgIkNvbnRlbnQuQ29udGVudEl0ZW0uQ29udGVudFR5cGUiIDogIkJsb2dQb3N0IiB9IAogIH0sCiAgInNvcnQiOiB7ICJDb250ZW50LkNvbnRlbnRJdGVtLkNyZWF0ZWRVdGMiOiB7ICJvcmRlciI6ICJkZXNjIiwgImZpZWxkVHlwZSI6ICJkb3VibGUiIH0gfSwKICAic2l6ZSI6IDMKfQ==')]",
           "Schema": "[js:base64('ew0KICAgICJ0eXBlIjogIkNvbnRlbnRJdGVtL0Jsb2dQb3N0Ig0KfQ==')]",
           "ReturnContentItems": true
         }

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -860,7 +860,7 @@
           "Source": "Lucene",
           "Name": "RecentBlogPosts",
           "Index": "Search",
-          "Template": "[js:base64('ewogICJxdWVyeSI6IHsKICAgICJ0ZXJtIiA6IHsgIkNvbnRlbnQuQ29udGVudEl0ZW0uQ29udGVudFR5cGUiIDogIkJsb2dQb3N0IiB9IAogIH0sCiAgInNvcnQiOiB7ICJDb250ZW50LkNvbnRlbnRJdGVtLkNyZWF0ZWRVdGMiOiB7ICJvcmRlciI6ICJkZXNjIiwgImZpZWxkVHlwZSI6ICJkb3VibGUiIH0gfSwKICAic2l6ZSI6IDMKfQ==')]",
+          "Template": "[file:text('Snippets/recentBlogPosts.json')]",
           "Schema": "[js:base64('ew0KICAgICJ0eXBlIjogIkNvbnRlbnRJdGVtL0Jsb2dQb3N0Ig0KfQ==')]",
           "ReturnContentItems": true
         }

--- a/src/OrchardCore/OrchardCore.Lucene.Core/LuceneQueryService.cs
+++ b/src/OrchardCore/OrchardCore.Lucene.Core/LuceneQueryService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -38,6 +38,7 @@ namespace OrchardCore.Lucene
 
             string sortField = null;
             string sortOrder = null;
+            var sortFieldType = SortFieldType.STRING;
 
             if (sortProperty != null)
             {
@@ -49,13 +50,14 @@ namespace OrchardCore.Lucene
                 {
                     sortField = ((JProperty)sortProperty.First).Name;
                     sortOrder = ((JProperty)sortProperty.First).Value["order"].ToString();
+                    Enum.TryParse(((JProperty)sortProperty.First).Value["fieldType"]?.ToString().ToUpper(), out sortFieldType);
                 }
             }
 
             TopDocs docs = context.IndexSearcher.Search(
                 query,
                 size + from,
-                sortField == null ? Sort.RELEVANCE : new Sort(new SortField(sortField, SortFieldType.STRING, sortOrder == "desc"))
+                sortField == null ? Sort.RELEVANCE : new Sort(new SortField(sortField, sortFieldType, sortOrder == "desc"))
             );
 
             if (from > 0)


### PR DESCRIPTION
Issue:
Lucene query search sort order currently only works on strings.

Steps to reproduce:
Whilst I initially encountered this sorting by a numeric field the same is also true of the default query in the blog theme. 
Setup - Create site with blog theme and add an additional blog post.
Run 'RecentBlogPosts' query. Changing the sort order and re-running has no effect.  I believe this is because the Lucene sort field type is hard coded to SortFieldType.STRING.

PR exposes this to the query syntax using "fieldType" property of the sort object in the json. Updated query looks like:

{
  "query": {
    "term" : { "Content.ContentItem.ContentType" : "BlogPost" } 
  },
  "sort": { "Content.ContentItem.CreatedUtc": { "order": "desc", "fieldType": "double" } },
  "size": 3
}



