### PR TITLE
FormValueRequiredEndpointComparer

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Routing/FormValueRequiredMatcherPolicy.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Routing/FormValueRequiredMatcherPolicy.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Routing.Matching;
 
 namespace OrchardCore.Routing
 {
-    public class FormValueRequiredMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy
+    public class FormValueRequiredMatcherPolicy : MatcherPolicy, IEndpointSelectorPolicy, IEndpointComparerPolicy
     {
         public FormValueRequiredMatcherPolicy()
         {
@@ -63,6 +63,16 @@ namespace OrchardCore.Routing
             }
 
             return Task.CompletedTask;
+        }
+
+        public IComparer<Endpoint> Comparer => new FormValueRequiredEndpointComparer();
+
+        private class FormValueRequiredEndpointComparer : EndpointMetadataComparer<FormValueRequiredAttribute>
+        {
+            protected override int CompareMetadata(FormValueRequiredAttribute x, FormValueRequiredAttribute y)
+            {
+                return base.CompareMetadata(x, y);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #4399 

- So, currently if 2 actions have the same pattern, action name, and include the same verb, having a `FormValueRequiredAttribute` on one of them doesn't prevent from an `AmbiguousMatchException`.

- Currently, if the required form value is not there, only one of them is selected, so that's ok. But if the required form value is there, both actions are selected.

- So, here the new comparer just checks the one that has the related attribute, knowing that if the form value is not be there, it would not have been selected at all.