### PR TITLE
Documentation tweaks (mostly broken links)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/README.md
@@ -34,7 +34,7 @@ For instance the `HtmlBodyPart` of a custom settings section named `BlogSettings
 Custom Settings are a ContentItem, and by accessing it as a `ContentItem` you can access its parts and metadata.
 
 !!! note
-    You'll need to register your `ContentPart`s with Dependency Injection as demonstrated in the [ContentTypes documentation](../../OrchardCore.Modules.CMS/OrchardCore.ContentTypes/README/).
+    You'll need to register your `ContentPart`s with Dependency Injection as demonstrated in the [ContentTypes documentation](../../OrchardCore.Modules/OrchardCore.ContentTypes/).
 
 Here is an example of getting the `HtmlBodyPart` of a custom settings section named `BlogSettings`:
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Media/README.md
@@ -184,7 +184,7 @@ The following configuration values are used by default and can be customized:
       "SupportedSizes": [ 16, 32, 50, 100, 160, 240, 480, 600, 1024, 2048 ],
 
       // The number of days to store images in the browser cache.
-      // NB: To control cache headers for module static assets, refer to [this section](../../OrchardCore/OrchardCore/Modules/README.md).
+      // NB: To control cache headers for module static assets, refer to the Orchard Core Modules Section.
       "MaxBrowserCacheDays": 30,
 
       // The number of days a cached resized media item will be valid for, before being rebuilt on request.

--- a/src/OrchardCore.Modules/OrchardCore.Templates/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/README.md
@@ -269,7 +269,7 @@ This template is called when a content field shape type is rendered for a given 
 The differentiator uniquely identifies a shape in a zone. When rendering a content item, the shape has a `Content` property that contains
 all the shapes provided by content display drivers, including the ones for content parts and content fields.
 
-Differentiators can be used to configure the placement information (c.f. [Placement documentation page](../../OrchardCore/OrchardCore.DisplayManagement/README)), or to access specific shapes in a zone using these template helpers:
+Differentiators can be used to configure the placement information (c.f. [Placement documentation page](../../OrchardCore/OrchardCore.DisplayManagement/)), or to access specific shapes in a zone using these template helpers:
 
 ### Content Part differentiator
 
@@ -341,6 +341,7 @@ Views/Shared/{0}.cshtml
 ### Overriding Login view
 
 For example, if you want to override the `OrchardCore.Users\Views\Account\Login.cshtml` view you would need to create a file in your theme and place 
-it under `YourTheme\Views\OrchardCore.Users\Account\Login.cshtml`. For this particular file, you would also need to select the `Use site theme for login page`
+it under `YourTheme\Views\OrchardCore.Users\Account\Login.cshtml`. 
+For this particular file, you would also need to select the `Use site theme for login page`
 option under the `Configuration->Login` page in the admin.
 

--- a/src/OrchardCore.Modules/OrchardCore.Themes/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/README.md
@@ -139,14 +139,14 @@ In this case we can provide a template named `Content-Portfolio.cshtml` in order
 This file can be created by copying the original `Content.cshtml` file or by creating a brand new one.
 
 Many other alternates are available to be able to selectively create templates for a content item.
-See [Content templates](../OrchardCore.Templates/README/#content-templates)
+See [Content templates](../OrchardCore.Templates/#content-templates)
 
 ### Customizing Part templates
 
 It might not be necessary to change the __Content__ template, but only to change how a single part or field is rendered.
 These are also rendered as shapes and have specific templates that can be customized.
 
-The __Title__ part can be customized by creating a template for the `TitlePart` shape. See [`Title`](../OrchardCore.Title/README/)
+The __Title__ part can be customized by creating a template for the `TitlePart` shape. See [`Title`](../OrchardCore.Title/)
 
 Changing how the title is rendered for every content items would mean creating one of these files:
 
@@ -162,7 +162,7 @@ Changing how the title is rendered for every content items would mean creating o
 <h1>{{ Model.Title }}</h1>
 ```
 
-Assuming only the title of __Portfolio__ content items should be customized, alternates can be used to create a specialized template. Content part shapes have alternates specific to their parent's content type, in this case `Portfolio__TitlePart`. see [Content type, Display type, Part type](../OrchardCore.Templates/README/#contenttype_displaytype__parttype)
+Assuming only the title of __Portfolio__ content items should be customized, alternates can be used to create a specialized template. Content part shapes have alternates specific to their parent's content type, in this case `Portfolio__TitlePart`. see [Content type, Display type, Part type](../OrchardCore.Templates/#contenttype_displaytype__parttype)
 
 The template file name for this shape is `Portfolio-TitlePart.cshtml`.
 
