### PR TITLE
Fix namespace on the Media Cache Controller

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
@@ -9,7 +9,7 @@ using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.Media.ViewModels;
 using OrchardCore.Modules;
 
-namespace OrchardCore.Media.Azure.Controllers
+namespace OrchardCore.Media.Controllers
 {
     [Feature("OrchardCore.Media.Cache")]
     [Admin]


### PR DESCRIPTION
Accidently left Azure in the namespace