### PR TITLE
Prevent liquid tag helper conflicts.

### DIFF
--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
@@ -8,7 +8,7 @@
     {% resources type: "Meta" %}
 
     <!-- Bootstrap core CSS -->
-    {% style source:"/TheAgencyTheme/vendor/bootstrap/css/bootstrap.min.css", debug_src:"/TheAgencyTheme/vendor/bootstrap/css/bootstrap.css" %}
+    {% style src:"/TheAgencyTheme/vendor/bootstrap/css/bootstrap.min.css", debug_src:"/TheAgencyTheme/vendor/bootstrap/css/bootstrap.css" %}
 
     <!-- Custom fonts for this template -->
     {% style name:"font-awesome", version:"5" %}
@@ -18,20 +18,20 @@
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
-    {% style source:"/TheAgencyTheme/css/agency.min.css", debug_src:"/TheAgencyTheme/css/agency.css" %}
-    {% style source:"/TheAgencyTheme/bootstrap-grid-ext.min.css", debug_src:"/TheAgencyTheme/bootstrap-grid-ext.css" %}
+    {% style src:"/TheAgencyTheme/css/agency.min.css", debug_src:"/TheAgencyTheme/css/agency.css" %}
+    {% style src:"/TheAgencyTheme/bootstrap-grid-ext.min.css", debug_src:"/TheAgencyTheme/bootstrap-grid-ext.css" %}
 
     <!-- Bootstrap core JavaScript -->
-    {% script source:"/TheAgencyTheme/vendor/jquery/jquery.min.js", debug_src:"/TheAgencyTheme/vendor/jquery/jquery.js", at:"Foot" %}
-    {% script source:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.min.js", debug_src:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.js", at:"Foot" %}
+    {% script src:"/TheAgencyTheme/vendor/jquery/jquery.min.js", debug_src:"/TheAgencyTheme/vendor/jquery/jquery.js", at:"Foot" %}
+    {% script src:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.min.js", debug_src:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.js", at:"Foot" %}
 
     <!-- Plugin JavaScript -->
-    {% script source:"/TheAgencyTheme/vendor/jquery-easing/jquery.easing.min.js", debug_src:"/TheAgencyTheme/vendor/jquery-easing/jquery.easing.js", at:"Foot" %}
+    {% script src:"/TheAgencyTheme/vendor/jquery-easing/jquery.easing.min.js", debug_src:"/TheAgencyTheme/vendor/jquery-easing/jquery.easing.js", at:"Foot" %}
     
     <!-- Contact form JavaScript -->
 
     <!-- Custom scripts for this template -->
-    {% script source:"/TheAgencyTheme/js/agency.min.js", debug_src:"/TheAgencyTheme/js/agency.min.js", at:"Foot" %}
+    {% script src:"/TheAgencyTheme/js/agency.min.js", debug_src:"/TheAgencyTheme/js/agency.min.js", at:"Foot" %}
 
     {% resources type: "HeadScript" %}
     {% resources type: "HeadLink" %}

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
@@ -8,7 +8,7 @@
     {% resources type: "Meta" %}
 
     <!-- Bootstrap core CSS -->
-    {% style src:"/TheAgencyTheme/vendor/bootstrap/css/bootstrap.min.css", debug_src:"/TheAgencyTheme/vendor/bootstrap/css/bootstrap.css" %}
+    {% style source:"/TheAgencyTheme/vendor/bootstrap/css/bootstrap.min.css", debug_src:"/TheAgencyTheme/vendor/bootstrap/css/bootstrap.css" %}
 
     <!-- Custom fonts for this template -->
     {% style name:"font-awesome", version:"5" %}
@@ -18,20 +18,20 @@
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
-    {% style src:"/TheAgencyTheme/css/agency.min.css", debug_src:"/TheAgencyTheme/css/agency.css" %}
-    {% style src:"/TheAgencyTheme/bootstrap-grid-ext.min.css", debug_src:"/TheAgencyTheme/bootstrap-grid-ext.css" %}
+    {% style source:"/TheAgencyTheme/css/agency.min.css", debug_src:"/TheAgencyTheme/css/agency.css" %}
+    {% style source:"/TheAgencyTheme/bootstrap-grid-ext.min.css", debug_src:"/TheAgencyTheme/bootstrap-grid-ext.css" %}
 
     <!-- Bootstrap core JavaScript -->
