### PR TITLE
IUpdater null check

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ListPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ListPartDisplayDriver.cs
@@ -72,7 +72,7 @@ namespace OrchardCore.Lists.Drivers
         {
             var settings = GetSettings(part);
             PagerSlimParameters pagerParameters = new PagerSlimParameters();
-            await updater.TryUpdateModelAsync(pagerParameters);
+            await (updater?.TryUpdateModelAsync(pagerParameters) ?? Task.CompletedTask);
 
             PagerSlim pager = new PagerSlim(pagerParameters, settings.PageSize);
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
@@ -93,7 +93,7 @@ namespace OrchardCore.ContentManagement.Display
                 groupId,
                 _shapeFactory,
                 await _layoutAccessor.GetLayoutAsync(),
-                new ModelStateWrapperUpdater(updater)
+                updater != null ? new ModelStateWrapperUpdater(updater) : null
             );
 
             await BindPlacementAsync(context);


### PR DESCRIPTION
Allows to build a content item with a list part when there is no `IUpdater`, e. in the context of a razor page. But maybe not intended to be used in this context.