### PR TITLE
Implement IUserClaimStore to enable individual user claims.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Migrations.cs
@@ -27,5 +27,13 @@ namespace OrchardCore.Users
                 .Column<string>("ProviderKey"));
             return 2;
         }
+
+        public int UpdateFrom2()
+        {
+            SchemaBuilder.CreateMapIndexTable(nameof(UserByClaimIndex), table => table
+                .Column<string>(nameof(UserByClaimIndex.ClaimType))
+                .Column<string>(nameof(UserByClaimIndex.ClaimValue)));
+            return 3;
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -80,6 +80,7 @@ namespace OrchardCore.Users
             services.TryAddScoped<IUserEmailStore<IUser>>(sp => sp.GetRequiredService<UserStore>());
             services.TryAddScoped<IUserSecurityStampStore<IUser>>(sp => sp.GetRequiredService<UserStore>());
             services.TryAddScoped<IUserLoginStore<IUser>>(sp => sp.GetRequiredService<UserStore>());
+            services.TryAddScoped<IUserClaimStore<IUser>>(sp => sp.GetRequiredService<UserStore>());
 
             services.ConfigureApplicationCookie(options =>
             {
@@ -101,6 +102,7 @@ namespace OrchardCore.Users
             services.AddSingleton<IIndexProvider, UserIndexProvider>();
             services.AddSingleton<IIndexProvider, UserByRoleNameIndexProvider>();
             services.AddSingleton<IIndexProvider, UserByLoginInfoIndexProvider>();
+            services.AddSingleton<IIndexProvider, UserByClaimIndexProvider>();
             services.AddScoped<IDataMigration, Migrations>();
 
             services.AddScoped<IUserService, UserService>();

--- a/src/OrchardCore/OrchardCore.Users.Core/Indexes/UserByClaimIndex.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Indexes/UserByClaimIndex.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using OrchardCore.Users.Models;
+using YesSql.Indexes;
+
+namespace OrchardCore.Users.Indexes
+{
+    public class UserByClaimIndex : MapIndex
+    {
+        public string ClaimType { get; set; }
+
+        public string ClaimValue { get; set; }
+    }
+
+    public class UserByClaimIndexProvider : IndexProvider<User>
+    {
+        public override void Describe(DescribeContext<User> context)
+        {
+            context.For<UserByClaimIndex>()
+                .Map(user => user.UserClaims.Select(x => new UserByClaimIndex
+                {
+                    ClaimType = x.ClaimType,
+                    ClaimValue = x.ClaimValue,
+                }));
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Users.Core/Models/User.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Models/User.cs
@@ -16,6 +16,7 @@ namespace OrchardCore.Users.Models
         public bool EmailConfirmed { get; set; }
         public string ResetToken { get; set; }
         public IList<string> RoleNames { get; set; } = new List<string>();
+        public IList<UserClaim> UserClaims { get; set; } = new List<UserClaim>();
         public IList<UserLoginInfo> LoginInfos { get; set; } = new List<UserLoginInfo>();
 
         public override string ToString()

--- a/src/OrchardCore/OrchardCore.Users.Core/Models/UserClaim.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Models/UserClaim.cs
@@ -1,0 +1,25 @@
+using System.Security.Claims;
+
+namespace OrchardCore.Users.Models
+{
+    /// <summary>
+    /// Represents a claim that is granted to a specific user.
+    /// </summary>
+    public class UserClaim
+    {
+        /// <summary>
+        /// Gets or sets the claim type for this claim.
+        /// </summary>
+        public string ClaimType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the claim value for this claim.
+        /// </summary>
+        public string ClaimValue { get; set; }
+
+        public Claim ToClaim()
+        {
+            return new Claim(ClaimType, ClaimValue);
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserStore.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserStore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
@@ -15,7 +16,7 @@ using YesSql;
 namespace OrchardCore.Users.Services
 {
     public class UserStore :
-        IUserStore<IUser>,
+        IUserClaimStore<IUser>,
         IUserRoleStore<IUser>,
         IUserPasswordStore<IUser>,
         IUserEmailStore<IUser>,
@@ -441,6 +442,77 @@ namespace OrchardCore.Users.Services
             return Task.CompletedTask;
         }
 
+        #endregion
+
+        #region IUserClaimStore<IUser>
+        public Task<IList<Claim>> GetClaimsAsync(IUser user, CancellationToken cancellationToken)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user));
+            }
+
+            return Task.FromResult<IList<Claim>>(((User)user).UserClaims.Select(x => x.ToClaim()).ToList());
+        }
+
+        public Task AddClaimsAsync(IUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        {
+            if (user == null)
+                throw new ArgumentNullException(nameof(user));
+            if (claims == null)
+                throw new ArgumentNullException(nameof(claims));
+
+            foreach (var claim in claims)
+            {
+                ((User)user).UserClaims.Add(new UserClaim{ClaimType = claim.Type, ClaimValue = claim.Value});
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task ReplaceClaimAsync(IUser user, Claim claim, Claim newClaim, CancellationToken cancellationToken)
+        {
+            if (user == null)
+                throw new ArgumentNullException(nameof(user));
+            if (claim == null)
+                throw new ArgumentNullException(nameof(claim));
+            if (newClaim == null)
+                throw new ArgumentNullException(nameof(newClaim));
+
+            foreach (var userClaim in ((User) user).UserClaims.Where(uc => uc.ClaimValue == claim.Value && uc.ClaimType == claim.Type))
+            {
+                userClaim.ClaimValue = newClaim.Value;
+                userClaim.ClaimType = newClaim.Type;
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveClaimsAsync(IUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        {
+            if (user == null)
+                throw new ArgumentNullException(nameof(user));
+            if (claims == null)
+                throw new ArgumentNullException(nameof(claims));
+
+            foreach (var claim in claims)
+            {
+                foreach (var userClaim in ((User)user).UserClaims.Where(uc => uc.ClaimValue == claim.Value && uc.ClaimType == claim.Type).ToList())
+                    ((User)user).UserClaims.Remove(userClaim);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public async Task<IList<IUser>> GetUsersForClaimAsync(Claim claim, CancellationToken cancellationToken)
+        {
+            if (claim == null)
+                throw new ArgumentNullException(nameof(claim));
+            
+            var users = await _session.Query<User, UserByClaimIndex>(uc => uc.ClaimType == claim.Type && uc.ClaimValue == claim.Value).ListAsync();
+
+            return users.Cast<IUser>().ToList();
+        }
         #endregion
     }
 }


### PR DESCRIPTION
This adds the implementation of the `IUserClaimStore` interface to the `UserStore`. 

I have also added a new map index to index users by claim to implement the [GetUsersForClaim](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.identity.iuserclaimstore-1.getusersforclaimasync?view=aspnetcore-2.2) method.