### PR TITLE
[GraphQL] fix settings format in documentation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
@@ -84,9 +84,9 @@ Configuration is done via the standard shell configuration, as follows.
       "ExposeExceptions": true,
       "MaxDepth": 50, 
       "MaxComplexity": 100, 
-      "FieldImpact": 2.0 ,
-      "DefaultNumberOfResults": 100
-      "MaxNumberOfResults": 1000
+      "FieldImpact": 2.0,
+      "DefaultNumberOfResults": 100,
+      "MaxNumberOfResults": 1000,
       "MaxNumberOfResultsValidationMode": "Default"
     }
   }


### PR DESCRIPTION
Fixes formatting of the settings example in the documentation