### PR TITLE
Revert html body part's wysiwyg toolbar to be always visible

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
@@ -18,21 +18,8 @@
 
 <script at="Foot">
     $(function () {
-        var editor = $('#@Html.IdFor(m => m.Source)').trumbowyg();
-        editor.on('tbwchange', function () {
+        $('#@Html.IdFor(m => m.Source)').trumbowyg().on('tbwchange', function () {
             $(document).trigger('contentpreview:render');
         });
-
-        // hide toolbar when editor is not in focus (to avoid z-index clashes with dropdown components that may be on the page)
-        (function toolbarToggler() {
-            function getButtonPane(textarea) {
-                return $(textarea).siblings('.trumbowyg-button-pane');
-            }
-            editor.on('tbwfocus', function () { getButtonPane(this).fadeIn(); });
-            editor.on('tbwblur', function () { getButtonPane(this).fadeOut(); });
-
-            // hide initially
-            editor.siblings('.trumbowyg-button-pane').css("display", "none");
-        }());
     });
 </script>


### PR DESCRIPTION
Reverting the changes made by #2590. 
Not needed anymore after #2896.
The revert is necessary because the code was causing another issue: #2634
