### PR TITLE
Workflow Content Item ID functionality

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Design.cshtml
@@ -1,0 +1,14 @@
+@model ContentTaskViewModel<RetrieveContentTask>
+
+<header>
+    <h4><i class="fa fa-cloud-upload"></i>@Model.Activity.GetTitleOrDefault(() => T["Retrieve Content"])</h4>
+</header>
+
+@if (string.IsNullOrWhiteSpace(Model.Activity.Content?.Expression))
+{
+    <span>@T["Retrieve content provided via the <em>ContentItemId</em> input argument"]</span>
+}
+else
+{
+    <span>@T["Retrieve content using expression: <em>{0}</em>", Model.Activity.Content.Expression]</span>
+}

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Design.cshtml
@@ -1,7 +1,7 @@
 @model ContentTaskViewModel<RetrieveContentTask>
 
 <header>
-    <h4><i class="fa fa-cloud-upload"></i>@Model.Activity.GetTitleOrDefault(() => T["Retrieve Content"])</h4>
+    <h4><i class="fa fa-search"></i>@Model.Activity.GetTitleOrDefault(() => T["Retrieve Content"])</h4>
 </header>
 
 @if (string.IsNullOrWhiteSpace(Model.Activity.Content?.Expression))

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Edit.cshtml
@@ -5,5 +5,5 @@
     <label asp-for="ContentItemId">@T["ContentItemId"]</label>
     <input type="text" asp-for="ContentItemId" class="form-control code" autofocus />
     <span asp-validation-for="ContentItemId"></span>
-    <span class="hint">@T["Enter a the Id of the Content Item you would like to fetch."]</span>
+    <span class="hint">@T["Enter a JavaScript expression that evaluates to the Content Item's ID(ContentItemId) to be retrieved."]</span>
 </fieldset>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Edit.cshtml
@@ -1,0 +1,9 @@
+@using OrchardCore.Contents.Workflows.ViewModels
+@model RetrieveContentTaskViewModel
+
+<fieldset class="form-group" asp-validation-class-for="ContentItemId">
+    <label asp-for="ContentItemId">@T["ContentItemId"]</label>
+    <input type="text" asp-for="ContentItemId" class="form-control code" autofocus />
+    <span asp-validation-for="ContentItemId"></span>
+    <span class="hint">@T["Enter a the Id of the Content Item you would like to fetch."]</span>
+</fieldset>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/RetrieveContentTask.Fields.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+<h4 class="card-title"><i class="fa fa-search"></i>@T["Retrieve Content"]</h4>
+<p>@T["Retrieve a content item."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UnpublishContentTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/UnpublishContentTask.Fields.Design.cshtml
@@ -1,7 +1,7 @@
 @model ContentTaskViewModel<UnpublishContentTask>
 
 <header>
-    <h4><i class="fa fa-cloud-upload"></i>@Model.Activity.GetTitleOrDefault(() => T["Unpublish Content"])</h4>
+    <h4><i class="fa fa-cloud-download"></i>@Model.Activity.GetTitleOrDefault(() => T["Unpublish Content"])</h4>
 </header>
 
 @if (string.IsNullOrWhiteSpace(Model.Activity.Content?.Expression))

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
@@ -76,5 +76,39 @@ namespace OrchardCore.Contents.Workflows.Activities
 
             return null;
         }
