### PR TITLE
Prevents a deferred task lambda from holding a ref on a scoped service.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Indexing/IndexingTaskManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/IndexingTaskManager.cs
@@ -68,15 +68,15 @@ namespace OrchardCore.Indexing.Services
                 Type = type
             };
 
-            lock (_tasksQueue)
+            if (_tasksQueue.Count == 0)
             {
-                if (_tasksQueue.Count == 0)
-                {
-                    ShellScope.AddDeferredTask(scope => FlushAsync(scope, _tasksQueue));
-                }
+                var tasksQueue = _tasksQueue;
 
-                _tasksQueue.Add(indexingTask);
+                // Using a local var prevents the lambda from holding a ref on this scoped service.
+                ShellScope.AddDeferredTask(scope => FlushAsync(scope, tasksQueue));
             }
+
+            _tasksQueue.Add(indexingTask);
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
This by using a local variable in place of using a field of the scoped service

I did it in `IndexingTaskManager` the only place where there is this use case.

Then i also removed the lock on `_tasksQueue` because it is hold by a scoped service.

Already integrated in #4001.