### PR TITLE
GraphQL fixes where case sensity issues in postgres

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/PredicateQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/PredicateQuery.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using OrchardCore.ContentManagement.Records;
 using OrchardCore.Environment.Shell;
 using YesSql;
 
@@ -60,8 +62,17 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
                 {
                     // Return the default alias
                     // ContentItemId -> ContentItemIndex.ContentItemId
-                    _usedAliases.Add(alias);
-                    return Dialect.QuoteForTableName($"{_tablePrefix}{alias}") + "." + Dialect.QuoteForColumnName(values[0]);
+                    // Ensures its actually a property of ContentItemIndex and gets the correct casing.
+                    var propertyName = values[0];
+
+                    var contentItemIndexProperty = typeof(ContentItemIndex)
+                                                    .GetProperties()
+                                                    .FirstOrDefault(x => x.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase));
+
+                    if (contentItemIndexProperty != null) { 
+                        _usedAliases.Add(alias);
+                        return Dialect.QuoteForTableName($"{_tablePrefix}{alias}") + "." + Dialect.QuoteForColumnName(contentItemIndexProperty.Name);
+                    }
                 }
             }
             else

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/PredicateQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/PredicateQuery.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.Environment.Shell;
@@ -11,9 +9,9 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
 {
     public class PredicateQuery : IPredicateQuery
     {
-        private static ConcurrentDictionary<string, string> _indexMapping = new ConcurrentDictionary<string, string>();
-		private readonly HashSet<string> _usedAliases = new HashSet<string>();
-        private readonly IDictionary<string, string> _aliases = new Dictionary<string, string>();
+        private static Dictionary<string, string> _contentItemIndexProperties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _usedAliases = new HashSet<string>();
+        private readonly Dictionary<string, string> _aliases = new Dictionary<string, string>();
         private readonly string _tablePrefix;
 
         public PredicateQuery(ISqlDialect dialect, ShellSettings shellSettings)
@@ -27,6 +25,14 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
         public ISqlDialect Dialect { get; set; }
 
         public IDictionary<string, object> Parameters { get; } = new Dictionary<string, object>();
+
+        static PredicateQuery()
+        {
+            foreach(var property in typeof(ContentItemIndex).GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase))
+            {
+                _contentItemIndexProperties[property.Name] = property.Name;
+            }            
+        }
 
         public string NewQueryParameter(object value)
         {
@@ -51,32 +57,23 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
             if (propertyPath == null) throw new ArgumentNullException(nameof(propertyPath));
 
             // Check if there's an alias for the full path
-			// aliasPart.Alias -> AliasFieldIndex.Alias
+            // aliasPart.Alias -> AliasFieldIndex.Alias
             if (_aliases.TryGetValue(propertyPath, out string alias))
             {
                 _usedAliases.Add(alias);
                 return Dialect.QuoteForColumnName(alias);
             }
 
-            var values = propertyPath.Split(new []{'.'}, 2);
+            var values = propertyPath.Split(new[] { '.' }, 2);
             if (values.Length == 1)
             {
                 if (_aliases.TryGetValue(string.Empty, out alias))
                 {
                     // Return the default alias
-                    // ContentItemId -> ContentItemIndex.ContentItemId
-                    // Ensures its actually a property of ContentItemIndex and gets the correct casing.
-                    var propertyName = values[0].ToLower();
+                    // contentItemId -> ContentItemIndex.ContentItemId
 
-                    var indexKey = nameof(ContentItemIndex) + propertyName;
-
-                    if (!_indexMapping.TryGetValue(indexKey, out var columnName))
+                    if (_contentItemIndexProperties.TryGetValue(values[0], out var columnName))
                     {
-                        columnName = typeof(ContentItemIndex).GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase)?.Name;
-                        _indexMapping.TryAdd(indexKey, columnName);
-                    }
-
-                    if (columnName is object) { 
                         _usedAliases.Add(alias);
                         return Dialect.QuoteForTableName($"{_tablePrefix}{alias}") + "." + Dialect.QuoteForColumnName(columnName);
                     }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/PredicateQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/PredicateQuery.cs
@@ -72,7 +72,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
 
                     if (!_indexMapping.TryGetValue(indexKey, out var columnName))
                     {
-                        columnName = typeof(ContentItemIndex).GetProperty(propertyName, BindingFlags.IgnoreCase)?.Name;
+                        columnName = typeof(ContentItemIndex).GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase)?.Name;
                         _indexMapping.TryAdd(indexKey, columnName);
                     }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/PredicateQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/PredicateQuery.cs
@@ -76,7 +76,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
                         _indexMapping.TryAdd(indexKey, columnName);
                     }
 
-                    if (columnName != null) { 
+                    if (columnName is object) { 
                         _usedAliases.Add(alias);
                         return Dialect.QuoteForTableName($"{_tablePrefix}{alias}") + "." + Dialect.QuoteForColumnName(columnName);
                     }


### PR DESCRIPTION
See #3684 

This actually ended up been two sep issues

1. where clauses that used the contentitemindex when the db used a prefix didnt work (i fixed this already)
2. Postgres column names are case sensitive so the where clauses on contentitemindex's also fail there (cos graphql converts leading characters to lower., this PR ensures the casing of col names in sql matches the index.