+
+
+        protected virtual async Task<string> GetContentByIdAsync(WorkflowExecutionContext workflowContext)
+        {
+            // Try and evaluate a content item from the Content expression, if provided.
+            if (!string.IsNullOrWhiteSpace(Content.Expression))
+            {
+                var expression = new WorkflowExpression<object> { Expression = Content.Expression };
+                var contentItemIdResult = await ScriptEvaluator.EvaluateAsync(expression, workflowContext);
+
+                if (contentItemIdResult is string contentItem)
+                {
+                    return contentItem;
+                }
+
+                // Try to map the result to a content item
+                //var contentItemJson = JsonConvert.SerializeObject(contentItemResult);
+                //var res = JsonConvert.DeserializeObject<ContentItem>(contentItemJson);
+
+                //return res.ContentItemId;
+            }
+
+            // If no expression was provided, see if the content item was provided as an input or as a property.
+            var content = workflowContext.Input.GetValue<IContent>(ContentsHandler.ContentItemInputKey)
+                ?? workflowContext.Properties.GetValue<IContent>(ContentsHandler.ContentItemInputKey);
+
+            if (content != null)
+            {
+                return content.ContentItem.ContentItemId;
+            }
+
+            return null;
+        }
+
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using OrchardCore.ContentManagement;
+using OrchardCore.Workflows.Abstractions.Models;
+using OrchardCore.Workflows.Activities;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Services;
+
+namespace OrchardCore.Contents.Workflows.Activities
+{
+    public class RetrieveContentTask : ContentTask
+    {
+        public RetrieveContentTask(IContentManager contentManager, IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<RetrieveContentTask> localizer) : base(contentManager, scriptEvaluator, localizer)
+        {
+        }
+
+        public override string Name => nameof(RetrieveContentTask);
+        public override LocalizedString DisplayText => T["Retrieve Content Task"];
+        public override LocalizedString Category => T["Content"];
+
+        public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            return Outcomes(T["Retrieve"]);
+        }
+
+        public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            var contentItemId = await GetContentByIdAsync(workflowContext);
+
+            var contentItem = await ContentManager.GetAsync("", VersionOptions.Published);
+            //publishedItem = await GetAsync(contentItem.ContentItemId, VersionOptions.Published);
+
+            return Outcomes("Retrieve");
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
@@ -21,17 +21,15 @@ namespace OrchardCore.Contents.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Retrieve"]);
+            return Outcomes(T["Retrieved"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            var contentItemId = await GetContentByIdAsync(workflowContext);
-
-            var contentItem = await ContentManager.GetAsync("", VersionOptions.Published);
-            //publishedItem = await GetAsync(contentItem.ContentItemId, VersionOptions.Published);
-
-            return Outcomes("Retrieve");
+            var contentItemId = await GetContentItemIdAsync(workflowContext);
+            var contentItem = await ContentManager.GetAsync(contentItemId, VersionOptions.Latest);
+            workflowContext.LastResult = contentItem;
+            return Outcomes("Retrieved");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Drivers/RetrieveContentTaskDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Drivers/RetrieveContentTaskDisplay.cs
@@ -1,0 +1,21 @@
+using OrchardCore.ContentManagement;
+using OrchardCore.Contents.Workflows.Activities;
+using OrchardCore.Contents.Workflows.ViewModels;
+using OrchardCore.Workflows.Models;
+
+namespace OrchardCore.Contents.Workflows.Drivers
+{
+    public class RetrieveContentTaskDisplay : ContentTaskDisplayDriver<RetrieveContentTask, RetrieveContentTaskViewModel>
+    {
+
+        protected override void EditActivity(RetrieveContentTask activity, RetrieveContentTaskViewModel model)
+        {
+            model.ContentItemId = activity.Content.Expression;
+        }
+
+        protected override void UpdateActivity(RetrieveContentTaskViewModel model, RetrieveContentTask activity)
+        {
+            activity.Content = new WorkflowExpression<IContent>(model.ContentItemId);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Startup.cs
@@ -24,6 +24,7 @@ namespace OrchardCore.Contents.Workflows
             services.AddActivity<PublishContentTask, PublishContentTaskDisplay>();
             services.AddActivity<UnpublishContentTask, UnpublishContentTaskDisplay>();
             services.AddActivity<CreateContentTask, CreateContentTaskDisplay>();
+            services.AddActivity<RetrieveContentTask, RetrieveContentTaskDisplay>();
 
             services.AddScoped<IContentHandler, ContentsHandler>();
             services.AddScoped<IWorkflowValueSerializer, ContentItemSerializer>();

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/ViewModels/RetrieveContentTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/ViewModels/RetrieveContentTaskViewModel.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Contents.Workflows.ViewModels
     public class RetrieveContentTaskViewModel : ContentTaskViewModel<RetrieveContentTask>
     {
         /// <summary>
-        /// The expression resulting into a content item or content item ID to unpublish.
+        /// The expression resulting into a content item ID to retrieve.
         /// </summary>
         public string ContentItemId { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/ViewModels/RetrieveContentTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/ViewModels/RetrieveContentTaskViewModel.cs
@@ -1,0 +1,12 @@
+using OrchardCore.Contents.Workflows.Activities;
+
+namespace OrchardCore.Contents.Workflows.ViewModels
+{
+    public class RetrieveContentTaskViewModel : ContentTaskViewModel<RetrieveContentTask>
+    {
+        /// <summary>
+        /// The expression resulting into a content item or content item ID to unpublish.
+        /// </summary>
+        public string ContentItemId { get; set; }
+    }
+}


### PR DESCRIPTION
The workflow Content Interaction had no direct interaction method other than if you already had a handle on the content item. 

These changes allow interaction through the Content Item Id.
I've made the assumption that you would interact with the latest version of the content item as this allows interaction with unpublished content.

I also added a new task to just get an content item by ID as this seems  to be fairly useful.