### PR TITLE
Small refactors to Resources CDN and settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -43,39 +43,33 @@ namespace OrchardCore.Resources
                 .SetUrl("~/OrchardCore.Resources/Scripts/jquery-ui-i18n.min.js", "~/OrchardCore.Resources/Scripts/jquery-ui-i18n.js")
                 .SetCdn("https://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/i18n/jquery-ui-i18n.min.js", "https://ajax.googleapis.com/ajax/libs/jqueryui/1.7.2/i18n/jquery-ui-i18n.js")
                 .SetCdnIntegrity("sha384-0rV7y4NH7acVmq+7Y9GM6evymvReojk9li+7BYb/ug61uqPSsXJ4uIScVY+N9qtd", "sha384-EEQKK6fEtofGTgGugeA6uehhNCEM1w2nYp1rgUGV9lU4wRFjekt9mPFH3ZplAw2Y")
-                .SetVersion("1.7.2")
-                ;
+                .SetVersion("1.7.2");
 
             manifest
                 .DefineScript("bootstrap")
                 .SetDependencies("jQuery")
                 .SetCdn("https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js", "https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.js")
                 .SetCdnIntegrity("sha384-vhJnz1OVIdLktyixHY4Uk3OHEwdQqPppqYR8+5mjsauETgLOcEynD9oPHhhz18Nw", "sha384-it0Suwx+VjMafDIVf5t+ozEbrflmNjEddSX5LstI/Xdw3nv4qP/a4e8K4k5hH6l4")
-                .SetVersion("3.4.0")
-                .SetAppendVersion(false);
+                .SetVersion("3.4.0");
 
             manifest
                 .DefineStyle("bootstrap")
                 .SetCdn("https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.min.css", "https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.css")
                 .SetCdnIntegrity("sha384-PmY9l28YgO4JwMKbTvgaS7XNZJ30MK9FAZjjzXtlqyZCqBY6X6bXIkM++IkyinN+", "sha384-/5bQ8UYbZnrNY3Mfy6zo9QLgIQD/0CximLKk733r8/pQnXn2mgvhvKhcy43gZtJV")
-                .SetVersion("3.4.0")
-                .SetAppendVersion(false);
+                .SetVersion("3.4.0");
 
             manifest
                 .DefineStyle("bootstrap-theme")
                 .SetCdn("https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap-theme.min.css", "https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap-theme.css")
                 .SetCdnIntegrity("sha384-jzngWsPS6op3fgRCDTESqrEJwRKck+CILhJVO5VvaAZCq8JYf8HsR/HPpBOOPZfR", "sha384-RtiWe5OsslAYZ9AVyorBziI2VQL7E27rzWygBJh7wrZuVPyK5jeQLLytnJIpJqfD")
-                .SetVersion("3.4.0")
-                .SetAppendVersion(false);
+                .SetVersion("3.4.0");
 
             manifest
                 .DefineScript("popper")
                 .SetUrl("~/OrchardCore.Resources/Scripts/popper.min.js", "~/OrchardCore.Resources/Scripts/popper.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js", "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.js")
                 .SetCdnIntegrity("sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1", "sha384-+pJF094Ta2RnahQyTGMfUIP/QGRrcV9M7UybKYko0JCH3B5ukTC6V0kEUSWTWhrn")
-                .SetVersion("1.14.7")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("1.14.7");
 
             manifest
                 .DefineScript("bootstrap")
@@ -91,18 +85,14 @@ namespace OrchardCore.Resources
                 .SetUrl("~/OrchardCore.Resources/Scripts/bootstrap.bundle.min.js", "~/OrchardCore.Resources/Scripts/bootstrap.bundle.js")
                 .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.min.js", "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.bundle.js")
                 .SetCdnIntegrity("sha384-xrRywqdh3PHs8keKZN+8zzc5TX0GRTLCcmivcbNJWm2rs5C8PRhcEn3czEjhAO9o", "sha384-szbKYgPl66wivXHlSpJF+CKDAVckMVnlGrP25Sndhe+PwOBcXV9LlFh4MUpRhjIB")
