### PR TITLE
PluralRule is null for locale not recognized.

### DIFF
--- a/src/OrchardCore/OrchardCore.Localization.Core/DefaultPluralRuleProvider.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/DefaultPluralRuleProvider.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Localization
         {
             Rules = new Dictionary<string, PluralizationRuleDelegate>();
 
-            AddRule(new[] { "ay", "bo", "cgg", "dz", "fa", "id", "ja", "jbo", "ka", "kk", "km", "ko", "ky", "lo", "ms", "my", "sah", "su", "th", "tt", "ug", "vi", "wo", "zh-CN", "zh-HK", "zh-TW", "zh-Hans-CN", "zh-Hant-HK", "zh-Hant-TW" }, n => 0);
+            AddRule(new[] { "ay", "bo", "cgg", "dz", "fa", "id", "ja", "jbo", "ka", "kk", "km", "ko", "ky", "lo", "ms", "my", "sah", "su", "th", "tt", "ug", "vi", "wo", "zh" }, n => 0);
             AddRule(new[] { "ach", "ak", "am", "arn", "br", "fil", "fr", "gun", "ln", "mfe", "mg", "mi", "oc", "pt-BR", "tg", "ti", "tr", "uz", "wa" }, n => (n > 1 ? 1 : 0));
             AddRule(new[] { "af", "an", "anp", "as", "ast", "az", "bg", "bn", "brx", "ca", "da", "de", "doi", "el", "en", "eo", "es", "es-AR", "et", "eu", "ff", "fi", "fo", "fur", "fy", "gl", "gu", "ha", "he", "hi", "hne", "hu", "hy", "ia", "it", "kl", "kn", "ku", "lb", "mai", "ml", "mn", "mni", "mr", "nah", "nap", "nb", "ne", "nl", "nn", "no", "nso", "or", "pa", "pap", "pms", "ps", "pt", "rm", "rw", "sat", "sco", "sd", "se", "si", "so", "son", "sq", "sv", "sw", "ta", "te", "tk", "ur", "yo" }, n => (n != 1 ? 1 : 0));
             AddRule(new[] { "is" }, n => (n % 10 != 1 || n % 100 == 11 ? 1 : 0));
@@ -52,17 +52,30 @@ namespace OrchardCore.Localization
         {
             rule = null;
 
-            if (Rules.TryGetValue(culture.Name, out rule))
-            {
-                return true;
-            }
+            var cultureForPlural = GetBaseCulture(culture);
 
-            if (culture.Parent != null && Rules.TryGetValue(culture.Parent.Name, out rule))
+            if (Rules.TryGetValue(cultureForPlural.Name, out rule))
             {
                 return true;
             }
 
             return false;
+        }
+
+
+        /// <summary>
+        /// Get the base culture of the provided culture.
+        /// e.g., zh-Hans-CN -> zh-Hans -> zh
+        /// </summary>
+        private CultureInfo GetBaseCulture(CultureInfo culture)
+        {
+            var returnCulture = culture;
+            // we stop at "" (Invariant Language)
+            while (returnCulture.Parent.Name != "")
+            {
+                returnCulture = returnCulture.Parent;
+            }
+            return returnCulture;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Localization.Core/DefaultPluralRuleProvider.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/DefaultPluralRuleProvider.cs
@@ -6,6 +6,7 @@ namespace OrchardCore.Localization
     /// <summary>
     /// This class provides the pluralization rules based on the Unicode Common Locale Data Repository.
     /// c.f. http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html
+    /// c.f. https://github.com/unicode-org/cldr/blob/master/common/supplemental/plurals.xml
     /// </summary>
     public class DefaultPluralRuleProvider : IPluralRuleProvider
     {

--- a/src/OrchardCore/OrchardCore.Localization.Core/DefaultPluralRuleProvider.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/DefaultPluralRuleProvider.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Localization
         {
             Rules = new Dictionary<string, PluralizationRuleDelegate>();
 
-            AddRule(new[] { "ay", "bo", "cgg", "dz", "fa", "id", "ja", "jbo", "ka", "kk", "km", "ko", "ky", "lo", "ms", "my", "sah", "su", "th", "tt", "ug", "vi", "wo", "zh-CN", "zh-HK", "zh-TW" }, n => 0);
+            AddRule(new[] { "ay", "bo", "cgg", "dz", "fa", "id", "ja", "jbo", "ka", "kk", "km", "ko", "ky", "lo", "ms", "my", "sah", "su", "th", "tt", "ug", "vi", "wo", "zh-CN", "zh-HK", "zh-TW", "zh-Hans-CN", "zh-Hant-HK", "zh-Hant-TW" }, n => 0);
             AddRule(new[] { "ach", "ak", "am", "arn", "br", "fil", "fr", "gun", "ln", "mfe", "mg", "mi", "oc", "pt-BR", "tg", "ti", "tr", "uz", "wa" }, n => (n > 1 ? 1 : 0));
             AddRule(new[] { "af", "an", "anp", "as", "ast", "az", "bg", "bn", "brx", "ca", "da", "de", "doi", "el", "en", "eo", "es", "es-AR", "et", "eu", "ff", "fi", "fo", "fur", "fy", "gl", "gu", "ha", "he", "hi", "hne", "hu", "hy", "ia", "it", "kl", "kn", "ku", "lb", "mai", "ml", "mn", "mni", "mr", "nah", "nap", "nb", "ne", "nl", "nn", "no", "nso", "or", "pa", "pap", "pms", "ps", "pt", "rm", "rw", "sat", "sco", "sd", "se", "si", "so", "son", "sq", "sv", "sw", "ta", "te", "tk", "ur", "yo" }, n => (n != 1 ? 1 : 0));
             AddRule(new[] { "is" }, n => (n % 10 != 1 || n % 100 == 11 ? 1 : 0));

--- a/src/OrchardCore/OrchardCore.Localization.Core/LocalizationManager.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/LocalizationManager.cs
@@ -40,7 +40,7 @@ namespace OrchardCore.Localization
                     }
                 }
 
-                var dictionary = new CultureDictionary(culture.Name, rule);
+                var dictionary = new CultureDictionary(culture.Name, rule ?? DefaultPluralRule);
                 _translationProvider.LoadTranslations(culture.Name, dictionary);
 
                 return dictionary;

--- a/test/OrchardCore.Tests/Localization/DefaultPluralRuleProviderTests.cs
+++ b/test/OrchardCore.Tests/Localization/DefaultPluralRuleProviderTests.cs
@@ -1,0 +1,31 @@
+
+using System.Globalization;
+using OrchardCore.Localization;
+using Xunit;
+
+namespace OrchardCore.Tests.Localization
+{
+    public class DefaultPluralRuleProviderTests
+    {
+        [Theory]
+        [InlineData("en-US", "en")]
+        [InlineData("zh-TW", "zh")]
+        [InlineData("zh-HanT-TW", "zh")]
+        [InlineData("zh-CN", "zh")]
+        [InlineData("zh-Hans-CN", "zh")]
+        [InlineData("zh-Hans", "zh")]
+        [InlineData("zh-Hant", "zh")]
+        public void TryGetRuleShouldReturnRuleForTopCulture(string culture, string expected) {
+            var expectedCulture = CultureInfo.GetCultureInfo(expected);
+            var testCulture = CultureInfo.GetCultureInfo(culture);
+
+            IPluralRuleProvider pluralProvider = new DefaultPluralRuleProvider();
+            pluralProvider.TryGetRule(expectedCulture, out var expectedPlural);
+            pluralProvider.TryGetRule(testCulture, out var testPlural);
+
+            Assert.NotNull(expectedPlural);
+            Assert.NotNull(testPlural);
+            Assert.Same(expectedPlural, testPlural);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Localization/DefaultPluralRuleProviderTests.cs
+++ b/test/OrchardCore.Tests/Localization/DefaultPluralRuleProviderTests.cs
@@ -15,7 +15,8 @@ namespace OrchardCore.Tests.Localization
         [InlineData("zh-Hans-CN", "zh")]
         [InlineData("zh-Hans", "zh")]
         [InlineData("zh-Hant", "zh")]
-        public void TryGetRuleShouldReturnRuleForTopCulture(string culture, string expected) {
+        public void TryGetRuleShouldReturnRuleForTopCulture(string culture, string expected)
+        {
             var expectedCulture = CultureInfo.GetCultureInfo(expected);
             var testCulture = CultureInfo.GetCultureInfo(culture);
 

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -201,6 +201,26 @@ namespace OrchardCore.Tests.Localization
         }
 
         [Theory]
+        [InlineData("zh-Hans", "zh", "球", 1, new string[] { "球" })]
+        [InlineData("zh-Hans", "zh", "球", 2, new string[] { "球" })]
+        public void LocalizerReturnsCorrectTranslationForPluralIfNoPluralFormsSpecified(string culture, string parentCulture, string expected, int count, string[] translations)
+        {
+            var translationCulture = CultureInfo.GetCultureInfo(parentCulture);
+            var currentCulture = CultureInfo.GetCultureInfo(culture);
+            CultureInfo.CurrentUICulture = currentCulture;
+
+            // using DefaultPluralRuleProvider to test it returns correct rule
+            TryGetRuleFromDefaultPluralRuleProvider(currentCulture, out var rule);
+            Assert.NotNull(rule);
+
+            SetupDictionary(culture, new[] { new CultureDictionaryRecord("ball", null, translations), }, rule);
+            var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
+            var translation = localizer.Plural(count, "ball", "{0} balls", count);
+
+            Assert.Equal(expected, translation);
+        }
+
+        [Theory]
         [InlineData("míč", 1)]
         [InlineData("2 míče", 2)]
         [InlineData("5 míčů", 5)]
@@ -295,6 +315,11 @@ namespace OrchardCore.Tests.Localization
             dictionary.MergeTranslations(records);
 
             _localizationManager.Setup(o => o.GetDictionary(It.Is<CultureInfo>(c => c.Name == cultureName))).Returns(dictionary);
+        }
+
+        private bool TryGetRuleFromDefaultPluralRuleProvider(CultureInfo culture, out PluralizationRuleDelegate rule)
+        {
+            return ((IPluralRuleProvider)new DefaultPluralRuleProvider()).TryGetRule(culture, out rule);
         }
     }
 }

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -201,11 +201,10 @@ namespace OrchardCore.Tests.Localization
         }
 
         [Theory]
-        [InlineData("zh-Hans", "zh", "球", 1, new string[] { "球" })]
-        [InlineData("zh-Hans", "zh", "球", 2, new string[] { "球" })]
-        public void LocalizerReturnsCorrectTranslationForPluralIfNoPluralFormsSpecified(string culture, string parentCulture, string expected, int count, string[] translations)
+        [InlineData("zh-Hans", "球", 1, new string[] { "球" })]
+        [InlineData("zh-Hans", "球", 2, new string[] { "球" })]
+        public void LocalizerReturnsCorrectTranslationForPluralIfNoPluralFormsSpecified(string culture, string expected, int count, string[] translations)
         {
-            var translationCulture = CultureInfo.GetCultureInfo(parentCulture);
             var currentCulture = CultureInfo.GetCultureInfo(culture);
             CultureInfo.CurrentUICulture = currentCulture;
 


### PR DESCRIPTION
I was getting this error when I update a old beta3 to newest version.  Not sure why but the name of the chinese locale changed.  They are changed in Mac and Debian container.  I haven't tried in Windows.

```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at OrchardCore.Localization.PortableObject.PortableObjectStringLocalizer.GetTranslation(String[] pluralForms, CultureInfo culture, Nullable`1 count) in C:\projects\orchardcore\src\OrchardCore\OrchardCore.Localization.Core\PortableObject\PortableObjectStringLocalizer.cs:line 148
   at OrchardCore.Localization.PortableObject.PortableObjectStringLocalizer.GetTranslation(String name, Object[] arguments) in C:\projects\orchardcore\src\OrchardCore\OrchardCore.Localization.Core\PortableObject\PortableObjectStringLocalizer.cs:line 110
   at OrchardCore.Localization.PortableObject.PortableObjectHtmlLocalizer.get_Item(String name, Object[] arguments) in C:\projects\orchardcore\src\OrchardCore\OrchardCore.Localization.Core\PortableObject\PortableObjectHtmlLocalizer.cs:line 42
   at Microsoft.AspNetCore.Mvc.Localization.HtmlLocalizer`1.get_Item(String name, Object[] arguments)
```

Since I am not sure whether Windows still use the old one (zh-CN, zh-TW, zh-HK), I add the new one (zh-Hans-CH, zh-Hant-TW, zh-Hant-HK).  

And I make sure that `PluralRule` is not null in GetTranslation.

Not sure if it is the correct fix though. 