### PR TITLE
Don't call UpdatePartFieldEditorAsync twice

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -640,7 +640,6 @@ namespace OrchardCore.ContentTypes.Controllers
                 return NotFound();
             }
             viewModel.PartFieldDefinition = field;
-            viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, this);
 
             if (field.DisplayName() != viewModel.DisplayName)
             {
@@ -659,6 +658,8 @@ namespace OrchardCore.ContentTypes.Controllers
 
                 if (!ModelState.IsValid)
                 {
+                    // Calls update to build editor shape with the display name validation failures, and other validation errors.
+                    viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, this);
                     _session.Cancel();
 
                     ViewData["ReturnUrl"] = returnUrl;


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4722

`UpdatePartFieldEditorAsync` was getting called twice, always. 
Which meant multiple validation errors, if validation failed.

Updated to build shape at the correct place (once) when validation of display name (not done by driver) has failed.

/cc @agriffard 