### PR TITLE
GraphQL - allowed configuration for max depth/complexity and fieldimpact

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Http;
+using GraphQL.Validation.Complexity;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -165,6 +166,11 @@ namespace OrchardCore.Apis.GraphQL
                 _.Inputs = request.Variables.ToInputs();
                 _.UserContext = _settings.BuildUserContext?.Invoke(context);
                 _.ExposeExceptions = _settings.ExposeExceptions;
+                _.ComplexityConfiguration = new ComplexityConfiguration {
+                    MaxDepth = _settings.MaxDepth,
+                    MaxComplexity = _settings.MaxComplexity,
+                    FieldImpact = _settings.FieldImpact
+                };
             });
 
             var httpResult = result.Errors?.Count > 0

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLSettings.cs
@@ -7,6 +7,10 @@ namespace OrchardCore.Apis.GraphQL
     {
         public PathString Path { get; set; } = "/api/graphql";
         public Func<HttpContext, object> BuildUserContext { get; set; }
-        public bool ExposeExceptions = false;
+
+        public bool ExposeExceptions { get; set; } = false;
+        public int? MaxDepth { get; set; }
+        public int? MaxComplexity { get; set; }
+        public double? FieldImpact { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
@@ -93,7 +93,7 @@ Configuration is done via the standard shell configuration, as follows.
 
 If set to true stack traces are exposed to graphql clients
 
-*MaxDepth (int?, Default: null)*
+*MaxDepth (int?, Default: 10)*
 
 Enforces the total maximum nesting across all queries in a request.
 

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
@@ -70,3 +70,35 @@ Executing a GraphQL query requires the issuer to have the `ExecuteGraphQL` permi
 cookie and OAuth 2.0 authentication. This means it's compatible with the OpenId module and supports JSON Web Token (JWT).
 
 By default anonymous users are not able to execute a GraphQL query.
+
+## Configuration
+
+It's possible to configure graphql options for exposing exceptions and max depth, max complexity and field impact.
+
+Configuration is done via the standard shell configuration, as follows.
+
+```json
+{
+  "OrchardCore": {
+    "OrchardCore.Apis.GraphQL": {
+      "ExposeExceptions": true,
+      "MaxDepth": 10, 
+      "MaxComplexity": 100, 
+      "FieldImpact": 2.0 
+    }
+  }
+}
+```
+*ExposeExceptions (bool, Default: false for production, true for development)*
+
+If set to true stack traces are exposed to graphql clients
+
+*MaxDepth (int?, Default: null)*
+
+Enforces the total maximum nesting across all queries in a request.
+
+*MaxComplexity (int?, Default: null)*
+
+*FieldImpact (double?, Default: null)*
+
+For more information on MaxDepth, MaxComplexity, FieldImpact & protecting against malicious queries view the graphql-dot-net documentation at https://graphql-dotnet.github.io/docs/getting-started/malicious-queries/ 

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
@@ -52,7 +52,10 @@ namespace OrchardCore.Apis.GraphQL
                     User = ctx.User,
                     ServiceProvider = ctx.RequestServices,
                 },
-                ExposeExceptions = exposeExceptions
+                ExposeExceptions = exposeExceptions,
+                MaxDepth = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxDepth)}"),
+                MaxComplexity = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxComplexity)}"),
+                FieldImpact = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.FieldImpact)}")
             });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
@@ -53,7 +53,7 @@ namespace OrchardCore.Apis.GraphQL
                     ServiceProvider = ctx.RequestServices,
                 },
                 ExposeExceptions = exposeExceptions,
-                MaxDepth = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxDepth)}"),
+                MaxDepth = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxDepth)}") ?? 10,
                 MaxComplexity = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxComplexity)}"),
                 FieldImpact = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.FieldImpact)}")
             });


### PR DESCRIPTION
Allows more graphql execution configuration, specifically max depth, complexity and fieldimpact

fixes #3753 