### PR TITLE
An OC.ContentTypes view was outputed on publishing

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/OrchardCore.ContentTypes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/OrchardCore.ContentTypes.csproj
@@ -5,13 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="Views\GraphQLContentTypePartSettings.Edit.cshtml">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <Pack>$(IncludeRazorContentInPack)</Pack>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Deployment.Abstractions\OrchardCore.Deployment.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />


### PR DESCRIPTION
So that `GraphQLContentTypePartSettings.Edit.cshtml` is not physically outputed on publishing.