### PR TITLE
Continuation of #3230 - provide empty rss feed description & better rss feed encoding

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Mvc;
@@ -44,9 +46,9 @@ namespace OrchardCore.Contents.Feeds.Builders
                         guid.Add(url);
                     });
 
-                    feedItem.Element.SetElementValue("title", contentItem.DisplayText);
+                    feedItem.Element.SetElementValue("title", WebUtility.HtmlEncode(contentItem.DisplayText));
                     feedItem.Element.Add(link);
-                    feedItem.Element.SetElementValue("description", bodyAspect.Body?.ToString());
+                    feedItem.Element.SetElementValue("description", bodyAspect.Body != null ? $"<![CDATA[{bodyAspect.Body?.ToString()}]]>" : String.Empty);
 
                     if (contentItem.PublishedUtc != null)
                     {
@@ -71,8 +73,8 @@ namespace OrchardCore.Contents.Feeds.Builders
                         context.Builder.AddProperty(context, feedItem, "link", url);
                     });
 
-                    context.Builder.AddProperty(context, feedItem, "title", contentItem.DisplayText);
-                    context.Builder.AddProperty(context, feedItem, "description", bodyAspect.Body?.ToString());
+                    context.Builder.AddProperty(context, feedItem, "title", WebUtility.HtmlEncode(contentItem.DisplayText));
+                    context.Builder.AddProperty(context, feedItem, "description", bodyAspect.Body != null ? $"<![CDATA[{bodyAspect.Body?.ToString()}]]>" : String.Empty);
 
                     if (contentItem.PublishedUtc != null)
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
@@ -72,7 +72,7 @@ namespace OrchardCore.Contents.Feeds.Builders
                     });
 
                     context.Builder.AddProperty(context, feedItem, "title", contentItem.DisplayText);
-                    context.Builder.AddProperty(context, feedItem, "description", bodyAspect.Body.ToString());
+                    context.Builder.AddProperty(context, feedItem, "description", bodyAspect.Body?.ToString());
 
                     if (contentItem.PublishedUtc != null)
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
@@ -48,6 +48,7 @@ namespace OrchardCore.Contents.Feeds.Builders
 
                     feedItem.Element.SetElementValue("title", WebUtility.HtmlEncode(contentItem.DisplayText));
                     feedItem.Element.Add(link);
+
                     feedItem.Element.SetElementValue("description", bodyAspect.Body != null ? $"<![CDATA[{bodyAspect.Body?.ToString()}]]>" : String.Empty);
 
                     if (contentItem.PublishedUtc != null)

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
@@ -64,10 +64,7 @@ namespace OrchardCore.Lists.Feeds
                 context.Response.Element.SetElementValue("title", contentItem.DisplayText);
                 context.Response.Element.Add(link);
 
-                if (bodyAspect.Body != null)
-                {
-                    context.Response.Element.SetElementValue("description", bodyAspect.Body.ToString());
-                }
+                context.Response.Element.SetElementValue("description", bodyAspect.Body?.ToString());
 
                 context.Response.Contextualize(contextualize =>
                 {
@@ -81,10 +78,7 @@ namespace OrchardCore.Lists.Feeds
             {
                 context.Builder.AddProperty(context, null, "title", contentItem.DisplayText);
 
-                if (bodyAspect.Body != null)
-                {
-                    context.Builder.AddProperty(context, null, "description", bodyAspect.Body.ToString());
-                }
+                context.Builder.AddProperty(context, null, "description", bodyAspect.Body?.ToString());
 
                 context.Response.Contextualize(contextualize =>
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Mvc;
@@ -61,10 +63,10 @@ namespace OrchardCore.Lists.Feeds
             if (context.Format == "rss")
             {
                 var link = new XElement("link");
-                context.Response.Element.SetElementValue("title", contentItem.DisplayText);
+                context.Response.Element.SetElementValue("title", WebUtility.HtmlEncode(contentItem.DisplayText));
                 context.Response.Element.Add(link);
 
-                context.Response.Element.SetElementValue("description", bodyAspect.Body?.ToString());
+                context.Response.Element.SetElementValue("description", bodyAspect.Body != null ? $"<![CDATA[{bodyAspect.Body?.ToString()}]]>" : String.Empty);
 
                 context.Response.Contextualize(contextualize =>
                 {
@@ -78,7 +80,7 @@ namespace OrchardCore.Lists.Feeds
             {
                 context.Builder.AddProperty(context, null, "title", contentItem.DisplayText);
 
-                context.Builder.AddProperty(context, null, "description", bodyAspect.Body?.ToString());
+                context.Builder.AddProperty(context, null, "description", bodyAspect.Body != null ? $"<![CDATA[{bodyAspect.Body?.ToString()}]]>" : String.Empty);
 
                 context.Response.Contextualize(contextualize =>
                 {


### PR DESCRIPTION
This provides a better fix to #3230
* Empty string for description if no BodyAspect available (FlowParts)
* Encodes Title to get a valid feed if it has characters like & in it
* Wraps BodyAspect in [CDATA] section so that html characters pass validation

checked feeds against https://validator.w3.org/feed/

@sebastienros Re: FlowPart should provide BodyAspect comment from #3230 - yes it should, but what happens when an item has a body part and a flow part that both provide a BodyAspect? Suspect you get two body aspects. Wonder if `ContentManager.PopulateAspectAsync` would benefit from having a Builder arrangement plumbed in, with Priorities, and via providers, so that you could control how aspects are generated. Would potentially make Aspects more useful for generating SEO content or Image metadata content. An aspect provider could then figure out the metadata for content item images by perusing the contentitem as a whole rather than just looking at individual parts. 

Might be useful for #3404 - when you create a image content type as...
```
I will never repeat it enough, if you really want it, it's 4 clicks away, create a content type and add aefia field, or two, or three, plus text fields, ...
```
you could also create your ImageAspect provider to plumb into metadata
