### PR TITLE
HTML Escaping - Change 'Raw' to 'raw'

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -9,7 +9,7 @@ For more information about the Liquid syntax, please refer to this site: <https:
 
 All outputs are encoded into HTML by default.
 This means that any HTML reserved chars will be converted to the corresponding HTML entities.
-If you need to render some raw HTML chars you can use the `Raw` filter.
+If you need to render some raw HTML chars you can use the `raw` filter.
 
 ## Content Item Filters
 


### PR DESCRIPTION
The liquid filter needs to be lowercase 'raw' to work, uppercase 'Raw' did not work for me.