### PR TITLE
Update Packages versions

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -17,22 +17,22 @@
     <PackageManagement Include="Lucene.Net" Version="4.8.0-beta00006" />
     <PackageManagement Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00006" />
     <PackageManagement Include="Lucene.Net.QueryParser" Version="4.8.0-beta00006" />
-    <PackageManagement Include="MailKit" Version="2.3.1.6" />
-    <PackageManagement Include="Markdig" Version="0.17.1" />
+    <PackageManagement Include="MailKit" Version="2.3.2" />
+    <PackageManagement Include="Markdig" Version="0.18.0" />
     <PackageManagement Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageManagement Include="MiniProfiler.AspNetCore.Mvc" Version="4.1.0-preview.32" />
-    <PackageManagement Include="Moq" Version="4.13.0" />
+    <PackageManagement Include="MiniProfiler.AspNetCore.Mvc" Version="4.1.0" />
+    <PackageManagement Include="Moq" Version="4.13.1" />
     <PackageManagement Include="Nancy" Version="2.0.0" />
     <PackageManagement Include="ncrontab" Version="3.3.1" />
     <PackageManagement Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageManagement Include="NLog.Web.AspNetCore" Version="4.8.5" />
+    <PackageManagement Include="NLog.Web.AspNetCore" Version="4.9.0" />
     <PackageManagement Include="NodaTime" Version="2.4.7" />
     <PackageManagement Include="OpenIddict" Version="2.0.1" />
     <PackageManagement Include="OpenIddict.Core" Version="2.0.1" />
     <PackageManagement Include="OpenIddict.EntityFrameworkCore" Version="2.0.1" />
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-rc1-100729" />
-    <PackageManagement Include="Serilog" Version="2.8.0" />
-    <PackageManagement Include="Serilog.AspNetCore" Version="3.0.0" />
+    <PackageManagement Include="Serilog" Version="2.9.0" />
+    <PackageManagement Include="Serilog.AspNetCore" Version="3.1.0" />
     <PackageManagement Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageManagement Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageManagement Include="Serilog.Sinks.RollingFile" Version="3.3.0" />

--- a/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
+++ b/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgraded the latest version of these packages:

- MailKit: 2.3.1.6 -> 2.3.2
- Markdig: 0.17.1 -> 0.18.0
- MiniProfiler.AspNetCore.Mvc: 4.1.0-preview.32 -> 4.1.0
- NLog.Web.AspNetCore: 4.8.5 -> 4.9.0
- Serilog: 2.8.0 -> 2.9.0
- Serilog.AspNetCore: 3.0.0 -> 3.1.0
- Moq: 4.13.0 -> 4.13.1

Didn't touch to Microsoft.NET.Test.Sdk: 16.2.0 -> 16.3.0
  
Updated in the Benchmark csproj:
BenchmarkDotNet  0.11.5 -> 0.12.0
  