-                .SetVersion("4.3.1")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("4.3.1");
 
             manifest
                 .DefineStyle("bootstrap")
                 .SetUrl("~/OrchardCore.Resources/Styles/bootstrap.min.css", "~/OrchardCore.Resources/Styles/bootstrap.css")
                 .SetCdn("https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css", "https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.css")
                 .SetCdnIntegrity("sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T", "sha384-t4IGnnWtvYimgcRMiXD2ZD04g28Is9vYsVaHo5LcWWJkoQGmMwGg+QS0mYlhbVv3")
-                .SetVersion("4.3.1")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("4.3.1");
 
             manifest
                 .DefineScript("codemirror")
@@ -116,54 +106,42 @@ namespace OrchardCore.Resources
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/addon/display/autorefresh.min.js", "~/OrchardCore.Resources/Scripts/codemirror/addon/display/autorefresh.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/display/autorefresh.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/display/autorefresh.js")
                 .SetCdnIntegrity("sha384-RJTX2U27s6bG/uQqwUnSXT4c8lTmHkfEbmb9d6KRrNW1qJuPdJs6r9SGFcPhRrYh", "sha384-5wrQkkCzj5dJInF+DDDYjE1itTGaIxO+TL6gMZ2eZBo9OyWLczkjolFX8kixX/9X")
-                .SetVersion("5.42.0")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("5.42.0");
 
             manifest
                 .DefineScript("codemirror-addon-mode-multiplex")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/addon/mode/multiplex.min.js", "~/OrchardCore.Resources/Scripts/codemirror/addon/mode/multiplex.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/multiplex.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/multiplex.js")
                 .SetCdnIntegrity("sha384-5hVMruka72NXmFobYoE3ORYWcUc4wOh3fXfboJ3JjnBR8mhU94TrsoJ0bH2mPBEV", "sha384-tevfdBRzMxaUn5LZDUoDVAR24aItzKRH9ufnEuzu9VcIXDr6SEfU7bem2iCpfQ/Y")
-                .SetVersion("5.42.0")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("5.42.0");
 
             manifest
                 .DefineScript("codemirror-addon-mode-simple")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/addon/mode/simple.min.js", "~/OrchardCore.Resources/Scripts/codemirror/addon/mode/simple.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/simple.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/addon/mode/simple.js")
                 .SetCdnIntegrity("sha384-CbSz/CPF0sQaPi+ZKRa9G1Bs4b06Byb6m0tH7Z4KCZNLUFEYXPpmEK0Mz59P+62i", "sha384-ntjFEzI50GYBTbLGaOVgBt97cxp74jfCqMDmZYlGWk8ZZp2leFMJYOp85T3tOeG9")
-                .SetVersion("5.42.0")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("5.42.0");
 
             manifest
                 .DefineScript("codemirror-mode-javascript")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/javascript/javascript.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/javascript/javascript.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/javascript/javascript.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/javascript/javascript.js")
                 .SetCdnIntegrity("sha384-qkQBR4SvYVYypOG0YovM6ESyHGdIxVnNVzTjxlosL2G6a1k5l7PQq5Es6UcK7s28", "sha384-enNKmlcXaN/m72b+eJp7imTZv4QSaCnJU3ifoDddzaeaOzN+BEuTgdS+HluPzk7y")
-                .SetVersion("5.42.0")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("5.42.0");
 
             manifest
                 .DefineScript("codemirror-mode-sql")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/sql/sql.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/sql/sql.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/sql/sql.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/sql/sql.js")
                 .SetCdnIntegrity("sha384-ujhASHKo2gNRZSQ/Q9V4fJkRekMw4o6rP46KxNrfRBGkiLUrkt7edeQzKcptitlP", "sha384-DNKIo1GnJyP28fs1kgoEHgWTmVSgAwJUKiAfEzIDDZeCbmbHPyM+pSFTOZrFHsKa")
-                .SetVersion("5.42.0")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("5.42.0");
 
             manifest
                 .DefineScript("codemirror-mode-xml")
                 .SetUrl("~/OrchardCore.Resources/Scripts/codemirror/mode/xml/xml.min.js", "~/OrchardCore.Resources/Scripts/codemirror/mode/xml/xml.js")
                 .SetCdn("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/xml/xml.min.js", "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.42.0/mode/xml/xml.js")
                 .SetCdnIntegrity("sha384-b6ENctnjsA8765OrHJ99pTSFwslh472P/F1dkCwgwHoS5vt0GnCjg2GVCOMAM/nO", "sha384-Fwj4mOSYqdnz4tUEeELhXbwTJWq+aGpRvHnE7XNaUquMFhMkj8UFX5rvNQD2zHlQ")
