### PR TITLE
Update assets references to use app-relative paths

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Items/LinkAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Items/LinkAdminNode.Fields.TreeEdit.cshtml
@@ -1,11 +1,11 @@
 @model LinkAdminNodeViewModel
 
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees.css" at="Head" depends-on="admin"></style>
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" at="Head" depends-on="admin"></style>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees.css" at="Head" depends-on="admin"></style>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" at="Head" depends-on="admin"></style>
 
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
-<script asp-src="/OrchardCore.AdminTrees/Scripts/admin-trees.js" at="Foot" depends-on="admin"></script>
-<script asp-src="/OrchardCore.AdminTrees/Scripts/admin-trees-icon-picker.js" at="Foot" depends-on="admin"></script>
+<script asp-src="~/OrchardCore.AdminTrees/Scripts/admin-trees.js" at="Foot" depends-on="admin"></script>
+<script asp-src="~/OrchardCore.AdminTrees/Scripts/admin-trees-icon-picker.js" at="Foot" depends-on="admin"></script>
 
 <h5>@T["Link"]</h5>
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Items/PlaceholderAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Items/PlaceholderAdminNode.Fields.TreeEdit.cshtml
@@ -1,11 +1,11 @@
 @model PlaceholderAdminNodeViewModel
 
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees.css"at="Head" depends-on="admin"></style>
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" at="Head" depends-on="admin"></style>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees.css"at="Head" depends-on="admin"></style>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" at="Head" depends-on="admin"></style>
 
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
-<script asp-src="/OrchardCore.AdminTrees/Scripts/admin-trees.js" at="Foot" depends-on="admin"></script>
-<script asp-src="/OrchardCore.AdminTrees/Scripts/admin-trees-icon-picker.js" at="Foot" depends-on="admin"></script>
+<script asp-src="~/OrchardCore.AdminTrees/Scripts/admin-trees.js" at="Foot" depends-on="admin"></script>
+<script asp-src="~/OrchardCore.AdminTrees/Scripts/admin-trees-icon-picker.js" at="Foot" depends-on="admin"></script>
 
 <h5>@T["Placeholder"]</h5>
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Node/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Node/List.cshtml
@@ -6,8 +6,8 @@
     var index = 0;
 }
 
-<script asp-src="/OrchardCore.AdminTrees/Scripts/admin-trees.js" at="Foot" depends-on="admin"></script>
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees.css" debug-src="/OrchardCore.AdminTrees/Styles/admin-trees.css"></style>
+<script asp-src="~/OrchardCore.AdminTrees/Scripts/admin-trees.js" at="Foot" depends-on="admin"></script>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees.css" debug-src="~/OrchardCore.AdminTrees/Styles/admin-trees.css"></style>
 
 <div asp-validation-summary="All"></div>
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Tree/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Tree/Edit.cshtml
@@ -1,5 +1,5 @@
 @model AdminTreeEditViewModel
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees.css" debug-src="/OrchardCore.AdminTrees/Styles/admin-trees.css"></style>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees.css" debug-src="~/OrchardCore.AdminTrees/Styles/admin-trees.css"></style>
 
 <h1>@RenderTitleSegments(T["Edit Admin Tree: {0}", Model.Name])</h1>
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Tree/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminTrees/Views/Tree/List.cshtml
@@ -1,7 +1,7 @@
 @model AdminTreeListViewModel
 
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees.css" debug-src="/OrchardCore.AdminTrees/Styles/admin-trees.css" ></style>
-<script asp-src="/OrchardCore.AdminTrees/Scripts/admin-trees.js" asp-name="admin-tree" at="Foot" depends-on="admin"></script>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees.css" debug-src="~/OrchardCore.AdminTrees/Styles/admin-trees.css" ></style>
+<script asp-src="~/OrchardCore.AdminTrees/Scripts/admin-trees.js" asp-name="admin-tree" at="Foot" depends-on="admin"></script>
 
 <h1>@RenderTitleSegments(T["Admin Trees"])</h1>
 

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Views/Admin/Index.cshtml
@@ -1,23 +1,23 @@
-<style asp-src="/OrchardCore.Apis.GraphQL/Styles/graphiql.min.css"
-       debug-src="/OrchardCore.Apis.GraphQL/Styles/graphiql.css">
+<style asp-src="~/OrchardCore.Apis.GraphQL/Styles/graphiql.min.css"
+       debug-src="~/OrchardCore.Apis.GraphQL/Styles/graphiql.css">
 </style>
 
-<style asp-src="/OrchardCore.Apis.GraphQL/Styles/graphiql-orchard.min.css"
-       debug-src="/OrchardCore.Apis.GraphQL/Styles/graphiql-orchard.css">
+<style asp-src="~/OrchardCore.Apis.GraphQL/Styles/graphiql-orchard.min.css"
+       debug-src="~/OrchardCore.Apis.GraphQL/Styles/graphiql-orchard.css">
 </style>
 
-<script asp-src="/OrchardCore.Apis.GraphQL/Scripts/react.min.js"
-        debug-src="/OrchardCore.Apis.GraphQL/Scripts/react.js"
+<script asp-src="~/OrchardCore.Apis.GraphQL/Scripts/react.min.js"
+        debug-src="~/OrchardCore.Apis.GraphQL/Scripts/react.js"
         at="Foot">
 </script>
 
-<script asp-src="/OrchardCore.Apis.GraphQL/Scripts/react-dom.min.js"
-        debug-src="/OrchardCore.Apis.GraphQL/Scripts/react-dom.js"
+<script asp-src="~/OrchardCore.Apis.GraphQL/Scripts/react-dom.min.js"
+        debug-src="~/OrchardCore.Apis.GraphQL/Scripts/react-dom.js"
         at="Foot">
 </script>
 
-<script asp-src="/OrchardCore.Apis.GraphQL/Scripts/graphiql.min.js"
-        debug-src="/OrchardCore.Apis.GraphQL/Scripts/graphiql.js"
+<script asp-src="~/OrchardCore.Apis.GraphQL/Scripts/graphiql.min.js"
+        debug-src="~/OrchardCore.Apis.GraphQL/Scripts/graphiql.js"
         at="Foot">
 </script>
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
@@ -17,8 +17,8 @@
     var multiple = settings.Multiple.ToString().ToLowerInvariant();
 }
 
-<script asp-src="/OrchardCore.ContentFields/Scripts/contentPicker.js" asp-name="contentPicker" at="Foot" depends-on="vuejs, vuemultiselect"></script>
-<style asp-src="/OrchardCore.ContentFields/Styles/contentPicker.min.css" debug-src="/OrchardCore.ContentFields/Styles/contentPicker.css"></style>
+<script asp-src="~/OrchardCore.ContentFields/Scripts/contentPicker.js" asp-name="contentPicker" at="Foot" depends-on="vuejs, vuemultiselect"></script>
+<style asp-src="~/OrchardCore.ContentFields/Styles/contentPicker.min.css" debug-src="~/OrchardCore.ContentFields/Styles/contentPicker.css"></style>
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
 <script asp-src="https://unpkg.com/vue-multiselect@2.1.0/dist/vue-multiselect.min.js" asp-name="vuemultiselect" at="Foot"></script>
 <style asp-src="https://unpkg.com/vue-multiselect@2.1.0/dist/vue-multiselect.min.css"></style>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
