### PR TITLE
#3169 extends servicecollection to update env.WebRootFileProvider

### DIFF
--- a/src/OrchardCore.Cms.Web/Startup.cs
+++ b/src/OrchardCore.Cms.Web/Startup.cs
@@ -18,8 +18,6 @@ namespace OrchardCore.Cms.Web
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseStaticFiles();
-
             app.UseOrchardCore();
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -189,7 +189,6 @@ namespace OrchardCore.Media
 
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
-            var env = serviceProvider.GetRequiredService<IHostingEnvironment>();
             var shellOptions = serviceProvider.GetRequiredService<IOptions<ShellOptions>>();
             var shellSettings = serviceProvider.GetRequiredService<ShellSettings>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -199,13 +199,7 @@ namespace OrchardCore.Media
             {
                 Directory.CreateDirectory(mediaPath);
             }
-
-            var fileProviders = new List<IFileProvider>();
-            fileProviders.Add(env.WebRootFileProvider);
-            fileProviders.Add(new PhysicalFileProvider(mediaPath));
-
-            env.WebRootFileProvider = new CompositeFileProvider(fileProviders);
-
+            
             // ImageSharp before the static file provider
             app.UseImageSharp();
 
@@ -213,7 +207,7 @@ namespace OrchardCore.Media
             {
                 // The tenant's prefix is already implied by the infrastructure
                 RequestPath = AssetsUrlPrefix,
-                FileProvider = env.WebRootFileProvider,
+                FileProvider = new PhysicalFileProvider(mediaPath),
                 ServeUnknownFileTypes = true,
             });
         }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Manifest.cs
@@ -19,6 +19,5 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.Tenants.FileProvider",
     Name = "Static File Provider",
     Description = "Provides a way to serve independent static files for each tenant.",
-    Category = "Infrastructure",
-    DefaultTenantOnly = true
+    Category = "Infrastructure"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Startup.cs
@@ -39,7 +39,6 @@ namespace OrchardCore.Tenants
         
         public override void Configure(IApplicationBuilder app, IRouteBuilder routes, IServiceProvider serviceProvider)
         {
-            var env = serviceProvider.GetRequiredService<IHostingEnvironment>();
             var shellOptions = serviceProvider.GetRequiredService<IOptions<ShellOptions>>();
             var shellSettings = serviceProvider.GetRequiredService<ShellSettings>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Startup.cs
@@ -50,15 +50,9 @@ namespace OrchardCore.Tenants
                 Directory.CreateDirectory(contentRoot);
             }
             
-            var fileProviders = new List<IFileProvider>();
-            fileProviders.Add(env.WebRootFileProvider);
-            fileProviders.Add(new PhysicalFileProvider(contentRoot));
-
-            env.WebRootFileProvider = new CompositeFileProvider(fileProviders);
-
             app.UseStaticFiles(new StaticFileOptions
             {
-                FileProvider = env.WebRootFileProvider,
+                FileProvider = new PhysicalFileProvider(contentRoot),
                 DefaultContentType = "application/octet-stream",
                 ServeUnknownFileTypes = true,
 

--- a/src/OrchardCore.Mvc.Web/Startup.cs
+++ b/src/OrchardCore.Mvc.Web/Startup.cs
@@ -24,9 +24,7 @@ namespace OrchardCore.Mvc.Web
             {
                 app.UseDeveloperExceptionPage();
             }
-
-            app.UseStaticFiles();
-
+            
             app.UseOrchardCore();
         }
     }

--- a/src/OrchardCore.Nancy.Web/Startup.cs
+++ b/src/OrchardCore.Nancy.Web/Startup.cs
@@ -25,8 +25,6 @@ namespace OrchardCore.Nancy.Web
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseStaticFiles();
-
             app.UseOrchardCore();
         }
     }

--- a/src/OrchardCore/OrchardCore.Logging.Serilog/readme.md
+++ b/src/OrchardCore/OrchardCore.Logging.Serilog/readme.md
@@ -60,7 +60,6 @@ add a reference to `OrchardCore.Logging.Serilog`
             {
                 app.UseDeveloperExceptionPage();
             }
