### PR TITLE
Adding missing ContentPart.TermAdmin template

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/ContentPart.TermAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/ContentPart.TermAdmin.cshtml
@@ -1,0 +1,15 @@
+@using OrchardCore.Mvc.Utilities
+
+@{
+    string name = Model.Metadata.Name;
+}
+
+@if (Model.Content != null)
+{
+    // We don't render anything from custom parts in the terms list
+    // This can be customized per part by creating custom templates
+
+    @*<div class="contentpart contentpart-@name.HtmlClassify()">
+        @await DisplayAsync(Model.Content)
+    </div>*@    
+}


### PR DESCRIPTION
Fixes #3078

The TermAdmin display type is used when rendering the terms list.
The ContentPart.TermAdmin fallback template is required.