### PR TITLE
DisplayDriver PrefixRoot

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerMetadataWelder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerMetadataWelder.cs
@@ -25,6 +25,11 @@ namespace OrchardCore.Layers.Drivers
         protected override void BuildPrefix(ContentItem model, string htmlFieldPrefix)
         {
             Prefix = "LayerMetadata";
+
+            if (!String.IsNullOrEmpty(htmlFieldPrefix))
+            {
+                Prefix = htmlFieldPrefix + "." + Prefix;
+            }
         }
 
         public override async Task<IDisplayResult> EditAsync(ContentItem model, BuildEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerMetadataWelder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerMetadataWelder.cs
@@ -24,11 +24,10 @@ namespace OrchardCore.Layers.Drivers
 
         protected override void BuildPrefix(ContentItem model, string htmlFieldPrefix)
         {
-            Prefix = "LayerMetadata";
-
-            if (!String.IsNullOrEmpty(htmlFieldPrefix))
-            {
-                Prefix = htmlFieldPrefix + "." + Prefix;
+            base.BuildPrefix(model, htmlFieldPrefix);
+            if (string.IsNullOrWhiteSpace(htmlFieldPrefix))
+            { 
+                Prefix = "LayerMetadata";
             }
         }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriver.cs
@@ -13,7 +13,6 @@ namespace OrchardCore.DisplayManagement.Handlers
         where TEditorContext : BuildEditorContext
         where TUpdateContext : UpdateEditorContext
     {
-        protected string PrefixRoot { get; set; } = typeof(TModel).Name;
 
         /// <summary>
         /// Returns <c>true</c> if the model can be handle by the current driver.
@@ -117,7 +116,7 @@ namespace OrchardCore.DisplayManagement.Handlers
 
         protected virtual void BuildPrefix(TModel model, string htmlFieldPrefix)
         {
-            Prefix = PrefixRoot;
+            Prefix = typeof(TModel).Name;
 
             if (!String.IsNullOrEmpty(htmlFieldPrefix))
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriver.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.DisplayManagement.Handlers
         where TEditorContext : BuildEditorContext
         where TUpdateContext : UpdateEditorContext
     {
+        protected string PrefixRoot { get; set; } = typeof(TModel).Name;
 
         /// <summary>
         /// Returns <c>true</c> if the model can be handle by the current driver.
@@ -116,7 +117,7 @@ namespace OrchardCore.DisplayManagement.Handlers
 
         protected virtual void BuildPrefix(TModel model, string htmlFieldPrefix)
         {
-            Prefix = typeof(TModel).Name;
+            Prefix = PrefixRoot;
 
             if (!String.IsNullOrEmpty(htmlFieldPrefix))
             {


### PR DESCRIPTION
Do what @KeithRaven suggested here: https://github.com/OrchardCMS/OrchardCore/issues/2908#issuecomment-449180212

With this change, the Title, Render Title and the Layer dropdown are not displayed multiple times at each level of the hierarchy in a Widget.

Fixes #2908, #4079, #4537
/cc @deanmarcussen @ns8482e 