### PR TITLE
Potential fix for disabeling core modules

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Manifest.cs
@@ -12,5 +12,6 @@ using OrchardCore.Modules.Manifest;
     Name = "Features",
     Description = "The Features module enables the administrator of the site to manage the installed modules as well as activate and de-activate features.",
     Dependencies = new [] { "OrchardCore.Resources" },
-    Category = "Infrastructure"
+    Category = "Infrastructure",
+    IsAlwaysEnabled = true
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Manifest.cs
@@ -11,5 +11,6 @@ using OrchardCore.Modules.Manifest;
         "OrchardCore.Features",
         "OrchardCore.Scripting"
     },
-    Category = "Infrastructure"
+    Category = "Infrastructure",
+    IsAlwaysEnabled = true
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Scripting/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Scripting/Manifest.cs
@@ -6,5 +6,6 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0",
     Description = "Adds scripting capabilities.",
-    Category = "Infrastructure"
+    Category = "Infrastructure",
+    IsAlwaysEnabled = true
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Manifest.cs
@@ -6,5 +6,6 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0",
     Description = "The settings module creates site settings that other modules can contribute to.",
-    Category = "Configuration"
+    Category = "Configuration",
+    IsAlwaysEnabled = true
 )]

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
@@ -19,6 +19,7 @@ namespace OrchardCore.Environment.Extensions.Features
         public string Description { get; set; }
         public string[] FeatureDependencyIds { get; set; }
         public bool DefaultTenantOnly { get; set; }
+        public bool IsAlwaysEnabled { get; set;}
     }
 
     public abstract class FeatureBuilderEvents : IFeatureBuilderEvents

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureInfo.cs
@@ -10,5 +10,7 @@ namespace OrchardCore.Environment.Extensions.Features
         bool DefaultTenantOnly { get; }
         IExtensionInfo Extension { get; }
         string[] Dependencies { get; }
+
+        bool IsAlwaysEnabled { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/InternalFeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/InternalFeatureInfo.cs
@@ -14,6 +14,7 @@ namespace OrchardCore.Environment.Extensions.Features
             DefaultTenantOnly = false;
             Extension = extensionInfo;
             Dependencies = new string[0];
+            IsAlwaysEnabled = false;
         }
 
         public string Id { get; }
@@ -24,5 +25,6 @@ namespace OrchardCore.Environment.Extensions.Features
         public bool DefaultTenantOnly { get; }
         public IExtensionInfo Extension { get; }
         public string[] Dependencies { get; }
+        public bool IsAlwaysEnabled { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ManifestAttributes.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ManifestAttributes.cs
@@ -85,6 +85,11 @@ namespace OrchardCore.Modules.Manifest
         /// Set to <c>true</c> to only allow the Default tenant to enable it.
         /// </summary>
         public bool DefaultTenantOnly { get; set; }
+
+        /// <summary>
+        /// If the feature is always enabled, you can't disabled it
+        /// </summary>
+        public bool IsAlwaysEnabled { get; set; } = false;
     }
 
     /// <summary>

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ManifestAttributes.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ManifestAttributes.cs
@@ -87,7 +87,7 @@ namespace OrchardCore.Modules.Manifest
         public bool DefaultTenantOnly { get; set; }
 
         /// <summary>
-        /// If the feature is always enabled, you can't disabled it
+        /// Check whether the feature is always enabled. Defaults to false.
         /// </summary>
         public bool IsAlwaysEnabled { get; set; } = false;
     }

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellFeaturesManager.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellFeaturesManager.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Environment.Shell
 
         public Task<IEnumerable<IFeatureInfo>> GetAlwaysEnabledFeaturesAsync()
         {
-            return Task.FromResult(_extensionManager.GetFeatures().Where(f => _shellDescriptor.Features.Any(sf => sf.Id == f.Id && sf.AlwaysEnabled)));
+            return Task.FromResult(_extensionManager.GetFeatures().Where(f => f.IsAlwaysEnabled || _shellDescriptor.Features.Any(sf => sf.Id == f.Id && sf.AlwaysEnabled)));
         }
 
         public Task<IEnumerable<IFeatureInfo>> GetDisabledFeaturesAsync()

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
@@ -10,7 +10,8 @@ namespace OrchardCore.Environment.Extensions.Features
             string description,
             IExtensionInfo extension,
             string[] dependencies,