@@ -6,8 +6,8 @@
     var settings = Model.PartFieldDefinition.Settings.ToObject<HtmlFieldSettings>();
 }
 
-<script name="trumbowyg" depends-on="admin" asp-src="/OrchardCore.Resources/Scripts/trumbowyg.min.js" debug-src="/OrchardCore.Resources/Scripts/trumbowyg.js" at="Foot"></script>
-<style name="trumbowyg" asp-src="/OrchardCore.Resources/Styles/trumbowyg.min.css" debug-src="/OrchardCore.Resources/Styles/trumbowyg.css"></style>
+<script name="trumbowyg" depends-on="admin" asp-src="~/OrchardCore.Resources/Scripts/trumbowyg.min.js" debug-src="~/OrchardCore.Resources/Scripts/trumbowyg.js" at="Foot"></script>
+<style name="trumbowyg" asp-src="~/OrchardCore.Resources/Styles/trumbowyg.min.css" debug-src="~/OrchardCore.Resources/Styles/trumbowyg.css"></style>
 
 <fieldset class="form-group">
     <label asp-for="Html">@Model.PartFieldDefinition.DisplayName()</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/Media-HtmlField.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/Media-HtmlField.Modal.cshtml
@@ -1,4 +1,4 @@
-<script asp-src="/OrchardCore.ContentFields/Scripts/trumbowyg.media.min.js" debug-src="/OrchardCore.ContentFields/Scripts/trumbowyg.media.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.ContentFields/Scripts/trumbowyg.media.min.js" debug-src="~/OrchardCore.ContentFields/Scripts/trumbowyg.media.js" at="Foot"></script>
 
 <div class="modal fade" id="mediaModalHtmlField">
     <div class="modal-dialog modal-lg" role="document">
@@ -19,8 +19,8 @@
     </div>
 </div>
 
-<script asp-src="/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
-<style asp-src="/OrchardCore.Media/Styles/media.min.css" debug-src="/OrchardCore.Media/Styles/media.css"></style>
+<script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
+<style asp-src="~/OrchardCore.Media/Styles/media.min.css" debug-src="~/OrchardCore.Media/Styles/media.css"></style>
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
 <script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js" debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js" debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable" depends-on="vuejs, sortable" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -11,8 +11,8 @@
     string id = Html.IdFor(m => m.Value);
 }
 
-<script asp-name="bootstrap-slider" depends-on="admin" asp-src="/OrchardCore.Resources/Scripts/bootstrap-slider.min.js" debug-src="/OrchardCore.Resources/Scripts/bootstrap-slider.js" at="Foot"></script>
-<style asp-name="bootstrap-slider" asp-src="/OrchardCore.Resources/Styles/bootstrap-slider.min.css" debug-src="/OrchardCore.Resources/Styles/bootstrap-slider.css"></style>
+<script asp-name="bootstrap-slider" depends-on="admin" asp-src="~/OrchardCore.Resources/Scripts/bootstrap-slider.min.js" debug-src="~/OrchardCore.Resources/Scripts/bootstrap-slider.js" at="Foot"></script>
+<style asp-name="bootstrap-slider" asp-src="~/OrchardCore.Resources/Styles/bootstrap-slider.min.css" debug-src="~/OrchardCore.Resources/Styles/bootstrap-slider.css"></style>
 
 <fieldset class="form-group">
     <div class="row col-sm-2">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-IconPicker.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-IconPicker.Edit.cshtml
@@ -6,12 +6,12 @@
     var settings = Model.PartFieldDefinition.Settings.ToObject<TextFieldSettings>();
 }
 
-<style name="fontpickerStyle" at="Head" asp-src="/OrchardCore.ContentFields/Styles/fontawesome-iconpicker-min.css" debug-src="/OrchardCore.ContentFields/Styles/fontawesome-iconpicker.css"></style>
-<style name="fontpickerCustomStyle" at="Head" asp-src="/OrchardCore.ContentFields/Styles/iconpicker-custom.css"></style>
+<style name="fontpickerStyle" at="Head" asp-src="~/OrchardCore.ContentFields/Styles/fontawesome-iconpicker-min.css" debug-src="~/OrchardCore.ContentFields/Styles/fontawesome-iconpicker.css"></style>
+<style name="fontpickerCustomStyle" at="Head" asp-src="~/OrchardCore.ContentFields/Styles/iconpicker-custom.css"></style>
 <script asp-name="popper" at="Foot"></script>
 <script asp-name="bootstrap" at="Foot" depends-on="popper"></script>
-<script name="fontpickerScript" asp-src="/OrchardCore.ContentFields/Scripts/fontawesome-iconpicker.min.js" debug-src="/OrchardCore.ContentFields/Scripts/fontawesome-iconpicker.js" at="Foot"></script>
-<script name="iconpickerCustomScript" asp-src="/OrchardCore.ContentFields/Scripts/iconpicker-custom.js" at="Foot"></script>
+<script name="fontpickerScript" asp-src="~/OrchardCore.ContentFields/Scripts/fontawesome-iconpicker.min.js" debug-src="~/OrchardCore.ContentFields/Scripts/fontawesome-iconpicker.js" at="Foot"></script>
+<script name="iconpickerCustomScript" asp-src="~/OrchardCore.ContentFields/Scripts/iconpicker-custom.js" at="Foot"></script>
 
 <fieldset class="form-group">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextFieldPredefinedListEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextFieldPredefinedListEditorSettings.Edit.cshtml
@@ -1,8 +1,8 @@
 @using OrchardCore.ContentFields.Settings
 @model OrchardCore.ContentFields.ViewModels.PredefinedListSettingsViewModel
 
-<script asp-src="/OrchardCore.ContentFields/Scripts/optionsEditor.js" asp-name="optionsEditor" at="Foot" depends-on="vuejs, vuemultiselect"></script>
-<style asp-src="/OrchardCore.ContentFields/Styles/optionsEditor.min.css" debug-src="/OrchardCore.ContentFields/Styles/optionsEditor.css"></style>
+<script asp-src="~/OrchardCore.ContentFields/Scripts/optionsEditor.js" asp-name="optionsEditor" at="Foot" depends-on="vuejs, vuemultiselect"></script>
+<style asp-src="~/OrchardCore.ContentFields/Styles/optionsEditor.min.css" debug-src="~/OrchardCore.ContentFields/Styles/optionsEditor.css"></style>
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
 <script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js" debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js" debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable" depends-on="vuejs, sortable" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/ContentPreview.Button.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/ContentPreview.Button.cshtml
@@ -10,4 +10,4 @@
 <div id="previewContentItemId" style="display:none" data-value="@Model.ContentItem.ContentItemId"></div>
 <div id="previewContentItemVersionId" style="display:none" data-value="@Model.ContentItem.ContentItemVersionId"></div>
 
-<script asp-src="/OrchardCore.ContentPreview/Scripts/contentpreview.edit.js" depends-on="admin" at="Foot"></script>
+<script asp-src="~/OrchardCore.ContentPreview/Scripts/contentpreview.edit.js" depends-on="admin" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -5,7 +5,7 @@
 
 <style asp-name="bootstrap"></style>
 <script asp-name="bootstrap" at="Foot"></script>