-            app.UseStaticFiles();
             app.UseOrchardCore(c => c.UseSerilogTenantNameLoggingMiddleware());
         }
 ```

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
@@ -19,6 +20,17 @@ namespace Microsoft.AspNetCore.Builder
             env.ContentRootFileProvider = new CompositeFileProvider(
                 new ModuleEmbeddedFileProvider(appContext),
                 env.ContentRootFileProvider);
+
+            var fileProviders = new List<IFileProvider>();
+            fileProviders.Add(new ModuleEmbeddedStaticFileProvider(appContext));
+            fileProviders.Add(env.WebRootFileProvider);
+
+            if (env.IsDevelopment())
+            {
+                fileProviders.Insert(0, new ModuleProjectStaticFileProvider(appContext));
+            }
+
+            env.WebRootFileProvider = new CompositeFileProvider(fileProviders);
 
             app.UseMiddleware<PoweredByMiddleware>();
 

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -119,14 +119,20 @@ namespace Microsoft.Extensions.DependencyInjection
                 if (env.IsDevelopment())
                 {
                     var fileProviders = new List<IFileProvider>();
+                    fileProviders.Add(env.WebRootFileProvider);
                     fileProviders.Add(new ModuleProjectStaticFileProvider(appContext));
                     fileProviders.Add(new ModuleEmbeddedStaticFileProvider(appContext));
                     fileProvider = new CompositeFileProvider(fileProviders);
                 }
                 else
                 {
-                    fileProvider = new ModuleEmbeddedStaticFileProvider(appContext);
+                    var fileProviders = new List<IFileProvider>();
+                    fileProviders.Add(env.WebRootFileProvider);
+                    fileProviders.Add(new ModuleEmbeddedStaticFileProvider(appContext));
+                    fileProvider = new CompositeFileProvider(fileProviders);
                 }
+
+                env.WebRootFileProvider = fileProvider;
 
                 var options = serviceProvider.GetRequiredService<IOptions<StaticFileOptions>>().Value;
 

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -113,31 +113,11 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Configure((app, routes, serviceProvider) =>
             {
                 var env = serviceProvider.GetRequiredService<IHostingEnvironment>();
-                var appContext = serviceProvider.GetRequiredService<IApplicationContext>();
-
-                IFileProvider fileProvider;
-                if (env.IsDevelopment())
-                {
-                    var fileProviders = new List<IFileProvider>();
-                    fileProviders.Add(env.WebRootFileProvider);
-                    fileProviders.Add(new ModuleProjectStaticFileProvider(appContext));
-                    fileProviders.Add(new ModuleEmbeddedStaticFileProvider(appContext));
-                    fileProvider = new CompositeFileProvider(fileProviders);
-                }
-                else
-                {
-                    var fileProviders = new List<IFileProvider>();
-                    fileProviders.Add(env.WebRootFileProvider);
-                    fileProviders.Add(new ModuleEmbeddedStaticFileProvider(appContext));
-                    fileProvider = new CompositeFileProvider(fileProviders);
-                }
-
-                env.WebRootFileProvider = fileProvider;
-
+                
                 var options = serviceProvider.GetRequiredService<IOptions<StaticFileOptions>>().Value;
 
                 options.RequestPath = "";
-                options.FileProvider = fileProvider;
+                options.FileProvider = env.WebRootFileProvider;
 
                 var shellConfiguration = serviceProvider.GetRequiredService<IShellConfiguration>();
 

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/Startup.cs
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/Startup.cs
@@ -21,8 +21,6 @@ namespace OrchardCore.Templates.Cms.Web
             {
                 app.UseDeveloperExceptionPage();
             }
-
-            app.UseStaticFiles();
 #if (UseSerilog)
             app.UseOrchardCore(c => c.UseSerilogTenantNameLoggingMiddleware());
 #else

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/Startup.cs
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/Startup.cs
@@ -18,8 +18,7 @@ namespace OrchardCore.Templates.Mvc.Web
             {
                 app.UseDeveloperExceptionPage();
             }
-
-            app.UseStaticFiles();
+            
             app.UseOrchardCore();
         }
     }

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/Startup.cs
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/Startup.cs
@@ -18,8 +18,6 @@ namespace OrchardCore.Application.Pages
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseStaticFiles();
-
             app.UseOrchardCore();
         }
     }


### PR DESCRIPTION
This updates the env.WebRootFileProvider to include module/theme static resources and resolves issue #3169 

It enables use of asp-append-version taghelper when used with asp tag helpers, e.g. 
`<link rel="stylesheet" type="text/css" href="~/Theme/styles/theme.css" asp-append-version="true">
`
If this is an appropriate change then I'd like to extend the Orchard Tag Helpers to support asp-append-version 