-            bool defaultTenantOnly)
+            bool defaultTenantOnly,
+            bool isAlwaysEnabled)
         {
             Id = id;
             Name = name;
@@ -20,6 +21,7 @@ namespace OrchardCore.Environment.Extensions.Features
             Extension = extension;
             Dependencies = dependencies;
             DefaultTenantOnly = defaultTenantOnly;
+            IsAlwaysEnabled = isAlwaysEnabled;
         }
 
         public string Id { get; }
@@ -30,5 +32,6 @@ namespace OrchardCore.Environment.Extensions.Features
         public bool DefaultTenantOnly { get; }
         public IExtensionInfo Extension { get; }
         public string[] Dependencies { get; }
+        public bool IsAlwaysEnabled { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
@@ -53,6 +53,7 @@ namespace OrchardCore.Environment.Extensions.Features
                     var featureCategory = feature.Category ?? manifestInfo.ModuleInfo.Category;
                     var featureDescription = feature.Description ?? manifestInfo.ModuleInfo.Description;
                     var featureDefaultTenantOnly = feature.DefaultTenantOnly;
+                    var featureIsAlwaysEnabled = feature.IsAlwaysEnabled;
 
                     var context = new FeatureBuildingContext
                     {
@@ -65,6 +66,7 @@ namespace OrchardCore.Environment.Extensions.Features
                         Priority = featurePriority,
                         FeatureDependencyIds = featureDependencyIds,
                         DefaultTenantOnly = featureDefaultTenantOnly,
+                        IsAlwaysEnabled = featureIsAlwaysEnabled
                     };
 
                     foreach (var builder in _featureBuilderEvents)
@@ -80,7 +82,8 @@ namespace OrchardCore.Environment.Extensions.Features
                         featureDescription,
                         extensionInfo,
                         featureDependencyIds,
-                        featureDefaultTenantOnly);
+                        featureDefaultTenantOnly,
+                        featureIsAlwaysEnabled);
 
                     foreach (var builder in _featureBuilderEvents)
                     {
@@ -107,6 +110,7 @@ namespace OrchardCore.Environment.Extensions.Features
                 var featureCategory = manifestInfo.ModuleInfo.Category;
                 var featureDescription = manifestInfo.ModuleInfo.Description;
                 var featureDefaultTenantOnly = manifestInfo.ModuleInfo.DefaultTenantOnly;
+                var featureIsAlwaysEnabled = manifestInfo.ModuleInfo.IsAlwaysEnabled;
 
                 var context = new FeatureBuildingContext
                 {
@@ -119,6 +123,7 @@ namespace OrchardCore.Environment.Extensions.Features
                     Priority = featurePriority,
                     FeatureDependencyIds = featureDependencyIds,
                     DefaultTenantOnly = featureDefaultTenantOnly,
+                    IsAlwaysEnabled = featureIsAlwaysEnabled
                 };
 
                 foreach (var builder in _featureBuilderEvents)
@@ -134,7 +139,8 @@ namespace OrchardCore.Environment.Extensions.Features
                     context.Description,
                     context.ExtensionInfo,
                     context.FeatureDependencyIds,
-                    context.DefaultTenantOnly);
+                    context.DefaultTenantOnly,
+                    context.IsAlwaysEnabled);
 
                 foreach (var builder in _featureBuilderEvents)
                 {

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -22,13 +22,23 @@ using Xunit;
 
 namespace OrchardCore.Tests.DisplayManagement.Decriptors
 {
+    public static class StringArrayExtensions
+    {
+        private static readonly string[] _emptyStringArray = new string[0];
+
+        public static string[] Empty
+        {
+            get {  return _emptyStringArray; }
+        }
+    }
+
     public class DefaultShapeTableManagerTests : IDisposable
     {
         IServiceProvider _serviceProvider;
 
         private class TestFeatureInfo : IFeatureInfo
         {
-            public string[] Dependencies { get; set; } = new string[0];
+            public string[] Dependencies { get; set; } = StringArrayExtensions.Empty;
             public IExtensionInfo Extension { get; set; }
             public string Id { get; set; }
             public string Name { get; set; }
@@ -64,7 +74,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[0], false, false) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, StringArrayExtensions.Empty, false, false) }
                     };
 
                 Features = features;
