### PR TITLE
Fix namespace for content part handler coordinator

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Modules;
 
-namespace OrchardCore.ContentManagement.Drivers.Coordinators
+namespace OrchardCore.ContentManagement.Handlers
 {
     /// <summary>
     /// This component coordinates how parts are affecting content items.

--- a/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OrchardCore.ContentManagement.Cache;
-using OrchardCore.ContentManagement.Drivers.Coordinators;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Records;


### PR DESCRIPTION
Saw this as well, so thought I'd fix it, while I was tidying up some other things.

Original namespace doesn't exist anywhere else, but it's been this way since the Orchard Core renaming, so if it's intentionally this way, just close it :)