### PR TITLE
Msbuild target to copy translation files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -187,8 +187,11 @@ nuget.exe
 node_modules/
 
 wwwroot
+Localization
 !src/OrchardCore.Modules/**/wwwroot
 !src/OrchardCore.Themes/**/wwwroot
+!src/OrchardCore.Modules/**/Localization
+!src/OrchardCore.Themes/**/Localization
 !src/Templates/**/content/**
 src/Templates/**/content/**/[Bb]in/
 src/Templates/**/content/**/[Oo]bj/

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -27,7 +27,7 @@
     <PackageManagement Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="4.8.5" />
     <PackageManagement Include="NodaTime" Version="2.4.7" />
-    <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-beta3-100243" />
+    <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-beta3-100246" />
     <PackageManagement Include="OpenIddict" Version="2.0.0" />
     <PackageManagement Include="OpenIddict.Core" Version="2.0.0" />
     <PackageManagement Include="OpenIddict.EntityFrameworkCore" Version="2.0.0" />

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -11,10 +11,6 @@
     <ResolvedFileToPublish Include="App_Data\**" Exclude="App_Data\**\*.log">
       <RelativePath>App_Data\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
     </ResolvedFileToPublish>
-
-    <ResolvedFileToPublish Include="Localization\**">
-      <RelativePath>Localization\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
-    </ResolvedFileToPublish>
   </ItemGroup>
 
   <Target Name="MakeWebRootFolder" BeforeTargets="MakeLocalizationFolder" Condition="!Exists('wwwroot/.placeholder')">
@@ -31,6 +27,13 @@
       SourceFiles="%(PackageTranslationFiles.FullPath)"
       DestinationFolder="Localization\%(RecursiveDir)"
       Condition="'@(PackageTranslationFiles)' != ''" />
+
+    <ItemGroup>
+      <LocalizationFiles Include="Localization\**" />
+      <ResolvedFileToPublish Include="@(LocalizationFiles)">
+        <RelativePath>Localization\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
+      </ResolvedFileToPublish>
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -25,4 +25,12 @@
     <WriteLinesToFile Lines="" Encoding="Unicode" File="Localization/.placeholder" />
   </Target>
 
+  <Target Name="CopyPackageTranslationFiles" AfterTargets="Build">
+    <Message Text="Copying translation files: $(MSBuildProjectName)" Importance="high" />
+    <Copy
+      SourceFiles="%(PackageTranslationFiles.FullPath)"
+      DestinationFolder="Localization\%(RecursiveDir)"
+      Condition="'@(PackageTranslationFiles)' != ''" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Fixes #4329 

- So, here i added a target in `OC.Application.Cms.Core.Targets.targets` so that translations files, from referenced translation packages (even transitively), are copied under the project root folder.

- I also updated the place where we mark them to be published so that it works even we do a publish without having done any 1st build before.


- I thought about a target to clean the localization files before building or on a cleaning cmd, but i removed it to let the ability to manualy add some translation files under the `Localization` folder.

**What we have to do in the translations repo**

- No need to change the `*.nuspec` template.

- We just need to create somewhere the following shared `Package.Build.props` file. Then, when creating a translation package, this file need to be copied under the package `buildTransitive` folder and renamed to `{PackageId}.props` => `buildTransitive/{PackageId}.props`.

      <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
        <ItemGroup>
          <PackageTranslationFiles Include="$(MSBuildThisFileDirectory)..\content\Localization\**\*" />
        </ItemGroup>
      </Project>
