### PR TITLE
Fixes multiple tenant shells initialization.

### DIFF
--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/ShellContextFactory.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/ShellContextFactory.cs
@@ -37,7 +37,7 @@ namespace OrchardCore.Environment.Shell.Builders
             var describedContext = await CreateDescribedContextAsync(settings, MinimumShellDescriptor());
 
             ShellDescriptor currentDescriptor;
-            using (var scope = describedContext.CreateScope())
+            using (var scope = describedContext.ServiceProvider.CreateScope())
             {
                 var shellDescriptorManager = scope.ServiceProvider.GetService<IShellDescriptorManager>();
                 currentDescriptor = await shellDescriptorManager.GetShellDescriptorAsync();

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -177,11 +177,11 @@ namespace OrchardCore.Environment.Shell
             else
             {
                 // Load all tenants, and activate their shell.
-                await Task.WhenAll(allSettings.Select(async settings =>
+                await Task.WhenAll(allSettings.Select(settings =>
                 {
                     try
                     {
-                        await GetOrCreateShellContextAsync(settings);
+                        return GetOrCreateShellContextAsync(settings);
                     }
                     catch (Exception ex)
                     {
@@ -191,6 +191,8 @@ namespace OrchardCore.Environment.Shell
                         {
                             throw;
                         }
+
+                        return Task.CompletedTask;
                     }
                 }));
             }

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -177,11 +177,11 @@ namespace OrchardCore.Environment.Shell
             else
             {
                 // Load all tenants, and activate their shell.
-                await Task.WhenAll(allSettings.Select(settings =>
+                await Task.WhenAll(allSettings.Select(async settings =>
                 {
                     try
                     {
-                        return GetOrCreateShellContextAsync(settings);
+                        await GetOrCreateShellContextAsync(settings);
                     }
                     catch (Exception ex)
                     {
@@ -191,8 +191,6 @@ namespace OrchardCore.Environment.Shell
                         {
                             throw;
                         }
-
-                        return Task.CompletedTask;
                     }
                 }));
             }


### PR DESCRIPTION
Fixes #2977.

I could repro the issue by creating multiple tenants on my machine.

- When entering in our custom shell scope we swap the existing `RequestServices` with our scoped service provider until the end of the scope. The problem is when using `Task.WhenAll` to 1st initialize all tenants where, even if no full parallelism, the flow of each individual task progresses in "parallel".

    In this context, a tenant scope may cache and then return to the `RequestServices` the service provider of another tenant scope that will be disposed. It fails in the new `ShellViewFeatureProvider` where we use `RequestServices` to resolve application singletons. An easy fix is to resolve them later, i tried it. But i think that this issue just highlighted another problem that we need to fix in another way.

- I had this kind of issues in background tasks, the other place where we create multiple shells, here with full parallelism. We needed to isolate the `HttpContext`, now naturally done in a host service, and in each task we needed to create a new isolated `HttpContext`. But here maybe better to find a simpler way.

- But but but, when we 1st compose all shells (i don't talk about building the pipeline) the only place where we use our custom scope is in `ShellContextFactory`, just to resolve `IShellDescriptorManager`. This is here that i saw the interleaving of scopes creation / disposing and the mixing of services. **So, replacing `describedContext.CreateScope()` with `describedContext.ServiceProvider.CreateScope()` to use a regular `IServiceScope` also fixed the issue**.

- For infos, i also saw that `ShellContextFactory` resolves `IShellDescriptorManager` => `ISession` => we add this session in `httpContext.Items` which is not concurrent. I had this issue when creating shells with full parallelism but not isolated httpContext. But with `Task.WhenAll` where tasks are not triggered e.g by task run, as i checked non async codes between 2 await are not fully run in parallel so seems to be ok.

    So, on the 1st tenants init, the result is just that the last initialized tenant wins to put its session in `httpContext.Items`, but afterwards we create a new scope on the right tenant to really serve the request, so seems to be ok. I tried it by starting with an url to edit directly an item of a given tenant.