### PR TITLE
Raised ContentPicker matches from 20 to 50

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
@@ -31,7 +31,7 @@ namespace OrchardCore.ContentFields.Services
                 query.With<ContentItemIndex>(x => x.DisplayText.Contains(searchContext.Query) || x.ContentType.Contains(searchContext.Query));
             }
 
-            var contentItems = await query.Take(20).ListAsync();
+            var contentItems = await query.Take(50).ListAsync();
 
             var results = new List<ContentPickerResult>();
 


### PR DESCRIPTION
Raised number of ContentPicker matches from 20 to 50 in DefaultContentPickerResultProvider.cs. 20 is too small for most scenarios.

There was also a mismatch: DefaultContentPickerResultProvider returned 20 results but LuceneContentPickerResultProvider returns 50 results. They should both use the same value.

See also #4699 
