### PR TITLE
Improve Kebab-casing performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ wwwroot
 !src/Templates/**/content/**
 .template.config/
 /OrchardCore.sln.GhostDoc.xml
+
+# Rider
+/.idea

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
+
 using Fluid;
 using Fluid.Values;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Localization;
+
 using OrchardCore.Mvc.Utilities;
 
 namespace OrchardCore.DisplayManagement.Liquid.Filters
@@ -57,7 +58,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
             foreach (var name in arguments.Names)
             {
-                properties.Add(LowerKebabToPascalCase(name), arguments[name].ToObjectValue());
+                properties.Add(name.ToPascalCase('_'), arguments[name].ToObjectValue());
             }
 
             return FluidValue.Create(await ((IShapeFactory)shapeFactory).CreateAsync(type, Arguments.From(properties)));
@@ -91,35 +92,6 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
             }
 
             return NilValue.Instance;
-        }
-
-        public static string LowerKebabToPascalCase(string attribute)
-        {
-            attribute = attribute.Trim();
-            var nextIsUpper = true;
-            var result = new StringBuilder();
-            for (int i = 0; i < attribute.Length; i++)
-            {
-                var c = attribute[i];
-                if (c == '_')
-                {
-                    nextIsUpper = true;
-                    continue;
-                }
-
-                if (nextIsUpper)
-                {
-                    result.Append(c.ToString().ToUpper());
-                }
-                else
-                {
-                    result.Append(c);
-                }
-
-                nextIsUpper = false;
-            }
-
-            return result.ToString();
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
@@ -2,11 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
 using Fluid;
 using Fluid.Values;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+
+using OrchardCore.Mvc.Utilities;
 
 namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
 {
@@ -91,7 +94,7 @@ namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
 
             foreach (var name in arguments.Names)
             {
-                var propertyName = Filters.LiquidViewFilters.LowerKebabToPascalCase(name);
+                var propertyName = name.ToPascalCase('_');
 
                 var found = false;
 
@@ -121,7 +124,7 @@ namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
             return tagHelper;
         }
 
-        private class ReusableTagHelperFactory<T> where T : ITagHelper
+        private class ReusableTagHelperFactory<T> where T : class, ITagHelper
         {
             public static ITagHelper CreateTagHelper(ITagHelperFactory tagHelperFactory, ViewContext viewContext)
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperFactory.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+
 using Fluid;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor;
@@ -10,7 +11,6 @@ using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.CodeAnalysis;
 
 namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
 {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapePagerTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapePagerTag.cs
@@ -1,20 +1,26 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+
 using Fluid;
 using Fluid.Ast;
 using Fluid.Values;
-using OrchardCore.DisplayManagement.Liquid.Filters;
+
 using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.Liquid.Ast;
+using OrchardCore.Mvc.Utilities;
 
 namespace OrchardCore.DisplayManagement.Liquid.Tags
 {
     public class ShapePagerTag : ExpressionArgumentsTag
     {
-        private static readonly string[] _properties = { "PreviousText", "NextText", "PreviousClass", "NextClass" };
+        private static readonly HashSet<string> _properties = new HashSet<string>
+        {
+            "PreviousText", "NextText", "PreviousClass", "NextClass"
+        };
 
         public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, Expression expression, FilterArgument[] args)
         {
@@ -29,7 +35,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
                     foreach (var name in arguments.Names)
                     {
                         var argument = arguments[name];
-                        var propertyName = LiquidViewFilters.LowerKebabToPascalCase(name);
+                        var propertyName = name.ToPascalCase('_');
 
                         if (_properties.Contains(propertyName))
                         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
@@ -1,16 +1,22 @@
 using System;
-using System.Linq;
-using System.Text;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+
+using OrchardCore.Mvc.Utilities;
 
 namespace OrchardCore.DisplayManagement.TagHelpers
 {
     public abstract class BaseShapeTagHelper : TagHelper
     {
-        private static readonly string[] InternalProperties = { "id", "type", "cache-id", "cache-context", "cache-dependency", "cache-tag", "cache-fixed-duration", "cache-sliding-duration" };
+        private static readonly HashSet<string> InternalProperties = new HashSet<string>
+        {
+            "id", "type", "cache-id", "cache-context", "cache-dependency", "cache-tag", "cache-fixed-duration", "cache-sliding-duration"
+        };
+
         private static readonly char[] Separators = { ',', ' ' };
 
         protected IShapeFactory _shapeFactory;
@@ -36,10 +42,14 @@ namespace OrchardCore.DisplayManagement.TagHelpers
         public override async Task ProcessAsync(TagHelperContext tagHelperContext, TagHelperOutput output)
         {
             // Extract all attributes from the tag helper to
-            var properties = output.Attributes
-                .Where(x => !InternalProperties.Contains(x.Name))
-                .ToDictionary(x => LowerKebabToPascalCase(x.Name), x => (object)x.Value.ToString())
-                ;
+            var properties = new Dictionary<string, string>();
+            foreach (var pair in output.Attributes)
+            {
+                if (!InternalProperties.Contains(pair.Name))
+                {
+                    properties[pair.Name.ToPascalCase('-')] = pair.Value.ToString();
+                }
+            }
 
             if (string.IsNullOrWhiteSpace(Type))
             {
@@ -133,38 +143,6 @@ namespace OrchardCore.DisplayManagement.TagHelpers
 
             // We don't want any encapsulating tag around the shape
             output.TagName = null;
-        }
-
-        /// <summary>
-        /// Converts foo-bar to FooBar
-        /// </summary>
-        private static string LowerKebabToPascalCase(string attribute)
-        {
-            attribute = attribute.Trim();
-            bool nextIsUpper = true;
-            var result = new StringBuilder();
-            for (int i = 0; i < attribute.Length; i++)
-            {
-                var c = attribute[i];
-                if (c == '-')
-                {
-                    nextIsUpper = true;
-                    continue;
-                }
-
-                if (nextIsUpper)
-                {
-                    result.Append(c.ToString().ToUpper());
-                }
-                else
-                {
-                    result.Append(c);
-                }
-
-                nextIsUpper = false;
-            }
-
-            return result.ToString();
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+
 using Microsoft.Extensions.Localization;
 
 namespace OrchardCore.Mvc.Utilities
@@ -378,6 +378,48 @@ namespace OrchardCore.Mvc.Utilities
         {
             int place = source.LastIndexOf(find);
             return source.Remove(place, find.Length).Insert(place, replace);
+        }
+
+        public static string ToPascalCase(this string attribute, char upperAfterDelimiter)
+        {
+            attribute = attribute.Trim();
+            foreach (var c in attribute)
+            {
+                if (c == upperAfterDelimiter)
+                {
+                    return DoPascalCase(attribute, upperAfterDelimiter);
+                }
+            }
+
+            // no need
+            return attribute;
+        }
+
+        private static string DoPascalCase(string attribute, char upperAfterDelimiter)
+        {
+            var nextIsUpper = true;
+            var result = new StringBuilder(attribute.Length);
+            foreach (var c in attribute)
+            {
+                if (c == upperAfterDelimiter)
+                {
+                    nextIsUpper = true;
+                    continue;
+                }
+
+                if (nextIsUpper)
+                {
+                    result.Append(Char.ToUpperInvariant(c));
+                }
+                else
+                {
+                    result.Append(c);
+                }
+
+                nextIsUpper = false;
+            }
+
+            return result.ToString();
         }
     }
 }


### PR DESCRIPTION
* renamed ToPascalCase, accepting the delimiter to start upper-casing after
* don't build string builder if not going to change the string
* less LINQ

Only problematic thing is exposing new public API and removing old one.