### PR TITLE
Support for validation error class

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Forms/Views/Items/InputPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Views/Items/InputPart.cshtml
@@ -6,6 +6,16 @@
     var elementId = formElementPart.Id;
     var fieldName = formInputElementPart.Name;
     var fieldId = !string.IsNullOrEmpty(elementId) ? elementId : !string.IsNullOrEmpty(fieldName) ? Html.GenerateIdFromName(fieldName) : default(string);
-    var fieldValue = ViewData.ModelState.ContainsKey(fieldName) ? ViewData.ModelState[fieldName].AttemptedValue : Model.Value.DefaultValue;
+    var fieldValue = Model.Value.DefaultValue;
+    var fieldClass = "form-control";
+
+    if (ViewData.ModelState.TryGetValue(fieldName, out var fieldEntry))
+    {
+        fieldValue = fieldEntry.AttemptedValue;
+        if (fieldEntry.Errors.Count > 0)
+        {
+            fieldClass = "form-control input-validation-error";
+        }
+    }
 }
-<input id="@fieldId" name="@fieldName" type="@Model.Value.Type" class="form-control" value="@fieldValue" placeholder="@Model.Value.Placeholder" />
+<input id="@fieldId" name="@fieldName" type="@Model.Value.Type" class="@fieldClass" value="@fieldValue" placeholder="@Model.Value.Placeholder" />

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Views/Items/TextAreaPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Views/Items/TextAreaPart.cshtml
@@ -4,8 +4,18 @@
     var formElementPart = Model.Value.ContentItem.As<FormElementPart>();
     var formInputElementPart = Model.Value.ContentItem.As<FormInputElementPart>();
     var elementId = formElementPart.Id;
-    var elementName = formInputElementPart.Name;
-    var id = !string.IsNullOrEmpty(elementId) ? elementId : !string.IsNullOrEmpty(elementName) ? Html.GenerateIdFromName(elementName) : default(string);
-    var fieldValue = ViewData.ModelState.ContainsKey(elementName) ? ViewData.ModelState[elementName].AttemptedValue : Model.Value.DefaultValue?.Trim();
+    var fieldName = formInputElementPart.Name;
+    var fieldId = !string.IsNullOrEmpty(elementId) ? elementId : !string.IsNullOrEmpty(fieldName) ? Html.GenerateIdFromName(fieldName) : default(string);
+    var fieldValue = Model.Value.DefaultValue?.Trim();
+    var fieldClass = "form-control";
+
+    if (ViewData.ModelState.TryGetValue(fieldName, out var fieldEntry))
+    {
+        fieldValue = fieldEntry.AttemptedValue;
+        if (fieldEntry.Errors.Count > 0)
+        {
+            fieldClass = "form-control input-validation-error";
+        }
+    }
 }
-<textarea id="@id" name="@elementName" class="form-control" placeholder="@Model.Value.Placeholder">@fieldValue</textarea>
+<textarea id="@fieldId" name="@fieldName" class="@fieldClass" placeholder="@Model.Value.Placeholder">@fieldValue</textarea>


### PR DESCRIPTION
Fix: #4354

Solution is based on: 

https://github.com/aspnet/AspNetCore/blob/master/src/Mvc/Mvc.ViewFeatures/src/DefaultHtmlGenerator.cs

In MVC both Input and TextArea use ValidationInputCssClassName which is: "input-validation-error".

This validation class is also generated for Select fields, but I can't find where Orchard renders select widget.