### PR TITLE
Setting the default culture as supported

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,6 +33,10 @@ namespace OrchardCore.Localization
             if (!String.IsNullOrEmpty(siteSettings.Culture))
             {
                 options.SetDefaultCulture(siteSettings.Culture);
+            }
+            else
+            {
+                options.SetDefaultCulture(CultureInfo.InstalledUICulture.Name);
             }
 
             if (siteSettings.SupportedCultures.Length > 0)

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
@@ -34,8 +34,9 @@ namespace OrchardCore.Localization
             {
                 options.SetDefaultCulture(siteSettings.Culture);
             }
-            else
+            else if (siteSettings.SupportedCultures.Length > 0)
             {
+                // If other cultures are added, the system one won't be, so we add it manually
                 options.SetDefaultCulture(CultureInfo.InstalledUICulture.Name);
             }
 

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/appsettings.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/appsettings.json
@@ -3,9 +3,11 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft": "Error",
+      "System": "Error"
     }
-  },
+  }
   //#endif
   //#if (UseSerilog)
   "Serilog": {
@@ -23,7 +25,7 @@
         "Args": {
           "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
           "outputTemplate": "{Timestamp:HH:mm:ss}|{TenantName}|{RequestId}|{SourceContext}|{Level:u3}|{Message:lj}{NewLine}{Exception}",
-          "restrictedToMinimumLevel": "Information"
+          "restrictedToMinimumLevel": "Warning"
         }
       },
       {


### PR DESCRIPTION
When enabling localization, the default culture is not added to the supported list, if it's the system one.