### PR TITLE
Bootstrap / Popper version  & cdn-integrity fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4976,7 +4976,7 @@
         "bootstrap-slider": "10.4.1",
         "codemirror": "5.42.0",
         "jquery": "3.3.1",
-        "popper.js": "1.15.0",
+        "popper.js": "1.14.7",
         "trumbowyg": "2.12.2"
       },
       "dependencies": {
@@ -4997,7 +4997,7 @@
       "requires": {
         "bootstrap": "4.3.*",
         "jquery": "3.3.*",
-        "popper.js": "1.15.0"
+        "popper.js": "1.14.7"
       },
       "dependencies": {
         "bootstrap": {
@@ -5016,7 +5016,7 @@
       "version": "file:src/OrchardCore.Themes/TheAdmin",
       "requires": {
         "bootstrap": "4.3.*",
-        "popper.js": "1.15.0"
+        "popper.js": "1.14.7"
       },
       "dependencies": {
         "bootstrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -358,7 +358,9 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true,
+      "optional": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -1035,11 +1037,6 @@
         "is-plain-object": "^2.0.1"
       }
     },
-    "core-js": {
-      "version": "1.2.7",
-      "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1068,16 +1065,6 @@
             "json-parse-better-errors": "^1.0.1"
           }
         }
-      }
-    },
-    "create-react-class": {
-      "version": "15.6.3",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
-      "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
       }
     },
     "cross-fetch": {
@@ -1433,14 +1420,6 @@
       "integrity": "sha512-wOWwM4vQpmb97VNkExnwE5e/sUMUb7NXurlEnhE89JOarUp6FOOMKjtTGgj9bmqskZkeRA7u+p0IztJ/y2OP5Q==",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
@@ -1710,20 +1689,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      }
     },
     "file-match": {
       "version": "1.0.2",
@@ -2652,23 +2617,10 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
-    "graphiql": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/graphiql/-/graphiql-0.12.0.tgz",
-      "integrity": "sha512-OM5dpcONLK1B2prez2WVTfohQlQKe4Fwv1YwNQYQhN+fFGEW87D5v5fN2M8ZebzxbZHqP12KkHicO3sv8k30TQ==",
-      "requires": {
-        "codemirror": "^5.26.0",
-        "codemirror-graphql": "^0.7.1",
-        "markdown-it": "^8.4.0"
-      }
-    },
-    "graphql": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-0.12.0.tgz",
-      "integrity": "sha512-ZxOV6ilO1yWntO1K7mFBFjRtj9KJvaxN9D2Ig/KfOlhz4yP/4uQDrbL4wU1fAKuxym8aYmFXRU0lVcoWq3sYaQ==",
-      "requires": {
-        "iterall": "1.1.3"
-      }
+    "graphiql-explorer": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/graphiql-explorer/-/graphiql-explorer-0.4.3.tgz",
+      "integrity": "sha512-8WST2MfVPesgspCDYOucZHhWjeL0du8GB/vy2o44qrI/Y0iLaZ9BwCVw6jEz658S8AgxcAkKBl1jPCkMRxsdsQ=="
     },
     "graphql-config": {
       "version": "2.0.1",
@@ -3624,14 +3576,6 @@
         "sshpk": "^1.7.0"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -3933,11 +3877,6 @@
         "is-unc-path": "^1.0.0"
       }
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "is-svg": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
@@ -3998,36 +3937,11 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
-    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
-    },
-    "iterall": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.1.3.tgz",
-      "integrity": "sha512-Cu/kb+4HiNSejAPhSaN1VukdNTTi/r4/e+yykqjlG/IW+1gZH5b4+Bq3whDX4tvbYugta3r8KTMUiqT3fIGxuQ=="
     },
     "jquery": {
       "version": "3.3.1",
@@ -5001,9 +4915,57 @@
       "version": "file:src/OrchardCore.Modules/OrchardCore.Apis.GraphQL",
       "requires": {
         "graphiql": "0.13.0",
+        "graphiql-explorer": "0.4.3",
         "graphql": "14.3.1",
         "react": "16.8.6",
         "react-dom": "16.8.6"
+      },
+      "dependencies": {
+        "graphiql": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/graphiql/-/graphiql-0.13.0.tgz",
+          "integrity": "sha512-m2RBtSY1CQLz4XqCftQC0V9ZcbUXEx2Uwvuok3L/TJtsN5HOHUmPxGhOAZs7mESaAsg7Z8Tgy04BmYirDyfWug==",
+          "requires": {
+            "codemirror": "^5.26.0",
+            "codemirror-graphql": "^0.7.1",
+            "markdown-it": "^8.4.0"
+          }
+        },
+        "graphql": {
+          "version": "14.3.1",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.3.1.tgz",
+          "integrity": "sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==",
+          "requires": {
+            "iterall": "^1.2.2"
+          }
+        },
+        "iterall": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
+          "integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+        },
+        "react": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+          "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.13.6"
+          }
+        },
+        "react-dom": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+          "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.13.6"
+          }
+        }
       }
     },
     "orchardcore.resources": {
@@ -5020,11 +4982,13 @@
       "dependencies": {
         "bootstrap-scss": {
           "version": "4.3.1",
-          "resolved": false
+          "resolved": "https://registry.npmjs.org/bootstrap-scss/-/bootstrap-scss-4.3.1.tgz",
+          "integrity": "sha512-9S2yVFoiCALs8nIBR9Tljdh9zDaBODZwVWajTgGuzONUxotDj44/SgW8s5Z3siJSyT4mye9PDbs0OPMmOfwoyg=="
         },
         "popper.js": {
           "version": "1.15.0",
-          "resolved": false
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+          "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
         }
       }
     },
