### PR TITLE
Make encoding of LiquidTemplates different for Queries

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/JsonFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/JsonFilter.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using System.Web;
+using Fluid;
+using Fluid.Values;
+
+namespace OrchardCore.Liquid.Filters
+{
+    public class JsonFilter : ILiquidFilter
+    {
+        public Task<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            var content = input.ToStringValue();
+
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return Task.FromResult(input);
+            }
+
+            return Task.FromResult<FluidValue>(new StringValue("\"" + HttpUtility.JavaScriptStringEncode(content) + "\""));
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
@@ -48,6 +48,7 @@ namespace OrchardCore.Liquid
             services.AddLiquidFilter<DisplayUrlFilter>("display_url");
             services.AddLiquidFilter<ContentUrlFilter>("href");
             services.AddLiquidFilter<AbsoluteUrlFilter>("absolute_url");
+            services.AddLiquidFilter<JsonFilter>("json");
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneQuerySource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneQuerySource.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Fluid;
@@ -64,8 +65,12 @@ namespace OrchardCore.Lucene
 
                 templateContext.AmbientValues.Add("TemplateType", "Query");
 
-                var tokenizedContent = await _liquidTemplateManager.RenderAsync(luceneQuery.Template, templateContext);
-                var parameterizedQuery = JObject.Parse(tokenizedContent);
+                JObject parameterizedQuery;
+                using (var writer = new StringWriter())
+                {
+                    await _liquidTemplateManager.RenderAsync(luceneQuery.Template, writer, NullEncoder.Default, templateContext);
+                    parameterizedQuery = JObject.Parse(writer.ToString());
+                }
 
                 var analyzer = _luceneAnalyzerManager.CreateAnalyzer(LuceneSettings.StandardAnalyzer);
                 var context = new LuceneQueryContext(searcher, LuceneSettings.DefaultVersion, analyzer);

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneQuerySource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneQuerySource.cs
@@ -62,6 +62,8 @@ namespace OrchardCore.Lucene
                     }
                 }
 
+                templateContext.AmbientValues.Add("TemplateType", "Query");
+
                 var tokenizedContent = await _liquidTemplateManager.RenderAsync(luceneQuery.Template, templateContext);
                 var parameterizedQuery = JObject.Parse(tokenizedContent);
 

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlQuerySource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlQuerySource.cs
@@ -46,6 +46,8 @@ namespace OrchardCore.Queries.Sql
                 }
             }
 
+            templateContext.AmbientValues.Add("TemplateType", "Query");
+
             var tokenizedQuery = await _liquidTemplateManager.RenderAsync(sqlQuery.Template, templateContext);
 
             var connection = _store.Configuration.ConnectionFactory.CreateConnection();

--- a/src/OrchardCore/OrchardCore.Liquid.Abstractions/ILiquidTemplateManager.cs
+++ b/src/OrchardCore/OrchardCore.Liquid.Abstractions/ILiquidTemplateManager.cs
@@ -15,9 +15,11 @@ namespace OrchardCore.Liquid
     {
         public static async Task<string> RenderAsync(this ILiquidTemplateManager manager, string template, TemplateContext context)
         {
+            context.AmbientValues.TryGetValue("TemplateType", out var templateType);
+
             using (var sw = new StringWriter())
             {
-                await manager.RenderAsync(template, sw, HtmlEncoder.Create(UnicodeRanges.All), context);
+                await manager.RenderAsync(template, sw, templateType != null && templateType.ToString() == "Query" ? NullEncoder.Default : HtmlEncoder.Default, context);
                 return sw.ToString();
             }
         }

--- a/src/OrchardCore/OrchardCore.Liquid.Abstractions/ILiquidTemplateManager.cs
+++ b/src/OrchardCore/OrchardCore.Liquid.Abstractions/ILiquidTemplateManager.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text.Encodings.Web;
+using System.Text.Unicode;
 using System.Threading.Tasks;
 using Fluid;
 
@@ -16,7 +17,7 @@ namespace OrchardCore.Liquid
         {
             using (var sw = new StringWriter())
             {
-                await manager.RenderAsync(template, sw, HtmlEncoder.Default, context);
+                await manager.RenderAsync(template, sw, HtmlEncoder.Create(UnicodeRanges.All), context);
                 return sw.ToString();
             }
         }

--- a/src/OrchardCore/OrchardCore.Liquid.Abstractions/ILiquidTemplateManager.cs
+++ b/src/OrchardCore/OrchardCore.Liquid.Abstractions/ILiquidTemplateManager.cs
@@ -15,11 +15,9 @@ namespace OrchardCore.Liquid
     {
         public static async Task<string> RenderAsync(this ILiquidTemplateManager manager, string template, TemplateContext context)
         {
-            context.AmbientValues.TryGetValue("TemplateType", out var templateType);
-
             using (var sw = new StringWriter())
             {
-                await manager.RenderAsync(template, sw, templateType != null && templateType.ToString() == "Query" ? NullEncoder.Default : HtmlEncoder.Default, context);
+                await manager.RenderAsync(template, sw, HtmlEncoder.Default, context);
                 return sw.ToString();
             }
         }


### PR DESCRIPTION
Make encoding of LiquidTemplates unicode to support Accents and other special chars for Queries.

After testing Queries and using "escape" Liquid filter on querystring params passed to my Query Liquid template. I'm using "url_decode" afterward in my Query template and it's not working. Though if I don't escape it will not UrlEncode special chars so it works. 