### PR TITLE
Prevent ConnectionResetException on SelectedContentType change.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -142,11 +142,6 @@
             console.log(value);
             var newAction = "@formActionWithoutTypeName" + "/" + value;
             $("#items-form").attr("action", newAction);
-            $("[name='submit.Filter']").click();
-        });
-
-        $(".filter-options input").on("change", function () {
-            $("[name='submit.Filter']").click();
         });
 
         $('select').on('changed.bs.select', function (e, clickedIndex, isSelected, previousValue) {

--- a/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
@@ -14,8 +14,4 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement.Abstractions\OrchardCore.ResourceManagement.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="wwwroot\images\" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Sometimes when changing the content type selection under the content items index page.

It doesn't stop the app but errors are logged.

    Microsoft.AspNetCore.Connections.ConnectionResetException: 'The client has disconnected'
    0x800704CD "An operation was attempted on a nonexistent network connection."

It was 1st failing in our `FormValueRequiredMatcherPolicy`, i could fix it by checking `httpContext.IsRequestAborted` but then it was failing elsewhere in aspnetcore.

So here i tried the following on client side that seems to fix the issue.

- I removed an event that seems to be never triggered. Note: i was not able to use breakpoints (and right now i didn't search to do so) in a script that is inside a razor view.

- Then, when changing the content type selection, i kept the update of the action attribute but i removed the form submission that seems to be done in the following event. So i think the form was submitted twice and we were processing the 2nd one while the page was refreshing on the client side.

@agriffard when you will have time