### PR TITLE
Enable Trace logs for Workflow by default

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -4,7 +4,8 @@
     "LogLevel": {
       "Default": "Warning",
       "System": "Error",
-      "Microsoft": "Error"
+      "Microsoft": "Error",
+      "OrchardCore.Workflows": "Trace"
     }
   },
   "OrchardCore": {

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/appsettings.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/appsettings.json
@@ -3,7 +3,9 @@
   "Logging": {
     "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Warning",
+      "Microsoft": "Error",
+      "OrchardCore.Workflows": "Trace"
     }
   },
   //#endif
@@ -14,7 +16,8 @@
       "Override": {
         "Default": "Warning",
         "Microsoft": "Error",
-        "System": "Error"
+        "System": "Error",
+        "OrchardCore.Workflows": "Trace"
       }
     },
     "WriteTo": [


### PR DESCRIPTION
This will allow users to use all log levels in the Log Activity by default.

I had trouble figuring out why my nlog file was not outputting workflow Trace logs. I think the trace log should always be enabled for workflows since they are dynamic.