### PR TITLE
Liquid filter and tags to mutate shape properties

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -355,7 +355,7 @@ Output
 Monday, September 11, 2017 3:29:26 PM
 ```
 
-### `shape_property`
+### `shape_properties`
 
 Returns a shape with the added properties.
 Property names get converted to PascalCase. Ex: `prop_name1` can be accessed via `Model.PropName1` in the shape template. 
@@ -363,7 +363,7 @@ Property names get converted to PascalCase. Ex: `prop_name1` can be accessed via
 Input
 
 ```liquid
-{% assign my_shape = "MyCustomShape" | shape_new | shape_property: prop_value1: "some value", prop_value2: 5 %}
+{% assign my_shape = "MyCustomShape" | shape_new | shape_properties: prop_value1: "some value", prop_value2: 5 %}
 ```
 
 ## Layout Tags

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -516,7 +516,7 @@ Removes a property from a shape by name.
 Input
 
 ```liquid
-{% shape_remove_property "prop_name1" %}
+{% shape_remove_property my_shape "prop_name1" %}
 ```
 
 ### `shape_type`

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -322,11 +322,16 @@ Input
 {% assign date_time = "DateTime" | shape_new %}
 ```
 
+You can also pass properties when creating the shape.
+Property names get converted to PascalCase. Ex: `prop_name1` can be accessed via `Model.PropName1` in the shape template. 
+
+```liquid
+{{ Model.Content | shape_new: prop_value1: "some value", prop_value2: 5 }}
+```
+
 ### `shape_render`
 
 Renders a shape.
-
-Input
 
 ```liquid
 {{ Model.Content | shape_render }}
@@ -348,6 +353,17 @@ Output
 
 ```text
 Monday, September 11, 2017 3:29:26 PM
+```
+
+### `shape_property`
+
+Returns a shape with the added properties.
+Property names get converted to PascalCase. Ex: `prop_name1` can be accessed via `Model.PropName1` in the shape template. 
+
+Input
+
+```liquid
+{% assign my_shape = "MyCustomShape" | shape_new | shape_property: prop_value1: "some value", prop_value2: 5 %}
 ```
 
 ## Layout Tags
@@ -480,6 +496,27 @@ Input
 
 ```liquid
 {% shape_add_attributes my_shape attr_name1: "value1", attr_name2: "value2" ... %}
