### PR TITLE
In GraphQl tests add a delay after a tenant setup.

### DIFF
--- a/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
@@ -54,6 +54,8 @@ namespace OrchardCore.Tests.Apis.Context
             var setupResult = await DefaultTenantClient.PostAsJsonAsync("api/tenants/setup", setupModel);
             setupResult.EnsureSuccessStatusCode();
 
+            await Task.Delay(100);
+
             Client = Site.CreateDefaultClient(url);
             GraphQLClient = new OrchardGraphQLClient(Client);
         }


### PR DESCRIPTION
So that Lucene has a better chance to update its indexes and close its writer, before doing a first query.

Just to see if `ShouldListBlogPostWhenCallingAQuery` fails because of a timing issue.

related to #3157.


