### PR TITLE
Copy Widget view to Widget.Summary to prevent exceptions 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.Summary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.Summary.cshtml
@@ -1,0 +1,23 @@
+<div class="@String.Join(" ", Model.Classes.ToArray())">
+    @if (Model.Header != null || Model.Meta != null)
+    {
+    <div class="widget-header">
+        @await DisplayAsync(Model.Header)
+        @if (Model.Meta != null)
+        {
+            <div class="widget-metadata">
+                @await DisplayAsync(Model.Meta)
+            </div>
+        }
+    </div>
+    }
+    <div class="widget-body">
+    @await DisplayAsync(Model.Content)
+    </div>
+    @if (Model.Footer != null)
+    {
+    <div class="widget-footer">
+        @await DisplayAsync(Model.Footer)
+    </div>
+    }
+</div>


### PR DESCRIPTION
Further follow on from #4376

Add a `Widget.Summary` view to prevent exceptions when display type is Summary