### PR TITLE
Fixes ISite.GetConfiguredCultures()

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.Localization
             var options = serviceProvider.GetService<IOptions<RequestLocalizationOptions>>().Value;
 
             // If no specific default culture is defined, use the system language by not calling SetDefaultCulture
-            if (!String.IsNullOrEmpty(siteSettings.Culture))
+            if (siteSettings.Culture != null)
             {
                 options.SetDefaultCulture(siteSettings.Culture);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.Localization
                 options.SetDefaultCulture(siteSettings.Culture);
             }
 
-            if (siteSettings.SupportedCultures.Length > 0)
+            if (siteSettings.SupportedCultures?.Length > 0)
             {
                 var supportedCulture = siteSettings.GetConfiguredCultures();
 

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -37,11 +36,9 @@ namespace OrchardCore.Localization
 
             if (siteSettings.SupportedCultures?.Length > 0)
             {
-                var supportedCulture = siteSettings.GetConfiguredCultures();
-
                 options
-                    .AddSupportedCultures(supportedCulture)
-                    .AddSupportedUICultures(supportedCulture);
+                    .AddSupportedCultures(siteSettings.SupportedCultures)
+                    .AddSupportedUICultures(siteSettings.SupportedCultures);
             }
 
             app.UseRequestLocalization(options);

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Settings/SiteExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Settings/SiteExtensions.cs
@@ -6,8 +6,7 @@ namespace OrchardCore.Settings
     public static class SiteExtensions
     {
         public static string[] GetConfiguredCultures(this ISite site)
-        {
-            return new[] { CultureInfo.InstalledUICulture.Name }.Union(site.SupportedCultures).ToArray();
-        }
+            => new[] { site.Culture ?? CultureInfo.InstalledUICulture.Name }
+            .Union(site?.SupportedCultures ?? new string[] { }).ToArray();
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Settings/SiteExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Settings/SiteExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Linq;
 
@@ -6,7 +7,20 @@ namespace OrchardCore.Settings
     public static class SiteExtensions
     {
         public static string[] GetConfiguredCultures(this ISite site)
-            => new[] { site.Culture ?? CultureInfo.InstalledUICulture.Name }
-            .Union(site?.SupportedCultures ?? new string[] { }).ToArray();
+        {
+            if (site == null)
+            {
+                throw new ArgumentNullException(nameof(site));
+            }
+
+            var configuredCultures = new[] { site.Culture ?? CultureInfo.InstalledUICulture.Name };
+
+            if (site.SupportedCultures != null)
+            {
+                configuredCultures = configuredCultures.Union(site.SupportedCultures).ToArray();
+            }
+
+            return configuredCultures;
+        }
     }
 }

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace OrchardCore.Tests.Localization
 {
-    public class PortableObjectStringLocalizerTests
+    public class SiteExtensionsTests
     {
         private static PluralizationRuleDelegate _csPluralRule = n => ((n == 1) ? 0 : (n >= 2 && n <= 4) ? 1 : 2);
         private static PluralizationRuleDelegate _enPluralRule = n => (n == 1) ? 0 : 1;
@@ -20,7 +20,7 @@ namespace OrchardCore.Tests.Localization
         private Mock<ILocalizationManager> _localizationManager;
         private Mock<ILogger> _logger;
 
-        public PortableObjectStringLocalizerTests()
+        public SiteExtensionsTests()
         {
             _localizationManager = new Mock<ILocalizationManager>();
             _logger = new Mock<ILogger>();

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -46,6 +46,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OrchardCore.Cms.Web\OrchardCore.Cms.Web.csproj" />
+    <ProjectReference Include="..\..\src\OrchardCore.Modules\OrchardCore.Localization\OrchardCore.Localization.csproj" />
     <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Apis.GraphQL.Client\OrchardCore.Apis.GraphQL.Client.csproj" />
   </ItemGroup>
 

--- a/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
@@ -1,12 +1,25 @@
+using System;
 using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using Moq;
 using OrchardCore.Settings;
 using Xunit;
+using OrchardCoreLocalization = OrchardCore.Localization;
 
 namespace OrchardCore.Tests.Settings
 {
     public class SiteExtensionsTests
     {
+        private const string DefaultCulture = "en-US";
+
         private Mock<ISite> _site;
 
         public SiteExtensionsTests()
@@ -47,10 +60,78 @@ namespace OrchardCore.Tests.Settings
             Assert.Equal(new string[] { CultureInfo.InstalledUICulture.Name, "ar", "fr" }, configuredCultures);
         }
 
+        [Theory]
+        [InlineData(null, null, DefaultCulture, new string[] { DefaultCulture })]
+        [InlineData(null, new string[] { }, DefaultCulture, new string[] { DefaultCulture })]
+        [InlineData(null, new string[] { "ar", "fr" }, DefaultCulture, new string[] { DefaultCulture, "ar", "fr" })]
+        [InlineData("ar", new string[] { "ar", "fr" }, "ar", new string[] { "ar", "fr" })]
+        public Task SiteReturnGetConfiguredCulturesWithLocalizationMiddleware(string defaultCulture, string[] supportedCultures, string expectedDefaultCulture, string[] expectedSupportedCultures)
+            => RunTest(defaultCulture, supportedCultures, expectedDefaultCulture, expectedSupportedCultures);
+
+        [Fact]
+        public Task SiteReturnGetConfiguredCulturesWithLocalizationMiddlewareAndInvariantCulture()
+            => RunTest(CultureInfo.InstalledUICulture.Name, new string[] { }, CultureInfo.InstalledUICulture.Name, new[] { CultureInfo.InstalledUICulture.Name });
+
+        private async Task RunTest(string defaultCulture, string[] supportedCultures, string expectedDefaultCulture, string[] expectedSupportedCultures)
+        {
+            var localizationStartup = new OrchardCoreLocalization.Startup();
+            var webHostBuilder = new WebHostBuilder()
+                .ConfigureServices(services =>
+                {
+                    SetupSiteSettingsCultures(defaultCulture, supportedCultures);
+                    services.AddTransient<ISiteService>(_ => new SiteService(_site.Object));
+
+                    services.AddRouting();
+
+                    localizationStartup.ConfigureServices(services);
+                })
+                .Configure(app =>
+                {
+                    localizationStartup.Configure(app, new RouteBuilder(app), app.ApplicationServices);
+
+                    app.Run(context =>
+                    {
+                        var requestLocalizationOptions = context.RequestServices.GetService<IOptions<RequestLocalizationOptions>>().Value;
+                        var defaultRequestCulture = requestLocalizationOptions.DefaultRequestCulture;
+
+                        Assert.Equal(expectedDefaultCulture, requestLocalizationOptions.DefaultRequestCulture.Culture.Name);
+                        Assert.Equal(expectedSupportedCultures, requestLocalizationOptions.SupportedCultures.Select(c => c.Name).ToArray());
+
+                        return Task.FromResult(0);
+                    });
+                });
+
+            using (var server = new TestServer(webHostBuilder))
+            {
+                var client = server.CreateClient();
+                var requestedCulture = "en";
+                var response = await client.GetAsync($"page/?culture={requestedCulture}&ui-culture={requestedCulture}");
+            }
+        }
+
         private void SetupSiteSettingsCultures(string defaultCulture, string[] supportedCultures)
         {
             _site.Setup(s => s.Culture).Returns(defaultCulture);
-            _site.Setup(s=> s.SupportedCultures).Returns(supportedCultures);
+            _site.Setup(s => s.SupportedCultures).Returns(supportedCultures);
+        }
+
+        private class SiteService : ISiteService
+        {
+            private readonly ISite _site;
+
+            public SiteService(ISite site)
+            {
+                _site = site;
+            }
+
+            public IChangeToken ChangeToken => throw new NotImplementedException();
+
+            public Task<ISite> GetSiteSettingsAsync() => Task.FromResult(_site);
+
+            public Task UpdateSiteSettingsAsync(ISite site)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace OrchardCore.Tests.Settings
 {
-    public class SiteExtensionsTests
+    public class SiteSettingsTests
     {
         private const string InvariantCulture = "";
 
@@ -24,42 +24,9 @@ namespace OrchardCore.Tests.Settings
 
         private Mock<ISite> _site;
 
-        public SiteExtensionsTests()
+        public SiteSettingsTests()
         {
             _site = new Mock<ISite>();
-        }
-
-        [Theory]
-        [InlineData(null, null, new string[] { "en-US" })]
-        [InlineData(null, new string[] { "ar", "fr" }, new string[] { "en-US", "ar", "fr" })]
-        [InlineData("ar", new string[] { "ar", "fr" }, new string[] { "ar", "fr" })]
-        public void SiteReturnGetConfiguredCultures(string defaultCulture, string[] supportedCultures, string[] expected)
-        {
-            SetupSiteSettingsCultures(defaultCulture, supportedCultures);
-
-            var configuredCultures = SiteExtensions.GetConfiguredCultures(_site.Object);
-
-            Assert.Equal(expected, configuredCultures);
-        }
-
-        [Fact]
-        public void SiteReturnGetConfiguredCulturesWithInvariantCultures()
-        {
-            SetupSiteSettingsCultures(CultureInfo.InstalledUICulture.Name, new string[] { "ar", "fr" });
-
-            var configuredCultures = SiteExtensions.GetConfiguredCultures(_site.Object);
-
-            Assert.Equal(new string[] { CultureInfo.InstalledUICulture.Name, "ar", "fr" }, configuredCultures);
-        }
-
-        [Fact]
-        public void SiteReturnGetConfiguredCulturesContainsInvariantCultureIfDefaultCultureIsNull()
-        {
-            SetupSiteSettingsCultures(null, new string[] { "ar", "fr" });
-
-            var configuredCultures = SiteExtensions.GetConfiguredCultures(_site.Object);
-
-            Assert.Equal(new string[] { CultureInfo.InstalledUICulture.Name, "ar", "fr" }, configuredCultures);
         }
 
         [Theory]
@@ -69,7 +36,7 @@ namespace OrchardCore.Tests.Settings
         [InlineData(null, new string[] { }, null, null)]
         [InlineData(null, new string[] { "ar", "fr" }, null, new string[] { "ar", "fr" })]
         [InlineData("ar", new string[] { "ar", "fr" }, "ar", new string[] { "ar", "fr" })]
-        public async Task SiteReturnGetConfiguredCulturesWithLocalizationMiddleware(string defaultCulture, string[] supportedCultures, string expectedDefaultCulture, string[] expectedSupportedCultures)
+        public async Task SiteReturnsConfiguredCultures(string defaultCulture, string[] supportedCultures, string expectedDefaultCulture, string[] expectedSupportedCultures)
         {
             SimulateEnvironmentCulture();
 
@@ -88,7 +55,7 @@ namespace OrchardCore.Tests.Settings
         }
 
         [Fact]
-        public async Task SiteReturnGetConfiguredCulturesWithLocalizationMiddlewareAndInvariantCulture()
+        public async Task SiteReturnsConfiguredCulturesWithInvariantCulture()
         {
             await RunTestWithAcceptLanguageHttpHeader(_nonSupportedCulture, CultureInfo.InstalledUICulture.Name, new string[] { }, CultureInfo.InstalledUICulture.Name, new[] { CultureInfo.InstalledUICulture.Name });
             await RunTestWithQueryString(CultureInfo.InstalledUICulture.Name, new string[] { }, CultureInfo.InstalledUICulture.Name, new[] { CultureInfo.InstalledUICulture.Name });

--- a/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Moq;
 using OrchardCore.Settings;
 using Xunit;
@@ -24,6 +25,26 @@ namespace OrchardCore.Tests.Settings
             var configuredCultures = SiteExtensions.GetConfiguredCultures(_site.Object);
 
             Assert.Equal(expected, configuredCultures);
+        }
+
+        [Fact]
+        public void SiteReturnGetConfiguredCulturesWithInvariantCultures()
+        {
+            SetupSiteSettingsCultures(CultureInfo.InstalledUICulture.Name, new string[] { "ar", "fr" });
+
+            var configuredCultures = SiteExtensions.GetConfiguredCultures(_site.Object);
+
+            Assert.Equal(new string[] { CultureInfo.InstalledUICulture.Name, "ar", "fr" }, configuredCultures);
+        }
+
+        [Fact]
+        public void SiteReturnGetConfiguredCulturesContainsInvariantCultureIfDefaultCultureIsNull()
+        {
+            SetupSiteSettingsCultures(null, new string[] { "ar", "fr" });
+
+            var configuredCultures = SiteExtensions.GetConfiguredCultures(_site.Object);
+
+            Assert.Equal(new string[] { CultureInfo.InstalledUICulture.Name, "ar", "fr" }, configuredCultures);
         }
 
         private void SetupSiteSettingsCultures(string defaultCulture, string[] supportedCultures)

--- a/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
@@ -1,0 +1,35 @@
+using Moq;
+using OrchardCore.Settings;
+using Xunit;
+
+namespace OrchardCore.Tests.Settings
+{
+    public class SiteExtensionsTests
+    {
+        private Mock<ISite> _site;
+
+        public SiteExtensionsTests()
+        {
+            _site = new Mock<ISite>();
+        }
+
+        [Theory]
+        [InlineData(null, null, new string[] { "en-US" })]
+        [InlineData(null, new string[] { "ar", "fr" }, new string[] { "en-US", "ar", "fr" })]
+        [InlineData("ar", new string[] { "ar", "fr" }, new string[] { "ar", "fr" })]
+        public void SiteReturnGetConfiguredCultures(string defaultCulture, string[] supportedCultures, string[] expected)
+        {
+            SetupSiteSettingsCultures(defaultCulture, supportedCultures);
+
+            var configuredCultures = SiteExtensions.GetConfiguredCultures(_site.Object);
+
+            Assert.Equal(expected, configuredCultures);
+        }
+
+        private void SetupSiteSettingsCultures(string defaultCulture, string[] supportedCultures)
+        {
+            _site.Setup(s => s.Culture).Returns(defaultCulture);
+            _site.Setup(s=> s.SupportedCultures).Returns(supportedCultures);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
@@ -62,8 +62,9 @@ namespace OrchardCore.Tests.Settings
 
         [Theory]
         [InlineData(null, null, DefaultCulture, new string[] { DefaultCulture })]
+        [InlineData("", null, DefaultCulture, new string[] { DefaultCulture })]
         [InlineData(null, new string[] { }, DefaultCulture, new string[] { DefaultCulture })]
-        [InlineData(null, new string[] { "ar", "fr" }, DefaultCulture, new string[] { DefaultCulture, "ar", "fr" })]
+        [InlineData(null, new string[] { "ar", "fr" }, DefaultCulture, new string[] { "ar", "fr" })]
         [InlineData("ar", new string[] { "ar", "fr" }, "ar", new string[] { "ar", "fr" })]
         public Task SiteReturnGetConfiguredCulturesWithLocalizationMiddleware(string defaultCulture, string[] supportedCultures, string expectedDefaultCulture, string[] expectedSupportedCultures)
             => RunTest(defaultCulture, supportedCultures, expectedDefaultCulture, expectedSupportedCultures);

--- a/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Settings/SiteExtensionsTests.cs
@@ -19,6 +19,7 @@ namespace OrchardCore.Tests.Settings
     public class SiteExtensionsTests
     {
         private const string DefaultCulture = "en-US";
+        private const string InvariantCulture = "";
 
         private static readonly string _nonSupportedCulture = "it";
 
@@ -64,7 +65,7 @@ namespace OrchardCore.Tests.Settings
 
         [Theory]
         [InlineData(null, null, DefaultCulture, new string[] { DefaultCulture })]
-        [InlineData("", null, DefaultCulture, new string[] { DefaultCulture })]
+        [InlineData(InvariantCulture, null, InvariantCulture, new string[] { DefaultCulture })]
         [InlineData(null, new string[] { }, DefaultCulture, new string[] { DefaultCulture })]
         [InlineData(null, new string[] { "ar", "fr" }, DefaultCulture, new string[] { "ar", "fr" })]
         [InlineData("ar", new string[] { "ar", "fr" }, "ar", new string[] { "ar", "fr" })]


### PR DESCRIPTION
Fixes #3661

I still have a doubt about the `GetConfiguredCultures()` I'm not sure why we don't TRUST localization middleware to fallback to the appropriate cultures even if the user doesn't setup default culture or supported cultures from the admin site

/cc @Skrypt @sebastienros