-                .SetVersion("5.42.0")
-                .SetAppendVersion(true)
-                ;
+                .SetVersion("5.42.0");
 
             manifest
                 .DefineStyle("codemirror")
@@ -183,22 +161,19 @@ namespace OrchardCore.Resources
                 .DefineStyle("font-awesome")
                 .SetCdn("https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.7.2/css/all.min.css", "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.7.2/css/all.css")
                 .SetCdnIntegrity("sha256-nAmazAk6vS34Xqo0BSrTb+abbtFlgsFK7NKSi6o7Y78=", "sha256-DVK12s61Wqwmj3XI0zZ9MFFmnNH8puF/eRHTB4ftKwk=")
-                .SetVersion("5.7.2")
-                .SetAppendVersion(false);
+                .SetVersion("5.7.2");
 
             manifest
                 .DefineScript("font-awesome")
                 .SetCdn("https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.7.2/js/all.min.js", "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.7.2/js/all.js")
                 .SetCdnIntegrity("sha256-Oq0ot7xtAl3WqR2277bwtP+iuV2uOTCh03M1ZCjIsJw=", "sha256-3thD9grC33Xa/xFJXfs8ZryCIwIn+LTX/k3r3KxSel0=")
-                .SetVersion("5.7.2")
-                .SetAppendVersion(false);
+                .SetVersion("5.7.2");
 
             manifest
                 .DefineScript("font-awesome-v4-shims")
                 .SetCdn("https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.7.2/js/v4-shims.min.js", "https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.7.2/js/v4-shims.js")
                 .SetCdnIntegrity("sha256-Dy8KjLriNkSRrlgRJaVAoXdvxOlz8ico4RVRmZJsxD8=", "sha256-Hr8WbqmgdrcXJGhodaZ1ATNeusCHFbb3GxGVyA32C9E=")
-                .SetVersion("5.7.2")
-                .SetAppendVersion(false);
+                .SetVersion("5.7.2");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
@@ -18,41 +18,6 @@
     <span class="hint">@T["Enter the fully qualified base URL of the web site."]</span>
 </fieldset>
 
-<fieldset class="form-group" asp-validation-class-for="AppendVersion">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="@Model.AppendVersion" />
-        <label class="custom-control-label" asp-for="@Model.AppendVersion">@T["Use resources cache busting"]</label>
-        <span class="hint">@T[" — Whether cache busting (append a version) is used for scripts and stylesheets"]</span>
-    </div>
-</fieldset>
-
-<fieldset class="form-group" asp-validation-class-for="UseCdn">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="@Model.UseCdn" />
-        <label class="custom-control-label" asp-for="@Model.UseCdn">@T["Use CDN (Content Delivery Network)"]</label>
-        <span class="hint">@T[" — Whether the defined CDN value is used for scripts and stylesheets, or their local version"]</span>
-    </div>
-</fieldset>
-
-<fieldset class="form-group" asp-validation-class-for="CdnBaseUrl">
-    <label asp-for="CdnBaseUrl">@T["CDN Base url"]</label>
-    <input asp-for="CdnBaseUrl" class="form-control" />
-    <span asp-validation-for="CdnBaseUrl"></span>
-    <span class="hint">@T["A CDN Base url applied to locally hosted scripts and stylesheets, if empty no CDN Base url is applied, and is disabled in Resource Debug Mode"]</span>
-</fieldset>
-
-<div class="row">
-    <fieldset class="from-group col-xl-6" asp-validation-class-for="ResourceDebugMode">
-        <label asp-for="ResourceDebugMode">@T["Resource Debug Mode"]</label>
-        <select asp-for="ResourceDebugMode" class="form-control">
-            <option value="@ResourceDebugMode.FromConfiguration.ToString()">@T["From environment — enabled in <em>Production</em>, disabled otherwise)"]</option>
-            <option value="@ResourceDebugMode.Enabled.ToString()">@T["Enabled — use debuggable version of resources"]</option>
-            <option value="@ResourceDebugMode.Disabled.ToString()">@T["Disabled — use minified version of resources"]</option>
-        </select>
-        <span class="hint">@T["Determines whether scripts and stylesheets load in their debuggable or minified form."]</span>
-    </fieldset>
-</div>
-
 <div class="row">
     <fieldset class="form-group col-xl-6" asp-validation-class-for="TimeZone">
         <label asp-for="TimeZone">@T["Default Time Zone"]</label>
