### PR TITLE
Temporary fix for default culture settings

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Settings/SiteExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Settings/SiteExtensions.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Settings
     {
         public static string[] GetConfiguredCultures(this ISite site)
         {
-            return new[] { CultureInfo.InstalledUICulture.Name }.Union(site.SupportedCultures).ToArray();
+            return new[] { site.Culture ?? CultureInfo.InstalledUICulture.Name }.Union(site.SupportedCultures).ToArray();
         }
     }
 }


### PR DESCRIPTION
We are going to refactor the implementation but we should fix the current implementation so that it works properly first. This fixes issues reported with the default culture. Right now it will always take the default system culture as default culture without looking first in the site.Culture settings. This allows to assign manually a default culture back.