### PR TITLE
Set content types during azure blob creation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
@@ -38,8 +39,9 @@ namespace OrchardCore.Media.Azure
                 {
                     var options = serviceProvider.GetRequiredService<IOptions<MediaBlobStorageOptions>>().Value;
                     var clock = serviceProvider.GetRequiredService<IClock>();
+                    var contentTypeProvider = serviceProvider.GetRequiredService<IContentTypeProvider>();
 
-                    var fileStore = new BlobFileStore(options, clock);
+                    var fileStore = new BlobFileStore(options, clock, contentTypeProvider);
 
                     var mediaBaseUri = fileStore.BaseUri;
                     if (!String.IsNullOrEmpty(options.PublicHostName))

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobDirectory.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobDirectory.cs
@@ -14,7 +14,8 @@ namespace OrchardCore.FileStorage.AzureBlob
         {
             _path = path;
             _lastModifiedUtc = lastModifiedUtc;
-            _name = _path.Split('/').Last();
+            // Use GetFileName rather than GetDirectoryName as GetDirectoryName requires a delimeter
+            _name = System.IO.Path.GetFileName(path);
             _directoryPath = _path.Length > _name.Length ? _path.Substring(0, _path.Length - _name.Length - 1) : "";
         }
 

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFile.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFile.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.FileStorage.AzureBlob
         {
             _path = path;
             _blobProperties = blobProperties;
-            _name = _path.Split('/').Last();
+            _name = System.IO.Path.GetFileName(_path);
 
             if (_name == _path) // file is in root Directory
             {

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -270,9 +270,8 @@ namespace OrchardCore.FileStorage.AzureBlob
 
             if (!overwrite && await blob.ExistsAsync())
                 throw new FileStoreException($"Cannot create file '{path}' because it already exists.");
-
-            var name = path.Split('/').Last();
-            _contentTypeProvider.TryGetContentType(name, out var contentType);
+            
+            _contentTypeProvider.TryGetContentType(path, out var contentType);
 
             blob.Properties.ContentType = contentType ?? "application/octet-stream";
 

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Blob;
 using OrchardCore.Modules;
@@ -37,11 +38,13 @@ namespace OrchardCore.FileStorage.AzureBlob
         private readonly CloudBlobClient _blobClient;
         private readonly CloudBlobContainer _blobContainer;
         private readonly Task _verifyContainerTask;
+        private readonly IContentTypeProvider _contentTypeProvider;
 
-        public BlobFileStore(BlobStorageOptions options, IClock clock)
+        public BlobFileStore(BlobStorageOptions options, IClock clock, IContentTypeProvider contentTypeProvider)
         {
             _options = options;
             _clock = clock;
+            _contentTypeProvider = contentTypeProvider;
             _storageAccount = CloudStorageAccount.Parse(_options.ConnectionString);
             _blobClient = _storageAccount.CreateCloudBlobClient();
             _blobContainer = _blobClient.GetContainerReference(_options.ContainerName);
@@ -264,6 +267,11 @@ namespace OrchardCore.FileStorage.AzureBlob
             await _verifyContainerTask;
 
             var blob = GetBlobReference(path);
+
+            var name = path.Split('/').Last();
+            _contentTypeProvider.TryGetContentType(name, out var contentType);
+
+            blob.Properties.ContentType = contentType ?? "application/octet-stream";
 
             if (!overwrite && await blob.ExistsAsync())
                 throw new FileStoreException($"Cannot create file '{path}' because it already exists.");

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -268,13 +268,13 @@ namespace OrchardCore.FileStorage.AzureBlob
 
             var blob = GetBlobReference(path);
 
+            if (!overwrite && await blob.ExistsAsync())
+                throw new FileStoreException($"Cannot create file '{path}' because it already exists.");
+
             var name = path.Split('/').Last();
             _contentTypeProvider.TryGetContentType(name, out var contentType);
 
             blob.Properties.ContentType = contentType ?? "application/octet-stream";
-
-            if (!overwrite && await blob.ExistsAsync())
-                throw new FileStoreException($"Cannot create file '{path}' because it already exists.");
 
             await blob.UploadFromStreamAsync(inputStream);
         }

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/3853

Set the blob properties during file creation.

I had to take a reference on `Microsoft.AspNetCore.StaticFiles` to get access to the `IContentTypeProvider` - those `FileStorage` projects don't have any Mvc references. 
@jtkech maybe if you have a moment you can let me know if it is ok to take an Mvc reference there?

![some-content-types](https://user-images.githubusercontent.com/13782679/60120984-02c85b00-977a-11e9-96dd-e80b1fbf9a88.PNG)
