### PR TITLE
Fix SiteSettings defaults

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/Deployment/SiteSettingsDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Deployment/SiteSettingsDeploymentSource.cs
@@ -62,6 +62,10 @@ namespace OrchardCore.Settings.Deployment
                         data.Add(new JProperty(nameof(ISite.SiteName), site.SiteName));
                         break;
 
+                    case "PageTitleFormat":
+                        data.Add(new JProperty(nameof(ISite.PageTitleFormat), site.PageTitleFormat));
+                        break;
+
                     case "SiteSalt":
                         data.Add(new JProperty(nameof(ISite.SiteSalt), site.SiteSalt));
                         break;
@@ -76,6 +80,14 @@ namespace OrchardCore.Settings.Deployment
 
                     case "UseCdn":
                         data.Add(new JProperty(nameof(ISite.UseCdn), site.UseCdn));
+                        break;
+
+                    case "CdnBaseUrl":
+                        data.Add(new JProperty(nameof(ISite.CdnBaseUrl), site.CdnBaseUrl));
+                        break;
+
+                    case "AppendVersion":
+                        data.Add(new JProperty(nameof(ISite.AppendVersion), site.AppendVersion));
                         break;
 
                     case "HomeRoute":

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Recipes/SettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Recipes/SettingsStep.cs
@@ -61,6 +61,10 @@ namespace OrchardCore.Settings.Recipes
                         site.SiteName = property.Value.ToString();
                         break;
 
+                    case "PageTitleFormat":
+                        site.PageTitleFormat = property.Value.ToString();
+                        break;
+
                     case "SiteSalt":
                         site.SiteSalt = property.Value.ToString();
                         break;
@@ -75,6 +79,10 @@ namespace OrchardCore.Settings.Recipes
 
                     case "UseCdn":
                         site.UseCdn = property.Value.Value<bool>();
+                        break;
+
+                    case "CdnBaseUrl":
+                        site.CdnBaseUrl = property.Value.ToString();
                         break;
 
                     case "AppendVersion":

--- a/src/OrchardCore.Modules/OrchardCore.Settings/SiteSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/SiteSettings.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.AspNetCore.Routing;
 using OrchardCore.Entities;
 
@@ -18,9 +17,9 @@ namespace OrchardCore.Settings
         public string SiteSalt { get; set; }
         public string PageTitleFormat { get; set; }
         public string SuperUser { get; set; }
-        public bool UseCdn { get; set; }
+        public bool UseCdn { get; set; } = true;
         public string CdnBaseUrl { get; set; }
         public RouteValueDictionary HomeRoute { get; set; } = new RouteValueDictionary();
-        public bool AppendVersion { get; set; }
+        public bool AppendVersion { get; set; } = true;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/SiteSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/SiteSettings.cs
@@ -3,6 +3,7 @@ using OrchardCore.Entities;
 
 namespace OrchardCore.Settings
 {
+    // When updating class also update SiteSettingsDeploymentSource and SettingsStep.
     public class SiteSettings : Entity, ISite
     {
         public int Id { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
@@ -70,7 +70,7 @@
     <fieldset class="col-xl-6" asp-validation-class-for="ResourceDebugMode">
         <label asp-for="ResourceDebugMode">@T["Resource Debug Mode"]</label>
         <select asp-for="ResourceDebugMode" class="form-control">
-            <option value="@ResourceDebugMode.FromConfiguration.ToString()">@T["From environment — enabled in <em>Production</em>, disabled otherwise"]</option>
+            <option value="@ResourceDebugMode.FromConfiguration.ToString()">@T["From environment — disabled in <em>Production</em>, enabled otherwise"]</option>
             <option value="@ResourceDebugMode.Enabled.ToString()">@T["Enabled — use debuggable version of resources"]</option>
             <option value="@ResourceDebugMode.Disabled.ToString()">@T["Disabled — use minified version of resources"]</option>
         </select>

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
@@ -2,7 +2,7 @@ namespace OrchardCore.ResourceManagement
 {
     public class ResourceManagementOptions
     {
-        public bool UseCdn { get; set; }
+        public bool UseCdn { get; set; } = true;
 
         public string CdnBaseUrl { get; set; }
 
@@ -10,7 +10,7 @@ namespace OrchardCore.ResourceManagement
 
         public string Culture { get; set; }
 
-        public bool AppendVersion { get; set; }
+        public bool AppendVersion { get; set; } = true;
 
         /// <summary>
         /// The prefix path that is used when a url starts with "~/".

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
@@ -1,22 +1,20 @@
-using System;
-
 namespace OrchardCore.ResourceManagement
 {
     public class ResourceManagementOptions
     {
-        public bool UseCdn { get; set; } = true;
+        public bool UseCdn { get; set; }
 
         public string CdnBaseUrl { get; set; }
 
-        public bool DebugMode { get; set; } = false;
+        public bool DebugMode { get; set; }
 
         public string Culture { get; set; }
 
-        public bool AppendVersion { get; set; } = true;
+        public bool AppendVersion { get; set; }
 
         /// <summary>
         /// The prefix path that is used when a url starts with "~/".
         /// </summary>
-        public string ContentBasePath { get; set; } = String.Empty;
+        public string ContentBasePath { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceManagementOptions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace OrchardCore.ResourceManagement
 {
     public class ResourceManagementOptions
@@ -15,6 +17,6 @@ namespace OrchardCore.ResourceManagement
         /// <summary>
         /// The prefix path that is used when a url starts with "~/".
         /// </summary>
-        public string ContentBasePath { get; set; }
+        public string ContentBasePath { get; set; } = String.Empty;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4562

Also fixes null reference exception when importing sitesettings deployment due to missing properties, from recent additions to SiteSettings (CdnBaseUrl, AppendVersion, PageTitleFormat).

Also updates the description for `ResourceDebugMode.FromConfiguration` (environment) to be 
`From environment — disabled in <em>Production</em>, enabled otherwise`

as it was the opposite, and didn't make sense.

i.e. `DebugMode = true` is actually disabled when in production, and otherwise it is enabled.

![oc-site-settings](https://user-images.githubusercontent.com/13782679/67080720-b45a2480-f18d-11e9-9eff-4b622b151c65.PNG)
