### PR TITLE
Fix wrong corresponding end tag in HtmlBodyPart

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
@@ -26,7 +26,7 @@
         <textarea asp-for="Html" rows="5" class="form-control"></textarea>
     }
     <span class="hint">@T["The body of the content item."]</span>
-</div>
+</fieldset>
 
 <script at="Foot">
     $(function () {


### PR DESCRIPTION
This cause the wrong layout https://github.com/OrchardCMS/OrchardCore/issues/4797 when a content-type has HtmlBodyPart.