### PR TITLE
Upgrade Azure Blob Packages

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -37,7 +37,7 @@
     <PackageManagement Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageManagement Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.0-beta0009" />
-    <PackageManagement Include="WindowsAzure.Storage" Version="9.3.3" />
+    <PackageManagement Include="Microsoft.Azure.Storage.Blob" Version="11.1.0" />
     <PackageManagement Include="xunit.analyzers" Version="0.10.0" />
     <PackageManagement Include="xunit" Version="2.4.1" />
     <PackageManagement Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFile.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFile.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob;
 
 namespace OrchardCore.FileStorage.AzureBlob
 {

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.StaticFiles;
-using Microsoft.WindowsAzure.Storage;
-using Microsoft.WindowsAzure.Storage.Blob;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Storage;
 using OrchardCore.Modules;
 
 namespace OrchardCore.FileStorage.AzureBlob

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobStorageOptions.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobStorageOptions.cs
@@ -1,5 +1,3 @@
-using Microsoft.WindowsAzure.Storage.Blob;
-
 namespace OrchardCore.FileStorage.AzureBlob
 {
     public abstract class BlobStorageOptions

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
@@ -9,12 +9,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\OrchardCore.Abstractions\OrchardCore.Abstractions.csproj" />
-    <ProjectReference Include="..\OrchardCore.FileStorage.Abstractions\OrchardCore.FileStorage.Abstractions.csproj" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" />
+    <ProjectReference Include="..\OrchardCore.Abstractions\OrchardCore.Abstractions.csproj" />
+    <ProjectReference Include="..\OrchardCore.FileStorage.Abstractions\OrchardCore.FileStorage.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrades Azure Blob from the old `WindowsAzure.Storage` library to the new library where they have split Storage into 4 separate NuGet packages, `Microsoft.Azure.Storage.Blob` etc, and changed the namespaces.

Merge https://github.com/OrchardCMS/OrchardCore/pull/4671 first and I will fix any merge conflicts

We couldn't take this version previously because it wanted dotnet standard 2.0.1

Tested, works fine. 

Also noting that Azure DataProtection had an underlying reference to this library, so actually it brings them inline 