### PR TITLE
Adding Visual Studio extension and training demo module references to index.md

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -73,6 +73,8 @@ Here is a more detailed [roadmap](https://github.com/OrchardCMS/OrchardCore/wiki
 
 - Follow the samples on <https://github.com/OrchardCMS/OrchardCore.Samples> that will guide you on how to build **modular** and **multi-tenant** applications
 
+- Follow the tutorial inside the [Training Demo Module](https://github.com/Lombiq/Orchard-Training-Demo-Module) to learn how to develop Orchard Core modules.
+
 ### Command line
 
 - Install the latest version of the .NET Core SDK from this page <https://www.microsoft.com/net/download/core>
@@ -88,6 +90,7 @@ You can also read the [Code Generation Templates documentation](Templates/README
 - Download Visual Studio 2017 (any edition) from <https://www.visualstudio.com/downloads/>.
 - Open `OrchardCore.sln` and wait for Visual Studio to restore all Nuget packages.
 - Ensure `OrchardCore.Cms.Web` is the startup project and run it.
+- Optionally install [Lombiq Orchard Visual Studio Extension](https://marketplace.visualstudio.com/items?itemName=LombiqVisualStudioExtension.LombiqOrchardVisualStudioExtension) to add some useful utilities to your Visual Studio such as an error log watcher or a dependency injector.
 
 ### Contributing
 

--- a/src/index.md
+++ b/src/index.md
@@ -90,7 +90,7 @@ You can also read the [Code Generation Templates documentation](Templates/README
 - Download Visual Studio 2017 (any edition) from <https://www.visualstudio.com/downloads/>.
 - Open `OrchardCore.sln` and wait for Visual Studio to restore all Nuget packages.
 - Ensure `OrchardCore.Cms.Web` is the startup project and run it.
-- Optionally install [Lombiq Orchard Visual Studio Extension](https://marketplace.visualstudio.com/items?itemName=LombiqVisualStudioExtension.LombiqOrchardVisualStudioExtension) to add some useful utilities to your Visual Studio such as an error log watcher or a dependency injector.
+- Optionally install the [Lombiq Orchard Visual Studio Extension](https://marketplace.visualstudio.com/items?itemName=LombiqVisualStudioExtension.LombiqOrchardVisualStudioExtension) to add some useful utilities to your Visual Studio such as an error log watcher or a dependency injector.
 
 ### Contributing
 


### PR DESCRIPTION
As discussed in the community meeting I am adding Lombiq Orchard Visual Studio Extension and Orchard Training Demo Module references to the Orchard Core docs.