### PR TITLE
Add pathbase.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
@@ -1,18 +1,15 @@
 @model OrchardCore.ContentFields.ViewModels.EditContentPickerFieldViewModel
-@using OrchardCore.ContentManagement.Metadata.Models
-@using OrchardCore.ContentFields.Settings;
 @using Newtonsoft.Json;
 @using Newtonsoft.Json.Serialization;
-@using OrchardCore.Environment.Shell;
-
-@inject ShellSettings ShellSettings
+@using OrchardCore.ContentFields.Settings;
+@using OrchardCore.ContentManagement.Metadata.Models
 
 @{
     var settings = Model.PartFieldDefinition.Settings.ToObject<ContentPickerFieldSettings>();
     var selectedItems = Html.Raw(JsonConvert.SerializeObject(Model.SelectedItems, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() }));
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
     var fieldName = Model.PartFieldDefinition.Name;
-    var tenantPath = string.IsNullOrEmpty(ShellSettings.RequestUrlPrefix) ? string.Empty : "/" + ShellSettings.RequestUrlPrefix;
+    var tenantPath = Context.Request.PathBase.ToString();
     var vueElementId = $"ContentPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
     var multiple = settings.Multiple.ToString().ToLowerInvariant();
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
@@ -1,17 +1,16 @@
 using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Localization;
-using OrchardCore.ContentManagement.Metadata;
-using OrchardCore.AdminMenu.Services;
-using OrchardCore.Navigation;
 using System.Linq;
-using OrchardCore.ContentManagement.Metadata.Settings;
-using OrchardCore.ContentManagement.Metadata.Models;
-using Microsoft.Extensions.Logging;
-using OrchardCore.Environment.Shell;
 using System.Threading.Tasks;
-using OrchardCore.Contents.Security;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using OrchardCore.AdminMenu.Services;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentManagement.Metadata.Settings;
+using OrchardCore.Contents.Security;
+using OrchardCore.Navigation;
 
 namespace OrchardCore.Contents.AdminNodes
 {
@@ -23,15 +22,13 @@ namespace OrchardCore.Contents.AdminNodes
 
         public ContentTypesAdminNodeNavigationBuilder(
             IContentDefinitionManager contentDefinitionManager,
-            ShellSettings shellSettings,
             IHttpContextAccessor httpContextAccessor,
             ILogger<ContentTypesAdminNodeNavigationBuilder> logger)
         {
             _contentDefinitionManager = contentDefinitionManager;
 
-            var tenantPrefix = ('/' + (shellSettings.RequestUrlPrefix ?? string.Empty)).TrimEnd('/');
             var pathBase = httpContextAccessor.HttpContext.Request.PathBase;
-            _contentItemlistUrl = tenantPrefix + pathBase +  "/Admin/Contents/ContentItems/";
+            _contentItemlistUrl = pathBase + "/Admin/Contents/ContentItems/";
 
             _logger = logger;
         }
@@ -58,7 +55,7 @@ namespace OrchardCore.Contents.AdminNodes
                     cTypeMenu.Priority(node.Priority);
                     cTypeMenu.Position(node.Position);
                     cTypeMenu.Permission(
-                        ContentTypePermissions.CreateDynamicPermission(ContentTypePermissions.PermissionTemplates[Permissions.PublishOwnContent.Name] , ctd));
+                        ContentTypePermissions.CreateDynamicPermission(ContentTypePermissions.PermissionTemplates[Permissions.PublishOwnContent.Name], ctd));
 
                     GetIconClasses(ctd, node).ToList().ForEach(c => cTypeMenu.AddClass(c));
                 });
@@ -105,7 +102,7 @@ namespace OrchardCore.Contents.AdminNodes
         {
             if (node.ShowAll)
             {
-              return AddPrefixToClasses(node.IconClass);
+                return AddPrefixToClasses(node.IconClass);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using OrchardCore.Environment.Shell;
 using System.Threading.Tasks;
 using OrchardCore.Contents.Security;
+using Microsoft.AspNetCore.Http;
 
 namespace OrchardCore.Contents.AdminNodes
 {
@@ -23,13 +24,14 @@ namespace OrchardCore.Contents.AdminNodes
         public ContentTypesAdminNodeNavigationBuilder(
             IContentDefinitionManager contentDefinitionManager,
             ShellSettings shellSettings,
+            IHttpContextAccessor httpContextAccessor,
             ILogger<ContentTypesAdminNodeNavigationBuilder> logger)
         {
             _contentDefinitionManager = contentDefinitionManager;
 
             var tenantPrefix = ('/' + (shellSettings.RequestUrlPrefix ?? string.Empty)).TrimEnd('/');
-            _contentItemlistUrl = tenantPrefix + "/Admin/Contents/ContentItems/";
-
+            var pathBase = httpContextAccessor.HttpContext.Request.PathBase;
+            _contentItemlistUrl = tenantPrefix + pathBase +  "/Admin/Contents/ContentItems/";
 
             _logger = logger;
         }
@@ -46,7 +48,7 @@ namespace OrchardCore.Contents.AdminNodes
                 return;
             }
 
-            // Add ContentTypes specific children            
+            // Add ContentTypes specific children
             var typesToShow = GetContentTypesToShow(node);
             foreach (var ctd in typesToShow)
             {
@@ -61,7 +63,7 @@ namespace OrchardCore.Contents.AdminNodes
                     GetIconClasses(ctd, node).ToList().ForEach(c => cTypeMenu.AddClass(c));
                 });
             }
