### PR TITLE
Allow to exclude App_Data / Localization files on publishing.

### DIFF
--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -14,6 +14,11 @@
     <PreserveCompilationReferences>true</PreserveCompilationReferences>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <DefaultItemExcludes>$(DefaultItemExcludes);App_Data\**\Media\*</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Localization\ar\*</DefaultItemExcludes>
+  </PropertyGroup>
+
   <ItemGroup>
     <Folder Include="wwwroot\" />
     <Folder Include="Localization\" />

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -14,11 +14,6 @@
     <PreserveCompilationReferences>true</PreserveCompilationReferences>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <DefaultItemExcludes>$(DefaultItemExcludes);App_Data\**\Media\*</DefaultItemExcludes>
-    <DefaultItemExcludes>$(DefaultItemExcludes);Localization\ar\*</DefaultItemExcludes>
-  </PropertyGroup>
-
   <ItemGroup>
     <Folder Include="wwwroot\" />
     <Folder Include="Localization\" />

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -8,7 +8,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ResolvedFileToPublish Include="App_Data\**" Exclude="App_Data\**\*.log">
+    <ResolvedFileToPublish Include="App_Data\**" Exclude="$(DefaultItemExcludes);App_Data\**\*.log">
       <RelativePath>App_Data\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
     </ResolvedFileToPublish>
   </ItemGroup>
@@ -29,7 +29,7 @@
       Condition="'@(PackageTranslationFiles)' != ''" />
 
     <ItemGroup>
-      <LocalizationFiles Include="Localization\**" />
+      <LocalizationFiles Include="Localization\**" Exclude="$(DefaultItemExcludes)" />
       <ResolvedFileToPublish Include="@(LocalizationFiles)">
         <RelativePath>Localization\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
       </ResolvedFileToPublish>


### PR DESCRIPTION
So, as commented on gitter

> about `DefaultItemExcludes`, yes not so simple, it is historical because i was asked to not show at all the `App_Data files` under the VS solution but to still publish them, that's why we needed to act on `ResolvedFileToPublish` in a targets file (so after the .csproj). So here taking into account `DefaultItemExcludes` would allow an app csproj to add more items under `App_Data` to be excluded.

So here, from the app project file, it allows to exclude `App_Data / Localization` files on publishing, this by using the standard `DefaultItemExcludes` property, e.g.

    <PropertyGroup>
      <DefaultItemExcludes>$(DefaultItemExcludes);App_Data\**\Media\*</DefaultItemExcludes>
      <DefaultItemExcludes>$(DefaultItemExcludes);Localization\ar\*</DefaultItemExcludes>
    </PropertyGroup>
