### PR TITLE
Use concrete array to traverse content handlers

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Handlers/ContentLocalizationPartHandlerCoordinator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Handlers/ContentLocalizationPartHandlerCoordinator.cs
@@ -1,31 +1,32 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+
 using Microsoft.Extensions.Logging;
+
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Modules;
 
 namespace OrchardCore.ContentLocalization.Handlers
 {
-    class ContentLocalizationPartHandlerCoordinator : ContentLocalizationHandlerBase
+    public class ContentLocalizationPartHandlerCoordinator : ContentLocalizationHandlerBase
     {
         private readonly ITypeActivatorFactory<ContentPart> _contentPartFactory;
-        private readonly IEnumerable<IContentLocalizationPartHandler> _partHandlers;
+        private readonly IContentLocalizationPartHandler[] _partHandlers;
         private readonly ITypeActivatorFactory<ContentField> _contentFieldFactory;
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ILogger<ContentLocalizationPartHandlerCoordinator> _logger;
 
         public ContentLocalizationPartHandlerCoordinator(
-
             ITypeActivatorFactory<ContentPart> contentPartFactory,
             IEnumerable<IContentLocalizationPartHandler> partHandlers,
             ITypeActivatorFactory<ContentField> contentFieldFactory,
             IContentDefinitionManager contentDefinitionManager,
-            ILogger<ContentLocalizationPartHandlerCoordinator> logger
-        )
+            ILogger<ContentLocalizationPartHandlerCoordinator> logger)
         {
             _contentPartFactory = contentPartFactory;
-            _partHandlers = partHandlers;
+            _partHandlers = partHandlers as IContentLocalizationPartHandler[] ?? partHandlers.ToArray();
             _contentFieldFactory = contentFieldFactory;
             _contentDefinitionManager = contentDefinitionManager;
             _logger = logger;
@@ -41,9 +42,8 @@ namespace OrchardCore.ContentLocalization.Handlers
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.LocalizingAsync(context, part), _logger);
                 }
@@ -60,9 +60,8 @@ namespace OrchardCore.ContentLocalization.Handlers
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.LocalizedAsync(context, part), _logger);
                 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Extensions/InvokeExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Extensions/InvokeExtensions.cs
@@ -84,6 +84,43 @@ namespace OrchardCore.Modules
             }
         }
 
