### PR TITLE
Fixes ToPascalCase

### DIFF
--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -42,7 +42,7 @@
                 <span class="sr-only">{{ "Toggle navigation" | t }}</span>
                 {{ "Menu" | t }} <i class="fa fa-bars"></i>
             </button>
-            {% shape "menu", alias: "alias:main-menu" %}
+            {% shape "menu", alias: "alias:main-menu", cache_id: "main-menu", cache_fixed_duration: "00:05:00", cache_tag: "alias:main-menu" %}
         </div>
     </nav>
     {% render_section "Header", required: false %}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -42,7 +42,7 @@
                 <span class="sr-only">{{ "Toggle navigation" | t }}</span>
                 {{ "Menu" | t }} <i class="fa fa-bars"></i>
             </button>
-            {% shape "menu", alias: "alias:main-menu", cache_id: "main-menu", cache_fixed_duration: "00:05:00", cache_tag: "alias:main-menu" %}
+            {% shape "menu", alias: "alias:main-menu" %}
         </div>
     </nav>
     {% render_section "Header", required: false %}

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -58,7 +58,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
 
             foreach (var name in arguments.Names)
             {
-                properties.Add(name.ToPascalCase('_'), arguments[name].ToObjectValue());
+                properties.Add(name.ToPascalCaseUnderscore(), arguments[name].ToObjectValue());
             }
 
             return FluidValue.Create(await ((IShapeFactory)shapeFactory).CreateAsync(type, Arguments.From(properties)));

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
@@ -94,7 +94,7 @@ namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
 
             foreach (var name in arguments.Names)
             {
-                var propertyName = name.ToPascalCase('_');
+                var propertyName = name.ToPascalCaseUnderscore();
 
                 var found = false;
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapePagerTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapePagerTag.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
                     foreach (var name in arguments.Names)
                     {
                         var argument = arguments[name];
-                        var propertyName = name.ToPascalCase('_');
+                        var propertyName = name.ToPascalCaseUnderscore();
 
                         if (_properties.Contains(propertyName))
                         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/IShapeFactory.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/IShapeFactory.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.DisplayManagement
         {
             return factory.CreateAsync(shapeType, Arguments.From(model));
         }
-        
+
         private static IShape CreateShape(Type baseType)
         {
             // Don't generate a proxy for shape types
@@ -95,10 +95,10 @@ namespace OrchardCore.DisplayManagement
             });
         }
 
