### PR TITLE
Page endpoint priority.

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageMvcCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageMvcCoreBuilderExtensions.cs
@@ -31,6 +31,8 @@ namespace OrchardCore.Mvc.RazorPages
                 services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, PageLoaderMatcherPolicy>());
             }
 
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<MatcherPolicy, PageEndpointComparerPolicy>());
+
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<RazorPagesOptions>, ModularPageRazorPagesOptionsSetup>());
 

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/PageEndpointComparerPolicy.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/PageEndpointComparerPolicy.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Matching;
+
+namespace OrchardCore.Mvc.RazorPages
+{
+    public sealed class PageEndpointComparerPolicy : MatcherPolicy, IEndpointComparerPolicy
+    {
+        public override int Order => -1000;
+
+        public IComparer<Endpoint> Comparer => new PageEndpointComparer();
+
+        private class PageEndpointComparer : EndpointMetadataComparer<PageActionDescriptor>
+        {
+            protected override int CompareMetadata(PageActionDescriptor x, PageActionDescriptor y)
+            {
+                return base.CompareMetadata(x, y);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Reported [here](https://github.com/OrchardCMS/OrchardCore/issues/4261#issuecomment-531979402) in #4261.

> As a reminder, again due to the home route transformer, if you define an home route and also an application razor Index page, we ends up with 2 valid endpoints for the path /. So, here it complains that these 2 endpoints for the same path have the same order.

- Notice that if at the app level i have e.g an `About` razor page and also an `About` Autoroute, it doesn't fails, the razor page wins.

- So, this is a special case of the app level `Index` page where mvc generate 2 endpoints, one for `/` and one for `/index`. Note: if you disable the home feature or delete the `Index` page (or define another route for it), it works.

- So, maybe not an issue, but here i created a `PageEndpointComparerPolicy` so that, when a razor page endpoint is compared to another kind of endpoint (e.g a controller one), the razor page endpoint wins with no ambiguity. So that it behaves as before when using the home route middleware.