### PR TITLE
Revert email appsettings.json change

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -24,11 +24,5 @@
     //  "ConnectionString": "", // Set to your Azure Storage account connection string.
     //  "ContainerName": "dataprotection"
     //},
-
-    // Uncomment to configure SMTP settings.
-    //"OrchardCore.Email": {
-    //  "Host": "localhost",
-    //  "Port": "2525"
-    //}
   }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Email/README.md
+++ b/src/OrchardCore.Modules/OrchardCore.Email/README.md
@@ -20,18 +20,6 @@ Enabling the `OrchardCore.Email` module will allow the user to set the following
 | `UserName` | The username for the sender. |
 | `Password` | The password for the sender. |
 
-## Configuration
-`OrchardCore.Email` can be configured through `appsettings.json` as the following:
-
-```json
-    "OrchardCore.Email": {
-            "DefaultSender": "webmaster@orchardcore.info",
-            "Host": "Server",
-            "Port": 25,
-            ...
-    }
-```
-
 ## Credits
 
 ### MailKit

--- a/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpSettingsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpSettingsConfiguration.cs
@@ -1,10 +1,8 @@
 using System;
 using Microsoft.AspNetCore.DataProtection;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Entities;
-using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Email.Services
@@ -14,10 +12,8 @@ namespace OrchardCore.Email.Services
         private readonly ISiteService _site;
         private readonly IDataProtectionProvider _dataProtectionProvider;
         private readonly ILogger<SmtpSettingsConfiguration> _logger;
-        private SmtpSettings _smtpSettings;
 
         public SmtpSettingsConfiguration(
-            IShellConfiguration shellConfiguration,
             ISiteService site,
             IDataProtectionProvider dataProtectionProvider,
             ILogger<SmtpSettingsConfiguration> logger)
@@ -25,36 +21,32 @@ namespace OrchardCore.Email.Services
             _site = site;
             _dataProtectionProvider = dataProtectionProvider;
             _logger = logger;
-            _smtpSettings = shellConfiguration.GetSection("OrchardCore.Email").Get<SmtpSettings>();
-
         }
 
         public void Configure(SmtpSettings options)
         {
-            if (_smtpSettings == null)
-            {
-                _smtpSettings = _site.GetSiteSettingsAsync()
-                    .GetAwaiter().GetResult().As<SmtpSettings>();
-            }
+            var settings = _site.GetSiteSettingsAsync()
+                .GetAwaiter().GetResult()
+                .As<SmtpSettings>();
 
-            options.DefaultSender = _smtpSettings.DefaultSender;
-            options.DeliveryMethod = _smtpSettings.DeliveryMethod;
-            options.PickupDirectoryLocation = _smtpSettings.PickupDirectoryLocation;
-            options.Host = _smtpSettings.Host;
-            options.Port = _smtpSettings.Port;
-            options.EncryptionMethod = _smtpSettings.EncryptionMethod;
-            options.AutoSelectEncryption = _smtpSettings.AutoSelectEncryption;
-            options.RequireCredentials = _smtpSettings.RequireCredentials;
-            options.UseDefaultCredentials = _smtpSettings.UseDefaultCredentials;
-            options.UserName = _smtpSettings.UserName;
+            options.DefaultSender = settings.DefaultSender;
+            options.DeliveryMethod = settings.DeliveryMethod;
+            options.PickupDirectoryLocation = settings.PickupDirectoryLocation;
+            options.Host = settings.Host;
+            options.Port = settings.Port;
+            options.EncryptionMethod = settings.EncryptionMethod;
+            options.AutoSelectEncryption = settings.AutoSelectEncryption;
+            options.RequireCredentials = settings.RequireCredentials;
+            options.UseDefaultCredentials = settings.UseDefaultCredentials;
+            options.UserName = settings.UserName;
 
             // Decrypt the password
-            if (!String.IsNullOrWhiteSpace(_smtpSettings.Password))
+            if (!String.IsNullOrWhiteSpace(settings.Password))
             {
                 try
                 {
                     var protector = _dataProtectionProvider.CreateProtector(nameof(SmtpSettingsConfiguration));
-                    options.Password = protector.Unprotect(_smtpSettings.Password);
+                    options.Password = protector.Unprotect(settings.Password);
                 }
                 catch
                 {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4656

The PR #4637 has a couple of issues

It overrides UI settings, if email settings are supplied via appsettings, with no notification to the user

It tries to decrypt a password with the dataprotector from appsettings, but the password in appsettings will be in plain text, so will throw an exception

It creates an ambiguity as to where email is configured.

I looked at the code that introduced email to appsettings, and think it was testing code from when workflows were introduced on #1378

The correct way to it, I believe, is to only configure email from settings UI, but if someone wants to override that for development with a setting from configuration, they should implement their own `SmtpOptions` in their own startup to override the UI settings

/cc @hishamco Do you understand the issue here?

So in this PR 

- I've reverted the appssettings email change
- Removed email appsettings.json from Startup
- Remove email appsettings.json from docs

If we do want to support appsettings as well as UI settings we need a better design direction, with an implementation that works. and need to consider it's affect on all UI / IConfiguration arrangements.