### PR TITLE
Fix content_item_id filter for single ID

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemFilter.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Contents.Liquid
             }
             else
             {
-                var contentItemId = input.ToString();
+                var contentItemId = input.ToStringValue();
 
                 return FluidValue.Create(await contentManager.GetAsync(contentItemId));
             }


### PR DESCRIPTION
`input.ToString()` returns `Fluid.Values.StringValue` instead of the value itself.