### PR TITLE
by updating a  contentItem, it must replace existing array not merging it 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/ContentMethodsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/ContentMethodsProvider.cs
@@ -55,7 +55,7 @@ namespace OrchardCore.Contents.Scripting
                     var props = JObject.FromObject(properties);
                     var content = (JObject)contentItem.ContentItem.Content;
 
-                    content.Merge(props);
+                    content.Merge(props, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
                 })
             };
         }


### PR DESCRIPTION
by updating a  ContentItem, it must replace existing array not merging it which result in duplicated values