### PR TITLE
Allows to Cancel content definition storage.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -132,6 +132,7 @@ namespace OrchardCore.ContentTypes.Controllers
             if (!ModelState.IsValid)
             {
                 _session.Cancel();
+                _contentDefinitionManager.Cancel();
                 return View(viewModel);
             }
 
@@ -188,7 +189,7 @@ namespace OrchardCore.ContentTypes.Controllers
             if (!ModelState.IsValid)
             {
                 _session.Cancel();
-
+                _contentDefinitionManager.Cancel();
                 return View(viewModel);
             }
             else
@@ -318,6 +319,7 @@ namespace OrchardCore.ContentTypes.Controllers
             if (!ModelState.IsValid)
             {
                 _session.Cancel();
+                _contentDefinitionManager.Cancel();
                 return await AddPartsTo(id);
             }
 
@@ -381,6 +383,7 @@ namespace OrchardCore.ContentTypes.Controllers
             if (!ModelState.IsValid)
             {
                 _session.Cancel();
+                _contentDefinitionManager.Cancel();
                 return await AddReusablePartTo(id);
             }
 
@@ -533,6 +536,7 @@ namespace OrchardCore.ContentTypes.Controllers
             if (!ModelState.IsValid)
             {
                 _session.Cancel();
+                _contentDefinitionManager.Cancel();
                 return View(viewModel);
             }
             else
@@ -647,6 +651,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 viewModel.Fields = _contentDefinitionService.GetFields().Select(x => x.Name).OrderBy(x => x).ToList();
 
                 _session.Cancel();
+                _contentDefinitionManager.Cancel();
 
                 ViewData["ReturnUrl"] = returnUrl;
                 return View(viewModel);
@@ -750,7 +755,9 @@ namespace OrchardCore.ContentTypes.Controllers
                 {
                     // Calls update to build editor shape with the display name validation failures, and other validation errors.
                     viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, this);
+
                     _session.Cancel();
+                    _contentDefinitionManager.Cancel();
 
                     ViewData["ReturnUrl"] = returnUrl;
                     return View(viewModel);
@@ -769,6 +776,7 @@ namespace OrchardCore.ContentTypes.Controllers
             if (!ModelState.IsValid)
             {
                 _session.Cancel();
+                _contentDefinitionManager.Cancel();
 
                 ViewData["ReturnUrl"] = returnUrl;
                 return View(viewModel);
@@ -917,7 +925,9 @@ namespace OrchardCore.ContentTypes.Controllers
                     if (!ModelState.IsValid)
                     {
                         viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, this);
+
                         _session.Cancel();
+                        _contentDefinitionManager.Cancel();
                         return View(viewModel);
                     }
 
@@ -931,6 +941,7 @@ namespace OrchardCore.ContentTypes.Controllers
             if (!ModelState.IsValid)
             {
                 _session.Cancel();
+                _contentDefinitionManager.Cancel();
                 return View(viewModel);
             }
             else

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/ContentDefinitionDisplayCoordinator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/ContentDefinitionDisplayCoordinator.cs
@@ -36,7 +36,9 @@ namespace OrchardCore.ContentTypes.Editors
             {
                 var result = await contentDisplay.BuildEditorAsync(model, context);
                 if (result != null)
+                {
                     await result.ApplyAsync(context);
+                }
             }, Logger);
         }
 
@@ -46,7 +48,9 @@ namespace OrchardCore.ContentTypes.Editors
             {
                 var result = await contentDisplay.UpdateEditorAsync(model, context);
                 if (result != null)
+                {
                     await result.ApplyAsync(context);
+                }
             }, Logger);
         }
 
@@ -56,7 +60,9 @@ namespace OrchardCore.ContentTypes.Editors
             {
                 var result = await contentDisplay.BuildEditorAsync(model, context);
                 if (result != null)
+                {
                     await result.ApplyAsync(context);
+                }
             }, Logger);
         }
 
@@ -66,7 +72,9 @@ namespace OrchardCore.ContentTypes.Editors
             {
                 var result = await contentDisplay.UpdateEditorAsync(model, context);
                 if (result != null)
+                {
                     await result.ApplyAsync(context);
+                }
             }, Logger);
         }
 
@@ -76,7 +84,9 @@ namespace OrchardCore.ContentTypes.Editors
             {
                 var result = await contentDisplay.BuildEditorAsync(model, context);
                 if (result != null)
+                {
                     await result.ApplyAsync(context);
+                }
             }, Logger);
         }
 
