### PR TITLE
Small improvement to ImageSharp pipeline

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileProvider.cs
@@ -25,13 +25,11 @@ namespace OrchardCore.Media.Processing
         private readonly IMediaFileStore _mediaStore;
         private readonly FormatUtilities _formatUtilities;
         private readonly int[] _supportedSizes;
-        private readonly PathString _requestPath;
 
         public MediaFileProvider(
             IMediaFileStore mediaStore,
             IOptions<ImageSharpMiddlewareOptions> options,
-            IShellConfiguration shellConfiguration,
-            PathString requestPath
+            IShellConfiguration shellConfiguration
             )
         {
             _mediaStore = mediaStore;
@@ -39,7 +37,6 @@ namespace OrchardCore.Media.Processing
 
             var configurationSection = shellConfiguration.GetSection("OrchardCore.Media");
             _supportedSizes = configurationSection.GetSection("SupportedSizes").Get<int[]>()?.OrderBy(s => s).ToArray() ?? DefaultSizes;
-            _requestPath = requestPath;
         }
 
         /// <inheritdoc/>
@@ -51,7 +48,7 @@ namespace OrchardCore.Media.Processing
         /// <inheritdoc/>
         public bool IsValidRequest(HttpContext context)
         {
-            if (!context.Request.Path.StartsWithSegments(_requestPath))
+            if (!context.Request.Path.StartsWithSegments(Startup.AssetsRequestPath))
             {
                 return false;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaFileProvider.cs
@@ -30,8 +30,7 @@ namespace OrchardCore.Media.Processing
         public MediaFileProvider(
             IMediaFileStore mediaStore,
             IOptions<ImageSharpMiddlewareOptions> options,
-            IShellConfiguration shellConfiguration
-            ,
+            IShellConfiguration shellConfiguration,
             PathString requestPath
             )
         {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/3852 and allows ImageSharp to get out of the request pipeline just a little bit faster

**Note** A bug in the ImageSharp builder extensions requires registering this manually. Issue has been fixed on latest ImageSharp master, so will be in the next ImageSharp release