### PR TITLE
Append --source https://api.nuget.org/v3/index.json when using develo…

### DIFF
--- a/src/docs/guides/create-modular-application-mvc/index.md
+++ b/src/docs/guides/create-modular-application-mvc/index.md
@@ -43,7 +43,7 @@ From the root of the folder containing both projects, run this command:
 `dotnet run --project .\MySite\MySite.csproj`
 
 !!! note
-    If you are using the development branch of the templates, run `dotnet restore .\MySite\MySite.csproj --source https://www.myget.org/F/orchardcore-preview/api/v3/index.json` before running the application
+    If you are using the development branch of the templates, run `dotnet restore .\MySite\MySite.csproj --source https://www.myget.org/F/orchardcore-preview/api/v3/index.json --source https://api.nuget.org/v3/index.json` before running the application
 
 Your application should now be running and contain the open ports:
 


### PR DESCRIPTION
…pment branch

Without appending the standard v3 nuget source I was getting this error when restoring from the development branch:

> error NU1101: Unable to find package NodaTime. No packages exist with this id in source(s): https://www.myget.org/F/orchardcore-preview/api/v3/index.json