### PR TITLE
Fixes attribute name conflicts in BaseShapeTagHelper

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.DisplayManagement.TagHelpers
     {
         private static readonly HashSet<string> InternalProperties = new HashSet<string>
         {
-            "id", "type", "cache-id", "cache-context", "cache-dependency", "cache-tag", "cache-fixed-duration", "cache-sliding-duration"
+            "id", "alternate", "wrapper", "cache-id", "cache-context", "cache-tag", "cache-fixed-duration", "cache-sliding-duration"
         };
 
         protected const string PropertyPrefix = "prop-";
@@ -24,11 +24,11 @@ namespace OrchardCore.DisplayManagement.TagHelpers
         protected IDisplayHelper _displayHelper;
 
         public string Type { get; set; }
-        public string Cache { get; set; }
-        public TimeSpan? FixedDuration { get; set; }
-        public TimeSpan? SlidingDuration { get; set; }
-        public string Context { get; set; }
-        public string Tag { get; set; }
+        internal string Cache { get; set; }
+        internal TimeSpan? FixedDuration { get; set; }
+        internal TimeSpan? SlidingDuration { get; set; }
+        internal string Context { get; set; }
+        internal string Tag { get; set; }
 
         [HtmlAttributeNotBound]
         [ViewContext]
@@ -51,7 +51,7 @@ namespace OrchardCore.DisplayManagement.TagHelpers
             var properties = new Dictionary<string, object>();
 
             // These prefixed properties are bound with their original type and not converted as IHtmlContent
-            foreach(var property in Properties)
+            foreach (var property in Properties)
             {
                 var normalizedName = property.Key.ToPascalCaseDash();
                 properties.Add(normalizedName, property.Value);

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/BaseShapeTagHelper.cs
@@ -24,6 +24,11 @@ namespace OrchardCore.DisplayManagement.TagHelpers
         protected IDisplayHelper _displayHelper;
 
         public string Type { get; set; }
+
+        // The following properties are declared as internal to prevent any attribute with a
+        // matching name from being automatically bound and removed from the output attributes,
+        // and then not added to the properties of the shape we are building.
+
         internal string Cache { get; set; }
         internal TimeSpan? FixedDuration { get; set; }
         internal TimeSpan? SlidingDuration { get; set; }


### PR DESCRIPTION
Fixes #4666 

**Note**: So, with a shape tag helper we already can pass a simple string attribute that will become a shape property. We also can pass other object types by using an attribute with the `prop-` prefix, useful for razor but simpler in liquid by just assigning a var and pass it through a non prefixed attribute.

**The issue**: Here the problem is when we want to pass a simple string attribute e.g `tag` that matches the name of an existing public property of `BaseShapeTagHelper`, e.g `Tag` that is related to another usage (caching). In this case the attribute is naturally bound to the property and removed from the output attributes and then not added to the shape properties. There are diffierent ways to fix it.

- In `BaseShapeTagHelper`, rename these public properties to match the attributes names, e.g `Tag => CacheTag` related to `cache-tag`, so that there are automatically bound and removed from the output attributes, so we don't need to do it ourselves, and we don't need to filter them to not be added to the shape properties, and there is no more conflict if we want to use e.g a `tag` attribute to be added as a shape property.

- Remove these properties and just use local variables for internal usage.

- Make these properties non public e.g internal so that there are not bound and the related attributes not removed automatically from the output attributes. I opted for this solution that implies less changes.

    I let the `Type` property public because it already matches the `type` attribute and then is automatically bound and the attribute is removed if specified. So i removed it from the `InternalProperties` because we don't need to filter it because already removed.

    Note: I added `alternate` and `wrapper` to the `InternalProperties` because there are used to add an alternate and a wrapper to the shape we have built, but they don't need to be part of the properties of this shape.

    Regarding the `Type` property, for the `shape` tag helper we need to specify the attribute, for other tag helpers inheriting from `BaseShapeTagHelper` e.g `MenuTagHelper` the `Type` is initialized in their ctor so we don't need the type attribute. So in both cases the following code seems to be useless.

            if (string.IsNullOrWhiteSpace(Type))
            {
                Type = output.TagName;
            }

    So i thought about removing it if the rule of these tag helpers is to always specify their shape `Type`. OR i thought about keeping it and, to be clearer, removing the initialization in the ctor of these tag helpers, the rule being that they need to initialize their shape `Type` only if it doesn't matches their tag name. But not so important so i kept this code as is.

That said, this PR, as it is, fixes the related issue, if we pass e.g `tag="li"` the shape will have a `Tag` property set to `"li"` without any conflict with the internal `Tag` property used for caching.