### PR TITLE
Use MailKit as default mail sender

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -17,6 +17,7 @@
     <PackageManagement Include="Lucene.Net" Version="4.8.0-beta00005" />
     <PackageManagement Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00005" />
     <PackageManagement Include="Lucene.Net.QueryParser" Version="4.8.0-beta00005" />
+    <PackageManagement Include="MailKit" Version="2.1.4" />
     <PackageManagement Include="Markdig" Version="0.15.5" />
     <PackageManagement Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageManagement Include="MiniProfiler.AspNetCore.Mvc" Version="4.0.138" />

--- a/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Net.Mail;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
@@ -91,55 +89,13 @@ namespace OrchardCore.Email.Controllers
 
         private MailMessage CreateMessageFromViewModel(SmtpSettingsViewModel testSettings)
         {
-            var message = new MailMessage();
-
-            foreach (var email in ParseEmailAddresses(testSettings.To))
+            var message = new MailMessage
             {
-                if (ValidateEmail(email))
-                {
-                    message.To.Add(email);
-                }
-                else
-                {
-                    ModelState.AddModelError(string.Empty, T["Invalid \"To\" email : "] + email);
-                }
-            }
-
-            foreach (var email in ParseEmailAddresses(testSettings.Bcc))
-            {
-                if (ValidateEmail(email))
-                {
-                    message.Bcc.Add(email);
-                }
-                else
-                {
-                    ModelState.AddModelError(string.Empty, T["Invalid \"Bcc\" email : "] + email);
-                }
-            }
-
-            foreach (var email in ParseEmailAddresses(testSettings.Cc))
-            {
-                if (ValidateEmail(email))
-                {
-                    message.CC.Add(email);
-                }
-                else
-                {
-                    ModelState.AddModelError(string.Empty, T["Invalid \"Cc\" email : "] + email);
-                }
-            }
-
-            foreach (var email in ParseEmailAddresses(testSettings.ReplyTo))
-            {
-                if (ValidateEmail(email))
-                {
-                    message.ReplyToList.Add(email);
-                }
-                else
-                {
-                    ModelState.AddModelError(string.Empty, T["Invalid \"Reply To\" email : "] + email);
-                }
-            }
+                To = testSettings.To,
+                Bcc = testSettings.Bcc,
+                Cc = testSettings.Cc,
+                ReplyTo = testSettings.ReplyTo
+            };
 
             if (!String.IsNullOrWhiteSpace(testSettings.Subject))
             {
@@ -152,16 +108,6 @@ namespace OrchardCore.Email.Controllers
             }
 
             return message;