@@ -68,5 +33,41 @@
         <span asp-validation-for="TimeZone"></span>
         <span class="hint">@T["Determines the default time zone used when displaying and editing dates and times. DST (daylight saving time) will be applied automatically per time zone if available."]</span>
     </fieldset>
-
 </div>
+
+<h5 class="form-group">@T["Resource Settings"]<span class="hint"> — @T["Control settings for scripts and stylesheets"]</span></h5>
+<fieldset class="form-group" asp-validation-class-for="AppendVersion">
+    <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" asp-for="@Model.AppendVersion" />
+        <label class="custom-control-label" asp-for="@Model.AppendVersion">@T["Use resources cache busting"]</label>
+        <span class="hint">— @T["Whether cache busting (append a version) is used for scripts and stylesheets"]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="UseCdn">
+    <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" asp-for="@Model.UseCdn" />
+        <label class="custom-control-label" asp-for="@Model.UseCdn">@T["Use framework CDN (Content Delivery Network)"]</label>
+        <span class="hint">— @T["Whether a framework CDN is used for registered scripts and stylesheets, such as jQuery, or their local version"]</span>
+    </div>
+</fieldset>
+
+<fieldset class="form-group" asp-validation-class-for="CdnBaseUrl">
+    <label asp-for="CdnBaseUrl">@T["Host CDN (Content Delivery Network) base url"]</label>
+    <input asp-for="CdnBaseUrl" class="form-control" />
+    <span asp-validation-for="CdnBaseUrl"></span>
+    <span class="hint">@T["A base CDN URL prefixed to this hosts, non framework, scripts and stylesheets, if empty no base CDN URL is applied, and it is disabled in Resource Debug Mode"]</span>
+</fieldset>
+
+<div class="row form-group">
+    <fieldset class="col-xl-6" asp-validation-class-for="ResourceDebugMode">
+        <label asp-for="ResourceDebugMode">@T["Resource Debug Mode"]</label>
+        <select asp-for="ResourceDebugMode" class="form-control">
+            <option value="@ResourceDebugMode.FromConfiguration.ToString()">@T["From environment — enabled in <em>Production</em>, disabled otherwise)"]</option>
+            <option value="@ResourceDebugMode.Enabled.ToString()">@T["Enabled — use debuggable version of resources"]</option>
+            <option value="@ResourceDebugMode.Disabled.ToString()">@T["Disabled — use minified version of resources"]</option>
+        </select>
+        <span class="hint">@T["Determines whether scripts and stylesheets load in their debuggable or minified form."]</span>
+    </fieldset>
+</div>
+

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
@@ -56,7 +56,7 @@
     <label asp-for="CdnBaseUrl">@T["Site CDN (Content Delivery Network) base url"]</label>
     <input asp-for="CdnBaseUrl" class="form-control" />
     <span asp-validation-for="CdnBaseUrl"></span>
-    <span class="hint">@T["A base CDN URL prefixed to the sites, scripts and stylesheets, if empty no base CDN URL is applied, and it is disabled in Resource Debug Mode"]</span>
+    <span class="hint">@T["A base CDN URL prefixed to the local scripts and stylesheets. It is disabled if the value is empty or if the Resource Debug Mode is enabled, e.g. <em>https://cdn.mysite.com</em>"]</span>
 </fieldset>
 
 <div class="row form-group">

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
@@ -35,7 +35,7 @@
     </fieldset>
 </div>
 
