### PR TITLE
Fixes #4763: DiscardDraft removes the published item from the indexes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Indexing/CreateIndexingTaskContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/CreateIndexingTaskContentHandler.cs
@@ -19,7 +19,12 @@ namespace OrchardCore.Indexing
 
         public override Task RemovedAsync(RemoveContentContext context)
         {
-            return _indexingTaskManager.CreateTaskAsync(context.ContentItem, IndexingTaskTypes.Delete);
+            if (context.NoActiveVersionLeft)
+            {
+                return _indexingTaskManager.CreateTaskAsync(context.ContentItem, IndexingTaskTypes.Delete);
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
@@ -44,9 +44,12 @@ namespace OrchardCore.Lucene.Handlers
         {
             // TODO: ignore if this index is not configured for the content type
 
-            foreach (var index in _luceneIndexManager.List())
+            if (context.NoActiveVersionLeft)
             {
-                _luceneIndexManager.DeleteDocuments(index, new string[] { context.ContentItem.ContentItemId });
+                foreach (var index in _luceneIndexManager.List())
+                {
+                    _luceneIndexManager.DeleteDocuments(index, new string[] { context.ContentItem.ContentItemId });
+                }
             }
 
             return Task.CompletedTask;


### PR DESCRIPTION
Fixes #4763

Repro

1. Add and publish a blog post.
2. Redit it and save, so we have a published and a draft versions.
3. Do a `DiscarDraft` on it, so we only have the published.
    But running the `BlogPostsQuery` we can see that it is no more indexed.
4. Rebuild the index.
    The blog post is still not indexed.

Because

 - When discarding a draft **we trigger a removed event** then, if there is a published version we set it to be the latest (no event here) and we set the `context.NoActiveVersionLeft` to false.

Fix

- When checking `context.NoActiveVersionLeft` in `LuceneIndexingContentHandler` this is okay for 1., 2. and 3., but not for 4. rebuilding the index remove again the post from the index.

- Doing the same in `CreateIndexingTaskContentHandler` then it is also okay for 4.

