### PR TITLE
NoWarnOnRazorViewImportedTypeConflicts

### DIFF
--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
@@ -32,6 +32,12 @@
       Text="The 'Microsoft.NET.Sdk.Razor' SDK is required on Themes and Modules for Razor files to be precompiled." />
   </Target>
 
+  <Target Name="NoWarnOnRazorViewImportedTypeConflicts" BeforeTargets="RazorCoreCompile">
+    <PropertyGroup>
+      <NoWarn>$(NoWarn);0436</NoWarn>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="EmbeddModuleAssets" AfterTargets="AfterResolveReferences">
     <RemoveDuplicates Inputs="@(EmbeddedResource)">
       <Output TaskParameter="Filtered" ItemName="ModuleAssetFiles"/>


### PR DESCRIPTION
Fixes #3716 

- Hides the warning for razor compilation where each razor view becomes a type whose name may conflict with an imported one when a module project references another module as a package.

- The only little concern is that it may hide the warning for another type conflict (not a view type) but knowing that it fallbacks to the type defined in the module project.

- And knowing that the warning is not hidden when compiling other cs files, razor view are compiled last.