### PR TITLE
Ensure meta tags are rendered self closing

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/MetaEntry.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/MetaEntry.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.ResourceManagement
             _builder.TagRenderMode = TagRenderMode.SelfClosing;
         }
 
-        public MetaEntry(string name = null, string content = null, string httpEquiv = null, string charset = null)
+        public MetaEntry(string name = null, string content = null, string httpEquiv = null, string charset = null) : this()
         {
             if (!String.IsNullOrEmpty(name))
             {


### PR DESCRIPTION
Noticed when initializing `MetaEntry` with parameters, the meta tag wouldn't be rendered self closing. Fix was to make the constructor with parameters also call the empty constructor.