### PR TITLE
Added validation for AliasPart to test for duplicate aliases (#2310)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
@@ -7,16 +7,27 @@ using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Alias.Models;
 using OrchardCore.Alias.Settings;
 using OrchardCore.Alias.ViewModels;
+using YesSql;
+using OrchardCore.Alias.Indexes;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Mvc.ModelBinding;
 
 namespace OrchardCore.Alias.Drivers
 {
     public class AliasPartDisplayDriver : ContentPartDisplayDriver<AliasPart>
     {
         private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly ISession _session;
+        private readonly IStringLocalizer<AliasPartDisplayDriver> T;
 
-        public AliasPartDisplayDriver(IContentDefinitionManager contentDefinitionManager)
+        public AliasPartDisplayDriver(
+            IContentDefinitionManager contentDefinitionManager,
+            ISession session,
+            IStringLocalizer<AliasPartDisplayDriver> localizer)
         {
             _contentDefinitionManager = contentDefinitionManager;
+            _session = session;
+            T = localizer;
         }
 
         public override IDisplayResult Edit(AliasPart aliasPart)
@@ -29,7 +40,9 @@ namespace OrchardCore.Alias.Drivers
             var settings = GetAliasPartSettings(model);
 
             await updater.TryUpdateModelAsync(model, Prefix, t => t.Alias);
-            
+
+            await ValidateAsync(model, updater);
+
             return Edit(model);
         }
 
@@ -49,6 +62,14 @@ namespace OrchardCore.Alias.Drivers
             model.Alias = part.Alias;
             model.AliasPart = part;
             model.Settings = settings;
+        }
+
+        private async Task ValidateAsync(AliasPart alias, IUpdateModel updater)
+        {
+            if (alias.Alias != null && (await _session.QueryIndex<AliasPartIndex>(o => o.Alias == alias.Alias && o.ContentItemId != alias.ContentItem.ContentItemId).CountAsync()) > 0)
+            {
+                updater.ModelState.AddModelError(Prefix, nameof(alias.Alias), T["Your alias is already in use."]);
+            }
         }
     }
 }


### PR DESCRIPTION
Initial validation for AliasPart to test for duplicate aliases. 
Based on same validation checks as the AutoRoutePart, however I haven't bought over the invalid character checks as it doesn't feel like an alias needs any further validation