### PR TITLE
Default pattern for autoroute and alias

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Indexing.Abstractions\OrchardCore.Indexing.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Settings/AliasPartSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Settings/AliasPartSettings.cs
@@ -1,7 +1,10 @@
-﻿namespace OrchardCore.Alias.Settings
+using System.ComponentModel;
+
+namespace OrchardCore.Alias.Settings
 {
     public class AliasPartSettings
     {
-        public string Pattern { get; set; }
+        [DefaultValue("{{ ContentItem.DisplayText | slugify }}")]
+        public string Pattern { get; set; } = "{{ ContentItem.DisplayText | slugify }}";
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Views/AliasPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Views/AliasPartSettings.Edit.cshtml
@@ -1,9 +1,31 @@
 @model OrchardCore.Alias.Settings.AliasPartSettingsViewModel
+<script asp-name="codemirror" depends-on="admin" at="Foot"></script>
+<script asp-name="codemirror-mode-javascript" at="Foot"></script>
+<script asp-name="codemirror-addon-display-autorefresh" at="Foot"></script>
+<script asp-name="codemirror-addon-mode-simple" at="Foot"></script>
+<script asp-name="codemirror-addon-mode-multiplex" at="Foot"></script>
+<script asp-name="codemirror-mode-xml" at="Foot"></script>
+
+<script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
 <div class="form-group row">
     <div class="col-lg">
         <label asp-for="Pattern">@T["Pattern"]</label>
-        <input asp-for="Pattern" class="form-control" />
+        <textarea asp-for="Pattern" rows="5" class="form-control"></textarea>
         <span class="hint">@T["The pattern used to render the alias of this content type."]</span>
     </div>
 </div>
+
+<script at="Foot" depends-on="jquery">
+    //<![CDATA[
+    $(function () {
+        editor = CodeMirror.fromTextArea(document.getElementById('@Html.IdFor(x => x.Pattern)'), {
+            autoRefresh: true,
+            lineNumbers: true,
+            styleActiveLine: true,
+            matchBrackets: true,
+            mode: { name: "liquid" },
+        });
+    });
+    //]]>
+</script>

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Views/_ViewImports.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Views/_ViewImports.cshtml
@@ -6,5 +6,6 @@
 @inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, OrchardCore.DisplayManagement
+@addTagHelper *, OrchardCore.ResourceManagement
 
 @using OrchardCore.Alias.ViewModels

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartSettings.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+
 namespace OrchardCore.Autoroute.Models
 {
     public class AutoroutePartSettings
@@ -10,7 +12,8 @@ namespace OrchardCore.Autoroute.Models
         /// <summary>
         /// The pattern used to build the Path.
         /// </summary>
-        public string Pattern { get; set; }
+        [DefaultValue("{{ ContentItem.DisplayText | slugify }}")]
+        public string Pattern { get; set; } = "{{ ContentItem.DisplayText | slugify }}";
 
         /// <summary>
         /// Whether to display an option to set the content item as the homepage.

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/OrchardCore.Autoroute.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/OrchardCore.Autoroute.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Indexing.Abstractions\OrchardCore.Indexing.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.MetaWeblog.Abstractions\OrchardCore.MetaWeblog.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4526

Did a default alias pattern as well (the same default)

And added the same codemirror to alias as for autoroute,.

Also fixed autoroute codemirror, which was not always working properly in the screenshot from the issue, because it didn't have a reference to `OrchardCore.Resources` so jquery not always loading.

result is this for both alias and autoroute
![autoroute-alias](https://user-images.githubusercontent.com/13782679/67569470-e12ab080-f726-11e9-92d4-6eefdfada4b7.PNG)
