### PR TITLE
Add ability to generate DisplayText with a Pattern

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Views/AutoroutePartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Views/AutoroutePartSettings.Edit.cshtml
@@ -13,7 +13,7 @@
     <div class="col-lg">
         <label asp-for="Pattern">@T["Pattern"]</label>
         <textarea asp-for="Pattern" rows="5" class="form-control"></textarea>
-        <span class="hint">@T["The pattern used to render the custom url of this content type."]</span>
+        <span class="hint">@T["The pattern used to render the custom url of this content type. With Liquid support."]</span>
     </div>
 </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplay.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Title.Models;
@@ -9,6 +12,11 @@ namespace OrchardCore.Title.Drivers
 {
     public class TitlePartDisplay : ContentPartDisplayDriver<TitlePart>
     {
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+        public TitlePartDisplay(IContentDefinitionManager contentDefinitionManager)
+        {
+            _contentDefinitionManager = contentDefinitionManager;
+        }
         public override IDisplayResult Display(TitlePart titlePart)
         {
             return Initialize<TitlePartViewModel>("TitlePart", model =>
@@ -26,8 +34,7 @@ namespace OrchardCore.Title.Drivers
             {
                 model.Title = titlePart.ContentItem.DisplayText;
                 model.TitlePart = titlePart;
-
-                return new ValueTask();
+                model.Settings = GetSettings(titlePart);
             });
         }
 
@@ -39,5 +46,14 @@ namespace OrchardCore.Title.Drivers
 
             return Edit(model);
         }
+
+
+        private TitlePartSettings GetSettings(TitlePart titlePart)
+        {
+            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(titlePart.ContentItem.ContentType);
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(TitlePart), StringComparison.Ordinal));
+            return contentTypePartDefinition?.GetSettings<TitlePartSettings>();
+        }
+
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Fluid;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Handlers;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Liquid;
+using OrchardCore.Title.Models;
+
+namespace OrchardCore.Title.Handlers
+{
+    public class TitlePartHandler : ContentPartHandler<TitlePart>
+    {
+        private readonly ILiquidTemplateManager _liquidTemplateManager;
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+
+        public TitlePartHandler(
+            ILiquidTemplateManager liquidTemplateManager,
+            IContentDefinitionManager contentDefinitionManager)
+        {
+            _liquidTemplateManager = liquidTemplateManager;
+            _contentDefinitionManager = contentDefinitionManager;
+        }
+
+
+        public override async Task UpdatedAsync(UpdateContentContext context, TitlePart part)
+        {
+            var settings = GetSettings(part);
+            // Do not compute the title if the user can modify it and the text is already set.
+            if (settings.AllowCustomTitle == true && !String.IsNullOrWhiteSpace(part.ContentItem.DisplayText))
+            {
+                return;
+            }
+
+            if (!String.IsNullOrEmpty(settings.Pattern))
+            {
+                var templateContext = new TemplateContext();
+                templateContext.SetValue("ContentItem", part.ContentItem);
+
+                var title = await _liquidTemplateManager.RenderAsync(settings.Pattern, NullEncoder.Default, templateContext);
+                title = title.Replace("\r", String.Empty).Replace("\n", String.Empty);
+
+                part.Title = title;
+                part.ContentItem.DisplayText = title;
+                part.Apply();
+            }
+        }
+
+        private TitlePartSettings GetSettings(TitlePart part)
+        {
+            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => String.Equals(x.PartDefinition.Name, nameof(TitlePart), StringComparison.Ordinal));
+            return contentTypePartDefinition.GetSettings<TitlePartSettings>();
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.Title.Handlers
         {
             var settings = GetSettings(part);
             // Do not compute the title if the user can modify it and the text is already set.
-            if (settings.AllowCustomTitle == true && !String.IsNullOrWhiteSpace(part.ContentItem.DisplayText))
+            if (settings.Options == TitlePartOptions.Editable && !String.IsNullOrWhiteSpace(part.ContentItem.DisplayText))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Models/TitlePart.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Models/TitlePart.cs
@@ -1,11 +1,9 @@
 using OrchardCore.ContentManagement;
-using System.ComponentModel.DataAnnotations;
 
 namespace OrchardCore.Title.Models
 {
     public class TitlePart : ContentPart
     {
-        [Required]
         public string Title { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Models/TitlePartSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Models/TitlePartSettings.cs
@@ -1,0 +1,15 @@
+namespace OrchardCore.Title.Models
+{
+    public class TitlePartSettings
+    {
+        /// <summary>
+        /// Gets or sets whether a user can define a custom title
+        /// </summary>
+        public bool? AllowCustomTitle { get; set; }
+
+        /// <summary>
+        /// The pattern used to build the Title.
+        /// </summary>
+        public string Pattern { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Title/Models/TitlePartSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Models/TitlePartSettings.cs
@@ -2,13 +2,19 @@ using System.ComponentModel;
 
 namespace OrchardCore.Title.Models
 {
+    public enum TitlePartOptions
+    {
+        Editable,
+        GeneratedDisabled,
+        GeneratedHidden,
+    }
     public class TitlePartSettings
     {
         /// <summary>
         /// Gets or sets whether a user can define a custom title
         /// </summary>
-        [DefaultValue(true)]
-        public bool AllowCustomTitle { get; set; } = true;
+        [DefaultValue(TitlePartOptions.Editable)]
+        public TitlePartOptions Options { get; set; } = TitlePartOptions.Editable;
 
         /// <summary>
         /// The pattern used to build the Title.

--- a/src/OrchardCore.Modules/OrchardCore.Title/Models/TitlePartSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Models/TitlePartSettings.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace OrchardCore.Title.Models
 {
     public class TitlePartSettings
@@ -5,7 +7,8 @@ namespace OrchardCore.Title.Models
         /// <summary>
         /// Gets or sets whether a user can define a custom title
         /// </summary>
-        public bool? AllowCustomTitle { get; set; }
+        [DefaultValue(true)]
+        public bool AllowCustomTitle { get; set; } = true;
 
         /// <summary>
         /// The pattern used to build the Title.

--- a/src/OrchardCore.Modules/OrchardCore.Title/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Title/README.md
@@ -1,22 +1,39 @@
 # Title (`OrchardCore.Title`)
 
-The `Title` module provides a **Title Part** that lets user define a title for a content item.
-It also defines the `DisplayText` property of the `ContentItemMetadata` aspect.
+The `Title` module provides a **Title Part** that lets you customize the DisplayText property of a content item.
+The DisplayText property is used throughout the Admin interface to help you recognize your content items.
+
+## TitlePart
+
+Attach this part to your content items to customize the DisplayText property of a ContentItem.
+
+### TitlePart Settings
+
+By default, attaching the TitlePart will allow content editors to manually edit the DisplayText(title) of a ContentItem.
+
+You can also generate the Title by specifying a pattern using a Liquid expression.
+
+The Pattern has access the current ContentItem and is executed on ContentItem update.
+For example, fields can be used to generate the pattern. The following example uses a __Text field__ named `Name`, on a `Product` content type.
+
+```liquid
+{{ ContentItem.Content.Product.Name.Text }}
+```
 
 ## Theming
 
 The following shapes are rendered when the **Title Part** is attached to a content type.
 
-| Name | Display Type | Default Location | Model Type |
-| ------| ------------ |----------------- | ---------- |
-| `TitlePart` | `Detail` | `Header:5` | `TitlePartViewModel` |
-| `TitlePart` | `Summary` | `Header:10` | `TitlePartViewModel` |
+| Name        | Display Type | Default Location | Model Type           |
+| ----------- | ------------ | ---------------- | -------------------- |
+| `TitlePart` | `Detail`     | `Header:5`       | `TitlePartViewModel` |
+| `TitlePart` | `Summary`    | `Header:10`      | `TitlePartViewModel` |
 
 ### View Model
 
 The following properties are available in the `TitlePartViewModel` class.
 
-| Name | Type | Description |
-| -----| ---- |------------ |
-| `Title` | `string` | The title property of the part. |
-| `TitlePart` | `TitlePart` | The `TitlePart` instance. |
+| Name        | Type        | Description                     |
+| ----------- | ----------- | ------------------------------- |
+| `Title`     | `string`    | The title property of the part. |
+| `TitlePart` | `TitlePart` | The `TitlePart` instance.       |

--- a/src/OrchardCore.Modules/OrchardCore.Title/Settings/TitlePartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Settings/TitlePartSettingsDisplayDriver.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Title.Models;
+using OrchardCore.Title.ViewModels;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Liquid;
+
+namespace OrchardCore.Title.Settings
+{
+    public class TitlePartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
+    {
+        private readonly ILiquidTemplateManager _templateManager;
+
+        public TitlePartSettingsDisplayDriver(ILiquidTemplateManager templateManager, IStringLocalizer<TitlePartSettingsDisplayDriver> localizer)
+        {
+            _templateManager = templateManager;
+            T = localizer;
+        }
+
+        public IStringLocalizer T { get; private set; }
+
+        public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
+        {
+            if (!String.Equals(nameof(TitlePart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            return Initialize<TitlePartSettingsViewModel>("TitlePartSettings_Edit", model =>
+            {
+                var settings = contentTypePartDefinition.GetSettings<TitlePartSettings>();
+
+                model.AllowCustomTitle = settings.AllowCustomTitle.HasValue ? settings.AllowCustomTitle.Value : true;
+                model.Pattern = settings.Pattern;
+                model.TitlePartSettings = settings;
+            }).Location("Content");
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
+        {
+            if (!String.Equals(nameof(TitlePart), contentTypePartDefinition.PartDefinition.Name, StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            var model = new TitlePartSettingsViewModel();
+
+            await context.Updater.TryUpdateModelAsync(model, Prefix, 
+                m => m.Pattern,
+                m => m.AllowCustomTitle);
+
+            if (!string.IsNullOrEmpty(model.Pattern) && !_templateManager.Validate(model.Pattern, out var errors))
+            {
+                context.Updater.ModelState.AddModelError(nameof(model.Pattern), T["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+            } else {
+                context.Builder.WithSettings(new TitlePartSettings
+                {
+                    Pattern = model.Pattern,
+                    AllowCustomTitle = model.AllowCustomTitle,
+                });
+            }
+
+            return Edit(contentTypePartDefinition, context.Updater);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Title/Settings/TitlePartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Settings/TitlePartSettingsDisplayDriver.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.Title.Settings
             {
                 var settings = contentTypePartDefinition.GetSettings<TitlePartSettings>();
 
-                model.AllowCustomTitle = settings.AllowCustomTitle.HasValue ? settings.AllowCustomTitle.Value : true;
+                model.AllowCustomTitle = settings.AllowCustomTitle;
                 model.Pattern = settings.Pattern;
                 model.TitlePartSettings = settings;
             }).Location("Content");

--- a/src/OrchardCore.Modules/OrchardCore.Title/Settings/TitlePartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Settings/TitlePartSettingsDisplayDriver.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.Title.Settings
             {
                 var settings = contentTypePartDefinition.GetSettings<TitlePartSettings>();
 
-                model.AllowCustomTitle = settings.AllowCustomTitle;
+                model.Options = settings.Options;
                 model.Pattern = settings.Pattern;
                 model.TitlePartSettings = settings;
             }).Location("Content");
@@ -51,17 +51,15 @@ namespace OrchardCore.Title.Settings
 
             await context.Updater.TryUpdateModelAsync(model, Prefix, 
                 m => m.Pattern,
-                m => m.AllowCustomTitle);
+                m => m.Options);
 
             if (!string.IsNullOrEmpty(model.Pattern) && !_templateManager.Validate(model.Pattern, out var errors))
             {
                 context.Updater.ModelState.AddModelError(nameof(model.Pattern), T["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
-            } else {
-                context.Builder.WithSettings(new TitlePartSettings
-                {
-                    Pattern = model.Pattern,
-                    AllowCustomTitle = model.AllowCustomTitle,
-                });
+            }
+            else
+            {
+                context.Builder.WithSettings(new TitlePartSettings {Pattern = model.Pattern, Options = model.Options,});
             }
 
             return Edit(contentTypePartDefinition, context.Updater);

--- a/src/OrchardCore.Modules/OrchardCore.Title/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Startup.cs
@@ -2,12 +2,16 @@ using Fluid;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.ContentManagement.Handlers;
+using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
 using OrchardCore.Title.Drivers;
+using OrchardCore.Title.Handlers;
 using OrchardCore.Title.Indexing;
 using OrchardCore.Title.Models;
+using OrchardCore.Title.Settings;
 using OrchardCore.Title.ViewModels;
 
 namespace OrchardCore.Title
@@ -17,6 +21,7 @@ namespace OrchardCore.Title
         static Startup()
         {
             TemplateContext.GlobalMemberAccessStrategy.Register<TitlePartViewModel>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<TitlePartSettingsViewModel>();
         }
 
         public override void ConfigureServices(IServiceCollection services)
@@ -25,6 +30,8 @@ namespace OrchardCore.Title
             services.AddScoped<IContentPartDisplayDriver, TitlePartDisplay>();
             services.AddContentPart<TitlePart>();
             services.AddScoped<IContentPartIndexHandler, TitlePartIndexHandler>();
+            services.AddScoped<IContentPartHandler, TitlePartHandler>();
+            services.AddScoped<IContentTypePartDefinitionDisplayDriver, TitlePartSettingsDisplayDriver>();
 
             services.AddScoped<IDataMigration, Migrations>();
         }

--- a/src/OrchardCore.Modules/OrchardCore.Title/ViewModels/TitlePartSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/ViewModels/TitlePartSettingsViewModel.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Title.ViewModels
 {
     public class TitlePartSettingsViewModel
     {
-        public bool AllowCustomTitle { get; set; } = true;
+        public bool AllowCustomTitle { get; set; }
         public string Pattern { get; set; }
 
         [BindNever]

--- a/src/OrchardCore.Modules/OrchardCore.Title/ViewModels/TitlePartSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/ViewModels/TitlePartSettingsViewModel.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Title.ViewModels
 {
     public class TitlePartSettingsViewModel
     {
-        public bool AllowCustomTitle { get; set; }
+        public TitlePartOptions Options { get; set; }
         public string Pattern { get; set; }
 
         [BindNever]

--- a/src/OrchardCore.Modules/OrchardCore.Title/ViewModels/TitlePartSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/ViewModels/TitlePartSettingsViewModel.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using OrchardCore.Title.Models;
+
+namespace OrchardCore.Title.ViewModels
+{
+    public class TitlePartSettingsViewModel
+    {
+        public bool AllowCustomTitle { get; set; } = true;
+        public string Pattern { get; set; }
+
+        [BindNever]
+        public TitlePartSettings TitlePartSettings { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Title/ViewModels/TitlePartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/ViewModels/TitlePartViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.Title.Models;
 
 namespace OrchardCore.Title.ViewModels
@@ -9,5 +9,7 @@ namespace OrchardCore.Title.ViewModels
 
         [BindNever]
         public TitlePart TitlePart { get; set; }
+        [BindNever]
+        public TitlePartSettings Settings { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePart.Edit.cshtml
@@ -9,7 +9,14 @@
 
 <fieldset class="form-group" asp-validation-class-for="Title">
     <label asp-for="Title">@T["Title"]</label>
-    <input asp-for="Title" class="form-control content-preview-text content-caption-text" autofocus="autofocus" dir="@culture.GetLanguageDirection()" />
+    <input asp-for="Title" class="form-control content-preview-text content-caption-text" disabled="@(Model.Settings?.AllowCustomTitle == false)" autofocus="autofocus" dir="@culture.GetLanguageDirection()" />
     <span asp-validation-for="Title"></span>
-    <span class="hint">@T["The title of the content item."]</span>
+    @if (!String.IsNullOrWhiteSpace(Model.Settings?.Pattern) && Model.Settings?.AllowCustomTitle == true)
+    {
+        <span class="hint">@T["The title of the content item. Set empty to generate it using the pattern."]</span>
+    }
+    else
+    {
+        <span class="hint">@T["The title of the content item. It will be automatically generated."]</span>
+    }
 </fieldset>

--- a/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePart.Edit.cshtml
@@ -1,22 +1,25 @@
 @model TitlePartViewModel
 @using OrchardCore.ContentLocalization
 @using OrchardCore.Localization
+@using OrchardCore.Title.Models
 @using OrchardCore.Title.ViewModels;
 
 @{
     var culture = await Orchard.GetContentCultureAsync(Model.TitlePart.ContentItem);
 }
-
-<fieldset class="form-group" asp-validation-class-for="Title">
-    <label asp-for="Title">@T["Title"]</label>
-    <input asp-for="Title" class="form-control content-preview-text content-caption-text" disabled="@(Model.Settings?.AllowCustomTitle == false)" autofocus="autofocus" dir="@culture.GetLanguageDirection()" />
-    <span asp-validation-for="Title"></span>
-    @if (!String.IsNullOrWhiteSpace(Model.Settings?.Pattern) && Model.Settings?.AllowCustomTitle == true)
-    {
-        <span class="hint">@T["The title of the content item. Set empty to generate it using the pattern."]</span>
-    }
-    else
-    {
-        <span class="hint">@T["The title of the content item. It will be automatically generated."]</span>
-    }
-</fieldset>
+@if (Model.Settings?.Options != TitlePartOptions.GeneratedHidden)
+{
+    <fieldset class="form-group" asp-validation-class-for="Title">
+        <label asp-for="Title">@T["Title"]</label>
+        <input asp-for="Title" class="form-control content-preview-text content-caption-text" disabled="@(Model.Settings?.Options == TitlePartOptions.GeneratedDisabled)" autofocus="autofocus" dir="@culture.GetLanguageDirection()"/>
+        <span asp-validation-for="Title"></span>
+        @if (String.IsNullOrWhiteSpace(Model.Settings?.Pattern) && Model.Settings?.Options == TitlePartOptions.Editable)
+        {
+            <span class="hint">@T["The title of the content item. Set empty to generate it using the pattern."]</span>
+        }
+        else
+        {
+            <span class="hint">@T["The title of the content item. It will be automatically generated."]</span>
+        }
+    </fieldset>
+}

--- a/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePartSettings.Edit.cshtml
@@ -1,3 +1,4 @@
+@using OrchardCore.Title.Models
 @model OrchardCore.Title.ViewModels.TitlePartSettingsViewModel
 
 <script asp-name="codemirror" depends-on="admin" at="Foot"></script>
@@ -9,15 +10,15 @@
 
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
-<div class="form-group">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="AllowCustomTitle" checked="@Model.AllowCustomTitle">
-        <label class="custom-control-label" asp-for="AllowCustomTitle">@T["Allow custom Title"]</label>
-        <span class="hint">@T["Check to allow users to set a custom Title, otherwise it will be automatically generated."]</span>
-    </div>
+<div class="row col-sm-6 mb-3">
+    <label asp-for="Options">@T["Options"]</label>
+    <select asp-for="Options" class="form-control">
+        <option value="@TitlePartOptions.Editable" selected="@(Model.Options == TitlePartOptions.Editable)">@T["Title is editable"]</option>
+        <option value="@TitlePartOptions.GeneratedDisabled" selected="@(Model.Options == TitlePartOptions.GeneratedDisabled)">@T["Title is generated and input is disabled"]</option>
+        <option value="@TitlePartOptions.GeneratedHidden" selected="@(Model.Options == TitlePartOptions.GeneratedHidden)">@T["Title is generated and input is hidden"]</option>
+    </select>
 </div>
-
-<div class="form-group row">
+<div class="row mb-3">
     <div class="col-lg">
         <label asp-for="Pattern">@T["Pattern"]</label>
         <textarea asp-for="Pattern" rows="5" class="form-control"></textarea>

--- a/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePartSettings.Edit.cshtml
@@ -1,0 +1,38 @@
+@model OrchardCore.Title.ViewModels.TitlePartSettingsViewModel
+
+<script asp-name="codemirror" depends-on="admin" at="Foot"></script>
+<script asp-name="codemirror-mode-javascript" at="Foot"></script>
+<script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
+<script asp-name="codemirror-addon-mode-simple" at="Foot"></script>
+<script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
+<script asp-name="codemirror-mode-xml" at="Foot"></script>
+
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
+
+<div class="form-group">
+    <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" asp-for="AllowCustomTitle" checked="@Model.AllowCustomTitle">
+        <label class="custom-control-label" asp-for="AllowCustomTitle">@T["Allow custom Title"]</label>
+        <span class="hint">@T["Check to allow users to set a custom Title, otherwise it will be automatically generated."]</span>
+    </div>
+</div>
+
+<div class="form-group row">
+    <div class="col-lg">
+        <label asp-for="Pattern">@T["Pattern"]</label>
+        <textarea asp-for="Pattern" rows="5" class="form-control"></textarea>
+        <span class="hint">@T["The pattern used to render the title of this content type. With Liquid support."]</span>
+    </div>
+</div>
+
+<script at="Foot" depends-on="jquery">
+    $(function () {
+        editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Pattern)'), {
+            autoRefresh: true,
+            lineNumbers: true,
+            styleActiveLine: true,
+            matchBrackets: true,
+            mode: { name: "liquid" },
+        });
+    });
+</script>


### PR DESCRIPTION
Add settings to TitlePart
- Options: editable, generated, generated hidden
- Pattern: Liquid pattern used to generate the DisplayText property

TheTitle is no longer a required field. 
Couple issues with setting the default value of a setting. If we use `public bool AllowCustomTitle { get; set; } = true;` it would always change back to true when visiting the settings again.