-        }
-
-        private static IEnumerable<string> ParseEmailAddresses(string adresses)
-        {
-            if (String.IsNullOrWhiteSpace(adresses))
-            {
-                return Array.Empty<string>();
-            }
-
-            return adresses.Split(new[] { ',', ';', ' ' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         private static bool ValidateEmail(string email)

--- a/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="MailKit" Version="2.1.3" />
+    <PackageReference Include="MailKit" />
   </ItemGroup>
 
 

--- a/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="MailKit" Version="2.1.3" />
   </ItemGroup>
 
 

--- a/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpService.cs
@@ -1,10 +1,12 @@
 using System;
-using System.Net;
-using System.Net.Mail;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using MailKit.Net.Smtp;
+using MimeKit;
 
 namespace OrchardCore.Email.Services
 {
@@ -12,6 +14,8 @@ namespace OrchardCore.Email.Services
     {
         private readonly SmtpSettings _options;
         private readonly ILogger<SmtpService> _logger;
+        private static readonly char[] EmailsSeparator = new char[] { ',', ';', ' ' };
+        private const string EmailExtension = ".eml";
 
         public SmtpService(
             IOptions<SmtpSettings> options,
@@ -33,68 +37,113 @@ namespace OrchardCore.Email.Services
                 return SmtpResult.Failed(S["SMTP settings must be configured before an email can be sent."]);
             }
 
-            if (message.From == null)
-            {
-                message.From = new MailAddress(_options.DefaultSender);
-            }
-            
+            var mimeMessage = FromMailMessage(message);         
             try
             {
-                using (var client = GetClient())
+                using (var client = new SmtpClient())
                 {
-                    await client.SendMailAsync(message);
+                    switch(_options.DeliveryMethod)
+                    {
+                        case SmtpDeliveryMethod.Network:
+                            await SendOnlineMessage(mimeMessage, client);
+                            break;
+                        case SmtpDeliveryMethod.SpecifiedPickupDirectory:
+                            await SendOfflineMessage(mimeMessage, _options.PickupDirectoryLocation);
+                            break;
+                        default:
+                            throw new NotSupportedException($"The '{_options.DeliveryMethod}' delivery method is not supported.");
+
+                    }
+                    client.Disconnect(true);
+
                     return SmtpResult.Success;
                 }
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                return SmtpResult.Failed(S["An error occurred while sending an email: '{0}'", e.Message]);
+                return SmtpResult.Failed(S["An error occurred while sending an email: '{0}'", ex.Message]);
             }
         }
 
-        private SmtpClient GetClient()
+        private MimeMessage FromMailMessage(MailMessage message)
         {
-            var smtp = new SmtpClient()
+            var mimeMessage = new MimeMessage
             {
-                DeliveryMethod = _options.DeliveryMethod
+                Sender = (message.From == null
+                    ? new MailboxAddress(_options.DefaultSender)
+                    : new MailboxAddress(message.From))
             };
-            
-            switch (smtp.DeliveryMethod)
+
+            if (message.To != null)
             {
-                case SmtpDeliveryMethod.Network:
-                    smtp.Host = _options.Host;
-                    smtp.Port = _options.Port;
-                    smtp.EnableSsl = _options.EnableSsl;
-
-                    smtp.UseDefaultCredentials = _options.RequireCredentials && _options.UseDefaultCredentials;
-
-                    if (_options.RequireCredentials)
-                    {
-                        if (_options.UseDefaultCredentials)
-                        {
-                            smtp.UseDefaultCredentials = true;
-                        }
-                        else if (!String.IsNullOrWhiteSpace(_options.UserName))
-                        {
-                            smtp.Credentials = new NetworkCredential(_options.UserName, _options.Password);
-                        }
-                    }
-
-                    break;
-
-                case SmtpDeliveryMethod.PickupDirectoryFromIis:
-                    // Nothing to configure
-                    break;
-
-                case SmtpDeliveryMethod.SpecifiedPickupDirectory:
-                    smtp.PickupDirectoryLocation = _options.PickupDirectoryLocation;
-                    break;
-
-                default:
-                    throw new NotSupportedException($"The '{smtp.DeliveryMethod}' delivery method is not supported."); ;
+                foreach (var address in message.To.Split(EmailsSeparator, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    mimeMessage.To.Add(new MailboxAddress(address));
+                }
             }
 
-            return smtp;
+            if (message.Cc != null)
+            {
+                foreach (var address in message.Cc.Split(EmailsSeparator, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    mimeMessage.Cc.Add(new MailboxAddress(address));
+                }
+            }
+
+            if (message.Bcc != null)
+            {
+                foreach (var address in message.Bcc.Split(EmailsSeparator, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    mimeMessage.Bcc.Add(new MailboxAddress(address));
+                }
+            }
+
+            if (message.ReplyTo != null)
+            {
+                foreach (var address in message.ReplyTo.Split(EmailsSeparator, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    mimeMessage.ReplyTo.Add(new MailboxAddress(address));
+                }
+            }
+
+            mimeMessage.Subject = message.Subject;
+            var body = new BodyBuilder();
+            if (message.IsBodyHtml)
+            {
+                body.TextBody = message.Body;
+            }
+            else
+            {
+                body.HtmlBody = message.Body;
+            }
+            mimeMessage.Body = body.ToMessageBody();
+
+            return mimeMessage;
+        }
+
+        private async Task SendOnlineMessage(MimeMessage message, SmtpClient client)
+        {
+            await client.ConnectAsync(_options.Host, _options.Port, _options.EnableSsl);    
+            var useDefaultCredentials = _options.RequireCredentials && _options.UseDefaultCredentials;
+            if (_options.RequireCredentials)
+            {
+                if (_options.UseDefaultCredentials)
+                {
+                    // There's no notion of 'UseDefaultCredentials' in MailKit, so empty credentials is passed in
+                    await client.AuthenticateAsync(String.Empty, String.Empty);
+                }
+                else if (!String.IsNullOrWhiteSpace(_options.UserName))
+                {
+                    await client.AuthenticateAsync(_options.UserName, _options.Password);
+                }
+            }
+            await client.SendAsync(message);
+        }
+
+        private async Task SendOfflineMessage(MimeMessage message, string pickupDirectory)
+        {
+            var mailPath = Path.Combine(pickupDirectory, Guid.NewGuid().ToString() + EmailExtension);
+            await message.WriteToAsync(mailPath, CancellationToken.None);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/SmtpSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/SmtpSettings.Edit.cshtml
@@ -1,5 +1,5 @@
-@model OrchardCore.Email.SmtpSettings
-@using System.Net.Mail
+@using OrchardCore.Email
+@model SmtpSettings
 
 <p class="alert alert-warning">@T["The current tenant will be reloaded when the settings are saved."]</p>
 
@@ -15,9 +15,6 @@
     <select asp-for="DeliveryMethod" class="form-control">
         <option value="@SmtpDeliveryMethod.Network" selected="@(SmtpDeliveryMethod.Network == Model.DeliveryMethod)" data-target="#@Html.Id("NetworkOptions")">
             @T["Network"]
-        </option>
-        <option value="@SmtpDeliveryMethod.PickupDirectoryFromIis" selected="@(SmtpDeliveryMethod.PickupDirectoryFromIis == Model.DeliveryMethod)" data-target="#@Html.Id("PickupDirectoryFromIisOptions")">
-            @T["Pickup directory from IIS"]
         </option>
         <option value="@SmtpDeliveryMethod.SpecifiedPickupDirectory" selected="@(SmtpDeliveryMethod.SpecifiedPickupDirectory == Model.DeliveryMethod)" data-target="#@Html.Id("SpecifiedPickupDirectoryOptions")">
             @T["Specified pickup directory"]
@@ -91,19 +88,6 @@
                         </fieldset>
                     </div>
                 </div>
-            </div>
-        </div>
-
-    </div>
-    <div class="collapse" id="@Html.Id("PickupDirectoryFromIisOptions")" data-parent="#@Html.Id("DeliveryMethodOptions")">
-
-        <div class="card">
-            <div class="card-body">
-                <h2 class="card-title">@T["Pickup directory from IIS delivery options"]</h2>
-
-                <p>
-                    @T["No options."]
-                </p>
             </div>
         </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Activities/EmailTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Activities/EmailTask.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Net.Mail;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
@@ -82,16 +81,15 @@ namespace OrchardCore.Email.Workflows.Activities
 
             var message = new MailMessage
             {
+                To = recipientsTask.Result.Trim(),
                 Subject = subjectTask.Result.Trim(),
                 Body = bodyTask.Result?.Trim(),
                 IsBodyHtml = IsBodyHtml
             };
 
-            message.To.Add(recipientsTask.Result.Trim());
-
             if(!string.IsNullOrWhiteSpace(senderTask.Result))
             {
-                message.From = new MailAddress(senderTask.Result.Trim());
+                message.From = senderTask.Result.Trim();
             }
 
             var result = await _smtpService.SendAsync(message);

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/BaseEmailController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/BaseEmailController.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using System.Net.Mail;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -59,12 +58,11 @@ namespace OrchardCore.Users.Controllers
 
             var message = new MailMessage()
             {
+                To = email,
+                Subject = subject,
                 Body = body,
-                IsBodyHtml = true,
-                Subject = subject
+                IsBodyHtml = true
             };
-
-            message.To.Add(email);
 
             var result = await _smtpService.SendAsync(message);
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Net.Mail;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -113,8 +111,7 @@ namespace OrchardCore.Users.Workflows.Activities
 
                     var body = await _expressionEvaluator.EvaluateAsync(ConfirmationEmailTemplate, workflowContext);
                     var localized = new LocalizedHtmlString(nameof(RegisterUserTask), body);
-                    var message = new MailMessage() { Body = localized.IsResourceNotFound ? body : localized.Value, IsBodyHtml = true, BodyEncoding = Encoding.UTF8 };
-                    message.To.Add(email);
+                    var message = new MailMessage() { To = email, Body = localized.IsResourceNotFound ? body : localized.Value, IsBodyHtml = true };
                     var smtpService = _httpContextAccessor.HttpContext.RequestServices.GetService<ISmtpService>();
 
                     if (smtpService == null)

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/ISmtpService.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/ISmtpService.cs
@@ -1,4 +1,3 @@
-using System.Net.Mail;
 using System.Threading.Tasks;
 
 namespace OrchardCore.Email

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/MailMessage.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/MailMessage.cs
@@ -1,0 +1,14 @@
+namespace OrchardCore.Email
+{
+    public class MailMessage
+    {
+        public string From {get; set;}
+        public string To {get; set;}
+        public string Cc {get; set;}
+        public string Bcc {get; set;}
+        public string ReplyTo {get; set;}
+        public string Subject {get; set;}
+        public string Body {get; set;}
+        public bool IsBodyHtml { get; set; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpDeliveryMethod.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpDeliveryMethod.cs
@@ -1,0 +1,8 @@
+namespace OrchardCore.Email
+{
+    public enum SmtpDeliveryMethod
+    {
+        Network,
+        SpecifiedPickupDirectory
+    }
+}

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpSettings.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpSettings.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Net.Mail;
 using Microsoft.Extensions.Localization;
 
 namespace OrchardCore.Email
@@ -38,8 +37,6 @@ namespace OrchardCore.Email
                     {
                         yield return new ValidationResult(S["The {0} field is required.", "Host name"], new[] { nameof(Host) });
                     }
-                    break;
-                case SmtpDeliveryMethod.PickupDirectoryFromIis:
                     break;
                 case SmtpDeliveryMethod.SpecifiedPickupDirectory:
                     if (String.IsNullOrEmpty(PickupDirectoryLocation))


### PR DESCRIPTION
Replace System.Net.Mail.SmtpClient with MailKit.Net.Smtp.SmtpClient because it is poorly designed

Fixes #3407