### PR TITLE
Add CultureInfo to Liquid TemplateContext

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
@@ -88,6 +88,10 @@ namespace OrchardCore.ContentLocalization
     [RequireFeatures("OrchardCore.Liquid")]
     public class LiquidStartup : StartupBase
     {
+        static LiquidStartup()
+        {
+            TemplateContext.GlobalMemberAccessStrategy.Register<CultureInfo>();
+        }
         public override void ConfigureServices(IServiceCollection services)
         {
             services.AddLiquidFilter<ContentLocalizationFilter>("localization_set");


### PR DESCRIPTION
Fix code removed by mistake when merging dev into https://github.com/OrchardCMS/OrchardCore/pull/3819/ 

This adds CultureInfo object to liquid