### PR TITLE
Duplicate code in ShellDescriptorManager

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
@@ -53,11 +53,6 @@ namespace OrchardCore.Environment.Shell.Data.Descriptors
             {
                 _shellDescriptor = await _session.Query<ShellDescriptor>().FirstOrDefaultAsync();
 
-                if (_shellDescriptor == null)
-                {
-                    _shellDescriptor = await _session.Query<ShellDescriptor>().FirstOrDefaultAsync();
-                }
-
                 if (_shellDescriptor != null)
                 {
                     var configuredFeatures = new ConfiguredFeatures();


### PR DESCRIPTION

At some point we were using this code

     _shellDescriptor = await _session.Query<ShellDescriptor>().FirstOrDefaultAsync();

    if (_shellDescriptor == null)
    {
        // If no descriptor was found, try to update from Beta2
        await UpgradeFromBeta2();
        _shellDescriptor = await _session.Query<ShellDescriptor>().FirstOrDefaultAsync();
    }

Then, after migrating to 3.0 we only removed `await UpgradeFromBeta2();`, we forgot to remove all the if block.