### PR TITLE
ContentPickerField display error when used with Lucene results

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneContentPickerResultProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneContentPickerResultProvider.cs
@@ -60,7 +60,8 @@ namespace OrchardCore.Lucene.Services
                     results.Add(new ContentPickerResult
                     {
                         ContentItemId = doc.GetField("ContentItemId").GetStringValue(),
-                        DisplayText = doc.GetField("Content.ContentItem.DisplayText").GetStringValue()
+                        DisplayText = doc.GetField("Content.ContentItem.DisplayText").GetStringValue(),
+                        HasPublished = doc.GetField("Content.ContentItem.Published").GetStringValue() == "true" ? true : false 
                     });
                 }
 


### PR DESCRIPTION
Return HasPublished in ContentPickerResult when used with Lucene.
Here the issue is that we are assuming that a content item has been published if it's indexed with Lucene but we are not returning the HasPublished field because of that. Later on if we want to also index drafted content items this could be usefull to return the value indexed in "Content.ContentItem.Published" but for now we could have also simply returned "true"

Enhancement : Shouldn't we do `return results.OrderBy(x =>x.DisplayName)` for those ContentPicker lists?

Fixes #3803