-    {% script src:"/TheAgencyTheme/vendor/jquery/jquery.min.js", debug_src:"/TheAgencyTheme/vendor/jquery/jquery.js", at:"Foot" %}
-    {% script src:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.min.js", debug_src:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.js", at:"Foot" %}
+    {% script source:"/TheAgencyTheme/vendor/jquery/jquery.min.js", debug_src:"/TheAgencyTheme/vendor/jquery/jquery.js", at:"Foot" %}
+    {% script source:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.min.js", debug_src:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.js", at:"Foot" %}
 
     <!-- Plugin JavaScript -->
-    {% script src:"/TheAgencyTheme/vendor/jquery-easing/jquery.easing.min.js", debug_src:"/TheAgencyTheme/vendor/jquery-easing/jquery.easing.js", at:"Foot" %}
+    {% script source:"/TheAgencyTheme/vendor/jquery-easing/jquery.easing.min.js", debug_src:"/TheAgencyTheme/vendor/jquery-easing/jquery.easing.js", at:"Foot" %}
     
     <!-- Contact form JavaScript -->
 
     <!-- Custom scripts for this template -->
-    {% script src:"/TheAgencyTheme/js/agency.min.js", debug_src:"/TheAgencyTheme/js/agency.min.js", at:"Foot" %}
+    {% script source:"/TheAgencyTheme/js/agency.min.js", debug_src:"/TheAgencyTheme/js/agency.min.js", at:"Foot" %}
 
     {% resources type: "HeadScript" %}
     {% resources type: "HeadLink" %}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -8,7 +8,7 @@
     {% resources type: "Meta" %}
 
     <!-- Bootstrap core CSS -->
-    {% style source:"/TheBlogTheme/vendor/bootstrap/css/bootstrap.min.css", debug_src:"/TheBlogTheme/vendor/bootstrap/css/bootstrap.css" %}
+    {% style src:"/TheBlogTheme/vendor/bootstrap/css/bootstrap.min.css", debug_src:"/TheBlogTheme/vendor/bootstrap/css/bootstrap.css" %}
 
     <!-- Custom fonts for this template -->
     {% style name:"font-awesome", version:"5" %}
@@ -16,18 +16,18 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
-    {% style source:"/TheBlogTheme/css/clean-blog.min.css", debug_src:"/TheBlogTheme/css/clean-blog.css" %}
-    {% style source:"/TheBlogTheme/css/bootstrap-grid-ext.min.css", debug_src:"/TheBlogTheme/css/bootstrap-grid-ext.css" %}
+    {% style src:"/TheBlogTheme/css/clean-blog.min.css", debug_src:"/TheBlogTheme/css/clean-blog.css" %}
+    {% style src:"/TheBlogTheme/css/bootstrap-grid-ext.min.css", debug_src:"/TheBlogTheme/css/bootstrap-grid-ext.css" %}
 
     <!-- Bootstrap core JavaScript -->
-    {% script source:"/TheBlogTheme/vendor/jquery/jquery.min.js", debug_src:"/TheBlogTheme/vendor/jquery/jquery.js", at:"Foot" %}
-    {% script source:"/TheBlogTheme/vendor/bootstrap/js/bootstrap.bundle.min.js", debug_src:"/TheBlogTheme/vendor/bootstrap/js/bootstrap.bundle.js", at:"Foot" %}
+    {% script src:"/TheBlogTheme/vendor/jquery/jquery.min.js", debug_src:"/TheBlogTheme/vendor/jquery/jquery.js", at:"Foot" %}
+    {% script src:"/TheBlogTheme/vendor/bootstrap/js/bootstrap.bundle.min.js", debug_src:"/TheBlogTheme/vendor/bootstrap/js/bootstrap.bundle.js", at:"Foot" %}
 
     <!-- Custom scripts for this template -->
-    {% script source:"/TheBlogTheme/js/clean-blog.min.js", debug_src:"/TheBlogTheme/js/clean-blog.js", at:"Foot" %}
+    {% script src:"/TheBlogTheme/js/clean-blog.min.js", debug_src:"/TheBlogTheme/js/clean-blog.js", at:"Foot" %}
 
