### PR TITLE
Use AddInitialRequestCultureProvider

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using OrchardCore.ContentLocalization.Drivers;
 using OrchardCore.ContentLocalization.Handlers;
 using OrchardCore.ContentLocalization.Indexing;
@@ -58,7 +59,7 @@ namespace OrchardCore.ContentLocalization
             services.AddScoped<IDisplayDriver<ISite>, ContentCulturePickerSettingsDriver>();
             services.Configure<RequestLocalizationOptions>(options =>
             {
-                options.RequestCultureProviders.Insert(0, new ContentRequestCultureProvider());
+                options.AddInitialRequestCultureProvider(new ContentRequestCultureProvider());
             });
         }
 


### PR DESCRIPTION
After we used 3.0 I'd like to introduce a new localization API that I have created few months ago that initializes the default `RequestCultureProvider`

/cc @jptissot