### PR TITLE
Fix connection usage not supplying transaction during upgrade beta 2

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
@@ -159,8 +159,8 @@ namespace OrchardCore.Environment.Shell.Data.Descriptors
 
                     var updateShellStateCmd = $"UPDATE {documentTable} SET {dialect.QuoteForColumnName(nameof(Document.Type))} = {dialect.GetSqlValue(newShellStateType)} WHERE {dialect.QuoteForColumnName(nameof(Document.Type))} = {dialect.GetSqlValue(oldShellStateType)}";
 
-                    await connection.ExecuteAsync(updateShellDescriptorCmd);
-                    await connection.ExecuteAsync(updateShellStateCmd);
+                    await connection.ExecuteAsync(updateShellDescriptorCmd, null, transaction);
+                    await connection.ExecuteAsync(updateShellStateCmd, null, transaction);
 
                     transaction.Commit();
                 }


### PR DESCRIPTION
Noticed I was getting an error when setting up a new site. 

```
InvalidOperationException: BeginExecuteNonQuery requires the command to have a transaction when the connection assigned to the command is in a pending local transaction. The Transaction property of the command has not been initialized.
```

Tracked the issue down to a recent commit (abbc8060d46a6504f8540f78b0b01caaa20581e8) from @sebastienros where when running database queries for handling upgrading from beta 2, the active database transaction wasn't being provided to `ExecuteAsync`.