-<h5 class="form-group">@T["Resource Settings"]<span class="hint"> — @T["Control settings for scripts and stylesheets"]</span></h5>
+<h5 class="form-group">@T["Resource Settings"]<span class="hint"> — @T["Settings for scripts and stylesheets"]</span></h5>
 <fieldset class="form-group" asp-validation-class-for="AppendVersion">
     <div class="custom-control custom-checkbox">
         <input type="checkbox" class="custom-control-input" asp-for="@Model.AppendVersion" />
@@ -53,10 +53,10 @@
 </fieldset>
 
 <fieldset class="form-group" asp-validation-class-for="CdnBaseUrl">
-    <label asp-for="CdnBaseUrl">@T["Host CDN (Content Delivery Network) base url"]</label>
+    <label asp-for="CdnBaseUrl">@T["Site CDN (Content Delivery Network) base url"]</label>
     <input asp-for="CdnBaseUrl" class="form-control" />
     <span asp-validation-for="CdnBaseUrl"></span>
-    <span class="hint">@T["A base CDN URL prefixed to this hosts, non framework, scripts and stylesheets, if empty no base CDN URL is applied, and it is disabled in Resource Debug Mode"]</span>
+    <span class="hint">@T["A base CDN URL prefixed to the sites, scripts and stylesheets, if empty no base CDN URL is applied, and it is disabled in Resource Debug Mode"]</span>
 </fieldset>
 
 <div class="row form-group">

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
@@ -63,7 +63,7 @@
     <fieldset class="col-xl-6" asp-validation-class-for="ResourceDebugMode">
         <label asp-for="ResourceDebugMode">@T["Resource Debug Mode"]</label>
         <select asp-for="ResourceDebugMode" class="form-control">
