### PR TITLE
make XmlRpc working again with dotnet 3.0

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.XmlRpc/MethodCallModelBinder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.XmlRpc/MethodCallModelBinder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
@@ -10,7 +12,7 @@ namespace OrchardCore.XmlRpc
 {
     public class MethodCallModelBinder : IModelBinder
     {
-        public Task BindModelAsync(ModelBindingContext bindingContext)
+        public async Task BindModelAsync(ModelBindingContext bindingContext)
         {
             if (bindingContext == null)
             {
@@ -20,12 +22,17 @@ namespace OrchardCore.XmlRpc
             if (bindingContext.ModelType == typeof(XRpcMethodCall))
             {
                 var mapper = bindingContext.HttpContext.RequestServices.GetRequiredService<IXmlRpcReader>();
-                var element = XElement.Load(bindingContext.HttpContext.Request.Body);
+                var bodyTextContent = String.Empty;
+                // For some reasons we can't use XElement.LoadAsync. This method fails on big request body. I tested this with a picture with 2 MB of size.
+                // This code is maybe bad. Because if someone send a very big XML to this endpoint the server will die a out of memory exception.
+                using (StreamReader reader = new StreamReader(bindingContext.HttpContext.Request.Body, Encoding.UTF8, true, 1024, true))
+                {                    
+                    bodyTextContent = await reader.ReadToEndAsync();
+                }
+                var element = XElement.Parse(bodyTextContent);
 
                 bindingContext.Result = ModelBindingResult.Success(mapper.MapToMethodCall(element));
             }
-
-            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
This PR try to solve #4770 .

So what was happens here? The simple answer is: The `HttpRequest.Body` doesn't allow synchronize reads anymore. So all must be async.

So I tried to use `XElement.LoadAsync` but this errors on big requests. (see the code comment)

So I now finial use `StreamReader.AsyncReadToEnd()`. This isn't good I think because this can end in a out of memory exception, that a user of the cms is able to trigger with a single request.

So maybe somebody has a better solution to read XML from request body in 3.0 :)


> Oh and before I forgot. This code currently works. 🧙‍♂️