-<script asp-src="/OrchardCore.Templates/js.cookie.js" depends-on="jquery" at="Foot"></script>
+<script asp-src="~/OrchardCore.Templates/js.cookie.js" depends-on="jquery" at="Foot"></script>
 
 <resources type="Header" />
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.Edit.cshtml
@@ -4,7 +4,7 @@
         Display.LocalNavigation(Tabs: tabs);
     }*@
 
-<style asp-src="/OrchardCore.Contents/Styles/Contents.min.css" debug-src="/OrchardCore.Contents/Styles/Contents.css"></style>
+<style asp-src="~/OrchardCore.Contents/Styles/Contents.min.css" debug-src="~/OrchardCore.Contents/Styles/Contents.css"></style>
 
 <div class="edit-container">
     <div class="edit-body">

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesAdminNode.Fields.TreeEdit.cshtml
@@ -1,10 +1,10 @@
 @model ContentTypesAdminNodeViewModel
 
-<style asp-src="/OrchardCore.Contents/Styles/Contents.min.css" debug-src="/OrchardCore.Contents/Styles/Contents.css"></style>
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" debug-src="/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" at="Head" depends-on="admin"></style>
+<style asp-src="~/OrchardCore.Contents/Styles/Contents.min.css" debug-src="~/OrchardCore.Contents/Styles/Contents.css"></style>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" debug-src="~/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" at="Head" depends-on="admin"></style>
 
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
-<script asp-src="/OrchardCore.AdminTrees/Scripts/admin-trees-icon-picker.js" at="Foot" depends-on="admin"></script>
+<script asp-src="~/OrchardCore.AdminTrees/Scripts/admin-trees-icon-picker.js" at="Foot" depends-on="admin"></script>
 
 <h5>@T["Content Types"]</h5>
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/CreateContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/CreateContentTask.Fields.Edit.cshtml
@@ -28,7 +28,7 @@
 <script asp-name="codemirror-addon-mode-simple" at="Foot"></script>
 <script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
-<script asp-src="/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
 $(function () {

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/Items/EmailTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/Items/EmailTask.Fields.Edit.cshtml
@@ -41,7 +41,7 @@
 <script asp-name="codemirror-addon-mode-simple" at="Foot"></script>
 <script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
-<script asp-src="/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
 $(function () {

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Edit.cshtml
@@ -64,8 +64,8 @@
         Context.Items["BagPart.Edit"] = new object();
         <input type="hidden" id="buildEditorUrl" value="@Url.Action("BuildEditor", "Admin", new { area = "OrchardCore.Flows" })" />
 
-        <script asp-src="/OrchardCore.Flows/Scripts/flows.edit.js" at="Foot" depends-on="admin"></script>
-        <style asp-src="/OrchardCore.Flows/Styles/flows.edit.css"></style>
+        <script asp-src="~/OrchardCore.Flows/Scripts/flows.edit.js" at="Foot" depends-on="admin"></script>
+        <style asp-src="~/OrchardCore.Flows/Styles/flows.edit.css"></style>
     }
 
     @* Rendered only once per type to initialize the scripts its editor will need *@

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -71,8 +71,8 @@
             await DisplayAsync(await ContentItemDisplayManager.BuildEditorAsync(contentItem, Model.Updater, true, "", Guid.NewGuid().ToString("n")));
         }
 
-        <script asp-src="/OrchardCore.Flows/Scripts/flows.edit.js" at="Foot" depends-on="admin"></script>
-        <style asp-src="/OrchardCore.Flows/Styles/flows.edit.css"></style>
+        <script asp-src="~/OrchardCore.Flows/Scripts/flows.edit.js" at="Foot" depends-on="admin"></script>
+        <style asp-src="~/OrchardCore.Flows/Styles/flows.edit.css"></style>
     }
 
     <script at="Foot">

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
@@ -7,8 +7,8 @@
     var settings = Model.TypePartDefinition.Settings.ToObject<HtmlBodyPartSettings>();
 }
 
-<script asp-name="trumbowyg" depends-on="admin" asp-src="/OrchardCore.Resources/Scripts/trumbowyg.min.js" debug-src="/OrchardCore.Resources/Scripts/trumbowyg.js" at="Foot"></script>
-<style asp-name="trumbowyg" asp-src="/OrchardCore.Resources/Styles/trumbowyg.min.css" debug-src="/OrchardCore.Resources/Styles/trumbowyg.css"></style>
+<script asp-name="trumbowyg" depends-on="admin" asp-src="~/OrchardCore.Resources/Scripts/trumbowyg.min.js" debug-src="~/OrchardCore.Resources/Scripts/trumbowyg.js" at="Foot"></script>
+<style asp-name="trumbowyg" asp-src="~/OrchardCore.Resources/Styles/trumbowyg.min.css" debug-src="~/OrchardCore.Resources/Styles/trumbowyg.css"></style>
 
 <fieldset class="form-group">
     <label asp-for="Source">@Model.TypePartDefinition.DisplayName()</label>

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/Media-HtmlBodyPart.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/Media-HtmlBodyPart.Modal.cshtml
@@ -1,4 +1,4 @@
-<script asp-src="/OrchardCore.Html/Scripts/trumbowyg.media.min.js" debug-src="/OrchardCore.Html/Scripts/trumbowyg.media.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Html/Scripts/trumbowyg.media.min.js" debug-src="~/OrchardCore.Html/Scripts/trumbowyg.media.js" at="Foot"></script>
 
 <div class="modal fade" id="mediaModalBody">
     <div class="modal-dialog modal-lg" role="document">
@@ -19,8 +19,8 @@
     </div>
 </div>
 
-<script asp-src="/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
-<style asp-src="/OrchardCore.Media/Styles/media.min.css" debug-src="/OrchardCore.Media/Styles/media.css"></style>
+<script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
+<style asp-src="~/OrchardCore.Media/Styles/media.min.css" debug-src="~/OrchardCore.Media/Styles/media.css"></style>
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
 <script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js" debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js" debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable" depends-on="vuejs, sortable" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Views/LiquidPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Views/LiquidPart.Edit.cshtml
@@ -6,7 +6,7 @@
 <script asp-name="codemirror-addon-mode-simple" at="Foot"></script>
 <script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
-<script asp-src="/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <fieldset class="form-group">
     <label asp-for="Liquid">@T["Body"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/Items/ListsAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/Items/ListsAdminNode.Fields.TreeEdit.cshtml
@@ -1,9 +1,9 @@
 @model ListsAdminNodeViewModel
 
-<style asp-src="/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" at="Head" depends-on="admin"></style>
+<style asp-src="~/OrchardCore.AdminTrees/Styles/admin-trees-icon-picker.css" at="Head" depends-on="admin"></style>
 
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
-<script asp-src="/OrchardCore.AdminTrees/Scripts/admin-trees-icon-picker.js" at="Foot" depends-on="admin"></script>
+<script asp-src="~/OrchardCore.AdminTrees/Scripts/admin-trees-icon-picker.js" at="Foot" depends-on="admin"></script>
 
 
 <h5>@T["Lists"]</h5>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
@@ -7,8 +7,8 @@
     var settings = Model.TypePartDefinition.Settings.ToObject<MarkdownBodyPartSettings>();
 }
 
