### PR TITLE
 [GraphQL] Improvements to ContentTypeQueryResourceBuilder

### DIFF
--- a/test/OrchardCore.Tests/Apis/Context/BlogContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogContext.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Tests.Apis.Context
                 .Query("blog", builder =>
                 {
                     builder
-                        .AddField("contentItemId");
+                        .WithField("contentItemId");
                 });
 
             BlogContentItemId = result["data"]["blog"].First["contentItemId"].ToString();

--- a/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Tests.Apis.GraphQL.Blog
                     .Query("Blog", builder =>
                     {
                         builder
-                            .AddField("contentItemId");
+                            .WithField("contentItemId");
                     });
 
                 Assert.Single(result["data"]["blog"].Children()["contentItemId"]
@@ -84,10 +84,10 @@ namespace OrchardCore.Tests.Apis.GraphQL.Blog
                     .Query("BlogPost", builder =>
                     {
                         builder
-                            .WithQueryField("path", "Path1");
+                            .WithQueryStringArgument("where", "path", "Path1");
 
                         builder
-                            .AddField("DisplayText");
+                            .WithField("DisplayText");
                     });
 
                 Assert.Equal(
@@ -108,7 +108,7 @@ namespace OrchardCore.Tests.Apis.GraphQL.Blog
                     .Content
                     .Query("BlogPost", builder =>
                     {
-                        builder.AddField("Subtitle");
+                        builder.WithField("Subtitle");
                     });
 
                 Assert.Equal(
@@ -157,10 +157,10 @@ namespace OrchardCore.Tests.Apis.GraphQL.Blog
                     .Query("BlogPost", builder =>
                     {
                         builder
-                            .WithQueryField("ContentItemId", blogPostContentItemId);
+                            .WithQueryStringArgument("where", "ContentItemId", blogPostContentItemId);
 
                         builder
-                            .AddField("Subtitle");
+                            .WithField("Subtitle");
                     });
 
                 Assert.Equal(

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentTypeQueryResourceBuilderTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentTypeQueryResourceBuilderTests.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Threading.Tasks;
+using OrchardCore.Autoroute.Model;
+using OrchardCore.ContentManagement;
+using OrchardCore.Tests.Apis.Context;
+using Xunit;
+
+namespace OrchardCore.Tests.Apis.GraphQL
+{
+    public class ContentTypeQueryResourceBuilderTests
+    {
+        
+        [Fact]
+        public async Task ShouldBeAbleToCreateMultiArgumentQuery()
+        {
+            using (var context = new BlogContext())
+            {
+                await context.InitializeAsync();
+
+                await context
+                    .CreateContentItem("BlogPost", builder =>
+                    {
+                        builder.Published = true;
+                        builder.Latest = true;
+                        builder.DisplayText = "It worked!";
+
+                        builder
+                            .Weld(new AutoroutePart
+                            {
+                                Path = "Path1"
+                            });
+                    }, draft: true);
+
+                await context
+                    .CreateContentItem("BlogPost", builder =>
+                    {
+                        builder.Published = true;
+                        builder.Latest = true;
+                        builder.DisplayText = "don't get this one";
+
+                        builder
+                            .Weld(new AutoroutePart
+                            {
+                                Path = "Path1"
+                            });
+                    });
+
+                await context
+                    .CreateContentItem("BlogPost", builder =>
+                    {
+                        builder.Published = true;
+                        builder.Latest = true;
+                        builder.DisplayText = "or this one";
+
+                        builder
+                            .Weld(new AutoroutePart
+                            {
+                                Path = "Path2"
+                            });
+                    }, draft: true);
+
+                var result = await context
+                    .GraphQLClient
+                    .Content
+                    .Query("blogPost", builder =>
+                    {
+                        builder.WithQueryStringArgument("where", "path", "Path1");
+                        builder.WithQueryArgument("status", "DRAFT");
+                        builder
+                            .WithField("displayText");
+                    });
+
+                var nodes = result["data"]["blogPost"];
+
+                Assert.Single(nodes);
+                Assert.Equal("It worked!", nodes[0]["displayText"].ToString());
+            }
+        }
+
+        [Fact]
+        public async Task ShouldBeAbleToCreateMultiFieldArgument()
+        {
+            using (var context = new BlogContext())
+            {
+                await context.InitializeAsync();
+
+                await context
+                    .CreateContentItem("BlogPost", builder =>
+                    {
+                        builder.Published = true;
+                        builder.Latest = true;
+                        builder.DisplayText = "Great Blog";
+
+                        builder
+                            .Weld(new AutoroutePart
+                            {
+                                Path = "Path1"
+                            });
+                    });
+
+                await context
+                    .CreateContentItem("BlogPost", builder =>
+                    {
+                        builder.Published = true;
+                        builder.Latest = true;
+                        builder.DisplayText = "Another Great Blog";
+
+                        builder
+                            .Weld(new AutoroutePart
+                            {
+                                Path = "Path1"
+                            });
+                    });
+
+                await context
+                    .CreateContentItem("BlogPost", builder =>
+                    {
+                        builder.Published = true;
+                        builder.Latest = true;
+                        builder.DisplayText = "Great Blog";
+
+                        builder
+                            .Weld(new AutoroutePart
+                            {
+                                Path = "Path2"
+                            });
+                    });
+
+                var result = await context
+                    .GraphQLClient
+                    .Content
+                    .Query("blogPost", builder =>
+                    {
+                        builder.WithQueryStringArgument("where", "displayText", "Great Blog");
+                        builder.WithQueryStringArgument("where", "path", "Path1");
+                        builder
+                            .WithField("displayText")
+                            .WithField("path");
+                    });
+
+                var nodes = result["data"]["blogPost"];
+
+                Assert.Single(nodes);
+                Assert.Equal("Great Blog", nodes[0]["displayText"].ToString());
+                Assert.Equal("Path1", nodes[0]["path"].ToString());
+            }
+        }
+
+        [Fact]
+        public async Task ShouldNotBeAbleToIncludeDuplicateArguments()
+        {
+            using (var context = new BlogContext())
+            {
+                await context.InitializeAsync();
+
+                await Assert.ThrowsAsync<Exception>(async () => await context
+                    .GraphQLClient
+                    .Content
+                    .Query("blogPost", builder =>
+                    {
+                        builder.WithQueryArgument("status", "PUBLISHED");
+                        builder.WithQueryArgument("status", "DRAFT");
+                    }));
+
+                await Assert.ThrowsAsync<Exception>(async () => await context
+                    .GraphQLClient
+                    .Content
+                    .Query("blogPost", builder =>
+                    {
+                        builder.WithQueryArgument("status", "PUBLISHED");
+                        builder.WithQueryArgument("status", "field", "DRAFT");
+                    }));
+
+                await Assert.ThrowsAsync<Exception>(async () => await context
+                    .GraphQLClient
+                    .Content
+                    .Query("blogPost", builder =>
+                    {
+                        builder.WithQueryArgument("status", "PUBLISHED");
+                        builder.WithNestedQueryArgument("status", "field", "DRAFT");
+                    }));
+
+                await Assert.ThrowsAsync<Exception>(async () => await context
+                    .GraphQLClient
+                    .Content
+                    .Query("blogPost", builder =>
+                    {
+                        builder.WithQueryArgument("status", "field", "DRAFT");
+                        builder.WithQueryArgument("status", "PUBLISHED");
+                    }));
+
+                await Assert.ThrowsAsync<Exception>(async () => await context
+                    .GraphQLClient
+                    .Content
+                    .Query("blogPost", builder =>
+                    {
+                        builder.WithNestedQueryArgument("status", "field", "DRAFT");
+                        builder.WithQueryArgument("status", "PUBLISHED");
+                    }));
+            }
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
@@ -36,7 +36,7 @@ namespace OrchardCore.Tests.Apis.GraphQL.Queries
                     .Query("RecentBlogPosts", builder =>
                     {
                         builder
-                            .AddField("displayText");
+                            .WithField("displayText");
                     });
 
                 var nodes = result["data"]["recentBlogPosts"];


### PR DESCRIPTION
1. Ability to include any argument, not just "where".
2. Ability to use top-level arguments e.g. blogPost( status: PUBLISHED )
3. Ability to use non-string values in queries like in the example above ^
4. Add some tests
5. Rename functions to make more sense


