### PR TITLE
Add Tenant media cache store

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/AsyncKeyLock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/AsyncKeyLock.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OrchardCore.Media.Processing
+{
+    /// <summary>
+    /// The async key lock prevents multiple asynchronous threads acting upon the same object with the given key at the same time.
+    /// It is designed so that it does not block unique requests allowing a high throughput.
+    /// </summary>
+    internal sealed class AsyncKeyLock
+    {
+        /// <summary>
+        /// A collection of doorman counters used for tracking references to the same key.
+        /// </summary>
+        private static readonly Dictionary<string, Doorman> Keys = new Dictionary<string, Doorman>();
+
+        /// <summary>
+        /// A pool of unused doorman counters that can be re-used to avoid allocations.
+        /// </summary>
+        private static readonly Stack<Doorman> Pool = new Stack<Doorman>(MaxPoolSize);
+
+        /// <summary>
+        /// Maximum size of the doorman pool. If the pool is already full when releasing
+        /// a doorman, it is simply left for garbage collection.
+        /// </summary>
+        private const int MaxPoolSize = 20;
+
+        /// <summary>
+        /// SpinLock used to protect access to the Keys and Pool collections.
+        /// </summary>
+        private static SpinLock spinLock = new SpinLock(false);
+
+        /// <summary>
+        /// Locks the current thread in read mode asynchronously.
+        /// </summary>
+        /// <param name="key">The key identifying the specific object to lock against.</param>
+        /// <returns>
+        /// The <see cref="Task{IDisposable}"/> that will release the lock.
+        /// </returns>
+        public async Task<IDisposable> ReaderLockAsync(string key)
+        {
+            Doorman doorman = GetDoorman(key);
+
+            return await doorman.ReaderLockAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Locks the current thread in write mode asynchronously.
+        /// </summary>
+        /// <param name="key">The key identifying the specific object to lock against.</param>
+        /// <returns>
+        /// The <see cref="Task{IDisposable}"/> that will release the lock.
+        /// </returns>
+        public async Task<IDisposable> WriterLockAsync(string key)
+        {
+            Doorman doorman = GetDoorman(key);
+
+            return await doorman.WriterLockAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the doorman for the specified key. If no such doorman exists, an unused doorman
+        /// is obtained from the pool (or a new one is allocated if the pool is empty), and it's
+        /// assigned to the requested key.
+        /// </summary>
+        /// <param name="key">The key for the desired doorman.</param>
+        /// <returns>The <see cref="Doorman"/>.</returns>
+        private static Doorman GetDoorman(string key)
+        {
+            Doorman doorman;
+            bool lockTaken = false;
+            try
+            {
+                spinLock.Enter(ref lockTaken);
+
+                if (!Keys.TryGetValue(key, out doorman))
+                {
+                    doorman = (Pool.Count > 0) ? Pool.Pop() : new Doorman(ReleaseDoorman);
+                    doorman.Key = key;
+                    Keys.Add(key, doorman);
+                }
+
+                doorman.RefCount++;
+            }
+            finally
+            {
+                if (lockTaken)
+                {
+                    spinLock.Exit();
+                }
+            }
+
+            return doorman;
+        }
+
+        /// <summary>
+        /// Releases a reference to a doorman. If the ref-count hits zero, then the doorman is
+        /// returned to the pool (or is simply left for the garbage collector to cleanup if the
+        /// pool is already full).
+        /// </summary>
+        /// <param name="doorman">The <see cref="Doorman"/>.</param>
+        private static void ReleaseDoorman(Doorman doorman)
+        {
+            bool lockTaken = false;
+            try
+            {
+                spinLock.Enter(ref lockTaken);
+
+                if (--doorman.RefCount == 0)
+                {
+                    Keys.Remove(doorman.Key);
+                    if (Pool.Count < MaxPoolSize)
+                    {
+                        doorman.Key = null;
+                        Pool.Push(doorman);
+                    }
+                }
+            }
+            finally
+            {
+                if (lockTaken)
+                {
+                    spinLock.Exit();
+                }
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/CacheEntry.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/CacheEntry.cs
@@ -6,6 +6,7 @@ namespace OrchardCore.Media.Processing
 {
     public class CacheEntry
     {
+        //unused, but could be required to AsyncLock
         public string FileKey { get; }
 
         public string[] FilePaths { get; }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/CacheEntry.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/CacheEntry.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OrchardCore.Media.Processing
+{
+    public class CacheEntry
+    {
+        public string FileKey { get; }
+
+        public string[] FilePaths { get; }
+
+        public CacheEntry(string fileKey, string[] filePaths)
+        {
+            FileKey = fileKey;
+            FilePaths = filePaths;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/Doorman.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/Doorman.cs
@@ -1,0 +1,171 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OrchardCore.Media.Processing
+{
+    /// <summary>
+    /// An asynchronous locker that provides read and write locking policies.
+    /// </summary>
+    internal sealed class Doorman
+    {
+        private readonly Queue<TaskCompletionSource<Releaser>> waitingWriters;
+        private readonly Task<Releaser> readerReleaser;
+        private readonly Task<Releaser> writerReleaser;
+        private readonly Action<Doorman> reset;
+        private TaskCompletionSource<Releaser> waitingReader;
+        private int readersWaiting;
+        private int status;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Doorman"/> class.
+        /// </summary>
+        /// <param name="reset">The reset action.</param>
+        public Doorman(Action<Doorman> reset)
+        {
+            this.waitingWriters = new Queue<TaskCompletionSource<Releaser>>();
+            this.waitingReader = new TaskCompletionSource<Releaser>();
+            this.status = 0;
+
+            this.readerReleaser = Task.FromResult(new Releaser(this, false));
+            this.writerReleaser = Task.FromResult(new Releaser(this, true));
+            this.reset = reset;
+        }
+
+        /// <summary>
+        /// Gets or sets the key that this doorman is mapped to.
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current reference count on this doorman.
+        /// </summary>
+        public int RefCount { get; set; }
+
+        /// <summary>
+        /// Locks the current thread in read mode asynchronously.
+        /// </summary>
+        /// <returns>The <see cref="Task{Releaser}"/>.</returns>
+        public Task<Releaser> ReaderLockAsync()
+        {
+            lock (this.waitingWriters)
+            {
+                if (this.status >= 0 && this.waitingWriters.Count == 0)
+                {
+                    ++this.status;
+                    return this.readerReleaser;
+                }
+                else
+                {
+                    ++this.readersWaiting;
+                    return this.waitingReader.Task.ContinueWith(t => t.Result);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Locks the current thread in write mode asynchronously.
+        /// </summary>
+        /// <returns>The <see cref="Task{Releaser}"/>.</returns>
+        public Task<Releaser> WriterLockAsync()
+        {
+            lock (this.waitingWriters)
+            {
+                if (this.status == 0)
+                {
+                    this.status = -1;
+                    return this.writerReleaser;
+                }
+                else
+                {
+                    var waiter = new TaskCompletionSource<Releaser>();
+                    this.waitingWriters.Enqueue(waiter);
+                    return waiter.Task;
+                }
+            }
+        }
+
+        private void ReaderRelease()
+        {
+            TaskCompletionSource<Releaser> toWake = null;
+
+            lock (this.waitingWriters)
+            {
+                --this.status;
+
+                if (this.status == 0)
+                {
+                    if (this.waitingWriters.Count > 0)
+                    {
+                        this.status = -1;
+                        toWake = this.waitingWriters.Dequeue();
+                    }
+                }
+            }
+
+            this.reset(this);
+
+            toWake?.SetResult(new Releaser(this, true));
+        }
+
+        private void WriterRelease()
+        {
+            TaskCompletionSource<Releaser> toWake = null;
+            bool toWakeIsWriter = false;
+
+            lock (this.waitingWriters)
+            {
+                if (this.waitingWriters.Count > 0)
+                {
+                    toWake = this.waitingWriters.Dequeue();
+                    toWakeIsWriter = true;
+                }
+                else if (this.readersWaiting > 0)
+                {
+                    toWake = this.waitingReader;
+                    this.status = this.readersWaiting;
+                    this.readersWaiting = 0;
+                    this.waitingReader = new TaskCompletionSource<Releaser>();
+                }
+                else
+                {
+                    this.status = 0;
+                }
+            }
+
+            this.reset(this);
+
+            toWake?.SetResult(new Releaser(this, toWakeIsWriter));
+        }
+
+        public readonly struct Releaser : IDisposable
+        {
+            private readonly Doorman toRelease;
+            private readonly bool writer;
+
+            internal Releaser(Doorman toRelease, bool writer)
+            {
+                this.toRelease = toRelease;
+                this.writer = writer;
+            }
+
+            public void Dispose()
+            {
+                if (this.toRelease != null)
+                {
+                    if (this.writer)
+                    {
+                        this.toRelease.WriterRelease();
+                    }
+                    else
+                    {
+                        this.toRelease.ReaderRelease();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileCache.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileCache.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Six Labors and contributors.
+// Licensed under the Apache License, Version 2.0.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Shell;
+using SixLabors.ImageSharp.Web;
+using SixLabors.ImageSharp.Web.Caching;
+using SixLabors.ImageSharp.Web.Helpers;
+using SixLabors.ImageSharp.Web.Middleware;
+using SixLabors.ImageSharp.Web.Resolvers;
+using SixLabors.Memory;
+
+namespace OrchardCore.Media.Processing
+{
+    //to replace this cache (with a blob storage one, for example, replace the registration against IImagecache with a new implementation)
+
+    public class MediaFileCache : IImageCache
+    {
+        public const string Folder = "CacheFolder";
+
+        public const string DefaultCacheFolder = "MediaCache";
+
+        private readonly string _cacheRoot;
+
+        private readonly IFileProvider _fileProvider;
+
+        private readonly ImageSharpMiddlewareOptions _options;
+
+        private readonly FormatUtilities _formatUtilies;
+
+        public MediaFileCache(
+            IOptions<ImageSharpMiddlewareOptions> options,
+            IOptions<ShellOptions> shellOptions,
+            ShellSettings shellSettings
+            )
+        {
+            _cacheRoot = GetCacheRoot(shellOptions.Value, shellSettings);
+
+            if (!Directory.Exists(_cacheRoot))
+            {
+                Directory.CreateDirectory(_cacheRoot);
+            }
+            _fileProvider = new PhysicalFileProvider(_cacheRoot);
+            _options = options.Value;
+            _formatUtilies = new FormatUtilities(this._options.Configuration);
+        }
+
+        //TODO use this (follow the IS pattern), but register it based on OC settings
+        //Also pass the other cache related settings in here
+        public IDictionary<string, string> Settings { get; }
+            = new Dictionary<string, string>
+            {
+                { Folder, DefaultCacheFolder }
+            };
+
+        public async Task<IImageResolver> GetAsync(string key)
+        {
+            var path = ToFilePath(key);
+
+            var metaFileInfo = _fileProvider.GetFileInfo(ToMetaDataFilePath(path));
+            if (!metaFileInfo.Exists)
+            {
+                return null;
+            }
+
+            ImageMetaData metadata = default;
+            using (var stream = metaFileInfo.CreateReadStream())
+            {
+                metadata = await ImageMetaData.ReadAsync(stream).ConfigureAwait(false);
+            }
+
+            var fileInfo = _fileProvider.GetFileInfo(ToImageFilePath(path, metadata));
+
+            // Check to see if the file exists.
+            if (!fileInfo.Exists)
+            {
+                return null;
+            }
+
+            return new PhysicalFileSystemResolver(fileInfo, metadata);
+        }
+
+        public async Task SetAsync(string key, Stream stream, ImageMetaData metadata)
+        {
+            var path = Path.Combine(_cacheRoot, ToFilePath(key));
+            var imagePath = ToImageFilePath(path, metadata);
+            var metaPath = ToMetaDataFilePath(path);
+            var directory = Path.GetDirectoryName(path);
+
+            if (!Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            using (var fileStream = File.Create(imagePath))
+            {
+                await stream.CopyToAsync(fileStream).ConfigureAwait(false);
+            }
+
+            using (var fileStream = File.Create(metaPath))
+            {
+                await metadata.WriteAsync(fileStream).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Gets the path to the image file based on the supplied root and metadata.
+        /// </summary>
+        /// <param name="path">The root path.</param>
+        /// <param name="metaData">The image metadata.</param>
+        /// <returns>The <see cref="string"/>.</returns>
+        private string ToImageFilePath(string path, in ImageMetaData metaData) => $"{path}.{_formatUtilies.GetExtensionFromContentType(metaData.ContentType)}";
+
+        /// <summary>
+        /// Gets the path to the image file based on the supplied root.
+        /// </summary>
+        /// <param name="path">The root path.</param>
+        /// <returns>The <see cref="string"/>.</returns>
+        private string ToMetaDataFilePath(string path) => $"{path}.meta";
+
+        /// <summary>
+        /// Converts the key into a nested file path.
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        /// <returns>The <see cref="string"/>.</returns>
+        //private string ToFilePath(string key) => $"{string.Join("/", key.Substring(0, (int)_options.CachedNameLength).ToCharArray())}/{key}";
+
+            //TODO renable this - just disabled for easy debugging of file system
+        private string ToFilePath(string key) => key;
+
+        private string GetCacheRoot(ShellOptions shellOptions, ShellSettings shellSettings)
+        {
+            return Path.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellSettings.Name, Settings[Folder]);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileCache.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileCache.cs
@@ -1,32 +1,26 @@
-// Copyright (c) Six Labors and contributors.
-// Licensed under the Apache License, Version 2.0.
-
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Configuration;
 using SixLabors.ImageSharp.Web;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.Helpers;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Resolvers;
-using SixLabors.Memory;
 
 namespace OrchardCore.Media.Processing
 {
-    //to replace this cache (with a blob storage one, for example, replace the registration against IImagecache with a new implementation)
-
     public class MediaFileCache : IImageCache
     {
-        public const string Folder = "CacheFolder";
-
-        public const string DefaultCacheFolder = "MediaCache";
-
-        private readonly string _cacheRoot;
+        private readonly string _cachePath;
 
         private readonly IFileProvider _fileProvider;
 
@@ -34,35 +28,92 @@ namespace OrchardCore.Media.Processing
 
         private readonly FormatUtilities _formatUtilies;
 
+        /// <summary>
+        /// Maximum cache entries, disabled if 0
+        /// </summary>
+        private readonly int _maxCacheEntries;
+
+        private readonly ConcurrentQueue<CacheEntry> _entries = new ConcurrentQueue<CacheEntry>();
+
         public MediaFileCache(
+            ILogger<MediaFileCache> logger,
             IOptions<ImageSharpMiddlewareOptions> options,
             IOptions<ShellOptions> shellOptions,
-            ShellSettings shellSettings
+            ShellSettings shellSettings,
+            IShellConfiguration shellConfiguration
             )
         {
-            _cacheRoot = GetCacheRoot(shellOptions.Value, shellSettings);
+            Logger = logger;
+            var configurationSection = shellConfiguration.GetSection("OrchardCore.Media");
+            _maxCacheEntries = configurationSection.GetValue("MaxCacheEntries", 0);
+            var mediaCachePath = configurationSection.GetValue("MediaCachePath", "MediaCache");
 
-            if (!Directory.Exists(_cacheRoot))
+            _cachePath = GetCachePath(shellOptions.Value, shellSettings, mediaCachePath);
+
+            if (!Directory.Exists(_cachePath))
             {
-                Directory.CreateDirectory(_cacheRoot);
+                Directory.CreateDirectory(_cachePath);
             }
-            _fileProvider = new PhysicalFileProvider(_cacheRoot);
+            _fileProvider = new PhysicalFileProvider(_cachePath);
             _options = options.Value;
-            _formatUtilies = new FormatUtilities(this._options.Configuration);
+            _formatUtilies = new FormatUtilities(_options.Configuration);
+
+            //fire and forget, do not care about exceptions, better to not impact startup speed.
+            if (_maxCacheEntries != 0)
+            {
+                Task.Run(() => InitializeCacheEntries());
+            }
         }
 
-        //TODO use this (follow the IS pattern), but register it based on OC settings
-        //Also pass the other cache related settings in here
-        public IDictionary<string, string> Settings { get; }
-            = new Dictionary<string, string>
+        public ILogger Logger { get; }
+
+        private void InitializeCacheEntries()
+        {
+            try
             {
-                { Folder, DefaultCacheFolder }
-            };
+                var dirInfo = new DirectoryInfo(_cachePath);
+                var files = dirInfo
+                            .EnumerateDirectories()
+                            .AsParallel()
+                            .SelectMany(di => di.EnumerateFiles("*.*", SearchOption.AllDirectories))
+                            .OrderBy(fi => fi.CreationTimeUtc)
+                            .GroupBy(x => Path.GetFileNameWithoutExtension(x.Name))
+                            .ToArray();
+
+                //this won't work perfectly, as it's in the background, and an image maybe resized
+                //and added to it during this processing after startup
+                //we could enqueue resized images into a second queue, then clear it, at the end of this,
+                //and not use the second queue anymore, but perfect cache integrity is not important
+                //speed is
+                foreach (var fileGroup in files)
+                {
+                    //TODO IS does not Evict from cache if options.MaxCacheDays is reached.
+                    //it just refreshes on read (assuming image is read). So can remain dead in cache folder forever
+                    //we could do this refresh here, but would need to run even if cache limiting is disabled (_maxMediaFileCacheEntries = 0)
+                    //suspect non issue. either enable cache limiting and it will sort itself out
+                    //(with x number images always dead in cache if using cdn), or don't cache limit
+                    EnqueueCacheEntry(fileGroup.Key, fileGroup.Select(x => x.FullName).ToArray());
+                }
+                EvictCacheEntries();
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Erroring retrieving cache entries");
+            }
+        }
+
+        private void EnqueueCacheEntry(string key, string[] filePaths)
+        {
+            _entries.Enqueue(new CacheEntry(key, filePaths));
+        }
+
+        //TODO obsolete this and use OC settings in constructor
+        [Obsolete("Use OrchardCore.Media Settings to manage MediaFileCache")]
+        public IDictionary<string, string> Settings { get; }
 
         public async Task<IImageResolver> GetAsync(string key)
         {
             var path = ToFilePath(key);
-
             var metaFileInfo = _fileProvider.GetFileInfo(ToMetaDataFilePath(path));
             if (!metaFileInfo.Exists)
             {
@@ -88,7 +139,7 @@ namespace OrchardCore.Media.Processing
 
         public async Task SetAsync(string key, Stream stream, ImageMetaData metadata)
         {
-            var path = Path.Combine(_cacheRoot, ToFilePath(key));
+            var path = Path.Combine(_cachePath, ToFilePath(key));
             var imagePath = ToImageFilePath(path, metadata);
             var metaPath = ToMetaDataFilePath(path);
             var directory = Path.GetDirectoryName(path);
@@ -106,6 +157,47 @@ namespace OrchardCore.Media.Processing
             using (var fileStream = File.Create(metaPath))
             {
                 await metadata.WriteAsync(fileStream).ConfigureAwait(false);
+            }
+
+            if (_maxCacheEntries != 0)
+            {
+                EnqueueCacheEntry(key, new string[] { imagePath, metaPath });
+                EvictCacheEntries();
+            }
+        }
+
+        private void EvictCacheEntries()
+        {
+            var _entriesToEvict = _entries.Count - _maxCacheEntries;
+            if (_entriesToEvict > 0)
+            {
+                for (var i = 0; i < _entriesToEvict; i++)
+                {
+                    if (_entries.TryDequeue(out var entryToEvict))
+                    {
+                        try
+                        {
+                            foreach (var file in entryToEvict.FilePaths)
+                            {
+                                File.Delete(file);
+                                Logger.LogDebug($"Evicting cache entry {file}");
+                            }
+                        }
+                        //catch if file locked by PhysicalFileSystemResolver.OpenReadStream()
+                        catch (Exception e)
+                        {
+                            Logger.LogWarning(e, $"Could not delete cache entry {entryToEvict.FileKey}");
+                            //return to end cache for deletion another time.
+                            //one file may no longer be present in cacheEntry.FilePaths
+                            //however it will not throw when trying to delete if missing.
+                            //multiple keys may end up in cache list, however cache key is irrelevant,
+                            //and we do not rely on cache key to determine existance in cache
+                            //so perfect integrity is not important.
+                            //speed is preferable.
+                            _entries.Enqueue(entryToEvict);
+                        }
+                    };
+                }
             }
         }
 
@@ -129,14 +221,11 @@ namespace OrchardCore.Media.Processing
         /// </summary>
         /// <param name="key">The cache key.</param>
         /// <returns>The <see cref="string"/>.</returns>
-        //private string ToFilePath(string key) => $"{string.Join("/", key.Substring(0, (int)_options.CachedNameLength).ToCharArray())}/{key}";
+        private string ToFilePath(string key) => $"{string.Join("/", key.Substring(0, (int)_options.CachedNameLength).ToCharArray())}/{key}";
 
-            //TODO renable this - just disabled for easy debugging of file system
-        private string ToFilePath(string key) => key;
-
-        private string GetCacheRoot(ShellOptions shellOptions, ShellSettings shellSettings)
+        private string GetCachePath(ShellOptions shellOptions, ShellSettings shellSettings, string cacheFolder)
         {
-            return Path.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellSettings.Name, Settings[Folder]);
+            return Path.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellSettings.Name, cacheFolder);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -153,6 +153,12 @@ The following configuration values are used by default and can be customized:
       // The number of days to store images in the image cache
       "MaxCacheDays": 365,
 
+      // The maximum number of entries to store in the image cache. Cache Eviction is disabled by default, when MaxCacheEntries is 0
+      "MaxCacheEntries": 0,
+
+      // The Media Cache Path, App_Data/Sites/tenant_name/MediaCache by default
+      "MediaCachePath": "MediaCache",
+
       // The maximum size of an uploaded file in bytes. 
       // NB: You might still need to configure the limit in IIS (https://docs.microsoft.com/en-us/iis/configuration/system.webserver/security/requestfiltering/requestlimits/)
       "MaxFileSize": 30000000,

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -165,17 +165,7 @@ namespace OrchardCore.Media
 
             .SetRequestParser<QueryCollectionRequestParser>()
             .SetMemoryAllocator<ArrayPoolMemoryAllocator>()
-            .SetCache(serviceProvider =>
-            {
-                var cache = new MediaFileCache(
-                    serviceProvider.GetRequiredService<IOptions<ImageSharpMiddlewareOptions>>(),
-                    serviceProvider.GetRequiredService<IOptions<ShellOptions>>(),
-                    serviceProvider.GetRequiredService<ShellSettings>());
-                //TODO get this from OC settings - going to be a merge conflict there.
-                cache.Settings[MediaFileCache.Folder] = MediaFileCache.DefaultCacheFolder;
-
-                return cache;
-            })
+            .SetCache<MediaFileCache>()
             .SetCacheHash<CacheHash>()
             .AddProvider<MediaFileProvider>()
             .AddProcessor<ResizeWebProcessor>()

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -38,6 +38,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Caching;
 using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.DependencyInjection;
+using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Processors;
 using SixLabors.Memory;
 
@@ -164,7 +165,17 @@ namespace OrchardCore.Media
 
             .SetRequestParser<QueryCollectionRequestParser>()
             .SetMemoryAllocator<ArrayPoolMemoryAllocator>()
-            .SetCache<PhysicalFileSystemCache>()
+            .SetCache(serviceProvider =>
+            {
+                var cache = new MediaFileCache(
+                    serviceProvider.GetRequiredService<IOptions<ImageSharpMiddlewareOptions>>(),
+                    serviceProvider.GetRequiredService<IOptions<ShellOptions>>(),
+                    serviceProvider.GetRequiredService<ShellSettings>());
+                //TODO get this from OC settings - going to be a merge conflict there.
+                cache.Settings[MediaFileCache.Folder] = MediaFileCache.DefaultCacheFolder;
+
+                return cache;
+            })
             .SetCacheHash<CacheHash>()
             .AddProvider<MediaFileProvider>()
             .AddProcessor<ResizeWebProcessor>()


### PR DESCRIPTION
This further addresses #3459 by providing a replacement for the ImageSharp PhysicalFileSystemCache and it provides cache size limiting to prevent excessive cache growth (could not find a specific issue for cache limiting, but has been discussed a few times recently on Gitter etc)

It moves the cache to a file provider based under the tenant's root. Default name is now `MediaCache` - adjustable via appSettings

It provides an appSetting to select how many images should be kept in the cache `"MaxCacheEntries"`.
If `"MaxCacheEntries" = 0` cache eviction is disabled, but > 0 will limit based on the number of images in the MediaCache folder (so not size in bytes - as a count was faster than a file size calculation) 

The count is based on cache key name, so `MaxCacheEntries = 10` will actually allow 20 files in 
the `MediaCache` folder, one the `.png`, the other the associated ImageSharp metadata file `.meta`
@Skrypt Will a count rather than file size work for your issue?

I originally did this with a ConcurrentQueue (see commit #c7251eb) and then in the last commit (#11e5598) converted to a threadlocked LinkedList and borrowed the AsyncKeyLock from IS to read/write lock file operations - that would work better if `ImageSharpMiddleWare.AsyncLock` was public but it's not. 

Could always PR ImageSharp to request that feature if preferable?

@jtkech I have not included the FileProvider into the WebRoot composite file provider as I couldn't see a need to expose these cached images to anything but ImageSharp (no need for file version control at this lower level) - any thoughts?

This also meant that I could drop the directory tree structure typically used by ImageSharp in favour of a flat directory structure which makes Cache Eviction faster (as it does not have to parse multiple directories to remove unused directories when evicting cache). Not totally sure about this, but I suspect the purpose of the tree structure was to obfuscate the cached images in the `wwwroot` folder so that they were harder to find if you had UseStaticFiles enabled.
Open to thoughts on this change. It does mean the folder items can get quite lengthy, but then the previous tree structure created a very deep, hard to examine, structure.

I've tested this with a largeish quantity of images (1,000), and the cache settings low (at 1 image maximum) and have not had any issues, other than resizing happening on every refresh.

There's still a bunch of comments in the code for someone to review before this is ready - not sure about the use of AsyncKeyLock etc - but from the ImageSharp.Web commit history you did a bunch  of work on that @sebastienros.