-    {% script source:"/OrchardCore.Menu/Scripts/activate-links.min.js", debug_src:"/OrchardCore.Menu/Scripts/activate-links.js", at:"Foot" %}
-    {% script source:"/TheBlogTheme/js/clean-blog-ext.min.js", debug_src:"/TheBlogTheme/js/clean-blog-ext.js", at:"Foot" %}
+    {% script src:"/OrchardCore.Menu/Scripts/activate-links.min.js", debug_src:"/OrchardCore.Menu/Scripts/activate-links.js", at:"Foot" %}
+    {% script src:"/TheBlogTheme/js/clean-blog-ext.min.js", debug_src:"/TheBlogTheme/js/clean-blog-ext.js", at:"Foot" %}
 
     {% resources type: "HeadScript" %}
     {% resources type: "HeadLink" %}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -8,7 +8,7 @@
     {% resources type: "Meta" %}
 
     <!-- Bootstrap core CSS -->
-    {% style src:"/TheBlogTheme/vendor/bootstrap/css/bootstrap.min.css", debug_src:"/TheBlogTheme/vendor/bootstrap/css/bootstrap.css" %}
+    {% style source:"/TheBlogTheme/vendor/bootstrap/css/bootstrap.min.css", debug_src:"/TheBlogTheme/vendor/bootstrap/css/bootstrap.css" %}
 
     <!-- Custom fonts for this template -->
     {% style name:"font-awesome", version:"5" %}
@@ -16,12 +16,12 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
-    {% style src:"/TheBlogTheme/css/clean-blog.min.css", debug_src:"/TheBlogTheme/css/clean-blog.min.css" %}
-    {% style src:"/TheBlogTheme/css/bootstrap-grid-ext.min.css", debug_src:"/TheBlogTheme/css/bootstrap-grid-ext.css" %}
+    {% style source:"/TheBlogTheme/css/clean-blog.min.css", debug_src:"/TheBlogTheme/css/clean-blog.css" %}
+    {% style source:"/TheBlogTheme/css/bootstrap-grid-ext.min.css", debug_src:"/TheBlogTheme/css/bootstrap-grid-ext.css" %}
 
     <!-- Bootstrap core JavaScript -->
-    {% script src:"/TheAgencyTheme/vendor/jquery/jquery.min.js", debug_src:"/TheAgencyTheme/vendor/jquery/jquery.js", at:"Foot" %}
-    {% script src:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.min.js", debug_src:"/TheAgencyTheme/vendor/bootstrap/js/bootstrap.bundle.js", at:"Foot" %}
+    {% script source:"/TheBlogTheme/vendor/jquery/jquery.min.js", debug_src:"/TheBlogTheme/vendor/jquery/jquery.js", at:"Foot" %}
+    {% script source:"/TheBlogTheme/vendor/bootstrap/js/bootstrap.bundle.min.js", debug_src:"/TheBlogTheme/vendor/bootstrap/js/bootstrap.bundle.js", at:"Foot" %}
 
     <!-- Custom scripts for this template -->
     {% script source:"/TheBlogTheme/js/clean-blog.min.js", debug_src:"/TheBlogTheme/js/clean-blog.js", at:"Foot" %}

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
@@ -65,7 +65,7 @@ namespace OrchardCore.Mvc
         private void AddModularFrameworkParts(IServiceProvider services, ApplicationPartManager manager)
         {
             var httpContextAccessor = services.GetRequiredService<IHttpContextAccessor>();
-            manager.ApplicationParts.Add(new ShellFeatureApplicationPart(httpContextAccessor));
+            manager.ApplicationParts.Insert(0, new ShellFeatureApplicationPart(httpContextAccessor));
             manager.FeatureProviders.Add(new ShellViewFeatureProvider(httpContextAccessor));
         }
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/IResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/IResourceManager.cs
@@ -110,5 +110,10 @@ namespace OrchardCore.ResourceManagement
         /// Renders the registered footer script tags.
         /// </summary>
         void RenderFootScript(IHtmlContentBuilder builder);
+
+        /// <summary>
+        /// Renders the registered local script tags.
+        /// </summary>
+        void RenderLocalScript(RequireSettings settings, IHtmlContentBuilder builder);
     }
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -22,6 +22,7 @@ namespace OrchardCore.ResourceManagement
         private Dictionary<string, MetaEntry> _metas;
         private List<IHtmlContent> _headScripts;
         private List<IHtmlContent> _footScripts;
