### PR TITLE
GraphQL: Don't include ignored contenttype fields in where filters

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLContentOptions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLContentOptions.cs
@@ -159,7 +159,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
         internal bool ShouldSkip(Type fieldType, string fieldName)
         {
             return HiddenFields
-                .Any(x => x.FieldType == fieldType && x.FieldName == fieldName);
+                .Any(x => x.FieldType == fieldType && x.FieldName.Equals(fieldName, StringComparison.OrdinalIgnoreCase));
         }
 
         public bool IsHiddenByDefault(ContentTypePartDefinition definition)

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemsFieldType.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemsFieldType.cs
@@ -6,9 +6,11 @@ using System.Threading.Tasks;
 using GraphQL.Resolvers;
 using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.Apis.GraphQL.Queries;
+using OrchardCore.ContentManagement.GraphQL.Options;
 using OrchardCore.ContentManagement.GraphQL.Queries.Predicates;
 using OrchardCore.ContentManagement.GraphQL.Queries.Types;
 using OrchardCore.ContentManagement.Records;
@@ -36,13 +38,13 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
             }
         }
 
-        public ContentItemsFieldType(string contentItemName, ISchema schema)
+        public ContentItemsFieldType(string contentItemName, ISchema schema, IOptions<GraphQLContentOptions> optionsAccessor)
         {
             Name = "ContentItems";
 
             Type = typeof(ListGraphType<ContentItemType>);
 
-            var whereInput = new ContentItemWhereInput(contentItemName);
+            var whereInput = new ContentItemWhereInput(contentItemName, optionsAccessor);
             var orderByInput = new ContentItemOrderByInput(contentItemName);
 
             Arguments = new QueryArguments(

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
@@ -50,7 +50,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
                     Description = T["Represents a {0}.", typeDefinition.DisplayName]
                 };
 
-                var query = new ContentItemsFieldType(typeDefinition.Name, schema)
+                var query = new ContentItemsFieldType(typeDefinition.Name, schema, _optionsAccessor)
                 {
                     Name = typeDefinition.Name,
                     Description = T["Represents a {0}.", typeDefinition.DisplayName],

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/ContentItemWhereInput.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/ContentItemWhereInput.cs
@@ -1,6 +1,8 @@
 using GraphQL.Types;
+using Microsoft.Extensions.Options;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.Apis.GraphQL.Queries;
+using OrchardCore.ContentManagement.GraphQL.Options;
 
 namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
 {
@@ -9,25 +11,37 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
     [GraphQLFieldName("Not", "NOT")]
     public class ContentItemWhereInput : WhereInputObjectGraphType
     {
-        public ContentItemWhereInput(string contentItemName)
+        private readonly IOptions<GraphQLContentOptions> _optionsAccessor;
+
+        public ContentItemWhereInput(string contentItemName, IOptions<GraphQLContentOptions> optionsAccessor)
         {
+            _optionsAccessor = optionsAccessor;
+
             Name =  $"{contentItemName}WhereInput";
             
             Description = $"the {contentItemName} content item filters";
 
-            AddScalarFilterFields<IdGraphType>("contentItemId", "content item id");
-            AddScalarFilterFields<IdGraphType>("contentItemVersionId", "the content item version id");
-            AddScalarFilterFields<StringGraphType>("displayText", "the display text of the content item");
-            AddScalarFilterFields<DateTimeGraphType>("createdUtc", "the date and time of creation");
-            AddScalarFilterFields<DateTimeGraphType>("modifiedUtc", "the date and time of modification");
-            AddScalarFilterFields<DateTimeGraphType>("publishedUtc", "the date and time of publication");
-            AddScalarFilterFields<StringGraphType>("owner", "the owner of the content item");
-            AddScalarFilterFields<StringGraphType>("author", "the author of the content item");
+            AddFilterField<IdGraphType>("contentItemId", "content item id");
+            AddFilterField<IdGraphType>("contentItemVersionId", "the content item version id");
+            AddFilterField<StringGraphType>("displayText", "the display text of the content item");
+            AddFilterField<DateTimeGraphType>("createdUtc", "the date and time of creation");
+            AddFilterField<DateTimeGraphType>("modifiedUtc", "the date and time of modification");
+            AddFilterField<DateTimeGraphType>("publishedUtc", "the date and time of publication");
+            AddFilterField<StringGraphType>("owner", "the owner of the content item");
+            AddFilterField<StringGraphType>("author", "the author of the content item");
 
             var whereInputType = new ListGraphType(this);
             Field<ListGraphType<ContentItemWhereInput>>("Or", "OR logical operation").ResolvedType = whereInputType;
             Field<ListGraphType<ContentItemWhereInput>>("And", "AND logical operation").ResolvedType = whereInputType;
             Field<ListGraphType<ContentItemWhereInput>>("Not", "NOT logical operation").ResolvedType = whereInputType;
+        }
+
+        void AddFilterField<T>(string name, string description)
+        {
+            if (!_optionsAccessor.Value.ShouldSkip(typeof(ContentItemType), name))
+            {
+                AddScalarFilterFields<T>(name, description);
+            }
         }
     }
 }

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
@@ -6,10 +6,12 @@ using System.Threading.Tasks;
 using GraphQL.Resolvers;
 using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.Apis.GraphQL.Queries;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.GraphQL.Options;
 using OrchardCore.ContentManagement.GraphQL.Queries;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.Environment.Shell;
@@ -133,7 +135,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema());
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
 
                 context.Arguments["where"] = JObject.Parse("{ contentItemId: \"1\" }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -183,7 +185,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema());
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
 
                 context.Arguments["where"] = JObject.Parse("{ contentItemId: \"1\" }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -229,7 +231,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema());
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
 
                 context.Arguments["where"] = JObject.Parse("{ cats: { name: \"doug\" } }");
                 var cats = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -292,7 +294,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci2);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema());
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
 
                 context.Arguments["where"] = JObject.Parse("{ animals: { name: \"doug\", isScary: true } }");
                 var animals = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -343,7 +345,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema());
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
 
                 context.Arguments["where"] = JObject.Parse("{ animal: { name: \"doug\" } }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -403,7 +405,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema());
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
 
                 context.Arguments["where"] = JObject.Parse("{ name: \"doug\" }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);


### PR DESCRIPTION
We have the ability in graphql currently to ignore default contenttype fields.

eg.

```
   services.Configure<GraphQLContentOptions>(options =>
            {
                options.IgnoreField<ContentItemType>("Author")
            });
```

This stops the field getting added and exposed via graphql, it doesn't stop it from appearing in graphql where filters though, this PR does that.