### PR TITLE
Update Autoroute handler tags

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -142,7 +142,7 @@ namespace OrchardCore.Autoroute.Handlers
 
         private Task RemoveTagAsync(AutoroutePart part)
         {
-            return _tagCache.RemoveTagAsync($"alias:{part.Path}");
+            return _tagCache.RemoveTagAsync($"slug:{part.Path}");
         }
 
         /// <summary>


### PR DESCRIPTION
For #1588 

I tested it with the blog theme and the _tagCache object did not have an entry for the Slug. Where is this cache being updated for Autoroute ?