### PR TITLE
[GraphQL] Fixes UserContext being null for collapsed  fields

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
@@ -62,6 +62,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                                         Arguments = context.Arguments,
                                         Source = resolvedPart,
                                         FieldDefinition = field,
+                                        UserContext = context.UserContext
                                     });
                                 })
                             };


### PR DESCRIPTION
Currently if a part is marked as collapsed the UserContext property is null if you try to do ResolveAsync on it, this solves that by passing the context through to collapsed fields.

/cc @Jetski5822 