### PR TITLE
Implemented siteLayers graphql query.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
@@ -68,7 +68,7 @@ namespace OrchardCore.Layers.Controllers
 			}
 
 			var layers = await _layerService.GetLayersAsync();
-			var widgets = await _layerService.GetLayerWidgetsAsync(c => c.Latest == true);
+			var widgets = await _layerService.GetLayerWidgetsMetadataAsync(c => c.Latest == true);
 
 			var model = new LayersIndexViewModel { Layers = layers.Layers };
 
@@ -218,7 +218,7 @@ namespace OrchardCore.Layers.Controllers
 				return NotFound();
 			}
 
-			var widgets = await _layerService.GetLayerWidgetsAsync(c => c.Latest == true);
+			var widgets = await _layerService.GetLayerWidgetsMetadataAsync(c => c.Latest == true);
 
 			if (!widgets.Any(x => String.Equals(x.Layer, name, StringComparison.OrdinalIgnoreCase)))
 			{

--- a/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/LayerQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/LayerQueryObjectType.cs
@@ -1,0 +1,48 @@
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.FileStorage;
+
+namespace OrchardCore.Layers.GraphQL
+{
+    public class LayerQueryObjectType : ObjectGraphType<Layer>
+    {
+        public LayerQueryObjectType()
+        {
+            Name = "Layer";
+
+            Field(layer => layer.Name).Description("The name of the layer.");
+            Field(layer => layer.Rule).Description("The rule that activates the layer.");
+            Field(layer => layer.Description).Description("The description of the layer.");
+
+            Field<ListGraphType<LayerWidgetQueryObjectType>>()
+                .Name("widgets")
+                .Description("The widgets for this layer.")
+                .Argument<PublicationStatusGraphType>("status", "publication status of the content item", PublicationStatusEnum.Published)
+                .Resolve(ctx => {
+                    var context = (GraphQLContext)ctx.UserContext;
+                    var layerService = context.ServiceProvider.GetService<ILayerService>();
+                    
+                    var filter = x => x.Published;
+                    if (ctx.HasPopulatedArgument("status"))
+                    {
+                        filter = GetVersionFilter(ctx.GetArgument<PublicationStatusEnum>("status"));
+                    }
+
+                    return layerService.GetLayerWidgetsAsync(filter);
+                });
+        }
+
+        private Expression<Func<ContentItemIndex, bool>> GetVersionFilter(PublicationStatusEnum status)
+        {
+            switch (status)
+            {
+                case PublicationStatusEnum.Published: return x => x.Published;
+                case PublicationStatusEnum.Draft: return x => x.Draft;
+                case PublicationStatusEnum.Latest: return x => x.Latest;
+                case PublicationStatusEnum.All: return x => true;
+                default: return x => x.Published;
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/LayerWidgetQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/LayerWidgetQueryObjectType.cs
@@ -1,10 +1,11 @@
 using GraphQL.Types;
-using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.Apis.GraphQL;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.GraphQL.Queries.Types;
+using OrchardCore.Layers.Models;
 
 namespace OrchardCore.Layers.GraphQL
 {
-    public class LayerWidgetQueryObjectType : ObjectGraphType<IContentItem>
+    public class LayerWidgetQueryObjectType : ObjectGraphType<ContentItem>
     {
         public LayerWidgetQueryObjectType()
         {
@@ -12,30 +13,23 @@ namespace OrchardCore.Layers.GraphQL
 
             Field<StringGraphType>(
                 "zone", 
-                "The name of the widget's zone.", 
-                resolve: context => AsLayerMetadata(context.Source, x => x.Zone));
+                "The name of the widget's zone.",
+                resolve: context => context.Source.As<LayerMetadata>()?.Zone);
 
-            Field<StringGraphType>(
+            Field<DecimalGraphType>(
                 "position", 
                 "The position of the widget in the zone.", 
-                resolve: context => AsLayerMetadata(context.Source, x => x.Position));
+                resolve: context => context.Source.As<LayerMetadata>()?.Position);
 
-            Field<StringGraphType>(
+            Field<BooleanGraphType>(
                 "renderTitle", 
                 "Whether to render the widget's title.", 
-                resolve: context => AsLayerMetadata(context.Source, x => x.RenderTitle));
+                resolve: context => context.Source.As<LayerMetadata>()?.RenderTitle);
 
             Field<ContentItemInterface>(
                 "widget",
                 "A widget on this layer.",
                 resolve: context => context.Source);
-        }
-
-        private string AsLayerMetadata(IContentItem contentItem, Expression<Func<LayerMetadata, string>> propAccessor)
-        {
-            var layerMetadata = contentItem.As<LayerMetadata>();
-            if(layerMetadata == null) return null;
-            return propAccessor(layerMetadata);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/LayerWidgetQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/LayerWidgetQueryObjectType.cs
@@ -1,0 +1,41 @@
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Apis.GraphQL;
+
+namespace OrchardCore.Layers.GraphQL
+{
+    public class LayerWidgetQueryObjectType : ObjectGraphType<IContentItem>
+    {
+        public LayerWidgetQueryObjectType()
+        {
+            Name = "LayerWidget";
+
+            Field<StringGraphType>(
+                "zone", 
+                "The name of the widget's zone.", 
+                resolve: context => AsLayerMetadata(context.Source, x => x.Zone));
+
+            Field<StringGraphType>(
+                "position", 
+                "The position of the widget in the zone.", 
+                resolve: context => AsLayerMetadata(context.Source, x => x.Position));
+
+            Field<StringGraphType>(
+                "renderTitle", 
+                "Whether to render the widget's title.", 
+                resolve: context => AsLayerMetadata(context.Source, x => x.RenderTitle));
+
+            Field<ContentItemInterface>(
+                "widget",
+                "A widget on this layer.",
+                resolve: context => context.Source);
+        }
+
+        private string AsLayerMetadata(IContentItem contentItem, Expression<Func<LayerMetadata, string>> propAccessor)
+        {
+            var layerMetadata = contentItem.As<LayerMetadata>();
+            if(layerMetadata == null) return null;
+            return propAccessor(layerMetadata);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/SiteLayersQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/SiteLayersQuery.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.Resolvers;
 using GraphQL.Types;
@@ -8,12 +7,13 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Primitives;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.Layers.Models;
+using OrchardCore.Layers.Services;
 
 namespace OrchardCore.Layers.GraphQL
 {
     public class SiteLayersQuery : ISchemaBuilder
     {
-        public SiteLayersQuery(IStringLocalizer<LayerQuery> localizer)
+        public SiteLayersQuery(IStringLocalizer<SiteLayersQuery> localizer)
         {
             T = localizer;
         }
@@ -26,7 +26,7 @@ namespace OrchardCore.Layers.GraphQL
             {
                 Name = "SiteLayers",
                 Description = T["Site layers define the rules and zone placement for widgets."],
-                Type = typeof(ListGraphType<LayerObjectType>),
+                Type = typeof(ListGraphType<LayerQueryObjectType>),
                 Resolver = new AsyncFieldResolver<IEnumerable<Layer>>(ResolveAsync)
             };
 
@@ -35,13 +35,13 @@ namespace OrchardCore.Layers.GraphQL
             return Task.FromResult<IChangeToken>(null);
         }
 
-        private async Task<IEnumerable<IFileStoreEntry>> ResolveAsync(ResolveFieldContext resolveContext)
+        private async Task<IEnumerable<Layer>> ResolveAsync(ResolveFieldContext resolveContext)
         {
             var context = (GraphQLContext)resolveContext.UserContext;
             var layerService = context.ServiceProvider.GetService<ILayerService>();
 
             var allLayers = await layerService.GetLayersAsync();
-            return allLayers;
+            return allLayers.Layers;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/SiteLayersQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/SiteLayersQuery.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Primitives;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.Layers.Models;
+
+namespace OrchardCore.Layers.GraphQL
+{
+    public class SiteLayersQuery : ISchemaBuilder
+    {
+        public SiteLayersQuery(IStringLocalizer<LayerQuery> localizer)
+        {
+            T = localizer;
+        }
+
+        public IStringLocalizer T { get; set; }
+
+        public Task<IChangeToken> BuildAsync(ISchema schema)
+        {
+            var field = new FieldType
+            {
+                Name = "SiteLayers",
+                Description = T["Site layers define the rules and zone placement for widgets."],
+                Type = typeof(ListGraphType<LayerObjectType>),
+                Resolver = new AsyncFieldResolver<IEnumerable<Layer>>(ResolveAsync)
+            };
+
+            schema.Query.AddField(field);
+
+            return Task.FromResult<IChangeToken>(null);
+        }
+
+        private async Task<IEnumerable<IFileStoreEntry>> ResolveAsync(ResolveFieldContext resolveContext)
+        {
+            var context = (GraphQLContext)resolveContext.UserContext;
+            var layerService = context.ServiceProvider.GetService<ILayerService>();
+
+            var allLayers = await layerService.GetLayersAsync();
+            return allLayers;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/Startup.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Apis;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.Media.Fields;
+using OrchardCore.Modules;
+
+namespace OrchardCore.Layers.GraphQL
+{
+    [RequireFeatures("OrchardCore.Apis.GraphQL")]
+    public class Startup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddSingleton<ISchemaBuilder, SiteLayersQuery>();
+            services.AddTransient<LayerQueryObjectType>();
+            services.AddTransient<LayerWidgetQueryObjectType>();
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/Startup.cs
@@ -1,7 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.Apis;
 using OrchardCore.Apis.GraphQL;
-using OrchardCore.Media.Fields;
 using OrchardCore.Modules;
 
 namespace OrchardCore.Layers.GraphQL

--- a/src/OrchardCore.Modules/OrchardCore.Layers/OrchardCore.Layers.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/OrchardCore.Layers.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Apis.GraphQL.Abstractions\OrchardCore.Apis.GraphQL.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Deployment.Abstractions\OrchardCore.Deployment.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/ILayerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/ILayerService.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.Layers.Models;
 
@@ -10,7 +11,8 @@ namespace OrchardCore.Layers.Services
     public interface ILayerService
     {
 		Task<LayersDocument> GetLayersAsync();
-		Task<IEnumerable<LayerMetadata>> GetLayerWidgetsAsync(Expression<Func<ContentItemIndex, bool>> predicate);
+		Task<IEnumerable<ContentItem>> GetLayerWidgetsAsync(Expression<Func<ContentItemIndex, bool>> predicate);
+        Task<IEnumerable<LayerMetadata>> GetLayerWidgetsMetadataAsync(Expression<Func<ContentItemIndex, bool>> predicate);
 		Task UpdateAsync(LayersDocument layers);
 	}
 }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
@@ -74,7 +74,7 @@ namespace OrchardCore.Layers.Services
                 var widgets = await _memoryCache.GetOrCreateAsync("OrchardCore.Layers.LayerFilter:AllWidgets", entry =>
                 {
                     entry.AddExpirationToken(_signal.GetToken(LayerMetadataHandler.LayerChangeToken));
-                    return _layerService.GetLayerWidgetsAsync(x => x.Published);
+                    return _layerService.GetLayerWidgetsMetadataAsync(x => x.Published);
                 });
 
 				var layers = (await _layerService.GetLayersAsync()).Layers.ToDictionary(x => x.Name);

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerService.cs
@@ -61,12 +61,19 @@ namespace OrchardCore.Layers.Services
 			return layers;
 		}
 
-		public async Task<IEnumerable<LayerMetadata>> GetLayerWidgetsAsync(Expression<Func<ContentItemIndex, bool>> predicate)
+		public async Task<IEnumerable<ContentItem>> GetLayerWidgetsAsync(
+            Expression<Func<ContentItemIndex, bool>> predicate)
 		{
-            var allWidgets = await _session
+            return await _session
                 .Query<ContentItem, LayerMetadataIndex>()
                 .With(predicate)
                 .ListAsync();
+        }
+
+        public async Task<IEnumerable<LayerMetadata>> GetLayerWidgetsMetadataAsync(
+            Expression<Func<ContentItemIndex, bool>> predicate)
+        {
+            var allWidgets = await GetLayerWidgetsAsync(predicate);
 
             return allWidgets
                 .Select(x => x.As<LayerMetadata>())
@@ -74,7 +81,7 @@ namespace OrchardCore.Layers.Services
                 .OrderBy(x => x.Position)
                 .ToList();
 
-		}
+        }
 
 		public async Task UpdateAsync(LayersDocument layers)
 		{


### PR DESCRIPTION
Query will return all the configured layers and their widgets. Useful for defining header/footer content on GatsbyJS or similar sites.

```
query LayersQuery {
  siteLayers {
    description
    name
    rule
    widgets(status: DRAFT) {
      widget {
        contentType
        ... on Markdown {
          markdownBody {
            html
            markdown
          }
        }
      }
      position
      renderTitle
      zone
    }
  }
}
```