### PR TITLE
Localizations files search paths

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.Localization
                 yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id, poFileName)));
 
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/OrchardCore.Cms.Web-fr-CA.po
-                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + "-" + poFileName)));
+                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + "." + poFileName)));
 
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/fr-CA/OrchardCore.Cms.Web.po
                 yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, cultureName, extension.Id + PoFileExtension)));

--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -57,13 +57,13 @@ namespace OrchardCore.Localization
             foreach (var extension in extensions)
             {
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/OrchardCore.Cms.Web/fr-CA.po
-                yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id, poFileName));
+                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id, poFileName)));
 
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/OrchardCore.Cms.Web-fr-CA.po
-                yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + "-" + poFileName));
+                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + "-" + poFileName)));
 
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/fr-CA/OrchardCore.Cms.Web.po
-                yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, cultureName, extension.Id + PoFileExtension));
+                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, cultureName, extension.Id + PoFileExtension)));
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -39,9 +39,10 @@ namespace OrchardCore.Localization
         public IEnumerable<IFileInfo> GetLocations(string cultureName)
         {
             var poFileName = cultureName + PoFileExtension;
+            var extensions = _extensionsManager.GetExtensions();
 
             // Load .po files in each extension folder first, based on the extensions order
-            foreach (var extension in _extensionsManager.GetExtensions())
+            foreach (var extension in extensions)
             {
                 yield return _fileProvider.GetFileInfo(PathExtensions.Combine(extension.SubPath, ExtensionDataFolder, _resourcesContainer, poFileName));
             }
@@ -49,8 +50,21 @@ namespace OrchardCore.Localization
             // Then load global .po file for the applications
             yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, poFileName)));
 
-            // Finally load tenant-specific .po file
+            // Load tenant-specific .po file
             yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_shellDataContainer, _resourcesContainer, poFileName)));
+
+            // Load each modules .po file for extending localization when using Orchard Core as a Nuget package
+            foreach (var extension in extensions)
+            {
+                // \src\OrchardCore.Cms.Web\App_Data/Localization/OrchardCore.Cms.Web/fr-CA.po
+                yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id, poFileName));
+
+                // \src\OrchardCore.Cms.Web\App_Data/Localization/OrchardCore.Cms.Web-fr-CA.po
+                yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + "-" + poFileName));
+
+                // \src\OrchardCore.Cms.Web\App_Data/Localization/fr-CA/OrchardCore.Cms.Web.po
+                yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, cultureName, extension.Id + PoFileExtension));
+            }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Localization/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/README.md
@@ -15,7 +15,7 @@ whith source code :
 with Nuget package solution : 
 - For each module and theme all files matching 
     - `[YourCustomProjectFolder]/App_Data/Localization/[ModuleId]/[CultureName].po`
-    - `[YourCustomProjectFolder]/App_Data/Localization/[ModuleId]-[CultureName].po`
+    - `[YourCustomProjectFolder]/App_Data/Localization/[ModuleId].[CultureName].po`
     - `[YourCustomProjectFolder]/App_Data/Localization/[CultureName]/[ModuleId].po`
 
 ## File format

--- a/src/OrchardCore.Modules/OrchardCore.Localization/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/README.md
@@ -5,18 +5,22 @@ It also supports plural forms.
 
 ## PO files locations
 
-PO files are found via the following steps:
+PO files are found at these locations:
 
-whith source code : 
 - For each module and theme all files matching `[ModuleLocation]/App_Data/Localization/[CultureName].po`
-- Then all files matching `/App_Data/Localization/[CultureName].po`
+- All files matching `/App_Data/Localization/[CultureName].po`
 - For each tenant all files matching `/App_Data/Sites/[TenantName]/Localization/[CultureName].po`
-
-with Nuget package solution : 
 - For each module and theme all files matching 
-    - `[YourCustomProjectFolder]/App_Data/Localization/[ModuleId]/[CultureName].po`
-    - `[YourCustomProjectFolder]/App_Data/Localization/[ModuleId].[CultureName].po`
-    - `[YourCustomProjectFolder]/App_Data/Localization/[CultureName]/[ModuleId].po`
+    - `/App_Data/Localization/[ModuleId]/[CultureName].po`
+    - `/App_Data/Localization/[ModuleId].[CultureName].po`
+    - `/App_Data/Localization/[CultureName]/[ModuleId].po`
+
+`[CultureName]` can is either the culture neutral part, e.g. `fr`, or the full one, e.g. `fr-CA`.
+
+### Examples:
+`/App_Data/Localization/fr.po`
+`/App_Data/Localization/fr-CA.po`
+`/App_Data/Localization/es-MX.po`
 
 ## File format
 

--- a/src/OrchardCore.Modules/OrchardCore.Localization/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/README.md
@@ -7,9 +7,16 @@ It also supports plural forms.
 
 PO files are found via the following steps:
 
+whith source code : 
 - For each module and theme all files matching `[ModuleLocation]/App_Data/Localization/[CultureName].po`
 - Then all files matching `/App_Data/Localization/[CultureName].po`
 - For each tenant all files matching `/App_Data/Sites/[TenantName]/Localization/[CultureName].po`
+
+with Nuget package solution : 
+- For each module and theme all files matching 
+    - `[YourCustomProjectFolder]/App_Data/Localization/[ModuleId]/[CultureName].po`
+    - `[YourCustomProjectFolder]/App_Data/Localization/[ModuleId]-[CultureName].po`
+    - `[YourCustomProjectFolder]/App_Data/Localization/[CultureName]/[ModuleId].po`
 
 ## File format
 

--- a/src/OrchardCore.Modules/OrchardCore.Localization/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/README.md
@@ -18,9 +18,9 @@ PO files are found at these locations:
 `[CultureName]` can is either the culture neutral part, e.g. `fr`, or the full one, e.g. `fr-CA`.
 
 ### Examples:
-`/App_Data/Localization/fr.po`
-`/App_Data/Localization/fr-CA.po`
-`/App_Data/Localization/es-MX.po`
+- `/App_Data/Localization/fr.po`
+- `/App_Data/Localization/fr-CA.po`
+- `/App_Data/Localization/es-MX.po`
 
 ## File format
 


### PR DESCRIPTION
Adding paths where to find module localizations when using Orchard Core as a Nuget package.

Fixes #2980