### PR TITLE
BeforeDispose Insert in place of Add

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -227,7 +227,7 @@ namespace OrchardCore.Environment.Shell.Scope
         /// <summary>
         /// Registers a delegate to be invoked when 'BeforeDisposeAsync()' is called on this scope.
         /// </summary>
-        private void BeforeDispose(Func<ShellScope, Task> callback) => _beforeDispose.Add(callback);
+        private void BeforeDispose(Func<ShellScope, Task> callback) => _beforeDispose.Insert(0, callback);
 
         /// <summary>
         /// Adds a Signal (if not already present) to be sent just after 'BeforeDisposeAsync()'.


### PR DESCRIPTION
So, right now the only place we use `RegisterBeforeDispose()` is to commit the session asynchronously and before any scoped service (e.g scoped index providers) may have been disposed.

Then, if we use it in another place, better to insert a new callback in place of adding it at the end of the list, so that by default the callback will be executed before the session is committed, otherwise we would have better to use a deferred task.