### PR TITLE
Fix null error when BodyAspect is not populated

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
@@ -46,10 +46,7 @@ namespace OrchardCore.Contents.Feeds.Builders
 
                     feedItem.Element.SetElementValue("title", contentItem.DisplayText);
                     feedItem.Element.Add(link);
-                    if (bodyAspect.Body != null)
-                    {
-                        feedItem.Element.SetElementValue("description", bodyAspect.Body.ToString());
-                    }
+                    feedItem.Element.SetElementValue("description", bodyAspect.Body?.ToString());
 
                     if (contentItem.PublishedUtc != null)
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
@@ -46,7 +46,10 @@ namespace OrchardCore.Contents.Feeds.Builders
 
                     feedItem.Element.SetElementValue("title", contentItem.DisplayText);
                     feedItem.Element.Add(link);
-                    feedItem.Element.SetElementValue("description", bodyAspect.Body.ToString());
+                    if (bodyAspect.Body != null)
+                    {
+                        feedItem.Element.SetElementValue("description", bodyAspect.Body.ToString());
+                    }
 
                     if (contentItem.PublishedUtc != null)
                     {


### PR DESCRIPTION
Fix for content items that do not have a body aspect which causes the feed to throw a null reference error.