### PR TITLE
Disable Layers on Admin themes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
@@ -10,6 +10,7 @@ using OrchardCore.Admin;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.DisplayManagement.Layout;
 using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Environment.Cache;
 using OrchardCore.Layers.Handlers;
 using OrchardCore.Layers.ViewModels;
@@ -27,7 +28,9 @@ namespace OrchardCore.Layers.Services
         private readonly IServiceProvider _serviceProvider;
         private readonly IMemoryCache _memoryCache;
         private readonly ISignal _signal;
-		private readonly ILayerService _layerService;
+        private readonly IThemeManager _themeManager;
+        private readonly IAdminThemeService _adminThemeService;
+        private readonly ILayerService _layerService;
 
 		public LayerFilter(
 			ILayerService layerService,
@@ -37,7 +40,9 @@ namespace OrchardCore.Layers.Services
             IScriptingManager scriptingManager,
             IServiceProvider serviceProvider,
             IMemoryCache memoryCache,
-            ISignal signal)
+            ISignal signal,
+            IThemeManager themeManager,
+            IAdminThemeService adminThemeService)
         {
 			_layerService = layerService;
 			_layoutAccessor = layoutAccessor;
@@ -47,6 +52,8 @@ namespace OrchardCore.Layers.Services
             _serviceProvider = serviceProvider;
             _memoryCache = memoryCache;
             _signal = signal;
+            _themeManager = themeManager;
+            _adminThemeService = adminThemeService;
         }
 
         public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
@@ -55,7 +62,17 @@ namespace OrchardCore.Layers.Services
 			if ((context.Result is ViewResult || context.Result is PageResult) &&
                 !AdminAttribute.IsApplied(context.HttpContext))
 			{
-				var widgets = await _memoryCache.GetOrCreateAsync("OrchardCore.Layers.LayerFilter:AllWidgets", entry =>
+                // Even if the Admin attribute is not applied we might be using the admin theme, for instance in Login views.
+                // In this case don't render Layers.
+                var selectedTheme = (await _themeManager.GetThemeAsync()).Id;
+                var adminTheme = await _adminThemeService.GetAdminThemeNameAsync();
+                if (selectedTheme == adminTheme)
+                {
+                    await next.Invoke();
+                    return;
+                }
+
+                var widgets = await _memoryCache.GetOrCreateAsync("OrchardCore.Layers.LayerFilter:AllWidgets", entry =>
                 {
                     entry.AddExpirationToken(_signal.GetToken(LayerMetadataHandler.LayerChangeToken));
                     return _layerService.GetLayerWidgetsAsync(x => x.Published);

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Services/SiteThemeSelector.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Services/SiteThemeSelector.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http;
 using OrchardCore.DisplayManagement.Theming;
 using System;
 using System.Threading.Tasks;
@@ -13,14 +13,10 @@ namespace OrchardCore.Themes.Services
     public class SiteThemeSelector : IThemeSelector
     {
         private readonly ISiteThemeService _siteThemeService;
-        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public SiteThemeSelector(
-            ISiteThemeService siteThemeService, 
-            IHttpContextAccessor httpContextAccessor)
+        public SiteThemeSelector(ISiteThemeService siteThemeService)
         {
             _siteThemeService = siteThemeService;
-            _httpContextAccessor = httpContextAccessor;
         }
 
         public async Task<ThemeSelectorResult> GetThemeAsync()

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/UsersThemeSelector.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/UsersThemeSelector.cs
@@ -57,6 +57,7 @@ namespace OrchardCore.Users.Services
                 }
 
                 string adminThemeName = await _adminThemeService.GetAdminThemeNameAsync();
+
                 if (String.IsNullOrEmpty(adminThemeName))
                 {
                     return null;


### PR DESCRIPTION
This prevents Layers from injecting widgets on the admin theme when the [Admin] attribute is not set. For instance when rendering the authentication views with the admin theme

/cc @TFleury 