-            
+
 
             // Add external children
             foreach (var childNode in node.Items)
@@ -124,7 +126,7 @@ namespace OrchardCore.Contents.AdminNodes
                 .ToList<string>()
                 ?? new List<string>();
         }
-        
+
     }
 
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -2,7 +2,6 @@
 @using OrchardCore.ContentManagement;
 @using OrchardCore.Contents.ViewModels;
 @inject IContentManager ContentManager
-@inject OrchardCore.Environment.Shell.ShellSettings ShellSettings
 
 @{
     var contentTypeDisplayName = Model.Options.ContentTypeOptions.Find(x => x.Value == Model.Options.SelectedContentType && x.Value != null)?.Text;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -14,8 +14,7 @@
         createLinkText = T["Create New {0}", (string)contentTypeDisplayName];
     }
 
-    var tenantPrefix = ("/" + ShellSettings.RequestUrlPrefix ?? string.Empty).TrimEnd('/');
-    var formActionWithoutTypeName = tenantPrefix + Context.Request.PathBase + "/Admin/Contents/ContentItems";
+    var formActionWithoutTypeName = Context.Request.PathBase + "/Admin/Contents/ContentItems";
 }
 
 <h1>@RenderTitleSegments(pageTitle)</h1>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -15,7 +15,7 @@
     }
 
     var tenantPrefix = ("/" + ShellSettings.RequestUrlPrefix ?? string.Empty).TrimEnd('/');
-    var formActionWithoutTypeName = tenantPrefix + "/Admin/Contents/ContentItems";
+    var formActionWithoutTypeName = tenantPrefix + Context.Request.PathBase + "/Admin/Contents/ContentItems";
 }
 
 <h1>@RenderTitleSegments(pageTitle)</h1>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
@@ -1,70 +1,62 @@
 @model AdminIndexViewModel
-@inject ShellSettings ShellSettings
-@using Microsoft.AspNetCore.Http;
-@using OrchardCore.Data;
-@using OrchardCore.Environment.Shell.Models
-@using OrchardCore.Environment.Shell
 @using System.Collections.Generic
 @using System.Net
+@using OrchardCore.Environment.Shell
+@using OrchardCore.Environment.Shell.Models
 
 @{
-    List<SelectListItem> tenantStates = new List<SelectListItem>() {
-new SelectListItem() { Text = T["All states"].Value, Value = TenantsFilter.All.ToString() },
-new SelectListItem() { Text = T["Running"].Value, Value = TenantsFilter.Running.ToString() },
-new SelectListItem() { Text = T["Disabled"].Value, Value = TenantsFilter.Disabled.ToString() },
-new SelectListItem() { Text = T["Uninitialized"].Value, Value = TenantsFilter.Uninitialized.ToString() }
-};
+    var originalPathBase = Context.Features.Get<ShellContextFeature>().OriginalPathBase.ToString();
 
-    List<SelectListItem> tenantSorts = new List<SelectListItem>() {
-new SelectListItem() { Text = T["Sort by name"].Value, Value = TenantsOrder.Name.ToString() },
-new SelectListItem() { Text = T["Sort by state"].Value, Value = TenantsOrder.State.ToString() }
-};
+    List<SelectListItem> tenantStates = new List<SelectListItem>()
+    {
+        new SelectListItem() { Text = T["All states"].Value, Value = TenantsFilter.All.ToString() },
+        new SelectListItem() { Text = T["Running"].Value, Value = TenantsFilter.Running.ToString() },
+        new SelectListItem() { Text = T["Disabled"].Value, Value = TenantsFilter.Disabled.ToString() },
+        new SelectListItem() { Text = T["Uninitialized"].Value, Value = TenantsFilter.Uninitialized.ToString() }
+    };
 
-    List<SelectListItem> tenantActions = new List<SelectListItem>() {
-new SelectListItem() { Text = T["Disable"].Value, Value = BulkAction.Disable.ToString() },
-new SelectListItem() { Text = T["Enable"].Value, Value = BulkAction.Enable.ToString() }
-};
+    List<SelectListItem> tenantSorts = new List<SelectListItem>()
+    {
+        new SelectListItem() { Text = T["Sort by name"].Value, Value = TenantsOrder.Name.ToString() },
+        new SelectListItem() { Text = T["Sort by state"].Value, Value = TenantsOrder.State.ToString() }
+    };
+
+    List<SelectListItem> tenantActions = new List<SelectListItem>()
+    {
+        new SelectListItem() { Text = T["Disable"].Value, Value = BulkAction.Disable.ToString() },
+        new SelectListItem() { Text = T["Enable"].Value, Value = BulkAction.Enable.ToString() }
+    };
 }
 
