### PR TITLE
Docs updated to be more descriptive and inline with the fix of #4564

### DIFF
--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -111,11 +111,36 @@ namespace MyNewWebsite
 #### Module commands
 
 ```CMD
+dotnet new ocmodulecms
+```
+
+The above command will use the default options.
+
+You can pass the following CLI parameters to setup options
+
+```CMD
+Orchard Core Module (C#)
+Author: Orchard Project
+Options:
+  -A|--AddPart           Add dependency injection for part in Startup.cs. If PartName is not provided, default name will be used
+                         bool - Optional
+                         Default: false / (*) true
+
+  -P|--PartName          Add all files required for a part
+                         string - Optional
+                         Default: MyTest
+
+  -ov|--orchard-version  Specifies which version of Orchard Core packages to use.
+                         string - Optional
+                         Default: 1.0.0-rc1
+```
+
+```CMD
 dotnet new ocmodulecms -n ModuleName.OrchardCore
 
-dotnet new ocmodulecms -n ModuleName.OrchardCore --PartName TestPart
+dotnet new ocmodulecms -n ModuleName.OrchardCore --AddPart true
 
-dotnet new ocmodulecms -n ModuleName.OrchardCore --PartName TestPart --AddPart true
+dotnet new ocmodulecms -n ModuleName.OrchardCore --AddPart true --PartName TestPart 
 ```
 
 ### New module from Visual Studio (manual way)


### PR DESCRIPTION
I updated the docs for [Code Generation Templates](https://orchardcore.readthedocs.io/en/dev/docs/getting-started/templates/)

[Create a new CMS module](https://orchardcore.readthedocs.io/en/dev/docs/getting-started/templates/#create-a-new-cms-module) is now described similar as [Create a new website](https://orchardcore.readthedocs.io/en/dev/docs/getting-started/templates/#create-a-new-website) section.

Also, after #4581, command` dotnet new ocmodulecms -n ModuleName.OrchardCore --PartName TestPart` does nothing  different than `dotnet new ocmodulecms -n ModuleName.OrchardCore`, so I updated that section.