-            <option value="@ResourceDebugMode.FromConfiguration.ToString()">@T["From environment — enabled in <em>Production</em>, disabled otherwise)"]</option>
+            <option value="@ResourceDebugMode.FromConfiguration.ToString()">@T["From environment — enabled in <em>Production</em>, disabled otherwise"]</option>
             <option value="@ResourceDebugMode.Enabled.ToString()">@T["Enabled — use debuggable version of resources"]</option>
             <option value="@ResourceDebugMode.Disabled.ToString()">@T["Disabled — use minified version of resources"]</option>
         </select>

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ResourceUrlFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ResourceUrlFilter.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Values;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using OrchardCore.Liquid;
+using OrchardCore.ResourceManagement;
+
+namespace OrchardCore.DisplayManagement.Liquid.Filters
+{
+    /// <summary>
+    /// Returns the Cdn Base Url of the specified resource path.
+    /// </summary>
+    public class ResourceUrlFilter : ILiquidFilter
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ResourceManagementOptions _options;
+
+        public ResourceUrlFilter(
+            IHttpContextAccessor httpContextAccessor,
+            IOptions<ResourceManagementOptions> options
+            )
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _options = options.Value;
+        }
+
+        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        {
+            var resourcePath = input.ToStringValue();
+
+            if (resourcePath.StartsWith("~/", StringComparison.Ordinal))
+            {
+                if (!String.IsNullOrEmpty(_httpContextAccessor.HttpContext.Request.PathBase))
+                {
+                    resourcePath = _httpContextAccessor.HttpContext.Request.PathBase + resourcePath.Substring(1);
+                }
+                else
+                {
+                    resourcePath = resourcePath.Substring(1);
+                }
+            }
+
+            // Don't prefix cdn if the path is absolute, or is in debug mode.
+            if (!_options.DebugMode
+                && !String.IsNullOrEmpty(_options.CdnBaseUrl)
+                && !Uri.TryCreate(resourcePath, UriKind.Absolute, out var uri))
+            {
+                resourcePath = _options.CdnBaseUrl + resourcePath;
+            }
+
+            return new ValueTask<FluidValue>(new StringValue(resourcePath));
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCore.DisplayManagement.Liquid.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCore.DisplayManagement.Liquid.csproj
@@ -8,6 +8,7 @@
     <ProjectReference Include="..\OrchardCore.DynamicCache.Abstractions\OrchardCore.DynamicCache.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\OrchardCore.Liquid.Abstractions\OrchardCore.Liquid.Abstractions.csproj" />
+    <ProjectReference Include="..\OrchardCore.ResourceManagement.Abstractions\OrchardCore.ResourceManagement.Abstractions.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddScoped<ILiquidTemplateEventHandler, CultureLiquidTemplateEventHandler>();
 
                 services.AddLiquidFilter<AppendVersionFilter>("append_version");
+                services.AddLiquidFilter<ResourceUrlFilter>("resource_url");
             });
 
             return builder;

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -131,7 +131,7 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
-        public RequireSettings SetAppendVersion(bool? appendVersion)
+        public RequireSettings ShouldAppendVersion(bool? appendVersion)
         {
             AppendVersion = appendVersion;
             return this;
@@ -202,7 +202,7 @@ namespace OrchardCore.ResourceManagement
                 .UseCulture(Culture).UseCulture(other.Culture)
                 .UseCondition(Condition).UseCondition(other.Condition)
                 .UseVersion(Version).UseVersion(other.Version)
-                .SetAppendVersion(AppendVersion).SetAppendVersion(other.AppendVersion)
+                .ShouldAppendVersion(AppendVersion).ShouldAppendVersion(other.AppendVersion)
                 .Define(InlineDefinition).Define(other.InlineDefinition);
             settings._attributes = MergeAttributes(other);
             return settings;

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -165,6 +165,10 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
+        /// <summary>
+        /// Should a file version be appended to the resource.
+        /// </summary>
+        /// <param name="appendVersion"></param>
         public ResourceDefinition ShouldAppendVersion(bool? appendVersion)
         {
             AppendVersion = appendVersion;

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -165,7 +165,7 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
-        public ResourceDefinition SetAppendVersion(bool? appendVersion)
+        public ResourceDefinition ShouldAppendVersion(bool? appendVersion)
         {
             AppendVersion = appendVersion;
             return this;

--- a/src/OrchardCore/OrchardCore.ResourceManagement/OrchardCore.ResourceManagement.csproj
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/OrchardCore.ResourceManagement.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\OrchardCore.Abstractions\OrchardCore.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.ResourceManagement.Abstractions\OrchardCore.ResourceManagement.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement/Razor/ResourceCdnHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/Razor/ResourceCdnHelperExtensions.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore;
+using OrchardCore.ResourceManagement;
+
+public static class ResourceCdnHelperExtensions
+{
+    /// <summary>
+    /// Returns the Cdn Base Url of the specified resource path.
+    /// </summary>
+    public static string ResourceUrl(this IOrchardHelper orchardHelper, string resourcePath)
+    {
+        var options = orchardHelper.HttpContext.RequestServices.GetRequiredService<IOptions<ResourceManagementOptions>>().Value;
+
+        if (resourcePath.StartsWith("~/", StringComparison.Ordinal))
+        {
+            if (!String.IsNullOrEmpty(orchardHelper.HttpContext.Request.PathBase))
+            {
+                resourcePath = orchardHelper.HttpContext.Request.PathBase + resourcePath.Substring(1);
+            }
+            else
+            {
+                resourcePath = resourcePath.Substring(1);
+            }
+        }
+
+        // Don't prefix cdn if the path is absolute, or is in debug mode.
+        if (!options.DebugMode
+            && !String.IsNullOrEmpty(options.CdnBaseUrl)
+            && !Uri.TryCreate(resourcePath, UriKind.Absolute, out var uri))
+        {
+            resourcePath = options.CdnBaseUrl + resourcePath;
+        }
+
+        return resourcePath;
+    }
+}

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -485,7 +485,7 @@ namespace OrchardCore.ResourceManagement
             {
                 if (!first)
                 {
-                    builder.AppendHtml(Environment.NewLine);
+                    builder.AppendHtml(System.Environment.NewLine);
                 }
 
                 first = false;
@@ -502,7 +502,7 @@ namespace OrchardCore.ResourceManagement
             {
                 if (!first)
                 {
-                    builder.AppendHtml(Environment.NewLine);
+                    builder.AppendHtml(System.Environment.NewLine);
                 }
 
                 first = false;
@@ -521,7 +521,7 @@ namespace OrchardCore.ResourceManagement
             {
                 if (!first)
                 {
-                    builder.AppendHtml(Environment.NewLine);
+                    builder.AppendHtml(System.Environment.NewLine);
                 }
 
                 first = false;
@@ -540,7 +540,7 @@ namespace OrchardCore.ResourceManagement
             {
                 if (!first)
                 {
-                    builder.AppendHtml(Environment.NewLine);
+                    builder.AppendHtml(System.Environment.NewLine);
                 }
 
                 first = false;
@@ -552,7 +552,7 @@ namespace OrchardCore.ResourceManagement
             {
                 if (!first)
                 {
-                    builder.AppendHtml(Environment.NewLine);
+                    builder.AppendHtml(System.Environment.NewLine);
                 }
 
                 first = false;
@@ -571,7 +571,7 @@ namespace OrchardCore.ResourceManagement
             {
                 if (!first)
                 {
-                    builder.AppendHtml(Environment.NewLine);
+                    builder.AppendHtml(System.Environment.NewLine);
                 }
 
                 first = false;
@@ -583,7 +583,7 @@ namespace OrchardCore.ResourceManagement
             {
                 if (!first)
                 {
-                    builder.AppendHtml(Environment.NewLine);
+                    builder.AppendHtml(System.Environment.NewLine);
                 }
 
                 first = false;
@@ -604,7 +604,7 @@ namespace OrchardCore.ResourceManagement
                 {
                     if (!first)
                     {
-                        builder.AppendHtml(Environment.NewLine);
+                        builder.AppendHtml(System.Environment.NewLine);
                     }
 
                     first = false;

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -124,7 +124,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
                 if (AppendVersion.HasValue)
                 {
-                    setting.SetAppendVersion(AppendVersion);
+                    setting.ShouldAppendVersion(AppendVersion);
                 }
 
                 foreach (var attribute in output.Attributes)
@@ -170,7 +170,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
                 if (AppendVersion.HasValue)
                 {
-                    setting.SetAppendVersion(AppendVersion);
+                    setting.ShouldAppendVersion(AppendVersion);
                 }
 
                 if (!String.IsNullOrEmpty(Version))

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -91,7 +91,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
                     if (AppendVersion.HasValue)
                     {
-                        definition.SetAppendVersion(AppendVersion);
+                        definition.ShouldAppendVersion(AppendVersion);
                     }
 
                     if (!String.IsNullOrEmpty(Version))
@@ -212,7 +212,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
                 if (AppendVersion.HasValue)
                 {
-                    definition.SetAppendVersion(AppendVersion);
+                    definition.ShouldAppendVersion(AppendVersion);
                 }
 
                 if (!String.IsNullOrEmpty(Version))

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -67,7 +67,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
                 if (AppendVersion.HasValue == true)
                 {
-                    setting.SetAppendVersion(AppendVersion);
+                    setting.ShouldAppendVersion(AppendVersion);
                 }
 
                 if (Debug != null)
@@ -117,7 +117,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
                 if (AppendVersion.HasValue == true)
                 {
-                    setting.SetAppendVersion(AppendVersion);
+                    setting.ShouldAppendVersion(AppendVersion);
                 }
 
                 if (!String.IsNullOrEmpty(Version))


### PR DESCRIPTION
Slightly delayed refactors requested a couple of weeks back in the community meeting for the resources cache busting and cdn settings.

- Refactor SetAppendVersion to ShouldAppendVersion as better api name
- Add Razor Helper to prefix the CDN Base Url, if it was a static file located in a theme or module.
- Add liquid filter to do the same
- Try and make site settings a bit clearer for the CDN / Resources section

Not sure that `ResourceManagement` is the best place for the extension. I think this would probably only be used if you needed to build a href link to a static image or similar in a theme, so technically not a `Resource`. Open to suggestions if there is a better place for it?

It could also have a tag helper to go with if that is wanted, but will work with the asp net tag helper as is?

I removed the references to `SetAppendVersion(false)` from the `ResourceManifest`. On further looking it was probably not achieving anything useful in terms of allocations, and the `ShellFileVersionProvider` will no-op, on a full url so, removed.

Altered the order, and made a section for Resources in the site settings, and tried to make the wording a bit clearer. Use CDN, I changed to Use Framework CDN, with a better description in the hint text.

![oc-site-resources](https://user-images.githubusercontent.com/13782679/63115646-8723a700-bf8f-11e9-89c3-9d9f7af947bb.PNG)