+        private HashSet<string> _localScripts;
 
         private readonly IResourceManifestState _resourceManifestState;
         private readonly IOptions<ResourceManagementOptions> _options;
@@ -38,6 +39,7 @@ namespace OrchardCore.ResourceManagement
             _providers = resourceProviders;
 
             _builtResources = new Dictionary<string, IList<ResourceRequiredContext>>(StringComparer.OrdinalIgnoreCase);
+            _localScripts = new HashSet<string>();
         }
 
         public IEnumerable<ResourceManifest> ResourceManifests
@@ -61,7 +63,7 @@ namespace OrchardCore.ResourceManagement
         {
             get
             {
-                if(_dynamicManifest == null)
+                if (_dynamicManifest == null)
                 {
                     _dynamicManifest = new ResourceManifest();
                 }
@@ -179,18 +181,18 @@ namespace OrchardCore.ResourceManagement
             ResourceDefinition resource;
 
             var resources = (from p in ResourceManifests
-                            from r in p.GetResources(type)
-                            where name.Equals(r.Key, StringComparison.OrdinalIgnoreCase)
-                            select r.Value).SelectMany(x => x);
+                             from r in p.GetResources(type)
+                             where name.Equals(r.Key, StringComparison.OrdinalIgnoreCase)
+                             select r.Value).SelectMany(x => x);
 
-            if(!String.IsNullOrEmpty(settings.Version))
+            if (!String.IsNullOrEmpty(settings.Version))
             {
                 // Specific version, filter
                 var upper = GetUpperBoundVersion(settings.Version);
                 var lower = GetLowerBoundVersion(settings.Version);
                 resources = from r in resources
                             let version = r.Version != null ? new Version(r.Version) : null
-                            where lower <= version && version < upper 
+                            where lower <= version && version < upper
                             select r;
             }
 
@@ -203,8 +205,8 @@ namespace OrchardCore.ResourceManagement
             if (resource == null && _dynamicManifest != null)
             {
                 resources = (from r in _dynamicManifest.GetResources(type)
-                            where name.Equals(r.Key, StringComparison.OrdinalIgnoreCase)
-                            select r.Value).SelectMany(x => x);
+                             where name.Equals(r.Key, StringComparison.OrdinalIgnoreCase)
+                             select r.Value).SelectMany(x => x);
 
                 if (!String.IsNullOrEmpty(settings.Version))
                 {
@@ -253,7 +255,7 @@ namespace OrchardCore.ResourceManagement
                 if (int.TryParse(minimumVersion, out major))
                 {
                     return new Version(major + 1, 0, 0);
-                }                
+                }
             }
 
             if (version.Build != -1)
@@ -265,7 +267,7 @@ namespace OrchardCore.ResourceManagement
             {
                 return new Version(version.Major, version.Minor + 1, 0);
             }
-            
+
             return version;
         }
 
@@ -286,7 +288,7 @@ namespace OrchardCore.ResourceManagement
                     return new Version(major, 0, 0);
                 }
             }
-            
+
             return version;
         }
 
@@ -326,7 +328,7 @@ namespace OrchardCore.ResourceManagement
 
         public IEnumerable<MetaEntry> GetRegisteredMetas()
         {
-            if(_metas == null)
+            if (_metas == null)
             {
                 return Enumerable.Empty<MetaEntry>();
             }
@@ -403,7 +405,7 @@ namespace OrchardCore.ResourceManagement
 
         public void RegisterLink(LinkEntry link)
         {
-            if(_links == null)
+            if (_links == null)
             {
                 _links = new List<LinkEntry>();
             }
@@ -418,7 +420,7 @@ namespace OrchardCore.ResourceManagement
                 return;
             }
 
-            if(_metas == null)
+            if (_metas == null)
             {
                 _metas = new Dictionary<string, MetaEntry>();
             }
@@ -555,7 +557,7 @@ namespace OrchardCore.ResourceManagement
 
                 first = false;
 
-                builder.AppendHtml( context.GetHtmlContent(_pathBase));
+                builder.AppendHtml(context.GetHtmlContent(_pathBase));
             }
 
             foreach (var context in GetRegisteredFootScripts())
