### PR TITLE
Added edit_uri: edit/dev/src/

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,9 +4,9 @@ theme: readthedocs
 # Repository
 repo_name: OrchardCMS/OrchardCore
 repo_url: https://github.com/OrchardCMS/OrchardCore
-edit_uri: edit/dev/src/
 
 # Options
+edit_uri: edit/dev/src/
 docs_dir: src
 
 extra_css: 


### PR DESCRIPTION
Fixes #4411

This changes the GitHub default of edit/master/docs/