### PR TITLE
Fix locking on FileContentDefinitionStore by making it a singleton

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
@@ -37,7 +37,7 @@ namespace OrchardCore.ContentManagement
         public static IServiceCollection AddFileContentDefinitionStore(this IServiceCollection services)
         {
             services.RemoveAll<IContentDefinitionStore>();
-            services.TryAddScoped<IContentDefinitionStore, FileContentDefinitionStore>();
+            services.AddSingleton<IContentDefinitionStore, FileContentDefinitionStore>();
 
             return services;
         }


### PR DESCRIPTION
As said in #4863 

- The 2 `lock (this)` in `FileContentDefinitionStore` are useless because it is a scoped service. Here i just make it a singleton because it only inject 2 singleton services.

