### PR TITLE
Remove unnecessary fields from content picker view model

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
@@ -35,6 +35,7 @@ namespace OrchardCore.ContentFields.Fields
         {
             return Initialize<DisplayContentPickerFieldViewModel>(GetDisplayShapeType(context), model =>
             {
+                model.ContentItemIds = field.ContentItemIds;
                 model.Field = field;
                 model.Part = context.ContentPart;
                 model.PartFieldDefinition = context.PartFieldDefinition;

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
@@ -33,14 +33,11 @@ namespace OrchardCore.ContentFields.Fields
 
         public override IDisplayResult Display(ContentPickerField field, BuildFieldDisplayContext context)
         {
-            return Initialize<DisplayContentPickerFieldViewModel>(GetDisplayShapeType(context), async model =>
+            return Initialize<DisplayContentPickerFieldViewModel>(GetDisplayShapeType(context), model =>
             {
                 model.Field = field;
                 model.Part = context.ContentPart;
                 model.PartFieldDefinition = context.PartFieldDefinition;
-                model.Updater = context.Updater;
-                model.SelectedContentItemIds = string.Join(",", field.ContentItemIds);
-                model.ContentItems = await _contentManager.GetAsync(field.ContentItemIds);
             })
             .Location("Content")
             .Location("SummaryAdmin", "");

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
@@ -35,7 +35,6 @@ namespace OrchardCore.ContentFields.Fields
         {
             return Initialize<DisplayContentPickerFieldViewModel>(GetDisplayShapeType(context), model =>
             {
-                model.ContentItemIds = field.ContentItemIds;
                 model.Field = field;
                 model.Part = context.ContentPart;
                 model.PartFieldDefinition = context.PartFieldDefinition;

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/README.md
@@ -24,12 +24,12 @@ This modules provides common content fields.
 From a `Content` template, you can reference a field's value like this
 (if the content type is `Article` and has a Text Field named `MyField`):
 
-```csharp
-var fieldValue = Model.ContentItem.Content.Article.MyField.Text;
-```
-
 ```liquid
 {{ Model.ContentItem.Content.Article.MyField.Value }}
+```
+
+```razor
+var fieldValue = Model.ContentItem.Content.Article.MyField.Text;
 ```
 
 From a field shape (see Shape Type in the table listing all the fields) you can also access properties specific to each view model.
@@ -46,13 +46,15 @@ The convention for a field view model is to also expose these properties:
 
 Some view models have special properties that are computed from the actual field data and which are more useful for templating.
 
-### `DisplayHtmlFieldViewModel`
+### `HtmlField`
+
+#### `DisplayHtmlFieldViewModel`
 
 | Property | Description |
 | --- | --- |
 | `Html` | The processed HTML, once all liquid tags have been processed. |
 
-#### `HtmlField` Example
+#### Example
 
 ```liquid
 {{ Model.Html }}
@@ -64,13 +66,15 @@ or, to display the raw content before the tags are converted:
 {{ Model.Field.Html }}
 ```
 
-### `DisplayDateTimeFieldViewModel`
+### `DateTimeField`
+
+#### `DisplayDateTimeFieldViewModel`
 
 | Property | Description |
 | --- | --- |
 | `LocalDateTime` | The date time in the time zone of the site. |
 
-#### `DateTimeField` example
+#### Example
 
 ```liquid
 {{ Model.LocalDateTime }}
@@ -82,18 +86,22 @@ or, to display the UTC value before is it converted:
 {{ Model.Field.Value }}
 ```
 
-### `DisplayContentPickerFieldViewModel`
+### `ContentPickerField`
 
-| Property | Description |
-| --- | --- |
-| `ContentItems` | The list of content items. |
-
-#### `ContentPickerField` example
+#### Example
 
 ```liquid
-{% for contentItem in Model.ContentItems %}
+{% assign contentItems = Model.Field.Content.ContentItemIds | content_item_id %}
+{% for contentItem in contentItems %}
     {{ contentItem.DisplayText }}
 {% endfor %}
+```
+
+```razor
+@foreach (var contentItem in await Orchard.GetContentItemsByIdAsync(Model.Field.ContentItemIds))
+{
+    @contentItem.DisplayText
+}
 ```
 
 ## Creating Custom Fields
@@ -153,7 +161,7 @@ This shape type will match a template file named `{FIELDTYPE}-{EDITORNAME}.Optio
 
 This template will need to render an `<option>` tag. Here is an example for a Wysiwyg options on the Html Field:
 
-```csharp
+```razor
 @{
     string currentEditor = Model.Editor;
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/README.md
@@ -91,14 +91,14 @@ or, to display the UTC value before is it converted:
 #### Example
 
 ```liquid
-{% assign contentItems = Model.Field.Content.ContentItemIds | content_item_id %}
+{% assign contentItems = Model.ContentItemIds | content_item_id %}
 {% for contentItem in contentItems %}
     {{ contentItem.DisplayText }}
 {% endfor %}
 ```
 
 ```razor
-@foreach (var contentItem in await Orchard.GetContentItemsByIdAsync(Model.Field.ContentItemIds))
+@foreach (var contentItem in await Orchard.GetContentItemsByIdAsync(Model.ContentItemIds))
 {
     @contentItem.DisplayText
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/README.md
@@ -83,7 +83,7 @@ or, to display the raw content before the tags are converted:
 or, to display the UTC value before is it converted:
 
 ```liquid
-{{ Model.Field.Value }}
+{{ Model.Value }}
 ```
 
 ### `ContentPickerField`

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayBooleanFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayBooleanFieldViewModel.cs
@@ -6,6 +6,7 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayBooleanFieldViewModel
     {
+        public bool Value => Field.Value;
         public BooleanField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayContentPickerFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayContentPickerFieldViewModel.cs
@@ -8,6 +8,7 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayContentPickerFieldViewModel
     {
+        public string[] ContentItemIds { get; set; }
         public ContentPickerField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayContentPickerFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayContentPickerFieldViewModel.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayContentPickerFieldViewModel
     {
-        public string[] ContentItemIds { get; set; }
+        public string[] ContentItemIds => Field.ContentItemIds;
         public ContentPickerField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayContentPickerFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayContentPickerFieldViewModel.cs
@@ -8,9 +8,6 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayContentPickerFieldViewModel
     {
-        public IEnumerable<ContentItem> ContentItems { get; set; }
-        public string SelectedContentItemIds { get; set; }
-        public IUpdateModel Updater { get; set; }
         public ContentPickerField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayDateFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayDateFieldViewModel.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayDateFieldViewModel
     {
-        public DateTime? Value { get; set; }
+        public DateTime? Value => Field.Value;
         public DateField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayDateTimeFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayDateTimeFieldViewModel.cs
@@ -7,6 +7,7 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayDateTimeFieldViewModel
     {
+        public DateTime? Value => Field.Value;
         public DateTime? LocalDateTime { get; set; }
         public DateTimeField Field { get; set; }
         public ContentPart Part { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayLinkFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayLinkFieldViewModel.cs
@@ -6,6 +6,8 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayLinkFieldViewModel
     {
+        public string Url => Field.Url;
+        public string Text => Field.Text;
         public LinkField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayNumericFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayNumericFieldViewModel.cs
@@ -6,6 +6,7 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayNumericFieldViewModel
     {
+        public decimal? Value => Field.Value;
         public NumericField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayTextFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayTextFieldViewModel.cs
@@ -6,6 +6,7 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayTextFieldViewModel
     {
+        public string Text => Field.Text;
         public TextField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayTimeFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/DisplayTimeFieldViewModel.cs
@@ -7,6 +7,7 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class DisplayTimeFieldViewModel
     {
+        public TimeSpan? Value => Field.Value;
         public TimeField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditYoutubeFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditYoutubeFieldViewModel.cs
@@ -8,10 +8,13 @@ using OrchardCore.ContentManagement.Metadata.Models;
 
 namespace OrchardCore.ContentFields.ViewModels
 {
-    public class EditYoutubeFieldViewModel : YoutubeFieldDisplayViewModel
+    public class EditYoutubeFieldViewModel
     {
         [DataType(DataType.Url, ErrorMessage = "The field only accepts Urls")]
         public string RawAddress { get; set; }
         public string EmbeddedAddress { get; set; }
+        public YoutubeField Field { get; set; }
+        public ContentPart Part { get; set; }
+        public ContentPartFieldDefinition PartFieldDefinition { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/YoutubeFieldDisplayViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/YoutubeFieldDisplayViewModel.cs
@@ -9,6 +9,8 @@ namespace OrchardCore.ContentFields.ViewModels
 {
     public class YoutubeFieldDisplayViewModel
     {
+        public string EmbeddedAddress => Field.EmbeddedAddress;
+        public string RawAddress => Field.RawAddress;
         public YoutubeField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField.cshtml
@@ -6,5 +6,5 @@
 }
 
 <div class="field field-type-booleanfield field-name-@name">
-    @Model.Field.Value
+    @Model.Value
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.cshtml
@@ -6,7 +6,7 @@
 
 @{
     var name = (Model.PartFieldDefinition.PartDefinition.Name + "-" + Model.PartFieldDefinition.Name).HtmlClassify();
-    var contentItems = await ContentManager.GetAsync(Model.Field.ContentItemIds);
+    var contentItems = await ContentManager.GetAsync(Model.ContentItemIds);
 }
 
 <div class="field field-type-contentpickerfield field-name-@name">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.cshtml
@@ -2,18 +2,21 @@
 @using OrchardCore.Mvc.Utilities
 @using OrchardCore.ContentManagement.Metadata.Models
 
+@inject OrchardCore.ContentManagement.IContentManager ContentManager
+
 @{
     var name = (Model.PartFieldDefinition.PartDefinition.Name + "-" + Model.PartFieldDefinition.Name).HtmlClassify();
+    var contentItems = await ContentManager.GetAsync(Model.Field.ContentItemIds);
 }
 
 <div class="field field-type-contentpickerfield field-name-@name">
     <span class="name">@Model.PartFieldDefinition.DisplayName():</span>
-    @if (Model.ContentItems.Any())
+    @if (contentItems.Any())
     {
-        foreach (var contentItem in Model.ContentItems)
+        foreach (var contentItem in contentItems)
         {
             <span class="value"><a display-for="@contentItem">@contentItem.DisplayText</a></span>
-            if (contentItem != Model.ContentItems.Last())
+            if (contentItem != contentItems.Last())
             {
                 <span>,</span>
             }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.cshtml
@@ -5,9 +5,9 @@
     var name = (Model.PartFieldDefinition.PartDefinition.Name + "-" + Model.PartFieldDefinition.Name).HtmlClassify();
 }
 
-@if (Model.Field.Value.HasValue)
+@if (Model.Value.HasValue)
 {
     <div class="field field-type-datefield field-name-@name">
-        @Model.Field.Value.Value.ToShortDateString()
+        @Model.Value.Value.ToShortDateString()
     </div>
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.cshtml
@@ -8,7 +8,7 @@
 
 @{
     var settings = Model.PartFieldDefinition.Settings.ToObject<LinkFieldSettings>();
-    string text = Model.Field.Text;
+    string text = Model.Text;
     switch (settings.LinkTextMode)
     {
         case LinkTextMode.Static:
@@ -18,20 +18,20 @@
             }
             else
             {
-                text = Model.Field.Url;
+                text = Model.Url;
             }
             break;
         case LinkTextMode.Url:
-            text = Model.Field.Url;
+            text = Model.Url;
             break;
         case LinkTextMode.Optional:
             if (String.IsNullOrWhiteSpace(text))
             {
-                text = Model.Field.Url;
+                text = Model.Url;
             }
             break;
     }
 }
 <div class="field field-type-linkfield field-name-@name">
-    <a href="@Model.Field.Url">@text</a>
+    <a href="@Model.Url">@text</a>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.cshtml
@@ -6,5 +6,5 @@
 }
 
 <div class="field field-type-numericfield field-name-@name">
-    @Model.Field.Value
+    @Model.Value
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Header.Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Header.Display.cshtml
@@ -11,5 +11,5 @@
 }
 
 @tagBuilder.RenderStartTag()
-    @Model.Field.Text
+    @Model.Text
 @tagBuilder.RenderEndTag()

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField.cshtml
@@ -6,5 +6,5 @@
 }
 
 <div class="field field-type-textfield field-name-@name">
-    @Model.Field.Text
+    @Model.Text
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.cshtml
@@ -6,5 +6,5 @@
 }
 
 <div class="field field-type-datetimefield field-name-@name">
-    @Model.Field.Value
+    @Model.Value
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/YoutubeField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/YoutubeField.cshtml
@@ -11,9 +11,9 @@
 
 <div class="field field-type-textfield field-name-@name">
     @{
-        if (!string.IsNullOrEmpty(Model.Field.EmbeddedAddress))
+        if (!string.IsNullOrEmpty(Model.EmbeddedAddress))
         {
-            <iframe width="@width" height="@height" src="@Model.Field.EmbeddedAddress" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+            <iframe width="@width" height="@height" src="@Model.EmbeddedAddress" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
         }
     }
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -107,21 +107,21 @@ Stretches the resized image to fit the bounds of its container.
 
 To obtain the correct URL for an asset, use the `AssetUrl` helper extension method on the view's base `Orchard` property, e.g.:
 
-`@Orchard.AssetUrl(Model.Field.Paths[0])`
+`@Orchard.AssetUrl(Model.Paths[0])`
 
 To obtain the correct URL for a resized asset use `AssetUrl` with the optional width, height and resizeMode parameters, e.g.:
 
-`@Orchard.AssetUrl(Model.Field.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Crop)`
+`@Orchard.AssetUrl(Model.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Crop)`
 
 ### Razor image resizing tag helpers
 
 To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to `_ViewImports.cshtml`. `asset-src` is used to obtain the correct URL for the asset and set the `src` attribute. Width, height and resize mode can be set using `img-width`, `img-height` and `img-resize-mode` respectively. e.g.:
 
-`<img asset-src="Model.Field.Paths[0]" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" />`
+`<img asset-src="Model.Paths[0]" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" />`
 
 Alternatively the Asset Url can be resolved independently and the `src` attribute used:
 
-`<img src="@Orchard.AssetUrl(Model.Field.Paths[0])" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" />`
+`<img src="@Orchard.AssetUrl(Model.Paths[0])" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" />`
 
 > The Razor Helper is accessible on the `Orchard` property if the view is using Orchard Core's Razor base class, or by injecting `OrchardCore.IOrchardHelper` in all other cases.
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/ViewModels/DisplayMediaFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/ViewModels/DisplayMediaFieldViewModel.cs
@@ -6,6 +6,7 @@ namespace OrchardCore.Media.ViewModels
 {
     public class DisplayMediaFieldViewModel
     {
+        public string[] Paths => Field.Paths;
         public MediaField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.cshtml
@@ -2,5 +2,5 @@
 @using OrchardCore.ContentManagement.Metadata.Models
 
 <div>
-    @Model.PartFieldDefinition.DisplayName(): @String.Join(", ", Model.Field.Paths ?? Array.Empty<string>())
+    @Model.PartFieldDefinition.DisplayName(): @String.Join(", ", Model.Paths ?? Array.Empty<string>())
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/README.md
@@ -37,9 +37,9 @@ The following properties are available on the `DisplayTaxonomyFieldViewModel` cl
 Returns a the term from its content item id and taxonomy.
 
 ```
-@foreach(var termId in Model.Field.TermContentItemIds)
+@foreach(var termId in Model.TermContentItemIds)
 {
-    @await OrchardCore.GetTaxonomyTermAsync(Model.Field.TaxonomyContentItemId, termId);
+    @await OrchardCore.GetTaxonomyTermAsync(Model.TaxonomyContentItemId, termId);
 }
 ```
 
@@ -48,10 +48,10 @@ Returns a the term from its content item id and taxonomy.
 Returns the list of terms including their parents.
 
 ```
-@foreach(var termId in Model.Field.TermContentItemIds)
+@foreach(var termId in Model.TermContentItemIds)
 {
     <div>
-    @foreach(var parent in await OrchardCore.GetInheritedTermsAsync(Model.Field.TaxonomyContentItemId, termId))
+    @foreach(var parent in await OrchardCore.GetInheritedTermsAsync(Model.TaxonomyContentItemId, termId))
     {
         @parent
     }    

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/ViewModels/DisplayTaxonomyFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/ViewModels/DisplayTaxonomyFieldViewModel.cs
@@ -6,6 +6,8 @@ namespace OrchardCore.Taxonomies.ViewModels
 {
     public class DisplayTaxonomyFieldViewModel
     {
+        public string TaxonomyContentItemId => Field.TaxonomyContentItemId;
+        public string[] TermContentItemIds => Field.TermContentItemIds;
         public TaxonomyField Field { get; set; }
         public ContentPart Part { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.cshtml
@@ -6,9 +6,9 @@
 }
 
 <div class="field field-type-taxonomyfield field-name-@name">
-    @foreach (var contentItemId in Model.Field.TermContentItemIds)
+    @foreach (var contentItemId in Model.TermContentItemIds)
     {
-        var term = await Orchard.GetTaxonomyTermAsync(Model.Field.TaxonomyContentItemId, contentItemId);
+        var term = await Orchard.GetTaxonomyTermAsync(Model.TaxonomyContentItemId, contentItemId);
         <span class="taxonomy-term">@term</span>
     }
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/README.md
@@ -183,13 +183,13 @@ To create a link for this field we can create these templates:
 #### `Project-Url.cshtml`
 
 ```razor
-<a href="@Model.Field.Text">External url</a>
+<a href="@Model.Text">External url</a>
 ```
 
 #### `Project-Url.liquid`
 
 ```liquid
-<a href="{{ Model.Field.Text }}">External url</a>
+<a href="{{ Model.Text }}">External url</a>
 ```
 
 ### Display types


### PR DESCRIPTION
This is to stop eagerly loading content items in the content picker display driver. Instead the content items can be lazily loaded in a template.

Fixes https://github.com/OrchardCMS/OrchardCore/issues/3267