### PR TITLE
2 little async tweaks

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -270,19 +270,21 @@ namespace OrchardCore.DisplayManagement.Liquid
             return null;
         }
 
-        public static async Task ContextualizeAsync(this TemplateContext context, IServiceProvider services)
+        public static Task ContextualizeAsync(this TemplateContext context, IServiceProvider services)
         {
             if (!context.AmbientValues.ContainsKey("Services"))
             {
                 var displayHelper = services.GetRequiredService<IDisplayHelper>();
 
-                await context.ContextualizeAsync(new DisplayContext
+                return context.ContextualizeAsync(new DisplayContext
                 {
                     ServiceProvider = services,
                     DisplayAsync = displayHelper,
                     Value = null
                 });
             }
+
+            return Task.CompletedTask;
         }
 
         public static Task ContextualizeAsync(this TemplateContext context, RazorPage page, object model)

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -158,7 +158,7 @@ namespace OrchardCore.Environment.Shell
             var defaultSettings = allSettings.FirstOrDefault(s => s.Name == ShellHelper.DefaultShellName);
             var otherSettings = allSettings.Except(new[] { defaultSettings }).ToArray();
 
-            features.Wait();
+            await features;
 
             // The 'Default' tenant is not running, run the Setup.
             if (defaultSettings?.State != TenantState.Running)


### PR DESCRIPTION
For one of them, in `ShellHost` we are doing this

            var features = _extensionManager.LoadFeaturesAsync();

            // Intended to do some stuff while LoadFeaturesAsync() is executing

            features.Wait();

Currently this seems to be useless because in fact `LoadFeaturesAsync` runs synchronously, it doesn't use any async / await, it uses a `Parallel.ForEach()` but that is not awaitable. To check this i added this test.

            var features = _extensionManager.LoadFeaturesAsync();

            if (features.IsCompleted)
            {
                // We go always here meaning that loading is already completed
                ;
            }

            // Intended to do some stuff while LoadFeaturesAsync() is executing

            features.Wait();

But this pattern is okay if one day a `LoadFeaturesAsync()` is really async, so here i just replaced `features.Wait()` with `await features`.

Hmm, this let me think that we have an extension to start tasks in parallel and that is awaitable, i will check it.

**Update**: Done so that part of `LoadFeaturesAsync()` is now running async. I tested it with the same breakpoint that now is not hit, meaning that we can do stuff while features are loading. Note: Useful for a certain amount of tenants, and the gain can't be more than around 100 ms, the time to load the features.