### PR TITLE
Revert "Call PublishAsync instead of using VersionOptions. (#3420)"

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/CreateContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/CreateContentTask.cs
@@ -65,12 +65,8 @@ namespace OrchardCore.Contents.Workflows.Activities
                 ((JObject)contentItem.Content).Merge(propertyObject);
             }
 
-            await ContentManager.CreateAsync(contentItem);
-
-            if (Publish)
-            {
-                await ContentManager.PublishAsync(contentItem);
-            }
+            var versionOptions = Publish ? VersionOptions.Published : VersionOptions.Draft;
+            await ContentManager.CreateAsync(contentItem, versionOptions);
 
             workflowContext.LastResult = contentItem;
             workflowContext.CorrelationId = contentItem.ContentItemId;


### PR DESCRIPTION
This reverts commit b19eda5f25a6e1c5f06ac103903aca844bb07848.

Did not fix the real issue. Introduced a bug where the content would always be published since I did not pass VersionOptions.Draft.