### PR TITLE
Optimize modules loading.

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Application.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Application.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -8,7 +7,7 @@ namespace OrchardCore.Modules
 {
     public class Application
     {
-        private readonly Dictionary<string, List<Module>> _modulesByName;
+        private readonly Dictionary<string, Module> _modulesByName;
         private readonly List<Module> _modules;
 
         public static readonly string ModulesPath = "Areas";
@@ -26,7 +25,7 @@ namespace OrchardCore.Modules
             Assembly = Assembly.Load(new AssemblyName(Name));
 
             _modules = new List<Module>(modules);
-            _modulesByName = _modules.GroupBy(x => x.Name).ToDictionary(x => x.Key, x => x.ToList());
+            _modulesByName = _modules.ToDictionary(m => m.Name, m => m);
         }
 
         public string Name { get; }
@@ -39,12 +38,12 @@ namespace OrchardCore.Modules
 
         public Module GetModule(string name)
         {
-            if (!_modulesByName.TryGetValue(name, out var modules) || modules.Count == 0)
+            if (!_modulesByName.TryGetValue(name, out var module))
             {
                 return new Module(string.Empty);
             }
 
-            return modules[modules.Count - 1];
+            return module;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/ModularApplicationContext.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/ModularApplicationContext.cs
@@ -52,15 +52,15 @@ namespace OrchardCore.Modules
             var modules = new ConcurrentBag<Module>();
             modules.Add(new Module(_environment.ApplicationName, true));
 
-            foreach (var provider in _moduleNamesProviders)
-            {
-                var names = provider.GetModuleNames().Distinct();
+            var names = _moduleNamesProviders
+                .SelectMany(p => p.GetModuleNames())
+                .Where(n => n != _environment.ApplicationName)
+                .Distinct();
 
-                Parallel.ForEach(names, new ParallelOptions { MaxDegreeOfParallelism = 8 }, (name) =>
-                {
-                    modules.Add(new Module(name, name == _environment.ApplicationName));
-                });
-            }
+            Parallel.ForEach(names, new ParallelOptions { MaxDegreeOfParallelism = 8 }, (name) =>
+            {
+                modules.Add(new Module(name, false));
+            });
 
             return modules;
         }


### PR DESCRIPTION

- Features loading was done through the ctor of `ShellContainerFactory`, here it is normally triggered by `ShellHost` just before loading shell settings.

- At some point, each module was loaded inside the `Parallel.ForEach()` of `ExtensionManager`, but the module was loaded inside a lock block and it would have been better to load it outside and just update the related non concurrent dico inside the lock block.

- Anyway, now modules can only be loaded in one pass and this is done before the `Parallel.ForEach()` of `ExtensionManager`. But that's ok, so here the suggestion is just to load modules in parallel. The workload is not so heavy but enough to benefit from doing it in parallel when there are many modules.