### PR TITLE
Remove interpolated strings from calls to IStringLocalizer

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Commands/RecipesCommands.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Commands/RecipesCommands.cs
@@ -37,12 +37,12 @@ namespace OrchardCore.Recipes.Commands
 
             foreach (var recipe in recipes)
             {
-                await Context.Output.WriteLineAsync(T[$"Recipe: {recipe.Name}"]);
-                await Context.Output.WriteLineAsync(T[$"  Version:     {recipe.Version}"]);
-                await Context.Output.WriteLineAsync(T[$"  Tags:        {string.Join(",", recipe.Tags)}"]);
-                await Context.Output.WriteLineAsync(T[$"  Description: {recipe.Description}"]);
-                await Context.Output.WriteLineAsync(T[$"  Author:      {recipe.Author}"]);
-                await Context.Output.WriteLineAsync(T[$"  Website:     {recipe.WebSite}"]);
+                await Context.Output.WriteLineAsync(T["Recipe: {0}", recipe.Name]);
+                await Context.Output.WriteLineAsync(T["  Version:     {0}", recipe.Version]);
+                await Context.Output.WriteLineAsync(T["  Tags:        {0}", string.Join(",", recipe.Tags)]);
+                await Context.Output.WriteLineAsync(T["  Description: {0}", recipe.Description]);
+                await Context.Output.WriteLineAsync(T["  Author:      {0}", recipe.Author]);
+                await Context.Output.WriteLineAsync(T["  Website:     {0}", recipe.WebSite]);
             }
         }
     }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Commands/Builtin/HelpCommand.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Commands/Builtin/HelpCommand.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
@@ -47,7 +47,7 @@ namespace OrchardCore.Environment.Commands.Builtin
 
             if (!descriptors.Any())
             {
-                await Context.Output.WriteLineAsync(T[$"Command {command} doesn't exist"]);
+                await Context.Output.WriteLineAsync(T["Command {0} doesn't exist", command]);
             }
             else
             {
@@ -68,7 +68,7 @@ namespace OrchardCore.Environment.Commands.Builtin
         {
             if (string.IsNullOrEmpty(descriptor.HelpText))
             {
-                return T[$"{descriptor.MethodInfo.DeclaringType?.FullName}.{descriptor.MethodInfo.Name}: no help text"];
+                return T["{0}.{1}: no help text", descriptor.MethodInfo.DeclaringType?.FullName, descriptor.MethodInfo.Name];
             }
 
             return T[descriptor.HelpText];

--- a/src/OrchardCore/OrchardCore.Infrastructure/Commands/CommandHostAgent.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Commands/CommandHostAgent.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -79,7 +79,7 @@ namespace OrchardCore.Environment.Commands
         {
             // Display header
             await output.WriteLineAsync();
-            await output.WriteLineAsync(T[$"{title}"]);
+            await output.WriteLineAsync(title);
 
             // Push exceptions in a stack so we display from inner most to outer most
             var errors = new Stack<Exception>();


### PR DESCRIPTION
Because the string is interpolated before it is passed to a localizer, it doesn't work as intended.

e.g. `T[$"Command {command} doesn't exist"]` calls the localizer with `"Command some_command doesn't exist`". 