### PR TITLE
Use qs instead of path for content type admin menu

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminNodes/ContentTypesAdminNodeNavigationBuilder.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.Contents.AdminNodes
         {
             _contentDefinitionManager = contentDefinitionManager;
 
-            _contentItemlistUrl = httpContextAccessor.HttpContext.Request.PathBase.Add("/Admin/Contents/ContentItems/").Value;
+            _contentItemlistUrl = httpContextAccessor.HttpContext.Request.PathBase.Add("/Admin/Contents/ContentItems/?Options.SelectedContentType=").Value;
 
             _logger = logger;
         }


### PR DESCRIPTION
Latest dev.

Current admin menu for content types use links like:
`/Admin/Contents/ContentItems/CategoryPage`

It works but the new type selection won't work.

This PR, change the link to the new qs format.
`/Admin/Contents/ContentItems/?Options.SelectedContentType=CategoryPage`
