### PR TITLE
Allow script/style tag helpers to add dependencies

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -20,6 +20,7 @@ namespace OrchardCore.ResourceManagement
         public string Condition { get; set; }
         public string Version { get; set; }
         public bool? AppendVersion { get; set; }
+        public List<string> Dependencies { get; set; }
         public Action<ResourceDefinition> InlineDefinition { get; set; }
 
         public Dictionary<string, string> Attributes
@@ -149,6 +150,19 @@ namespace OrchardCore.ResourceManagement
         public RequireSettings ShouldAppendVersion(bool? appendVersion)
         {
             AppendVersion = appendVersion;
+            return this;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public RequireSettings SetDependencies(params string[] dependencies)
+        {
+            if (Dependencies == null)
+            {
+                Dependencies = new List<string>();
+            }
+
+            Dependencies.AddRange(dependencies);
+
             return this;
         }
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -194,6 +194,18 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
+        public ResourceDefinition SetDependencies(List<string> dependencies)
+        {
+            if (Dependencies == null)
+            {
+                Dependencies = new List<string>();
+            }
+
+            Dependencies.AddRange(dependencies);
+
+            return this;
+        }
+
         public TagBuilder GetTagBuilder(RequireSettings settings,
             string applicationPath,
             IFileVersionProvider fileVersionProvider)

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -370,6 +370,8 @@ namespace OrchardCore.ResourceManagement
                     throw new InvalidOperationException($"Could not find a resource of type '{settings.Type}' named '{settings.Name}' with version '{settings.Version ?? "any"}'.");
                 }
 
+                // Register any additional dependencies for the resource here, 
+                // rather than in Combine as they are additive, and should not be Combined.
                 if (settings.Dependencies != null)
                 {
                     resource.SetDependencies(settings.Dependencies);

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -369,6 +369,12 @@ namespace OrchardCore.ResourceManagement
                 {
                     throw new InvalidOperationException($"Could not find a resource of type '{settings.Type}' named '{settings.Name}' with version '{settings.Version ?? "any"}'.");
                 }
+
+                if (settings.Dependencies != null)
+                {
+                    resource.SetDependencies(settings.Dependencies);
+                }
+
                 ExpandDependencies(resource, settings, allResources);
             }
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -177,6 +177,12 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.UseVersion(Version);
                 }
 
+                // This allows additions to the pre registered scripts dependencies.
+                if (!String.IsNullOrEmpty(DependsOn))
+                {
+                    setting.SetDependencies(DependsOn.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
+                }
+
                 if (At == ResourceLocation.Unspecified)
                 {
                     _resourceManager.RenderLocalScript(setting, output.Content);

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -121,6 +121,12 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 {
                     setting.UseVersion(Version);
                 }
+
+                // This allows additions to the pre registered scripts dependencies.
+                if (!String.IsNullOrEmpty(DependsOn))
+                {
+                    setting.SetDependencies(DependsOn.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
+                }
             }
             else if (!String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
             {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4789

Discussed in some detail on the issue.

Adds the ability for the script / style tag helper to add to the dependencies defined on a `ResourceManifest`

A lot of the script tags uses `depends-on="admin"` for no good reason.

However that doesn't work when the resource is registered with a `ResourceManifest`.

A `ResourceManifest` can set it's own dependencies, but until now a script tag helper cannot add to them.

It makes sense that a resource manifest entry should define it's own dependencies, however not being able to add to them is confusing (and has led to some 30-40 entries using `depends-on="admin"` in the OC razor code, that are useless currently.)

The best actual use case for wanting to add to dependencies on the fly is for the `bootstrap-select`.

It's manifest depends on `jQuery` which is good, but it also needs `bootstrap`.
But bootstrap is compiled into the admin.js. So the manifest can't refer to that, or it will fail when used elsewhere without the admin. So it makes sense to define the admin dependency on the fly. 
Noting that it currently works, in the correct order, because the jquery dependency also exists in the admin, and it gets lucky. essentially.

But also open to this not being the right way to fix the issue.

/cc @jtkech 

PR to follow (have run out of time) removing `depends-on="admin"` where it is unnecessary (codemirror does not need it at all, yet it is everywhere, and useless).
Assuming you agree @jtkech 
