### PR TITLE
Update theme templates to use liquid filter on html fields

### DIFF
--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Widget-Paragraph.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Widget-Paragraph.liquid
@@ -1,3 +1,3 @@
-﻿<article class="{{ Model.Classes | join: " " }}">
-    {{ Model.ContentItem.Content.Paragraph.Content.Html | raw }}
+<article class="{{ Model.Classes | join: " " }}">
+    {{ Model.ContentItem.Content.Paragraph.Content.Html | liquid | raw }}
 </article>

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Widget-RawHtml.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Widget-RawHtml.liquid
@@ -1,1 +1,1 @@
-﻿{{ Model.ContentItem.Content.RawHtml.Content.Html | raw }}
+{{ Model.ContentItem.Content.RawHtml.Content.Html | liquid | raw }}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Widget-Paragraph.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Widget-Paragraph.liquid
@@ -1,3 +1,3 @@
-﻿<article class="{{ Model.Classes | join: " " }}">
-    {{ Model.ContentItem.Content.Paragraph.Content.Html | raw }}
+<article class="{{ Model.Classes | join: " " }}">
+    {{ Model.ContentItem.Content.Paragraph.Content.Html | liquid | raw }}
 </article>

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Widget-RawHtml.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Widget-RawHtml.liquid
@@ -1,1 +1,1 @@
-﻿{{ Model.ContentItem.Content.RawHtml.Content.Html | raw }}
+{{ Model.ContentItem.Content.RawHtml.Content.Html | liquid | raw }}


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/3892

Adds `liquid` filter to `Widget-Paragraph.liquid` templates in `TheAgencyTheme` and `TheBlogTheme`

Maybe not necessary to add this on the `Widget-RawHtml.liquid` templates as well, but seemed sensible