### PR TITLE
Remove the testing mode feature and replace it by automatic signing certificate generation

### DIFF
--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -7,6 +7,7 @@
     <PackageManagement Include="Microsoft.AspNetCore.Antiforgery" Version="2.2.0" />
     <PackageManagement Include="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.2.0" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.2.0" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Core" Version="2.2.0" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Facebook" Version="2.2.0" />
@@ -174,10 +175,7 @@
     <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Templating" Version="2.2.0" />
     <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGeneration.Utils" Version="2.2.0" />
     <PackageManagement Include="Microsoft.VisualStudio.Web.CodeGenerators.Mvc" Version="2.2.0" />
+    <PackageManagement Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageManagement Include="System.Security.Cryptography.Cng" Version="4.5.0" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <SystemComponentModelAnnotations>4.5.0</SystemComponentModelAnnotations>
-    <SystemSecurityCryptographyCng>4.5.0</SystemSecurityCryptographyCng>
-  </PropertyGroup>
 </Project>

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -178,5 +178,6 @@
 
   <PropertyGroup>
     <SystemComponentModelAnnotations>4.5.0</SystemComponentModelAnnotations>
+    <SystemSecurityCryptographyCng>4.5.0</SystemSecurityCryptographyCng>
   </PropertyGroup>
 </Project>

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -18,7 +18,6 @@
     <PackageManagement Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00005" />
     <PackageManagement Include="Lucene.Net.QueryParser" Version="4.8.0-beta00005" />
     <PackageManagement Include="Markdig" Version="0.15.5" />
-    <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.2.0" />
     <PackageManagement Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageManagement Include="MiniProfiler.AspNetCore.Mvc" Version="4.0.138" />
     <PackageManagement Include="Moq" Version="4.10.1" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/AdminMenu.cs
@@ -3,8 +3,8 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
-using OrchardCore.Navigation;
 using OrchardCore.Environment.Shell.Descriptor.Models;
+using OrchardCore.Navigation;
 
 namespace OrchardCore.OpenId
 {
@@ -51,7 +51,7 @@ namespace OrchardCore.OpenId
                         if (features.Contains(OpenIdConstants.Features.Server))
                         {
                             settings.Add(T["Authorization server"], "2", server => server
-                                    .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "OrchardCore.OpenId.Server" })
+                                    .Action("Index", "ServerConfiguration", "OrchardCore.OpenId")
                                     .Permission(Permissions.ManageServerSettings)
                                     .LocalNav());
                         }
@@ -59,7 +59,7 @@ namespace OrchardCore.OpenId
                         if (features.Contains(OpenIdConstants.Features.Validation))
                         {
                             settings.Add(T["Token validation"], "3", validation => validation
-                                    .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "OrchardCore.OpenId.Validation" })
+                                    .Action("Index", "ValidationConfiguration", "OrchardCore.OpenId")
                                     .Permission(Permissions.ManageValidationSettings)
                                     .LocalNav());
                         }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
@@ -108,7 +108,7 @@ namespace OrchardCore.OpenId.Configuration
             options.IgnoreScopePermissions = true;
             options.UseRollingTokens = settings.UseRollingTokens;
 
-            foreach (var key in GetSigningKeysAsync().GetAwaiter().GetResult())
+            foreach (var key in _serverService.GetSigningKeysAsync().GetAwaiter().GetResult())
             {
                 options.SigningCredentials.AddKey(key);
             }
@@ -154,7 +154,7 @@ namespace OrchardCore.OpenId.Configuration
             }
 
             options.TokenValidationParameters.ValidAudience = OpenIdConstants.Prefixes.Tenant + _shellSettings.Name;
-            options.TokenValidationParameters.IssuerSigningKeys = GetSigningKeysAsync().GetAwaiter().GetResult();
+            options.TokenValidationParameters.IssuerSigningKeys = _serverService.GetSigningKeysAsync().GetAwaiter().GetResult();
 
             // If an authority was explicitly set in the OpenID server options,
             // prefer it to the dynamic tenant comparison as it's more efficient.
@@ -208,21 +208,6 @@ namespace OrchardCore.OpenId.Configuration
             }
 
             return settings;
-        }
-
-        private async Task<ImmutableArray<SecurityKey>> GetSigningKeysAsync()
-        {
-            // If no signing credentials were found, generate a new key and persist it.
-            var keys = await _serverService.GetSigningKeysAsync();
-            if (keys.IsDefaultOrEmpty)
-            {
-                var key = await _serverService.GenerateSigningKeyAsync();
-                await _serverService.AddSigningKeyAsync(key);
-
-                return ImmutableArray.Create(key);
-            }
-
-            return keys;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdValidationConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdValidationConfiguration.cs
@@ -144,7 +144,7 @@ namespace OrchardCore.OpenId.Configuration
                 // to choose the valid audiences, as this would otherwise allow it
                 // to validate/introspect tokens meant to be used with another tenant.
                 options.TokenValidationParameters.ValidAudience = OpenIdConstants.Prefixes.Tenant + _shellSettings.Name;
-                options.TokenValidationParameters.IssuerSigningKeys = GetSigningKeysAsync(service).GetAwaiter().GetResult();
+                options.TokenValidationParameters.IssuerSigningKeys = service.GetSigningKeysAsync().GetAwaiter().GetResult();
 
                 // If an authority was explicitly set in the OpenID server options,
                 // prefer it to the dynamic tenant comparison as it's more efficient.
@@ -253,21 +253,6 @@ namespace OrchardCore.OpenId.Configuration
             }
 
             return settings;