@@ -170,11 +170,11 @@ The template file name for this shape is `Portfolio-TitlePart.cshtml`.
 
 Because multiple fields of the same type can be added to the same content type or even the same content part, their shape type is not the optimal way to customize the template. Fortunately different alternates based on their name are available.
 
-For a list of available shape alternates for fields see [Content field templates](../OrchardCore.Templates/README/#content-field-templates)
+For a list of available shape alternates for fields see [Content field templates](../OrchardCore.Templates/#content-field-templates)
 
 In our case, the __Project__ has a __Text__ field named `Url`. The best shape to override in this case is `Project__Url` which will match the template `Project-Url.cshtml`.
 
-The model accessible from this field is described here [Available fields](../OrchardCore.ContentFields/README/#available-fields)
+The model accessible from this field is described here [Available fields](../OrchardCore.ContentFields/#available-fields)
 
 This page explains that the __Text__ field contains a property `Text` that contains the value of the field.
 
@@ -200,7 +200,7 @@ When content items are rendered in a list, the convention is to use the `Summary
 Looking at how our __Portfolio__ content item is rendered, the __Project__ content items are displayed as a list, using the `Summary` display type.
 Alternates exist to target templates for a specific display type.
 For instance we can customize how __Project__ content items are displayed when rendered as part of a list by create a template for the shape `Content_Summary__Project`, which corresponds to the file `Content-Project.Summary.cshtml`.
-See [Templates documentation](../OrchardCore.Templates/README/#content_displaytype__contenttype)
+See [Templates documentation](../OrchardCore.Templates/#content_displaytype__contenttype)
 
 Here, the `_` in the shape name is replaced by a dot (`.`) in the template name, and the dotted portion of the name is moved at the end.
 
@@ -220,7 +220,7 @@ The `TitlePart` shape is rendered in the zone called `Header`.
 Some templating helpers provide ways to select and remove these shapes.
 
 In order to cherrypick specific shapes from a zone, shapes are given a nickname called a __Differentiator__.
-This is necessary, as multiple identical shape types can be added to content zones. See [Shape differentiators](../OrchardCore.Templates/README/#shape-differentiators)
+This is necessary, as multiple identical shape types can be added to content zones. See [Shape differentiators](../OrchardCore.Templates/#shape-differentiators)
 
 For the `Url` text field the differentiator is `Project-Url`. For the __Markdown__ part it is `MarkdownPart`.
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/README.md
@@ -201,7 +201,7 @@ For example, if you have a workflow that starts with the **Content Created Event
 {{ Workflow.Input.ContentItem.DisplayText }}
 ```
 
-For more examples of supported content item filters, see the documentation on [Liquid ](https://orchardcore.readthedocs.io/en/latest/OrchardCore.Modules/OrchardCore.Liquid/README/).
+For more examples of supported content item filters, see the documentation on [Liquid ](..//OrchardCore.Modules/OrchardCore.Liquid/).
 
 ## Activities out of the box
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/README.md
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/README.md
@@ -180,4 +180,4 @@ Result:
 
 ## Shape differentiators
 
-You can find information about shape differenciators in the [Templates documentation](../../OrchardCore.Modules/OrchardCore.Templates/README/#content-field-differentiator)
+You can find information about shape differenciators in the [Templates documentation](../../OrchardCore.Modules/OrchardCore.Templates/#content-field-differentiator)

--- a/src/OrchardCore/OrchardCore/Environment/Shell/README.md
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/README.md
@@ -2,7 +2,7 @@
 
 Orchard Core extends ASP.NET Core `IConfiguration` with `IShellConfiguration`.
 
-To learn more about ASP.NET Core `IConfiguration` visit https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration
+To learn more about ASP.NET Core `IConfiguration` visit <https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration>
 
 ### Config Sources
 

--- a/src/index.md
+++ b/src/index.md
@@ -83,7 +83,7 @@ Here is a more detailed [roadmap](https://github.com/OrchardCMS/OrchardCore/wiki
 - Call `dotnet run`.
 - Then open the `http://localhost:5000` URL in your browser.
 
-You can also read the [Code Generation Templates documentation](Templates/README) to create new applications from predefined templates.
+You can also read the [Code Generation Templates documentation](./docs/templates/) to create new applications from predefined templates.
 
 ### Visual Studio 2017
 


### PR DESCRIPTION
Went through readthedocs just to fix a few mistakes I'd made previously. Ended up fixing some other things too.

- Fixed a link that doesn't render in Media
- Added a link bracket to Configuration
- Updated a lot of deadlinks, that were refering to /README, rather than / which doesn't work /README.md does also work. Maybe something changed there at some point.
- Others that didn't didn't get updated when some document moved to ../docs

@agriffard is it possible to run readthedocs locally to see how things actually renders, and check links without having to guess?