### PR TITLE
Update BagPartSettings default display type, placeholder, and hint to Detail

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPartSettings.Edit.cshtml
@@ -9,7 +9,7 @@
 <fieldset class="form-group">
     <div class="row col-sm-6">
         <label asp-for="DisplayType">@T["Display Type"]</label>
-        <input asp-for="DisplayType" placeholder="Summary" class="form-control medium" />
-        <span class="hint">@T["The display type to use when rendering the content items. Default is Summary."]</span>
+        <input asp-for="DisplayType" placeholder="Detail" class="form-control medium" />
+        <span class="hint">@T["The display type to use when rendering the content items. Default is Detail."]</span>
     </div>
 </fieldset>


### PR DESCRIPTION
Follow on from https://github.com/OrchardCMS/OrchardCore/pull/4376

Just update the placeholder and hint text.

We should probably still add the Widget-Summary override as well, so that it doesn't break if display type Summary is used.

Hoping one day this branch might get revived https://github.com/OrchardCMS/OrchardCore/tree/sebros/routable at which point we _might_ want different display types, hard to say.

I'll do a separate pr for the summary, so as you prefer