### PR TITLE
Features List : prevent form submit on searchbox

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -13,7 +13,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text bg-secondary text-light">@T["Filter:"]</span>
                 </div>
-                <input id="search-box" class="form-control" type="text" placeholder="@T[" Search"]" autofocus="autofocus">
+                <input id="search-box" class="form-control" type="text" placeholder="@T["Search"]" autofocus="autofocus">
             </div>
 
             <div class="input-group w-xl-50">

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -13,7 +13,7 @@
                 <div class="input-group-prepend">
                     <span class="input-group-text bg-secondary text-light">@T["Filter:"]</span>
                 </div>
-                <input id="search-box" class="form-control" type="text" placeholder="@T["Search"]" autofocus="autofocus">
+                <input id="search-box" class="form-control" type="text" placeholder="@T[" Search"]" autofocus="autofocus">
             </div>
 
             <div class="input-group w-xl-50">
@@ -73,7 +73,7 @@
                             var dependencies = (from d in feature.FeatureDependencies
                                                 select (from f in Model.Features where f.Descriptor.Id == d.Id select f).SingleOrDefault()).Where(f => f != null).OrderBy(f => f.Descriptor.Name);
                             var missingDependencies = feature.FeatureDependencies
-                                .Where(d => !Model.Features.Any(f => f.Descriptor.Id == d.Id));
+                            .Where(d => !Model.Features.Any(f => f.Descriptor.Id == d.Id));
                             var showDisable = !feature.IsAlwaysEnabled && categoryName != "Core" && feature.Descriptor.Name != Application.ModuleName;
                             var showEnable = Model.IsAllowed(feature.Descriptor) && !missingDependencies.Any() && feature.Descriptor.Id != "OrchardCore.Setup";
 
@@ -137,49 +137,49 @@
         }
     }
 
-    @*<li class="@featureClassName" id="@featureId" title="@string.Format(feature.IsEnabled ? "{0} is enabled" : "{0} is disabled", featureName)">
+    @*<li class="@featureClassName" id="@featureId" title="@string.Format(feature.IsEnabled ? " {0} is enabled" : "{0} is disabled" , featureName)">
             <div class="panel panel-default panel-heading-fullwidth panel-borders">
                 <div class="panel-heading">
                     <div class="title">
                         @if ((showEnable && !feature.IsEnabled) || (showDisable && feature.IsEnabled))
                         {
-                            <span class="or-checkbox">
-                                <input type="checkbox" name="featureIds" id="@feature.Descriptor.Id" value="@feature.Descriptor.Id" />
-                                <label for="@feature.Descriptor.Id">
-                                    @featureName
-                                </label>
-                            </span>
+                        <span class="or-checkbox">
+                            <input type="checkbox" name="featureIds" id="@feature.Descriptor.Id" value="@feature.Descriptor.Id" />
+                            <label for="@feature.Descriptor.Id">
+                                @featureName
+                            </label>
+                        </span>
                         }
                         else
                         {
-                            @featureName
+                        @featureName
                         }
                     </div>
                     <div class="tools">
                         @if (showDisable && feature.IsEnabled)
                         {
-                            var dependantsJoined = string.Join(", ", feature.DependentFeatures.Select(f => f.Name));
-                            <div class="switch-button">
-                                <input type="checkbox" checked="" name="swt@(feature.Descriptor.Id)" id="swt@(feature.Descriptor.Id)"><span>
-                                    <label for="swt@(feature.Descriptor.Id)" data-feature-id="@feature.Descriptor.Id" data-feature-action="@FeaturesBulkAction.Disable" data-feature-force="true" data-feature-dependants="@dependantsJoined">@T["Disable"]</label>
-                                </span>
-                            </div>
+                        var dependantsJoined = string.Join(", ", feature.DependentFeatures.Select(f => f.Name));
+                        <div class="switch-button">
+                            <input type="checkbox" checked="" name="swt@(feature.Descriptor.Id)" id="swt@(feature.Descriptor.Id)"><span>
+                                <label for="swt@(feature.Descriptor.Id)" data-feature-id="@feature.Descriptor.Id" data-feature-action="@FeaturesBulkAction.Disable" data-feature-force="true" data-feature-dependants="@dependantsJoined">@T["Disable"]</label>
+                            </span>
+                        </div>
                         }
 
                         @if (showEnable && !feature.IsEnabled)
                         {
-                            <div class="switch-button">
-                                <input type="checkbox" name="swt@(feature.Descriptor.Id)" id="swt@(feature.Descriptor.Id)"><span>
-                                    <label for="swt@(feature.Descriptor.Id)" data-feature-id="@feature.Descriptor.Id" data-feature-action="@FeaturesBulkAction.Enable" data-feature-force="true">@T["Enable"]</label>
-                                </span>
-                            </div>
+                        <div class="switch-button">
+                            <input type="checkbox" name="swt@(feature.Descriptor.Id)" id="swt@(feature.Descriptor.Id)"><span>
+                                <label for="swt@(feature.Descriptor.Id)" data-feature-id="@feature.Descriptor.Id" data-feature-action="@FeaturesBulkAction.Enable" data-feature-force="true">@T["Enable"]</label>
+                            </span>
+                        </div>
                         }
 
                         @if (feature.NeedsUpdate)
                         {
-                            <span class="icon s7-upload">
-                                <a href="#" data-feature-id="@feature.Descriptor.Id" data-feature-action="@FeaturesBulkAction.Update" data-feature-force="false">@T["Update"]</a>
-                            </span>
+                        <span class="icon s7-upload">
+                            <a href="#" data-feature-id="@feature.Descriptor.Id" data-feature-action="@FeaturesBulkAction.Update" data-feature-force="false">@T["Update"]</a>
+                        </span>
                         }
                     </div>
                 </div>
