### PR TITLE
Include subdirectories in graphiql query if specified

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetQuery.cs
@@ -56,7 +56,15 @@ namespace OrchardCore.Media.GraphQL
             var includeSubDirectories = resolveContext.GetArgument("includeSubDirectories", false);
 
             var allFiles = await mediaFileStore.GetDirectoryContentAsync(path, includeSubDirectories);
-            return allFiles.Where(x => !x.IsDirectory);
+
+            if (includeSubDirectories)
+            {
+                return allFiles;
+            }
+            else
+            {
+                return allFiles.Where(x => !x.IsDirectory);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4469

Include subdirectories flag wasn't being used everywhere.

**Note** There is still a small descripancy between results returned from blob or local storage, due to the differences in listing blob directories with `listSegments`, but it is not easily resolvable, just one azure blob's peculiarites, and I think we can live with it.