### PR TITLE
Fix assets app position when a warning is visible.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
@@ -6,6 +6,41 @@
 
 <script at="Foot">
     initializeMediaApplication(true, '@Url.Action("MediaApplication", "Admin", new { area = "OrchardCore.Media" })');
+
+    @* mediaApp is absolutely positioned. When a warning is shown we need to move it down to avoid overlapping. *@
+    $(function () {
+        if (!$('.message').length) { return; };
+        var mediaAppInitialTop = 0;
+        var mediaAppLoaded = false;
+
+        var repositionMediaApp = function () {
+
+            var messagesHeight = 0;
+            $('.message').each(function () {
+                messagesHeight += $(this).outerHeight(true);
+            });
+
+            var newTop = mediaAppInitialTop + messagesHeight;
+
+            $('#mediaApp').css('top', newTop + 'px');
+        }
+
+        $(window).on('resize', function () {
+            if (mediaAppLoaded) {
+                repositionMediaApp();
+            }
+        });
+
+        // before moving we need to wait until the vuejs mediaapp is loaded.
+        var checkMediaAppIsLoaded = setInterval(function () {
+            if ($('#mediaApp').length) {
+                mediaAppInitialTop = $('#mediaApp').offset().top;
+                clearInterval(checkMediaAppIsLoaded);
+                mediaAppLoaded = true;
+                repositionMediaApp();
+            }
+        }, 100);
+    });
 </script>
 
 <h1>@RenderTitleSegments(T["Assets"])</h1>


### PR DESCRIPTION
Fixes #3039
Not completely happy with this one. 
It is using javascript to move the media app down when there is a warning.
I would prefer to solve it by using CSS only. 
But I can't find a way to do it without changing a few things on theAdmin layout. That would potentially break the layout on other modules.

It works nicely though.
