### PR TITLE
Allows shared views across tenants.

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/LocationExpander/ComponentViewLocationExpanderProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/LocationExpander/ComponentViewLocationExpanderProvider.cs
@@ -11,8 +11,10 @@ namespace OrchardCore.Mvc.LocationExpander
 {
     public class ComponentViewLocationExpanderProvider : IViewLocationExpanderProvider
     {
+        private static readonly string ShareViewPath = "/Views/Shared/{0}" + RazorViewEngine.ViewExtension;
+        private static readonly string[] RazorExtensions = new[] { RazorViewEngine.ViewExtension };
         private const string CacheKey = "ModuleComponentViewLocations";
-        private static IList<IExtensionInfo> _modulesWithComponentViews;
+        private static List<IExtensionInfo> _modulesWithComponentViews;
         private static object _synLock = new object();
 
         private readonly IExtensionManager _extensionManager;
@@ -47,7 +49,7 @@ namespace OrchardCore.Mvc.LocationExpander
                     foreach (var module in orderedModules)
                     {
                         var moduleComponentsViewFilePaths = fileProviderAccessor.FileProvider.GetViewFilePaths(
-                            module.SubPath + "/Views/Shared/Components", new[] { RazorViewEngine.ViewExtension },
+                            module.SubPath + "/Views/Shared/Components", RazorExtensions,
                             viewsFolder: null, inViewsFolder: true, inDepth: true);
 
                         if (moduleComponentsViewFilePaths.Any())
@@ -81,19 +83,21 @@ namespace OrchardCore.Mvc.LocationExpander
 
             if (context.ViewName.StartsWith("Components/", StringComparison.Ordinal))
             {
-                if (!_memoryCache.TryGetValue(CacheKey, out IEnumerable<string> moduleComponentViewLocations))
+                if (!_memoryCache.TryGetValue(CacheKey, out string[] moduleComponentViewLocations))
                 {
                     var enabledIds = _extensionManager.GetFeatures().Where(f => _shellDescriptor
-                        .Features.Any(sf => sf.Id == f.Id)).Select(f => f.Extension.Id).Distinct().ToArray();
+                        .Features.Any(sf => sf.Id == f.Id)).Select(f => f.Extension.Id).ToHashSet();
 
-                    var enabledExtensions = _extensionManager.GetExtensions()
-                        .Where(e => enabledIds.Contains(e.Id)).ToArray();
-
-                    var sharedViewsPath = "/Views/Shared/{0}" + RazorViewEngine.ViewExtension;
+                    var enabledExtensionIds = _extensionManager
+                        .GetExtensions()
+                        .Where(e => enabledIds.Contains(e.Id))
+                        .Select(x => x.Id)
+                        .ToHashSet();
 
                     moduleComponentViewLocations = _modulesWithComponentViews
-                        .Where(m => enabledExtensions.Any(e => e.Id == m.Id))
-                        .Select(m => '/' + m.SubPath + sharedViewsPath);
+                        .Where(m => enabledExtensionIds.Contains(m.Id))
+                        .Select(m => '/' + m.SubPath + ShareViewPath)
+                        .ToArray();
 
                     _memoryCache.Set(CacheKey, moduleComponentViewLocations);
                 }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/LocationExpander/SharedViewLocationExpanderProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/LocationExpander/SharedViewLocationExpanderProvider.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.Extensions.Caching.Memory;
+using OrchardCore.Environment.Extensions;
+using OrchardCore.Environment.Shell.Descriptor.Models;
+using OrchardCore.Mvc.FileProviders;
+
+namespace OrchardCore.Mvc.LocationExpander
+{
+    public class SharedViewLocationExpanderProvider : IViewLocationExpanderProvider
+    {
+        private const string CacheKey = "ModuleSharedViewLocations";
+        private const string PageCacheKey = "ModulePageSharedViewLocations";
+        private static IList<IExtensionInfo> _modulesWithPageSharedViews;
+        private static IList<IExtensionInfo> _modulesWithSharedViews;
+        private static object _synLock = new object();
+
+        private readonly IExtensionManager _extensionManager;
+        private readonly ShellDescriptor _shellDescriptor;
+        private readonly IMemoryCache _memoryCache;
+
+        public SharedViewLocationExpanderProvider(
+            RazorCompilationFileProviderAccessor fileProviderAccessor,
+            IExtensionManager extensionManager,
+            ShellDescriptor shellDescriptor,
+            IMemoryCache memoryCache)
+        {
+            _extensionManager = extensionManager;
+            _shellDescriptor = shellDescriptor;
+            _memoryCache = memoryCache;
+
+            if (_modulesWithSharedViews != null)
+            {
+                return;
+            }
+
+            lock (_synLock)
+            {
+                if (_modulesWithSharedViews == null)
+                {
+                    var orderedModules = _extensionManager.GetExtensions()
+                        .Where(e => e.Manifest.Type.Equals("module", StringComparison.OrdinalIgnoreCase))
+                        .Reverse();
+
+                    var modulesWithPageSharedViews = new List<IExtensionInfo>();
+                    foreach (var module in orderedModules)
+                    {
+                        var modulePageSharedViewFilePaths = fileProviderAccessor.FileProvider.GetViewFilePaths(
+                            module.SubPath + "Pages/Shared", new[] { RazorViewEngine.ViewExtension },
+                            viewsFolder: null, inViewsFolder: true, inDepth: true);
+
+                        if (modulePageSharedViewFilePaths.Any())
+                        {
+                            modulesWithPageSharedViews.Add(module);
+                        }
+                    }
+
+                    var modulesWithSharedViews = new List<IExtensionInfo>();
+                    foreach (var module in orderedModules)
+                    {
+                        var moduleSharedViewFilePaths = fileProviderAccessor.FileProvider.GetViewFilePaths(
+                            module.SubPath + "/Views/Shared", new[] { RazorViewEngine.ViewExtension },
+                            viewsFolder: null, inViewsFolder: true, inDepth: true);
+
+                        if (moduleSharedViewFilePaths.Any())
+                        {
+                            modulesWithSharedViews.Add(module);
+                        }
+                    }
+
+                    _modulesWithPageSharedViews = modulesWithPageSharedViews;
+                    _modulesWithSharedViews = modulesWithSharedViews;
+                }
+            }
+        }
+
+        public int Priority => 5;
+
+        /// <inheritdoc />
+        public void PopulateValues(ViewLocationExpanderContext context)
+        {
+        }
+
+        /// <inheritdoc />
+        public virtual IEnumerable<string> ExpandViewLocations(ViewLocationExpanderContext context,
+                                                               IEnumerable<string> viewLocations)
+        {
+            if (context.AreaName == null)
+            {
+                return viewLocations;
+            }
+
+            var result = new List<string>();
+
+            if (context.PageName != null)
+            {
+                if (!_memoryCache.TryGetValue(PageCacheKey, out IEnumerable<string> modulePageSharedViewLocations))
+                {
+                    var enabledIds = _extensionManager.GetFeatures().Where(f => _shellDescriptor
+                        .Features.Any(sf => sf.Id == f.Id)).Select(f => f.Extension.Id).Distinct().ToArray();
+
+                    var enabledExtensions = _extensionManager.GetExtensions()
+                        .Where(e => enabledIds.Contains(e.Id)).ToArray();
+
+                    var pageSharedViewsPath = "/Pages/Shared/{0}" + RazorViewEngine.ViewExtension;
+
+                    modulePageSharedViewLocations = _modulesWithSharedViews
+                        .Where(m => enabledExtensions.Any(e => e.Id == m.Id))
+                        .Select(m => '/' + m.SubPath + pageSharedViewsPath);
+
+                    _memoryCache.Set(PageCacheKey, modulePageSharedViewLocations);
+                }
+
+                result.AddRange(modulePageSharedViewLocations);
+            }
+
+            if (!_memoryCache.TryGetValue(CacheKey, out IEnumerable<string> moduleSharedViewLocations))
+            {
+                var enabledIds = _extensionManager.GetFeatures().Where(f => _shellDescriptor
+                    .Features.Any(sf => sf.Id == f.Id)).Select(f => f.Extension.Id).Distinct().ToArray();
+
+                var enabledExtensions = _extensionManager.GetExtensions()
+                    .Where(e => enabledIds.Contains(e.Id)).ToArray();
+
+                var sharedViewsPath = "/Views/Shared/{0}" + RazorViewEngine.ViewExtension;
+
+                moduleSharedViewLocations = _modulesWithSharedViews
+                    .Where(m => enabledExtensions.Any(e => e.Id == m.Id))
+                    .Select(m => '/' + m.SubPath + sharedViewsPath);
+
+                _memoryCache.Set(CacheKey, moduleSharedViewLocations);
+            }
+
+            result.AddRange(moduleSharedViewLocations);
+            result.AddRange(viewLocations);
+
+            return result;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
@@ -109,6 +109,7 @@ namespace OrchardCore.Mvc
         internal static void AddMvcModuleCoreServices(IServiceCollection services)
         {
             services.AddScoped<IViewLocationExpanderProvider, ComponentViewLocationExpanderProvider>();
+            services.AddScoped<IViewLocationExpanderProvider, SharedViewLocationExpanderProvider>();
 
             services.TryAddEnumerable(
                 ServiceDescriptor.Singleton<IApplicationModelProvider, ModularApplicationModelProvider>());


### PR DESCRIPTION
Without using the theme engine, it allows e.g to have for a given module (enabled in 2 tenants) to have a controller mvc view that uses a given layout e.g `Layout = _Layout1` that is defined in 2 different modules acting as pseudo themes. Then, the layout that will be used by a given tenant will depend on its enabled pseudo themes.