### PR TITLE
Add default paging to GraphQL queries

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using GraphQL;
+using GraphQL.Validation;
 using GraphQL.Validation.Complexity;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -14,6 +15,7 @@ using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Apis.GraphQL.Queries;
+using OrchardCore.Apis.GraphQL.ValidationRules;
 
 namespace OrchardCore.Apis.GraphQL
 {
@@ -162,6 +164,9 @@ namespace OrchardCore.Apis.GraphQL
                 _.Inputs = request.Variables.ToInputs();
                 _.UserContext = _settings.BuildUserContext?.Invoke(context);
                 _.ExposeExceptions = _settings.ExposeExceptions;
+                _.ValidationRules = DocumentValidator.CoreRules()
+                                    .Concat(_settings.ValidationRules)
+                                    .Concat(new[] { new MaxNumberOfResultsValidationRule(_settings.MaxNumberOfResults, _settings.MaxNumberOfResultsValidationMode) });
                 _.ComplexityConfiguration = new ComplexityConfiguration
                 {
                     MaxDepth = _settings.MaxDepth,

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
@@ -165,8 +165,7 @@ namespace OrchardCore.Apis.GraphQL
                 _.UserContext = _settings.BuildUserContext?.Invoke(context);
                 _.ExposeExceptions = _settings.ExposeExceptions;
                 _.ValidationRules = DocumentValidator.CoreRules()
-                                    .Concat(_settings.ValidationRules)
-                                    .Concat(new[] { new MaxNumberOfResultsValidationRule(_settings.MaxNumberOfResults, _settings.MaxNumberOfResultsValidationMode) });
+                                    .Concat(context.RequestServices.GetServices<IValidationRule>());
                 _.ComplexityConfiguration = new ComplexityConfiguration
                 {
                     MaxDepth = _settings.MaxDepth,

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLSettings.cs
@@ -12,5 +12,6 @@ namespace OrchardCore.Apis.GraphQL
         public int? MaxDepth { get; set; }
         public int? MaxComplexity { get; set; }
         public double? FieldImpact { get; set; }
+        public int MaxNumberOfResults { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLSettings.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using GraphQL.Validation;
 using Microsoft.AspNetCore.Http;
 
 namespace OrchardCore.Apis.GraphQL
@@ -9,11 +12,14 @@ namespace OrchardCore.Apis.GraphQL
         public Func<HttpContext, object> BuildUserContext { get; set; }
 
         public bool ExposeExceptions { get; set; } = false;
+
         public int? MaxDepth { get; set; }
         public int? MaxComplexity { get; set; }
         public double? FieldImpact { get; set; }
         public int MaxNumberOfResults { get; set; }
         public MaxNumberOfResultsValidationMode MaxNumberOfResultsValidationMode { get; set; }
+
+        public IEnumerable<IValidationRule> ValidationRules { get; set; } = Enumerable.Empty<IValidationRule>();
     }
 
     public enum MaxNumberOfResultsValidationMode

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLSettings.cs
@@ -13,5 +13,13 @@ namespace OrchardCore.Apis.GraphQL
         public int? MaxComplexity { get; set; }
         public double? FieldImpact { get; set; }
         public int MaxNumberOfResults { get; set; }
+        public MaxNumberOfResultsValidationMode MaxNumberOfResultsValidationMode { get; set; }
+    }
+
+    public enum MaxNumberOfResultsValidationMode
+    {
+        Environment,
+        Debug,
+        Release
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/OrchardCore.Apis.GraphQL.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/OrchardCore.Apis.GraphQL.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Razor">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
@@ -86,6 +86,7 @@ Configuration is done via the standard shell configuration, as follows.
       "MaxComplexity": 100, 
       "FieldImpact": 2.0 ,
       "MaxNumberOfResults": 100
+      "MaxNumberOfResultsValidationMode": "Environment"
     }
   }
 }
@@ -94,8 +95,14 @@ Configuration is done via the standard shell configuration, as follows.
 
 If set to true stack traces are exposed to graphql clients
 
-*MaxNumberOfResults (int, Default: 1000)
+*MaxNumberOfResults (int, Default: 1000)*
 The maximum number of results returned by all paged fields/types.
+
+*MaxNumberOfResultsValidationMode (enum, Values: Environment|Debug|Release, Default: Environment)()
+Specify the validation behaviour if the max number of results is exceeded in a pager paramater
+* Environment - In production info will be logged and only the max number of results will be returned. In development a graphql validation error will be raised.
+* Debug - a graphql validation error will be raised
+* Release - Info will be logged and only the max number of results will be returned
 
 *MaxDepth (int?, Default: 20)*
 

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
@@ -96,7 +96,7 @@ Configuration is done via the standard shell configuration, as follows.
 
 If set to true stack traces are exposed to graphql clients
 