@@ -568,6 +570,28 @@ namespace OrchardCore.ResourceManagement
                 first = false;
 
                 builder.AppendHtml(context);
+            }
+        }
+
+        public void RenderLocalScript(RequireSettings settings, IHtmlContentBuilder builder)
+        {
+            var localScripts = this.GetRequiredResources("script");
+
+            var first = true;
+
+            foreach (var context in localScripts.Where(r => r.Settings.Location == ResourceLocation.Unspecified))
+            {
+                if (_localScripts.Add(context.Settings.Name) || context.Settings.Name == settings.Name)
+                {
+                    if (!first)
+                    {
+                        builder.AppendHtml(Environment.NewLine);
+                    }
+
+                    first = false;
+
+                    builder.AppendHtml(context.GetHtmlContent(_pathBase));
+                }
             }
         }
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -7,13 +7,11 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 {
 
     [HtmlTargetElement("script", Attributes = NameAttributeName)]
-    [HtmlTargetElement("script", Attributes = SourceAttributeName)]
     [HtmlTargetElement("script", Attributes = SrcAttributeName)]
     [HtmlTargetElement("script", Attributes = AtAttributeName)]
     public class ScriptTagHelper : TagHelper
     {
         private const string NameAttributeName = "asp-name";
-        private const string SourceAttributeName = "asp-source";
         private const string SrcAttributeName = "asp-src";
         private const string AtAttributeName = "at";
 
@@ -21,7 +19,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
         public string Name { get; set; }
 
         [HtmlAttributeName(SrcAttributeName)]
-        public string Source { get; set; }
+        public string Src { get; set; }
 
         public string CdnSrc { get; set; }
         public string DebugSrc { get; set; }
@@ -48,24 +46,24 @@ namespace OrchardCore.ResourceManagement.TagHelpers
         {
             output.SuppressOutput();
 
-            if (String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Source))
+            if (String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
             {
                 RequireSettings setting;
 
                 if (String.IsNullOrEmpty(DependsOn))
                 {
                     // Include custom script url
-                    setting = _resourceManager.Include("script", Source, DebugSrc);
+                    setting = _resourceManager.Include("script", Src, DebugSrc);
                 }
                 else
                 {
                     // Anonymous declaration with dependencies, then display
 
                     // Using the source as the name to prevent duplicate references to the same file
-                    var name = Source.ToLowerInvariant();
+                    var name = Src.ToLowerInvariant();
 
                     var definition = _resourceManager.InlineManifest.DefineScript(name);
-                    definition.SetUrl(Source, DebugSrc);
+                    definition.SetUrl(Src, DebugSrc);
 
                     if (!String.IsNullOrEmpty(Version))
                     {
@@ -120,7 +118,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.SetAttribute(attribute.Name, attribute.Value.ToString());
                 }
             }
-            else if (!String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Source))
+            else if (!String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Src))
             {
                 // Resource required
 
@@ -156,12 +154,12 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.UseVersion(Version);
                 }
             }
-            else if (!String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Source))
+            else if (!String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
             {
                 // Inline declaration
 
                 var definition = _resourceManager.InlineManifest.DefineScript(Name);
-                definition.SetUrl(Source, DebugSrc);
+                definition.SetUrl(Src, DebugSrc);
 
                 if (!String.IsNullOrEmpty(Version))
                 {
@@ -221,7 +219,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     }
                 }
             }
