### PR TITLE
Fixes liquid controller views.

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidPage.cs
@@ -8,11 +8,15 @@ namespace OrchardCore.DisplayManagement.Liquid
     {
         public override Task ExecuteAsync()
         {
+            var viewContextAccessor = Context.RequestServices.GetRequiredService<ViewContextAccessor>();
+
+            if (viewContextAccessor.ViewContext == null)
+            {
+                viewContextAccessor.ViewContext = ViewContext;
+            }
+
             if (RenderAsync != null && ViewContext.ExecutingFilePath == LiquidViewsFeatureProvider.DefaultRazorViewPath)
             {
-                var viewContextAccessor = Context.RequestServices.GetRequiredService<ViewContextAccessor>();
-                viewContextAccessor.ViewContext = ViewContext;
-
                 return RenderAsync(ViewContext.Writer);
             }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidPage.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace OrchardCore.DisplayManagement.Liquid
 {
@@ -8,13 +7,6 @@ namespace OrchardCore.DisplayManagement.Liquid
     {
         public override Task ExecuteAsync()
         {
-            var viewContextAccessor = Context.RequestServices.GetRequiredService<ViewContextAccessor>();
-
-            if (viewContextAccessor.ViewContext == null)
-            {
-                viewContextAccessor.ViewContext = ViewContext;
-            }
-
             if (RenderAsync != null && ViewContext.ExecutingFilePath == LiquidViewsFeatureProvider.DefaultRazorViewPath)
             {
                 return RenderAsync(ViewContext.Writer);

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -268,8 +268,6 @@ namespace OrchardCore.DisplayManagement.Liquid
                 context.AmbientValues.Add("LiquidPage", razorView.RazorPage);
             }
 
-            // TODO: Extract the request culture
-
             foreach (var handler in services.GetServices<ILiquidTemplateEventHandler>())
             {
                 await handler.RenderingAsync(context);

--- a/src/OrchardCore/OrchardCore.DisplayManagement/LocationExpander/ThemeViewLocationExpanderProvider.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/LocationExpander/ThemeViewLocationExpanderProvider.cs
@@ -59,8 +59,8 @@ namespace OrchardCore.DisplayManagement.LocationExpander
 
             var result = new List<string>();
 
-                foreach (var theme in currentThemeAndBaseThemesOrdered)
-                {
+            foreach (var theme in currentThemeAndBaseThemesOrdered)
+            {
                 if (context.AreaName != theme.Id)
                 {
                     var themePagesPath = '/' + theme.Extension.SubPath + "/Pages";

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -25,14 +25,21 @@ namespace OrchardCore.DisplayManagement.Razor
         private IOrchardDisplayHelper _orchardHelper;
         private ISite _site;
 
+        public override ViewContext ViewContext
+        {
+            get => base.ViewContext;
+            set
+            {
+                // We make the ViewContext available to other sub-systems that need it.
+                var viewContextAccessor = value.HttpContext.RequestServices.GetService<ViewContextAccessor>();
+                base.ViewContext = viewContextAccessor.ViewContext = value;
+            }
+        }
+
         private void EnsureDisplayHelper()
         {
             if (_displayHelper == null)
             {
-                // We make the ViewContext available to other sub-systems that need it.
-                var viewContextAccessor = Context.RequestServices.GetService<ViewContextAccessor>();
-                viewContextAccessor.ViewContext = ViewContext;
-
                 _displayHelper = Context.RequestServices.GetService<IDisplayHelper>();
             }
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorShapeTemplateViewEngine.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorShapeTemplateViewEngine.cs
@@ -54,7 +54,6 @@ namespace OrchardCore.DisplayManagement.Razor
 
         public Task<IHtmlContent> RenderAsync(string relativePath, DisplayContext displayContext)
         {
-
             var viewName = "/" + relativePath;
             viewName = Path.ChangeExtension(viewName, RazorViewEngine.ViewExtension);
 
@@ -114,8 +113,6 @@ namespace OrchardCore.DisplayManagement.Razor
                         _tempDataProvider),
                     output,
                     new HtmlHelperOptions());
-
-                _viewContextAccessor.ViewContext = viewContext;
 
                 await view.RenderAsync(viewContext);
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
@@ -18,14 +18,21 @@ namespace OrchardCore.DisplayManagement.RazorPages
         private IShapeFactory _shapeFactory;
         private IOrchardDisplayHelper _orchardHelper;
 
+        public override ViewContext ViewContext
+        {
+            get => base.ViewContext;
+            set
+            {
+                // We make the ViewContext available to other sub-systems that need it.
+                var viewContextAccessor = value.HttpContext.RequestServices.GetService<ViewContextAccessor>();
+                base.ViewContext = viewContextAccessor.ViewContext = value;
+            }
+        }
+
         private void EnsureDisplayHelper()
         {
             if (_displayHelper == null)
             {
-                // We make the ViewContext available to other sub-systems that need it.
-                var viewContextAccessor = HttpContext.RequestServices.GetService<ViewContextAccessor>();
-                viewContextAccessor.ViewContext = ViewContext;
-
                 _displayHelper = HttpContext.RequestServices.GetService<IDisplayHelper>();
             }
         }


### PR DESCRIPTION
For a liquid **controller** view, the `EnsureDisplayHelper()` of its inherited `Razor.RazorPage<dynamic>` is not  called, so the new `ViewContextAccessor` is not initialized.