### PR TITLE
Add Properties Dictionary to IShape interface

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/IShape.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/IShape.cs
@@ -3,17 +3,17 @@ using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.DisplayManagement
 {
-	/// <summary>
-	/// Interface present on dynamic shapes.
-	/// May be used to access attributes in a strongly typed fashion.
-	/// Note: Anything on this interface is a reserved word for the purpose of shape properties
-	/// </summary>
-	public interface IShape
-	{
-		ShapeMetadata Metadata { get; }
-		string Id { get; set; }
-		IList<string> Classes { get; }
-		IDictionary<string, string> Attributes { get; }
+    /// <summary>
+    /// Interface present on dynamic shapes.
+    /// May be used to access attributes in a strongly typed fashion.
+    /// Note: Anything on this interface is a reserved word for the purpose of shape properties
+    /// </summary>
+    public interface IShape
+    {
+        ShapeMetadata Metadata { get; }
+        string Id { get; set; }
+        IList<string> Classes { get; }
+        IDictionary<string, string> Attributes { get; }
         IDictionary<object, object> Properties { get; }
 	}
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/IShape.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/IShape.cs
@@ -14,6 +14,6 @@ namespace OrchardCore.DisplayManagement
         string Id { get; set; }
         IList<string> Classes { get; }
         IDictionary<string, string> Attributes { get; }
-        IDictionary<object, object> Properties { get; }
+        IDictionary<string, object> Properties { get; }
 	}
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/IShape.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/IShape.cs
@@ -14,5 +14,6 @@ namespace OrchardCore.DisplayManagement
 		string Id { get; set; }
 		IList<string> Classes { get; }
 		IDictionary<string, string> Attributes { get; }
+        IDictionary<object, object> Properties { get; }
 	}
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/PositionWrapper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/PositionWrapper.cs
@@ -19,9 +19,10 @@ namespace OrchardCore.DisplayManagement
 
 		public IDictionary<string, string> Attributes { get; }
 
-        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
+        private Dictionary<string, object> _properties;
+        public IDictionary<string, object> Properties => _properties = _properties ?? new Dictionary<string, object>();
 
