### PR TITLE
Update ReadMe and Documentation Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ Here is a more detailed [roadmap](https://github.com/OrchardCMS/OrchardCore/wiki
 
 ### Command line
 
-- Install the latest versions (current) for both Runtime and SDK of .NET Core from this page <https://www.microsoft.com/net/download/core>
-- Navigate to `D:\OrchardCore\src\OrchardCore.Cms.Web` or wherever your respective folder is on the command line in Administrator mode.
+- Install the latest version of the .NET Core SDK from this page <https://www.microsoft.com/net/download/core>
+- Call `dotnet build`.
+- Next, navigate to `D:\OrchardCore\src\OrchardCore.Cms.Web` or wherever your folder is on the commandline in Administrator mode.
 - Call `dotnet run`.
 - Then open the `http://localhost:5000` URL in your browser.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ Here is a more detailed [roadmap](https://github.com/OrchardCMS/OrchardCore/wiki
 ### Command line
 
 - Install the latest version of the .NET Core SDK from this page <https://www.microsoft.com/net/download/core>
-- Call `dotnet build`.
 - Next, navigate to `D:\OrchardCore\src\OrchardCore.Cms.Web` or wherever your folder is on the commandline in Administrator mode.
 - Call `dotnet run`.
 - Then open the `http://localhost:5000` URL in your browser.

--- a/src/README.md
+++ b/src/README.md
@@ -77,8 +77,9 @@ Here is a more detailed [roadmap](https://github.com/OrchardCMS/OrchardCore/wiki
 
 ### Command line
 
-- Install the latest versions (current) for both Runtime and SDK of .NET Core from this page <https://www.microsoft.com/net/download/core>
-- Navigate to `D:\OrchardCore\src\OrchardCore.Cms.Web` or wherever your respective folder is on the command line in Administrator mode.
+- Install the latest version of the .NET Core SDK from this page <https://www.microsoft.com/net/download/core>
+- Call `dotnet build`.
+- Next, navigate to `D:\OrchardCore\src\OrchardCore.Cms.Web` or wherever your folder is on the commandline in Administrator mode.
 - Call `dotnet run`.
 - Then open the `http://localhost:5000` URL in your browser.
 

--- a/src/README.md
+++ b/src/README.md
@@ -78,7 +78,6 @@ Here is a more detailed [roadmap](https://github.com/OrchardCMS/OrchardCore/wiki
 ### Command line
 
 - Install the latest version of the .NET Core SDK from this page <https://www.microsoft.com/net/download/core>
-- Call `dotnet build`.
 - Next, navigate to `D:\OrchardCore\src\OrchardCore.Cms.Web` or wherever your folder is on the commandline in Administrator mode.
 - Call `dotnet run`.
 - Then open the `http://localhost:5000` URL in your browser.


### PR DESCRIPTION
Instructions about command line installation:

- Install the latest version of the .NET Core SDK from this page <https://www.microsoft.com/net/download/core>
- Call `dotnet build`.
- Next, navigate to `D:\OrchardCore\src\OrchardCore.Cms.Web` or wherever your folder is on the commandline in Administrator mode.