### PR TITLE
Safer path to create / dispose a lucene index and increase lock timeout.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
@@ -94,7 +94,7 @@ namespace OrchardCore.Lucene
                 }
 
                 _timestamps.TryRemove(indexName, out var timestamp);
-                
+
                 var indexFolder = PathExtensions.Combine(_rootPath, indexName);
 
                 if (Directory.Exists(indexFolder))
@@ -267,10 +267,20 @@ namespace OrchardCore.Lucene
                         var analyzer = _luceneAnalyzerManager.CreateAnalyzer(LuceneSettings.StandardAnalyzer);
                         var config = new IndexWriterConfig(LuceneSettings.DefaultVersion, analyzer)
                         {
-                            OpenMode = OpenMode.CREATE_OR_APPEND
+                            OpenMode = OpenMode.CREATE_OR_APPEND,
+                            WriteLockTimeout = Lock.LOCK_POLL_INTERVAL * 3
                         };
 
-                        writer = _writers[indexName] = new IndexWriterWrapper(directory, config);
+                        writer = new IndexWriterWrapper(directory, config);
+
+                        if (close)
+                        {
+                            writer.Dispose();
+                            _timestamps[indexName] = _clock.UtcNow;
+                            return;
+                        }
+
+                        _writers[indexName] = writer;
                     }
                 }
             }
@@ -281,19 +291,6 @@ namespace OrchardCore.Lucene
             }
 
             action?.Invoke(writer);
-
-            if (close && !writer.IsClosing)
-            {
-                lock (this)
-                {
-                    if (!writer.IsClosing)
-                    {
-                        writer.IsClosing = true;
-                        writer.Dispose();
-                        _writers.TryRemove(indexName, out writer);
-                    }
-                }
-            }
 
             _timestamps[indexName] = _clock.UtcNow;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexManager.cs
@@ -275,6 +275,7 @@ namespace OrchardCore.Lucene
 
                         if (close)
                         {
+                            action?.Invoke(writer);
                             writer.Dispose();
                             _timestamps[indexName] = _clock.UtcNow;
                             return;


### PR DESCRIPTION
The last time i had the intermittent issue on the graphQl test, i had a lucene lock obtain timeout. In the trace i didn't see any other underlying `FailureReason`, so maybe just because lucene was still doing things (e.g after creating an index and dispose it) before being able to acquire again a lock and use a writer.

- So here i suggest to increase the lock timeout, **currently we only try once to obtain a lock**.

- I also suggest a safer path to create an index and then dispose it. This is only when we create an index that we use the `Write()` method with `close: true`. So assuming this (i could have used a more complex interlocking pattern) i suggest the following which result in less code.

    - when creating an index through the `Write()` with `close: true`, if the index is already in the dico, we let it in the dico and don't dispose it.

    - If not in the dico, we do a lock and create it as before, but (if close = true) we don't put it in the dico, we do the action and dispose it under the same lock. So, here we totally prevent to share an index that is intended to be disposed, knowing that, when creating an index, currently the action we pass do nothing.