-        }
-
-        private async Task<ImmutableArray<SecurityKey>> GetSigningKeysAsync(IOpenIdServerService service)
-        {
-            // If no signing credentials were found, generate a new key and persist it.
-            var keys = await service.GetSigningKeysAsync();
-            if (keys.IsDefaultOrEmpty)
-            {
-                var key = await service.GenerateSigningKeyAsync();
-                await service.AddSigningKeyAsync(key);
-
-                return ImmutableArray.Create(key);
-            }
-
-            return keys;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ServerConfigurationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ServerConfigurationController.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using OrchardCore.Admin;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Modules;
+using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Settings;
+
+namespace OrchardCore.OpenId.Controllers
+{
+    [Admin, Feature(OpenIdConstants.Features.Server)]
+    public class ServerConfigurationController : Controller, IUpdateModel
+    {
+        private readonly IAuthorizationService _authorizationService;
+        private readonly INotifier _notifier;
+        private readonly IOpenIdServerService _serverService;
+        private readonly IDisplayManager<OpenIdServerSettings> _serverSettingsDisplayManager;
+        private readonly IShellHost _shellHost;
+        private readonly ShellSettings _shellSettings;
+        private readonly IHtmlLocalizer<ServerConfigurationController> H;
+
+        public ServerConfigurationController(
+            IAuthorizationService authorizationService,
+            IHtmlLocalizer<ServerConfigurationController> htmlLocalizer,
+            INotifier notifier,
+            IOpenIdServerService serverService,
+            IDisplayManager<OpenIdServerSettings> serverSettingsDisplayManager,
+            IShellHost shellHost,
+            ShellSettings shellSettings)
+        {
+            _authorizationService = authorizationService;
+            H = htmlLocalizer;
+            _notifier = notifier;
+            _serverService = serverService;
+            _serverSettingsDisplayManager = serverSettingsDisplayManager;
+            _shellHost = shellHost;
+            _shellSettings = shellSettings;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageServerSettings))
+            {
+                return Unauthorized();
+            }
+
+            var settings = await _serverService.GetSettingsAsync();
+            var shape = await _serverSettingsDisplayManager.BuildEditorAsync(settings, updater: this, isNew: false);
+
+            return View(shape);
+        }
+
+        [HttpPost]
+        [ActionName(nameof(Index))]
+        public async Task<IActionResult> IndexPost()
+        {
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageServerSettings))
+            {
+                return Unauthorized();
+            }
+
+            var settings = await _serverService.GetSettingsAsync();
+            var shape = await _serverSettingsDisplayManager.UpdateEditorAsync(settings, updater: this, isNew: false);
+
+            if (!ModelState.IsValid)
+            {
+                return View(shape);
+            }
+
+            foreach (var result in await _serverService.ValidateSettingsAsync(settings))
+            {
+                if (result != ValidationResult.Success)
+                {
+                    var key = result.MemberNames.FirstOrDefault() ?? string.Empty;
+                    ModelState.AddModelError(key, result.ErrorMessage);
+                }
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View(shape);
+            }
+
+            await _serverService.UpdateSettingsAsync(settings);
+
+            _notifier.Success(H["OpenID server configuration successfully updated."]);
+
+            await _shellHost.ReloadShellContextAsync(_shellSettings);
+
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ValidationConfigurationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ValidationConfigurationController.cs
@@ -1,0 +1,100 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using OrchardCore.Admin;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Modules;
+using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Settings;
+
+namespace OrchardCore.OpenId.Controllers
+{
+    [Admin, Feature(OpenIdConstants.Features.Validation)]
+    public class ValidationConfigurationController : Controller, IUpdateModel
+    {
+        private readonly IAuthorizationService _authorizationService;
+        private readonly INotifier _notifier;
+        private readonly IOpenIdValidationService _validationService;
+        private readonly IDisplayManager<OpenIdValidationSettings> _validationSettingsDisplayManager;
+        private readonly IShellHost _shellHost;
+        private readonly ShellSettings _shellSettings;
+        private readonly IHtmlLocalizer<ValidationConfigurationController> H;
+
+        public ValidationConfigurationController(
+            IAuthorizationService authorizationService,
+            IHtmlLocalizer<ValidationConfigurationController> htmlLocalizer,
+            INotifier notifier,
+            IOpenIdValidationService validationService,
+            IDisplayManager<OpenIdValidationSettings> validationSettingsDisplayManager,
+            IShellHost shellHost,
+            ShellSettings shellSettings)
+        {
+            _authorizationService = authorizationService;
+            H = htmlLocalizer;
+            _notifier = notifier;
+            _validationService = validationService;
+            _validationSettingsDisplayManager = validationSettingsDisplayManager;
+            _shellHost = shellHost;
+            _shellSettings = shellSettings;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageValidationSettings))
+            {
+                return Unauthorized();
+            }
+
+            var settings = await _validationService.GetSettingsAsync();
+            var shape = await _validationSettingsDisplayManager.BuildEditorAsync(settings, updater: this, isNew: false);
+
+            return View(shape);
+        }
+
+        [HttpPost]
+        [ActionName(nameof(Index))]
+        public async Task<IActionResult> IndexPost()
+        {
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageValidationSettings))
+            {
+                return Unauthorized();
+            }
+
+            var settings = await _validationService.GetSettingsAsync();
+            var shape = await _validationSettingsDisplayManager.UpdateEditorAsync(settings, updater: this, isNew: false);
+
+            if (!ModelState.IsValid)
+            {
+                return View(shape);
+            }
+
+            foreach (var result in await _validationService.ValidateSettingsAsync(settings))
+            {
+                if (result != ValidationResult.Success)
+                {
+                    var key = result.MemberNames.FirstOrDefault() ?? string.Empty;
+                    ModelState.AddModelError(key, result.ErrorMessage);
+                }
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View(shape);
+            }
+
+            await _validationService.UpdateSettingsAsync(settings);
+
+            _notifier.Success(H["OpenID validation configuration successfully updated."]);
+
+            await _shellHost.ReloadShellContextAsync(_shellSettings);
+
+            return RedirectToAction(nameof(Index));
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdServerSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdServerSettingsDisplayDriver.cs
@@ -1,62 +1,24 @@
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Localization;
-using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
-using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.Environment.Shell;
 using OrchardCore.OpenId.Services;
 using OrchardCore.OpenId.Settings;
 using OrchardCore.OpenId.ViewModels;
-using OrchardCore.Settings;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 using static OrchardCore.OpenId.ViewModels.OpenIdServerSettingsViewModel;
 
 namespace OrchardCore.OpenId.Drivers
 {
-    public class OpenIdServerSettingsDisplayDriver : SectionDisplayDriver<ISite, OpenIdServerSettings>
+    public class OpenIdServerSettingsDisplayDriver : DisplayDriver<OpenIdServerSettings>
     {
-        private const string SettingsGroupId = "OrchardCore.OpenId.Server";
-
-        private readonly IAuthorizationService _authorizationService;
         private readonly IOpenIdServerService _serverService;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly INotifier _notifier;
-        private readonly IHtmlLocalizer<OpenIdServerSettingsDisplayDriver> T;
-        private readonly IShellHost _shellHost;
-        private readonly ShellSettings _shellSettings;
 
-        public OpenIdServerSettingsDisplayDriver(
-            IAuthorizationService authorizationService,
-            IOpenIdServerService serverService,
-            IHttpContextAccessor httpContextAccessor,
-            INotifier notifier,
-            IHtmlLocalizer<OpenIdServerSettingsDisplayDriver> stringLocalizer,
-            IShellHost shellHost,
-            ShellSettings shellSettings)
-        {
-            _authorizationService = authorizationService;
-            _serverService = serverService;
-            _notifier = notifier;
-            _httpContextAccessor = httpContextAccessor;
-            _shellHost = shellHost;
-            _shellSettings = shellSettings;
-            T = stringLocalizer;
-        }
+        public OpenIdServerSettingsDisplayDriver(IOpenIdServerService serverService)
+            => _serverService = serverService;
 
-        public override async Task<IDisplayResult> EditAsync(OpenIdServerSettings settings, BuildEditorContext context)
-        {
-            var user = _httpContextAccessor.HttpContext?.User;
-            if (user == null || !await _authorizationService.AuthorizeAsync(user, Permissions.ManageServerSettings))
-            {
-                return null;
-            }
-
-            return Initialize<OpenIdServerSettingsViewModel>("OpenIdServerSettings_Edit", async model =>
+        public override Task<IDisplayResult> EditAsync(OpenIdServerSettings settings, BuildEditorContext context)
+            => Task.FromResult<IDisplayResult>(Initialize<OpenIdServerSettingsViewModel>("OpenIdServerSettings_Edit", async model =>
             {
                 model.AccessTokenFormat = settings.AccessTokenFormat;
                 model.Authority = settings.Authority;
@@ -94,100 +56,75 @@ namespace OrchardCore.OpenId.Drivers
                         Archived = certificate.Archived
                     });
                 }
-            }).Location("Content:2").OnGroup(SettingsGroupId);
-        }
+            }).Location("Content:2"));
 