@@ -98,7 +108,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, "", "", this, new string[0], false, false)}
+                        {new FeatureInfo(name, name, 0, "", "", this, StringArrayExtensions.Empty, false, false)}
                     };
 
                 Features = features;
@@ -185,7 +195,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
             return new TestFeatureInfo
             {
                 Id = "Testing",
-                Dependencies = new string[0],
+                Dependencies = StringArrayExtensions.Empty,
                 Extension = new TestModuleExtensionInfo("Testing")
             };
         }

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -108,7 +108,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, "", "", this, StringArray.Empty, false, false)}
+                        { new FeatureInfo(name, name, 0, "", "", this, StringArray.Empty, false, false) }
                     };
 
                 Features = features;

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -22,13 +22,13 @@ using Xunit;
 
 namespace OrchardCore.Tests.DisplayManagement.Decriptors
 {
-    public static class StringArrayExtensions
+    public static class StringArray
     {
         private static readonly string[] _emptyStringArray = new string[0];
 
         public static string[] Empty
         {
-            get {  return _emptyStringArray; }
+            get { return _emptyStringArray; }
         }
     }
 
@@ -38,7 +38,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
 
         private class TestFeatureInfo : IFeatureInfo
         {
-            public string[] Dependencies { get; set; } = StringArrayExtensions.Empty;
+            public string[] Dependencies { get; set; } = StringArray.Empty;
             public IExtensionInfo Extension { get; set; }
             public string Id { get; set; }
             public string Name { get; set; }
@@ -74,7 +74,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, StringArrayExtensions.Empty, false, false) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, StringArray.Empty, false, false) }
                     };
 
                 Features = features;
@@ -108,7 +108,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, "", "", this, StringArrayExtensions.Empty, false, false)}
+                        {new FeatureInfo(name, name, 0, "", "", this, StringArray.Empty, false, false)}
                     };
 
                 Features = features;
@@ -135,7 +135,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 Features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[] { baseTheme.Id }, false, false)}
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[] { baseTheme.Id }, false, false) }
                     };
 
                 Id = name;
@@ -195,7 +195,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
             return new TestFeatureInfo
             {
                 Id = "Testing",
-                Dependencies = StringArrayExtensions.Empty,
+                Dependencies = StringArray.Empty,
                 Extension = new TestModuleExtensionInfo("Testing")
             };
         }

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -64,7 +64,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, "", "", this, new string[0], false, false)}
+                        {new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[0], false, false)}
                     };
 
                 Features = features;
@@ -125,7 +125,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 Features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, "", "", this, new string[] { baseTheme.Id }, false, false)}
+                        {new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[] { baseTheme.Id }, false, false)}
                     };
 
                 Id = name;

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -24,11 +24,11 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
 {
     public static class StringArray
     {
-        private static readonly string[] _emptyStringArray = new string[0];
+        private static string[] _empty = new string[0];
 
         public static string[] Empty
         {
-            get { return _emptyStringArray; }
+            get { return _empty; }
         }
     }
 
@@ -108,7 +108,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, "", "", this, StringArray.Empty, false, false) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, StringArray.Empty, false, false) }
                     };
 
                 Features = features;
