### PR TITLE
Update style tag helper to use depends-on instead of dependencies

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
         public string Condition { get; set; }
         public string Culture { get; set; }
         public bool? Debug { get; set; }
-        public string Dependencies { get; set; }
+        public string DependsOn { get; set; }
         public string Version { get; set; }
 
         public ResourceLocation At { get; set; }
@@ -147,9 +147,9 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     definition.SetCultures(Culture.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
                 }
 
-                if (!String.IsNullOrEmpty(Dependencies))
+                if (!String.IsNullOrEmpty(DependsOn))
                 {
-                    definition.SetDependencies(Dependencies.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
+                    definition.SetDependencies(DependsOn.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
                 }
 
                 // Also include the style


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/3926

Updates style tag helper to use `depends-on` rather than `dependencies`. 

If not this, then there are 6 views to update that currently use `depends-on`

None that use `dependencies`