@@ -187,41 +187,41 @@
                     <p class="description" title="@feature.Descriptor.Description">@feature.Descriptor.Description</p>
                     @if (feature.Descriptor.Dependencies != null && feature.Descriptor.Dependencies.Any())
                     {
-                        <div class="dependencies">
-                            <h4>@T["Depends on:"]</h4>
-                            <ul>
-                                @foreach (var d in dependencies)
-                                {
-                                    <li>
-                                        <a href="#@d">@(string.IsNullOrEmpty(d.Descriptor.Name) ? d.Descriptor.Id : d.Descriptor.Name)</a>
-                                    </li>
-                                }
-                            </ul>
-                        </div>
+                    <div class="dependencies">
+                        <h4>@T["Depends on:"]</h4>
+                        <ul>
+                            @foreach (var d in dependencies)
+                            {
+                            <li>
+                                <a href="#@d">@(string.IsNullOrEmpty(d.Descriptor.Name) ? d.Descriptor.Id : d.Descriptor.Name)</a>
+                            </li>
+                            }
+                        </ul>
+                    </div>
                     }
                     @if (missingDependencies.Any())
                     {
-                        <div class="missingdependencies">
-                            <h4>@T["Missing:"]</h4>
-                            <ul>
-                                @foreach (var d in missingDependencies)
-                                {
-                                    <li>
-                                        @d
-                                    </li>
-                                }
-                            </ul>
-                        </div>}
+                    <div class="missingdependencies">
+                        <h4>@T["Missing:"]</h4>
+                        <ul>
+                            @foreach (var d in missingDependencies)
+                            {
+                            <li>
+                                @d
+                            </li>
+                            }
+                        </ul>
+                    </div>}
                 </div>
                 <div class="panel-footer">
-                        @if (lifecycleStatus != LifecycleStatus.Production) {
-                            var iconClass = lifecycleStatusClassDictionary[lifecycleStatus];
-                            <div class="lifecycle-status lifecycle-status-@feature.Descriptor.Extension.LifecycleStatus.ToString().HtmlClassify()">
-                                <i class="fa @iconClass"></i>
-                                @T(lifecycleStatus.ToString())
-                            </div>
-                        }
+                    @if (lifecycleStatus != LifecycleStatus.Production) {
+                    var iconClass = lifecycleStatusClassDictionary[lifecycleStatus];
+                    <div class="lifecycle-status lifecycle-status-@feature.Descriptor.Extension.LifecycleStatus.ToString().HtmlClassify()">
+                        <i class="fa @iconClass"></i>
+                        @T(lifecycleStatus.ToString())
                     </div>
+                    }
+                </div>
             </div>
         </li>*@
 </form>
@@ -239,12 +239,21 @@
             if (e.keyCode == 27 || search == '') {
                 searchBox.val('');
                 elementsToFilter.toggle(true);
-            } else {
+            }
+            else {
                 elementsToFilter.each(function () {
                     var text = $(this).data('filter-value').toLowerCase();
                     var found = text.indexOf(search) > -1;
                     $(this).toggle(found);
                 });
+            }
+        });
+
+        //prevent posting form on pressing enter key
+        searchBox.keypress(function (e) {
+            var key = e.charCode || e.keyCode || 0;
+            if (key == 13) {
+                return false;
             }
         });
     });


### PR DESCRIPTION
Fixing a regression I created by changing the styling of the features filters items.
The way to prevent doing a form submit was to keep the input element out of the form which is something we can't really rely on. In the recent changes I moved back the search box inside the form so when pressing the "enter" key it will trigger a form submit. I fixed the issue by adding a javascript that prevents the form submit on that input.

Fixes #3620