### PR TITLE
Localization Bugfix

### DIFF
--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -11,7 +11,9 @@
 
   <ItemGroup>
     <Folder Include="wwwroot\" />
-    <Folder Include="Localization\" />
+    <Content Include="Localization\**" >
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Localization/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/README.md
@@ -26,6 +26,21 @@ PO files are found at these locations:
 It is suggested to put your localization files in the `/Localization/` folder if you are using docker. 
 Especially if mounting a volume at `/App_Data/` as mounting hides pre-existing files.
 
+### Publishing Localization files
+
+The PO files need to be included in the publish output directory. 
+Add the following configurations to your `[Web Project].csproj` file to include them as Content.
+
+``` xml
+  <ItemGroup>
+    <Content Include="Localization\**" >
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+```
+
+
+
 ## Recipe Step
 Cultures can be added during recipes using the settings step. Here is a sample step:
 

--- a/src/OrchardCore.Modules/OrchardCore.Setup/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/ModularPoFileLocationProvider.cs
@@ -46,35 +46,25 @@ namespace OrchardCore.Setup
             // Load .po files in each extension folder first, based on the extensions order
             foreach (var extension in extensions)
             {
-                yield return _fileProvider.GetFileInfo(PathExtensions.Combine(extension.SubPath, ExtensionDataFolder, _resourcesContainer, poFileName));
-                // Localization folder out of App_Data
+                // From [Extension]/Localization
                 yield return _fileProvider.GetFileInfo(PathExtensions.Combine(extension.SubPath, _resourcesContainer, poFileName));
             }
 
-            // Then load global .po file for the applications from the App_Data folder
-            yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, poFileName)));
-            // Then load global .po files in the Localization folder outside of App_Data
+            // Load global .po files from /Localization
             yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_resourcesContainer, poFileName));
 
-            // Load tenant-specific .po file
+            // Load tenant-specific .po file from /App_Data/Sites/[Tenant]/Localization
             yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_shellDataContainer, _resourcesContainer, poFileName)));
 
             // Load each modules .po file for extending localization when using Orchard Core as a Nuget package
             foreach (var extension in extensions)
             {
-                // \src\OrchardCore.Cms.Web\App_Data\Localization\OrchardCore.Cms.Web\fr-CA.po
-                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id, poFileName)));
-
-                // \src\OrchardCore.Cms.Web\App_Data\Localization\OrchardCore.Cms.Web-fr-CA.po
-                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, extension.Id + CultureDelimiter + poFileName)));
-
-                // \src\OrchardCore.Cms.Web\App_Data\Localization\fr-CA\OrchardCore.Cms.Web.po
-                yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_applicationDataContainer, _resourcesContainer, cultureName, extension.Id + PoFileExtension)));
-
                 // \src\OrchardCore.Cms.Web\Localization\OrchardCore.Cms.Web\fr-CA.po
                 yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_resourcesContainer, extension.Id, poFileName));
+
                 // \src\OrchardCore.Cms.Web\Localization\OrchardCore.Cms.Web-fr-CA.po
                 yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_resourcesContainer, extension.Id + CultureDelimiter + poFileName));
+
                 // \src\OrchardCore.Cms.Web\Localization\fr-CA\OrchardCore.Cms.Web.po
                 yield return _fileProvider.GetFileInfo(PathExtensions.Combine(_resourcesContainer, cultureName, extension.Id + PoFileExtension));
             }


### PR DESCRIPTION
I forgot to copy the `ModularPoFileLocationProvider.cs` version which removes the App_Data paths to the OrchardCore.Setup project. 

I also noticed that the po files are not properly being included when using publish. I added them as <Content> in the csproj