### PR TITLE
Register User class as an accessible Liquid member.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Liquid/UserLiquidTemplateEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Liquid/UserLiquidTemplateEventHandler.cs
@@ -19,6 +19,7 @@ namespace OrchardCore.Users.Liquid
         {
             var user = _httpContextAccessor.HttpContext.User;
 
+            context.MemberAccessStrategy.Register<User>();
             context.MemberAccessStrategy.Register<ClaimsPrincipal>();
             context.MemberAccessStrategy.Register<ClaimsIdentity>();
             context.SetValue("User", user);

--- a/src/OrchardCore.Modules/OrchardCore.Users/Liquid/UserLiquidTemplateEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Liquid/UserLiquidTemplateEventHandler.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Fluid;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.Liquid;
+using OrchardCore.Users.Models;
 
 namespace OrchardCore.Users.Liquid
 {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -139,6 +139,7 @@ namespace OrchardCore.Users
             services.AddLiquidFilter<HasPermissionFilter>("has_permission");
             services.AddLiquidFilter<HasClaimFilter>("has_claim");
             services.AddLiquidFilter<IsInRoleFilter>("is_in_role");
+            TemplateContext.GlobalMemberAccessStrategy.Register<User>();
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -139,7 +139,6 @@ namespace OrchardCore.Users
             services.AddLiquidFilter<HasPermissionFilter>("has_permission");
             services.AddLiquidFilter<HasClaimFilter>("has_claim");
             services.AddLiquidFilter<IsInRoleFilter>("is_in_role");
-            TemplateContext.GlobalMemberAccessStrategy.Register<User>();
         }
     }
 


### PR DESCRIPTION
Fixes #5026

For example if I want to get the Users fields from a Liquid template when I'm using the UserCreated event of a Workflow ; we require to make this class an available one from Liquid. Else the only value accessible is the Workflow.Input.User which returns the username.