### PR TITLE
Allow MediaFileStore to be resolved before building the tenant pipeline.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -82,12 +82,13 @@ namespace OrchardCore.Media
                 var fileStore = new FileSystemStore(mediaPath);
 
                 var mediaUrlBase = "/" + fileStore.Combine(shellSettings.RequestUrlPrefix, AssetsUrlPrefix);
-                var httpContext = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
 
-                if (httpContext != null && httpContext.Items.TryGetValue("OriginalPathBase", out var value)
-                    && value is PathString originalPathBase && originalPathBase.HasValue)
+                var originalPathBase = serviceProvider.GetRequiredService<IHttpContextAccessor>()
+                    .HttpContext?.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? null;
+
+                if (originalPathBase.HasValue)
                 {
-                    mediaUrlBase = fileStore.Combine(originalPathBase.ToString(), mediaUrlBase);
+                    mediaUrlBase = fileStore.Combine(originalPathBase, mediaUrlBase);
                 }
 
                 return new MediaFileStore(fileStore, mediaUrlBase);

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -82,12 +82,12 @@ namespace OrchardCore.Media
                 var fileStore = new FileSystemStore(mediaPath);
 
                 var mediaUrlBase = "/" + fileStore.Combine(shellSettings.RequestUrlPrefix, AssetsUrlPrefix);
-                var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
+                var httpContext = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
 
-                if (httpContextAccessor.HttpContext.Items.TryGetValue("OriginalPathBase", out var originalPathBase)
-                    && originalPathBase is PathString pathBase && pathBase.HasValue)
+                if (httpContext != null && httpContext.Items.TryGetValue("OriginalPathBase", out var value)
+                    && value is PathString originalPathBase && originalPathBase.HasValue)
                 {
-                    mediaUrlBase = fileStore.Combine(pathBase.ToString(), mediaUrlBase);
+                    mediaUrlBase = fileStore.Combine(originalPathBase.ToString(), mediaUrlBase);
                 }
 
                 return new MediaFileStore(fileStore, mediaUrlBase);

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellContextFeature.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellContextFeature.cs
@@ -12,6 +12,7 @@ namespace OrchardCore.Environment.Shell
         /// The current shell context.
         /// </summary>
         public ShellContext ShellContext { get; set; }
