### PR TITLE
Add permissions to content localization 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
@@ -19,18 +19,19 @@ namespace OrchardCore.ContentLocalization
 
         public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
-            if (!String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
+            if (String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
-                return Task.CompletedTask;
-            }
-
-            builder
+                builder
                 .Add(T["Configuration"], configuration => configuration
                     .Add(T["Settings"], settings => settings
                         .Add(T["ContentCulturePicker"], T["ContentCulturePicker"], registration => registration
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = ContentCulturePickerSettingsDriver.GroupId })
+                            .Permission(Permissions.ManageCulturePicker)
                             .LocalNav()
                         )));
+
+                return Task.CompletedTask;
+            }
 
             return Task.CompletedTask;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Permissions.cs
@@ -10,6 +10,7 @@ namespace OrchardCore.ContentLocalization
 
         public static readonly Permission LocalizeContent = new Permission("LocalizeContent", "Localize content for others");
         public static readonly Permission LocalizeOwnContent = new Permission("LocalizeOwnContent", "Localize own content", new[] { LocalizeContent });
+        public static readonly Permission ManageCulturePicker = new Permission("ManageCulturePicker", "Manage content culture picker");
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {
@@ -17,6 +18,7 @@ namespace OrchardCore.ContentLocalization
             {
                 LocalizeContent,
                 LocalizeOwnContent,
+                ManageCulturePicker,
             }
             .AsEnumerable());
         }
@@ -28,7 +30,7 @@ namespace OrchardCore.ContentLocalization
                 new PermissionStereotype
                 {
                     Name = "Administrator",
-                    Permissions = new[] { LocalizeContent, LocalizeOwnContent }
+                    Permissions = new[] { LocalizeContent, LocalizeOwnContent, ManageCulturePicker }
                 },
                 new PermissionStereotype
                 {


### PR DESCRIPTION
I've seen the same problem from https://github.com/OrchardCMS/OrchardCore/pull/3779.

Content localization currently has 2 permissions:

- `LocalizeContent`
- `LocalizeOwnContent`

However, in the `AdminMenu.cs`, there is another permission to be added for `OrchardCore.ContentLocalization.ContentCulturePicker`. With this, the user will be able to control whether to show or hide the culture picker setting in each role.

----

Edit: Sorry for not checking the guideline and contribution permission. I should have created the issue first. Sorry for this action, please consider closing the PR.