-<script name="simplemde" depends-on="admin" asp-src="/OrchardCore.Markdown/Scripts/simplemde.min.js" at="Foot"></script>
-<style name="simplemde" asp-src="/OrchardCore.Markdown/Styles/simplemde.min.css"></style>
+<script name="simplemde" depends-on="admin" asp-src="~/OrchardCore.Markdown/Scripts/simplemde.min.js" at="Foot"></script>
+<style name="simplemde" asp-src="~/OrchardCore.Markdown/Styles/simplemde.min.css"></style>
 
 <fieldset class="form-group">
     <label asp-for="Source">@Model.TypePartDefinition.DisplayName()</label>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -6,8 +6,8 @@
     var settings = Model.PartFieldDefinition.Settings.ToObject<MarkdownFieldSettings>();
 }
 
-<script name="simplemde" depends-on="admin" asp-src="/OrchardCore.Markdown/Scripts/simplemde.min.js" at="Foot"></script>
-<style name="simplemde" asp-src="/OrchardCore.Markdown/Styles/simplemde.min.css"></style>
+<script name="simplemde" depends-on="admin" asp-src="~/OrchardCore.Markdown/Scripts/simplemde.min.js" at="Foot"></script>
+<style name="simplemde" asp-src="~/OrchardCore.Markdown/Styles/simplemde.min.css"></style>
 
 
 <fieldset class="form-group">

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/Media-MarkdownBodyPart.Modal.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/Media-MarkdownBodyPart.Modal.cshtml
@@ -1,4 +1,4 @@
-<script asp-src="/OrchardCore.Markdown/Scripts/simplemde.media.min.js" debug-src="/OrchardCore.Markdown/Scripts/simplemde.media.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Markdown/Scripts/simplemde.media.min.js" debug-src="~/OrchardCore.Markdown/Scripts/simplemde.media.js" at="Foot"></script>
 
 <div class="modal fade" id="mediaModalMarkdown">
     <div class="modal-dialog modal-lg" role="document">
@@ -19,8 +19,8 @@
     </div>
 </div>
 
-<script asp-src="/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
-<style asp-src="/OrchardCore.Media/Styles/media.min.css" debug-src="/OrchardCore.Media/Styles/media.css"></style>
+<script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
+<style asp-src="~/OrchardCore.Media/Styles/media.min.css" debug-src="~/OrchardCore.Media/Styles/media.css"></style>
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
 <script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js" debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js" debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable" depends-on="vuejs, sortable" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -34,7 +34,7 @@ Renders an `<img src />` HTML tag.
 
 #### Output
 
-`<img src="/media/animals/kittens.jpg" />`
+`<img src="~/media/animals/kittens.jpg" />`
 
 #### Options
 
@@ -54,7 +54,7 @@ Convert the input URL to create a resized image with the specified size argument
 
 #### Output
 
-`<img src="/media/animals/kittens.jpg?width=100&height=240" />`
+`<img src="~/media/animals/kittens.jpg?width=100&height=240" />`
 
 #### Arguments
 
@@ -102,7 +102,7 @@ Stretches the resized image to fit the bounds of its container.
 
 ### Output
 
-`<img src="/media/animals/kittens.jpg?width=100&height=240&rmode=crop" />`
+`<img src="~/media/animals/kittens.jpg?width=100&height=240&rmode=crop" />`
 
 ## Razor Helpers
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
@@ -1,5 +1,5 @@
-<script asp-src="/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
-<style asp-src="/OrchardCore.Media/Styles/media.min.css" debug-src="/OrchardCore.Media/Styles/media.css"></style>
+<script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
+<style asp-src="~/OrchardCore.Media/Styles/media.min.css" debug-src="~/OrchardCore.Media/Styles/media.css"></style>
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
 <script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js" debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js" debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable" depends-on="vuejs, sortable" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
@@ -2,8 +2,8 @@
 @using OrchardCore.Media.Settings;
 @using OrchardCore.ContentManagement.Metadata.Models
 
-<script asp-src="/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
-<style asp-src="/OrchardCore.Media/Styles/media.min.css" debug-src="/OrchardCore.Media/Styles/media.css"></style>
+<script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable"></script>
+<style asp-src="~/OrchardCore.Media/Styles/media.min.css" debug-src="~/OrchardCore.Media/Styles/media.css"></style>
 <script asp-src="https://vuejs.org/js/vue.min.js" debug-src="https://vuejs.org/js/vue.js" asp-name="vuejs" at="Foot"></script>
 <script asp-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.min.js" debug-src="https://cdn.jsdelivr.net/sortable/1.4.2/Sortable.js" asp-name="sortable" at="Foot"></script>
 <script asp-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.min.js" debug-src="https://cdnjs.cloudflare.com/ajax/libs/Vue.Draggable/2.14.1/vuedraggable.js" asp-name="vuedraggable" depends-on="vuejs, sortable" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItem.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItem.Edit.cshtml
@@ -1,4 +1,4 @@
-﻿<style asp-src="/OrchardCore.Contents/Styles/Contents.min.css" debug-src="/OrchardCore.Contents/Styles/Contents.css"></style>
+﻿<style asp-src="~/OrchardCore.Contents/Styles/Contents.min.css" debug-src="~/OrchardCore.Contents/Styles/Contents.css"></style>
 
 <div class="edit-container">
     <div class="edit-body">

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuPart.Edit.cshtml
@@ -9,8 +9,8 @@
     The shape is created from MenuPartDisplayDriver
 *@
 
-<script asp-src="/OrchardCore.Menu/Scripts/menu.js" at="Foot" depends-on="admin"></script>
-<style asp-src="/OrchardCore.Menu/Styles/menu.min.css" debug-src="/OrchardCore.Menu/Styles/menu.css"></style>
+<script asp-src="~/OrchardCore.Menu/Scripts/menu.js" at="Foot" depends-on="admin"></script>
+<style asp-src="~/OrchardCore.Menu/Styles/menu.min.css" debug-src="~/OrchardCore.Menu/Styles/menu.css"></style>
 
 @using OrchardCore.ContentManagement.Metadata.Settings;
 

--- a/src/OrchardCore.Modules/OrchardCore.Resources/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/README.md
@@ -156,7 +156,7 @@ You can declare a new resource directly from a view, and it will be injected onl
 ```
 
 ```razor
-<script asp-name="foo" asp-src="/TheTheme/js/foo.min.js?v=1.0" debug-src="/TheTheme/js/foo.js?v=1.0" depends-on="baz:1.0" version="1.0"></script>
+<script asp-name="foo" asp-src="~/TheTheme/js/foo.min.js?v=1.0" debug-src="~/TheTheme/js/foo.js?v=1.0" depends-on="baz:1.0" version="1.0"></script>
 ```
 
 In this example we also define a dependency on the script named `baz` with the version `1.0`. If the version was not set
@@ -169,7 +169,7 @@ You can also do the same for a stylesheet:
 ```
 
 ```razor
-<style asp-src="/TheTheme/css/bar.min.css" debug-src="/TheTheme/css/bar.css"></style>
+<style asp-src="~/TheTheme/css/bar.min.css" debug-src="~/TheTheme/css/bar.css"></style>
 ```
 
 #### Custom scripts

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("jQuery")
-                .SetUrl("/OrchardCore.Resources/Scripts/jquery.min.js", "/OrchardCore.Resources/Scripts/jquery.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/jquery.min.js", "~/OrchardCore.Resources/Scripts/jquery.js")
                 .SetCdn("https://code.jquery.com/jquery-3.3.1.min.js", "https://code.jquery.com/jquery-3.3.1.js")
                 .SetCdnIntegrity("sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=", "sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60=")
                 .SetVersion("3.3.1")
