### PR TITLE
Update SqlQuerySource.cs

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlQuerySource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlQuerySource.cs
@@ -71,7 +71,7 @@ namespace OrchardCore.Queries.Sql
 
                     using (var transaction = connection.BeginTransaction(_session.Store.Configuration.IsolationLevel))
                     {
-                        documentIds = await connection.QueryAsync<int>(rawQuery, parameters);
+                        documentIds = await connection.QueryAsync<int>(rawQuery, parameters, transaction);
                     }
                 }
 
@@ -88,7 +88,7 @@ namespace OrchardCore.Queries.Sql
 
                     using (var transaction = connection.BeginTransaction(_session.Store.Configuration.IsolationLevel))
                     {
-                        queryResults = await connection.QueryAsync(rawQuery, parameters);
+                        queryResults = await connection.QueryAsync(rawQuery, parameters, transaction);
                     }
                 }
 


### PR DESCRIPTION
Fixes regression found with #4698 
Named Queries are currently failing to execute because it doesn't find a proper transaction.