-*MaxNumberOfResults (int, Default: 100)*
+*DefaultNumberOfResults (int, Default: 100)*
 The default number of results returned by all paged fields/types.
 
 *MaxNumberOfResults (int, Default: 1000)*

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
@@ -84,7 +84,8 @@ Configuration is done via the standard shell configuration, as follows.
       "ExposeExceptions": true,
       "MaxDepth": 50, 
       "MaxComplexity": 100, 
-      "FieldImpact": 2.0 
+      "FieldImpact": 2.0 ,
+      "MaxNumberOfResults": 100
     }
   }
 }
@@ -92,6 +93,9 @@ Configuration is done via the standard shell configuration, as follows.
 *ExposeExceptions (bool, Default: false for production, true for development)*
 
 If set to true stack traces are exposed to graphql clients
+
+*MaxNumberOfResults (int, Default: 1000)
+The maximum number of results returned by all paged fields/types.
 
 *MaxDepth (int?, Default: 20)*
 

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
@@ -85,8 +85,9 @@ Configuration is done via the standard shell configuration, as follows.
       "MaxDepth": 50, 
       "MaxComplexity": 100, 
       "FieldImpact": 2.0 ,
-      "MaxNumberOfResults": 100
-      "MaxNumberOfResultsValidationMode": "Environment"
+      "DefaultNumberOfResults": 100
+      "MaxNumberOfResults": 1000
+      "MaxNumberOfResultsValidationMode": "Default"
     }
   }
 }
@@ -95,14 +96,17 @@ Configuration is done via the standard shell configuration, as follows.
 
 If set to true stack traces are exposed to graphql clients
 
+*MaxNumberOfResults (int, Default: 100)*
+The default number of results returned by all paged fields/types.
+
 *MaxNumberOfResults (int, Default: 1000)*
 The maximum number of results returned by all paged fields/types.
 
-*MaxNumberOfResultsValidationMode (enum, Values: Environment|Debug|Release, Default: Environment)()
+*MaxNumberOfResultsValidationMode (enum, Values: Default|Enabled|Disabled, Default: Default)()
 Specify the validation behaviour if the max number of results is exceeded in a pager paramater
-* Environment - In production info will be logged and only the max number of results will be returned. In development a graphql validation error will be raised.
-* Debug - a graphql validation error will be raised
-* Release - Info will be logged and only the max number of results will be returned
+* Default - In production info will be logged and only the max number of results will be returned. In development a graphql validation error will be raised.
+* Enabled - a graphql validation error will be raised
+* Disabled - Info will be logged and only the max number of results will be returned
 
 *MaxDepth (int?, Default: 20)*
 

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
@@ -56,6 +56,7 @@ namespace OrchardCore.Apis.GraphQL
                 MaxComplexity = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxComplexity)}"),
                 FieldImpact = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.FieldImpact)}"),
                 MaxNumberOfResults = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxNumberOfResults)}") ?? 1000,
+                MaxNumberOfResultsValidationMode = _configuration.GetValue<MaxNumberOfResultsValidationMode?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxNumberOfResultsValidationMode)}") ?? MaxNumberOfResultsValidationMode.Environment
             });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
@@ -54,7 +54,8 @@ namespace OrchardCore.Apis.GraphQL
                 ExposeExceptions = exposeExceptions,
                 MaxDepth = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxDepth)}") ?? 20,
                 MaxComplexity = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxComplexity)}"),
-                FieldImpact = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.FieldImpact)}")
+                FieldImpact = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.FieldImpact)}"),
+                MaxNumberOfResults = _configuration.GetValue<int?>($"OrchardCore.Apis.GraphQL:{nameof(GraphQLSettings.MaxNumberOfResults)}") ?? 1000,
             });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/MaxNumberOfResultsValidationRule.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/MaxNumberOfResultsValidationRule.cs
@@ -1,0 +1,57 @@
+using GraphQL.Language.AST;
+using GraphQL.Validation;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+
+namespace OrchardCore.Apis.GraphQL.ValidationRules
+{
+    public class MaxNumberOfResultsValidationRule : IValidationRule
+    {
+        private readonly int _maxResults;
+        private readonly MaxNumberOfResultsValidationMode _maxNumberOfResultsValidationMode;
+
+        public MaxNumberOfResultsValidationRule(int maxNumberOfResults, MaxNumberOfResultsValidationMode maxNumberOfResultsValidationMode)
+        {
+            _maxResults = maxNumberOfResults;
+            _maxNumberOfResultsValidationMode = maxNumberOfResultsValidationMode;
+        }
+
+        public INodeVisitor Validate(ValidationContext validationContext)
+        {
+            return new EnterLeaveListener(_ =>
+            {
+                _.Match<Argument>(arg =>
+                {
+                    if ((arg.Name == "first" || arg.Name == "last") && arg.Value != null)
+                    {
+                        var context = (GraphQLContext)validationContext.UserContext;
+
+                        var value = (IntValue)arg.Value;
+
+                        if (value?.Value > _maxResults)
+                        {
+                            var localizer = context.ServiceProvider.GetService<IStringLocalizer<MaxNumberOfResultsValidationRule>>();
+                            var errorMessage = localizer[$"'{value}' exceeds the maximum number of results for '{arg.Name}' ({_maxResults})"];
+
+                            if (_maxNumberOfResultsValidationMode == MaxNumberOfResultsValidationMode.Debug)
+                            {
+                                validationContext.ReportError(new ValidationError(
+                                    validationContext.OriginalQuery,
+                                    "UserInputError",
+                                    errorMessage,
+                                    arg));
+                            }
+                            else
+                            {
+                                var logger = context.ServiceProvider.GetService<ILogger<MaxNumberOfResultsValidationMode>>();
+                                logger.LogInformation(errorMessage);
+                                arg.Value = new IntValue(_maxResults); // in release mode we just log info andf override the arg to be maxvalue
+                            }
+                        }
+                    }
+                });
+            });
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Extensions/ResolveFieldContextExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Extensions/ResolveFieldContextExtensions.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Builders;
 using GraphQL.Types;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace OrchardCore.Apis.GraphQL
 {
@@ -31,6 +33,12 @@ namespace OrchardCore.Apis.GraphQL
             var skip = context.GetArgument<int>("skip");
             var first = context.GetArgument<int>("first");
             var last = context.GetArgument<int>("last");
+
+            if (last == 0 && first == 0)
+            {
+                var serviceProvider = ((GraphQLContext)context.UserContext).ServiceProvider;
+                first = serviceProvider.GetService<IOptions<GraphQLSettings>>().Value.DefaultNumberOfResults;
+            }
 
             if (last > 0)
             {

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/GraphQLSettings.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/GraphQLSettings.cs
@@ -16,16 +16,15 @@ namespace OrchardCore.Apis.GraphQL
         public int? MaxDepth { get; set; }
         public int? MaxComplexity { get; set; }
         public double? FieldImpact { get; set; }
+        public int DefaultNumberOfResults { get; set; }
         public int MaxNumberOfResults { get; set; }
         public MaxNumberOfResultsValidationMode MaxNumberOfResultsValidationMode { get; set; }
-
-        public IEnumerable<IValidationRule> ValidationRules { get; set; } = Enumerable.Empty<IValidationRule>();
     }
 
     public enum MaxNumberOfResultsValidationMode
     {
-        Environment,
-        Debug,
-        Release
+        Default,
+        Enabled,
+        Disabled
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemsFieldType.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemsFieldType.cs
@@ -97,7 +97,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
             query = OrderBy(query, context);
 
             var contentItemsQuery = await FilterWhereArguments(query, where, context, session, graphContext);
-            contentItemsQuery = PageQuery(contentItemsQuery, context);
+            contentItemsQuery = PageQuery(contentItemsQuery, context, graphContext);
 
             var contentItems = await contentItemsQuery.ListAsync();
 
@@ -172,15 +172,18 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
             return contentQuery;
         }
 
-        private IQuery<ContentItem> PageQuery(IQuery<ContentItem> contentItemsQuery, ResolveFieldContext context)
+        private IQuery<ContentItem> PageQuery(IQuery<ContentItem> contentItemsQuery, ResolveFieldContext context, GraphQLContext graphQLContext)
         {
-            if (context.HasPopulatedArgument("first"))
-            {
-                var first = context.GetArgument<int>("first");
+            var first = context.GetArgument<int>("first");
 
-                contentItemsQuery = contentItemsQuery.Take(first);
+            if (first == 0)
+            {
+                var serviceProvider = graphQLContext.ServiceProvider;
+                first = serviceProvider.GetService<IOptions<GraphQLSettings>>().Value.DefaultNumberOfResults;
             }
 
+            contentItemsQuery = contentItemsQuery.Take(first);
+            
             if (context.HasPopulatedArgument("skip"))
             {
                 var skip = context.GetArgument<int>("skip");

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemsFieldType.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemsFieldType.cs
@@ -25,8 +25,8 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
     /// </summary>
     public class ContentItemsFieldType : FieldType
     {
-
         private static readonly List<string> ContentItemProperties;
+        private readonly int _defaultNumberOfItems;
 
         static ContentItemsFieldType()
         {
@@ -38,7 +38,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
             }
         }
 
-        public ContentItemsFieldType(string contentItemName, ISchema schema, IOptions<GraphQLContentOptions> optionsAccessor)
+        public ContentItemsFieldType(string contentItemName, ISchema schema, IOptions<GraphQLContentOptions> optionsAccessor, IOptions<GraphQLSettings> settingsAccessor)
         {
             Name = "ContentItems";
 
@@ -60,6 +60,8 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
             schema.RegisterType(whereInput);
             schema.RegisterType(orderByInput);
             schema.RegisterType<PublicationStatusGraphType>();
+
+            _defaultNumberOfItems = settingsAccessor.Value.DefaultNumberOfResults;
         }
 
         private async Task<IEnumerable<ContentItem>> Resolve(ResolveFieldContext context)
@@ -178,8 +180,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
 
             if (first == 0)
             {
-                var serviceProvider = graphQLContext.ServiceProvider;
-                first = serviceProvider.GetService<IOptions<GraphQLSettings>>().Value.DefaultNumberOfResults;
+                first = _defaultNumberOfItems;
             }
 
             contentItemsQuery = contentItemsQuery.Take(first);

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
@@ -22,14 +22,17 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
     public class ContentTypeQuery : ISchemaBuilder
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly IOptions<GraphQLContentOptions> _optionsAccessor;
+        private readonly IOptions<GraphQLContentOptions> _contentOptionsAccessor;
+        private readonly IOptions<GraphQLSettings> _settingsAccessor;
 
         public ContentTypeQuery(IHttpContextAccessor httpContextAccessor,
-            IOptions<GraphQLContentOptions> optionsAccessor,
+            IOptions<GraphQLContentOptions> contentOptionsAccessor,
+            IOptions<GraphQLSettings> settingsAccessor,
             IStringLocalizer<ContentTypeQuery> localizer)
         {
             _httpContextAccessor = httpContextAccessor;
-            _optionsAccessor = optionsAccessor;
+            _contentOptionsAccessor = contentOptionsAccessor;
+            _settingsAccessor = settingsAccessor;
             T = localizer;
         }
 
@@ -44,13 +47,13 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
 
             foreach (var typeDefinition in contentDefinitionManager.ListTypeDefinitions())
             {
-                var typeType = new ContentItemType(_optionsAccessor)
+                var typeType = new ContentItemType(_contentOptionsAccessor)
                 {
                     Name = typeDefinition.Name,
                     Description = T["Represents a {0}.", typeDefinition.DisplayName]
                 };
 
-                var query = new ContentItemsFieldType(typeDefinition.Name, schema, _optionsAccessor)
+                var query = new ContentItemsFieldType(typeDefinition.Name, schema, _contentOptionsAccessor, _settingsAccessor)
                 {
                     Name = typeDefinition.Name,
                     Description = T["Represents a {0}.", typeDefinition.DisplayName],

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
@@ -141,7 +141,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()), Options.Create(new GraphQLSettings { DefaultNumberOfResults = 10 } ));
 
                 context.Arguments["where"] = JObject.Parse("{ contentItemId: \"1\" }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -192,7 +192,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()), Options.Create(new GraphQLSettings { DefaultNumberOfResults = 10 }));
 
                 context.Arguments["where"] = JObject.Parse("{ contentItemId: \"1\" }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -239,7 +239,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()), Options.Create(new GraphQLSettings { DefaultNumberOfResults = 10 }));
 
                 context.Arguments["where"] = JObject.Parse("{ cats: { name: \"doug\" } }");
                 var cats = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -303,7 +303,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci2);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()), Options.Create(new GraphQLSettings { DefaultNumberOfResults = 10 }));
 
                 context.Arguments["where"] = JObject.Parse("{ animals: { name: \"doug\", isScary: true } }");
                 var animals = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -355,7 +355,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()), Options.Create(new GraphQLSettings { DefaultNumberOfResults = 10 }));
 
                 context.Arguments["where"] = JObject.Parse("{ animal: { name: \"doug\" } }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);
@@ -416,7 +416,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                 session.Save(ci);
                 await session.CommitAsync();
 
-                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()));
+                var type = new ContentItemsFieldType("Animal", new Schema(), Options.Create(new GraphQLContentOptions()), Options.Create(new GraphQLSettings { DefaultNumberOfResults = 10 }));
 
                 context.Arguments["where"] = JObject.Parse("{ name: \"doug\" }");
                 var dogs = await ((AsyncFieldResolver<IEnumerable<ContentItem>>)type.Resolver).Resolve(context);


### PR DESCRIPTION
see #2771

* New setting: MaxNumberOfResults - the max number of results any paged query (which is anything with a collection atm) is allowed to return. Currently i've defaulted to 1000; this seems a bit high to me ...
* new setting: MaxNumberOfResultsValidationMode (enum: Environment|Debug|Release) - controls what happens if maxnumberofresults is breached 
* Expose validation extension point
* new setting: DefaultNumberOfResults - number of results to return if first or last isnt specified
* moved options to abstractions and registered them