### PR TITLE
Fixes Pager in the home page

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutorouteRoute.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutorouteRoute.cs
@@ -55,7 +55,7 @@ namespace OrchardCore.Autoroute.Routing
                 {
                     foreach (var entry in context.Values)
                     {
-                        if (entry.Key == _options.ContentItemIdKey)
+                        if (String.Equals(entry.Key, _options.ContentItemIdKey, StringComparison.OrdinalIgnoreCase))
                         {
                             continue;
                         }

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/HomePageRoute.cs
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/HomePageRoute.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.WebUtilities;
 using OrchardCore.Settings;
 
 namespace OrchardCore.HomeRoute
@@ -48,7 +49,20 @@ namespace OrchardCore.HomeRoute
                 }
             }
 
-            return new VirtualPathData(_target, "/");
+            var path = "/";
+
+            if (context.Values.Count > homeRoute.Count)
+            {
+                foreach (var entry in context.Values)
+                {
+                    if (!homeRoute.ContainsKey(entry.Key))
+                    {
+                        path = QueryHelpers.AddQueryString(path, entry.Key, entry.Value.ToString());
+                    }
+                }
+            }
+
+            return new VirtualPathData(_target, path);
         }
     }
 }


### PR DESCRIPTION
Fixes #4110 

Todo: Fix it in the 3.0 branch.

Note: Yes, before it was working but only through AutoRoute and when using the pager under the home page the generated url was not still the home page e.g `/blog?after=...`, this is now fixed.