### PR TITLE
Replace localization culture delimiter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -14,6 +14,7 @@ namespace OrchardCore.Localization
     {
         private const string PoFileExtension = ".po";
         private const string ExtensionDataFolder = "App_Data";
+        private const string CultureDelimiter = "-";
 
         private readonly IExtensionManager _extensionsManager;
         private readonly IFileProvider _fileProvider;
@@ -60,7 +61,7 @@ namespace OrchardCore.Localization
                 yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id, poFileName)));
 
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/OrchardCore.Cms.Web-fr-CA.po
-                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + "-" + poFileName)));
+                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + CultureDelimiter + poFileName)));
 
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/fr-CA/OrchardCore.Cms.Web.po
                 yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, cultureName, extension.Id + PoFileExtension)));

--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.Localization
                 yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id, poFileName)));
 
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/OrchardCore.Cms.Web-fr-CA.po
-                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + "." + poFileName)));
+                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + "-" + poFileName)));
 
                 // \src\OrchardCore.Cms.Web\App_Data/Localization/fr-CA/OrchardCore.Cms.Web.po
                 yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, cultureName, extension.Id + PoFileExtension)));

--- a/src/OrchardCore.Modules/OrchardCore.Localization/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/README.md
@@ -12,7 +12,7 @@ PO files are found at these locations:
 - For each tenant all files matching `/App_Data/Sites/[TenantName]/Localization/[CultureName].po`
 - For each module and theme all files matching 
     - `/App_Data/Localization/[ModuleId]/[CultureName].po`
-    - `/App_Data/Localization/[ModuleId].[CultureName].po`
+    - `/App_Data/Localization/[ModuleId]-[CultureName].po`
     - `/App_Data/Localization/[CultureName]/[ModuleId].po`
 
 `[CultureName]` can is either the culture neutral part, e.g. `fr`, or the full one, e.g. `fr-CA`.


### PR DESCRIPTION
Replace `.` by `-`

=> `/App_Data/Localization/[ModuleId]-[CultureName].po`

Fixes #3070