### PR TITLE
Add support for typed shape tag helper properties

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
                 var allNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { property.Name };
                 var htmlAttribute = property.GetCustomAttribute<HtmlAttributeNameAttribute>();
 
-                if (htmlAttribute != null)
+                if (htmlAttribute != null && htmlAttribute.Name != null)
                 {
                     allNames.Add(htmlAttribute.Name.Replace('-', '_'));
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/ShapeTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/ShapeTagHelper.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 namespace OrchardCore.DisplayManagement.TagHelpers
 {
     [HtmlTargetElement("shape", Attributes = nameof(Type))]
+    [HtmlTargetElement("shape", Attributes = PropertyPrefix + "*")]
     public class ShapeTagHelper : BaseShapeTagHelper
     {
         public ShapeTagHelper(IShapeFactory shapeFactory, IDisplayHelper displayHelper)


### PR DESCRIPTION
With this PR we can use the shape tag helper this way:

```csharp
@{ 
    var intValue = 1;
    var stringValue = "a";
}

@await DisplayAsync(await New.MyShape(Foo: 1, Bar: "a"))

<shape type="MyShape" foo="1" bar="a" />

<shape type="MyShape" prop-foo="1" bar="a" />

<shape type="MyShape" prop-foo="@intValue" prop-bar="@stringValue" />
```

And the shape will keep the properties with the variable type instead of converting them to `IHtmlContent`.