### PR TITLE
Updated scripts to use  BuildEditor Action url

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/wwwroot/Scripts/flows.edit.js
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/wwwroot/Scripts/flows.edit.js
@@ -27,7 +27,7 @@ $(function () {
         var prefix = guid();
         var contentTypesName = $(this).data("contenttypes-name");
         $.ajax({
-            url: createEditorUrl + "/" + type + "?prefix=" + prefix + "&prefixesName=" + prefixesName + "&contentTypesName=" + contentTypesName + "&targetId=" + targetId + "&flowmetadata=" + flowmetadata
+            url: createEditorUrl + "?id=" + type + "&prefix=" + prefix + "&prefixesName=" + prefixesName + "&contentTypesName=" + contentTypesName + "&targetId=" + targetId + "&flowmetadata=" + flowmetadata
         }).done(function (data) {
             var result = JSON.parse(data);
             $(document.getElementById(targetId)).append(widgetTemplate(result.Content, prefixesName, prefix, contentTypesName, type));
@@ -49,7 +49,7 @@ $(function () {
         var prefix = guid();
         var contentTypesName = $(this).data("contenttypes-name");
         $.ajax({
-            url: createEditorUrl + "/" + type + "?prefix=" + prefix + "&prefixesName=" + prefixesName + "&contentTypesName=" + contentTypesName + "&targetId=" + targetId + "&flowmetadata=" + flowmetadata
+            url: createEditorUrl + "?id=" + type + "&prefix=" + prefix + "&prefixesName=" + prefixesName + "&contentTypesName=" + contentTypesName + "&targetId=" + targetId + "&flowmetadata=" + flowmetadata
         }).done(function (data) {
             var result = JSON.parse(data);
             $(widgetTemplate(result.Content, prefixesName, prefix, contentTypesName, type)).insertBefore(target);

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/wwwroot/Scripts/widgetslist.edit.js
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/wwwroot/Scripts/widgetslist.edit.js
@@ -22,7 +22,7 @@ $(function () {
         var prefix = guid();
         var contentTypesName = $(this).data("contenttypes-name");
         $.ajax({
-            url: createEditorUrl + "/" + type + "?prefix=" + prefix + "&prefixesName=" + prefixesName + "&contentTypesName=" + contentTypesName + "&zonesName=" + zonesName + "&zone=" + zone + "&targetId=" + targetId
+            url: createEditorUrl + "?id=" + type + "&prefix=" + prefix + "&prefixesName=" + prefixesName + "&contentTypesName=" + contentTypesName + "&zonesName=" + zonesName + "&zone=" + zone + "&targetId=" + targetId
         })
         .done(function (data) {
             var result = JSON.parse(data);
@@ -46,7 +46,7 @@ $(function () {
         var prefix = guid();
         var contentTypesName = $(this).data("contenttypes-name");
         $.ajax({
-            url: createEditorUrl + "/" + type + "?prefix=" + prefix + "&prefixesName=" + prefixesName + "&contentTypesName=" + contentTypesName + "&zonesName=" + zonesName + "&zone=" + zone + "&targetId=" + targetId
+            url: createEditorUrl + "?id=" + type + "&prefix=" + prefix + "&prefixesName=" + prefixesName + "&contentTypesName=" + contentTypesName + "&zonesName=" + zonesName + "&zone=" + zone + "&targetId=" + targetId
         })
         .done(function (data) {
             var result = JSON.parse(data);


### PR DESCRIPTION
Changed createEditorUrl in ajax call to use BuildEditor Action url instead of relative url of parent widget

Fixes #4443