@@ -5038,11 +5002,13 @@
       "dependencies": {
         "bootstrap": {
           "version": "4.3.1",
-          "resolved": false
+          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+          "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
         },
         "popper.js": {
           "version": "1.15.0",
-          "resolved": false
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+          "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
         }
       }
     },
@@ -5050,17 +5016,18 @@
       "version": "file:src/OrchardCore.Themes/TheAdmin",
       "requires": {
         "bootstrap": "4.3.*",
-        "popper.js": "1.14.7"
+        "popper.js": "1.15.0"
       },
       "dependencies": {
         "bootstrap": {
           "version": "4.3.1",
-          "resolved": false
+          "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+          "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
         },
         "popper.js": {
-          "version": "1.14.7",
-          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
-          "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+          "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
         }
       }
     },
@@ -5073,7 +5040,8 @@
       "dependencies": {
         "@types/bootstrap": {
           "version": "4.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-4.3.0.tgz",
+          "integrity": "sha512-v1BkpRVgNH9eXE+RtWFP1wh/+SAkPZaxHthS6umqf1sGV0tAvHdPHZpAOB+H74e91ElOxtS56dxbon+lXWk4AQ==",
           "requires": {
             "@types/jquery": "*",
             "popper.js": "^1.14.1"
@@ -5613,6 +5581,8 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "optional": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -5692,40 +5662,6 @@
       "requires": {
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
-      }
-    },
-    "react": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-15.6.0.tgz",
-      "integrity": "sha1-wjKZtI4w7TAlCM6J4aAskZ+Ca84=",
-      "requires": {
-        "create-react-class": "^15.5.2",
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "^15.5.7"
-      }
-    },
-    "react-dom": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.0.tgz",
-      "integrity": "sha1-i8I8sMgOcGNVt2yp+M5Hz3vfttE=",
-      "requires": {
-        "fbjs": "^0.8.9",
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.0",
-        "prop-types": "~15.5.7"
-      },
-      "dependencies": {
-        "prop-types": {
-          "version": "15.5.10",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-          "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
-          "requires": {
-            "fbjs": "^0.8.9",
-            "loose-envify": "^1.3.1"
-          }
-        }
       }
     },
     "read-pkg": {
@@ -6108,7 +6044,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -6127,6 +6064,15 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -6192,11 +6138,6 @@
           }
         }
       }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -6820,11 +6761,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
       "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
