### PR TITLE
BooleanField Default value NRE

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/BooleanFieldDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/BooleanFieldDriver.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.ContentFields.Fields
             {
                 model.Value = (context.IsNew == false) ?
                     field.Value :
-                    (bool)context.PartFieldDefinition.Settings["DefaultValue"];
+                    (bool)(context.PartFieldDefinition.Settings["DefaultValue"] ?? false);
 
                 model.Field = field;
                 model.Part = context.ContentPart;


### PR DESCRIPTION
In the pull request #3527 I introduced an issue that occurs when:

- Creating a new type with BooleanField without editing the properties for the BooleanField when creating the type.
- After upgrading the default value is not available. Issue occurs when creating new items.

Solved by defaulting to false if the default value is not present.