### PR TITLE
GraphQL - Increased default maxdepth to allow graphiql introspection query

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
@@ -82,7 +82,7 @@ Configuration is done via the standard shell configuration, as follows.
   "OrchardCore": {
     "OrchardCore.Apis.GraphQL": {
       "ExposeExceptions": true,
-      "MaxDepth": 10, 
+      "MaxDepth": 50, 
       "MaxComplexity": 100, 
       "FieldImpact": 2.0 
     }
@@ -93,7 +93,7 @@ Configuration is done via the standard shell configuration, as follows.
 
 If set to true stack traces are exposed to graphql clients
 
-*MaxDepth (int?, Default: 10)*
+*MaxDepth (int?, Default: 20)*
 
 Enforces the total maximum nesting across all queries in a request.
 

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
@@ -52,7 +52,7 @@ namespace OrchardCore.Apis.GraphQL
                     ServiceProvider = ctx.RequestServices,
                 },
                 ExposeExceptions = exposeExceptions,
-                MaxDepth = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxDepth)}") ?? 10,
+                MaxDepth = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxDepth)}") ?? 20,
                 MaxComplexity = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxComplexity)}"),
                 FieldImpact = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.FieldImpact)}")
             });


### PR DESCRIPTION
The default max depth of 10 breaks introspection, the graphiql introspection requires a depth of 15 ....

I've upped it to 20 to give it a buffer.