### PR TITLE
Fix regression from #3662.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -73,7 +73,7 @@ namespace OrchardCore.Contents.Controllers
         public ILogger Logger { get; set; }
 
         [HttpGet]
-        public async Task<IActionResult> List(ListContentsViewModel model, PagerParameters pagerParameters, string contentTypeName = "")
+        public async Task<IActionResult> List(ListContentsViewModel model, PagerParameters pagerParameters, string contentTypeId = "")
         {
             var siteSettings = await _siteService.GetSiteSettingsAsync();
             var pager = new Pager(pagerParameters, siteSettings.PageSize);
@@ -101,9 +101,9 @@ namespace OrchardCore.Contents.Controllers
                     break;
             }
 
-            if (contentTypeName != "")
+            if (contentTypeId != "")
             {
-                model.Options.SelectedContentType = contentTypeName;
+                model.Options.SelectedContentType = contentTypeId;
             }
 
             if (!string.IsNullOrEmpty(model.Options.SelectedContentType))

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -122,7 +122,7 @@ namespace OrchardCore.Contents
             routes.MapAreaRoute(
                 name: "ListContentItems",
                 areaName: "OrchardCore.Contents",
-                template: "Admin/Contents/ContentItems/{typeId?}",
+                template: "Admin/Contents/ContentItems/{contentTypeId?}",
                 defaults: new { controller = "Admin", action = "List" }
             );
         }


### PR DESCRIPTION
This adds back the functionnality of being able to navigate directly to a specific content type in the contents list page. Right now that feature is broken because it doesn't filter the on the passed content type.

Example : https://localhost:44300/Admin/Contents/ContentItems/Page