@@ -86,7 +96,9 @@ namespace OrchardCore.ContentTypes.Editors
             {
                 var result = await contentDisplay.UpdateEditorAsync(model, context);
                 if (result != null)
+                {
                     await result.ApplyAsync(context);
+                }
             }, Logger);
         }
 
@@ -96,7 +108,9 @@ namespace OrchardCore.ContentTypes.Editors
             {
                 var result = await contentDisplay.BuildEditorAsync(model, context);
                 if (result != null)
+                {
                     await result.ApplyAsync(context);
+                }
             }, Logger);
         }
 
@@ -106,7 +120,9 @@ namespace OrchardCore.ContentTypes.Editors
             {
                 var result = await contentDisplay.UpdateEditorAsync(model, context);
                 if (result != null)
+                {
                     await result.ApplyAsync(context);
+                }
             }, Logger);
         }
     }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -227,7 +227,7 @@ namespace OrchardCore.Environment.Shell.Scope
         /// <summary>
         /// Registers a delegate to be invoked when 'BeforeDisposeAsync()' is called on this scope.
         /// </summary>
-        private void BeforeDispose(Func<ShellScope, Task> callback) => _beforeDispose.Add(callback);
+        private void BeforeDispose(Func<ShellScope, Task> callback) => _beforeDispose.Insert(0, callback);
 
         /// <summary>
         /// Adds a Signal (if not already present) to be sent just after 'BeforeDisposeAsync()'.

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentDefinitionManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentDefinitionManager.cs
@@ -30,6 +30,7 @@ namespace OrchardCore.ContentManagement.Metadata
 
         void StoreTypeDefinition(ContentTypeDefinition contentTypeDefinition);
         void StorePartDefinition(ContentPartDefinition contentPartDefinition);
+        void Cancel();
 
         /// <summary>
         /// Returns a serial number representing the list of types and settings for the current tenant.

--- a/src/OrchardCore/OrchardCore.ContentManagement/ContentDefinitionManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ContentDefinitionManager.cs
@@ -351,16 +351,16 @@ namespace OrchardCore.ContentManagement
             {
                 _saved = true;
 
-                ShellScope.RegisterBeforeDispose(scope =>
+                ShellScope.RegisterBeforeDispose(async scope =>
                 {
                     if (_cancel)
                     {
-                        return Task.CompletedTask;
+                        return;
                     }
 
-                    var contentDefinitionRecord = LoadContentDefinitionRecord();
+                    var contentDefinitionRecord = await _contentDefinitionStore.LoadContentDefinitionAsync();
                     contentDefinitionRecord.Serial++;
-                    return _contentDefinitionStore.SaveContentDefinitionAsync(contentDefinitionRecord);
+                    await _contentDefinitionStore.SaveContentDefinitionAsync(contentDefinitionRecord);
                 });
             }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement/ContentDefinitionManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ContentDefinitionManager.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.ContentManagement
         private readonly Dictionary<string, ContentTypeDefinition> _scopedTypeDefinitions = new Dictionary<string, ContentTypeDefinition>();
         private readonly Dictionary<string, ContentPartDefinition> _scopedPartDefinitions = new Dictionary<string, ContentPartDefinition>();
 
-        private List<bool> _saved;
+        private bool _saved, _cancel;
 
         public ContentDefinitionManager(
             ISignal signal,
@@ -343,17 +343,17 @@ namespace OrchardCore.ContentManagement
             return record;
         }
 
-        public void Cancel() => _saved?.Clear();
+        public void Cancel() => _cancel = true;
 
         private void UpdateContentDefinitionRecord()
         {
-            if (_saved == null)
+            if (!_saved)
             {
-                _saved = new List<bool>() { true };
+                _saved = true;
 
                 ShellScope.RegisterBeforeDispose(scope =>
                 {
-                    if (!_saved.Any())
+                    if (_cancel)
                     {
                         return Task.CompletedTask;
                     }


### PR DESCRIPTION
- Just to show the idea that would be, in a given scope, to have the ability to cancel the changes applied to the content definition, even we are using the `FileContentDefinitionStore`, not the `DatabaseContentDefinitionStore` for which `_session.Cancel()` is okay.

    Hmm, one advantage would be that when there are multiple updates in the same scope, only one file write is done at the end of the scope.

- Working on this i realized that at some point i made `FileContentDefinitionStore` a tenant singleton, but it is now a scoped service as before. So, currently its usage of `lock (this)` is useless.

    In the distributed branch (on which i will re-work soon) i made a local lock service from which you can get by name a tenant singleton level async lock, would be useful here.

    I will try it in a separate PR.