-    },
-    "ua-parser-js": {
-      "version": "0.7.19",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
-      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
     },
     "uc.micro": {
       "version": "1.0.5",

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/package-lock.json
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/package-lock.json
@@ -2453,7 +2453,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2474,12 +2475,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2494,17 +2497,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2621,7 +2627,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2633,6 +2640,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2647,6 +2655,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2654,12 +2663,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2678,6 +2689,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2758,7 +2770,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2770,6 +2783,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2855,7 +2869,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2891,6 +2906,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2910,6 +2926,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2953,12 +2970,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -49,7 +49,7 @@ namespace OrchardCore.Resources
                 .DefineScript("jQuery-ui-i18n")
                 .SetDependencies("jQuery-ui")
                 .SetUrl("~/OrchardCore.Resources/Scripts/jquery-ui-i18n.min.js", "~/OrchardCore.Resources/Scripts/jquery-ui-i18n.js")
-                .SetCdn("http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/i18n/jquery-ui-i18n.min.js", "http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/i18n/jquery-ui-i18n.js")
+                .SetCdn("https://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/i18n/jquery-ui-i18n.min.js", "https://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/i18n/jquery-ui-i18n.js")
                 .SetCdnIntegrity("sha384-0rV7y4NH7acVmq+7Y9GM6evymvReojk9li+7BYb/ug61uqPSsXJ4uIScVY+N9qtd", "sha384-EEQKK6fEtofGTgGugeA6uehhNCEM1w2nYp1rgUGV9lU4wRFjekt9mPFH3ZplAw2Y")
                 .SetVersion("1.7.2")
                 ;

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -50,6 +50,7 @@ namespace OrchardCore.Resources
                 .SetDependencies("jQuery-ui")
                 .SetUrl("~/OrchardCore.Resources/Scripts/jquery-ui-i18n.min.js", "~/OrchardCore.Resources/Scripts/jquery-ui-i18n.js")
                 .SetCdn("http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/i18n/jquery-ui-i18n.min.js", "http://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/i18n/jquery-ui-i18n.js")
+                .SetCdnIntegrity("sha384-0rV7y4NH7acVmq+7Y9GM6evymvReojk9li+7BYb/ug61uqPSsXJ4uIScVY+N9qtd", "sha384-EEQKK6fEtofGTgGugeA6uehhNCEM1w2nYp1rgUGV9lU4wRFjekt9mPFH3ZplAw2Y")
                 .SetVersion("1.7.2")
                 ;
 
@@ -126,6 +127,7 @@ namespace OrchardCore.Resources
                 .DefineScript("codemirror-addon-display-autorefresh")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/addon/display/autorefresh.min.js", "~/OrchardCore.Resources/Scripts/codemirror/addon/display/autorefresh.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/display/autorefresh.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/display/autorefresh.js")
+                .SetCdnIntegrity("sha384-RJTX2U27s6bG/uQqwUnSXT4c8lTmHkfEbmb9d6KRrNW1qJuPdJs6r9SGFcPhRrYh", "sha384-5wrQkkCzj5dJInF+DDDYjE1itTGaIxO+TL6gMZ2eZBo9OyWLczkjolFX8kixX/9X")
                 .SetVersion("5.42.0")
                 .SetAppendVersion(true)
                 ;
@@ -134,6 +136,7 @@ namespace OrchardCore.Resources
                 .DefineScript("codemirror-addon-mode-multiplex")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/addon/mode/multiplex.min.js", "~/OrchardCore.Resources/Scripts/codemirror/addon/mode/multiplex.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/multiplex.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/multiplex.js")
+                .SetCdnIntegrity("sha384-5hVMruka72NXmFobYoE3ORYWcUc4wOh3fXfboJ3JjnBR8mhU94TrsoJ0bH2mPBEV", "sha384-tevfdBRzMxaUn5LZDUoDVAR24aItzKRH9ufnEuzu9VcIXDr6SEfU7bem2iCpfQ/Y")
                 .SetVersion("5.42.0")
                 .SetAppendVersion(true)
                 ;
@@ -142,6 +145,7 @@ namespace OrchardCore.Resources
                 .DefineScript("codemirror-addon-mode-simple")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/addon/mode/simple.min.js", "~/OrchardCore.Resources/Scripts/codemirror/addon/mode/simple.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/simple.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/simple.js")
+                .SetCdnIntegrity("sha384-CbSz/CPF0sQaPi+ZKRa9G1Bs4b06Byb6m0tH7Z4KCZNLUFEYXPpmEK0Mz59P+62i", "sha384-ntjFEzI50GYBTbLGaOVgBt97cxp74jfCqMDmZYlGWk8ZZp2leFMJYOp85T3tOeG9")
                 .SetVersion("5.42.0")
                 .SetAppendVersion(true)
                 ;
@@ -150,6 +154,7 @@ namespace OrchardCore.Resources
                 .DefineScript("codemirror-mode-javascript")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/javascript/javascript.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/javascript/javascript.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/javascript/javascript.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/javascript/javascript.js")
+                .SetCdnIntegrity("sha384-qkQBR4SvYVYypOG0YovM6ESyHGdIxVnNVzTjxlosL2G6a1k5l7PQq5Es6UcK7s28", "sha384-enNKmlcXaN/m72b+eJp7imTZv4QSaCnJU3ifoDddzaeaOzN+BEuTgdS+HluPzk7y")
                 .SetVersion("5.42.0")
                 .SetAppendVersion(true)
                 ;
@@ -158,6 +163,7 @@ namespace OrchardCore.Resources
                 .DefineScript("codemirror-mode-sql")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/sql/sql.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/sql/sql.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/sql/sql.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/sql/sql.js")
+                .SetCdnIntegrity("sha384-ujhASHKo2gNRZSQ/Q9V4fJkRekMw4o6rP46KxNrfRBGkiLUrkt7edeQzKcptitlP", "sha384-DNKIo1GnJyP28fs1kgoEHgWTmVSgAwJUKiAfEzIDDZeCbmbHPyM+pSFTOZrFHsKa")
                 .SetVersion("5.42.0")
                 .SetAppendVersion(true)
                 ;
@@ -166,6 +172,7 @@ namespace OrchardCore.Resources
                 .DefineScript("codemirror-mode-xml")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/xml/xml.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/xml/xml.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/xml/xml.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/xml/xml.js")
+                .SetCdnIntegrity("sha384-b6ENctnjsA8765OrHJ99pTSFwslh472P/F1dkCwgwHoS5vt0GnCjg2GVCOMAM/nO", "sha384-Fwj4mOSYqdnz4tUEeELhXbwTJWq+aGpRvHnE7XNaUquMFhMkj8UFX5rvNQD2zHlQ")
                 .SetVersion("5.42.0")
                 .SetAppendVersion(true)
                 ;

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -86,9 +86,9 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("bootstrap")
-                .SetDependencies("jQuery")
+                .SetDependencies("jQuery, popper")
                 .SetUrl("~/OrchardCore.Resources/Scripts/bootstrap.min.js", "~/OrchardCore.Resources/Scripts/bootstrap.js")
-                .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js", "https://maxcdn.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.js")
+                .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js", "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.js")
                 .SetCdnIntegrity("sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM", "sha384-rkSGcquOAzh5YMplX4tcXMuXXwmdF/9eRLkw/gNZG+1zYutPej7fxyVLiOgfoDgi")
                 .SetVersion("4.3.1")
                 .SetAppendVersion(true)
@@ -96,10 +96,10 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("bootstrap-bundle")
-                .SetDependencies("jQuery", "popper")
+                .SetDependencies("jQuery")
                 .SetUrl("~/OrchardCore.Resources/Scripts/bootstrap.bundle.min.js", "~/OrchardCore.Resources/Scripts/bootstrap.bundle.js")
                 .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js", "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.js")
-                .SetCdnIntegrity("sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM", "sha384-szbKYgPl66wivXHlSpJF+CKDAVckMVnlGrP25Sndhe+PwOBcXV9LlFh4MUpRhjIB")
+                .SetCdnIntegrity("sha384-xrRywqdh3PHs8keKZN+8zzc5TX0GRTLCcmivcbNJWm2rs5C8PRhcEn3czEjhAO9o", "sha384-szbKYgPl66wivXHlSpJF+CKDAVckMVnlGrP25Sndhe+PwOBcXV9LlFh4MUpRhjIB")
                 .SetVersion("4.3.1")
                 .SetAppendVersion(true)
                 ;

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -87,7 +87,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("bootstrap")
-                .SetDependencies("jQuery, popper")
+                .SetDependencies("jQuery", "popper")
                 .SetUrl("~/OrchardCore.Resources/Scripts/bootstrap.min.js", "~/OrchardCore.Resources/Scripts/bootstrap.js")
                 .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js", "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.js")
                 .SetCdnIntegrity("sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM", "sha384-rkSGcquOAzh5YMplX4tcXMuXXwmdF/9eRLkw/gNZG+1zYutPej7fxyVLiOgfoDgi")

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -79,9 +79,9 @@ namespace OrchardCore.Resources
             manifest
                 .DefineScript("popper")
                 .SetUrl("~/OrchardCore.Resources/Scripts/popper.min.js", "~/OrchardCore.Resources/Scripts/popper.js")
-                .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.15.0/umd/popper.min.js", "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.15.0/umd/popper.js")
-                .SetCdnIntegrity("sha384-L2pyEeut/H3mtgCBaUNw7KWzp5n9+4pDQiExs933/5QfaTh8YStYFFkOzSoXjlTb", "sha384-pPGXaBMsJRALMdm7MaTNILgYVlY/jHTDrtHn7e4DqC0TFAcZcyrUyypeAjpZrz7j")
-                .SetVersion("1.15.0")
+                .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js", "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.js")
+                .SetCdnIntegrity("sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1", "sha384-+pJF094Ta2RnahQyTGMfUIP/QGRrcV9M7UybKYko0JCH3B5ukTC6V0kEUSWTWhrn")
+                .SetVersion("1.14.7")
                 .SetAppendVersion(true)
                 ;
 

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -108,7 +108,7 @@ namespace OrchardCore.Resources
                 .DefineStyle("bootstrap")
                 .SetUrl("~/OrchardCore.Resources/Styles/bootstrap.min.css", "~/OrchardCore.Resources/Styles/bootstrap.css")
                 .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css", "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.css")
-                .SetCdnIntegrity("sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T", "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.css")
+                .SetCdnIntegrity("sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T", "sha384-t4IGnnWtvYimgcRMiXD2ZD04g28Is9vYsVaHo5LcWWJkoQGmMwGg+QS0mYlhbVv3")
                 .SetVersion("4.3.1")
                 .SetAppendVersion(true)
                 ;

--- a/src/OrchardCore.Modules/OrchardCore.Resources/package-lock.json
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/package-lock.json
@@ -4,10 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "bootstrap": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
+    },
     "bootstrap-scss": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap-scss/-/bootstrap-scss-4.1.3.tgz",