@@ -18,7 +18,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("jQuery.slim")
-                .SetUrl("/OrchardCore.Resources/Scripts/jquery.slim.min.js", "/OrchardCore.Resources/Scripts/jquery.slim.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/jquery.slim.min.js", "~/OrchardCore.Resources/Scripts/jquery.slim.js")
                 .SetCdn("https://code.jquery.com/jquery-3.3.1.slim.min.js", "https://code.jquery.com/jquery-3.3.1.slim.js")
                 .SetCdnIntegrity("sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo", "sha384-sh6iinGECmk2oNezd0GDVuXqoHrZzF3PTML2nyt/lC61v2p1W7hGll/JkRFCOcMf")
                 .SetVersion("3.3.1")
@@ -27,7 +27,7 @@ namespace OrchardCore.Resources
             manifest
                 .DefineScript("jQuery-ui")
                 .SetDependencies("jQuery")
-                .SetUrl("/OrchardCore.Resources/Scripts/jquery-ui.min.js", "/OrchardCore.Resources/Scripts/jquery-ui.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/jquery-ui.min.js", "~/OrchardCore.Resources/Scripts/jquery-ui.js")
                 .SetCdn("https://code.jquery.com/ui/1.12.1/jquery-ui.min.js", "https://code.jquery.com/ui/1.12.1/jquery-ui.js")
                 .SetCdnIntegrity("sha384-Dziy8F2VlJQLMShA6FHWNul/veM9bCkRUaLqr199K94ntO5QUrLJBEbYegdSkkqX", "sha384-JPbtLYL10d/Z1crlc6GGGGM3PavCzzoUJ1UxH0bXHOfguWHQ6XAWrIzW+MBGGXe5")
                 .SetVersion("1.12.1")
@@ -35,7 +35,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineStyle("jQuery-ui")
-                .SetUrl("/OrchardCore.Resources/Styles/jquery-ui.min.css", "/OrchardCore.Resources/Styles/jquery-ui.css")
+                .SetUrl("~/OrchardCore.Resources/Styles/jquery-ui.min.css", "~/OrchardCore.Resources/Styles/jquery-ui.css")
                 .SetCdn("https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.min.css", "https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css")
                 .SetCdnIntegrity("sha384-kcAOn9fN4XSd+TGsNu2OQKSuV5ngOwt7tg73O4EpaD91QXvrfgvf0MR7/2dUjoI6", "sha384-xewr6kSkq3dBbEtB6Z/3oFZmknWn7nHqhLVLrYgzEFRbU/DHSxW7K3B44yWUN60D")
                 .SetVersion("1.12.1")
@@ -65,7 +65,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("popper")
-                .SetUrl("/OrchardCore.Resources/Scripts/popper.min.js", "/OrchardCore.Resources/Scripts/popper.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/popper.min.js", "~/OrchardCore.Resources/Scripts/popper.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.min.js", "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.6/umd/popper.js")
                 .SetCdnIntegrity("sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut", "sha384-HzqOR2vfXkFlYAX/3YipGekTG6pn/9zeXoTLZZpSdO3w94laYDd5KXyKA22nTfuQ")
                 .SetVersion("1.14.6")
@@ -74,7 +74,7 @@ namespace OrchardCore.Resources
             manifest
                 .DefineScript("bootstrap")
                 .SetDependencies("jQuery")
-                .SetUrl("/OrchardCore.Resources/Scripts/bootstrap.min.js", "/OrchardCore.Resources/Scripts/bootstrap.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/bootstrap.min.js", "~/OrchardCore.Resources/Scripts/bootstrap.js")
                 .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js", "https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.js")
                 .SetCdnIntegrity("sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy", "sha384-fyOlGC+soQAvVFysE2KxkXaVKf75M1Zyo6RG7thLEEwD7p6/Cso7G/iV9tPM0C/a")
                 .SetVersion("4.1.3")
@@ -83,7 +83,7 @@ namespace OrchardCore.Resources
             manifest
                 .DefineScript("bootstrap-bundle")
                 .SetDependencies("jQuery", "popper")
-                .SetUrl("/OrchardCore.Resources/Scripts/bootstrap.bundle.min.js", "/OrchardCore.Resources/Scripts/bootstrap.bundle.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/bootstrap.bundle.min.js", "~/OrchardCore.Resources/Scripts/bootstrap.bundle.js")
                 .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.bundle.min.js", "https://maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.bundle.js")
                 .SetCdnIntegrity("sha384-pjaaA8dDz/5BgdFUPX6M/9SUZv4d12SUPF0axWc+VRZkx5xU3daN+lYb49+Ax+Tl", "sha384-DWBJ4L0qV7ffH95jHsoooM04DWR2qtntWspYadu41Wx5kw6d0Cs7W+7C2v2bh7vX")
                 .SetVersion("4.1.3")
@@ -91,7 +91,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineStyle("bootstrap")
-                .SetUrl("/OrchardCore.Resources/Styles/bootstrap.min.css", "/OrchardCore.Resources/Styles/bootstrap.css")
+                .SetUrl("~/OrchardCore.Resources/Styles/bootstrap.min.css", "~/OrchardCore.Resources/Styles/bootstrap.css")
                 .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css", "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.css")
                 .SetCdnIntegrity("sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO", "sha384-2QMA5oZ3MEXJddkHyZE/e/C1bd30ZUPdzqHrsaHMP3aGDbPA9yh77XDHXC9Imxw+")
                 .SetVersion("4.1.3")
@@ -99,7 +99,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("codemirror")
-                .SetUrl("/OrchardCore.Resources/Scripts/codemirror/codemirror.min.js", "/OrchardCore.Resources/Scripts/codemirror/codemirror.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/codemirror.min.js", "~/OrchardCore.Resources/Scripts/codemirror/codemirror.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/codemirror.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/codemirror.js")
                 .SetCdnIntegrity("sha384-1WlqTuBkhlft5hld74c3aAcO43Mp2uFKAl/z/6tYuEF0kDEnQRWnSIExi+EApxkW", "sha384-x1QKAzaJ+REY7xvp6SmcWnnyQdLJJaudAcV2KGSzDytetEOxiaYyaZ5PFLzBuvwR")
                 .SetVersion("4.1.3")
@@ -107,7 +107,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("codemirror")
-                .SetUrl("/OrchardCore.Resources/Scripts/codemirror/mode.min.js", "/OrchardCore.Resources/Scripts/codemirror/codemirror.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode.min.js", "~/OrchardCore.Resources/Scripts/codemirror/codemirror.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/codemirror.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/codemirror.js")
                 .SetCdnIntegrity("sha384-1WlqTuBkhlft5hld74c3aAcO43Mp2uFKAl/z/6tYuEF0kDEnQRWnSIExi+EApxkW", "sha384-x1QKAzaJ+REY7xvp6SmcWnnyQdLJJaudAcV2KGSzDytetEOxiaYyaZ5PFLzBuvwR")
                 .SetVersion("4.1.3")
