### PR TITLE
Added media assets graphql query support.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetObjectType.cs
@@ -1,0 +1,30 @@
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.FileStorage;
+
+namespace OrchardCore.Media.GraphQL
+{
+    public class MediaAssetObjectType : ObjectGraphType<IFileStoreEntry>
+    {
+        public MediaAssetObjectType()
+        {
+            Name = "MediaAsset";
+
+            Field(file => file.Name).Description("The name of the asset.");
+
+            Field<StringGraphType>()
+                .Name("path")
+                .Description("The url to the asset.")
+                .Resolve(x => {
+                    var path = x.Source.Path;
+                    var context = (GraphQLContext)x.UserContext;
+                    var mediaFileStore = context.ServiceProvider.GetService<IMediaFileStore>();
+                    return mediaFileStore.MapPathToPublicUrl(path);
+                });
+
+            Field(file => file.Length).Description("The length of the file.");
+            Field<DateTimeGraphType>("lastModifiedUtc", resolve: file => file.Source.LastModifiedUtc, description: "The date and time in UTC when the asset was last modified.");
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetQuery.cs
@@ -53,7 +53,7 @@ namespace OrchardCore.Media.GraphQL
             var mediaFileStore = context.ServiceProvider.GetService<IMediaFileStore>();
 
             var path = resolveContext.GetArgument("path", string.Empty);
-            var includeSubDirectories = resolveContext.GetArgument("includeSubDirectories", true);
+            var includeSubDirectories = resolveContext.GetArgument("includeSubDirectories", false);
 
             var allFiles = await mediaFileStore.GetDirectoryContentAsync(path, includeSubDirectories);
             return allFiles.Where(x => !x.IsDirectory);

--- a/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetQuery.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Primitives;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.FileStorage;
+
+namespace OrchardCore.Media.GraphQL
+{
+    public class MediaAssetQuery : ISchemaBuilder
+    {
+        public MediaAssetQuery(IStringLocalizer<MediaAssetQuery> localizer)
+        {
+            T = localizer;
+        }
+
+        public IStringLocalizer T { get; set; }
+
+        public Task<IChangeToken> BuildAsync(ISchema schema)
+        {
+            var field = new FieldType
+            {
+                Name = "MediaAssets",
+                Description = T["Media assets are items that are part of your media library."],
+                Type = typeof(ListGraphType<MediaAssetObjectType>),
+                Arguments = new QueryArguments(
+                    new QueryArgument<StringGraphType>
+                    {
+                        Name = "path",
+                        Description = T["Media asset path."]
+                    },
+                    new QueryArgument<BooleanGraphType>
+                    {
+                        Name = "includeSubDirectories",
+                        Description = T["Whether to get the assets from just the top directory or from all sub-directories as well."]
+                    }
+                ),
+                Resolver = new AsyncFieldResolver<IEnumerable<IFileStoreEntry>>(ResolveAsync)
+            };
+
+            schema.Query.AddField(field);
+
+            return Task.FromResult<IChangeToken>(null);
+        }
+
+        private async Task<IEnumerable<IFileStoreEntry>> ResolveAsync(ResolveFieldContext resolveContext)
+        {
+            var context = (GraphQLContext)resolveContext.UserContext;
+            var mediaFileStore = context.ServiceProvider.GetService<IMediaFileStore>();
+
+            var path = resolveContext.GetArgument("path", string.Empty);
+            var includeSubDirectories = resolveContext.GetArgument("includeSubDirectories", true);
+
+            var allFiles = await mediaFileStore.GetDirectoryContentAsync(path, includeSubDirectories);
+            return allFiles.Where(x => !x.IsDirectory);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaFieldQueryObjectType.cs
@@ -17,12 +17,8 @@ namespace OrchardCore.Media.GraphQL
                 .Name("paths")
                 .Description("the media paths")
                 .PagingArguments()
-                .Resolve(x =>
-                {
-                    return x.Page(x.Source.Paths);
-                });
-                
-
+                .Resolve(x => x.Page(x.Source.Paths));
+            
             Field<ListGraphType<StringGraphType>, IEnumerable<string>>()
                 .Name("urls")
                 .Description("the absolute urls of the media items")
@@ -35,6 +31,5 @@ namespace OrchardCore.Media.GraphQL
                     return paths.Select(p => mediaFileStore.MapPathToPublicUrl(p));
                 });
         }
-
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/Startup.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Apis;
+using OrchardCore.Apis.GraphQL;
 using OrchardCore.Media.Fields;
 using OrchardCore.Modules;
 
@@ -10,7 +11,9 @@ namespace OrchardCore.Media.GraphQL
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-             services.AddObjectGraphType<MediaField, MediaFieldQueryObjectType>();
+            services.AddSingleton<ISchemaBuilder, MediaAssetQuery>();
+            services.AddObjectGraphType<MediaField, MediaFieldQueryObjectType>();
+            services.AddTransient<MediaAssetObjectType>();
         }
     }
 }


### PR DESCRIPTION
We don't currently have a way to expose a list of all the media assets stored in the media library so this implements a ```mediaAssets``` GraphQL query to return available assets. This is useful when using Orchard as a headless CMS with Gatsby to statically compile images into the website.

![media-queries](https://user-images.githubusercontent.com/6826786/59168663-ca762980-8b8a-11e9-861c-5708c4b5aab9.PNG)
