### PR TITLE
Fix null reference exception in MediaField.cshtml

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.cshtml
@@ -1,6 +1,6 @@
 @model OrchardCore.Media.ViewModels.DisplayMediaFieldViewModel
 @using OrchardCore.ContentManagement.Metadata.Models
 
-    <div>
-        @Model.PartFieldDefinition.DisplayName(): @String.Join(", ", Model.Field.Paths ?? Array.Empty<string>())
-    </div>
+<div>
+    @Model.PartFieldDefinition.DisplayName(): @String.Join(", ", Model.Field.Paths ?? Array.Empty<string>())
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.cshtml
@@ -1,6 +1,6 @@
 @model OrchardCore.Media.ViewModels.DisplayMediaFieldViewModel
 @using OrchardCore.ContentManagement.Metadata.Models
 
-<div>
-    @Model.PartFieldDefinition.DisplayName(): @String.Join(", ", Model.Field.Paths)
-</div>
+    <div>
+        @Model.PartFieldDefinition.DisplayName(): @String.Join(", ", Model.Field.Paths ?? Array.Empty<string>())
+    </div>


### PR DESCRIPTION
When adding a media field to a content type with no value, the string.Join method throws.