### PR TITLE
Admin Site - content type creation limited, when a elements of the Content Type are listed

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -118,7 +118,7 @@ namespace OrchardCore.Contents.Controllers
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.Options.SelectedContentType);
                 if (contentTypeDefinition == null)
                     return NotFound();
-                contentTypeDefinitions= contentTypeDefinitions.Append(contentTypeDefinition);
+                contentTypeDefinitions = contentTypeDefinitions.Append(contentTypeDefinition);
 
                 // We display a specific type even if it's not listable so that admin pages
                 // can reuse the Content list page for specific types.

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -111,11 +111,14 @@ namespace OrchardCore.Contents.Controllers
                 model.Options.SelectedContentType = contentTypeId;
             }
 
+
+            IEnumerable<ContentTypeDefinition> contentTypeDefinitions = new List<ContentTypeDefinition>();
             if (!string.IsNullOrEmpty(model.Options.SelectedContentType))
             {
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.Options.SelectedContentType);
                 if (contentTypeDefinition == null)
                     return NotFound();
+                contentTypeDefinitions= contentTypeDefinitions.Append(contentTypeDefinition);
 
                 // We display a specific type even if it's not listable so that admin pages
                 // can reuse the Content list page for specific types.
@@ -123,6 +126,8 @@ namespace OrchardCore.Contents.Controllers
             }
             else
             {
+                contentTypeDefinitions = _contentDefinitionManager.ListTypeDefinitions();
+
                 var listableTypes = (await GetListableTypesAsync()).Select(t => t.Name).ToArray();
                 if (listableTypes.Any())
                 {
@@ -149,7 +154,6 @@ namespace OrchardCore.Contents.Controllers
                     break;
             }
 
-            var contentTypeDefinitions = _contentDefinitionManager.ListTypeDefinitions().OrderBy(d => d.Name);
             var contentTypes = contentTypeDefinitions.Where(ctd => ctd.GetSettings<ContentTypeSettings>().Creatable).OrderBy(ctd => ctd.DisplayName);
             var creatableList = new List<SelectListItem>();
             if (contentTypes.Any())

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -47,13 +47,20 @@
             <div class="btn-group float-right">
                 @if (Model.Options.CreatableTypes.Any())
                 {
-                    <button class="btn btn-sm btn-success dropdown-toggle" data-toggle="dropdown" id="new-dropdown" type="button" aria-haspopup="true" aria-expanded="false">@T["New"]</button>
-                    <div class="dropdown-menu dropdown-menu-right scrollable" aria-labelledby="new-dropdown">
-                        @foreach (var item in Model.Options.CreatableTypes)
-                        {
-                            <a class="dropdown-item" href="@Url.RouteUrl(new { area = "OrchardCore.Contents", controller = "Admin", action = "Create", id = @item.Value })">@item.Text</a>
-                        }
-                    </div>
+                    @if (Model.Options.CreatableTypes.Count == 1)
+                    {
+                        <a class="btn btn-sm btn-success" href="@Url.RouteUrl(new { area = "OrchardCore.Contents", controller = "Admin", action = "Create", id = @Model.Options.CreatableTypes.First().Value })">@T["New {0}", Model.Options.CreatableTypes.First().Text]</a>
+                    }
+                    else
+                    {
+                        <button class="btn btn-sm btn-success dropdown-toggle" data-toggle="dropdown" id="new-dropdown" type="button" aria-haspopup="true" aria-expanded="false">@T["New"]</button>
+                        <div class="dropdown-menu dropdown-menu-right scrollable" aria-labelledby="new-dropdown">
+                            @foreach (var item in Model.Options.CreatableTypes)
+                            {
+                                <a class="dropdown-item" href="@Url.RouteUrl(new { area = "OrchardCore.Contents", controller = "Admin", action = "Create", id = @item.Value })">@T[item.Text]</a>
+                            }
+                        </div>
+                    }
                 }
             </div>
         </div>


### PR DESCRIPTION
see https://github.com/OrchardCMS/OrchardCore/issues/4985

Updated the controller class to show the selected content type when "SelectedContentType" option is not empty and the Content Type is marked as creatable.

![SharedScreenshot](https://user-images.githubusercontent.com/2736009/70716515-d0d98f80-1cec-11ea-83db-1f34c5914291.jpg)
