### PR TITLE
Fix: OrchardCore.Media AllowedFileExtensions Configuration Does Not W…

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -171,7 +171,7 @@ namespace OrchardCore.Media.Controllers
 
             // var maxUploadSize = section.GetValue("MaxRequestBodySize", 100_000_000);
             var maxFileSize = section.GetValue("MaxFileSize", 30_000_000);
-            var allowedFileExtensions = section.GetValue("AllowedFileExtensions", DefaultAllowedFileExtensions);
+            var allowedFileExtensions = section.GetSection("AllowedFileExtensions").Get<string[]>() ?? DefaultAllowedFileExtensions;
 
             var result = new List<object>();
 


### PR DESCRIPTION
Fixes #3495 

Committed the suggested fix from the issue. Learned a great deal about the configuration system while verifying that it works.

Also searched for similar calls that returns arrays in the solution, but couldn't find any more.