### PR TITLE
Allow to publish an existing content item that is a draft.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/PublishContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/PublishContentTask.cs
@@ -27,7 +27,15 @@ namespace OrchardCore.Contents.Workflows.Activities
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
             var content = await GetContentAsync(workflowContext);
-            await ContentManager.PublishAsync(content.ContentItem);
+            var contentItem = await ContentManager.GetAsync(content.ContentItem.ContentItemId, VersionOptions.DraftRequired);
+            if (contentItem != null)
+            {
+                await ContentManager.PublishAsync(contentItem);
+            }
+            else
+            {
+                await ContentManager.PublishAsync(content.ContentItem);
+            }
             return Outcomes("Published");
         }
     }


### PR DESCRIPTION
From a Workflow PublishContentTask.

Else I get this error when executing this task on an existing content item : 

```
An unhandled exception occurred while processing the request.
ArgumentException: An item with the same key has already been added. Key: 4zb0d8zsd96p437anx0cg3v649
System.Collections.Generic.Dictionary<TKey, TValue>.TryInsert(TKey key, TValue value, InsertionBehavior behavior)

Stack Query Cookies Headers Routing
ArgumentException: An item with the same key has already been added. Key: 4zb0d8zsd96p437anx0cg3v649
System.Collections.Generic.Dictionary<TKey, TValue>.TryInsert(TKey key, TValue value, InsertionBehavior behavior)
System.Collections.Generic.Dictionary<TKey, TValue>.Add(TKey key, TValue value)
System.Linq.Enumerable.ToDictionary<TSource, TKey, TElement>(List<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
System.Linq.Enumerable.ToDictionary<TSource, TKey, TElement>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
System.Linq.Enumerable.ToDictionary<TSource, TKey, TElement>(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
OrchardCore.Lucene.LuceneQuerySource+<>c__DisplayClass10_0+<<ExecuteQueryAsync>b__0>d.MoveNext() in LuceneQuerySource.cs
+
                        var dbContentItemVersionIds = dbContentItems.ToDictionary(x => x.ContentItemVersionId, x => x);
OrchardCore.Lucene.LuceneIndexManager.SearchAsync(string indexName, Func<IndexSearcher, Task> searcher) in LuceneIndexManager.cs
+
                    await searcher(indexSearcher);
OrchardCore.Lucene.LuceneQuerySource.ExecuteQueryAsync(Query query, IDictionary<string, object> parameters) in LuceneQuerySource.cs
+
            await _luceneIndexProvider.SearchAsync(luceneQuery.Index, async searcher =>
AffairesExtra.Dashboard.Controllers.DashboardController.LuceneQueryAsync(string queryName, Dictionary<string, object> parameters) in DashboardController.cs
+
                queryResult = (LuceneQueryResults)await _queryManager.ExecuteQueryAsync(query, parameters);
AffairesExtra.Dashboard.Controllers.DashboardController.Index(DashboardViewModel model, PagerParameters pagerParameters) in DashboardController.cs
+
                var results = (LuceneQueryResults)await LuceneQueryAsync("AllAdsSearchAdmin", parameters);
Microsoft.AspNetCore.Mvc.Infrastructure.ActionMethodExecutor+TaskOfIActionResultExecutor.Execute(IActionResultTypeMapper mapper, ObjectMethodExecutor executor, object controller, object[] arguments)
System.Threading.Tasks.ValueTask<TResult>.get_Result()
Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeActionMethodAsync>g__Awaited|12_0(ControllerActionInvoker invoker, ValueTask<IActionResult> actionResultValueTask)
Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeNextActionFilterAsync>g__Awaited|10_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, object state, bool isCompleted)
Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Rethrow(ActionExecutedContextSealed context)
Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(ref State next, ref Scope scope, ref object state, ref bool isCompleted)
Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.<InvokeInnerFilterAsync>g__Awaited|13_0(ControllerActionInvoker invoker, Task lastTask, State next, Scope scope, object state, bool isCompleted)
Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextResourceFilter>g__Awaited|24_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, object state, bool isCompleted)
Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Rethrow(ResourceExecutedContextSealed context)
Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.Next(ref State next, ref Scope scope, ref object state, ref bool isCompleted)
Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeFilterPipelineAsync>g__Awaited|19_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, object state, bool isCompleted)
Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeAsync>g__Awaited|17_0(ResourceInvoker invoker, Task task, IDisposable scope)
Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g__AwaitRequestTask|6_0(Endpoint endpoint, Task requestTask, ILogger logger)
Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)
SixLabors.ImageSharp.Web.Middleware.ImageSharpMiddleware.Invoke(HttpContext context)
OrchardCore.Media.Services.MediaFileStoreResolverMiddleware.Invoke(HttpContext context) in MediaFileStoreResolverMiddleware.cs
+
                await _next(context);
Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context)
Microsoft.AspNetCore.Localization.RequestLocalizationMiddleware.Invoke(HttpContext context)
Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)
OrchardCore.Diagnostics.DiagnosticsStartupFilter+<>c__DisplayClass3_0+<<Configure>b__1>d.MoveNext() in DiagnosticsStartupFilter.cs
+
                    await next();
Microsoft.AspNetCore.Diagnostics.StatusCodePagesMiddleware.Invoke(HttpContext context)
OrchardCore.ContentPreview.PreviewStartupFilter+<>c+<<Configure>b__1_1>d.MoveNext() in PreviewStartupFilter.cs
+
                    await next();
OrchardCore.Environment.Shell.Scope.ShellScope.UsingAsync(Func<ShellScope, Task> execute) in ShellScope.cs
+
                await execute(this);
OrchardCore.Modules.ModularTenantContainerMiddleware.Invoke(HttpContext httpContext) in ModularTenantContainerMiddleware.cs
+
                await shellScope.UsingAsync(scope => _next.Invoke(httpContext));
Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware.Invoke(HttpContext context)

Show raw exception details
```