### PR TITLE
Most commonly used error pages 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Diagnostics/Controllers/DiagnosticsController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Diagnostics/Controllers/DiagnosticsController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using Microsoft.AspNetCore.Mvc;
 
@@ -7,18 +8,26 @@ namespace OrchardCore.Diagnostics.Controllers
     {
         public IActionResult Error(int? status)
         {
+            // Most commonly used error messages
             ViewData["StatusCode"] = status;
+            Enum.TryParse((status ?? 500).ToString(), true, out HttpStatusCode httpStatusCode);
 
-            if (status == (int)HttpStatusCode.NotFound)
-            {
-                return View("NotFound");
-            }
-            else if (status == (int)HttpStatusCode.Forbidden)
-            {
-                return View("Forbidden");
-            }
 
-            return View("Error");
+            switch (httpStatusCode)
+            {
+                case HttpStatusCode.InternalServerError:
+                default:
+                    return View("Error");
+                case HttpStatusCode.Forbidden:
+                    return View("Forbidden");
+                case HttpStatusCode.NotFound:
+                    return View("NotFound");
+                case HttpStatusCode.BadRequest:
+                    return View("BadRequest");
+                case HttpStatusCode.Unauthorized:
+                    return View("Unauthorized");
+
+            }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Diagnostics/Views/Diagnostics/BadRequest.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Diagnostics/Views/Diagnostics/BadRequest.cshtml
@@ -1,0 +1,1 @@
+<h1>@T["Your browser sent a request that this server could not understand."]</h1>


### PR DESCRIPTION
According to pingdom research, top 5 most common errors are : 401, 400, 404, 403, 500. I modified error pages accordingly. 
Ref: https://royal.pingdom.com/the-5-most-common-http-errors-according-to-google/