### PR TITLE
Reload resource settings on update

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Environment.Shell;
 using OrchardCore.Settings.ViewModels;
 
 namespace OrchardCore.Settings.Drivers
@@ -8,7 +9,19 @@ namespace OrchardCore.Settings.Drivers
     public class DefaultSiteSettingsDisplayDriver : DisplayDriver<ISite>
     {
         public const string GroupId = "general";
-        
+
+        private readonly IShellHost _shellHost;
+        private readonly ShellSettings _shellSettings;
+
+        public DefaultSiteSettingsDisplayDriver(
+            IShellHost shellHost,
+            ShellSettings shellSettings
+            )
+        {
+            _shellHost = shellHost;
+            _shellSettings = shellSettings;
+        }
+
         public override Task<IDisplayResult> EditAsync(ISite site, BuildEditorContext context)
         {
             return Task.FromResult<IDisplayResult>(
@@ -38,6 +51,8 @@ namespace OrchardCore.Settings.Drivers
                     site.UseCdn = model.UseCdn;
                     site.CdnBaseUrl = model.CdnBaseUrl;
                     site.ResourceDebugMode = model.ResourceDebugMode;
+
+                    await _shellHost.ReloadShellContextAsync(_shellSettings);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
@@ -2,6 +2,8 @@
 @inject OrchardCore.Modules.IClock Clock
 @using System.Globalization
 
+<p class="alert alert-warning">@T["The current tenant will be reloaded when the settings are saved."]</p>
+
 <fieldset class="form-group" asp-validation-class-for="SiteName">
     <label asp-for="SiteName">@T["Site name"]</label>
     <input asp-for="SiteName" class="form-control" />
@@ -25,10 +27,10 @@
 </fieldset>
 
 <fieldset class="form-group" asp-validation-class-for="CdnBaseUrl">
-        <label asp-for="CdnBaseUrl">@T["CDN Base url"]</label>
-        <input asp-for="CdnBaseUrl" class="form-control" />
-        <span asp-validation-for="CdnBaseUrl"></span>
-        <span class="hint">@T["A CDN Base url applied to locally hosted scripts and stylesheets, if empty no CDN Base url is applied, and is disabled in Resource Debug Mode"]</span>
+    <label asp-for="CdnBaseUrl">@T["CDN Base url"]</label>
+    <input asp-for="CdnBaseUrl" class="form-control" />
+    <span asp-validation-for="CdnBaseUrl"></span>
+    <span class="hint">@T["A CDN Base url applied to locally hosted scripts and stylesheets, if empty no CDN Base url is applied, and is disabled in Resource Debug Mode"]</span>
 </fieldset>
 
 <div class="row">


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/3970

Went with the first option, just reload the general site settings when they change, so that resources will change to debug / cdn / minified etc

**Question** Should the `OrchardCore.Settings.Controllers.AdminController` have an `[Admin]` attribute?