-        public override async Task<IDisplayResult> UpdateAsync(OpenIdServerSettings settings,  BuildEditorContext context)
+        public override async Task<IDisplayResult> UpdateAsync(OpenIdServerSettings settings, UpdateEditorContext context)
         {
-            var user = _httpContextAccessor.HttpContext?.User;
-            if (user == null || !await _authorizationService.AuthorizeAsync(user, Permissions.ManageServerSettings))
+            var model = new OpenIdServerSettingsViewModel();
+            await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+            settings.AccessTokenFormat = model.AccessTokenFormat;
+            settings.Authority = model.Authority;
+
+            settings.CertificateStoreLocation = model.CertificateStoreLocation;
+            settings.CertificateStoreName = model.CertificateStoreName;
+            settings.CertificateThumbprint = model.CertificateThumbprint;
+
+            settings.AuthorizationEndpointPath = model.EnableAuthorizationEndpoint ?
+                new PathString("/connect/authorize") : PathString.Empty;
+            settings.LogoutEndpointPath = model.EnableLogoutEndpoint ?
+                new PathString("/connect/logout") : PathString.Empty;
+            settings.TokenEndpointPath = model.EnableTokenEndpoint ?
+                new PathString("/connect/token") : PathString.Empty;
+            settings.UserinfoEndpointPath = model.EnableUserInfoEndpoint ?
+                new PathString("/connect/userinfo") : PathString.Empty;
+
+            if (model.AllowAuthorizationCodeFlow)
             {
-                return null;
+                settings.GrantTypes.Add(GrantTypes.AuthorizationCode);
+            }
+            else
+            {
+                settings.GrantTypes.Remove(GrantTypes.AuthorizationCode);
             }
 
-            if (context.GroupId == SettingsGroupId)
+            if (model.AllowImplicitFlow)
             {
-                var model = new OpenIdServerSettingsViewModel();
-                await context.Updater.TryUpdateModelAsync(model, Prefix);
-
-                settings.AccessTokenFormat = model.AccessTokenFormat;
-                settings.Authority = model.Authority;
-
-                settings.CertificateStoreLocation = model.CertificateStoreLocation;
-                settings.CertificateStoreName = model.CertificateStoreName;
-                settings.CertificateThumbprint = model.CertificateThumbprint;
-
-                settings.AuthorizationEndpointPath = model.EnableAuthorizationEndpoint ?
-                    new PathString("/connect/authorize") : PathString.Empty;
-                settings.LogoutEndpointPath = model.EnableLogoutEndpoint ?
-                    new PathString("/connect/logout") : PathString.Empty;
-                settings.TokenEndpointPath = model.EnableTokenEndpoint ?
-                    new PathString("/connect/token") : PathString.Empty;
-                settings.UserinfoEndpointPath = model.EnableUserInfoEndpoint ?
-                    new PathString("/connect/userinfo") : PathString.Empty;
-
-                if (model.AllowAuthorizationCodeFlow)
-                {
-                    settings.GrantTypes.Add(GrantTypes.AuthorizationCode);
-                }
-                else
-                {
-                    settings.GrantTypes.Remove(GrantTypes.AuthorizationCode);
-                }
-
-                if (model.AllowImplicitFlow)
-                {
-                    settings.GrantTypes.Add(GrantTypes.Implicit);
-                }
-                else
-                {
-                    settings.GrantTypes.Remove(GrantTypes.Implicit);
-                }
-
-                if (model.AllowClientCredentialsFlow)
-                {
-                    settings.GrantTypes.Add(GrantTypes.ClientCredentials);
-                }
-                else
-                {
-                    settings.GrantTypes.Remove(GrantTypes.ClientCredentials);
-                }
-
-                if (model.AllowPasswordFlow)
-                {
-                    settings.GrantTypes.Add(GrantTypes.Password);
-                }
-                else
-                {
-                    settings.GrantTypes.Remove(GrantTypes.Password);
-                }
-
-                if (model.AllowRefreshTokenFlow)
-                {
-                    settings.GrantTypes.Add(GrantTypes.RefreshToken);
-                }
-                else
-                {
-                    settings.GrantTypes.Remove(GrantTypes.RefreshToken);
-                }
-
-                settings.UseRollingTokens = model.UseRollingTokens;
-
-                foreach (var result in await _serverService.ValidateSettingsAsync(settings))
-                {
-                    if (result != ValidationResult.Success)
-                    {
-                        var key = result.MemberNames.FirstOrDefault() ?? string.Empty;
-                        context.Updater.ModelState.AddModelError(key, result.ErrorMessage);
-                    }
-                }
-
-                // If the settings are valid, reload the current tenant.
-                if (context.Updater.ModelState.IsValid)
-                {
-                    await _shellHost.ReloadShellContextAsync(_shellSettings);
-                }
+                settings.GrantTypes.Add(GrantTypes.Implicit);
             }
+            else
+            {
+                settings.GrantTypes.Remove(GrantTypes.Implicit);
+            }
+
+            if (model.AllowClientCredentialsFlow)
+            {
+                settings.GrantTypes.Add(GrantTypes.ClientCredentials);
+            }
+            else
+            {
+                settings.GrantTypes.Remove(GrantTypes.ClientCredentials);
+            }
+
+            if (model.AllowPasswordFlow)
+            {
+                settings.GrantTypes.Add(GrantTypes.Password);
+            }
+            else
+            {
+                settings.GrantTypes.Remove(GrantTypes.Password);
+            }
+
+            if (model.AllowRefreshTokenFlow)
+            {
+                settings.GrantTypes.Add(GrantTypes.RefreshToken);
+            }
+            else
+            {
+                settings.GrantTypes.Remove(GrantTypes.RefreshToken);
+            }
+
+            settings.UseRollingTokens = model.UseRollingTokens;
 
             return await EditAsync(settings, context);
         }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdServerSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdServerSettingsDisplayDriver.cs
@@ -58,7 +58,6 @@ namespace OrchardCore.OpenId.Drivers
 
             return Initialize<OpenIdServerSettingsViewModel>("OpenIdServerSettings_Edit", async model =>
             {
-                model.TestingModeEnabled = settings.TestingModeEnabled;
                 model.AccessTokenFormat = settings.AccessTokenFormat;
                 model.Authority = settings.Authority;
 
@@ -111,7 +110,6 @@ namespace OrchardCore.OpenId.Drivers
                 var model = new OpenIdServerSettingsViewModel();
                 await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-                settings.TestingModeEnabled = model.TestingModeEnabled;
                 settings.AccessTokenFormat = model.AccessTokenFormat;
                 settings.Authority = model.Authority;
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
@@ -1,64 +1,26 @@
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
-using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Descriptor.Models;
 using OrchardCore.Environment.Shell.Models;
-using OrchardCore.OpenId.Services;
 using OrchardCore.OpenId.Settings;
 using OrchardCore.OpenId.ViewModels;
-using OrchardCore.Settings;
 
 namespace OrchardCore.OpenId.Drivers
 {
-    public class OpenIdValidationSettingsDisplayDriver : SectionDisplayDriver<ISite, OpenIdValidationSettings>
+    public class OpenIdValidationSettingsDisplayDriver : DisplayDriver<OpenIdValidationSettings>
     {
-        private const string SettingsGroupId = "OrchardCore.OpenId.Validation";
-
-        private readonly IAuthorizationService _authorizationService;
-        private readonly IOpenIdValidationService _validationService;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly INotifier _notifier;
-        private readonly IHtmlLocalizer<OpenIdValidationSettingsDisplayDriver> T;
         private readonly IShellHost _shellHost;
-        private readonly ShellSettings _shellSettings;
 
-        public OpenIdValidationSettingsDisplayDriver(
-            IAuthorizationService authorizationService,
-            IOpenIdValidationService validationService,
-            IHttpContextAccessor httpContextAccessor,
-            INotifier notifier,
-            IHtmlLocalizer<OpenIdValidationSettingsDisplayDriver> stringLocalizer,
-            IShellHost shellHost,
-            ShellSettings shellSettings)
-        {
-            _authorizationService = authorizationService;
-            _validationService = validationService;
-            _notifier = notifier;
-            _httpContextAccessor = httpContextAccessor;
-            _shellHost = shellHost;
-            _shellSettings = shellSettings;
-            T = stringLocalizer;
-        }
+        public OpenIdValidationSettingsDisplayDriver(IShellHost shellHost)
+            => _shellHost = shellHost;
 
-        public override async Task<IDisplayResult> EditAsync(OpenIdValidationSettings settings, BuildEditorContext context)
-        {
-            var user = _httpContextAccessor.HttpContext?.User;
-            if (user == null || !await _authorizationService.AuthorizeAsync(user, Permissions.ManageValidationSettings))
-            {
-                return null;
-            }
-
-            return Initialize<OpenIdValidationSettingsViewModel>("OpenIdValidationSettings_Edit", async model =>
+        public override Task<IDisplayResult> EditAsync(OpenIdValidationSettings settings, BuildEditorContext context)
+            => Task.FromResult<IDisplayResult>(Initialize<OpenIdValidationSettingsViewModel>("OpenIdValidationSettings_Edit", async model =>
             {
                 model.Authority = settings.Authority;
                 model.Audience = settings.Audience;
@@ -81,42 +43,17 @@ namespace OrchardCore.OpenId.Drivers
 
                 model.AvailableTenants = availableTenants;
 
-            }).Location("Content:2").OnGroup(SettingsGroupId);
-        }
+            }).Location("Content:2"));
 
-        public override async Task<IDisplayResult> UpdateAsync(OpenIdValidationSettings settings, BuildEditorContext context)
+        public override async Task<IDisplayResult> UpdateAsync(OpenIdValidationSettings settings, UpdateEditorContext context)
         {
-            var user = _httpContextAccessor.HttpContext?.User;
-            if (user == null || !await _authorizationService.AuthorizeAsync(user, Permissions.ManageValidationSettings))
-            {
-                return null;
-            }
+            var model = new OpenIdValidationSettingsViewModel();
 
-            if (context.GroupId == SettingsGroupId)
-            {
-                var model = new OpenIdValidationSettingsViewModel();
+            await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-                await context.Updater.TryUpdateModelAsync(model, Prefix);
-
-                settings.Authority = model.Authority?.Trim();
-                settings.Audience = model.Audience?.Trim();
-                settings.Tenant = model.Tenant;
-
-                foreach (var result in await _validationService.ValidateSettingsAsync(settings))
-                {
-                    if (result != ValidationResult.Success)
-                    {
-                        var key = result.MemberNames.FirstOrDefault() ?? string.Empty;
-                        context.Updater.ModelState.AddModelError(key, result.ErrorMessage);
-                    }
-                }
-
-                // If the settings are valid, reload the current tenant.
-                if (context.Updater.ModelState.IsValid)
-                {
-                    await _shellHost.ReloadShellContextAsync(_shellSettings);
-                }
-            }
+            settings.Authority = model.Authority?.Trim();
+            settings.Audience = model.Audience?.Trim();
+            settings.Tenant = model.Tenant;
 
             return await EditAsync(settings, context);
         }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="OpenIddict" />
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCng)" />
+    <PackageReference Include="System.Security.Cryptography.Cng" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -10,7 +10,6 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Abstractions\OrchardCore.ContentManagement.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -1,7 +1,7 @@
-  <Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,5 +26,9 @@
     <PackageReference Include="OpenIddict" />
     <PackageReference Include="System.Security.Cryptography.Cng" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_CERTIFICATE_GENERATION;SUPPORTS_EPHEMERAL_KEY_SETS</DefineConstants>
+  </PropertyGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
     <PackageReference Include="OpenIddict" />
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="$(SystemSecurityCryptographyCng)" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netcoreapp2.2</TargetFrameworks>
@@ -28,7 +28,9 @@
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_CERTIFICATE_GENERATION;SUPPORTS_EPHEMERAL_KEY_SETS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_CERTIFICATE_GENERATION</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_EPHEMERAL_KEY_SETS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_DIRECT_KEY_CREATION_WITH_SPECIFIED_SIZE</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdServerSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdServerSettingsStep.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Settings;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Recipes.Services;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -18,13 +19,11 @@ namespace OrchardCore.OpenId.Recipes
         private readonly IOpenIdServerService _serverService;
 
         public OpenIdServerSettingsStep(IOpenIdServerService serverService)
-        {
-            _serverService = serverService;
-        }
+            => _serverService = serverService;
 
         public async Task ExecuteAsync(RecipeExecutionContext context)
         {
-            if (!string.Equals(context.Name, "OpenIdServerSettings", StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(context.Name, nameof(OpenIdServerSettings), StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
@@ -32,7 +31,6 @@ namespace OrchardCore.OpenId.Recipes
             var model = context.Step.ToObject<OpenIdServerSettingsStepModel>();
 
             var settings = await _serverService.GetSettingsAsync();
-            settings.TestingModeEnabled = model.TestingModeEnabled;
             settings.AccessTokenFormat = model.AccessTokenFormat;
             settings.Authority = model.Authority;
 
@@ -93,7 +91,6 @@ namespace OrchardCore.OpenId.Recipes
 
     public class OpenIdServerSettingsStepModel
     {
-        public bool TestingModeEnabled { get; set; } = false;
         public TokenFormat AccessTokenFormat { get; set; } = TokenFormat.Encrypted;
         public string Authority { get; set; }
         public StoreLocation CertificateStoreLocation { get; set; } = StoreLocation.LocalMachine;

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/IOpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/IOpenIdServerService.cs
@@ -14,5 +14,6 @@ namespace OrchardCore.OpenId.Services
         Task<ImmutableArray<ValidationResult>> ValidateSettingsAsync(OpenIdServerSettings settings);
         Task<ImmutableArray<(X509Certificate2 certificate, StoreLocation location, StoreName name)>> GetAvailableCertificatesAsync();
         Task<ImmutableArray<SecurityKey>> GetSigningKeysAsync();
+        Task PruneSigningKeysAsync();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/IOpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/IOpenIdServerService.cs
@@ -14,5 +14,8 @@ namespace OrchardCore.OpenId.Services
         Task<ImmutableArray<ValidationResult>> ValidateSettingsAsync(OpenIdServerSettings settings);
         Task<ImmutableArray<(X509Certificate2 certificate, StoreLocation location, StoreName name)>> GetAvailableCertificatesAsync();
         Task<ImmutableArray<SecurityKey>> GetSigningKeysAsync();
+        Task AddSigningKeyAsync(SecurityKey key);
+        Task<SecurityKey> GenerateSigningKeyAsync();
+        Task<SecurityKey> GenerateSigningKeyAsync<TSecurityKey>() where TSecurityKey : SecurityKey;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/IOpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/IOpenIdServerService.cs
@@ -14,8 +14,5 @@ namespace OrchardCore.OpenId.Services
         Task<ImmutableArray<ValidationResult>> ValidateSettingsAsync(OpenIdServerSettings settings);
         Task<ImmutableArray<(X509Certificate2 certificate, StoreLocation location, StoreName name)>> GetAvailableCertificatesAsync();
         Task<ImmutableArray<SecurityKey>> GetSigningKeysAsync();
-        Task AddSigningKeyAsync(SecurityKey key);
-        Task<SecurityKey> GenerateSigningKeyAsync();
-        Task<SecurityKey> GenerateSigningKeyAsync<TSecurityKey>() where TSecurityKey : SecurityKey;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
@@ -8,7 +8,6 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Localization;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
@@ -21,18 +20,15 @@ namespace OrchardCore.OpenId.Services
 {
     public class OpenIdServerService : IOpenIdServerService
     {
-        private readonly IMemoryCache _cache;
         private readonly IDataProtector _dataProtector;
         private readonly ISiteService _siteService;
         private readonly IStringLocalizer<OpenIdServerService> T;
 
         public OpenIdServerService(
-            IMemoryCache cache,
             IDataProtectionProvider dataProtectionProvider,
             ISiteService siteService,
             IStringLocalizer<OpenIdServerService> stringLocalizer)
         {
-            _cache = cache;
             _dataProtector = dataProtectionProvider.CreateProtector(nameof(OpenIdServerService));
             _siteService = siteService;
             T = stringLocalizer;

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
@@ -47,16 +47,6 @@ namespace OrchardCore.OpenId.Services
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            // Automatically remove expired keys before persisting the settings.
-            for (var index = settings.SigningKeys.Count - 1; index >= 0; index--)
-            {
-                var key = settings.SigningKeys[index];
-                if (key.ExpirationDate != null && key.ExpirationDate.Value.AddDays(5) < DateTimeOffset.UtcNow)
-                {
-                    settings.SigningKeys.RemoveAt(index);
-                }
-            }
-
             var container = await _siteService.GetSiteSettingsAsync();
             container.Properties[nameof(OpenIdServerSettings)] = JObject.FromObject(settings);
             await _siteService.UpdateSiteSettingsAsync(container);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Localization;
 using Microsoft.IdentityModel.Tokens;
@@ -18,15 +22,18 @@ namespace OrchardCore.OpenId.Services
     public class OpenIdServerService : IOpenIdServerService
     {
         private readonly IMemoryCache _cache;
+        private readonly IDataProtector _dataProtector;
         private readonly ISiteService _siteService;
         private readonly IStringLocalizer<OpenIdServerService> T;
 
         public OpenIdServerService(
             IMemoryCache cache,
+            IDataProtectionProvider dataProtectionProvider,
             ISiteService siteService,
             IStringLocalizer<OpenIdServerService> stringLocalizer)
         {
             _cache = cache;
+            _dataProtector = dataProtectionProvider.CreateProtector(nameof(OpenIdServerService));
             _siteService = siteService;
             T = stringLocalizer;
         }
@@ -42,6 +49,16 @@ namespace OrchardCore.OpenId.Services
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
+            }
+
+            // Automatically remove expired keys before persisting the settings.
+            for (var index = settings.SigningKeys.Count - 1; index >= 0; index--)
+            {
+                var key = settings.SigningKeys[index];
+                if (key.ExpirationDate != null && key.ExpirationDate.Value.AddDays(5) < DateTimeOffset.UtcNow)
+                {
+                    settings.SigningKeys.RemoveAt(index);
+                }
             }
 
             var container = await _siteService.GetSiteSettingsAsync();
@@ -80,80 +97,46 @@ namespace OrchardCore.OpenId.Services
                         nameof(settings.Authority)
                     }));
                 }
-
-                if (!settings.TestingModeEnabled && string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase))
-                {
-                    results.Add(new ValidationResult(T["The authority cannot be a HTTP URL when the testing mode is disabled."], new[]
-                    {
-                        nameof(settings.Authority)
-                    }));
-                }
             }
 
-            if (!settings.TestingModeEnabled)
+            if (settings.CertificateStoreLocation != null &&
+                settings.CertificateStoreName != null &&
+                !string.IsNullOrEmpty(settings.CertificateThumbprint))
             {
-                if (settings.CertificateStoreName == null)
-                {
-                    results.Add(new ValidationResult(T["The certificate store name is required."], new[]
-                    {
-                        nameof(settings.CertificateStoreName)
-                    }));
-                }
+                var certificate = GetCertificate(
+                    settings.CertificateStoreLocation.Value,
+                    settings.CertificateStoreName.Value, settings.CertificateThumbprint);
 
-                if (settings.CertificateStoreLocation == null)
+                if (certificate == null)
                 {
-                    results.Add(new ValidationResult(T["The certificate store location is required."], new[]
-                    {
-                        nameof(settings.CertificateStoreLocation)
-                    }));
-                }
-
-                if (string.IsNullOrEmpty(settings.CertificateThumbprint))
-                {
-                    results.Add(new ValidationResult(T["A certificate is required when testing mode is disabled."], new[]
+                    results.Add(new ValidationResult(T["The certificate cannot be found."], new[]
                     {
                         nameof(settings.CertificateThumbprint)
                     }));
                 }
 
-                if (settings.CertificateStoreLocation != null &&
-                    settings.CertificateStoreName != null &&
-                    !string.IsNullOrEmpty(settings.CertificateThumbprint))
+                else if (!certificate.HasPrivateKey)
                 {
-                    var certificate = GetCertificate(settings.CertificateStoreLocation.Value,
-                        settings.CertificateStoreName.Value, settings.CertificateThumbprint);
-
-                    if (certificate == null)
+                    results.Add(new ValidationResult(T["The certificate doesn't contain the required private key."], new[]
                     {
-                        results.Add(new ValidationResult(T["The certificate cannot be found."], new[]
-                        {
-                            nameof(settings.CertificateThumbprint)
-                        }));
-                    }
+                        nameof(settings.CertificateThumbprint)
+                    }));
+                }
 
-                    if (!certificate.HasPrivateKey)
+                else if (certificate.Archived)
+                {
+                    results.Add(new ValidationResult(T["The certificate is not valid because it is marked as archived."], new[]
                     {
-                        results.Add(new ValidationResult(T["The certificate doesn't contain the required private key."], new[]
-                        {
-                            nameof(settings.CertificateThumbprint)
-                        }));
-                    }
+                        nameof(settings.CertificateThumbprint)
+                    }));
+                }
 
-                    if (certificate.Archived)
+                else if (certificate.NotBefore > DateTime.Now || certificate.NotAfter < DateTime.Now)
+                {
+                    results.Add(new ValidationResult(T["The certificate is not valid for current date."], new[]
                     {
-                        results.Add(new ValidationResult(T["The certificate is not valid because it is marked as archived."], new[]
-                        {
-                            nameof(settings.CertificateThumbprint)
-                        }));
-                    }
-
-                    if (certificate.NotBefore > DateTime.Now || certificate.NotAfter < DateTime.Now)
-                    {
-                        results.Add(new ValidationResult(T["The certificate is not valid for current date."], new[]
-                        {
-                            nameof(settings.CertificateThumbprint)
-                        }));
-                    }
+                        nameof(settings.CertificateThumbprint)
+                    }));
                 }
             }
 
@@ -249,21 +232,11 @@ namespace OrchardCore.OpenId.Services
 
         public async Task<ImmutableArray<SecurityKey>> GetSigningKeysAsync()
         {
+            var keys = ImmutableArray.CreateBuilder<SecurityKey>();
+
             var settings = await GetSettingsAsync();
-            if (settings.TestingModeEnabled)
-            {
-                var parameters = _cache.Get(nameof(RSAParameters)) as RSAParameters?;
-                if (parameters == null)
-                {
-                    parameters = _cache.Set(nameof(RSAParameters), GenerateRsaKey(2048));
-                }
 
-                var algorithm = RSA.Create();
-                algorithm.ImportParameters(parameters.Value);
-
-                return ImmutableArray.Create<SecurityKey>(new RsaSecurityKey(algorithm));
-            }
-
+            // If a certificate was provided, register it before adding the signing keys.
             if (settings.CertificateStoreLocation != null &&
                 settings.CertificateStoreName != null &&
                 !string.IsNullOrEmpty(settings.CertificateThumbprint))
@@ -272,44 +245,187 @@ namespace OrchardCore.OpenId.Services
                     settings.CertificateStoreLocation.Value,
                     settings.CertificateStoreName.Value, settings.CertificateThumbprint);
 
-                return ImmutableArray.Create<SecurityKey>(new X509SecurityKey(certificate));
+                if (certificate != null)
+                {
+                    keys.Add(new X509SecurityKey(certificate));
+                }
             }
 
-            throw new InvalidOperationException("No appropriate signing key was found.");
-
-            RSAParameters GenerateRsaKey(int size)
+            foreach (var key in settings.SigningKeys.OrderByDescending(key => key.ExpirationDate).ToList())
             {
-                // Note: a 1024-bit key might be returned by RSA.Create() on .NET Desktop/Mono,
-                // where RSACryptoServiceProvider is still the default implementation and
-                // where custom implementations can be registered via CryptoConfig.
-                // To ensure the key size is always acceptable, replace it if necessary.
-                var rsa = RSA.Create();
+                // If the signing key has an expiration date, only add it if is still valid.
+                if (key.ExpirationDate != null && key.ExpirationDate.Value.AddDays(1) < DateTimeOffset.UtcNow)
+                {
+                    continue;
+                }
 
+                // Note: only RSA signing keys are currently supported by the OpenID module.
+                if (!string.Equals(key.Type, JsonWebAlgorithmsKeyTypes.RSA, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Note: the parameters may be null if the payload couldn't be decrypted.
+                var parameters = DecryptRsaSigningKey(key.Payload);
+                if (parameters == null)
+                {
+                    continue;
+                }
+
+                keys.Add(new RsaSecurityKey(parameters.Value));
+            }
+
+            return keys.ToImmutable();
+
+            RSAParameters? DecryptRsaSigningKey(ReadOnlySpan<byte> payload)
+            {
+                // Note: an exception thrown in this block may be caused by a corrupted or inappropriate key
+                // (for instance, if the key was created for another application or another environment).
+                // Always catch the exception and return null in this case to avoid leaking sensitive data.
                 try
                 {
-                    if (rsa.KeySize < size)
+                    var bytes = _dataProtector.Unprotect(payload.ToArray());
+                    if (bytes == null)
                     {
-                        rsa.KeySize = size;
+                        return null;
                     }
 
-                    if (rsa.KeySize < size && rsa is RSACryptoServiceProvider)
+                    using (var stream = new MemoryStream(bytes))
+                    using (var reader = new BinaryReader(stream))
                     {
-                        rsa.Dispose();
-                        rsa = new RSACryptoServiceProvider(size);
+                        return new RSAParameters
+                        {
+                            D = reader.ReadBytes(reader.ReadInt32()),
+                            DP = reader.ReadBytes(reader.ReadInt32()),
+                            DQ = reader.ReadBytes(reader.ReadInt32()),
+                            Exponent = reader.ReadBytes(reader.ReadInt32()),
+                            InverseQ = reader.ReadBytes(reader.ReadInt32()),
+                            Modulus = reader.ReadBytes(reader.ReadInt32()),
+                            P = reader.ReadBytes(reader.ReadInt32()),
+                            Q = reader.ReadBytes(reader.ReadInt32())
+                        };
+                    }
+                }
+
+                catch
+                {
+                    return null;
+                }
+            }
+        }
+
+        public async Task AddSigningKeyAsync(SecurityKey key)
+        {
+            var settings = await GetSettingsAsync();
+
+            if (key is RsaSecurityKey rsaSecurityKey)
+            {
+                settings.SigningKeys.Add(new OpenIdServerSettings.SigningKey
+                {
+                    CreationDate = DateTimeOffset.UtcNow,
+                    ExpirationDate = DateTimeOffset.UtcNow.AddDays(90),
+                    Payload = EncryptRsaSigningKey(rsaSecurityKey.Rsa).ToArray(),
+                    Type = JsonWebAlgorithmsKeyTypes.RSA
+                });
+            }
+            else
+            {
+                throw new InvalidOperationException("The specified security key is not supported.");
+            }
+
+            await UpdateSettingsAsync(settings);
+
+            ReadOnlySpan<byte> EncryptRsaSigningKey(RSA algorithm)
+            {
+                var parameters = algorithm.ExportParameters(includePrivateParameters: true);
+
+                using (var stream = new MemoryStream())
+                using (var writer = new BinaryWriter(stream))
+                {
+                    writer.Write(parameters.D.Length);
+                    writer.Write(parameters.D);
+                    writer.Write(parameters.DP.Length);
+                    writer.Write(parameters.DP);
+                    writer.Write(parameters.DQ.Length);
+                    writer.Write(parameters.DQ);
+                    writer.Write(parameters.Exponent.Length);
+                    writer.Write(parameters.Exponent);
+                    writer.Write(parameters.InverseQ.Length);
+                    writer.Write(parameters.InverseQ);
+                    writer.Write(parameters.Modulus.Length);
+                    writer.Write(parameters.Modulus);
+                    writer.Write(parameters.P.Length);
+                    writer.Write(parameters.P);
+                    writer.Write(parameters.Q.Length);
+                    writer.Write(parameters.Q);
+                    writer.Flush();
+
+                    return _dataProtector.Protect(stream.ToArray());
+                }
+            }
+        }
+
+        public Task<SecurityKey> GenerateSigningKeyAsync() => GenerateSigningKeyAsync<RsaSecurityKey>();
+
+        public Task<SecurityKey> GenerateSigningKeyAsync<TSecurityKey>() where TSecurityKey : SecurityKey
+        {
+            if (typeof(TSecurityKey) == typeof(RsaSecurityKey))
+            {
+                return Task.FromResult<SecurityKey>(new RsaSecurityKey(GenerateRsaSigningKey(size: 2048)));
+            }
+
+            throw new InvalidOperationException("The specified security key type is not supported.");
+
+            RSA GenerateRsaSigningKey(int size)
+            {
+                RSA algorithm = null;
+
+                // By default, the default RSA implementation used by .NET Core relies on the newest Windows CNG APIs.
+                // Unfortunately, when a new key is generated using the default RSA.Create() method, it is not bound
+                // to the machine account, which may cause security exceptions when running Orchard on IIS using a
+                // virtual application pool identity or without the profile loading feature enabled (off by default).
+                // To ensure a RSA key can be generated flawlessly, it is manually created using the managed CNG APIs.
+                // For more information, visit https://github.com/openiddict/openiddict-core/issues/204.
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    // Warning: ensure a null key name is specified to ensure the RSA key is not persisted by CNG.
+                    var key = CngKey.Create(CngAlgorithm.Rsa, keyName: null, new CngKeyCreationParameters
+                    {
+                        ExportPolicy = CngExportPolicies.AllowPlaintextExport,
+                        KeyCreationOptions = CngKeyCreationOptions.MachineKey,
+                        KeyUsage = CngKeyUsages.Signing,
+                        Parameters = { new CngProperty("Length", BitConverter.GetBytes(size), CngPropertyOptions.None) }
+                    });
+
+                    algorithm = new RSACng(key);
+                }
+
+                else
+                {
+                    algorithm = RSA.Create();
+
+                    // Note: a 1024-bit key might be returned by RSA.Create() on .NET Desktop/Mono,
+                    // where RSACryptoServiceProvider is still the default implementation and
+                    // where custom implementations can be registered via CryptoConfig.
+                    // To ensure the key size is always acceptable, replace it if necessary.
+                    if (algorithm.KeySize < size)
+                    {
+                        algorithm.KeySize = size;
                     }
 
-                    if (rsa.KeySize < size)
+                    if (algorithm.KeySize < size && algorithm is RSACryptoServiceProvider)
+                    {
+                        algorithm.Dispose();
+                        algorithm = new RSACryptoServiceProvider(size);
+                    }
+
+                    if (algorithm.KeySize < size)
                     {
                         throw new InvalidOperationException("The RSA key generation failed.");
                     }
-
-                    return rsa.ExportParameters(includePrivateParameters: true);
                 }
 
-                finally
-                {
-                    rsa?.Dispose();
-                }
+                return algorithm;
             }
         }
 
@@ -323,7 +439,7 @@ namespace OrchardCore.OpenId.Services
 
                 switch (certificates.Count)
                 {
-                    case 0: throw new InvalidOperationException("The certificate was not found.");
+                    case 0: return null;
                     case 1: return certificates[0];
                     default: throw new InvalidOperationException("Multiple certificates with the same thumbprint were found.");
                 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdServerSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdServerSettings.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Http;
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdServerSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdServerSettings.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Http;
 
@@ -7,7 +8,6 @@ namespace OrchardCore.OpenId.Settings
 {
     public class OpenIdServerSettings
     {
-        public bool TestingModeEnabled { get; set; }
         public TokenFormat AccessTokenFormat { get; set; }
         public string Authority { get; set; }
         public StoreLocation? CertificateStoreLocation { get; set; }
@@ -19,11 +19,20 @@ namespace OrchardCore.OpenId.Settings
         public PathString UserinfoEndpointPath { get; set; }
         public ISet<string> GrantTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
         public bool UseRollingTokens { get; set; }
+        public IList<SigningKey> SigningKeys { get; } = new List<SigningKey>();
 
         public enum TokenFormat
         {
             Encrypted = 0,
             JWT = 1
+        }
+
+        public class SigningKey
+        {
+            public DateTimeOffset? CreationDate { get; set; }
+            public DateTimeOffset? ExpirationDate { get; set; }
+            public byte[] Payload { get; set; }
+            public string Type { get; set; }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdServerSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdServerSettings.cs
@@ -18,20 +18,11 @@ namespace OrchardCore.OpenId.Settings
         public PathString UserinfoEndpointPath { get; set; }
         public ISet<string> GrantTypes { get; } = new HashSet<string>(StringComparer.Ordinal);
         public bool UseRollingTokens { get; set; }
-        public IList<SigningKey> SigningKeys { get; } = new List<SigningKey>();
 
         public enum TokenFormat
         {
             Encrypted = 0,
             JWT = 1
-        }
-
-        public class SigningKey
-        {
-            public DateTimeOffset? CreationDate { get; set; }
-            public DateTimeOffset? ExpirationDate { get; set; }
-            public byte[] Payload { get; set; }
-            public string Type { get; set; }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -19,6 +19,7 @@ using OpenIddict.Validation;
 using OpenIddict.Validation.Internal;
 using OrchardCore.BackgroundTasks;
 using OrchardCore.Data.Migration;
+using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
@@ -123,7 +124,8 @@ namespace OrchardCore.OpenId
         {
             services.TryAddSingleton<IOpenIdServerService, OpenIdServerService>();
             services.TryAddTransient<JwtBearerHandler>();
-            services.AddScoped<IDisplayDriver<ISite>, OpenIdServerSettingsDisplayDriver>();
+            services.AddScoped<IDisplayDriver<OpenIdServerSettings>, OpenIdServerSettingsDisplayDriver>();
+            services.AddScoped<IDisplayManager<OpenIdServerSettings>, DisplayManager<OpenIdServerSettings>>();
             services.AddSingleton<IBackgroundTask, OpenIdBackgroundTask>();
 
             services.AddRecipeExecutionStep<OpenIdServerSettingsStep>();
@@ -230,7 +232,8 @@ namespace OrchardCore.OpenId
         {
             services.TryAddSingleton<IOpenIdValidationService, OpenIdValidationService>();
             services.TryAddTransient<JwtBearerHandler>();
-            services.AddScoped<IDisplayDriver<ISite>, OpenIdValidationSettingsDisplayDriver>();
+            services.AddScoped<IDisplayDriver<OpenIdValidationSettings>, OpenIdValidationSettingsDisplayDriver>();
+            services.AddScoped<IDisplayManager<OpenIdValidationSettings>, DisplayManager<OpenIdValidationSettings>>();
 
             services.AddOpenIddict()
                 .AddValidation();

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
@@ -6,22 +6,51 @@ using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
 using OrchardCore.BackgroundTasks;
 using OrchardCore.OpenId.Abstractions.Managers;
+using OrchardCore.OpenId.Services;
 
 namespace OrchardCore.OpenId.Tasks
 {
-    [BackgroundTask(Schedule = "*/30 * * * *", Description = "Remove orphaned tokens / authorizations.")]
+    [BackgroundTask(Schedule = "*/30 * * * *", Description = "Performs various cleanup operations for OpenID-related features.")]
     public class OpenIdBackgroundTask : IBackgroundTask
     {
         private readonly ILogger<OpenIdBackgroundTask> _logger;
+        private readonly IOpenIdServerService _serverService;
 
-        public OpenIdBackgroundTask(ILogger<OpenIdBackgroundTask> logger)
+        public OpenIdBackgroundTask(
+            ILogger<OpenIdBackgroundTask> logger,
+            IOpenIdServerService serverService)
         {
             _logger = logger;
+            _serverService = serverService;
         }
 
         public async Task DoWorkAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
         {
-            // Note: this background task is responsible of automatically removing orphaned tokens/authorizations
+            // Remove signing keys that are no longer valid from the key set.
+            try
+            {
+                var settings = await _serverService.GetSettingsAsync();
+                for (var index = settings.SigningKeys.Count - 1; index >= 0; index--)
+                {
+                    var key = settings.SigningKeys[index];
+                    if (key.ExpirationDate != null && key.ExpirationDate.Value.AddDays(5) < DateTimeOffset.UtcNow)
+                    {
+                        settings.SigningKeys.RemoveAt(index);
+                    }
+                }
+
+                await _serverService.UpdateSettingsAsync(settings);
+            }
+            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
+            {
+                _logger.LogDebug("The signing key pruning task was aborted.");
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(exception, "An error occurred while pruning signing keys from the database.");
+            }
+
+            // Note: this background task is also responsible of automatically removing orphaned tokens/authorizations
             // (i.e tokens that are no longer valid and ad-hoc authorizations that have no valid tokens associated).
             // Since ad-hoc authorizations and their associated tokens are removed as part of the same operation
             // when they no longer have any token attached, it's more efficient to remove the authorizations first.

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
 using OrchardCore.BackgroundTasks;
 using OrchardCore.OpenId.Abstractions.Managers;
-using OrchardCore.OpenId.Services;
 
 namespace OrchardCore.OpenId.Tasks
 {
@@ -14,43 +13,13 @@ namespace OrchardCore.OpenId.Tasks
     public class OpenIdBackgroundTask : IBackgroundTask
     {
         private readonly ILogger<OpenIdBackgroundTask> _logger;
-        private readonly IOpenIdServerService _serverService;
 
-        public OpenIdBackgroundTask(
-            ILogger<OpenIdBackgroundTask> logger,
-            IOpenIdServerService serverService)
-        {
-            _logger = logger;
-            _serverService = serverService;
-        }
+        public OpenIdBackgroundTask(ILogger<OpenIdBackgroundTask> logger)
+            => _logger = logger;
 
         public async Task DoWorkAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
         {
-            // Remove signing keys that are no longer valid from the key set.
-            try
-            {
-                var settings = await _serverService.GetSettingsAsync();
-                for (var index = settings.SigningKeys.Count - 1; index >= 0; index--)
-                {
-                    var key = settings.SigningKeys[index];
-                    if (key.ExpirationDate != null && key.ExpirationDate.Value.AddDays(5) < DateTimeOffset.UtcNow)
-                    {
-                        settings.SigningKeys.RemoveAt(index);
-                    }
-                }
-
-                await _serverService.UpdateSettingsAsync(settings);
-            }
-            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
-            {
-                _logger.LogDebug("The signing key pruning task was aborted.");
-            }
-            catch (Exception exception)
-            {
-                _logger.LogError(exception, "An error occurred while pruning signing keys from the database.");
-            }
-
-            // Note: this background task is also responsible of automatically removing orphaned tokens/authorizations
+            // Note: this background task is responsible of automatically removing orphaned tokens/authorizations
             // (i.e tokens that are no longer valid and ad-hoc authorizations that have no valid tokens associated).
             // Since ad-hoc authorizations and their associated tokens are removed as part of the same operation
             // when they no longer have any token attached, it's more efficient to remove the authorizations first.

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using OpenIddict.Abstractions;
 using OrchardCore.BackgroundTasks;
 using OrchardCore.OpenId.Abstractions.Managers;
+using OrchardCore.OpenId.Services;
 
 namespace OrchardCore.OpenId.Tasks
 {
@@ -13,13 +14,32 @@ namespace OrchardCore.OpenId.Tasks
     public class OpenIdBackgroundTask : IBackgroundTask
     {
         private readonly ILogger<OpenIdBackgroundTask> _logger;
+        private readonly IOpenIdServerService _serverService;
 
-        public OpenIdBackgroundTask(ILogger<OpenIdBackgroundTask> logger)
-            => _logger = logger;
+        public OpenIdBackgroundTask(
+            ILogger<OpenIdBackgroundTask> logger,
+            IOpenIdServerService serverService)
+        {
+            _logger = logger;
+            _serverService = serverService;
+        }
 
         public async Task DoWorkAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
         {
-            // Note: this background task is responsible of automatically removing orphaned tokens/authorizations
+            try
+            {
+                await _serverService.PruneSigningKeysAsync();
+            }
+            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
+            {
+                _logger.LogDebug("The X.509 certificates pruning task was aborted.");
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(exception, "An error occurred while pruning X.509 certificates from the shell storage.");
+            }
+
+            // Note: this background task is also responsible of automatically removing orphaned tokens/authorizations
             // (i.e tokens that are no longer valid and ad-hoc authorizations that have no valid tokens associated).
             // Since ad-hoc authorizations and their associated tokens are removed as part of the same operation
             // when they no longer have any token attached, it's more efficient to remove the authorizations first.

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdServerSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdServerSettingsViewModel.cs
@@ -7,7 +7,6 @@ namespace OrchardCore.OpenId.ViewModels
 {
     public class OpenIdServerSettingsViewModel
     {
-        public bool TestingModeEnabled { get; set; }
         public TokenFormat AccessTokenFormat { get; set; }
         public string Authority { get; set; }
         public StoreLocation? CertificateStoreLocation { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdServerSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdServerSettings.Edit.cshtml
@@ -1,79 +1,9 @@
-@using Microsoft.Extensions.Options
 @using OrchardCore.OpenId.ViewModels
 @using OrchardCore.OpenId.Settings
 @using System.Security.Cryptography.X509Certificates
 @model OpenIdServerSettingsViewModel
 
 <p class="alert alert-warning">@T["The current tenant will be reloaded when the settings are saved."]</p>
-
-<fieldset class="form-group">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="TestingModeEnabled" data-toggle="collapse active" data-target="#certArea" checked="@Model.TestingModeEnabled">
-        <label class="custom-control-label" asp-for="TestingModeEnabled">@T["Enable Testing Mode"]</label>
-        <span class="hint">@T["— {0}", "Disables https requirement and uses an ephemeral signing key."]</span>
-    </div>
-</fieldset>
-
-<div id="certArea" class="collapse">
-    <fieldset class="form-group" asp-validation-class-for="CertificateStoreLocation">
-        <label asp-for="CertificateStoreLocation">@T["Certificate Store Location"]</label>
-        <select asp-for="CertificateStoreLocation" class="form-control">
-            @foreach (StoreLocation location in Enum.GetValues(typeof(StoreLocation)))
-            {
-                <option value="@location" selected="@(Model.CertificateStoreLocation == location)">@location.ToString()</option>
-            }
-        </select>
-        <span asp-validation-for="CertificateStoreLocation"></span>
-        <span class="hint">@T["Select the certificate location."]</span>
-    </fieldset>
-
-    <fieldset class="form-group" asp-validation-class-for="CertificateStoreName">
-        <label asp-for="CertificateStoreName">@T["Certificate Store Name"]</label>
-        <select asp-for="CertificateStoreName" class="form-control">
-            @foreach (StoreName store in Enum.GetValues(typeof(StoreName)))
-            {
-                <option value="@store" selected="@(Model.CertificateStoreName == store)">@store.ToString()</option>
-            }
-        </select>
-        <span asp-validation-for="CertificateStoreName"></span>
-        <span class="hint">@T["Select the certificate store."]</span>
-    </fieldset>
-
-    <fieldset class="form-group" asp-validation-class-for="CertificateThumbprint">
-        @if (Model.AvailableCertificates.Count != 0)
-        {
-
-            <label asp-for="CertificateThumbprint">@T["Certificate"]</label>
-            <select asp-for="CertificateThumbprint" class="form-control">
-                @foreach (var certificate in Model.AvailableCertificates)
-                {
-                    var selectedCertificate = Model.CertificateThumbprint == certificate.ThumbPrint
-                                                && Model.CertificateStoreLocation.HasValue && Model.CertificateStoreLocation.Value == certificate.StoreLocation
-                                                && Model.CertificateStoreName.HasValue && Model.CertificateStoreName == certificate.StoreName;
-                    if (string.IsNullOrWhiteSpace(certificate.ThumbPrint))
-                    {
-                        <option value="" data-StoreLocation="@certificate.StoreLocation" data-StoreName="@certificate.StoreName" selected="@(selectedCertificate)"></option>
-                        continue;
-                    }
-                    var friendlyName = certificate.FriendlyName;
-                    if (string.IsNullOrWhiteSpace(friendlyName) && !string.IsNullOrWhiteSpace(certificate.ThumbPrint))
-                    {
-                        friendlyName = "No Friendly Name";
-                    }
-                    <option value="@certificate.ThumbPrint" data-StoreLocation="@certificate.StoreLocation" data-StoreName="@certificate.StoreName" selected="@(selectedCertificate)">
-                        @friendlyName [@certificate.NotBefore.ToString("dd/MM/yy") - @certificate.NotAfter.ToString("dd/MM/yy")] @certificate.Subject
-                    </option>
-                }
-            </select>
-            <span asp-validation-for="CertificateThumbprint"></span>
-            <span class="hint">@T["Select the certificate for signing tokens."]</span>
-        }
-        else
-        {
-            <div class="alert alert-warning" asp-validation-for="CertificateThumbprint">@T["You need to add a certificate to your server for setting up OpenID Connect module."]</div>
-        }
-    </fieldset>
-</div>
 
 <h3>Endpoints</h3>
 <fieldset class="form-group" asp-validation-class-for="EnableTokenEndpoint">
@@ -158,6 +88,71 @@
     <span class="hint">@T["The base URL of the identity server (this site). If none is provided, a default value based on the site host is automatically computed."]</span>
 </fieldset>
 
+<fieldset class="form-group" asp-validation-class-for="CertificateStoreLocation">
+    <label asp-for="CertificateStoreLocation">@T["Certificate Store Location"]</label>
+    <select asp-for="CertificateStoreLocation" class="form-control">
+        <option value="">@T["None"]</option>
+
+        @foreach (StoreLocation location in Enum.GetValues(typeof(StoreLocation)))
+        {
+            <option value="@location" selected="@(Model.CertificateStoreLocation == location)">@location.ToString()</option>
+        }
+    </select>
+    <span asp-validation-for="CertificateStoreLocation"></span>
+    <span class="hint">@T["Select the certificate location."]</span>
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="CertificateStoreName">
+    <label asp-for="CertificateStoreName">@T["Certificate Store Name"]</label>
+    <select asp-for="CertificateStoreName" class="form-control">
+        <option value="">@T["None"]</option>
+
+        @foreach (StoreName store in Enum.GetValues(typeof(StoreName)))
+        {
+            <option value="@store" selected="@(Model.CertificateStoreName == store)">@store.ToString()</option>
+        }
+    </select>
+    <span asp-validation-for="CertificateStoreName"></span>
+    <span class="hint">@T["Select the certificate store."]</span>
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="CertificateThumbprint">
+    @if (Model.AvailableCertificates.Count != 0)
+    {
+
+        <label asp-for="CertificateThumbprint">@T["Certificate"]</label>
+        <select asp-for="CertificateThumbprint" class="form-control">
+            <option value="">@T["None"]</option>
+
+            @foreach (var certificate in Model.AvailableCertificates)
+            {
+                var selectedCertificate = Model.CertificateThumbprint == certificate.ThumbPrint
+                                            && Model.CertificateStoreLocation.HasValue && Model.CertificateStoreLocation.Value == certificate.StoreLocation
+                                            && Model.CertificateStoreName.HasValue && Model.CertificateStoreName == certificate.StoreName;
+                if (string.IsNullOrWhiteSpace(certificate.ThumbPrint))
+                {
+                    <option value="" data-StoreLocation="@certificate.StoreLocation" data-StoreName="@certificate.StoreName" selected="@(selectedCertificate)"></option>
+                    continue;
+                }
+                var friendlyName = certificate.FriendlyName;
+                if (string.IsNullOrWhiteSpace(friendlyName) && !string.IsNullOrWhiteSpace(certificate.ThumbPrint))
+                {
+                    friendlyName = "No Friendly Name";
+                }
+                <option value="@certificate.ThumbPrint" data-StoreLocation="@certificate.StoreLocation" data-StoreName="@certificate.StoreName" selected="@(selectedCertificate)">
+                    @friendlyName [@certificate.NotBefore.ToString("dd/MM/yy") - @certificate.NotAfter.ToString("dd/MM/yy")] @certificate.Subject
+                </option>
+            }
+        </select>
+        <span asp-validation-for="CertificateThumbprint"></span>
+        <span class="hint">@T["Select the certificate for signing tokens."]</span>
+    }
+    else
+    {
+        <div class="alert alert-warning" asp-validation-for="CertificateThumbprint">@T["You need to add a certificate to your server for setting up OpenID Connect module."]</div>
+    }
+</fieldset>
+
 <fieldset class="form-group" asp-validation-class-for="UseRollingTokens">
     <div class="custom-control custom-checkbox">
         <input type="checkbox" class="custom-control-input" asp-for="UseRollingTokens">
@@ -180,28 +175,44 @@
 <script at="Foot" type="text/javascript">
 ////<![CDATA[
     window.onload = function () {
-        refreshTestingModeEnabled();
+        refreshCertificates();
         refreshEndpoints();
         $("#@Html.IdFor(m => m.AccessTokenFormat)").change(function () {
             refreshTokenTypeHint();
         });
-        $("#@Html.IdFor(m => m.CertificateThumbprint)").children("option").hide();
-        $("#@Html.IdFor(m => m.CertificateThumbprint)").children("option[data-StoreLocation=" + $("#@Html.IdFor(m => m.CertificateStoreLocation)").val() + "][data-StoreName=" + $("#@Html.IdFor(m => m.CertificateStoreName)").val() + "]").show();
         $("#@Html.IdFor(m => m.CertificateStoreLocation)").change(function () {
-            $("#@Html.IdFor(m => m.CertificateThumbprint)").children("option").hide();
-            $("#@Html.IdFor(m => m.CertificateThumbprint)").children("option[data-StoreLocation=" + $(this).val() + "][data-StoreName=" + $("#@Html.IdFor(m => m.CertificateStoreName)").val() + "]").show();
+            refreshCertificates();
         });
         $("#@Html.IdFor(m => m.CertificateStoreName)").change(function () {
-            $("#@Html.IdFor(m => m.CertificateThumbprint)").children("option").hide();
-            $("#@Html.IdFor(m => m.CertificateThumbprint)").children("option[data-StoreLocation=" + $("#@Html.IdFor(m => m.CertificateStoreLocation)").val() + "][data-StoreName=" + $(this).val() + "]").show();
+            refreshCertificates()
         });
         $("#@Html.IdFor(m => m.EnableTokenEndpoint), #@Html.IdFor(m => m.EnableAuthorizationEndpoint), #@Html.IdFor(m => m.AllowPasswordFlow), #@Html.IdFor(m => m.AllowAuthorizationCodeFlow)").change(function () {
             refreshEndpoints();
         });
-        function refreshTestingModeEnabled() {
-            var testingModeEnabled = $("#@Html.IdFor(m => m.TestingModeEnabled)");
-            $("#certArea").collapse(testingModeEnabled.prop("checked") ? "hide" : "show");
+        function refreshCertificates() {
+            var location = $("#@Html.IdFor(m => m.CertificateStoreLocation)"),
+                name = $("#@Html.IdFor(m => m.CertificateStoreName)"),
+                thumbprint = $("#@Html.IdFor(m => m.CertificateThumbprint)");
 
+            if (location.val()) {
+                name.parent().show();
+
+                if (name.val()) {
+                    thumbprint.parent().show();
+                    thumbprint.children("option[value!='']").hide();
+                    thumbprint.children("option[data-StoreLocation=" + location.val() + "][data-StoreName=" + name.val() + "]").show();
+                }
+                else {
+                    thumbprint.parent().hide();
+                    thumbprint.val("");
+                }
+            }
+            else {
+                name.parent().hide();
+                name.val("");
+                thumbprint.parent().hide();
+                thumbprint.val("");
+            }
         }
         function refreshEndpoints() {
             refreshEnableTokenEndpoint();

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/ServerConfiguration/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/ServerConfiguration/Index.cshtml
@@ -1,0 +1,14 @@
+@model dynamic
+
+<h1>@RenderTitleSegments(T["Configure OpenID server settings"])</h1>
+
+<form asp-action="Index" method="post">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Content)
+
+    <fieldset>
+        <div class="form-group">
+            <button class="btn btn-primary" type="submit">@T["Update the server settings and reload the tenant"]</button>
+        </div>
+    </fieldset>
+</form>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/ValidationConfiguration/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/ValidationConfiguration/Index.cshtml
@@ -1,0 +1,14 @@
+@model dynamic
+
+<h1>@RenderTitleSegments(T["Configure OpenID validation settings"])</h1>
+
+<form asp-action="Index" method="post">
+    @Html.ValidationSummary()
+    @await DisplayAsync(Model.Content)
+
+    <fieldset>
+        <div class="form-group">
+            <button class="btn btn-primary" type="submit">@T["Update the server settings and reload the tenant"]</button>
+        </div>
+    </fieldset>
+</form>

--- a/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/OrchardCore.AdminMenu.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/OrchardCore.AdminMenu.Abstractions.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotations)" />
+    <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.2</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.2</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="$(SystemComponentModelAnnotations)" />
+    <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR removes the testing mode we introduced a while ago and replaces it by a managed key management system, where RSA X.509 certificates are automatically generated and stored in the App_Data folder by the OpenID module itself.

Since this system is expected to work even on production environments, it should be a good alternative to a manually set certificate, whose corresponding section was moved to the advanced settings of the server configuration page.