### PR TITLE
Reference Workflows/node_modules for bootstrap typings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Assets/Lib/jquery/typings.d.ts
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Assets/Lib/jquery/typings.d.ts
@@ -1,5 +1,5 @@
 ///<reference path="../../../../../../node_modules/@types/jquery/index.d.ts" />
-///<reference path="../../../../../../node_modules/@types/bootstrap/index.d.ts" />
+///<reference path="../../../node_modules/@types/bootstrap/index.d.ts" />
 
 interface JQuery {
     workflowEditor(): JQuery;


### PR DESCRIPTION
Bootstrap types are a dependency of workflows so installed in the `OrchardCode.Workflows/node_modules` rather than the root `node_modules`

Caused errors during `gulp rebuild` - no issue open, reported on gitter