### PR TITLE
Workflow improvements

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/DeleteContentTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/DeleteContentTask.Fields.Design.cshtml
@@ -5,7 +5,7 @@
 </header>
 @if (string.IsNullOrWhiteSpace(Model.Activity.Content?.Expression))
 {
-    <span>@T["Delete content provided via the <em>Content</em> input argument"]</span>
+    <span>@T["Delete content provided via the <em>ContentItem</em> input argument"]</span>
 }
 else
 {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/DeleteContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/DeleteContentTask.Fields.Edit.cshtml
@@ -5,5 +5,5 @@
     <label asp-for="Expression">@T["Expression"]</label>
     <input type="text" asp-for="Expression" class="form-control code" autofocus />
     <span asp-validation-for="Expression"></span>
-    <span class="hint">@T["Enter a JavaScript expression that evaluates to the content item to be deleted. For example: input(\"Content\"). If no expression is specified, the workflow's \"Content\" input variable or \"Content\" property will be used."]</span>
+    <span class="hint">@T["Enter a JavaScript expression that evaluates to the content item to be deleted. If no expression is specified, the workflow's \"ContentItem\" input variable or \"ContentItem\" property will be used."]</span>
 </fieldset>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/PublishContentTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/PublishContentTask.Fields.Design.cshtml
@@ -6,7 +6,7 @@
 
 @if (string.IsNullOrWhiteSpace(Model.Activity.Content?.Expression))
 {
-    <span>@T["Publish content provided via the <em>Content</em> input argument"]</span>
+    <span>@T["Publish content provided via the <em>ContentItem</em> input argument"]</span>
 }
 else
 {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/PublishContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/PublishContentTask.Fields.Edit.cshtml
@@ -5,5 +5,5 @@
     <label asp-for="Expression">@T["Expression"]</label>
     <input type="text" asp-for="Expression" class="form-control code" autofocus />
     <span asp-validation-for="Expression"></span>
-    <span class="hint">@T["Enter a JavaScript expression that evaluates to the content item to be published. For example: input(\"Content\"). If no expression is specified, the workflow's \"Content\" input variable or \"Content\" property will be used."]</span>
+    <span class="hint">@T["Enter a JavaScript expression that evaluates to the content item to be published. If no expression is specified, the workflow's \"ContentItem\" input variable or \"ContentItem\" property will be used."]</span>
 </fieldset>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UnpublishContentTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UnpublishContentTask.Fields.Design.cshtml
@@ -6,7 +6,7 @@
 
 @if (string.IsNullOrWhiteSpace(Model.Activity.Content?.Expression))
 {
-    <span>@T["Unpublish content provided via the <em>Content</em> input argument"]</span>
+    <span>@T["Unpublish content provided via the <em>ContentItem</em> input argument"]</span>
 }
 else
 {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UnpublishContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UnpublishContentTask.Fields.Edit.cshtml
@@ -5,5 +5,5 @@
     <label asp-for="Expression">@T["Expression"]</label>
     <input type="text" asp-for="Expression" class="form-control code" autofocus />
     <span asp-validation-for="Expression"></span>
-    <span class="hint">@T["Enter a JavaScript expression that evaluates to the content item to be unpublished. For example: input(\"Content\"). If no expression is specified, the workflow's \"Content\" input variable or \"Content\" property will be used."]</span>
+    <span class="hint">@T["Enter a JavaScript expression that evaluates to the content item to be unpublished. If no expression is specified, the workflow's \"ContentItem\" input variable or \"ContentItem\" property will be used."]</span>
 </fieldset>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
@@ -51,8 +51,17 @@ namespace OrchardCore.Contents.Workflows.Activities
             if (!string.IsNullOrWhiteSpace(Content.Expression))
             {
                 var expression = new WorkflowExpression<object> { Expression = Content.Expression };
-                var contentItemJson = JsonConvert.SerializeObject(await ScriptEvaluator.EvaluateAsync(expression, workflowContext));
+                var contentItemResult = await ScriptEvaluator.EvaluateAsync(expression, workflowContext);
+
+                if (contentItemResult is ContentItem contentItem)
+                {
+                    return contentItem;
+                }
+
+                // Try to map the result to a content item
+                var contentItemJson = JsonConvert.SerializeObject(contentItemResult);
                 var res = JsonConvert.DeserializeObject<ContentItem>(contentItemJson);
+
                 return res;
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ScriptTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ScriptTask.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -49,7 +48,8 @@ namespace OrchardCore.Workflows.Activities
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
             var outcomes = new List<string>();
-            await _scriptEvaluator.EvaluateAsync(Script, workflowContext, new OutcomeMethodProvider(outcomes));
+            workflowContext.LastResult = await _scriptEvaluator.EvaluateAsync(Script, workflowContext, new OutcomeMethodProvider(outcomes));
+
             return Outcomes(outcomes);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowManager.cs
@@ -300,7 +300,7 @@ namespace OrchardCore.Workflows.Services
                     break;
                 }
 
-                IList<string> outcomes = new List<string>(0);
+                var outcomes = Enumerable.Empty<string>();
 
                 try
                 {

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/Activity.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/Activity.cs
@@ -101,24 +101,29 @@ namespace OrchardCore.Workflows.Activities
             return names.Select(x => new Outcome(x));
         }
 
+        protected ActivityExecutionResult Outcomes(string name)
+        {
+            return new ActivityExecutionResult(new string[] { name });
+        }
+
         protected ActivityExecutionResult Outcomes(params string[] names)
         {
-            return ActivityExecutionResult.FromOutcomes(names);
+            return new ActivityExecutionResult(names);
         }
 
         protected ActivityExecutionResult Outcomes(IEnumerable<string> names)
         {
-            return ActivityExecutionResult.FromOutcomes(names);
+            return new ActivityExecutionResult(names);
         }
 
         protected ActivityExecutionResult Halt()
         {
-            return ActivityExecutionResult.Halt();
+            return ActivityExecutionResult.Halted;
         }
 
         protected ActivityExecutionResult Noop()
         {
-            return ActivityExecutionResult.Noop();
+            return ActivityExecutionResult.Empty;
         }
 
         protected virtual T GetProperty<T>(Func<T> defaultValue = null, [CallerMemberName]string name = null)

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/ActivityExecutionResult.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Activities/ActivityExecutionResult.cs
@@ -1,30 +1,26 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace OrchardCore.Workflows.Activities
 {
     public class ActivityExecutionResult
     {
-        public static ActivityExecutionResult Noop()
+        public static readonly ActivityExecutionResult Empty  = new ActivityExecutionResult(Array.Empty<string>());
+
+        public static readonly ActivityExecutionResult Halted = new ActivityExecutionResult(Array.Empty<string>()) { IsHalted = true };
+
+        public ActivityExecutionResult(IEnumerable<string> outcomes)
         {
-            return new ActivityExecutionResult();
+            Outcomes = outcomes;
         }
 
-        public static ActivityExecutionResult FromOutcomes(IEnumerable<string> outcomes)
+        public ActivityExecutionResult(string[] outcomes, bool halted)
         {
-            return new ActivityExecutionResult { Outcomes = outcomes.ToList() };
+            Outcomes = outcomes;
+            IsHalted = halted;
         }
 
-        public static ActivityExecutionResult Halt()
-        {
-            return new ActivityExecutionResult { IsHalted = true };
-        }
-
-        private ActivityExecutionResult()
-        {
-        }
-
-        public IList<string> Outcomes { get; private set; } = new List<string>(0);
-        public bool IsHalted { get; set; }
+        public IEnumerable<string> Outcomes { get; private set; }
+        public bool IsHalted { get; private set; }
     }
 }


### PR DESCRIPTION
- The content tasks are actually looking for `ContentItem` and not `Content`.
- Small perf on collections in outcomes.
- Assign the result of script tasks to `lastResult`
- If the input is already a content item, don't serialize it