### PR TITLE
Pre-calculate ShapeDescriptor results

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -51,16 +51,14 @@ namespace OrchardCore.DisplayManagement.Descriptors
         {
             var cacheKey = $"ShapeTable:{themeId}";
 
-            ShapeTable shapeTable;
-            if (!_memoryCache.TryGetValue(cacheKey, out shapeTable))
+            if (!_memoryCache.TryGetValue(cacheKey, out ShapeTable shapeTable))
             {
                 if (_logger.IsEnabled(LogLevel.Information))
                 {
                     _logger.LogInformation("Start building shape table");
                 }
 
-                var excludedFeatures = _shapeDescriptors.Count == 0 ? new List<string>() :
-                    _shapeDescriptors.Select(kv => kv.Value.Feature.Id).Distinct().ToList();
+                var excludedFeatures = new HashSet<string>(_shapeDescriptors.Select(kv => kv.Value.Feature.Id));
 
                 foreach (var bindingStrategy in _bindingStrategies)
                 {
@@ -99,11 +97,12 @@ namespace OrchardCore.DisplayManagement.Descriptors
                         shapeType: group.Key,
                         alterationKeys: group.Select(kv => kv.Key),
                         descriptors: _shapeDescriptors
-                    ));
+                    ))
+                    .ToList();
 
                 shapeTable = new ShapeTable
                 {
-                    Descriptors = descriptors.Cast<ShapeDescriptor>().ToDictionary(sd => sd.ShapeType, StringComparer.OrdinalIgnoreCase),
+                    Descriptors = descriptors.ToDictionary(sd => sd.ShapeType, x => (ShapeDescriptor) x, StringComparer.OrdinalIgnoreCase),
                     Bindings = descriptors.SelectMany(sd => sd.Bindings).ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase)
                 };
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeDescriptor.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeDescriptor.cs
@@ -22,95 +22,108 @@ namespace OrchardCore.DisplayManagement.Descriptors
 
     public class ShapeDescriptorIndex : ShapeDescriptor
     {
-        private IEnumerable<string> _alterationKeys;
-        private ConcurrentDictionary<string, FeatureShapeDescriptor> _descriptors;
+        private readonly ConcurrentDictionary<string, FeatureShapeDescriptor> _descriptors;
+        private readonly List<FeatureShapeDescriptor> _alternationDescriptors;
+        private readonly List<string> _wrappers;
+        private readonly List<string> _bindingSources;
+        private readonly Dictionary<string, ShapeBinding> _bindings;
+        private readonly List<Func<ShapeCreatingContext, Task>> _creatingAsync;
+        private readonly List<Func<ShapeCreatedContext, Task>> _createdAsync;
+        private readonly List<Func<ShapeDisplayContext, Task>> _displayingAsync;
+        private readonly List<Func<ShapeDisplayContext, Task>> _processingAsync;
+        private readonly List<Func<ShapeDisplayContext, Task>> _displayedAsync;
 
-        public ShapeDescriptorIndex(string shapeType, IEnumerable<string> alterationKeys, ConcurrentDictionary<string, FeatureShapeDescriptor> descriptors)
+        public ShapeDescriptorIndex(
+            string shapeType,
+            IEnumerable<string> alterationKeys,
+            ConcurrentDictionary<string, FeatureShapeDescriptor> descriptors)
         {
             ShapeType = shapeType;
-            _alterationKeys = alterationKeys;
             _descriptors = descriptors;
+
+            // pre-calculate as much as we can
+            _alternationDescriptors = alterationKeys
+                .Select(key => _descriptors[key])
+                .ToList();
+
+            _wrappers = _alternationDescriptors
+                .SelectMany(sd => sd.Wrappers)
+                .ToList();
+
+            _bindingSources = _alternationDescriptors
+                .SelectMany(sd => sd.BindingSources)
+                .ToList();
+
+            _bindings = _alternationDescriptors
+                .SelectMany(sd => sd.Bindings)
+                .GroupBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(kv => kv.Last())
+                .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
+
+            _creatingAsync = _alternationDescriptors
+                .SelectMany(sd => sd.CreatingAsync)
+                .ToList();
+
+            _createdAsync = _alternationDescriptors
+                .SelectMany(sd => sd.CreatedAsync)
+                .ToList();
+
+            _displayingAsync = _alternationDescriptors
+                .SelectMany(sd => sd.DisplayingAsync)
+                .ToList();
+
+            _processingAsync = _alternationDescriptors
+                .SelectMany(sd => sd.ProcessingAsync)
+                .ToList();
+
+            _displayedAsync = _alternationDescriptors
+                .SelectMany(sd => sd.DisplayedAsync)
+                .ToList();
         }
 
         /// <summary>
         /// The BindingSource is informational text about the source of the Binding delegate. Not used except for
         /// troubleshooting.
         /// </summary>
-        public override string BindingSource
-        {
-            get
-            {
-                ShapeBinding binding;
-                return Bindings.TryGetValue(ShapeType, out binding) ? binding.BindingSource : null;
-            }
-        }
+        public override string BindingSource =>
+            Bindings.TryGetValue(ShapeType, out var binding) ? binding.BindingSource : null;
 
-        public override Func<DisplayContext, Task<IHtmlContent>> Binding
-        {
-            get
-            {
-                ShapeBinding binding;
-                return Bindings.TryGetValue(ShapeType, out binding) ? binding.BindingAsync : null;
-            }
-        }
+        public override Func<DisplayContext, Task<IHtmlContent>> Binding =>
+            Bindings.TryGetValue(ShapeType, out var binding) ? binding.BindingAsync : null;
 
-        public override IDictionary<string, ShapeBinding> Bindings
-        {
-            get
-            {
-                return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.Bindings)
-                    .GroupBy(kv => kv.Key, StringComparer.OrdinalIgnoreCase).Select(kv => kv.Last())
-                    .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase);
-            }
-        }
+        public override IDictionary<string, ShapeBinding> Bindings => _bindings;
 
