### PR TITLE
Role based permissions to display admin menus

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Permissions.cs
@@ -1,16 +1,35 @@
+using System;
 using System.Collections.Generic;
 using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.AdminMenu
 {
-    // todo
     public class Permissions : IPermissionProvider
     {
         public static readonly Permission ManageAdminMenu = new Permission("ManageAdminMenu", "Manage the admin menu");
 
+        public static readonly Permission SeeAdminMenuAll = new Permission("SeeAdminMenuAll", "See Admin Menu - See All", new[] { ManageAdminMenu });
+
+        private static readonly Permission SeeAdminMenu = new Permission("SeeAdminMenu_{0}", "See Admin Menu - {0}", new[] { ManageAdminMenu, SeeAdminMenuAll });
+
+        private readonly IAdminMenuService _adminMenuService;
+
+        public Permissions(IAdminMenuService adminMenuService)
+        {
+            _adminMenuService = adminMenuService;
+        }
+
+
         public IEnumerable<Permission> GetPermissions()
         {
-            return new[] { ManageAdminMenu };
+            var list = new List<Permission> { ManageAdminMenu, SeeAdminMenuAll };
+
+            foreach (var adminMenu in _adminMenuService.GetAsync().GetAwaiter().GetResult())
+            {
+                list.Add(CreatePermissionForAdminMenu(adminMenu.Name));
+            }            
+
+            return list;            
         }
 
         public IEnumerable<PermissionStereotype> GetDefaultStereotypes()
@@ -21,8 +40,21 @@ namespace OrchardCore.AdminMenu
                 {
                     Name = "Administrator",
                     Permissions = new[] { ManageAdminMenu }
+                },
+                new PermissionStereotype {
+                    Name = "Editor",
+                    Permissions = new[] { ManageAdminMenu }
                 }
             };
+        }
+
+        public static Permission CreatePermissionForAdminMenu(string name)
+        {
+            return new Permission(
+                    String.Format(SeeAdminMenu.Name, name),
+                    String.Format(SeeAdminMenu.Description, name),
+                    SeeAdminMenu.ImpliedBy
+                );
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Permissions.cs
@@ -8,9 +8,9 @@ namespace OrchardCore.AdminMenu
     {
         public static readonly Permission ManageAdminMenu = new Permission("ManageAdminMenu", "Manage the admin menu");
 
-        public static readonly Permission SeeAdminMenuAll = new Permission("SeeAdminMenuAll", "See Admin Menu - See All", new[] { ManageAdminMenu });
+        public static readonly Permission ViewAdminMenuAll = new Permission("ViewAdminMenuAll", "View Admin Menu - View All", new[] { ManageAdminMenu });
 
-        private static readonly Permission SeeAdminMenu = new Permission("SeeAdminMenu_{0}", "See Admin Menu - {0}", new[] { ManageAdminMenu, SeeAdminMenuAll });
+        private static readonly Permission ViewAdminMenu = new Permission("ViewAdminMenu_{0}", "View Admin Menu - {0}", new[] { ManageAdminMenu, ViewAdminMenuAll });
 
         private readonly IAdminMenuService _adminMenuService;
 
@@ -22,7 +22,7 @@ namespace OrchardCore.AdminMenu
 
         public IEnumerable<Permission> GetPermissions()
         {
-            var list = new List<Permission> { ManageAdminMenu, SeeAdminMenuAll };
+            var list = new List<Permission> { ManageAdminMenu, ViewAdminMenuAll };
 
             foreach (var adminMenu in _adminMenuService.GetAsync().GetAwaiter().GetResult())
             {
@@ -51,9 +51,9 @@ namespace OrchardCore.AdminMenu
         public static Permission CreatePermissionForAdminMenu(string name)
         {
             return new Permission(
-                    String.Format(SeeAdminMenu.Name, name),
-                    String.Format(SeeAdminMenu.Description, name),
-                    SeeAdminMenu.ImpliedBy
+                    String.Format(ViewAdminMenu.Name, name),
+                    String.Format(ViewAdminMenu.Description, name),
+                    ViewAdminMenu.ImpliedBy
                 );
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/README.md
@@ -65,6 +65,13 @@ The Admin Menu that OrchardCore provides out of the box it's built broadly speak
 ## Deployment Plan Step and Recipe Step 
 The module provides an Admin Menu Deployment Step. So an admin user can expend some time configuring a custom admin menu, add it to a deployment plan, export a json file, and use the generated json on a setup recipe. This way the sites that are built using that recipe will have the admin menu as the user prepared it.
 
+## Permissions 
+There are two kind of permissions associated with the module: 
+
+1. Manage Admin Menus. It its about being able to create edit and delete admin menus from the admin.
+
+2. View Admin Menus. It enables the possibility to show or hide an admin menu per role. You can do that from the standard Edit Roles page
+
 
 ## Developing Custom Admin Node Types
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Services/AdminMenuNavigationProvidersCoordinator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Services/AdminMenuNavigationProvidersCoordinator.cs
@@ -16,20 +16,20 @@ namespace OrchardCore.AdminMenu.Services
     // This class is itself one more INavigationProvider so it can be called from this module's AdminMenu.cs
     public class AdminMenuNavigationProvidersCoordinator : INavigationProvider
     {
-        private readonly IAdminMenuService _AdminMenuService;
+        private readonly IAdminMenuService _adminMenuService;
         private readonly IAuthorizationService _authorizationService;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IEnumerable<IAdminNodeNavigationBuilder> _nodeBuilders;
         private readonly ILogger Logger;
 
         public AdminMenuNavigationProvidersCoordinator(
-            IAdminMenuService AdminMenuervice,
+            IAdminMenuService adminMenuService,
             IAuthorizationService authorizationService,
             IHttpContextAccessor httpContextAccessor,
             IEnumerable<IAdminNodeNavigationBuilder> nodeBuilders,
             ILogger<AdminMenuNavigationProvidersCoordinator> logger)
         {
-            _AdminMenuService = AdminMenuervice;
+            _adminMenuService = adminMenuService;
             _authorizationService = authorizationService;
             _httpContextAccessor = httpContextAccessor;
             _nodeBuilders = nodeBuilders;
@@ -45,7 +45,7 @@ namespace OrchardCore.AdminMenu.Services
                 return;
             }
 
-            var trees = (await _AdminMenuService.GetAsync())
+            var trees = (await _adminMenuService.GetAsync())
                 .Where(m => m.Enabled && m.MenuItems.Count > 0);
 
             foreach (var tree in trees)


### PR DESCRIPTION
Add role-based permissions to see menus created from admin menu module.

"Heavily inspired" by the Queries module ;)

Fixes #3628

![see-admin-menu-permissions](https://user-images.githubusercontent.com/2589629/60610655-962a0d80-9dc4-11e9-965d-b221f82bdddd.gif)
