### PR TITLE
HTTP header population changed for outbound HTTP requests in workflow module.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestTask.cs
@@ -162,7 +162,7 @@ namespace OrchardCore.Workflows.Http.Activities
 
                 foreach (var header in headers)
                 {
-                    httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+                    httpClient.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
                 }
 
                 var httpMethod = HttpMethod;


### PR DESCRIPTION
Chang HTTP header loop to use "TryAddWithoutValidation" instead of "Add" to allow for headers containing other characters, specifically "=" and ":" for key base Auth.