-        public override IEnumerable<Func<ShapeCreatingContext, Task>> CreatingAsync
-        {
-            get { return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.CreatingAsync); }
-        }
-        public override IEnumerable<Func<ShapeCreatedContext, Task>> CreatedAsync
-        {
-            get { return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.CreatedAsync); }
-        }
-        public override IEnumerable<Func<ShapeDisplayContext, Task>> DisplayingAsync
-        {
-            get { return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.DisplayingAsync); }
-        }
-        public override IEnumerable<Func<ShapeDisplayContext, Task>> ProcessingAsync
-        {
-            get { return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.ProcessingAsync); }
-        }
-        public override IEnumerable<Func<ShapeDisplayContext, Task>> DisplayedAsync
-        {
-            get { return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.DisplayedAsync); }
-        }
+        public override IEnumerable<Func<ShapeCreatingContext, Task>> CreatingAsync => _creatingAsync;
 
-        public override Func<ShapePlacementContext, PlacementInfo> Placement
+        public override IEnumerable<Func<ShapeCreatedContext, Task>> CreatedAsync => _createdAsync;
+
+        public override IEnumerable<Func<ShapeDisplayContext, Task>> DisplayingAsync => _displayingAsync;
+
+        public override IEnumerable<Func<ShapeDisplayContext, Task>> ProcessingAsync => _processingAsync;
+
+        public override IEnumerable<Func<ShapeDisplayContext, Task>> DisplayedAsync => _displayedAsync;
+
+        public override Func<ShapePlacementContext, PlacementInfo> Placement => CalculatePlacement;
+
+        private PlacementInfo CalculatePlacement(ShapePlacementContext ctx)
         {
-            get
+            PlacementInfo info = null;
+            for (var i = _alternationDescriptors.Count - 1; i >= 0; i--)
             {
-                return (ctx =>
+                var descriptor = _alternationDescriptors[i];
+                info = descriptor.Placement(ctx);
+                if (info != null)
                 {
-                    PlacementInfo info = null;
-                    foreach (var descriptor in _alterationKeys.Select(key => _descriptors[key]).Reverse())
-                    {
-                        info = descriptor.Placement(ctx);
-                        if (info != null)
-                            break;
-                    }
-                    return info ?? DefaultPlacementAction(ctx);
-                });
+                    break;
+                }
             }
+
+            return info ?? DefaultPlacementAction(ctx);
         }
 
-        public override IList<string> Wrappers
-        {
-            get { return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.Wrappers).ToList(); }
-        }
-        public override IList<string> BindingSources
-        {
-            get { return _alterationKeys.Select(key => _descriptors[key]).SelectMany(sd => sd.BindingSources).ToList(); }
-        }
+        public override IList<string> Wrappers => _wrappers;
+
+        public override IList<string> BindingSources => _bindingSources;
     }
 
     public class ShapeDescriptor
@@ -140,7 +153,10 @@ namespace OrchardCore.DisplayManagement.Descriptors
                 return null;
             }
 
-            return new PlacementInfo { Location = DefaultPlacement };
+            return new PlacementInfo
+            {
+                Location = DefaultPlacement
+            };
         }
 
         public string ShapeType { get; set; }
@@ -149,22 +165,11 @@ namespace OrchardCore.DisplayManagement.Descriptors
         /// The BindingSource is informational text about the source of the Binding delegate. Not used except for
         /// troubleshooting.
         /// </summary>
-        public virtual string BindingSource
-        {
-            get
-            {
-                ShapeBinding binding;
-                return Bindings.TryGetValue(ShapeType, out binding) ? binding.BindingSource : null;
-            }
-        }
+        public virtual string BindingSource =>
+            Bindings.TryGetValue(ShapeType, out var binding) ? binding.BindingSource : null;
 
-        public virtual Func<DisplayContext, Task<IHtmlContent>> Binding
-        {
-            get
-            {
-                return Bindings[ShapeType].BindingAsync;
-            }
-        }
+        public virtual Func<DisplayContext, Task<IHtmlContent>> Binding =>
+            Bindings[ShapeType].BindingAsync;
 
         public virtual IDictionary<string, ShapeBinding> Bindings { get; set; }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTableBuilder.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTableBuilder.cs
@@ -9,13 +9,13 @@ namespace OrchardCore.DisplayManagement.Descriptors
         private readonly IList<ShapeAlterationBuilder> _alterationBuilders = new List<ShapeAlterationBuilder>();
         private readonly IFeatureInfo _feature;
 
-        public ShapeTableBuilder(IFeatureInfo feature, IList<string> excludedFeatureIds = null)
+        public ShapeTableBuilder(IFeatureInfo feature, IReadOnlyCollection<string> excludedFeatureIds = null)
         {
             _feature = feature;
-            ExcludedFeatureIds = excludedFeatureIds ?? new List<string>();
+            ExcludedFeatureIds = excludedFeatureIds ?? new HashSet<string>();
         }
 
-        public IList<string> ExcludedFeatureIds { get; }
+        public IReadOnlyCollection<string> ExcludedFeatureIds { get; }
 
         public ShapeAlterationBuilder Describe(string shapeType)
         {


### PR DESCRIPTION
Thanks to @deanmarcussen I was able to get my hands on some real world setup. It showed that memory allocations were quite intense in `ShapeDescriptor`. It's constructed only once (source data won't change), but the results are calculated on every invocation. I changed this to be based on pre-calculated values when the descriptor has been build. 