### PR TITLE
Revert back to use @ in media fields and media app initialization.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Index.cshtml
@@ -6,7 +6,7 @@
 
 <script at="Foot">
     
-    initializeMediaApplication(true, $('#mediaApplicationUrl').val());
+    initializeMediaApplication(true, '@Url.Action("MediaApplication", "Admin", new { area = "OrchardCore.Media" })');
 
     @* mediaApp is absolutely positioned. When a warning is shown we need to move it down to avoid overlapping. *@
     $(function () {
@@ -46,5 +46,3 @@
 
 <h1>@RenderTitleSegments(T["Assets"])</h1>
 
-
-<input type="hidden" id="mediaApplicationUrl" value="@Url.Action("MediaApplication", "Admin", new { area = "OrchardCore.Media" })" />

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
@@ -10,14 +10,13 @@
 <partial name="Shared/MediaFieldEditResources.cshtml" />
 
 <script at="Foot">
-
     initializeAttachedMediaField(
-        document.getElementById($('#MediaFieldId').val()),
-         $('#MediaFieldId').val() + '-field-file-upload',
-         $('#UploadUrl').val(),
-         $('#GetMediaItemUrl').val(),
-         $('#SettingsMultiple').val(),
-         $('#TempUploadFolder').val());
+        document.getElementById('@mediaFieldId'),
+        '@mediaFieldId-field-file-upload',
+        '@Url.Action("Upload", "Admin", new { area = "OrchardCore.Media" })',
+        '@Url.Action("GetMediaItem", "Admin", new { area = "OrchardCore.Media" })',
+         @(settings.Multiple ? "true" : "false"),
+        '@Model.TempUploadFolder');
 </script>
 
 <div class="mediafield-editor" id="@mediaFieldId" data-for="@Html.IdFor(m => m.Paths)">
@@ -62,9 +61,4 @@
 
 <partial name="Shared/MediaFieldEditLocalization.cshtml" />
 
-<input type="hidden" id="MediaFieldId" value="@mediaFieldId" />
-<input type="hidden" id="SettingsMultiple" value="@(settings.Multiple ? "true" : "false")" />
-<input type="hidden" id="TempUploadFolder" value="@Model.TempUploadFolder" />
-<input type="hidden" id="UploadUrl" value="@Url.Action("Upload", "Admin", new { area = "OrchardCore.Media" })" />
-<input type="hidden" id="GetMediaItemUrl" value="@Url.Action("GetMediaItem", "Admin", new { area = "OrchardCore.Media" })" />
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
@@ -11,11 +11,11 @@
 
 
 <script at="Foot">
-    initializeMediaApplication(false,  $('#mediaApplicationUrl').val());
+    initializeMediaApplication(false,  '@Url.Action("MediaApplication", "Admin", new { area = "OrchardCore.Media" })');
     initializeMediaField(
         document.getElementById('@Html.IdFor(m => m)'),
         document.getElementById('@Html.IdFor(m => m)-ModalBody'),
-        $('#GetMediaItemUrl').val(),
+        '@Url.Action("GetMediaItem", "Admin", new { area = "OrchardCore.Media" })',
         @(settings.Multiple ? "true" : "false"));
 </script>
 
@@ -75,6 +75,3 @@
 </div>
 
 <partial name="Shared/MediaFieldEditLocalization.cshtml" />
-
-<input type="hidden" id="mediaApplicationUrl" value="@Url.Action("MediaApplication", "Admin", new { area = "OrchardCore.Media" })" />
-<input type="hidden" id="GetMediaItemUrl" value="@Url.Action("GetMediaItem", "Admin", new { area = "OrchardCore.Media" })" />


### PR DESCRIPTION
Fixes #3582 

This is a temporary workaround to put the flow content type in a working state again.

In my last PR we avoided using "@" in javascript. So we used hidden input tags and retrieved their values from jquery. This was working nicely when using a "normal" content type.
But I did not noticed that in the "flow" part editor, when the javascript retrieves the value on the tags, it is undefined sometimes.
I would like to merge this PR until I understand better how the flow part is loading the widgets.

Attached is a PR of the system working after the fix:


