### PR TITLE
Fix ResourceManager dependency resolution

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -434,7 +434,7 @@ namespace OrchardCore.ResourceManagement
                         continue;
                     }
 
-                    ExpandDependencies(dependency, tempSettings, allResources);
+                    ExpandDependencies(dependency, settings, allResources);
                 }
             }
             allResources[resource] = settings;


### PR DESCRIPTION
The original settings should be used in ExpandDependencies for recursive calls and amend scripts to this existing instance.