### PR TITLE
Add liquid example for ContentCulturePicker

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Liquid/ContentCulturePickerUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Liquid/ContentCulturePickerUrlFilter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Values;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using OrchardCore.Liquid;
+
+namespace OrchardCore.ContentLocalization.Liquid
+{
+    public class ContentCulturePickerUrlFilter : ILiquidFilter
+    {
+        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        {
+            if (!ctx.AmbientValues.TryGetValue("UrlHelper", out var urlHelperObj))
+            {
+                throw new ArgumentException("UrlHelper missing while invoking 'signal_url'");
+            }
+
+            var targetCulture = input.ToStringValue();
+            var urlHelper = (IUrlHelper)urlHelperObj;
+            var request = (HttpRequest)ctx.GetValue("Request").ToObjectValue();
+            var url = urlHelper.Action("RedirectToLocalizedContent",
+                "ContentculturePicker",
+                new
+                {
+                    area = "OrchardCore.ContentLocalization",
+                    targetculture = targetCulture,
+                    contentItemUrl = request.Path,
+                });
+            return new ValueTask<FluidValue>(FluidValue.Create(url));
+         }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Liquid/RemoveCultureFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Liquid/RemoveCultureFilter.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Values;
+using OrchardCore.ContentLocalization.ViewModels;
+using OrchardCore.Liquid;
+
+namespace OrchardCore.ContentLocalization.Liquid
+{
+    public class RemoveCultureFilter : ILiquidFilter
+    {
+        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
+        {
+            var cultureName = arguments["cultureName"]?.ToStringValue();
+            if (string.IsNullOrEmpty(cultureName))
+            {
+                throw new ArgumentException("(remove_culture_by_name) You must supply a cultureName argument");
+            }
+            
+
+            if (input == null || input.Type != FluidValues.Array)
+            {
+                throw new ArgumentException("(remove_culture_by_name) Input must be a list of CultureInfo objects");
+            }
+
+            var cultures = input.Enumerate().Select(x=>(CultureViewModel)x.ToObjectValue()).ToList();
+            return new ValueTask<FluidValue>(FluidValue.Create(cultures.Where(entry => !string.Equals(entry.Name, cultureName, StringComparison.OrdinalIgnoreCase))));
+         }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/README.md
@@ -16,7 +16,7 @@ Enabling this module results in
 
 -   A `ContentRequestCultureProvider` being added as the first method used to determine the current thread culture.
     This Provider will set the thread culture based on the ContentItem that matches the current url.
--   3 shapes (described below) are available to the frontend theme.
+-   2 shapes (described below) are available to the frontend theme.
 
 The ContentculturePicker selects the url to redirect using the following rules
 
@@ -24,15 +24,14 @@ The ContentculturePicker selects the url to redirect using the following rules
 -   OR If a HomePage is specified, attempts to find a Localization of the Homepage `ContentItem` for the current culture.
 -   OR redirects to the current page.
 
-### Setting the cookie
+### Localization Cookie
 
-To disable setting the Culture cookie when switching cultures, a setting exists under the
-`Configuration/Settings/ContentCulturePicker` admin menu.
+By default, the ContentCulturePicker sets a cookie for the `CookieRequestCultureProvider`. This can be disabled in the  `Configuration/Settings/ContentCulturePicker` settings page.
 
 #### Recipe Step
 The cookie can be set during recipes using the settings step. Here is a sample step:
 
-``` json
+```json
 {
   "name": "settings",
   "ContentCulturePickerSettings": {
@@ -45,62 +44,91 @@ The cookie can be set during recipes using the settings step. Here is a sample s
 
 #### `ContentCulturePicker`
 
-The `ContentCulturePicker` shape loads data for the ContentCulturePickerContainer shape.
+The `ContentCulturePicker` shape loads data for the ContentCulturePickerContainer shape. 
+You should always render this shape. in your theme. `{% shape "ContentCulturePicker" %}`
 
 #### `ContentCulturePickerContainer`
 
-The `ContentCulturePickerContainer` shape is used to render the CulturePicker.
+The `ContentCulturePickerContainer` shape is used to render the CulturePicker. 
+You should override this shape in your theme.
 
 | Property                  | Description                                                 |
 | ------------------------- | ----------------------------------------------------------- |
-| `Model.CurrentCulture`    | CultureInfo object representing the current thread culture. |
-| `Model.SupportedCultures` | A list of CultureInfo objects for all supported cultures.   |
+| `Model.CurrentCulture`    | CultureViewModel {Name, DisplayName} representing the current thread culture. |
+| `Model.SupportedCultures` | A list of CultureViewModel objects for all supported cultures.   |
 
 ##### ContentCulturePickerContainer Example
 
 ```liquid
-TODO
-```
-
-```razor
-@using System.Globalization
-
+{% assign otherCultures = Model.SupportedCultures | remove_culture: cultureName: Model.CurrentCulture.Name %}
 <ul>
     <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="oc-culture-picker" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">@Model.CurrentCulture.DisplayName</a>
+        <a class="nav-link dropdown-toggle" href="#" id="oc-culture-picker" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{Model.CurrentCulture.DisplayName}}</a>
         <div class="dropdown-menu" aria-labelledby="oc-culture-picker">
-            @foreach (var culture in ((IEnumerable<CultureInfo>)Model.SupportedCultures).Where(entry => !string.Equals(entry.Name, Model.CurrentCulture.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-            @await DisplayAsync(await New.ContentCulturePickerLink(
-               Culture: culture
-            ))
-            }
+            {% for culture in otherCultures %}
+                <a class="dropdown-item" href="{{culture.Name | content_culture_picker_url}}">{{culture.DisplayName}}</a
+            {% endfor %}
         </div>
     </li>
 </ul>
 
 ```
 
-#### `ContentCulturePickerLink`
-
-The `ContentCulturePickerRender` shape is used to render the CulturePicker
-
-| Property  | Description                                              |
-| --------- | -------------------------------------------------------- |
-| `Culture` | CultureInfo object representing the link target culture. |
-
-##### ContentCulturePickerLink Example
-
-```liquid
-TODO
+```razor
+@{ 
+    var otherCultures = ((IEnumerable<CultureViewModel>)Model.SupportedCultures).Where(entry => !string.Equals(entry.Name, Model.CurrentCulture.Name, StringComparison.OrdinalIgnoreCase));
+}
+<ul>
+    <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="oc-culture-picker" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">@Model.CurrentCulture.DisplayName</a>
+        <div class="dropdown-menu" aria-labelledby="oc-culture-picker">
+            @foreach (var culture in otherCultures)
+            {
+                <a asp-action="RedirectToLocalizedContent"
+                   asp-controller="ContentculturePicker"
+                   asp-route-area="OrchardCore.ContentLocalization"
+                   asp-route-targetculture="@culture.Name"
+                   asp-route-contentItemUrl="@Context.Request.Path"
+                   class="dropdown-item">@culture.DisplayName</a>
+            }
+        </div>
+    </li>
+</ul>
 ```
 
-```razor
-<a asp-action="RedirectToLocalizedContent"
-   asp-controller="ContentculturePicker"
-   asp-route-area="OrchardCore.ContentLocalization"
-   asp-route-targetculture="@Model.Culture.Name"
-   asp-route-contentItemUrl="@Context.Request.Path"
-   asp-route-queryString="@Context.Request.QueryString"
-   class="dropdown-item">@Model.Culture.DisplayName</a>
+## Liquid filters
+
+### `remove_culture`
+
+Removes a culture from a list of CultureViewModel. Assuming the following model:
+
+```text
+SupportedCultures = [{Name="fr", DisplayName="Français"}, {Name="en", DisplayName="English"}]
+Currentculture = {Name="fr", DisplayName="Français"}
+```
+
+Input
+```liquid
+{{ Model.SupportedCultures | remove_culture: cultureName: Model.CurrentCulture.Name }}
+```
+
+Output
+
+```text
+[ {Name="en", DisplayName="English"}]
+```
+### `content_culture_picker_url`
+
+Returns the URL of the `ContentCulturePicker` Action method.
+
+Input
+
+```liquid
+{{ Model.Culture.Name | content_culture_picker_url }}
+```
+
+Output
+
+```text
+/Loc1/RedirectToLocalizedContent?targetculture=fr&contentItemUrl=%2Fblog
 ```

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentLocalization.Drivers;
 using OrchardCore.ContentLocalization.Handlers;
 using OrchardCore.ContentLocalization.Indexing;
+using OrchardCore.ContentLocalization.Liquid;
 using OrchardCore.ContentLocalization.Models;
 using OrchardCore.ContentLocalization.Records;
 using OrchardCore.ContentLocalization.Security;
@@ -17,6 +18,7 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Indexing;
+using OrchardCore.Liquid;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
@@ -81,6 +83,19 @@ namespace OrchardCore.ContentLocalization
                 LocalizationSet = i.LocalizationSet,
                 Culture = i.Culture.ToLowerInvariant()
             }));
+        }
+    }
+    [RequireFeatures("OrchardCore.Liquid")]
+    public class LocalizationLiquidStartup : StartupBase
+    {
+        static LocalizationLiquidStartup()
+        {
+            TemplateContext.GlobalMemberAccessStrategy.Register<CultureViewModel>();
+        }
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddLiquidFilter<RemoveCultureFilter>("remove_culture");
+            services.AddLiquidFilter<ContentCulturePickerUrlFilter>("content_culture_picker_url");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/ViewModels/CultureViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/ViewModels/CultureViewModel.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace OrchardCore.ContentLocalization.ViewModels
+{
+   public class CultureViewModel
+    {
+        public string Name { get; set; }
+        public string DisplayName { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePicker.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePicker.cshtml
@@ -9,6 +9,11 @@
 }
 
 @await DisplayAsync(await New.ContentCulturePickerContainer(
-    CurrentCulture: currentCulture,
-    SupportedCultures: supportedCultures.Select(c => CultureInfo.GetCultureInfo(c))
-))
+    CurrentCulture: new CultureViewModel() { Name = currentCulture.Name, DisplayName = currentCulture.DisplayName },
+    SupportedCultures: supportedCultures.Select(c =>
+        {
+            var x = CultureInfo.GetCultureInfo(c);
+            return new CultureViewModel() { Name = x.Name, DisplayName = x.DisplayName };
+        }
+    )
+));

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePickerContainer.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePickerContainer.cshtml
@@ -1,14 +1,19 @@
-@using System.Globalization
-
+@{ 
+    var otherCultures = ((IEnumerable<CultureViewModel>)Model.SupportedCultures).Where(entry => !string.Equals(entry.Name, Model.CurrentCulture.Name, StringComparison.OrdinalIgnoreCase));
+}
 <ul>
     <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="oc-culture-picker" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">@Model.CurrentCulture.DisplayName</a>
         <div class="dropdown-menu" aria-labelledby="oc-culture-picker">
-            @foreach (var culture in ((IEnumerable<CultureInfo>)Model.SupportedCultures).Where(entry => !string.Equals(entry.Name, Model.CurrentCulture.Name, StringComparison.OrdinalIgnoreCase)))
+            @foreach (var culture in otherCultures)
             {
-                @await DisplayAsync(await New.ContentCulturePickerLink(
-                   Culture: culture
-                ))
+                <a asp-action="RedirectToLocalizedContent"
+                   asp-controller="ContentculturePicker"
+                   asp-route-area="OrchardCore.ContentLocalization"
+                   asp-route-targetculture="@culture.Name"
+                   asp-route-contentItemUrl="@Context.Request.Path"
+                   class="dropdown-item">@culture.DisplayName</a>
+
             }
         </div>
     </li>

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePickerLink.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePickerLink.cshtml
@@ -1,6 +1,0 @@
-<a asp-action="RedirectToLocalizedContent"
-   asp-controller="ContentculturePicker"
-   asp-route-area="OrchardCore.ContentLocalization"
-   asp-route-targetculture="@Model.Culture.Name"
-   asp-route-contentItemUrl="@Context.Request.Path"
-   class="dropdown-item">@Model.Culture.DisplayName</a>


### PR DESCRIPTION
fixes #4095 
- Refactored to use a CultureViewModel instead of the CultureInfo object
- Added 2 liquid filters to support the liquid ContentCulturePicker
- Removed the ContentculturePickerLink shape.
  it felt unnessesary as most will override the container.