+        /// <summary>
+        /// Safely invoke methods by catching non fatal exceptions and logging them
+        /// </summary>
+        public static async Task InvokeAsync<TEvents>(this TEvents[] events, Func<TEvents, Task> dispatch, ILogger logger)
+        {
+            foreach (var sink in events)
+            {
+                try
+                {
+                    await dispatch(sink);
+                }
+                catch (Exception ex)
+                {
+                    HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Safely invoke methods by catching non fatal exceptions and logging them
+        /// </summary>
+        public static async Task InvokeReversedAsync<TEvents>(this TEvents[] events, Func<TEvents, Task> dispatch, ILogger logger)
+        {
+            for (var i = events.Length - 1; i >= 0; i--)
+            {
+                var sink = events[i];
+                try
+                {
+                    await dispatch(sink);
+                }
+                catch (Exception ex)
+                {
+                    HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                }
+            }
+        }
+
         public static async Task<IEnumerable<TResult>> InvokeAsync<TEvents, TResult>(this IEnumerable<TEvents> events, Func<TEvents, Task<TResult>> dispatch, ILogger logger)
         {
             var results = new List<TResult>();

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
@@ -17,9 +18,9 @@ namespace OrchardCore.ContentManagement.Display
     /// </summary>
     public class ContentItemDisplayCoordinator : IContentDisplayHandler
     {
-        private readonly IEnumerable<IContentDisplayDriver> _displayDrivers;
-        private readonly IEnumerable<IContentFieldDisplayDriver> _fieldDisplayDrivers;
-        private readonly IEnumerable<IContentPartDisplayDriver> _partDisplayDrivers;
+        private readonly IContentDisplayDriver[] _displayDrivers;
+        private readonly IContentFieldDisplayDriver[] _fieldDisplayDrivers;
+        private readonly IContentPartDisplayDriver[] _partDisplayDrivers;
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ITypeActivatorFactory<ContentPart> _contentPartFactory;
 
@@ -33,9 +34,9 @@ namespace OrchardCore.ContentManagement.Display
         {
             _contentPartFactory = contentPartFactory;
             _contentDefinitionManager = contentDefinitionManager;
-            _displayDrivers = displayDrivers;
-            _fieldDisplayDrivers = fieldDisplayDrivers;
-            _partDisplayDrivers = partDisplayDrivers;
+            _displayDrivers = displayDrivers as IContentDisplayDriver[] ?? displayDrivers.ToArray();
+            _fieldDisplayDrivers = fieldDisplayDrivers as IContentFieldDisplayDriver[] ?? fieldDisplayDrivers.ToArray();
+            _partDisplayDrivers = partDisplayDrivers as IContentPartDisplayDriver[] ?? partDisplayDrivers.ToArray();
             Logger = logger;
         }
 
@@ -94,7 +95,7 @@ namespace OrchardCore.ContentManagement.Display
                     var tempContext = context;
 
                     // Create a custom ContentPart shape that will hold the fields for dynamic content part (not implicit parts)
-                    // This allows its fields to be grouped and templated 
+                    // This allows its fields to be grouped and templated
 
                     if (part.GetType() == typeof(ContentPart) && contentTypePartDefinition.PartDefinition.Name != contentTypePartDefinition.ContentTypeDefinition.Name)
                     {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
@@ -26,8 +26,8 @@ namespace OrchardCore.ContentManagement.Display
     /// </summary>
     public class ContentItemDisplayManager : BaseDisplayManager, IContentItemDisplayManager
     {
-        private readonly IEnumerable<IContentHandler> _contentHandlers;
-        private readonly IEnumerable<IContentDisplayHandler> _handlers;
+        private readonly IContentHandler[] _contentHandlers;
+        private readonly IContentDisplayHandler[] _handlers;
         private readonly IShapeTableManager _shapeTableManager;
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly IShapeFactory _shapeFactory;
@@ -45,8 +45,8 @@ namespace OrchardCore.ContentManagement.Display
             ILayoutAccessor layoutAccessor
             ) : base(shapeTableManager, shapeFactory, themeManager)
         {
-            _handlers = handlers;
-            _contentHandlers = contentHandlers;
+            _handlers = handlers as IContentDisplayHandler[] ?? handlers.ToArray();
+            _contentHandlers = contentHandlers as IContentHandler[] ?? contentHandlers.ToArray();
             _shapeTableManager = shapeTableManager;
             _contentDefinitionManager = contentDefinitionManager;
             _shapeFactory = shapeFactory;
@@ -172,7 +172,7 @@ namespace OrchardCore.ContentManagement.Display
 
             await _contentHandlers.InvokeAsync(handler => handler.UpdatingAsync(updateContentContext), Logger);
             await _handlers.InvokeAsync(handler => handler.UpdateEditorAsync(contentItem, context), Logger);
-            await _contentHandlers.Reverse().InvokeAsync(handler => handler.UpdatedAsync(updateContentContext), Logger);
+            await _contentHandlers.InvokeReversedAsync(handler => handler.UpdatedAsync(updateContentContext), Logger);
 
             return context.Shape;
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+
 using Microsoft.Extensions.Logging;
+
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Modules;
@@ -13,7 +16,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
     public class ContentPartHandlerCoordinator : ContentHandlerBase
     {
         private readonly ITypeActivatorFactory<ContentPart> _contentPartFactory;
-        private readonly IEnumerable<IContentPartHandler> _partHandlers;
+        private readonly IContentPartHandler[] _partHandlers;
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ITypeActivatorFactory<ContentField> _contentFieldFactory;
 
@@ -26,7 +29,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
         {
             _contentPartFactory = contentPartFactory;
             _contentFieldFactory = contentFieldFactory;
-            _partHandlers = partHandlers;
+            _partHandlers = partHandlers as IContentPartHandler[] ?? partHandlers.ToArray();
             _contentDefinitionManager = contentDefinitionManager;
 
             Logger = logger;
@@ -66,9 +69,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, partName) as ContentPart;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, partName) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.ActivatedAsync(context, part), Logger);
                 }
@@ -86,9 +88,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
 
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.CreatingAsync(context, part), Logger);
                 }
@@ -106,9 +106,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
 
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.CreatedAsync(context, part), Logger);
                 }
@@ -142,9 +140,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
 
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.InitializedAsync(context, part), Logger);
                 }
@@ -155,7 +151,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
         {
             // This method is called on Get()
             // Adds all the missing parts to a content item based on the content type definition.
-            // A part is missing if the content type is changed and an old content item is loaded, 
+            // A part is missing if the content type is changed and an old content item is loaded,
             // like edited.
 
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
@@ -204,9 +200,7 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
 
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.LoadedAsync(context, part), Logger);
                 }
@@ -223,9 +217,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.PublishingAsync(context, part), Logger);
                 }
@@ -242,9 +235,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.PublishedAsync(context, part), Logger);
                 }
@@ -261,9 +253,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.RemovingAsync(context, part), Logger);
                 }
@@ -280,9 +271,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.RemovedAsync(context, part), Logger);
                 }
@@ -299,9 +289,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.UnpublishingAsync(context, part), Logger);
                 }
@@ -318,9 +307,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.UnpublishedAsync(context, part), Logger);
                 }
@@ -337,9 +325,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.UpdatingAsync(context, part), Logger);
                 }
@@ -356,9 +343,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.UpdatedAsync(context, part), Logger);
                 }
@@ -417,9 +403,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.GetContentItemAspectAsync(context, part), Logger);
                 }
@@ -435,9 +420,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.ClonedAsync(context, part), Logger);
                 }
@@ -453,9 +437,8 @@ namespace OrchardCore.ContentManagement.Drivers.Coordinators
             {
                 var partName = typePartDefinition.PartDefinition.Name;
                 var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
 
-                if (part != null)
+                if (context.ContentItem.Get(activator.Type, typePartDefinition.Name) is ContentPart part)
                 {
                     await _partHandlers.InvokeAsync(handler => handler.CloningAsync(context, part), Logger);
                 }


### PR DESCRIPTION
* The passed content handlers enumerable is already an array, which is the most efficient to traverse, no need to allocate to materialize
* Created overload to InvokeAsync and and new InvokeReversedAsync that accepts array, no need to get slower enumerator which also allocates
* Kept to public IEnumerable properties even though they are not used