### PR TITLE
Lucene indexation : convention on null field values

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Indexing/AspectsContentIndexHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Indexing/AspectsContentIndexHandler.cs
@@ -26,18 +26,16 @@ namespace OrchardCore.Contents.Indexing
                     DocumentIndexOptions.Analyze | DocumentIndexOptions.Sanitize);
             }
 
-            if (context.ContentItem.DisplayText != null)
-            {
-                context.DocumentIndex.Set(
-                    IndexingConstants.DisplayTextAnalyzedKey,
-                    context.ContentItem.DisplayText,
-                    DocumentIndexOptions.Analyze | DocumentIndexOptions.Sanitize);
+            context.DocumentIndex.Set(
+                IndexingConstants.DisplayTextAnalyzedKey,
+                context.ContentItem.DisplayText,
+                DocumentIndexOptions.Analyze | DocumentIndexOptions.Sanitize);
 
-                context.DocumentIndex.Set(
-                    IndexingConstants.DisplayTextKey,
-                    context.ContentItem.DisplayText,
-                    DocumentIndexOptions.Store);
-            }
+            context.DocumentIndex.Set(
+                IndexingConstants.DisplayTextKey,
+                context.ContentItem.DisplayText,
+                DocumentIndexOptions.Store);
+
         }
     }
 }


### PR DESCRIPTION
Fixes #2778

![image](https://user-images.githubusercontent.com/3228637/63230305-e1637880-c1d8-11e9-9750-c48e0ac6b2d0.png)

Here an example of sorting by a numeric field that contains a content item with a NULL value : 

![image](https://user-images.githubusercontent.com/3228637/63231679-5fca1580-c1ed-11e9-9456-0c6ac84b6cf3.png)

By DateTimeField : 

![image](https://user-images.githubusercontent.com/3228637/63231729-00b8d080-c1ee-11e9-99dc-4282cc6fe825.png)

By TimeField

![image](https://user-images.githubusercontent.com/3228637/63231731-0d3d2900-c1ee-11e9-8d42-9aeab9bcfe54.png)

etc ...
