### PR TITLE
Apply cache control headers to non-resized images or other assets

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -182,7 +182,8 @@ The following configuration values are used by default and can be customized:
       // The accepted sizes for custom width and height
       "SupportedSizes": [ 16, 32, 50, 100, 160, 240, 480, 600, 1024, 2048 ],
 
-      // The number of days to store images in the browser cache
+      // The number of days to store images in the browser cache.
+      // NB: To control cache headers for module static assets, refer to [this section](../../OrchardCore/OrchardCore/Modules/README.md).
       "MaxBrowserCacheDays": 30,
 
       // The number of days to store images in the image cache

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Handlers;
@@ -194,12 +195,19 @@ namespace OrchardCore.Media
             // ImageSharp before the static file provider
             app.UseImageSharp();
 
+            // Use the same cache control header as ImageSharp does for resized images.
+            var cacheControl = "public, must-revalidate, max-age=" + TimeSpan.FromDays(_maxBrowserCacheDays).TotalSeconds.ToString();
+
             app.UseStaticFiles(new StaticFileOptions
             {
                 // The tenant's prefix is already implied by the infrastructure
                 RequestPath = AssetsRequestPath,
                 FileProvider = mediaFileProvider,
                 ServeUnknownFileTypes = true,
+                OnPrepareResponse = ctx =>
+                {
+                    ctx.Context.Response.Headers[HeaderNames.CacheControl] = cacheControl;
+                }
             });
         }
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/3807 and https://github.com/OrchardCMS/OrchardCore/issues/4134

Uses same logic as ImageSharp to construct cache control header
`public, must-revalidate, max-age=2592000`