### PR TITLE
Added liquid support to markdown graphql query.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Html/GraphQL/HtmlBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/GraphQL/HtmlBodyQueryObjectType.cs
@@ -1,6 +1,12 @@
+using System.Threading.Tasks;
+using Fluid;
 using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using OrchardCore.Apis.GraphQL;
 using OrchardCore.Html.Model;
+using OrchardCore.Html.ViewModels;
+using OrchardCore.Liquid;
 
 namespace OrchardCore.Html.GraphQL
 {
@@ -11,7 +17,22 @@ namespace OrchardCore.Html.GraphQL
             Name = "HtmlBodyPart";
             Description = T["Content stored as HTML."];
 
-            Field(x => x.Html);
+            Field<StringGraphType>()
+                .Name("html")
+                .Description(T["the HTML content"])
+                .ResolveAsync(RenderHtml);
+        }
+
+        private static async Task<object> RenderHtml(ResolveFieldContext<HtmlBodyPart> ctx)
+        {
+            var context = (GraphQLContext) ctx.UserContext;
+            var liquidTemplateManager = context.ServiceProvider.GetService<ILiquidTemplateManager>();
+
+            var templateContext = new TemplateContext();
+            templateContext.SetValue("ContentItem", ctx.Source.ContentItem);
+            templateContext.MemberAccessStrategy.Register<HtmlBodyPartViewModel>();
+
+            return await liquidTemplateManager.RenderAsync(ctx.Source.Html, templateContext);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
@@ -1,5 +1,10 @@
+using System.Threading.Tasks;
+using Fluid;
 using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.Liquid;
 using OrchardCore.Markdown.Model;
 
 namespace OrchardCore.Markdown.GraphQL
@@ -13,18 +18,24 @@ namespace OrchardCore.Markdown.GraphQL
 
             Field("markdown", x => x.Markdown, nullable: true)
                 .Description("the markdown value")
-                .Type(new StringGraphType())
-                ;
+                .Type(new StringGraphType());
 
-            Field("html", x => ToHtml(x.Markdown), nullable: true)
+            Field<StringGraphType>()
+                .Name("html")
                 .Description("the HTML representation of the markdown content")
-                .Type(new StringGraphType())
-                ;
+                .ResolveAsync(ToHtml);
         }
 
-        private static string ToHtml(string markdown)
+        private static async Task<object> ToHtml(ResolveFieldContext<MarkdownBodyPart> ctx)
         {
-            return Markdig.Markdown.ToHtml(markdown ?? "");
+            var context = (GraphQLContext) ctx.UserContext;
+            var liquidTemplateManager = context.ServiceProvider.GetService<ILiquidTemplateManager>();
+
+            var markdown = ctx.Source.Markdown;
+            var templateContext = new TemplateContext();
+            markdown = await liquidTemplateManager.RenderAsync(markdown, templateContext);
+
+            return Markdig.Markdown.ToHtml(markdown);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
@@ -17,12 +17,12 @@ namespace OrchardCore.Markdown.GraphQL
             Description = T["Content stored as Markdown. You can also query the HTML interpreted version of Markdown."];
 
             Field("markdown", x => x.Markdown, nullable: true)
-                .Description("the markdown value")
+                .Description(T["the markdown value"])
                 .Type(new StringGraphType());
 
             Field<StringGraphType>()
                 .Name("html")
-                .Description("the HTML representation of the markdown content")
+                .Description(T["the HTML representation of the markdown content"])
                 .ResolveAsync(ToHtml);
         }
 


### PR DESCRIPTION
Allows liquid expressions to be processed when generating the HTML through the GraphQL API.