-      "integrity": "sha512-WZndnzDpxSvMBu+tGUNpo9PkDfsSMoixmc3L9Jlebl5stwGjv5VP6Y6RLo+hCwADmplio+8hTac5b/G3Id428Q=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-scss/-/bootstrap-scss-4.3.1.tgz",
+      "integrity": "sha512-9S2yVFoiCALs8nIBR9Tljdh9zDaBODZwVWajTgGuzONUxotDj44/SgW8s5Z3siJSyT4mye9PDbs0OPMmOfwoyg=="
     },
     "bootstrap-slider": {
       "version": "10.4.1",
@@ -25,9 +30,9 @@
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "popper.js": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
-      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     },
     "trumbowyg": {
       "version": "2.12.2",

--- a/src/OrchardCore.Modules/OrchardCore.Resources/package-lock.json
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/package-lock.json
@@ -30,9 +30,9 @@
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
     },
     "trumbowyg": {
       "version": "2.12.2",

--- a/src/OrchardCore.Modules/OrchardCore.Resources/package.json
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/package.json
@@ -7,7 +7,7 @@
     "bootstrap-slider": "10.4.1",
     "codemirror": "5.42.0",
     "jquery": "3.3.1",
-    "popper.js": "1.15.0",
+    "popper.js": "1.14.7",
     "trumbowyg": "2.12.2"
   }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Setup/package-lock.json
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "bootstrap": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
-      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "jquery": {
       "version": "3.3.1",
@@ -15,9 +15,9 @@
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "popper.js": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
-      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     }
   }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Setup/package-lock.json
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/package-lock.json
@@ -15,9 +15,9 @@
       "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
     }
   }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Setup/package.json
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "dependencies": {
     "bootstrap": "4.3.*",
-    "popper.js": "1.15.0",
+    "popper.js": "1.14.7",
     "jquery": "3.3.*"
   }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/package-lock.json
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/package-lock.json
@@ -5,18 +5,18 @@
   "requires": true,
   "dependencies": {
     "@types/bootstrap": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-4.1.3.tgz",
-      "integrity": "sha512-4RCCokC8cNHrimMN06HX97lhwhPR7ZTVYXVItj/ZWfr3Sb96q/qgOV9th1irONxZR7KunG2uRyJ+ESQzHI+hAA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-4.3.0.tgz",
+      "integrity": "sha512-v1BkpRVgNH9eXE+RtWFP1wh/+SAkPZaxHthS6umqf1sGV0tAvHdPHZpAOB+H74e91ElOxtS56dxbon+lXWk4AQ==",
       "requires": {
         "@types/jquery": "*",
         "popper.js": "^1.14.1"
       }
     },
     "@types/jquery": {
-      "version": "3.3.28",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.28.tgz",
-      "integrity": "sha512-6+0asQBU38H5kdoKvxVGE7fY8JREBgQsxONw0na0noV9D3JLN2+odBPKkTvRcLW20xSNiP8BH0nyl+8PcIHYNw==",
+      "version": "3.3.30",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.30.tgz",
+      "integrity": "sha512-chB+QbLulamShZAFcTJtl8opZwHFBpDOP6nRLrPGkhC6N1aKWrDXg2Nc71tEg6ny6E8SQpRwbWSi9GdstH5VJA==",
       "requires": {
         "@types/sizzle": "*"
       }
@@ -32,9 +32,9 @@
       "integrity": "sha512-T01BjkzvHeH+vFa/Xk5l8rhtPwah+EWP/adidtdfdfLSD5ucngydr/IqK8rLTyQoGgp2yWOxQx70wTAR0ZBLmA=="
     },
     "popper.js": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
