### PR TITLE
Fixes part removal in where if the index has multiple aliases

### DIFF
--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
@@ -187,7 +187,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
         }
 
         [Fact]
-        public async Task ShouldFilterPartsWithoutPartPrefix()
+        public async Task ShouldFilterPartsWithoutAPrefixWhenThePartHasNoPrefix()
         {
             _store.RegisterIndexes<AnimalIndexProvider>();
 
@@ -221,7 +221,6 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 await session.CommitAsync();
 
                 var type = new ContentItemsFieldType("Animal", new Schema());
-
 
                 context.Arguments["where"] = JObject.Parse("{ animal: { name: \"doug\" } }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
@@ -185,6 +185,51 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 Assert.False(animals.First().As<Animal>().IsHappy);
             }
         }
+
+        [Fact]
+        public async Task ShouldFilterPartsWithoutPartPrefix()
+        {
+            _store.RegisterIndexes<AnimalIndexProvider>();
+
+            using (var services = new FakeServiceCollection())
+            {
+                services.Populate(new ServiceCollection());
+                services.Services.AddScoped(x => _store.CreateSession());
+                services.Services.AddScoped<IIndexProvider, ContentItemIndexProvider>();
+                services.Services.AddScoped<IIndexProvider, AnimalIndexProvider>();
+                services.Services.AddScoped<IIndexAliasProvider, MultipleAliasIndexProvider>();
+                services.Build();
+
+                var retrunType = new ListGraphType<StringGraphType>();
+                retrunType.ResolvedType = new StringGraphType() { Name = "Animal" };
+
+                var context = new ResolveFieldContext
+                {
+                    Arguments = new Dictionary<string, object>(),
+                    UserContext = new GraphQLContext
+                    {
+                        ServiceProvider = services
+                    },
+                    ReturnType = retrunType
+                };
+
+                var ci = new ContentItem { ContentType = "Animal", Published = true, ContentItemId = "1", ContentItemVersionId = "1" };
+                ci.Weld(new AnimalPart { Name = "doug" });
+
+                var session = ((GraphQLContext)context.UserContext).ServiceProvider.GetService<ISession>();
+                session.Save(ci);
+                await session.CommitAsync();
+
+                var type = new ContentItemsFieldType("Animal", new Schema());
+
+
+                context.Arguments["where"] = JObject.Parse("{ animal: { name: \"doug\" } }");
+                var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
+
+                Assert.Single(dogs);
+                Assert.Equal("doug", dogs.First().As<AnimalPart>().Name);
+            }
+        }
     }
 
     public class Animal : ContentPart
@@ -193,6 +238,8 @@ namespace OrchardCore.Tests.Apis.GraphQL
         public bool IsHappy { get; set; }
         public bool IsScary { get; set; }
     }
+
+    public class AnimalPart : Animal { };
 
     public class AnimalIndex : MapIndex
     {
@@ -208,7 +255,9 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 {
                     return new AnimalIndex
                     {
-                        Name = contentItem.As<Animal>().Name
+                        Name = contentItem.As<Animal>() != null ?
+                                contentItem.As<Animal>().Name
+                                : contentItem.As<AnimalPart>().Name
                     };
                 });
         }
@@ -227,10 +276,23 @@ namespace OrchardCore.Tests.Apis.GraphQL
             context.For<AnimalTraitsIndex>()
                 .Map(contentItem =>
                 {
+                    var animal = contentItem.As<Animal>();
+
+                    if (animal != null)
+                    {
+                        return new AnimalTraitsIndex
+                        {
+                            IsHappy = contentItem.As<Animal>().IsHappy,
+                            IsScary = contentItem.As<Animal>().IsScary
+                        };
+                    }
+
+                    var animalPartSuffix = contentItem.As<AnimalPart>();
+
                     return new AnimalTraitsIndex
                     {
-                        IsHappy = contentItem.As<Animal>().IsHappy,
-                        IsScary = contentItem.As<Animal>().IsScary
+                        IsHappy = animalPartSuffix.IsHappy,
+                        IsScary = animalPartSuffix.IsScary
                     };
                 });
         }
@@ -250,6 +312,12 @@ namespace OrchardCore.Tests.Apis.GraphQL
             new IndexAlias
             {
                 Alias = "dogs",
+                Index = nameof(AnimalIndex),
+                With = q => q.With<AnimalIndex>()
+            },
+            new IndexAlias
+            {
+                Alias = nameof(AnimalPart),
                 Index = nameof(AnimalIndex),
                 With = q => q.With<AnimalIndex>()
             }


### PR DESCRIPTION
Seems pr #3207 still had an issue if an index had multiple aliases, and the 'Part' one wasnt the first alias index.

This pr fixes that by validating against all aliases.

/cc @Jetski5822 