### PR TITLE
Some menu tweaks

### DIFF
--- a/src/OrchardCore/OrchardCore.Navigation.Core/NavigationHelper.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/NavigationHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Routing;
 
@@ -72,7 +73,9 @@ namespace OrchardCore.Navigation
             MarkAsSelectedIfMatchesRouteOrUrl(menuItem, menuItemShape, viewContext);
 
             foreach (var className in menuItem.Classes)
+            {
                 menuItemShape.Classes.Add(className);
+            }
 
             return menuItemShape;
         }
@@ -83,23 +86,19 @@ namespace OrchardCore.Navigation
             bool match = menuItem.RouteValues != null && RouteMatches(menuItem.RouteValues, viewContext.RouteData.Values);
 
             // if route match failed, try comparing URL strings, if
-            if (!match && !String.IsNullOrWhiteSpace(menuItem.Href) && menuItem.Href != "#")
+            if (!match && !String.IsNullOrWhiteSpace(menuItem.Href) && menuItem.Href[0] == '/')
             {
-                string url = menuItem.Href;
-                if (menuItem.Href.Contains("~/"))
+                PathString path = menuItem.Href.TrimEnd('/');
+
+                if (viewContext.HttpContext.Request.PathBase.HasValue)
                 {
-                    url = url.Replace("~/", viewContext.HttpContext.Request.PathBase);
-                }
-                else
-                {
-                    if(viewContext.HttpContext.Request.PathBase != null)
+                    if (path.StartsWithSegments(viewContext.HttpContext.Request.PathBase, StringComparison.OrdinalIgnoreCase, out var remaining))
                     {
-                        url = menuItem.Href.Replace(viewContext.HttpContext.Request.PathBase, "");
+                        path = remaining;
                     }
-                    
                 }
 
-                match = viewContext.HttpContext.Request.Path.Equals(url, StringComparison.OrdinalIgnoreCase);
+                match = viewContext.HttpContext.Request.Path.StartsWithSegments(path, StringComparison.OrdinalIgnoreCase);
             }
 
             menuItemShape.Selected = match;
@@ -199,7 +198,4 @@ namespace OrchardCore.Navigation
             return result;
         }
     }
-
-
-
 }

--- a/src/OrchardCore/OrchardCore.Navigation.Core/NavigationManager.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/NavigationManager.cs
@@ -203,10 +203,7 @@ namespace OrchardCore.Navigation
                 url = _urlHelper.RouteUrl(new UrlRouteContext { Values = routeValueDictionary });
             }
 
-            if (!string.IsNullOrEmpty(url) &&
-                actionContext?.HttpContext != null &&
-                url[0] != '/' && url[0] != '#' &&
-                !Schemes.Any(scheme => url.StartsWith(scheme + ":")))
+            if (!string.IsNullOrEmpty(url) && url[0] != '/' && url[0] != '#' && !Schemes.Any(scheme => url.StartsWith(scheme + ":")))
             {
                 if (url.StartsWith("~/"))
                 {

--- a/src/OrchardCore/OrchardCore.Navigation.Core/NavigationManager.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/NavigationManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -204,28 +205,15 @@ namespace OrchardCore.Navigation
 
             if (!string.IsNullOrEmpty(url) &&
                 actionContext?.HttpContext != null &&
-                !(url.StartsWith("/") ||
-                Schemes.Any(scheme => url.StartsWith(scheme + ":"))))
+                url[0] != '/' && url[0] != '#' &&
+                !Schemes.Any(scheme => url.StartsWith(scheme + ":")))
             {
                 if (url.StartsWith("~/"))
                 {
-                    if (!String.IsNullOrEmpty(_shellSettings.RequestUrlPrefix))
-                    {
-                        url = _shellSettings.RequestUrlPrefix + "/" + url.Substring(2);
-                    }
-                    else
-                    {
-                        url = url.Substring(2);
-                    }
+                    url = url.Substring(2);
                 }
 
-                if (!url.StartsWith("#"))
-                {
-                    var appPath = actionContext.HttpContext.Request.PathBase.ToString();
-                    if (appPath == "/")
-                        appPath = "";
-                    url = appPath + "/" + url;
-                }
+                url = actionContext.HttpContext.Request.PathBase + new PathString("/" + url);
             }
 
             return url;


### PR DESCRIPTION
Fixes #3431, at least partially.

- When the path of the **current page exactly matches** the url of an admin menu item, it is selected. So, just because e.g you can follow different paths in the admin tree to finally edit the same content item, to keep the same admin menu selection we would have to memorize the selected menu item so that when there is no new match we would still use the previous selection.

 - So here, at least i use a simple url convention by checking if the path of the **current page starts with the same segments** of a given menu item. So that e.g when we go to the content items index page and then edit a content item, the content items index page is still selected in the admin menu.

- Another fix i did here is to make working an admin node as `~/Admin/Contents/ContentItems/` while under a prefixed tenant.