### PR TITLE
Update mkdocs.yml to include decoupled guide and email docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
         - Creating a Modular ASP.NET Core Application: docs/guides/create-modular-application-mvc/index.md
         - Running Code on Startup: docs/guides/run-code-on-startup/index.md
         - Creating an Orchard Core CMS website: docs/guides/create-cms-application/index.md
+        - Creating an Orchard Core Decoupled CMS website: docs/guides/decoupled-cms/decoupled/
         - Adding a Menu Item to the Admin Navigation: docs/guides/add-admin-menu/index.md
         - Installing Localization Files: docs/guides/install-localization-files/index.md
     - Code Generation Templates: docs/templates/README.md
@@ -74,6 +75,7 @@ nav:
         - Configuration: OrchardCore/OrchardCore/Environment/Shell/README.md
         - Data: OrchardCore/OrchardCore.Data/README.md
         - Dynamic Cache: OrchardCore.Modules/OrchardCore.DynamicCache/README.md
+        - Email: OrchardCore.Modules/OrchardCore.Email/README.md
         - GraphQL: OrchardCore.Modules/OrchardCore.Apis.GraphQL/README.md
         - GraphQL queries: OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/README.md
         - Health Check: OrchardCore.Modules/OrchardCore.HealthChecks/README.md

--- a/src/OrchardCore.Modules/OrchardCore.Email/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Email/README.md
@@ -31,3 +31,12 @@ Enabling the `OrchardCore.Email` module will allow the user to set the following
             ...
     }
 ```
+
+## Credits
+
+### MailKit
+
+<https://github.com/jstedfast/MailKit>
+
+Copyright 2013-2019 Xamarin Inc
+Licensed under the MIT License


### PR DESCRIPTION
I went to find your new guide @sebastienros and it was buried in the Index.

Maybe you meant to keep it there?

Also added new email docs from https://github.com/OrchardCMS/OrchardCore/pull/4519 to the menu