### PR TITLE
Remove column indexes from alias and content fields for MySql

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -4,16 +4,22 @@ using OrchardCore.Data.Migration;
 using OrchardCore.Alias.Indexes;
 using OrchardCore.Alias.Models;
 using OrchardCore.Alias.Drivers;
+using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.Alias
 {
     public class Migrations : DataMigration
     {
         IContentDefinitionManager _contentDefinitionManager;
+        ShellSettings _shellSettings;
 
-        public Migrations(IContentDefinitionManager contentDefinitionManager)
+        public Migrations(
+            IContentDefinitionManager contentDefinitionManager,
+            ShellSettings shellSettings
+            )
         {
             _contentDefinitionManager = contentDefinitionManager;
+            _shellSettings = shellSettings;
         }
 
         public int Create()
@@ -29,9 +35,12 @@ namespace OrchardCore.Alias
                 .Column<string>("ContentItemId", c => c.WithLength(26))
             );
 
-            SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
-                .CreateIndex("IDX_AliasPartIndex_Alias", "Alias")
-            );
+            if (_shellSettings["DatabaseProvider"] != "MySql")
+            {
+                SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
+                    .CreateIndex("IDX_AliasPartIndex_Alias", "Alias")
+                );
+            }
 
             return 1;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
@@ -1,11 +1,18 @@
 using System;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.Data.Migration;
+using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.ContentFields.Indexing.SQL
 {
     public class Migrations : DataMigration
     {
+        ShellSettings _shellSettings;
+        public Migrations(ShellSettings shellSettings)
+        {
+            _shellSettings = shellSettings;
+        }
+
         public int Create()
         {
             SchemaBuilder.CreateMapIndexTable(nameof(TextFieldIndex), table => table
@@ -20,9 +27,12 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                 .Column<string>("BigText", column => column.Nullable().Unlimited())
             );
 
-            SchemaBuilder.AlterTable(nameof(TextFieldIndex), table => table
-                .CreateIndex("IDX_TextFieldIndex_ContentItemId", "ContentItemId")
-            );
+            if (_shellSettings["DatabaseProvider"] != "MySql")
+            {
+                SchemaBuilder.AlterTable(nameof(TextFieldIndex), table => table
+                    .CreateIndex("IDX_TextFieldIndex_ContentItemId", "ContentItemId")
+                );
+            }
 
             SchemaBuilder.AlterTable(nameof(TextFieldIndex), table => table
                 .CreateIndex("IDX_TextFieldIndex_ContentItemVersionId", "ContentItemVersionId")
@@ -48,9 +58,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                 .CreateIndex("IDX_TextFieldIndex_Latest", "Latest")
             );
 
-            SchemaBuilder.AlterTable(nameof(TextFieldIndex), table => table
-                .CreateIndex("IDX_TextFieldIndex_Text", "Text")
-            );
+            // MySql indexes are limited by length. 
+            if (_shellSettings["DatabaseProvider"] != "MySql")
+            {
+                SchemaBuilder.AlterTable(nameof(TextFieldIndex), table => table
+                    .CreateIndex("IDX_TextFieldIndex_Text", "Text")
+                );
+            }
 
             SchemaBuilder.CreateMapIndexTable(nameof(BooleanFieldIndex), table => table
                 .Column<string>("ContentItemId", column => column.WithLength(26))
@@ -350,13 +364,17 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                 .CreateIndex("IDX_LinkFieldIndex_Latest", "Latest")
             );
 
-            SchemaBuilder.AlterTable(nameof(LinkFieldIndex), table => table
-                .CreateIndex("IDX_LinkFieldIndex_Url", "Url")
-            );
+            // MySql indexes are limited by length. 
+            if (_shellSettings["DatabaseProvider"] != "MySql")
+            {
+                SchemaBuilder.AlterTable(nameof(LinkFieldIndex), table => table
+                    .CreateIndex("IDX_LinkFieldIndex_Url", "Url")
+                );
 
-            SchemaBuilder.AlterTable(nameof(LinkFieldIndex), table => table
-                .CreateIndex("IDX_LinkFieldIndex_Text", "Text")
-            );
+                SchemaBuilder.AlterTable(nameof(LinkFieldIndex), table => table
+                    .CreateIndex("IDX_LinkFieldIndex_Text", "Text")
+                );
+            }
 
             SchemaBuilder.CreateMapIndexTable(nameof(HtmlFieldIndex), table => table
                 .Column<string>("ContentItemId", column => column.WithLength(26))

--- a/src/OrchardCore/OrchardCore.Data/Migration/DataMigrationManager.cs
+++ b/src/OrchardCore/OrchardCore.Data/Migration/DataMigrationManager.cs
@@ -166,7 +166,7 @@ namespace OrchardCore.Data.Migration
                 var current = 0;
                 if (dataMigrationRecord != null)
                 {
-                    current = dataMigrationRecord.Version.Value;
+                    current = dataMigrationRecord.Version.HasValue ? dataMigrationRecord.Version.Value : current;
                 }
                 else
                 {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4753

This is the easiest fix, but not an ideal solution.

MySql is limited to 3072 total length for a column index.

You can truncate the length that goes into a column index, but YesSql has no way to do that, nor is it easy to calculate (depends on utf-8 encoding or latin in the MySql database settings)

So I've removed column indexes for all that I can see, that are too big for MySql.

The index tables still exist, so it's just the invidivdual colums that are affected.

Other alternative is we'd have to work something complicated into YesSql to apply only to MySql
