### PR TITLE
Support single JTokenType.Object in BooleanQueryProvider

### DIFF
--- a/src/OrchardCore/OrchardCore.Lucene.Core/QueryProviders/BooleanQueryProvider.cs
+++ b/src/OrchardCore/OrchardCore.Lucene.Core/QueryProviders/BooleanQueryProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Lucene.Net.Search;
 using Newtonsoft.Json.Linq;
 
@@ -43,6 +43,8 @@ namespace OrchardCore.Lucene.QueryProviders
                 switch (property.Value.Type)
                 {
                     case JTokenType.Object:
+
+                        boolQuery.Add(builder.CreateQueryFragment(context, (JObject)property.Value), occur);
 
                         break;
                     case JTokenType.Array:


### PR DESCRIPTION
Previously we required to use [ ] on a bool query like this : 

```json
{
  "query": {
    "bool": {
      "must": [
        {
          "term": {
            "Content.ContentItem.ContentType": "Acme"
          }
        }
      ]
    }
  }
}
```

But as stated in the ElasticSearch documentation we should be also able to pass a single object like this : 

```json
{
  "query": {
    "bool": {
      "must": {
        "term": {
          "Content.ContentItem.ContentType": "Acme"
        }
      }
    }
  }
}
```