### PR TITLE
Fix broken link in ContentLocalization when no cultures are installed

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/LocalizationPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/LocalizationPart.Edit.cshtml
@@ -19,7 +19,7 @@
                 @if (!Model.ContentItemCultures.Any())
                 {
                     <p>@T["Your site does not have any cultures. Current System culture is {1} | {0}", CultureInfo.InstalledUICulture.Name, CultureInfo.InstalledUICulture.DisplayName]</p>
-                    <p>@Html.ActionLink(T["Add or remove supported cultures for the site"].Value, "Culture", "Admin", new { area = "OrchardCore.Settings" })</p>
+                    <p>@Html.ActionLink(T["Add or remove supported cultures for the site"].Value, "Index", "Admin", new { area = "OrchardCore.Settings", groupId = "localization" })</p>
                 }
                 else
                 {


### PR DESCRIPTION
Fixes #3781 

Used magic string rather than the `LocalizationSettingsDisplayDriver.GroupId` so it didn't need to take a dependency on the Localization Project.

I assume the links supposed to link through to the admin menu?