@@ -381,14 +381,14 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
         [Fact]
         public void DescribedPlacementIsReturnedIfNotNull()
         {
-            var shapeDetail = new ShapePlacementContext("Foo", "Detail", "", null);
-            var shapeSummary = new ShapePlacementContext("Foo", "Summary", "", null);
-            var shapeTitle = new ShapePlacementContext("Foo", "Title", "", null);
+            var shapeDetail = new ShapePlacementContext("Foo", "Detail", String.Empty, null);
+            var shapeSummary = new ShapePlacementContext("Foo", "Summary", String.Empty, null);
+            var shapeTitle = new ShapePlacementContext("Foo", "Title", String.Empty, null);
 
             _serviceProvider.GetService<TestShapeProvider>().Discover =
                 builder => builder.Describe("Hello1").From(TestFeature())
                     .Placement(ctx => ctx.DisplayType == "Detail" ? new PlacementInfo { Location = "Main" } : null)
-                    .Placement(ctx => ctx.DisplayType == "Summary" ? new PlacementInfo { Location = "" } : null);
+                    .Placement(ctx => ctx.DisplayType == "Summary" ? new PlacementInfo { Location = String.Empty } : null);
 
             var manager = _serviceProvider.GetService<IShapeTableManager>();
             var hello = manager.GetShapeTable(null).Descriptors["Hello1"];
@@ -411,14 +411,14 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
         [Fact]
         public void TwoArgumentVariationDoesSameThing()
         {
-            var shapeDetail = new ShapePlacementContext("Foo", "Detail", "", null);
-            var shapeSummary = new ShapePlacementContext("Foo", "Summary", "", null);
-            var shapeTitle = new ShapePlacementContext("Foo", "Title", "", null);
+            var shapeDetail = new ShapePlacementContext("Foo", "Detail", String.Empty, null);
+            var shapeSummary = new ShapePlacementContext("Foo", "Summary", String.Empty, null);
+            var shapeTitle = new ShapePlacementContext("Foo", "Title", String.Empty, null);
 
             _serviceProvider.GetService<TestShapeProvider>().Discover =
                 builder => builder.Describe("Hello2").From(TestFeature())
                     .Placement(ctx => ctx.DisplayType == "Detail", new PlacementInfo { Location = "Main" })
-                    .Placement(ctx => ctx.DisplayType == "Summary", new PlacementInfo { Location = "" });
+                    .Placement(ctx => ctx.DisplayType == "Summary", new PlacementInfo { Location = String.Empty });
 
             var manager = _serviceProvider.GetService<IShapeTableManager>();
             var hello = manager.GetShapeTable(null).Descriptors["Hello2"];

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -36,6 +36,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
             public string Category { get; set; }
             public string Description { get; set; }
             public bool DefaultTenantOnly { get; set; }
+            public bool IsAlwaysEnabled { get; set; }
 
             public bool DependencyOn(IFeatureInfo feature)
             {
@@ -63,7 +64,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, "", "", this, new string[0], false)}
+                        {new FeatureInfo(name, name, 0, "", "", this, new string[0], false, false)}
                     };
 
                 Features = features;
@@ -97,7 +98,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, "", "", this, new string[0], false)}
+                        {new FeatureInfo(name, name, 0, "", "", this, new string[0], false, false)}
                     };
 
                 Features = features;
@@ -124,7 +125,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 Features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, "", "", this, new string[] { baseTheme.Id }, false)}
+                        {new FeatureInfo(name, name, 0, "", "", this, new string[] { baseTheme.Id }, false, false)}
                     };
 
                 Id = name;

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -64,7 +64,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        {new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[0], false, false)}
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[0], false, false) }
                     };
 
                 Features = features;

--- a/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
@@ -145,7 +145,7 @@ namespace OrchardCore.Tests.Shell
 
         public static IFeatureInfo AddStartup(ShellBlueprint shellBlueprint, Type startupType)
         {
-            var featureInfo = new FeatureInfo(startupType.Name, startupType.Name, 1, "Tests", null, null, null, false);
+            var featureInfo = new FeatureInfo(startupType.Name, startupType.Name, 1, "Tests", null, null, null, false, false);
             shellBlueprint.Dependencies.Add(startupType, new NonCompiledFeatureEntry(featureInfo));
 
             return featureInfo;


### PR DESCRIPTION
You can add set the IsAlwaysRunning property to true in your FeatureAttribute or ModuleAttribute to make sure your feature can't be disable the feature.

This is a fix for https://github.com/OrchardCMS/OrchardCore/issues/3403

Feedback is welcome