### PR TITLE
Add validation for patterns in the AutoroutePart and the AliasPart

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Settings/AutoroutePartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Settings/AutoroutePartSettingsDisplayDriver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
 using OrchardCore.Autoroute.Model;
 using OrchardCore.Autoroute.Models;
 using OrchardCore.Autoroute.ViewModels;
@@ -7,11 +8,22 @@ using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Liquid;
 
 namespace OrchardCore.Autoroute.Settings
 {
     public class AutoroutePartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
+        private readonly ILiquidTemplateManager _templateManager;
+
+        public AutoroutePartSettingsDisplayDriver(ILiquidTemplateManager templateManager, IStringLocalizer<AutoroutePartSettingsDisplayDriver> localizer)
+        {
+            _templateManager = templateManager;
+            T = localizer;
+        }
+
+        public IStringLocalizer T { get; private set; }
+
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
             if (!String.Equals(nameof(AutoroutePart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
@@ -46,10 +58,15 @@ namespace OrchardCore.Autoroute.Settings
                 m => m.AllowUpdatePath,
                 m => m.ShowHomepageOption);
 
-            context.Builder.WithSetting(nameof(AutoroutePartSettings.Pattern), model.Pattern);
-            context.Builder.WithSetting(nameof(AutoroutePartSettings.AllowCustomPath), model.AllowCustomPath.ToString());
-            context.Builder.WithSetting(nameof(AutoroutePartSettings.AllowUpdatePath), model.AllowUpdatePath.ToString());
-            context.Builder.WithSetting(nameof(AutoroutePartSettings.ShowHomepageOption), model.ShowHomepageOption.ToString());
+            if (!string.IsNullOrEmpty(model.Pattern) && !_templateManager.Validate(model.Pattern, out var errors))
+            {
+                context.Updater.ModelState.AddModelError(nameof(model.Pattern), T["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+            } else {
+                context.Builder.WithSetting(nameof(AutoroutePartSettings.Pattern), model.Pattern);
+                context.Builder.WithSetting(nameof(AutoroutePartSettings.AllowCustomPath), model.AllowCustomPath.ToString());
+                context.Builder.WithSetting(nameof(AutoroutePartSettings.AllowUpdatePath), model.AllowUpdatePath.ToString());
+                context.Builder.WithSetting(nameof(AutoroutePartSettings.ShowHomepageOption), model.ShowHomepageOption.ToString());
+            }
 
             return Edit(contentTypePartDefinition, context.Updater);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidTemplateManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidTemplateManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -51,6 +52,11 @@ namespace OrchardCore.Liquid.Services
             });
 
             return result.RenderAsync(_liquidOptions, _serviceProvider, textWriter, encoder, context);
+        }
+
+        public bool Validate(string template, out IEnumerable<string> errors)
+        {
+            return LiquidViewTemplate.TryParse(template, out _, out errors);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Liquid.Abstractions/ILiquidTemplateManager.cs
+++ b/src/OrchardCore/OrchardCore.Liquid.Abstractions/ILiquidTemplateManager.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ namespace OrchardCore.Liquid
     public interface ILiquidTemplateManager
     {
         Task RenderAsync(string template, TextWriter textWriter, TextEncoder encoder, TemplateContext context);
+        bool Validate(string template, out IEnumerable<string> errors);
     }
 
     public static class LiquidTemplateManagerExtensions


### PR DESCRIPTION
Right now, if a user enters an invalid Liquid expression in the AutoroutePartSetting or in the AliasPartSettings, no validation is performed and the invalid pattern is saved to the part definition. When a new route or alias is generated it contains an error from the Liquid parser.

<img width="817" alt="permalink-template-error" src="https://user-images.githubusercontent.com/2894161/57034454-d0a1ed80-6c4f-11e9-9d2e-5449461f4725.png">

This pull request adds validation for patterns and thus prevents users from entering invalid Liquid expressions.