+
         /// <summary>
         /// The original path base.
         /// </summary>

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellContextFeature.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellContextFeature.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Http;
+using OrchardCore.Hosting.ShellBuilders;
+
+namespace OrchardCore.Environment.Shell
+{
+    /// <summary>
+    /// Used to capture the shell context and original path infos.
+    /// </summary>
+    public class ShellContextFeature
+    {
+        /// <summary>
+        /// The current shell context.
+        /// </summary>
+        public ShellContext ShellContext { get; set; }
+        /// <summary>
+        /// The original path base.
+        /// </summary>
+        public PathString OriginalPathBase { get; set; }
+
+        /// <summary>
+        /// The original path.
+        /// </summary>
+        public PathString OriginalPath { get; set; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Logging.NLog/TenantLayoutRenderer.cs
+++ b/src/OrchardCore/OrchardCore.Logging.NLog/TenantLayoutRenderer.cs
@@ -2,7 +2,7 @@ using System.Text;
 using NLog;
 using NLog.LayoutRenderers;
 using NLog.Web.LayoutRenderers;
-using OrchardCore.Hosting.ShellBuilders;
+using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.Logging
 {
@@ -19,7 +19,7 @@ namespace OrchardCore.Logging
             var context = HttpContextAccessor.HttpContext;
 
             // If there is no ShellContext in the Features then the log is rendered from the Host
-            var tenantName = context.Features.Get<ShellContext>()?.Settings?.Name ?? "None";
+            var tenantName = context.Features.Get<ShellContextFeature>()?.ShellContext.Settings.Name ?? "None";
             builder.Append(tenantName);
         }
     }

--- a/src/OrchardCore/OrchardCore.Logging.Serilog/SerilogTenantNameLoggingMiddleware.cs
+++ b/src/OrchardCore/OrchardCore.Logging.Serilog/SerilogTenantNameLoggingMiddleware.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using OrchardCore.Hosting.ShellBuilders;
+using OrchardCore.Environment.Shell;
 using Serilog.Context;
 
 namespace OrchardCore.Logging
@@ -19,7 +16,7 @@ namespace OrchardCore.Logging
 
         public async Task Invoke(HttpContext context)
         {
-            string tenantName = context.Features.Get<ShellContext>()?.Settings?.Name ?? "None";
+            string tenantName = context.Features.Get<ShellContextFeature>()?.ShellContext.Settings.Name ?? "None";
             using (LogContext.PushProperty("TenantName", tenantName))
             {
                 await _next.Invoke(context);

--- a/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs
@@ -57,10 +57,12 @@ namespace OrchardCore.Modules
                 using (scope)
                 {
                     // Register the shell context as a custom feature
-                    httpContext.Features.Set(shellContext);
-
-                    // Needed to build some components if e.g under a virtual folder.
-                    httpContext.Items["OriginalPathBase"] = httpContext.Request.PathBase;
+                    httpContext.Features.Set(new ShellContextFeature
+                    {
+                        ShellContext = shellContext,
+                        OriginalPath = httpContext.Request.Path,
+                        OriginalPathBase = httpContext.Request.PathBase
+                    });
 
                     if (!shellContext.IsActivated)
                     {

--- a/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs
@@ -59,7 +59,7 @@ namespace OrchardCore.Modules
                     // Register the shell context as a custom feature
                     httpContext.Features.Set(shellContext);
 
-                    // Needed by some components to be aware e.g if under a virtual folder.
+                    // Needed to build some components if e.g under a virtual folder.
                     httpContext.Items["OriginalPathBase"] = httpContext.Request.PathBase;
 
                     if (!shellContext.IsActivated)

--- a/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs
@@ -59,6 +59,9 @@ namespace OrchardCore.Modules
                     // Register the shell context as a custom feature
                     httpContext.Features.Set(shellContext);
 
+                    // Needed by some components to be aware e.g if under a virtual folder.
+                    httpContext.Items["OriginalPathBase"] = httpContext.Request.PathBase;
+
                     if (!shellContext.IsActivated)
                     {
                         var semaphore = _semaphores.GetOrAdd(shellSettings.Name, (name) => new SemaphoreSlim(1));

--- a/src/OrchardCore/OrchardCore/Modules/ModularTenantRouterMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularTenantRouterMiddleware.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OrchardCore.Hosting.ShellBuilders;
+using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.Modules
 {
@@ -43,7 +43,7 @@ namespace OrchardCore.Modules
                 _logger.LogInformation("Begin Routing Request");
             }
 
-            var shellContext = httpContext.Features.Get<ShellContext>();
+            var shellContext = httpContext.Features.Get<ShellContextFeature>().ShellContext;
 
             // Define a PathBase for the current request that is the RequestUrlPrefix.
             // This will allow any view to reference ~/ as the tenant's base url.


### PR DESCRIPTION
Fix the issue @matiasmolleja had in this branch, see #3249.

- Allows to resolve `IMediaFileStore` before building the tenant pipeline, so before `PathBase` include the tenant prefix, e.g when resolved by an `IModularTenantEvents` when activating a shell.

- Also allows the service to be correctly resolved for a given tenant even if in the context of another tenant, and where `PathBase` would include the prefix of this other tenant.

When building `MediaFileStore` we pass a `mediaUrlBase` which depends on the `PathBase` e.g if under a virtual folder. As i remember, at some point i was using the `PathBase` dynamically inside the `MediaFileStore`, only when mapping urls / paths, but we use the same `MediaFileStore` when using `Media.Azure` where the `mediaUrlBase / publicUrlBase` is a full uri, so we would have to check this.

So maybe a little hacky and maybe some refactoring to do, maybe not the right place for the mapping methods. There are pending discussions around media, so right now this is the simpler fix i found.


