### PR TITLE
Only add a user claim when it is not present

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -417,9 +417,12 @@ namespace OrchardCore.OpenId.Controllers
 
             var identity = (ClaimsIdentity) principal.Identity;
 
-            identity.AddClaim(OpenIdConstants.Claims.EntityType, OpenIdConstants.EntityTypes.User,
-                OpenIddictConstants.Destinations.AccessToken,
-                OpenIddictConstants.Destinations.IdentityToken);
+            if (!identity.HasClaim(OpenIdConstants.Claims.EntityType, OpenIdConstants.EntityTypes.User))
+            {
+                identity.AddClaim(OpenIdConstants.Claims.EntityType, OpenIdConstants.EntityTypes.User,
+                    OpenIddictConstants.Destinations.AccessToken,
+                    OpenIddictConstants.Destinations.IdentityToken);
+            }
 
             // Note: while ASP.NET Core Identity uses the legacy WS-Federation claims (exposed by the ClaimTypes class),
             // OpenIddict uses the newer JWT claims defined by the OpenID Connect specification. To ensure the mandatory
@@ -484,7 +487,8 @@ namespace OrchardCore.OpenId.Controllers
                 // The other claims will only be added to the access_token, which is encrypted when using the default format.
                 if ((claim.Type == OpenIddictConstants.Claims.Name && ticket.HasScope(OpenIddictConstants.Scopes.Profile)) ||
                     (claim.Type == OpenIddictConstants.Claims.Email && ticket.HasScope(OpenIddictConstants.Scopes.Email)) ||
-                    (claim.Type == OpenIddictConstants.Claims.Role && ticket.HasScope(OpenIddictConstants.Claims.Roles)))
+                    (claim.Type == OpenIddictConstants.Claims.Role && ticket.HasScope(OpenIddictConstants.Claims.Roles)) ||
+                    (claim.Type == OpenIdConstants.Claims.EntityType))
                 {
                     destinations.Add(OpenIddictConstants.Destinations.IdentityToken);
                 }

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/Services/IUserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/Services/IUserService.cs
@@ -14,6 +14,7 @@ namespace OrchardCore.Users.Services
         Task<bool> ChangePasswordAsync(IUser user, string currentPassword, string newPassword, Action<string, string> reportError);
         Task<IUser> GetAuthenticatedUserAsync(ClaimsPrincipal principal);
         Task<IUser> GetUserAsync(string userName);
+        Task<IUser> GetUserByUniqueIdAsync(string userIdentifier);
         Task<IUser> GetForgotPasswordUserAsync(string userIdentifier);
         Task<bool> ResetPasswordAsync(string userIdentifier, string resetToken, string newPassword, Action<string, string> reportError);
         Task<ClaimsPrincipal> CreatePrincipalAsync(IUser user);

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -191,25 +191,12 @@ namespace OrchardCore.Users.Services
         /// </summary>
         /// <param name="userIdentification">The username or email address to refer to</param>
         private async Task<IUser> FindByUsernameOrEmailAsync(string userIdentifier)
-        {
-            userIdentifier = userIdentifier.Normalize();
+            => await _userManager.FindByNameAsync(userIdentifier) ??
+               await _userManager.FindByEmailAsync(userIdentifier);
 
-            var user = await _userManager.FindByNameAsync(userIdentifier);
+        public Task<IUser> GetUserAsync(string userName) => _userManager.FindByNameAsync(userName);
 
-            if (user == null)
-            {
-                user = await _userManager.FindByEmailAsync(userIdentifier);
-            }
-
-            return user;
-        }
-
-        public Task<IUser> GetUserAsync(string userName)
-        {
-            userName = userName.Normalize();
-
-            return _userManager.FindByNameAsync(userName);
-        }
+        public Task<IUser> GetUserByUniqueIdAsync(string userIdentifier) => _userManager.FindByIdAsync(userIdentifier);
 
         public void ProcessValidationErrors(IEnumerable<IdentityError> errors, User user, Action<string, string> reportError)
         {


### PR DESCRIPTION
Adding the claim on each request makes the token grow unnecessarily