@@ -115,42 +115,42 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("codemirror-addon-mode-multiplex")
-                .SetUrl("/OrchardCore.Resources/Scripts/codemirror/addon/mode/multiplex.min.js", "/OrchardCore.Resources/Scripts/codemirror/addon/mode/multiplex.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/addon/mode/multiplex.min.js", "~/OrchardCore.Resources/Scripts/codemirror/addon/mode/multiplex.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/multiplex.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/multiplex.js")
                 .SetVersion("4.1.3")
                 ;
 
             manifest
                 .DefineScript("codemirror-addon-mode-simple")
-                .SetUrl("/OrchardCore.Resources/Scripts/codemirror/addon/mode/simple.min.js", "/OrchardCore.Resources/Scripts/codemirror/addon/mode/simple.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/addon/mode/simple.min.js", "~/OrchardCore.Resources/Scripts/codemirror/addon/mode/simple.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/simple.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/simple.js")
                 .SetVersion("4.1.3")
                 ;
 
             manifest
                 .DefineScript("codemirror-mode-javascript")
-                .SetUrl("/OrchardCore.Resources/Scripts/codemirror/mode/javascript/javascript.min.js", "/OrchardCore.Resources/Scripts/codemirror/mode/javascript/javascript.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/javascript/javascript.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/javascript/javascript.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/javascript/javascript.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/javascript/javascript.js")
                 .SetVersion("4.1.3")
                 ;
 
             manifest
                 .DefineScript("codemirror-mode-sql")
-                .SetUrl("/OrchardCore.Resources/Scripts/codemirror/mode/sql/sql.min.js", "/OrchardCore.Resources/Scripts/codemirror/mode/sql/sql.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/sql/sql.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/sql/sql.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/sql/sql.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/sql/sql.js")
                 .SetVersion("4.1.3")
                 ;
 
             manifest
                 .DefineScript("codemirror-mode-xml")
-                .SetUrl("/OrchardCore.Resources/Scripts/codemirror/mode/xml/xml.min.js", "/OrchardCore.Resources/Scripts/codemirror/mode/xml/xml.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/xml/xml.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/xml/xml.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/xml/xml.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/xml/xml.js")
                 .SetVersion("4.1.3")
                 ;
 
             manifest
                 .DefineStyle("codemirror")
-                .SetUrl("/OrchardCore.Resources/Styles/codemirror/codemirror.min.css", "/OrchardCore.Resources/Styles/codemirror/codemirror.css")
+                .SetUrl("~/OrchardCore.Resources/Styles/codemirror/codemirror.min.css", "~/OrchardCore.Resources/Styles/codemirror/codemirror.css")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/codemirror.min.css", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/codemirror.css")
                 .SetCdnIntegrity("sha384-T6md2jYuokZmxpt4u/OxutZZs2NFnA/5oVdjrDkapBl/HHH3NfxhUMbFxEv5NTlh", "sha384-rTt9i9SnVCkukyC4WSJmDVMachnmXt3NchukWtR1miRFWpcgnyeOFxq2FBzsKltl")
                 .SetVersion("5.42.0")
@@ -158,7 +158,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineStyle("font-awesome")
-                .SetUrl("/OrchardCore.Resources/Styles/font-awesome.min.css", "/OrchardCore.Resources/Styles/font-awesome.css")
+                .SetUrl("~/OrchardCore.Resources/Styles/font-awesome.min.css", "~/OrchardCore.Resources/Styles/font-awesome.css")
                 .SetCdn("https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css", "https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.css")
                 .SetCdnIntegrity("sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN", "sha384-FckWOBo7yuyMS7In0aXZ0aoVvnInlnFMwCv77x9sZpFgOonQgnBj1uLwenWVtsEj")
                 .SetVersion("4.7.0")

--- a/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
@@ -227,7 +227,7 @@
         </div>
     </fieldset>
 </form>
