### PR TITLE
NoWarnOnRazorViewImportedTypeConflicts

### DIFF
--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -36,10 +36,4 @@
     </ItemGroup>
   </Target>
 
-  <Target Name="NoWarnOnRazorViewImportedTypeConflicts" BeforeTargets="RazorCoreCompile">
-    <PropertyGroup>
-      <NoWarn>$(NoWarn);0436</NoWarn>
-    </PropertyGroup>
-  </Target>
-
 </Project>

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -36,4 +36,10 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="NoWarnOnRazorViewImportedTypeConflicts" BeforeTargets="RazorCoreCompile">
+    <PropertyGroup>
+      <NoWarn>$(NoWarn);0436</NoWarn>
+    </PropertyGroup>
+  </Target>
+
 </Project>

--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.targets
@@ -28,4 +28,10 @@
     </ItemGroup>
   </Target>
 
+  <Target Name="NoWarnOnRazorViewImportedTypeConflicts" BeforeTargets="RazorCoreCompile">
+    <PropertyGroup>
+      <NoWarn>$(NoWarn);0436</NoWarn>
+    </PropertyGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
Fixes #4398 

As commented in the related issue

> we have already hidden this warning in an msbuild script but only at the module level

      <Target Name="NoWarnOnRazorViewImportedTypeConflicts" BeforeTargets="RazorCoreCompile">
        <PropertyGroup>
          <NoWarn>$(NoWarn);0436</NoWarn>
        </PropertyGroup>
      </Target>

> Here it's related to a view defined at the app level, so we would need to do the same at the app level in the app level related msbuild script, i will take a look on it this night.


TBH i was not able to repro, but here i also hidde this warning at the application level.