### PR TITLE
Fixed importing roles from setup recipes using existing documentation #2909

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Roles/Recipes/RolesStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Recipes/RolesStep.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
-using Newtonsoft.Json.Linq;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Recipes.Services;
 using OrchardCore.Security;
@@ -30,22 +29,23 @@ namespace OrchardCore.Roles.Recipes
             }
 
             var model = context.Step.ToObject<RolesStepModel>();
-            
-            foreach (var importedRole in model.Data)
+
+            foreach (var importedRole in model.Roles)
             {
-                if (string.IsNullOrWhiteSpace(importedRole.NormalizedRoleName)) 
+                if (string.IsNullOrWhiteSpace(importedRole.Name))
                     continue;
 
-                var role = (Role) await _roleManager.FindByNameAsync(importedRole.NormalizedRoleName);
+                var role = (Role)await _roleManager.FindByNameAsync(importedRole.Name);
                 var isNewRole = role == null;
-                
+
                 if (isNewRole)
                 {
-                    role = new Role { RoleName = importedRole.RoleName };                    
+                    role = new Role { RoleName = importedRole.Name };
                 }
-                role.RoleClaims.Clear();
-                role.RoleClaims.AddRange(importedRole.RoleClaims.Select(c=>new RoleClaim { ClaimType = c.ClaimType, ClaimValue = c.ClaimValue }));
-                
+
+                role.RoleClaims.RemoveAll(c => c.ClaimType == Permission.ClaimType);
+                role.RoleClaims.AddRange(importedRole.Permissions.Select(p => new RoleClaim { ClaimType = Permission.ClaimType, ClaimValue = p }));
+
                 if (isNewRole)
                 {
                     await _roleManager.CreateAsync(role);
@@ -56,9 +56,16 @@ namespace OrchardCore.Roles.Recipes
                 }
             }
         }
+
         public class RolesStepModel
         {
-            public Role[] Data { get; set; }
+            public RolesStepRoleModel[] Roles { get; set; }
         }
-    }    
+    }
+
+    public class RolesStepRoleModel
+    {
+        public string Name { get; set; }
+        public string[] Permissions { get; set; }
+    }
 }


### PR DESCRIPTION
Relates to #2909 ability to assign permissions to a role during recipe execution,

Some work it turns out was done (you could export the permissions in a deployment plan, and re-import them) But the exported file didnt match the documentation for setting permissions in a recipe file which i was gonna use in import ...

Documentation said to use this syntax ....
```
   {
      "name": "roles",
      "Roles": [
        {
          "Name": "Anonymous",
          "Permissions": [ "EditOwnContent" ]
        }
      ]
    }
```
Where the deployment plan exported it in this format ...

```
   {
      "name": "Roles",
      "Data": [
        {
          "RoleName": "Contributor",
          "NormalizedRoleName": "CONTRIBUTOR",
          "RoleClaims": [
            {
              "ClaimType": "Permission",
              "ClaimValue": "AccessAdminPanel"
            }
          }]
    }
```
This is the format the recipe step expects, ive updated the recipe step and deployment plan to use the first format which is inline with the documentation .... alternatively we need to update the documentation to be inline with the second format, i guess it depends if there will ever be other claimtypes.