-<script src="/OrchardCore.Setup/Scripts/setup.min.js" type="text/javascript"></script>
+<script src="~/OrchardCore.Setup/Scripts/setup.min.js" type="text/javascript"></script>
 <script type="text/javascript">
     //<![CDATA[
     $(function(){

--- a/src/OrchardCore.Modules/OrchardCore.Setup/Views/_Layout.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Views/_Layout.cshtml
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>Orchard Setup</title>
-    <link type="text/css" rel="stylesheet" href="/OrchardCore.Setup/Styles/setup.min.css" />
-    <link type="text/css" rel="stylesheet" href="/OrchardCore.Resources/Styles/font-awesome.min.css" />
+    <link type="text/css" rel="stylesheet" href="~/OrchardCore.Setup/Styles/setup.min.css" />
+    <link type="text/css" rel="stylesheet" href="~/OrchardCore.Resources/Styles/font-awesome.min.css" />
     @await RenderSectionAsync("Header", required: false)
 </head>
 <body>

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyPart.Edit.cshtml
@@ -11,8 +11,8 @@
     The shape is created from TaxonomyPartDisplayDriver
 *@
 
-<script asp-src="/OrchardCore.Taxonomies/Scripts/menu.js" at="Foot" depends-on="admin"></script>
-<style asp-src="/OrchardCore.Taxonomies/Styles/menu.min.css" debug-src="/OrchardCore.Taxonomies/Styles/menu.css"></style>
+<script asp-src="~/OrchardCore.Taxonomies/Scripts/menu.js" at="Foot" depends-on="admin"></script>
+<style asp-src="~/OrchardCore.Taxonomies/Styles/menu.min.css" debug-src="~/OrchardCore.Taxonomies/Styles/menu.css"></style>
 
 @{
     var updater = ModelUpdaterAccessor.ModelUpdater;

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/Term.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/Term.Edit.cshtml
@@ -1,4 +1,4 @@
-﻿<style asp-src="/OrchardCore.Contents/Styles/Contents.min.css" debug-src="/OrchardCore.Contents/Styles/Contents.css"></style>
+﻿<style asp-src="~/OrchardCore.Contents/Styles/Contents.min.css" debug-src="~/OrchardCore.Contents/Styles/Contents.css"></style>
 
 <div class="edit-container">
     <div class="edit-body">

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -5,7 +5,7 @@
 
 <style asp-name="bootstrap"></style>
 <script asp-name="bootstrap" at="Foot"></script>
-<script asp-src="/OrchardCore.Templates/js.cookie.js" depends-on="jquery" at="Foot"></script>
+<script asp-src="~/OrchardCore.Templates/js.cookie.js" depends-on="jquery" at="Foot"></script>
 
 <resources type="Header" />
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Create.cshtml
@@ -9,8 +9,8 @@
 <script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 
-<script asp-src="/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
-<script asp-src="/OrchardCore.Templates/templatepreview.edit.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Templates/templatepreview.edit.js" at="Foot"></script>
 
 <h1>@RenderTitleSegments(T["Create Template"])</h1>
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Edit.cshtml
@@ -9,8 +9,8 @@
 <script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 
-<script asp-src="/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
-<script asp-src="/OrchardCore.Templates/templatepreview.edit.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Templates/templatepreview.edit.js" at="Foot"></script>
 
 <h1>@RenderTitleSegments(T["Edit Template"])</h1>
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
@@ -86,4 +86,4 @@
     </fieldset>
 </form>
 
-<script at="Foot" type="text/javascript" asp-src="/OrchardCore.Tenants/Scripts/tenant.js" depends-on="jquery"></script>
+<script at="Foot" type="text/javascript" asp-src="~/OrchardCore.Tenants/Scripts/tenant.js" depends-on="jquery"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Edit.cshtml
@@ -89,4 +89,4 @@
     </fieldset>
 </form>
 
-<script at="Foot" type="text/javascript" asp-src="/OrchardCore.Tenants/Scripts/tenant.js" depends-on="jquery"></script>
+<script at="Foot" type="text/javascript" asp-src="~/OrchardCore.Tenants/Scripts/tenant.js" depends-on="jquery"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Admin/Index.cshtml
@@ -1,5 +1,5 @@
 @model OrchardCore.Themes.Models.SelectThemesViewModel
-<style asp-src="/OrchardCore.Themes/Styles/themes.admin.css"></style>
+<style asp-src="~/OrchardCore.Themes/Styles/themes.admin.css"></style>
 <div class="alert alert-warning">
     <h4>@T["Changing default themes"]</h4>
     <p>@T["This page lets you change the site's default themes for both the front-end and the back-end."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/WidgetsListPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/WidgetsListPart.Edit.cshtml
@@ -88,8 +88,8 @@
             await DisplayAsync(await ContentItemDisplayManager.BuildEditorAsync(contentItem, Model.Updater, true, "", Guid.NewGuid().ToString("n")));
         }
 
-        <script asp-src="/OrchardCore.Widgets/Scripts/widgetslist.edit.js" at="Foot" depends-on="admin"></script>
-        <style asp-src="/OrchardCore.Widgets/Styles/widgetslist.edit.css"></style>
+        <script asp-src="~/OrchardCore.Widgets/Scripts/widgetslist.edit.js" at="Foot" depends-on="admin"></script>
+        <style asp-src="~/OrchardCore.Widgets/Styles/widgetslist.edit.css"></style>
     }
 
     <script at="Foot">

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpRequestTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpRequestTask.Fields.Edit.cshtml
@@ -61,7 +61,7 @@
 <script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 
-<script asp-src="/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
     $(function () {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
@@ -41,7 +41,7 @@
 <script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 
-<script asp-src="/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <script at="Foot">
     $(function () {

--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout-Login.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout-Login.cshtml
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <link type="image/x-icon" rel="shortcut icon" href="/TheAdmin/favicon.ico" />
+    <link type="image/x-icon" rel="shortcut icon" href="~/TheAdmin/favicon.ico" />
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="/TheAdmin/Styles/TheAdmin.css">
+    <link rel="stylesheet" href="~/TheAdmin/Styles/TheAdmin.css">
 
     <script asp-name="font-awesome" at="Foot" version="5"></script>
     <script asp-name="font-awesome-v4-shims" at="Foot" version="5"></script>

--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
@@ -5,21 +5,21 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <link type="image/x-icon" rel="shortcut icon" href="/TheAdmin/favicon.ico" />
+    <link type="image/x-icon" rel="shortcut icon" href="~/TheAdmin/favicon.ico" />
 
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="/TheAdmin/Styles/TheAdmin.css">
+    <link rel="stylesheet" href="~/TheAdmin/Styles/TheAdmin.css">
 
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     
     <script asp-name="font-awesome" at="Foot" version="5"></script>
     <script asp-name="font-awesome-v4-shims" at="Foot" version="5"></script>
-    <script asp-name="admin" asp-src="/TheAdmin/Scripts/TheAdmin.min.js" debug-src="/TheAdmin/Scripts/TheAdmin.js" depends-on="jQuery, jQuery-ui" at="Foot"></script>
+    <script asp-name="admin" asp-src="~/TheAdmin/Scripts/TheAdmin.min.js" debug-src="~/TheAdmin/Scripts/TheAdmin.js" depends-on="jQuery, jQuery-ui" at="Foot"></script>
 
     <resources type="Header" />
 
     <!-- This script can't wait to the footer -->
-    <script type="text/javascript" src="/TheAdmin/Scripts/userPreferencesLoader.min.js" debug-src="/TheAdmin/Scripts/userPreferencesLoader.js"></script>
+    <script type="text/javascript" src="~/TheAdmin/Scripts/userPreferencesLoader.min.js" debug-src="~/TheAdmin/Scripts/userPreferencesLoader.js"></script>
 
     @await RenderSectionAsync("Header", required: false)
 </head>

--- a/src/OrchardCore.Themes/TheComingSoonTheme/Views/layout.liquid
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/Views/layout.liquid
@@ -13,16 +13,16 @@
     <title>{% page_title Site.SiteName %}</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="/TheComingSoonTheme/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="~/TheComingSoonTheme/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom fonts for this template -->
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,200i,300,300i,400,400i,600,600i,700,700i,900,900i" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Merriweather:300,300i,400,400i,700,700i,900,900i" rel="stylesheet">
-    {% comment %}<link href="/TheComingSoonTheme/vendor/fontawesome-free/css/all.min.css" rel="stylesheet">{% endcomment %}
+    {% comment %}<link href="~/TheComingSoonTheme/vendor/fontawesome-free/css/all.min.css" rel="stylesheet">{% endcomment %}
     {% style name:"font-awesome", version:"5" %}
 
     <!-- Custom styles for this template -->
-    <link href="/TheComingSoonTheme/css/coming-soon.min.css" rel="stylesheet">
+    <link href="~/TheComingSoonTheme/css/coming-soon.min.css" rel="stylesheet">
     {% resources type: "Meta" %}
     {% resources type: "HeadLink" %}
     {% resources type: "Stylesheet" %}
@@ -33,7 +33,7 @@
 
     <div class="overlay"></div>
     <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-      <source src="/TheComingSoonTheme/mp4/bg.mp4" type="video/mp4">
+      <source src="~/TheComingSoonTheme/mp4/bg.mp4" type="video/mp4">
     </video>
 
     {% render_section "Header", required: false %}
@@ -41,11 +41,11 @@
     {% render_section "Footer", required: false %}
 
     <!-- Bootstrap core JavaScript -->
-    <script src="/TheComingSoonTheme/vendor/jquery/jquery.min.js"></script>
-    <script src="/TheComingSoonTheme/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="~/TheComingSoonTheme/vendor/jquery/jquery.min.js"></script>
+    <script src="~/TheComingSoonTheme/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
     <!-- Custom scripts for this template -->
-    <script src="/TheComingSoonTheme/js/coming-soon.min.js"></script>
+    <script src="~/TheComingSoonTheme/js/coming-soon.min.js"></script>
 
     {% resources type: "FootScript" %}
   </body>

--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -5,11 +5,11 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@RenderTitleSegments(Site.SiteName, "before")</title>
-    <link type="image/x-icon" rel="shortcut icon" href="/TheTheme/favicon.ico" />
+    <link type="image/x-icon" rel="shortcut icon" href="~/TheTheme/favicon.ico" />
     <script asp-name="bootstrap" version="4" at="Foot"></script>
     <style asp-name="bootstrap" version="4"></style>
     <style asp-name="font-awesome" version="5"></style>
-    <style asp-src="/TheTheme/css/sticky-footer-navbar.css"></style>
+    <style asp-src="~/TheTheme/css/sticky-footer-navbar.css"></style>
     <resources type="Meta" />
     <resources type="HeadLink" />
     <resources type="Stylesheet" />

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -213,8 +213,15 @@ namespace OrchardCore.ResourceManagement
 
             if (url.StartsWith("~/", StringComparison.Ordinal))
             {
-                // For tilde slash paths, drop the leading ~ to make it work with the underlying IFileProvider.
-                url = url.Substring(1);
+                if (!String.IsNullOrEmpty(_basePath))
+                {
+                    url = _basePath + url.Substring(1);
+                }
+                else
+                {
+                    url = applicationPath + url.Substring(1);
+                }
+                
             }
 
             var tagBuilder = new TagBuilder(TagName)

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
 namespace OrchardCore.ResourceManagement
@@ -13,6 +14,7 @@ namespace OrchardCore.ResourceManagement
     {
         private readonly Dictionary<ResourceTypeName, RequireSettings> _required = new Dictionary<ResourceTypeName, RequireSettings>();
         private readonly Dictionary<string, IList<ResourceRequiredContext>> _builtResources;
+        private readonly string _pathBase;
         private readonly IEnumerable<IResourceManifestProvider> _providers;
         private ResourceManifest _dynamicManifest;
 
@@ -25,12 +27,14 @@ namespace OrchardCore.ResourceManagement
         private readonly IOptions<ResourceManagementOptions> _options;
 
         public ResourceManager(
+            IHttpContextAccessor httpContextAccessor,
             IEnumerable<IResourceManifestProvider> resourceProviders,
             IResourceManifestState resourceManifestState,
             IOptions<ResourceManagementOptions> options)
         {
             _resourceManifestState = resourceManifestState;
             _options = options;
+            _pathBase = httpContextAccessor.HttpContext.Request.PathBase;
             _providers = resourceProviders;
 
             _builtResources = new Dictionary<string, IList<ResourceRequiredContext>>(StringComparer.OrdinalIgnoreCase);
@@ -100,21 +104,22 @@ namespace OrchardCore.ResourceManagement
             {
                 throw new ArgumentNullException(nameof(resourceType));
             }
+
             if (resourcePath == null)
             {
                 throw new ArgumentNullException(nameof(resourcePath));
             }
 
             // ~/ ==> convert to absolute path (e.g. /orchard/..)
+
             if (resourcePath.StartsWith("~/", StringComparison.Ordinal))
             {
-                // For tilde slash paths, drop the leading ~ to make it work with the underlying IFileProvider.
-                resourcePath = resourcePath.Substring(1);
+                resourcePath = _pathBase + resourcePath.Substring(1);
             }
+
             if (resourceDebugPath != null && resourceDebugPath.StartsWith("~/", StringComparison.Ordinal))
             {
-                // For tilde slash paths, drop the leading ~ to make it work with the underlying IFileProvider.
-                resourceDebugPath = resourceDebugPath.Substring(1);
+                resourceDebugPath = _pathBase + resourceDebugPath.Substring(1);
             }
 
             return RegisterResource(resourceType, resourcePath).Define(d => d.SetUrl(resourcePath, resourceDebugPath));
@@ -500,7 +505,7 @@ namespace OrchardCore.ResourceManagement
 
                 first = false;
 
-                builder.AppendHtml(context.GetHtmlContent("/"));
+                builder.AppendHtml(context.GetHtmlContent(_pathBase));
             }
         }
 
@@ -519,7 +524,7 @@ namespace OrchardCore.ResourceManagement
 
                 first = false;
 
-                builder.AppendHtml(context.GetHtmlContent("/"));
+                builder.AppendHtml(context.GetHtmlContent(_pathBase));
             }
 
             foreach (var context in GetRegisteredHeadScripts())
@@ -550,7 +555,7 @@ namespace OrchardCore.ResourceManagement
 
                 first = false;
 
-                builder.AppendHtml(context.GetHtmlContent("/"));
+                builder.AppendHtml( context.GetHtmlContent(_pathBase));
             }
 
             foreach (var context in GetRegisteredFootScripts())
@@ -568,16 +573,13 @@ namespace OrchardCore.ResourceManagement
 
         private class ResourceTypeName : IEquatable<ResourceTypeName>
         {
-            private readonly string _type;
-            private readonly string _name;
-
-            public string Type { get { return _type; } }
-            public string Name { get { return _name; } }
+            public string Type { get; }
+            public string Name { get; }
 
             public ResourceTypeName(string resourceType, string resourceName)
             {
-                _type = resourceType;
-                _name = resourceName;
+                Type = resourceType;
+                Name = resourceName;
             }
 
             public bool Equals(ResourceTypeName other)
@@ -587,21 +589,21 @@ namespace OrchardCore.ResourceManagement
                     return false;
                 }
 
-                return _type.Equals(other._type) && _name.Equals(other._name);
+                return Type.Equals(other.Type) && Name.Equals(other.Name);
             }
 
             public override int GetHashCode()
             {
-                return _type.GetHashCode() << 17 + _name.GetHashCode();
+                return Type.GetHashCode() << 17 + Name.GetHashCode();
             }
 
             public override string ToString()
             {
                 var sb = new StringBuilder();
                 sb.Append("(");
-                sb.Append(_type);
+                sb.Append(Type);
                 sb.Append(", ");
-                sb.Append(_name);
+                sb.Append(Name);
                 sb.Append(")");
                 return sb.ToString();
             }

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Theme/Views/Layout.liquid
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Theme/Views/Layout.liquid
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width initial-scale=1.0">
     <title>{% page_title Site.SiteName, position: "before", separator: " - " %}</title>
-    <link type="image/x-icon" rel="shortcut icon" href="/OrchardCore.Templates.Theme/favicon.ico" />
+    <link type="image/x-icon" rel="shortcut icon" href="~/OrchardCore.Templates.Theme/favicon.ico" />
     {% style src:"https://maxcdn.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" %}
     {% style src:"/OrchardCore.Templates.Theme/Styles/sticky-footer-navbar.css" %}
     <!-- Custom Fonts -->

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Views/Layout.cshtml
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Views/Layout.cshtml
@@ -5,7 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@RenderTitleSegments(Site.SiteName, "before")</title>
-    <link type="image/x-icon" rel="shortcut icon" href="/Theme.Pages/favicon.ico" />
+    <link type="image/x-icon" rel="shortcut icon" href="~/Theme.Pages/favicon.ico" />
     <script asp-name="bootstrap" version="4" at="Foot"></script>
     <style asp-name="bootstrap" version="4"></style>
     <style asp-name="font-awesome" version="5"></style>


### PR DESCRIPTION
Partially fixes https://github.com/OrchardCMS/OrchardCore/issues/2891.

@sebastienros as mentioned in https://github.com/OrchardCMS/OrchardCore/issues/2891, this PR alone is not enough to fully address the issue and someone will have to dig deeper to fix the assets defined using the resources management feature, whose URL is not correct even after updating `ResourceManifest`.