### PR TITLE
Replace IAsyncViewResultFilter to IAsyncViewActionFilter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/Startup.cs
@@ -19,9 +19,11 @@ namespace OrchardCore.Admin
 
             services.Configure<MvcOptions>((options) =>
             {
-                options.Filters.Add(typeof(AdminZoneFilter));
                 options.Filters.Add(typeof(AdminFilter));
                 options.Filters.Add(typeof(AdminMenuFilter));
+
+                // Ordered to be called before any global filter.
+                options.Filters.Add(typeof(AdminZoneFilter), -1000);
             });
 
             services.AddScoped<IPermissionProvider, Permissions>();

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -378,11 +378,11 @@ namespace OrchardCore.DisplayManagement.Liquid
             var httpContext = services.GetRequiredService<IHttpContextAccessor>().HttpContext;
 
             actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
-            var filters = httpContext.RequestServices.GetServices<IAsyncViewResultFilter>();
+            var filters = httpContext.RequestServices.GetServices<IAsyncViewActionFilter>();
 
             foreach (var filter in filters)
             {
-                await filter.OnResultExecutionAsync(actionContext);
+                await filter.OnActionExecutionAsync(actionContext);
             }
 
             return actionContext;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/IAsyncViewActionFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/IAsyncViewActionFilter.cs
@@ -4,8 +4,8 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace OrchardCore.DisplayManagement
 {
-    public interface IAsyncViewResultFilter : IAsyncResultFilter
+    public interface IAsyncViewActionFilter : IAsyncActionFilter
     {
-        Task OnResultExecutionAsync(ActionContext context);
+        Task OnActionExecutionAsync(ActionContext context);
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
@@ -41,11 +41,11 @@ namespace Microsoft.Extensions.DependencyInjection
                     {
                         options.Filters.Add(typeof(ModelBinderAccessorFilter));
                         options.Filters.Add(typeof(NotifyFilter));
-                        options.Filters.Add(typeof(RazorViewResultFilter));
+                        options.Filters.Add(typeof(RazorViewActionFilter));
                     });
 
                     // Used as a service when we create a fake 'ActionContext'.
-                    services.AddScoped<IAsyncViewResultFilter, RazorViewResultFilter>();
+                    services.AddScoped<IAsyncViewActionFilter, RazorViewActionFilter>();
 
                     services.AddScoped<IUpdateModelAccessor, LocalModelBinderAccessor>();
                     services.AddScoped<ViewContextAccessor>();

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorShapeTemplateViewEngine.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorShapeTemplateViewEngine.cs
@@ -152,11 +152,11 @@ namespace OrchardCore.DisplayManagement.Razor
             var httpContext = _httpContextAccessor.HttpContext;
 
             var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
-            var filters = httpContext.RequestServices.GetServices<IAsyncViewResultFilter>();
+            var filters = httpContext.RequestServices.GetServices<IAsyncViewActionFilter>();
 
             foreach (var filter in filters)
             {
-                await filter.OnResultExecutionAsync(actionContext);
+                await filter.OnActionExecutionAsync(actionContext);
             }
 
             return actionContext;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorShapeTemplateViewEngine.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorShapeTemplateViewEngine.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -146,12 +147,18 @@ namespace OrchardCore.DisplayManagement.Razor
 
         private async Task<ActionContext> GetActionContextAsync()
         {
+            var httpContext = _httpContextAccessor.HttpContext;
+            var actionContext = httpContext.RequestServices.GetService<IActionContextAccessor>()?.ActionContext;
+
+            if (actionContext != null)
+            {
+                return actionContext;
+            }
+
             var routeData = new RouteData();
             routeData.Routers.Add(new RouteCollection());
 
-            var httpContext = _httpContextAccessor.HttpContext;
-
-            var actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
+            actionContext = new ActionContext(httpContext, routeData, new ActionDescriptor());
             var filters = httpContext.RequestServices.GetServices<IAsyncViewActionFilter>();
 
             foreach (var filter in filters)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorViewActionFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorViewActionFilter.cs
@@ -12,16 +12,16 @@ namespace OrchardCore.DisplayManagement.Razor
     /// Inject commonly used data through an HttpContext feature <see cref="RazorViewFeature"/> such that
     /// e.g a <see cref="RazorPage"/> can reuse them when it's executed.
     /// </summary>
-    public class RazorViewResultFilter : IAsyncViewResultFilter
+    public class RazorViewActionFilter : IAsyncViewActionFilter
     {
-        public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
-            await OnResultExecutionAsync(context);
+            await OnActionExecutionAsync(context);
             await next();
         }
 
         // Used as a service when we create a fake 'ActionContext'.
-        public async Task OnResultExecutionAsync(ActionContext context)
+        public async Task OnActionExecutionAsync(ActionContext context)
         {
             var razorViewFeature = context.HttpContext.Features.Get<RazorViewFeature>();
 


### PR DESCRIPTION
Fixes #4777

When rendering a liquid shape, if there is **no view context and no action context** we create them on the fly and call our custom view result filter that init a needed http feature.

But, as in the related issue, if we execute a liquid shape through a controller action but before returning an `IActionResult`, there is **no view context but there is an action context** and in that case we don't call our custom filter, and here it has not be called because it is a result filter, not an action filter.

**So here i made our `IAsyncViewResultFilter` an `IAsyncViewActionFilter` that is executed before.**

it was working with a razor view because when there is no view context we were not checking if an action context exists and we were always creating one and then calling our view result filter.

So, in case of a razor view, here i also check if an action context exists , as done for liquid.
