### PR TITLE
Setting and Removing HttpContext.Items from Liquid Template

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -72,6 +72,9 @@ namespace OrchardCore.DisplayManagement.Liquid
             Factory.RegisterTag<ShapeRemovePropertyTag>("shape_remove_property");
             Factory.RegisterTag<ShapePagerTag>("shape_pager");
 
+            Factory.RegisterTag<HttpContextAddItemTag>("httpcontext_add_items");
+            Factory.RegisterTag<HttpContextRemoveItemTag>("httpcontext_remove_items");
+
             Factory.RegisterTag<HelperTag>("helper");
             Factory.RegisterTag<NamedHelperTag>("shape");
             Factory.RegisterTag<NamedHelperTag>("contentitem");
@@ -84,7 +87,7 @@ namespace OrchardCore.DisplayManagement.Liquid
             Factory.RegisterBlock<HelperBlock>("block");
             Factory.RegisterBlock<NamedHelperBlock>("a");
             Factory.RegisterBlock<NamedHelperBlock>("zone");
-            Factory.RegisterBlock<NamedHelperBlock>("scriptblock");
+            Factory.RegisterBlock<NamedHelperBlock>("scriptblock");            
 
             // Dynamic caching
             Factory.RegisterBlock<CacheBlock>("cache");

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/RequestLiquidTemplateEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/RequestLiquidTemplateEventHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Fluid;
@@ -52,10 +53,20 @@ namespace OrchardCore.DisplayManagement.Liquid
 
                 return new ArrayValue(forms[name].Select(x => new StringValue(x)).ToArray());
             });
+            
+            TemplateContext.GlobalMemberAccessStrategy.Register<HttpContext, FluidValue>((httpcontext, name) =>
+            {
+                switch (name)
+                {
+                    case "Items": return new ObjectValue(new HttpContextItemsWrapper(httpcontext.Items));
+                    default: return null;
+                }
+            });
 
+            TemplateContext.GlobalMemberAccessStrategy.Register<HttpContextItemsWrapper, object>((httpContext, name) => httpContext.Items[name]); 
             TemplateContext.GlobalMemberAccessStrategy.Register<QueryCollection, string[]>((queries, name) => queries[name].ToArray());
             TemplateContext.GlobalMemberAccessStrategy.Register<CookieCollectionWrapper, string>((cookies, name) => cookies.RequestCookieCollection[name]);
-            TemplateContext.GlobalMemberAccessStrategy.Register<HeaderDictionaryWrapper, string[]>((headers, name) => headers.HeaderDictionary[name].ToArray());
+            TemplateContext.GlobalMemberAccessStrategy.Register<HeaderDictionaryWrapper, string[]>((headers, name) => headers.HeaderDictionary[name].ToArray());            
         }
 
         public RequestLiquidTemplateEventHandler(IServiceProvider serviceProvider)
@@ -71,6 +82,7 @@ namespace OrchardCore.DisplayManagement.Liquid
             if (_httpContext != null)
             {
                 context.SetValue("Request", _httpContext.Request);
+                context.SetValue("HttpContext", _httpContext);
             }
 
             return Task.CompletedTask;
@@ -93,6 +105,16 @@ namespace OrchardCore.DisplayManagement.Liquid
             public HeaderDictionaryWrapper(IHeaderDictionary headerDictionary)
             {
                 HeaderDictionary = headerDictionary;
+            }
+        }
+
+        private class HttpContextItemsWrapper
+        {
+            public readonly IDictionary<object,object> Items;
+
+            public HttpContextItemsWrapper(IDictionary<object,object> items)
+            {
+                Items = items;
             }
         }
     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/HttpContextAddItemTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/HttpContextAddItemTag.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Ast;
+using Fluid.Tags;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Liquid.Ast;
+using OrchardCore.Mvc.Utilities;
+
+namespace OrchardCore.DisplayManagement.Liquid.Tags
+{
+    public class HttpContextAddItemTag : ArgumentsTag
+    {
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context,  FilterArgument[] args)
+        {           
+           if (!context.AmbientValues.TryGetValue("Services", out var servicesValue))
+            {
+                throw new ArgumentException("Services missing while invoking 'helper'");
+            }
+
+            var services = servicesValue as IServiceProvider;
+
+            var httpContext = services.GetRequiredService<IHttpContextAccessor>()?.HttpContext;
+            
+            if(httpContext != null )
+            {
+                var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
+
+                foreach (var name in arguments.Names)
+                {
+                    httpContext.Items[name] = arguments[name].ToObjectValue();
+                }
+            }
+            return Completion.Normal;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/HttpContextRemoveItemTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/HttpContextRemoveItemTag.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Tags;
+using Fluid.Ast;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Liquid.Ast;
+using OrchardCore.Mvc.Utilities;
+
+namespace OrchardCore.DisplayManagement.Liquid.Tags
+{
+    public class HttpContextRemoveItemTag : ArgumentsTag
+    {
+        public override async ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context, FilterArgument[] args)
+        {
+            if (!context.AmbientValues.TryGetValue("Services", out var servicesValue))
+            {
+                throw new ArgumentException("Services missing while invoking 'helper'");
+            }
+
+            var services = servicesValue as IServiceProvider;
+
+            var httpContext = services.GetRequiredService<IHttpContextAccessor>()?.HttpContext;
+            
+            if(httpContext != null )
+            {
+                var arguments = (FilterArguments)(await new ArgumentsExpression(args).EvaluateAsync(context)).ToObjectValue();
+                var itemKey = arguments["item"].Or(arguments.At(0)).ToStringValue();
+                if (!string.IsNullOrEmpty(itemKey))
+                {
+                    httpContext.Items.Remove(itemKey);
+                }
+            
+            }
+            return Completion.Normal;
+        }
+    }
+}

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -313,6 +313,29 @@ The following properties are available on the `Culture` object.
 | `Name` | `en-US` | The request's culture as an ISO language code. |
 | `Dir` | `rtl` | The text writing direction. |
 
+
+### HttpContext
+
+Represents the HttpContext of the current request.
+
+The following properties are available on the `HttpContext` object.
+
+| Property | Example | Description |
+| --------- | ---- |------------ |
+| `Items` | `HttpContext.Items["Item1"]` | Returns an item with key Item1 |
+
+
+#### httpcontext_add_items
+Adds key/value to HttpContext.Items collection
+
+`{% httpcontext_add_items Item1:"value 1", Item2:"Value2"  %}`
+
+#### httpcontext_remove_items
+Removes key from HttpContext.Items collection
+
+`{% httpcontext_remove_items "Item1" %}`
+
+
 ## Shape Filters
 
 These filters let you create and filter shapes.


### PR DESCRIPTION
Fixes #4504 

Added Tags: 
### 1. httpcontext_add_items
Adds key/value to HttpContext.Items collection

**Usage**: 
`{% httpcontext_add_items Item1:"value 1", Item2:"Value2"  %}`

**Get**, 

`{{ HttpContext.Items["Item1"] }}`

### 2. httpcontext_remove_items
Removes key from HttpContext.Items collection

**Usage**:
`{% httpcontext_remove_items "Item1" %}`