-@functions {
-public string GetTenantUrl(ShellSettingsEntry shellSettingsEntry)
+@functions
 {
-    ShellSettings tenantShellSettings = shellSettingsEntry.ShellSettings;
-    var requestHostInfo = Context.Request.Host;
-
-    var tenantUrlHost = tenantShellSettings.RequestUrlHost?.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? requestHostInfo.Host;
-    if (requestHostInfo.Port.HasValue)
+    public string GetTenantUrl(ShellSettingsEntry shellSettingsEntry, string originalPathBase)
     {
-        tenantUrlHost += ":" + requestHostInfo.Port;
-    }
+        ShellSettings tenantShellSettings = shellSettingsEntry.ShellSettings;
+        var requestHostInfo = Context.Request.Host;
 
-    var pathBase = Context.Request.PathBase.Value ?? string.Empty;
-
-    if (!string.IsNullOrEmpty(ShellSettings.RequestUrlPrefix))
-    {
-        var prefix = "/" + ShellSettings.RequestUrlPrefix;
-
-        if (pathBase.EndsWith(prefix))
+        var tenantUrlHost = tenantShellSettings.RequestUrlHost?.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? requestHostInfo.Host;
+        if (requestHostInfo.Port.HasValue)
         {
-            pathBase = pathBase.Substring(0, pathBase.Length - prefix.Length);
+            tenantUrlHost += ":" + requestHostInfo.Port;
         }
+
+        var result = $"{Context.Request.Scheme}://{tenantUrlHost}{originalPathBase}";
+
+        if (!string.IsNullOrEmpty(tenantShellSettings.RequestUrlPrefix))
+        {
+            result += "/" + tenantShellSettings.RequestUrlPrefix;
+        }
+
+        if (!string.IsNullOrEmpty(shellSettingsEntry.Token))
+        {
+            result += "?token=" + WebUtility.UrlEncode(shellSettingsEntry.Token);
+        }
+
+        return result;
     }
-
-    var result = $"{Context.Request.Scheme}://{tenantUrlHost}{pathBase}";
-
-    if (!string.IsNullOrEmpty(tenantShellSettings.RequestUrlPrefix))
-    {
-        result += "/" + tenantShellSettings.RequestUrlPrefix;
-    }
-
-    if (!string.IsNullOrEmpty(shellSettingsEntry.Token))
-    {
-        result += "?token=" + WebUtility.UrlEncode(shellSettingsEntry.Token);
-    }
-
-    return result;
 }
-}
+
 <a asp-route-action="Create" class="btn btn-primary float-right" role="button">@T["Add Tenant"]</a>
 <h1>@RenderTitleSegments(T["Tenants"])</h1>
 <fieldset class="admin-toolbar container-fluid">
@@ -126,13 +118,13 @@ public string GetTenantUrl(ShellSettingsEntry shellSettingsEntry)
                         }
                         @if (entry.ShellSettings.State == TenantState.Uninitialized)
                         {
-                            <a class="btn btn-success btn-sm" id="btn-setup-@entry.Name" href="@GetTenantUrl(entry)">@T["Setup"]</a>
+                            <a class="btn btn-success btn-sm" id="btn-setup-@entry.Name" href="@GetTenantUrl(entry, originalPathBase)">@T["Setup"]</a>
                         }
                         <a asp-action="Reload" asp-route-id="@entry.Name" class="btn btn-secondary btn-sm" itemprop="UnsafeUrl">@T["Reload"]</a>
                     </div>
                     <h5>
-                        <a href="@GetTenantUrl(entry)">@entry.Name</a>
-                        <code class="hint">@entry.ShellSettings.RequestUrlHost/@entry.ShellSettings.RequestUrlPrefix</code>
+                        <a href="@GetTenantUrl(entry, originalPathBase)">@entry.Name</a>
+                        <code class="hint">@entry.ShellSettings.RequestUrlHost@originalPathBase/@entry.ShellSettings.RequestUrlPrefix</code>
                         @switch (entry.ShellSettings.State)
                         {
                             case TenantState.Disabled:


### PR DESCRIPTION
I have created a middleware that internally rewrite a url like this
`/zh-TW/audiobooks` to `/audiobooks` and put `/zh-TW` into `Request.PathBase`.

As far as I clicked around, everything seems fine.  Except, in the admin, the links generated by `AdminMenu` and the content type filter in `Content Items` are missing PathBase.