### PR TITLE
Add helper/block liquid tags to readme

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/README.md
@@ -678,6 +678,26 @@ Example
 {% antiforgerytoken %}
 ```
 
+### `helper` and `block`
+
+Allows custom Razor [TagHelpers](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro?view=aspnetcore-3.0) to be called from liquid.
+
+For attributes (HtmlAttributeName) use camel-case and replace all `-` with `_`.
+
+Helper Tag example
+
+```liquid
+{% helper "mycustomtag", customAttribute: "foo" %}
+```
+
+Block Tag example
+
+```liquid
+{% block "mycustomtag", customAttribute: "foo" %}
+{% endblock %}
+```
+
+
 ## Razor Helpers
 
 ### `LiquidToHtmlAsync`


### PR DESCRIPTION
Relates to issue #4384. It was non-obvious from the documentation how to call helpers.