### PR TITLE
Indexes a Content.ContentItem.Parent field in Lucene for ContainedPart.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ListPartContentIndexHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ListPartContentIndexHandler.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using OrchardCore.ContentManagement;
+using OrchardCore.Indexing;
+using OrchardCore.Lists.Models;
+
+namespace OrchardCore.Lists.Indexes
+{
+    public class ListPartContentIndexHandler : IContentItemIndexHandler
+    {
+        public const string ParentKey = "Content.ContentItem.Parent";
+
+        public Task BuildIndexAsync(BuildIndexContext context)
+        {
+            var parent = context.ContentItem.As<ContainedPart>();
+
+            if (parent == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            context.DocumentIndex.Set(
+                ParentKey,
+                parent.ListContentItemId,
+                DocumentIndexOptions.Store);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
@@ -12,6 +12,7 @@ using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Feeds;
+using OrchardCore.Indexing;
 using OrchardCore.Lists.AdminNodes;
 using OrchardCore.Lists.Drivers;
 using OrchardCore.Lists.Feeds;
@@ -46,6 +47,7 @@ namespace OrchardCore.Lists
             services.AddScoped<IContentPartHandler, ListPartHandler>();
             services.AddScoped<IContentTypePartDefinitionDisplayDriver, ListPartSettingsDisplayDriver>();
             services.AddScoped<IDataMigration, Migrations>();
+            services.AddScoped<IContentItemIndexHandler, ListPartContentIndexHandler>();
 
             // Feeds
             // TODO: Create feature


### PR DESCRIPTION
Fixes #3794, #3949

Need to filter to see if it will fix also other issues that I missed.