-        public static Task<IShape> CreateAsync(this IShapeFactory factory, string shapeType, INamedEnumerable<object> parameters = null)
+        public static Task<IShape> CreateAsync<T>(this IShapeFactory factory, string shapeType, INamedEnumerable<T> parameters = null)
         {
-            return factory.CreateAsync(shapeType, NewShape, null, createdContext => {
-
+            return factory.CreateAsync(shapeType, NewShape, null, createdContext =>
+            {
                 var shape = (Shape)createdContext.Shape;
 
                 // If only one non-Type, use it as the source object to copy

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
-
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-
 using OrchardCore.Mvc.Utilities;
 
 namespace OrchardCore.DisplayManagement.TagHelpers

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
@@ -45,7 +45,7 @@ namespace OrchardCore.DisplayManagement.TagHelpers
             {
                 if (!InternalProperties.Contains(pair.Name))
                 {
-                    properties[pair.Name.ToPascalCase('-')] = pair.Value.ToString();
+                    properties[pair.Name.ToPascalCaseDash()] = pair.Value.ToString();
                 }
             }
 

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net;
+using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -380,6 +381,59 @@ namespace OrchardCore.Mvc.Utilities
             return source.Remove(place, find.Length).Insert(place, replace);
         }
 
+        private static Dictionary<string, string> _underscorePascalCaseIndex = new Dictionary<string, string>();
+        private static Dictionary<string, string> _dashPascalCaseIndex = new Dictionary<string, string>();
+        private static object _synLock = new object();
+
+        /// <summary>
+        /// Converts a liquid attribute to pascal case
+        /// </summary>
+        public static string ToPascalCaseUnderscore(this string attribute)
+        {
+            if (_underscorePascalCaseIndex.TryGetValue(attribute, out var result))
+            {
+                return result;
+            }
+
+            lock (_synLock)
+            {
+                result = ToPascalCase(attribute, '_');
+
+                // Clone the dictionary as the existing one can be used by other threads
+
+                _underscorePascalCaseIndex = new Dictionary<string, string>(_underscorePascalCaseIndex);
+                _underscorePascalCaseIndex.Add(attribute, result);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Converts an html attribute to pascal case
+        /// </summary>
+        public static string ToPascalCaseDash(this string attribute)
+        {
+            if (_dashPascalCaseIndex.TryGetValue(attribute, out var result))
+            {
+                return result;
+            }
+
+            lock (_synLock)
+            {
+                result = ToPascalCase(attribute, '-');
+
+                // Clone the dictionary as the existing one can be used by other threads
+
+                _dashPascalCaseIndex = new Dictionary<string, string>(_dashPascalCaseIndex);
+                _dashPascalCaseIndex.Add(attribute, result);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Converts a string to pascal case.
+        /// </summary>
         public static string ToPascalCase(this string attribute, char upperAfterDelimiter)
         {
             var nextIsUpper = true;

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Net;
 using System.Runtime.InteropServices.ComTypes;
@@ -381,28 +382,18 @@ namespace OrchardCore.Mvc.Utilities
             return source.Remove(place, find.Length).Insert(place, replace);
         }
 
-        private static Dictionary<string, string> _underscorePascalCaseIndex = new Dictionary<string, string>();
-        private static Dictionary<string, string> _dashPascalCaseIndex = new Dictionary<string, string>();
-        private static object _synLock = new object();
+        private static ImmutableDictionary<string, string> _underscorePascalCaseIndex = ImmutableDictionary<string, string>.Empty;
+        private static ImmutableDictionary<string, string> _dashPascalCaseIndex = ImmutableDictionary<string, string>.Empty;
 
         /// <summary>
         /// Converts a liquid attribute to pascal case
         /// </summary>
         public static string ToPascalCaseUnderscore(this string attribute)
         {
-            if (_underscorePascalCaseIndex.TryGetValue(attribute, out var result))
-            {
-                return result;
-            }
-
-            lock (_synLock)
+            if (!_underscorePascalCaseIndex.TryGetValue(attribute, out var result))
             {
                 result = ToPascalCase(attribute, '_');
-
-                // Clone the dictionary as the existing one can be used by other threads
-
-                _underscorePascalCaseIndex = new Dictionary<string, string>(_underscorePascalCaseIndex);
-                _underscorePascalCaseIndex.Add(attribute, result);
+                _underscorePascalCaseIndex = _underscorePascalCaseIndex.Add(attribute, result);
             }
 
             return result;
@@ -413,19 +404,10 @@ namespace OrchardCore.Mvc.Utilities
         /// </summary>
         public static string ToPascalCaseDash(this string attribute)
         {
-            if (_dashPascalCaseIndex.TryGetValue(attribute, out var result))
-            {
-                return result;
-            }
-
-            lock (_synLock)
+            if (!_dashPascalCaseIndex.TryGetValue(attribute, out var result))
             {
                 result = ToPascalCase(attribute, '-');
-
-                // Clone the dictionary as the existing one can be used by other threads
-
-                _dashPascalCaseIndex = new Dictionary<string, string>(_dashPascalCaseIndex);
-                _dashPascalCaseIndex.Add(attribute, result);
+                _dashPascalCaseIndex = _dashPascalCaseIndex.Add(attribute, result);
             }
 
             return result;

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -383,22 +383,7 @@ namespace OrchardCore.Mvc.Utilities
         public static string ToPascalCase(this string attribute, char upperAfterDelimiter)
         {
             attribute = attribute.Trim();
-
-            foreach (var c in attribute)
-            {
-                if (c == upperAfterDelimiter)
-                {
-                    return DoPascalCase(attribute, upperAfterDelimiter);
-                }
-            }
-
-            attribute = Char.ToUpperInvariant(attribute[0]) + attribute.Substring(1);
-            //var result = new StringBuilder(attribute.Length);
-            //result.Append(Char.ToUpperInvariant(attribute[0]));
-            //result.Append(attribute, 1, attribute.Length - 1);
-
-            // no need
-            return attribute;// result.ToString();
+            return DoPascalCase(attribute, upperAfterDelimiter);
         }
 
         private static string DoPascalCase(string attribute, char upperAfterDelimiter)

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Net;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -393,7 +392,7 @@ namespace OrchardCore.Mvc.Utilities
             if (!_underscorePascalCaseIndex.TryGetValue(attribute, out var result))
             {
                 result = ToPascalCase(attribute, '_');
-                _underscorePascalCaseIndex = _underscorePascalCaseIndex.Add(attribute, result);
+                _underscorePascalCaseIndex = _underscorePascalCaseIndex.SetItem(attribute, result);
             }
 
             return result;
@@ -407,7 +406,7 @@ namespace OrchardCore.Mvc.Utilities
             if (!_dashPascalCaseIndex.TryGetValue(attribute, out var result))
             {
                 result = ToPascalCase(attribute, '-');
-                _dashPascalCaseIndex = _dashPascalCaseIndex.Add(attribute, result);
+                _dashPascalCaseIndex = _dashPascalCaseIndex.SetItem(attribute, result);
             }
 
             return result;

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -383,6 +383,7 @@ namespace OrchardCore.Mvc.Utilities
         public static string ToPascalCase(this string attribute, char upperAfterDelimiter)
         {
             attribute = attribute.Trim();
+
             foreach (var c in attribute)
             {
                 if (c == upperAfterDelimiter)
@@ -391,8 +392,13 @@ namespace OrchardCore.Mvc.Utilities
                 }
             }
 
+            attribute = Char.ToUpperInvariant(attribute[0]) + attribute.Substring(1);
+            //var result = new StringBuilder(attribute.Length);
+            //result.Append(Char.ToUpperInvariant(attribute[0]));
+            //result.Append(attribute, 1, attribute.Length - 1);
+
             // no need
-            return attribute;
+            return attribute;// result.ToString();
         }
 
         private static string DoPascalCase(string attribute, char upperAfterDelimiter)

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -382,13 +382,8 @@ namespace OrchardCore.Mvc.Utilities
 
         public static string ToPascalCase(this string attribute, char upperAfterDelimiter)
         {
-            attribute = attribute.Trim();
-            return DoPascalCase(attribute, upperAfterDelimiter);
-        }
-
-        private static string DoPascalCase(string attribute, char upperAfterDelimiter)
-        {
             var nextIsUpper = true;
+            attribute = attribute.Trim();
             var result = new StringBuilder(attribute.Length);
             foreach (var c in attribute)
             {


### PR DESCRIPTION
Repro and analysis

- Repro: Using the blog theme the menu shape is not rendered

- The first char of an attribute was not converted to en upper case.

- The wrong `IShapeFactory.CreateAsync` extension was called.

- Also, because most of the time the 1st char of an attribute is a lower case, most of the time we need to do the conversion without having to iterate twice.

Note on perf

- @sebastienros finally the `caching` branch doesn't decrease perf so much (maybe just a little because e.g i'm doing some cloning for thread safety), this was because in the instance i was using there was an additional widget, and i was comparing to the dev branch that was not converting attribute names.

- The `async` branch seems to improve perf a little, i'll redo some tests.

- With the corrected `ToPascalCase` perf are quite the same as before, but tested on my machine so maybe not very precise