### PR TITLE
Add "property" attribute to the meta tag helper.

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/MetaEntry.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/MetaEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -14,13 +14,16 @@ namespace OrchardCore.ResourceManagement
             _builder.TagRenderMode = TagRenderMode.SelfClosing;
         }
 
-        public MetaEntry(string name = null, string content = null, string httpEquiv = null, string charset = null) : this()
+        public MetaEntry(string name = null, string property = null, string content = null, string httpEquiv = null, string charset = null) : this()
         {
             if (!String.IsNullOrEmpty(name))
             {
                 Name = name;
             }
-
+            if (!String.IsNullOrEmpty(property))
+            {
+                Property = property;
+            }
             if (!String.IsNullOrEmpty(content))
             {
                 Content = content;
@@ -35,7 +38,6 @@ namespace OrchardCore.ResourceManagement
             {
                 Charset = charset;
             }
-
         }
 
         public static MetaEntry Combine(MetaEntry meta1, MetaEntry meta2, string contentSeparator)
@@ -80,6 +82,17 @@ namespace OrchardCore.ResourceManagement
                 return value;
             }
             set { SetAttribute("name", value); }
+        }
+
+        public string Property
+        {
+            get
+            {
+                string value;
+                _builder.Attributes.TryGetValue("property", out value);
+                return value;
+            }
+            set { SetAttribute("property", value); }
         }
 
         public string Content

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -432,7 +432,7 @@ namespace OrchardCore.ResourceManagement
                 _metas = new Dictionary<string, MetaEntry>();
             }
 
-            var index = meta.Name ?? meta.HttpEquiv ?? "charset";
+            var index = meta.Name ?? meta.Property ?? meta.HttpEquiv ?? "charset";
 
             _metas[index] = meta;
         }
@@ -444,7 +444,7 @@ namespace OrchardCore.ResourceManagement
                 return;
             }
 
-            var index = meta.Name ?? meta.HttpEquiv;
+            var index = meta.Name ?? meta.Property ?? meta.HttpEquiv;
 
             if (String.IsNullOrEmpty(index))
             {

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/MetaTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/MetaTagHelper.cs
@@ -5,13 +5,16 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 {
 
     [HtmlTargetElement("meta", Attributes = NameAttributeName)]
+    [HtmlTargetElement("meta", Attributes = PropertyAttributeName)]
     public class MetaTagHelper : TagHelper
     {
         private const string NameAttributeName = "asp-name";
+        private const string PropertyAttributeName = "asp-property";
 
         [HtmlAttributeName(NameAttributeName)]
         public string Name { get; set; }
 
+        [HtmlAttributeName(PropertyAttributeName)]
         public string Property { get; set; }
 
         public string Content { get; set; }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/MetaTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/MetaTagHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace OrchardCore.ResourceManagement.TagHelpers
@@ -11,6 +11,8 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
         [HtmlAttributeName(NameAttributeName)]
         public string Name { get; set; }
+
+        public string Property { get; set; }
 
         public string Content { get; set; }
 
@@ -29,11 +31,11 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
         public override void Process(TagHelperContext context, TagHelperOutput output)
         {
-            var metaEntry = new MetaEntry(Name, Content, HttpEquiv, Charset);
+            var metaEntry = new MetaEntry(Name, Property, Content, HttpEquiv, Charset);
 
             foreach (var attribute in output.Attributes)
             {
-                if (String.Equals(attribute.Name, "name", StringComparison.OrdinalIgnoreCase))
+                if (String.Equals(attribute.Name, "name", StringComparison.OrdinalIgnoreCase) || String.Equals(attribute.Name, "property", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }


### PR DESCRIPTION
The meta tag helpers need to support the property attribute so that it can be used with protocols such as Open Graph. For example:

`<meta property="og:title" content="European Travel Destinations">` 

Fixes #3210  

Before merging this PR I do need some guidance on one aspect: Currently, the meta tag helper requires the name attribute (or asp-name in razor). The property attribute replaces the name attribute in this case so the name is it is not always required however the property attribute should also allow appending additional content to an existing tag with the same property as the name does. Could someone suggest how to achieve this?