### PR TITLE
Media files not exported when all is selected

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStore.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.Media.Services
 
         public Task<IEnumerable<IFileStoreEntry>> GetDirectoryContentAsync(string path = null, bool includeSubDirectories = false)
         {
-            return _fileStore.GetDirectoryContentAsync(path);
+            return _fileStore.GetDirectoryContentAsync(path, includeSubDirectories);
         }
 
         public Task<bool> TryCreateDirectoryAsync(string path)


### PR DESCRIPTION
I'm not sure if this has been omitted intentionnally but here I found that the Media module service that retrieves folder assets was missing it's `includeSubDirectories` param which is required when we do a "Include All" for exporting medias.

Fixes #2849 