### PR TITLE
Change css class in Message shape

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/CoreShapes.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/CoreShapes.cs
@@ -104,8 +104,8 @@ namespace OrchardCore.DisplayManagement.Shapes
             TagBuilder tagBuilder = OrchardCore.DisplayManagement.Shapes.Shape.GetTagBuilder(Shape, "div");
             string type = Shape.Type.ToString().ToLowerInvariant();
             IHtmlContent message = Shape.Message;
-            tagBuilder.AddCssClass("message");
-            tagBuilder.AddCssClass("message-" + type);
+            tagBuilder.AddCssClass("alert");
+            tagBuilder.AddCssClass("alert-" + type);
             tagBuilder.Attributes["role"] = "alert";
             tagBuilder.InnerHtml.AppendHtml(message);
             return tagBuilder;


### PR DESCRIPTION
When you use a Notify Workflow Task a Message shape is created.
It generates a div with a `message` css class. 
As most of our themes use Bootstrap, it is more interesting to generate `alert alert-` or else the display won't be the expected one.

If we don't do this, it would require to create a Message override in your theme or in Admin template.

If someone wants to comment with the Liquid equivalent of this, it could be interesting:
```
            TagBuilder tagBuilder = OrchardCore.DisplayManagement.Shapes.Shape.GetTagBuilder(Shape, "div");
            string type = Shape.Type.ToString().ToLowerInvariant();
            IHtmlContent message = Shape.Message;
            tagBuilder.AddCssClass("message");
            tagBuilder.AddCssClass("message-" + type);
            tagBuilder.Attributes["role"] = "alert";
            tagBuilder.InnerHtml.AppendHtml(message);
            return tagBuilder;
```