-            else if (String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Source))
+            else if (String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Src))
             {
                 // Custom script content
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -7,11 +7,13 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 {
 
     [HtmlTargetElement("script", Attributes = NameAttributeName)]
+    [HtmlTargetElement("script", Attributes = SourceAttributeName)]
     [HtmlTargetElement("script", Attributes = SrcAttributeName)]
     [HtmlTargetElement("script", Attributes = AtAttributeName)]
     public class ScriptTagHelper : TagHelper
     {
         private const string NameAttributeName = "asp-name";
+        private const string SourceAttributeName = "asp-source";
         private const string SrcAttributeName = "asp-src";
         private const string AtAttributeName = "at";
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -117,6 +117,11 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 {
                     setting.SetAttribute(attribute.Name, attribute.Value.ToString());
                 }
+
+                if (At == ResourceLocation.Unspecified)
+                {
+                    _resourceManager.RenderLocalScript(setting, output.Content);
+                }
             }
             else if (!String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Src))
             {
@@ -152,6 +157,11 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 if (!String.IsNullOrEmpty(Version))
                 {
                     setting.UseVersion(Version);
+                }
+
+                if (At == ResourceLocation.Unspecified)
+                {
+                    _resourceManager.RenderLocalScript(setting, output.Content);
                 }
             }
             else if (!String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -5,19 +5,17 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 {
 
     [HtmlTargetElement("style", Attributes = NameAttributeName)]
-    [HtmlTargetElement("style", Attributes = SourceAttributeName)]
     [HtmlTargetElement("style", Attributes = SrcAttributeName)]
     public class StyleTagHelper : TagHelper
     {
         private const string NameAttributeName = "asp-name";
-        private const string SourceAttributeName = "asp-source";
         private const string SrcAttributeName = "asp-src";
 
         [HtmlAttributeName(NameAttributeName)]
         public string Name { get; set; }
 
         [HtmlAttributeName(SrcAttributeName)]
-        public string Source { get; set; }
+        public string Src { get; set; }
 
         public string CdnSrc { get; set; }
         public string DebugSrc { get; set; }
@@ -41,10 +39,10 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            if (String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Source))
+            if (String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
             {
                 // Include custom script
-                var setting = _resourceManager.Include("stylesheet", Source, DebugSrc);
+                var setting = _resourceManager.Include("stylesheet", Src, DebugSrc);
 
                 if (At != ResourceLocation.Unspecified)
                 {
@@ -70,7 +68,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.UseCulture(Culture);
                 }
             }
-            else if (!String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Source))
+            else if (!String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Src))
             {
                 // Resource required
 
@@ -110,12 +108,12 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.UseVersion(Version);
                 }
             }
-            else if (!String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Source))
+            else if (!String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
             {
                 // Inline declaration
 
                 var definition = _resourceManager.InlineManifest.DefineStyle(Name);
-                definition.SetUrl(Source, DebugSrc);
+                definition.SetUrl(Src, DebugSrc);
 
                 if (!String.IsNullOrEmpty(Version))
                 {

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -5,10 +5,12 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 {
 
     [HtmlTargetElement("style", Attributes = NameAttributeName)]
+    [HtmlTargetElement("style", Attributes = SourceAttributeName)]
     [HtmlTargetElement("style", Attributes = SrcAttributeName)]
     public class StyleTagHelper : TagHelper
     {
         private const string NameAttributeName = "asp-name";
+        private const string SourceAttributeName = "asp-source";
         private const string SrcAttributeName = "asp-src";
 
         [HtmlAttributeName(NameAttributeName)]


### PR DESCRIPTION
Related to #2598.

- With the `liquid script` tag helper when using the `src` attribute (not `source`), because of [this line in aspnet](https://github.com/aspnet/AspNetCore/blob/release/2.2/src/Mvc/src/Microsoft.AspNetCore.Mvc.Razor/TagHelpers/UrlResolutionTagHelper.cs#L47), this is the `UrlResolutionTagHelper` which is selected (at least now, maybe since 2.2).

        [HtmlTargetElement("script", Attributes = "[src^='~/']")]


- So, this doesn't affect e.g the `liquid style` tag helper, and it works with our `razor script` tag helper which fully uses `asp-src`, not only `src`.

- **The result is that in our themes some scripts are not rendered in the right place and with the minified version because e.g `debug-src` and `at` are not used and rendered as html attributes**.

---

- So, for the `liquid script` the rule would be to use `source`.

- Then trying to solve the #2598 issue, i removed the `at:"Foot"` argument. Then the script tag helper was not selected because `source` is not an `HtmlTargetElement`. So i added it and it was selected.

- But but but, still nothing was rendered because i think it's by design. No `resources` tag helper targetting `HeadScript` or `FootScript` can render a script without any location.

    Note: With the `liquid style` tag helper, if no location it always defaults to `Head`. For the `liquid script` it defaults to `Foot` but only if neither `source` neither `name` is used. **Let me know if we need to do something for the `liquid script` if no location**, at least here it would be selected.

- Then, to harmonize things in liquid, for the `style` tag helper, i also added `source` as an `HtmlTargetElement`. So that, when no location is specified, it is still working when using `source`.