-      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     }
   }
 }

--- a/src/OrchardCore.Themes/TheAdmin/package-lock.json
+++ b/src/OrchardCore.Themes/TheAdmin/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "bootstrap": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
-      "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "popper.js": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.6.tgz",
-      "integrity": "sha512-AGwHGQBKumlk/MDfrSOf0JHhJCImdDMcGNoqKmKkU+68GFazv3CQ6q9r7Ja1sKDZmYWTckY/uLyEznheTDycnA=="
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
+      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
     }
   }
 }

--- a/src/OrchardCore.Themes/TheAdmin/package-lock.json
+++ b/src/OrchardCore.Themes/TheAdmin/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "popper.js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.15.0.tgz",
-      "integrity": "sha512-w010cY1oCUmI+9KwwlWki+r5jxKfTFDVoadl7MSrIujHU5MJ5OR6HTDj6Xo8aoR/QsA56x8jKjA59qGH4ELtrA=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
     }
   }
 }

--- a/src/OrchardCore.Themes/TheAdmin/package.json
+++ b/src/OrchardCore.Themes/TheAdmin/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "bootstrap": "4.3.*",
-    "popper.js": "1.15.0"
+    "popper.js": "1.14.7"
   }
 }

--- a/src/OrchardCore.Themes/TheAdmin/package.json
+++ b/src/OrchardCore.Themes/TheAdmin/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "dependencies": {
     "bootstrap": "4.3.*",
-    "popper.js": "1.14.7"
+    "popper.js": "1.15.0"
   }
 }


### PR DESCRIPTION
This fixes some minor issues with the wrong popper versions reported on https://github.com/OrchardCMS/OrchardCore/issues/3725

Bootstrap 4.3.1 uses popper 1.14.7, rather than 1.15.0 

Also sets the correct cdn integrity hash, and included a number of missing hashes.

And sets bootstrap bundle to not rely on popper but bootstrap to rely on popper.

Without the popper version conflicts an `npm install` will now complete without a bunch of warnings about version differences.

Also included the `package-lock.json` files from the modules after the refresh

Will probably have merge conflicts with https://github.com/OrchardCMS/OrchardCore/pull/3960 😞 