### PR TITLE
Update shell container creation.

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ClonedSingletonDescriptor.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ClonedSingletonDescriptor.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OrchardCore.Environment.Shell.Builders
+{
+    public class ClonedSingletonDescriptor : ServiceDescriptor
+    {
+        public ClonedSingletonDescriptor(ServiceDescriptor hostDescriptor, object implementationInstance)
+            : base(hostDescriptor.ServiceType, implementationInstance)
+        {
+            HostDescriptor = hostDescriptor;
+        }
+
+        public ClonedSingletonDescriptor(ServiceDescriptor hostDescriptor, Func<IServiceProvider, object> implementationFactory)
+            : base(hostDescriptor.ServiceType, implementationFactory, ServiceLifetime.Singleton)
+        {
+            HostDescriptor = hostDescriptor;
+        }
+
+        public ServiceDescriptor HostDescriptor { get; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ClonedSingletonDescriptor.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ClonedSingletonDescriptor.cs
@@ -5,18 +5,18 @@ namespace OrchardCore.Environment.Shell.Builders
 {
     public class ClonedSingletonDescriptor : ServiceDescriptor
     {
-        public ClonedSingletonDescriptor(ServiceDescriptor hostDescriptor, object implementationInstance)
-            : base(hostDescriptor.ServiceType, implementationInstance)
+        public ClonedSingletonDescriptor(ServiceDescriptor parent, object implementationInstance)
+            : base(parent.ServiceType, implementationInstance)
         {
-            HostDescriptor = hostDescriptor;
+            Parent = parent;
         }
 
-        public ClonedSingletonDescriptor(ServiceDescriptor hostDescriptor, Func<IServiceProvider, object> implementationFactory)
-            : base(hostDescriptor.ServiceType, implementationFactory, ServiceLifetime.Singleton)
+        public ClonedSingletonDescriptor(ServiceDescriptor parent, Func<IServiceProvider, object> implementationFactory)
+            : base(parent.ServiceType, implementationFactory, ServiceLifetime.Singleton)
         {
-            HostDescriptor = hostDescriptor;
+            Parent = parent;
         }
 
-        public ServiceDescriptor HostDescriptor { get; }
+        public ServiceDescriptor Parent { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
@@ -7,10 +7,10 @@ namespace OrchardCore.Environment.Shell.Builders
     {
         public static Type GetImplementationType(this ServiceDescriptor descriptor)
         {
-            if (descriptor is ClonedSingletonDescriptor clonedSingleton)
+            if (descriptor is ClonedSingletonDescriptor cloned)
             {
                 // Use the parent descriptor as it was before being cloned.
-                return clonedSingleton.Parent.GetImplementationType();
+                return cloned.Parent.GetImplementationType();
             }
 
             if (descriptor.ImplementationType is object)

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OrchardCore.Environment.Shell.Builders
+{
+    public static class ServiceDescriptorExtensions
+    {
+        public static Type GetImplementationType(this ServiceDescriptor descriptor)
+        {
+            if (descriptor is HostSingleton hostSingleton)
+            {
+                return hostSingleton.HostDescriptor.GetImplementationType();
+            }
+
+            if (descriptor.ImplementationType is object)
+            {
+                return descriptor.ImplementationType;
+            }
+
+            if (descriptor.ImplementationInstance is object)
+            {
+                return descriptor.ImplementationInstance.GetType();
+            }
+
+            if (descriptor.ImplementationFactory is object)
+            {
+                return descriptor.ImplementationFactory.GetType().GenericTypeArguments[1];
+            }
+
+            return null;
+        }
+    }
+
+    public class HostSingleton : ServiceDescriptor
+    {
+        public HostSingleton(ServiceDescriptor hostDescriptor, object implementationInstance)
+            : base(hostDescriptor.ServiceType, implementationInstance)
+        {
+            HostDescriptor = hostDescriptor;
+        }
+
+        public HostSingleton(ServiceDescriptor hostDescriptor, Func<IServiceProvider, object> implementationFactory)
+            : base(hostDescriptor.ServiceType, implementationFactory, ServiceLifetime.Singleton)
+        {
+            HostDescriptor = hostDescriptor;
+        }
+
+        public ServiceDescriptor HostDescriptor { get; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
@@ -9,8 +9,8 @@ namespace OrchardCore.Environment.Shell.Builders
         {
             if (descriptor is ClonedSingletonDescriptor clonedSingleton)
             {
-                // Use the descriptor as it was before being cloned from the host.
-                return clonedSingleton.HostDescriptor.GetImplementationType();
+                // Use the parent descriptor as it was before being cloned.
+                return clonedSingleton.Parent.GetImplementationType();
             }
 
             if (descriptor.ImplementationType is object)

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
@@ -7,10 +7,10 @@ namespace OrchardCore.Environment.Shell.Builders
     {
         public static Type GetImplementationType(this ServiceDescriptor descriptor)
         {
-            if (descriptor is HostSingleton hostSingleton)
+            if (descriptor is ClonedSingletonDescriptor clonedSingleton)
             {
-                // Use the host descriptor as it was before cloning.
-                return hostSingleton.HostDescriptor.GetImplementationType();
+                // Use the descriptor as it was before being cloned from the host.
+                return clonedSingleton.HostDescriptor.GetImplementationType();
             }
 
             if (descriptor.ImplementationType is object)
@@ -30,22 +30,5 @@ namespace OrchardCore.Environment.Shell.Builders
 
             return null;
         }
-    }
-
-    public class HostSingleton : ServiceDescriptor
-    {
-        public HostSingleton(ServiceDescriptor hostDescriptor, object implementationInstance)
-            : base(hostDescriptor.ServiceType, implementationInstance)
-        {
-            HostDescriptor = hostDescriptor;
-        }
-
-        public HostSingleton(ServiceDescriptor hostDescriptor, Func<IServiceProvider, object> implementationFactory)
-            : base(hostDescriptor.ServiceType, implementationFactory, ServiceLifetime.Singleton)
-        {
-            HostDescriptor = hostDescriptor;
-        }
-
-        public ServiceDescriptor HostDescriptor { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
@@ -9,6 +9,7 @@ namespace OrchardCore.Environment.Shell.Builders
         {
             if (descriptor is HostSingleton hostSingleton)
             {
+                // Use the host descriptor as it was before cloning.
                 return hostSingleton.HostDescriptor.GetImplementationType();
             }
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceDescriptorExtensions.cs
@@ -13,17 +13,17 @@ namespace OrchardCore.Environment.Shell.Builders
                 return cloned.Parent.GetImplementationType();
             }
 
-            if (descriptor.ImplementationType is object)
+            if (descriptor.ImplementationType != null)
             {
                 return descriptor.ImplementationType;
             }
 
-            if (descriptor.ImplementationInstance is object)
+            if (descriptor.ImplementationInstance != null)
             {
                 return descriptor.ImplementationInstance.GetType();
             }
 
-            if (descriptor.ImplementationFactory is object)
+            if (descriptor.ImplementationFactory != null)
             {
                 return descriptor.ImplementationFactory.GetType().GenericTypeArguments[1];
             }

--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceCollectionExtensions.cs
@@ -5,22 +5,22 @@ namespace OrchardCore.Environment.Shell.Builders
 {
     internal static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddHostSingleton(
+        public static IServiceCollection CloneSingleton(
             this IServiceCollection services,
             ServiceDescriptor hostDescriptor,
             object implementationInstance)
         {
-            var serviceDescriptor = new HostSingleton(hostDescriptor, implementationInstance);
-            services.Add(serviceDescriptor);
+            var descriptor = new ClonedSingletonDescriptor(hostDescriptor, implementationInstance);
+            services.Add(descriptor);
             return services;
         }
 
-        public static IServiceCollection AddHostSingleton(
+        public static IServiceCollection CloneSingleton(
             this IServiceCollection collection,
             ServiceDescriptor hostDescriptor,
             Func<IServiceProvider, object> implementationFactory)
         {
-            var descriptor = new HostSingleton(hostDescriptor, implementationFactory);
+            var descriptor = new ClonedSingletonDescriptor(hostDescriptor, implementationFactory);
             collection.Add(descriptor);
             return collection;
         }

--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OrchardCore.Environment.Shell.Builders
+{
+    internal static class ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddHostSingleton(
+            this IServiceCollection services,
+            ServiceDescriptor hostDescriptor,
+            object implementationInstance)
+        {
+            var serviceDescriptor = new HostSingleton(hostDescriptor, implementationInstance);
+            services.Add(serviceDescriptor);
+            return services;
+        }
+
+        public static IServiceCollection AddHostSingleton(
+            this IServiceCollection collection,
+            ServiceDescriptor hostDescriptor,
+            Func<IServiceProvider, object> implementationFactory)
+        {
+            var descriptor = new HostSingleton(hostDescriptor, implementationFactory);
+            collection.Add(descriptor);
+            return collection;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceCollectionExtensions.cs
@@ -7,21 +7,21 @@ namespace OrchardCore.Environment.Shell.Builders
     {
         public static IServiceCollection CloneSingleton(
             this IServiceCollection services,
-            ServiceDescriptor hostDescriptor,
+            ServiceDescriptor parent,
             object implementationInstance)
         {
-            var descriptor = new ClonedSingletonDescriptor(hostDescriptor, implementationInstance);
-            services.Add(descriptor);
+            var cloned = new ClonedSingletonDescriptor(parent, implementationInstance);
+            services.Add(cloned);
             return services;
         }
 
         public static IServiceCollection CloneSingleton(
             this IServiceCollection collection,
-            ServiceDescriptor hostDescriptor,
+            ServiceDescriptor parent,
             Func<IServiceProvider, object> implementationFactory)
         {
-            var descriptor = new ClonedSingletonDescriptor(hostDescriptor, implementationFactory);
-            collection.Add(descriptor);
+            var cloned = new ClonedSingletonDescriptor(parent, implementationFactory);
+            collection.Add(cloned);
             return collection;
         }
     }

--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceProviderExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceProviderExtensions.cs
@@ -47,12 +47,12 @@ namespace OrchardCore.Environment.Shell.Builders
                         if (typeof(IDisposable).IsAssignableFrom(service.GetImplementationType()) || service.ImplementationFactory != null)
                         {
                             // If disposable, register an instance that we resolve immediately from the main container.
-                            clonedCollection.AddHostSingleton(service, serviceProvider.GetService(service.ServiceType));
+                            clonedCollection.CloneSingleton(service, serviceProvider.GetService(service.ServiceType));
                         }
                         else
                         {
                             // If not disposable, the singleton can be resolved through a factory when first requested.
-                            clonedCollection.AddHostSingleton(service, sp => serviceProvider.GetService(service.ServiceType));
+                            clonedCollection.CloneSingleton(service, sp => serviceProvider.GetService(service.ServiceType));
 
                             // Note: Most of the time a singleton of a given type is unique and not disposable. So,
                             // most of the time it will be resolved when first requested through a tenant container.
@@ -82,7 +82,7 @@ namespace OrchardCore.Environment.Shell.Builders
 
                     for (var i = 0; i < services.Count(); i++)
                     {
-                        clonedCollection.AddHostSingleton(services.ElementAt(i), instances.ElementAt(i));
+                        clonedCollection.CloneSingleton(services.ElementAt(i), instances.ElementAt(i));
                     }
                 }
 
@@ -99,7 +99,7 @@ namespace OrchardCore.Environment.Shell.Builders
                         {
                             if (services.ElementAt(i).Lifetime == ServiceLifetime.Singleton)
                             {
-                                clonedCollection.AddHostSingleton(services.ElementAt(i), instances.ElementAt(i));
+                                clonedCollection.CloneSingleton(services.ElementAt(i), instances.ElementAt(i));
                             }
                             else
                             {

--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceProviderExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/Extensions/ServiceProviderExtensions.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace OrchardCore.Environment.Shell.Builders
 {
@@ -15,97 +16,46 @@ namespace OrchardCore.Environment.Shell.Builders
         public static IServiceCollection CreateChildContainer(this IServiceProvider serviceProvider, IServiceCollection serviceCollection)
         {
             IServiceCollection clonedCollection = new ServiceCollection();
-            var servicesByType = serviceCollection.GroupBy(s => s.ServiceType);
+            var singletons = new Dictionary<Type, (int Index, IEnumerable<object> Instances)>();
 
-            foreach (var services in servicesByType)
+            foreach (var service in serviceCollection)
             {
                 // Prevent hosting 'IStartupFilter' to re-add middlewares to the tenant pipeline.
-                if (services.First().ServiceType == typeof(IStartupFilter))
+                if (service.ServiceType == typeof(IStartupFilter))
                 {
                     continue;
                 }
 
-                // if only one service of a given type
-                if (services.Count() == 1)
+                if (service.Lifetime != ServiceLifetime.Singleton || service.ServiceType.IsGenericTypeDefinition)
                 {
-                    var service = services.First();
-
-                    // Register the singleton instances to all containers
-                    if (service.Lifetime == ServiceLifetime.Singleton)
-                    {
-                        // Treat open-generic registrations differently
-                        if (service.ServiceType.IsGenericType && service.ServiceType.GenericTypeArguments.Length == 0)
-                        {
-                            // There is no Func based way to register an open-generic type, instead of
-                            // tenantServiceCollection.AddSingleton(typeof(IEnumerable<>), typeof(List<>));
-                            // Right now, we register them as singleton per cloned scope even though it's wrong
-                            // but in the actual examples it won't matter.
-                            clonedCollection.AddSingleton(service.ServiceType, service.ImplementationType);
-                        }
-                        else
-                        {
-                            // When a service from the main container is resolved, just add its instance to the container.
-                            // It will be shared by all tenant service providers.
-                            clonedCollection.AddSingleton(service.ServiceType, serviceProvider.GetService(service.ServiceType));
-
-                            // Ideally the service should be resolved when first requested, but ASP.NET DI will call Dispose()
-                            // and this would fail reusability of the instance across tenants' containers.
-                            // clonedCollection.AddSingleton(service.ServiceType, sp => serviceProvider.GetService(service.ServiceType));
-                        }
-                    }
-                    else
-                    {
-                        clonedCollection.Add(service);
-                    }
+                    // This is not a singleton or a generic type definition which is rather used to create other
+                    // constructed generic types. So, we just need to pass the descriptor.
+                    clonedCollection.Add(service);
                 }
-
-                // If multiple services of the same type
                 else
                 {
-                    // If all services of the same type are not singletons.
-                    if (services.All(s => s.Lifetime != ServiceLifetime.Singleton))
+                    // This is a singleton, a non generic or a constructed generic type.
+                    if (!singletons.TryGetValue(service.ServiceType, out var singleton))
                     {
-                        // We don't need to resolve them.
-                        foreach (var service in services)
+                        // Resolve once all singletons of this type.
+                        singleton = (0, serviceProvider.GetServices(service.ServiceType));
+
+                        if (singleton.Instances.Count() > 1)
                         {
-                            clonedCollection.Add(service);
+                            // Cache if multiple instances.
+                            singletons[service.ServiceType] = singleton;
                         }
                     }
 
-                    // If all services of the same type are singletons.
-                    else if (services.All(s => s.Lifetime == ServiceLifetime.Singleton))
-                    {
-                        // We can resolve them from the main container.
-                        var instances = serviceProvider.GetServices(services.Key);
+                    // Retrieve the indexed singleton instance to clone.
+                    var instance = singleton.Instances.ElementAt(singleton.Index++);
 
-                        foreach (var instance in instances)
-                        {
-                            clonedCollection.AddSingleton(services.Key, instance);
-                        }
-                    }
+                    // When a service from the main container is resolved, just add its instance to the container.
+                    // It will be shared by all tenant service providers.
+                    clonedCollection.AddSingleton(service.ServiceType, instance);
 
-                    // If singletons and scoped services are mixed.
-                    else
-                    {
-                        // We need a service scope to resolve them.
-                        using (var scope = serviceProvider.CreateScope())
-                        {
-                            var instances = scope.ServiceProvider.GetServices(services.Key);
-
-                            // Then we only keep singleton instances.
-                            for (var i = 0; i < services.Count(); i++)
-                            {
-                                if (services.ElementAt(i).Lifetime == ServiceLifetime.Singleton)
-                                {
-                                    clonedCollection.AddSingleton(services.Key, instances.ElementAt(i));
-                                }
-                                else
-                                {
-                                    clonedCollection.Add(services.ElementAt(i));
-                                }
-                            }
-                        }
-                    }
+                    // Ideally the service should be resolved when first requested, but ASP.NET DI will call Dispose()
+                    // and this would fail reusability of the instance across tenants' containers.
                 }
             }
 

--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/ShellContainerFactory.cs
@@ -156,15 +156,15 @@ namespace OrchardCore.Environment.Shell.Builders
 
         internal Type GetImplementationType(ServiceDescriptor descriptor)
         {
-            if (descriptor.ImplementationType != null)
+            if (descriptor.ImplementationType is object)
             {
                 return descriptor.ImplementationType;
             }
-            else if (descriptor.ImplementationInstance != null)
+            else if (descriptor.ImplementationInstance is object)
             {
                 return descriptor.ImplementationInstance.GetType();
             }
-            else if (descriptor.ImplementationFactory != null)
+            else if (descriptor.ImplementationFactory is object)
             {
                 return descriptor.ImplementationFactory.GetType().GenericTypeArguments[1];
             }

--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/ShellContainerFactory.cs
@@ -127,17 +127,11 @@ namespace OrchardCore.Environment.Shell.Builders
             {
                 foreach (var serviceDescriptor in featureServiceCollection.Value)
                 {
-                    if (serviceDescriptor.ImplementationType != null)
+                    var type = GetImplementationType(serviceDescriptor);
+
+                    if (type != null)
                     {
-                        typeFeatureProvider.TryAdd(serviceDescriptor.ImplementationType, featureServiceCollection.Key);
-                    }
-                    else if (serviceDescriptor.ImplementationInstance != null)
-                    {
-                        typeFeatureProvider.TryAdd(serviceDescriptor.ImplementationInstance.GetType(), featureServiceCollection.Key);
-                    }
-                    else
-                    {
-                        // Factory, we can't know which type will be returned
+                        typeFeatureProvider.TryAdd(type, featureServiceCollection.Key);
                     }
                 }
             }
@@ -158,6 +152,24 @@ namespace OrchardCore.Environment.Shell.Builders
                     }
                 }
             }
+        }
+
+        internal Type GetImplementationType(ServiceDescriptor descriptor)
+        {
+            if (descriptor.ImplementationType != null)
+            {
+                return descriptor.ImplementationType;
+            }
+            else if (descriptor.ImplementationInstance != null)
+            {
+                return descriptor.ImplementationInstance.GetType();
+            }
+            else if (descriptor.ImplementationFactory != null)
+            {
+                return descriptor.ImplementationFactory.GetType().GenericTypeArguments[1];
+            }
+
+            return null;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore/Environment/Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/Builders/ShellContainerFactory.cs
@@ -127,7 +127,7 @@ namespace OrchardCore.Environment.Shell.Builders
             {
                 foreach (var serviceDescriptor in featureServiceCollection.Value)
                 {
-                    var type = GetImplementationType(serviceDescriptor);
+                    var type = serviceDescriptor.GetImplementationType();
 
                     if (type != null)
                     {
@@ -152,24 +152,6 @@ namespace OrchardCore.Environment.Shell.Builders
                     }
                 }
             }
-        }
-
-        internal Type GetImplementationType(ServiceDescriptor descriptor)
-        {
-            if (descriptor.ImplementationType is object)
-            {
-                return descriptor.ImplementationType;
-            }
-            else if (descriptor.ImplementationInstance is object)
-            {
-                return descriptor.ImplementationInstance.GetType();
-            }
-            else if (descriptor.ImplementationFactory is object)
-            {
-                return descriptor.ImplementationFactory.GetType().GenericTypeArguments[1];
-            }
-
-            return null;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,7 @@ using Microsoft.Net.Http.Headers;
 using OrchardCore;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Environment.Shell.Descriptor.Models;
 using OrchardCore.Localization;
@@ -230,14 +231,13 @@ namespace Microsoft.Extensions.DependencyInjection
                     .Services;
 
                 // Retrieve the implementation type of the newly startup filter registered as a singleton
-                var startupFilterType = collection.FirstOrDefault(s => s.ServiceType == typeof(IStartupFilter))?.ImplementationType;
+                var startupFilterType = collection.FirstOrDefault(s => s.ServiceType == typeof(IStartupFilter))?.GetImplementationType();
 
                 if (startupFilterType != null)
                 {
                     // Remove any previously registered data protection startup filters.
                     var descriptors = services.Where(s => s.ServiceType == typeof(IStartupFilter) &&
-                        (s.ImplementationInstance?.GetType() == startupFilterType ||
-                        s.ImplementationType == startupFilterType)).ToArray();
+                        (s.GetImplementationType() == startupFilterType)).ToArray();
 
                     foreach (var descriptor in descriptors)
                     {

--- a/test/Functional/setup.test.js
+++ b/test/Functional/setup.test.js
@@ -129,7 +129,10 @@ describe('Create Tenants', () => {
         await expect(await page.content()).toMatch('Agency');
 
         // Go to Setup page
-        await page.click('#btn-setup-Agency');
+        await Promise.all([
+            page.waitForNavigation(),
+            page.click('#btn-setup-Agency')
+        ]);
 
         await expect(await page.content()).toMatch('Orchard Setup');
 
@@ -169,7 +172,10 @@ describe('Create Tenants', () => {
         await expect(await page.content()).toMatch('Blog');
 
         // Go to Setup page
-        await page.click('#btn-setup-Blog');
+        await Promise.all([
+            page.waitForNavigation(),
+            page.click('#btn-setup-Blog')
+        ]);
 
         await expect(await page.content()).toMatch('Orchard Setup');
 


### PR DESCRIPTION
- Don't group anymore services by service type.

- For a generic type definition which is not itself a type but which is rather used to create other constructed generic types, we just pass the service descriptor as onother non singleton service.

- Then, constructed generic types (singleton or not) are registered as other non generic types.

- When multiple services of the same type, we resolve only the singletons ones from the main container, not the non singleton of this type, so without having to create a intermediate scope. We let the others non singleton of this type be added as the others non singleton services.