### PR TITLE
Fixes HomeRoute if no home route.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutoRouteTransformer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutoRouteTransformer.cs
@@ -22,27 +22,12 @@ namespace OrchardCore.Autoroute.Routing
         {
             if (_entries.TryGetContentItemId(httpContext.Request.Path.ToString().TrimEnd('/'), out var contentItemId))
             {
-                var routeValues = new RouteValueDictionary(GetRouteValues(contentItemId));
-
-                if (values != null)
-                {
-                    foreach (var entry in values)
-                    {
-                        routeValues.TryAdd(entry.Key, entry.Value);
-                    }
-                }
-
+                var routeValues = new RouteValueDictionary(_options.GlobalRouteValues);
+                routeValues[_options.ContentItemIdKey] = contentItemId;
                 return new ValueTask<RouteValueDictionary>(routeValues);
             }
 
             return new ValueTask<RouteValueDictionary>((RouteValueDictionary)null);
-        }
-
-        private RouteValueDictionary GetRouteValues(string contentItemId)
-        {
-            var routeValues = new RouteValueDictionary(_options.GlobalRouteValues);
-            routeValues[_options.ContentItemIdKey] = contentItemId;
-            return routeValues;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Middlewares/NonBlockingMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Middlewares/NonBlockingMiddleware.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 
 namespace OrchardCore.Demo
@@ -14,7 +14,8 @@ namespace OrchardCore.Demo
 
         public async Task Invoke(HttpContext httpContext)
         {
-            httpContext.Response.Headers.Add("Orchard", "2.0");
+            // If the tenant pipeline is re-executed on error, the header is already set.
+            httpContext.Response.Headers["Orchard"] = "2.0";
             await _next.Invoke(httpContext);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteTransformer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteTransformer.cs
@@ -17,17 +17,7 @@ namespace OrchardCore.HomeRoute.Routing
 
         public override async ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
         {
-            var routeValues = new RouteValueDictionary((await _siteService.GetSiteSettingsAsync()).HomeRoute);
-
-            if (values != null)
-            {
-                foreach (var entry in values)
-                {
-                    routeValues.TryAdd(entry.Key, entry.Value);
-                }
-            }
-
-            return routeValues;
+            return new RouteValueDictionary((await _siteService.GetSiteSettingsAsync()).HomeRoute);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteValuesAddressScheme.cs
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteValuesAddressScheme.cs
@@ -59,6 +59,11 @@ namespace OrchardCore.HomeRoute.Routing
 
         private bool Match(RouteValueDictionary routeValues, RouteValueDictionary explicitValues)
         {
+            if (routeValues.Count == 0)
+            {
+                return false;
+            }
+
             foreach (var entry in routeValues)
             {
                 if (!String.Equals(explicitValues[entry.Key]?.ToString(), entry.Value?.ToString(), StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Fixes #4283 

Also mentioned in #4261 

- i also simplified the route transformers by not adding the additional values from the original route values, as it seems to be done by the `DynamicControllerEndpointMatcherPolicy`, [see here](https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/Mvc.Core/src/Routing/DynamicControllerEndpointMatcherPolicy.cs#L138).