### PR TITLE
Rename Package.json -> package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1931,7 +1931,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1952,12 +1953,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1972,17 +1975,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2099,7 +2105,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2111,6 +2118,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2125,6 +2133,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2132,12 +2141,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2156,6 +2167,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2236,7 +2248,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2248,6 +2261,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2333,7 +2347,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2369,6 +2384,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2388,6 +2404,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2431,12 +2448,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4981,10 +5000,10 @@
     "orchardcore.apis.graphql": {
       "version": "file:src/OrchardCore.Modules/OrchardCore.Apis.GraphQL",
       "requires": {
-        "graphiql": "0.12.0",
-        "graphql": "0.12.0",
-        "react": "15.6.0",
-        "react-dom": "15.6.0"
+        "graphiql": "0.13.0",
+        "graphql": "14.3.1",
+        "react": "16.8.6",
+        "react-dom": "16.8.6"
       }
     },
     "orchardcore.resources": {
@@ -5001,11 +5020,11 @@
       "dependencies": {
         "bootstrap-scss": {
           "version": "4.3.1",
-          "bundled": true
+          "resolved": false
         },
         "popper.js": {
           "version": "1.15.0",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -5019,11 +5038,11 @@
       "dependencies": {
         "bootstrap": {
           "version": "4.3.1",
-          "bundled": true
+          "resolved": false
         },
         "popper.js": {
           "version": "1.15.0",
-          "bundled": true
+          "resolved": false
         }
       }
     },
@@ -5036,11 +5055,12 @@
       "dependencies": {
         "bootstrap": {
           "version": "4.3.1",
-          "bundled": true
+          "resolved": false
         },
         "popper.js": {
-          "version": "1.15.0",
-          "bundled": true
+          "version": "1.14.7",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+          "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
         }
       }
     },
@@ -5053,7 +5073,7 @@
       "dependencies": {
         "@types/bootstrap": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
           "requires": {
             "@types/jquery": "*",
             "popper.js": "^1.14.1"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "private": true,
+  "scripts": {
+    "build": "gulp build",
+    "watch": " gulp watch"
+  },
   "devDependencies": {
     "es6-promise": "4.2.6",
     "file-system": "2.2.2",


### PR DESCRIPTION
Running `npm install` on linux failed because package.json had the wrong case.

I also added  two scripts to the `package.json` file that uses the locally install gulp to build / watch file changes.