-		public PositionWrapper(IHtmlContent value, string position)
+        public PositionWrapper(IHtmlContent value, string position)
         {
             _value = value;
             Position = position;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/PositionWrapper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/PositionWrapper.cs
@@ -19,6 +19,8 @@ namespace OrchardCore.DisplayManagement
 
 		public IDictionary<string, string> Attributes { get; }
 
+        public IDictionary<object, object> Properties { get; } = new Dictionary<object, object>();
+
 		public PositionWrapper(IHtmlContent value, string position)
         {
             _value = value;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/Composite.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/Composite.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.DisplayManagement.Shapes
 {
     public class Composite : DynamicObject
     {
-        protected readonly Dictionary<object, object> _props = new Dictionary<object, object>();
+        protected readonly Dictionary<string, object> _properties = new Dictionary<string, object>();
 
         public override bool TryGetMember(GetMemberBinder binder, out object result)
         {
@@ -16,7 +16,7 @@ namespace OrchardCore.DisplayManagement.Shapes
 
         protected virtual bool TryGetMemberImpl(string name, out object result)
         {
-            if (_props.TryGetValue(name, out result))
+            if (_properties.TryGetValue(name, out result))
             {
                 return true;
             }
@@ -32,7 +32,7 @@ namespace OrchardCore.DisplayManagement.Shapes
 
         protected virtual bool TrySetMemberImpl(string name, object value)
         {
-            _props[name] = value;
+            _properties[name] = value;
             return true;
         }
 
@@ -66,53 +66,50 @@ namespace OrchardCore.DisplayManagement.Shapes
 
         public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
         {
-            if (indexes.Length != 1)
+            if (indexes.Length == 1)
             {
-                return base.TryGetIndex(binder, indexes, out result);
+                var stringIndex = indexes[0] as string;
+
+                if (stringIndex != null && TryGetMemberImpl(stringIndex, out result))
+                {
+                    return true;
+                }
+                else
+                {
+                    // Returning false results in a RuntimeBinderException if the index supplied is not an existing string property name.
+                    result = null;
+                    return false;
+                }
             }
-
-            var index = indexes.First();
-
-            if (_props.TryGetValue(index, out result))
-            {
-                return true;
-            }
-
-            // try to access an existing member
-            var strinIndex = index as string;
-
-            if (strinIndex != null && TryGetMemberImpl(strinIndex, out result))
-            {
-                return true;
-            }
-
-            return base.TryGetIndex(binder, indexes, out result);
+            // Returning false results in a RuntimeBinderException if the index supplied is not an existing string property name.
+            result = null;
+            return false;
         }
 
         public override bool TrySetIndex(SetIndexBinder binder, object[] indexes, object value)
         {
-            if (indexes.Length != 1)
+            if (indexes.Length == 1)
             {
-                return base.TrySetIndex(binder, indexes, value);
+                // try to access an existing member.
+                var stringIndex = indexes[0] as string;
+
+                if (stringIndex != null && TrySetMemberImpl(stringIndex, value))
+                {
+                    return true;
+                }
+                else
+                {
+                    // Returning false results in a RuntimeBinderException if the index supplied is not an existing string property name.
+                    return false;
+                }
             }
-
-            var index = indexes[0];
-
-            // try to access an existing member
-            var strinIndex = index as string;
-
-            if (strinIndex != null && TrySetMemberImpl(strinIndex, value))
-            {
-                return true;
-            }
-
-            _props[indexes[0]] = value;
-            return true;
+            // Returning false results in a RuntimeBinderException if the index supplied is not an existing string property name.
+            return false;
         }
 
-        public IDictionary<object, object> Properties
+        public IDictionary<string, object> Properties
         {
-            get { return _props; }
+            get { return _properties; }
         }
 
         public static bool operator ==(Composite a, Nil b)
@@ -127,7 +124,7 @@ namespace OrchardCore.DisplayManagement.Shapes
 
         protected bool Equals(Composite other)
         {
-            return Equals(_props, other._props);
+            return Equals(_properties, other._properties);
         }
 
         public override bool Equals(object obj)
@@ -149,7 +146,7 @@ namespace OrchardCore.DisplayManagement.Shapes
 
         public override int GetHashCode()
         {
-            return (_props != null ? _props.GetHashCode() : 0);
+            return (_properties != null ? _properties.GetHashCode() : 0);
         }
     }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeDebugView.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeDebugView.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.DisplayManagement.Shapes
             get
             {
                 return _shape.Properties
-                    .Cast<KeyValuePair<object,object>>()
+                    .Cast<KeyValuePair<string, object>>()
                     .Select(entry => new KeyValuePairs(entry.Key, entry.Value))
                     .ToArray();
             }
@@ -36,7 +36,7 @@ namespace OrchardCore.DisplayManagement.Shapes
         [DebuggerDisplay(" { _shapeType == null ? _value : \"Shape: \" + _shapeType}", Name = "{_key,nq}")]
         public class KeyValuePairs
         {
-            public KeyValuePairs(object key, object value)
+            public KeyValuePairs(string key, object value)
             {
                 if (_value is IShape)
                 {
@@ -48,7 +48,7 @@ namespace OrchardCore.DisplayManagement.Shapes
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-            private object _key;
+            private string _key;
 
             [DebuggerBrowsable(DebuggerBrowsableState.Never)]
             private object _shapeType;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeViewModel.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeViewModel.cs
@@ -37,7 +37,7 @@ namespace OrchardCore.DisplayManagement.Views
         private Dictionary<string, string> _attributes;
         public IDictionary<string, string> Attributes => _attributes = _attributes ?? new Dictionary<string, string>();
 
-        private Dictionary<object, object> _properties;
-        public IDictionary<object, object> Properties => _properties = _properties ?? new Dictionary<object, object>();
+        private Dictionary<string, object> _properties;
+        public IDictionary<string, object> Properties => _properties = _properties ?? new Dictionary<string, object>();
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeViewModel.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeViewModel.cs
@@ -36,5 +36,8 @@ namespace OrchardCore.DisplayManagement.Views
 
         private Dictionary<string, string> _attributes;
         public IDictionary<string, string> Attributes => _attributes = _attributes ?? new Dictionary<string, string>();
+
+        private Dictionary<object, object> _properties;
+        public IDictionary<object, object> Properties => _properties = _properties ?? new Dictionary<object, object>();
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
@@ -97,31 +97,6 @@ namespace OrchardCore.DisplayManagement.Zones
             ((dynamic)_parent)[name] = value;
             return true;
         }
-
-        public override bool TryGetIndex(System.Dynamic.GetIndexBinder binder, object[] indexes, out object result)
-        {
-
-            if (indexes.Count() == 1)
-            {
-                var key = Convert.ToString(indexes.First());
-
-                return TryGetMemberImpl(key, out result);
-            }
-
-            return base.TryGetIndex(binder, indexes, out result);
-        }
-
-        public override bool TrySetIndex(System.Dynamic.SetIndexBinder binder, object[] indexes, object value)
-        {
-            if (indexes.Count() == 1)
-            {
-                var key = Convert.ToString(indexes.First());
-
-                return TrySetMemberImpl(key, value);
-            }
-
-            return base.TrySetIndex(binder, indexes, value);
-        }
     }
 
     /// <remarks>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/3371

Adds the dictionary to the interface, and as a consequence to the `PositionWrapper` and `ShapeViewModel`. Which then gets proxied nicely to a shapes ViewModel proxy.

You can use it in, for example a `Content` template to pass something to the underlying template
```
@{
    var shape = Model.Content.Named("MarkdownBodyPart");
    shape?.Properties.Add("foo", "bar");
}
```

NOTE : Using the existing Dictionary from `Composite` exposes the `_props` dictionary that holds the dynamic objects, so they now get exposed too, e.g. for a default shape
- `Parent`
- `ZoneName`

So if that isn't a great idea, we could create another Dictionary, like `Data` to hold these properties.

Thought I'd check on that first?

And maybe then need to update some of the shape tag helpers / liquid filters to allow them to write something to the properties dictionary
 