### PR TITLE
Add permission to ContentCulturePicker setting page

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
@@ -29,6 +29,7 @@ namespace OrchardCore.ContentLocalization
                     .Add(T["Settings"], settings => settings
                         .Add(T["ContentCulturePicker"], T["ContentCulturePicker"], registration => registration
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = ContentCulturePickerSettingsDriver.GroupId })
+                            .Permission(Permissions.ManageContentCulturePicker)
                             .LocalNav()
                         )));
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Permissions.cs
@@ -10,6 +10,7 @@ namespace OrchardCore.ContentLocalization
 
         public static readonly Permission LocalizeContent = new Permission("LocalizeContent", "Localize content for others");
         public static readonly Permission LocalizeOwnContent = new Permission("LocalizeOwnContent", "Localize own content", new[] { LocalizeContent });
+        public static readonly Permission ManageContentCulturePicker = new Permission("ManageContentCulturePicker", "Manage ContentCulturePicker settings");
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {
@@ -17,6 +18,7 @@ namespace OrchardCore.ContentLocalization
             {
                 LocalizeContent,
                 LocalizeOwnContent,
+                ManageContentCulturePicker
             }
             .AsEnumerable());
         }
@@ -28,12 +30,12 @@ namespace OrchardCore.ContentLocalization
                 new PermissionStereotype
                 {
                     Name = "Administrator",
-                    Permissions = new[] { LocalizeContent, LocalizeOwnContent }
+                    Permissions = new[] { LocalizeContent, LocalizeOwnContent, ManageContentCulturePicker }
                 },
                 new PermissionStereotype
                 {
                     Name = "Editor",
-                    Permissions = new[] { LocalizeContent, LocalizeOwnContent }
+                    Permissions = new[] { LocalizeContent, LocalizeOwnContent, ManageContentCulturePicker }
                 },
                 new PermissionStereotype
                 {


### PR DESCRIPTION
This properly hides the Admin menu for users that are not permitted.