### PR TITLE
Add in `crop` for Resize Mode

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -95,6 +95,10 @@ Resizes the image until the shortest side reaches the given dimension. Upscaling
 
 Stretches the resized image to fit the bounds of its container.
 
+##### `crop`
+
+Resizes the image using the same functionality as `max` then removes any image area falling outside the bounds of its container.
+
 ### Input
 
 `{{ 'animals/kittens.jpg' | asset_url | resize_url: width:100, height:240, mode:'crop' }}`


### PR DESCRIPTION
`crop` is already supported in liquid syntax, just isn't documented. Adding in this documentation.