### PR TITLE
Replace OrchardCore by Orchard in Razor sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ wwwroot
 !src/Templates/**/content/**
 .template.config/
 /OrchardCore.sln.GhostDoc.xml
+package-lock.json

--- a/src/OrchardCore.Modules/OrchardCore.Queries/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/README.md
@@ -118,7 +118,7 @@ You can use the `DisplayAsync` extension method (also in `OrchardCore.ContentMan
 For example, to run a query called `LatestBlogPosts`, and display the results:
 
 ```liquid
-@foreach (var contentItem in await OrchardCore.ContentQueryAsync("AllContent"))
+@foreach (var contentItem in await Orchard.ContentQueryAsync("AllContent"))
 {
     @await Orchard.DisplayAsync(contentItem)
 }


### PR DESCRIPTION
@foreach (var contentItem in await OrchardCore.ContentQueryAsync("AllContent"))

replaced by

@foreach (var contentItem in await Orchard.ContentQueryAsync("AllContent"))

