### PR TITLE
Support Placement for Field Editor Options

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
@@ -40,9 +40,14 @@ namespace OrchardCore.DisplayManagement
 
         private static PlacementInfo FindPlacementImpl(ShapeTable shapeTable, string shapeType, string differentiator, string displayType, IBuildShapeContext context)
         {
-            ShapeDescriptor descriptor;
+            var delimiterIndex = shapeType.IndexOf("__");
 
-            if (shapeTable.Descriptors.TryGetValue(shapeType, out descriptor))
+            if (delimiterIndex > 0)
+            {
+                shapeType = shapeType.Substring(0, delimiterIndex);
+            }
+
+            if (shapeTable.Descriptors.TryGetValue(shapeType, out var descriptor))
             {
                 var placementContext = new ShapePlacementContext(
                     shapeType,


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4483

When trying to find placement for a field editor options like `TextField_Edit__Color` the key in the shape descriptor lookup is expecting `TextField_Edit`, so this strips the `shapeType` in the same way that the `ShapeAlterationBuilder` does when creating the placement alteration.

Maybe fixing something in the wrong place again here though, as placement is a maze :)

@jtketch any thoughts? 