+```
+
+### `shape_add_properties`
+
+Adds properties to a shape. This can be useful to pass values from a parent shape. 
+Property names get converted to PascalCase. Ex: `prop_name1` can be accessed via `Model.PropName1` in the shape template. 
+
+Input
+
+```liquid
+{% shape_add_properties my_shape prop_name1: "value1", prop_name2: 2  %}
+```
+
+### `shape_remove_property`
+
+Removes a property from a shape by name.
+
+Input
+
+```liquid
+{% shape_remove_property "prop_name1" %}
 ```
 
 ### `shape_type`

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -20,6 +20,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
             filters.AddAsyncFilter("shape_new", NewShape);
             filters.AddAsyncFilter("shape_render", ShapeRender);
             filters.AddAsyncFilter("shape_stringify", ShapeStringify);
+            filters.AddFilter("shape_property", ShapeProperty);
 
             return filters;
         }
@@ -89,6 +90,20 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
             if (input.ToObjectValue() is IShape shape)
             {
                 return new HtmlContentValue(await (Task<IHtmlContent>)displayHelper(shape));
+            }
+
+            return NilValue.Instance;
+        }
+
+        public static FluidValue ShapeProperty(FluidValue input, FilterArguments arguments, TemplateContext context)
+        {
+            if (input.ToObjectValue() is IShape shape)
+            {
+                foreach (var name in arguments.Names)
+                {
+                    shape.Properties[name.ToPascalCaseUnderscore()] = arguments[name].ToObjectValue();
+                }
+                return FluidValue.Create(shape);
             }
 
             return NilValue.Instance;

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
             filters.AddAsyncFilter("shape_new", NewShape);
             filters.AddAsyncFilter("shape_render", ShapeRender);
             filters.AddAsyncFilter("shape_stringify", ShapeStringify);
-            filters.AddFilter("shape_property", ShapeProperty);
+            filters.AddFilter("shape_properties", ShapeProperties);
 
             return filters;
         }
@@ -95,7 +95,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
             return NilValue.Instance;
         }
 
-        public static FluidValue ShapeProperty(FluidValue input, FilterArguments arguments, TemplateContext context)
+        public static FluidValue ShapeProperties(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
             if (input.ToObjectValue() is IShape shape)
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -70,6 +70,8 @@ namespace OrchardCore.DisplayManagement.Liquid
             Factory.RegisterTag<ShapeCacheTag>("shape_cache");
             Factory.RegisterTag<ShapeTabTag>("shape_tab");
             Factory.RegisterTag<ShapeRemoveItemTag>("shape_remove_item");
+            Factory.RegisterTag<ShapeAddPropertyTag>("shape_add_properties");
+            Factory.RegisterTag<ShapeRemovePropertyTag>("shape_remove_property");
             Factory.RegisterTag<ShapePagerTag>("shape_pager");
 
             Factory.RegisterTag<HelperTag>("helper");

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeAddPropertyTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeAddPropertyTag.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Ast;
+using OrchardCore.Liquid.Ast;
+using OrchardCore.Mvc.Utilities;
+
+namespace OrchardCore.DisplayManagement.Liquid.Tags
+{
+    public class ShapeAddPropertyTag : ExpressionArgumentsTag
+    {
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, Expression expression, FilterArgument[] args)
+        {
+            var objectValue = (await expression.EvaluateAsync(context)).ToObjectValue();
+
+            if (objectValue is IShape shape)
+            {
+                var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
+
+                foreach (var name in arguments.Names)
+                {
+                    shape.Properties[name.ToPascalCaseUnderscore()] = arguments[name].ToObjectValue();
+                }
+            }
+
+            return Completion.Normal;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeRemovePropertyTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeRemovePropertyTag.cs
@@ -1,0 +1,26 @@
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Ast;
+using OrchardCore.Liquid.Ast;
+using OrchardCore.Mvc.Utilities;
+
+namespace OrchardCore.DisplayManagement.Liquid.Tags
+{
+    public class ShapeRemovePropertyTag : ExpressionArgumentsTag
+    {
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, Expression expression, FilterArgument[] args)
+        {
+            var objectValue = (await expression.EvaluateAsync(context)).ToObjectValue();
+
+            if (objectValue is IShape shape)
+            {
+                var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
+                shape.Properties.Remove(arguments["property"].Or(arguments.At(0)).ToStringValue().ToPascalCaseUnderscore());
+            }
+
+            return Completion.Normal;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeRemovePropertyTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ShapeRemovePropertyTag.cs
@@ -17,7 +17,11 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
             if (objectValue is IShape shape)
             {
                 var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
-                shape.Properties.Remove(arguments["property"].Or(arguments.At(0)).ToStringValue().ToPascalCaseUnderscore());
+                var propName = arguments["property"].Or(arguments.At(0)).ToStringValue();
+                if (!string.IsNullOrEmpty(propName))
+                {
+                    shape.Properties.Remove(propName.ToPascalCaseUnderscore());
+                }
             }
 
             return Completion.Normal;


### PR DESCRIPTION
Fixes #1625 

Adds
- `shape_properties` filter
- `shape_add_properties` and `shape_remove_property` tags

I also noticed that `shape_new` already accepts properties, I simply documented it.

Test case: 
- create a file  `Views\MyTestShape.liquid` in the active theme.
```liquid
<span>{{ Model.MyString }} - {{ Model.MyInt }}</span> 
```
- add the following to a template
```liquid
{% assign customShape = "MyTestShape" | shape_new %}

{% shape_add_properties customShape my_string: "String Test 3", my_int: 1 %}
</br>{{ customShape | shape_render }}

{% shape_remove_property customShape "my_string" %}
</br>{{ customShape | shape_render }}

{% assign customShape = "MyTestShape" | shape_new | shape_properties: my_int: 3, my_string: "String Test 3" %}
</br>{{ customShape | shape_render }}

{% assign customShape = "MyTestShape" | shape_new: my_int: 4, my_string: "String Test 4" %}
</br>{{ customShape | shape_render }}
```


