### PR TITLE
Update asset cache to check Azure Media Storage is Enabled

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Admin;
 using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Media.ViewModels;
 using OrchardCore.Modules;
 
 namespace OrchardCore.Media.Azure.Controllers
@@ -19,13 +22,13 @@ namespace OrchardCore.Media.Azure.Controllers
 
         public MediaCacheController(
             IAuthorizationService authorizationService,
-            IMediaFileStoreCache mediaFileStoreCache,
+            IServiceProvider serviceProvider,
             INotifier notifier,
             IHtmlLocalizer<MediaCacheController> htmlLocalizer
             )
         {
             _authorizationService = authorizationService;
-            _mediaFileStoreCache = mediaFileStoreCache;
+            _mediaFileStoreCache = serviceProvider.GetService<IMediaFileStoreCache>();
             _notifier = notifier;
             H = htmlLocalizer;
         }
@@ -36,8 +39,12 @@ namespace OrchardCore.Media.Azure.Controllers
             {
                 return Unauthorized();
             }
+            var model = new MediaCacheViewModel
+            {
+                IsConfigured = _mediaFileStoreCache == null ? false : true
+            };
 
-            return View();
+            return View(model);
         }
 
         [HttpPost]
@@ -46,6 +53,13 @@ namespace OrchardCore.Media.Azure.Controllers
             if (!await _authorizationService.AuthorizeAsync(User, MediaCachePermissions.ManageAssetCache))
             {
                 return Unauthorized();
+            }
+
+
+            if (_mediaFileStoreCache == null)
+            {
+                _notifier.Error(H["The asset cache cannot be purged. The feature is enabled, but a remote file store feature is not enabled, or not configured with appsettings.json."]);
+                RedirectToAction("Index");
             }
 
             var hasErrors = await _mediaFileStoreCache.PurgeAsync();

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
@@ -28,6 +28,7 @@ namespace OrchardCore.Media.Azure.Controllers
             )
         {
             _authorizationService = authorizationService;
+            // Resolve from service provider as the service will not be registered if configuration is invalid.
             _mediaFileStoreCache = serviceProvider.GetService<IMediaFileStoreCache>();
             _notifier = notifier;
             H = htmlLocalizer;
@@ -58,7 +59,7 @@ namespace OrchardCore.Media.Azure.Controllers
 
             if (_mediaFileStoreCache == null)
             {
-                _notifier.Error(H["The asset cache cannot be purged. The feature is enabled, but a remote media store feature is not enabled, or not configured with appsettings.json."]);
+                _notifier.Error(H["The asset cache feature is enabled, but a remote media store feature is not enabled, or not configured with appsettings.json."]);
                 RedirectToAction("Index");
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
@@ -58,7 +58,7 @@ namespace OrchardCore.Media.Azure.Controllers
 
             if (_mediaFileStoreCache == null)
             {
-                _notifier.Error(H["The asset cache cannot be purged. The feature is enabled, but a remote file store feature is not enabled, or not configured with appsettings.json."]);
+                _notifier.Error(H["The asset cache cannot be purged. The feature is enabled, but a remote media store feature is not enabled, or not configured with appsettings.json."]);
                 RedirectToAction("Index");
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
@@ -42,7 +42,7 @@ namespace OrchardCore.Media.Azure.Controllers
             }
             var model = new MediaCacheViewModel
             {
-                IsConfigured = _mediaFileStoreCache == null ? false : true
+                IsConfigured = _mediaFileStoreCache != null
             };
 
             return View(model);
@@ -55,7 +55,6 @@ namespace OrchardCore.Media.Azure.Controllers
             {
                 return Unauthorized();
             }
-
 
             if (_mediaFileStoreCache == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Media/ViewModels/MediaCacheViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/ViewModels/MediaCacheViewModel.cs
@@ -1,11 +1,7 @@
-using OrchardCore.ContentManagement;
-using OrchardCore.ContentManagement.Metadata.Models;
-using OrchardCore.Media.Fields;
-
 namespace OrchardCore.Media.ViewModels
 {
     public class MediaCacheViewModel
     {
-        public bool IsConfigured { get; set;}
+        public bool IsConfigured { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/ViewModels/MediaCacheViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/ViewModels/MediaCacheViewModel.cs
@@ -1,0 +1,11 @@
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.Media.Fields;
+
+namespace OrchardCore.Media.ViewModels
+{
+    public class MediaCacheViewModel
+    {
+        public bool IsConfigured { get; set;}
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
@@ -12,7 +12,7 @@
             <li class="list-group-item">
                 <div class="properties">
                     <div class="related">
-                        <a asp-action="Purge" class="btn btn-sm btn-danger float-right" data-title="@T["Purge All"]" data-message="@T["Are you sure you want to purge the entire asset cache?"]" data-ok-class="btn-danger" itemprop="RemoveUrl UnsafeUrl">@T["Purge All"]</a>
+                        <a asp-action="Purge" class="btn btn-sm btn-danger float-right" data-title="@T["Purge All"]" data-message="@T["Are you sure you want to purge the entire asset cache?"]" itemprop="RemoveUrl UnsafeUrl">@T["Purge All"]</a>
                     </div>
                     @T["Purge All"]
                     <span class="hint">— @T["Purge all the assets from the cache"]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
@@ -12,7 +12,7 @@
             <li class="list-group-item">
                 <div class="properties">
                     <div class="related">
-                        <a asp-action="Purge" class="btn btn-sm btn-danger float-right" data-title="@T["Purge All"]" data-message="@T["Are you sure you want to purge the entire asset cache?"]" itemprop="RemoveUrl UnsafeUrl">@T["Purge All"]</a>
+                        <a asp-action="Purge" class="btn btn-sm btn-danger float-right" data-title="@T["Purge All"]" data-message="@T["Are you sure you want to purge the entire asset cache?"]" data-ok-class="btn-danger" itemprop="RemoveUrl UnsafeUrl">@T["Purge All"]</a>
                     </div>
                     @T["Purge All"]
                     <span class="hint">— @T["Purge all the assets from the cache"]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
@@ -1,20 +1,28 @@
+@model OrchardCore.Media.ViewModels.MediaCacheViewModel
 <h1>@RenderTitleSegments(T["Asset Cache"])</h1>
 
-<p class="alert alert-secondary">@T["Media is configured with appsettings.json."]</p>
+@if (Model.IsConfigured)
+{
+    <p class="alert alert-secondary">@T["Media is configured with appsettings.json."]</p>
 
-<form asp-action="Purge">
-    @* the form is necessary to generate and antiforgery token for the purge action *@
+    <form asp-action="Purge">
+        @* the form is necessary to generate and antiforgery token for the purge action *@
 
-    <ul class="list-group">
-        <li class="list-group-item">
-            <div class="properties">
-                <div class="related">
-                    <a asp-action="Purge" class="btn btn-sm btn-danger float-right" data-title="@T["Purge All"]" data-message="@T["Are you sure you want to purge the entire asset cache?"]" itemprop="RemoveUrl UnsafeUrl">@T["Purge All"]</a>
+        <ul class="list-group">
+            <li class="list-group-item">
+                <div class="properties">
+                    <div class="related">
+                        <a asp-action="Purge" class="btn btn-sm btn-danger float-right" data-title="@T["Purge All"]" data-message="@T["Are you sure you want to purge the entire asset cache?"]" itemprop="RemoveUrl UnsafeUrl">@T["Purge All"]</a>
+                    </div>
+                    @T["Purge All"]
+                    <span class="hint">— @T["Purge all the assets from the cache"]</span>
                 </div>
-                @T["Purge All"]
-                <span class="hint">— @T["Purge all the assets from the cache"]</span>
-            </div>
-        </li>
-    </ul>
+            </li>
+        </ul>
 
-</form>
+    </form>
+}
+else
+{
+    <p class="alert alert-warning">@T["The asset cache feature is enabled, but a remote file store feature is not enabled, or not configured with appsettings.json."]</p>
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
@@ -24,5 +24,5 @@
 }
 else
 {
-    <p class="alert alert-warning">@T["The asset cache feature is enabled, but a remote file store feature is not enabled, or not configured with appsettings.json."]</p>
+    <p class="alert alert-danger">@T["The asset cache feature is enabled, but a remote file store feature is not enabled, or not configured with appsettings.json."]</p>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaCache/Index.cshtml
@@ -24,5 +24,5 @@
 }
 else
 {
-    <p class="alert alert-danger">@T["The asset cache feature is enabled, but a remote file store feature is not enabled, or not configured with appsettings.json."]</p>
+    <p class="alert alert-danger">@T["The asset cache feature is enabled, but a remote media store feature is not enabled, or not configured with appsettings.json."]</p>
 }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4228

Updates the media cache controller to check if the Azure Media Store is enabled / or configured correctly, and shows an error, rather than an exception.

![asset-cache](https://user-images.githubusercontent.com/13782679/65790991-af8aed80-e158-11e9-93b0-a213ddf0c83a.PNG)
