### PR TITLE
Fixes FileContentDefinitionStore scoped cache.

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
@@ -25,14 +25,14 @@ namespace OrchardCore.ContentManagement
         /// </summary>
         public async Task<ContentDefinitionRecord> LoadContentDefinitionAsync()
         {
-            var holder = ShellScope.Services.GetRequiredService<FileContentDefinitionScopedCache>();
+            var scopedCache = ShellScope.Services.GetRequiredService<FileContentDefinitionScopedCache>();
 
-            if (holder.ContentDefinitionRecord != null)
+            if (scopedCache.ContentDefinitionRecord != null)
             {
-                return holder.ContentDefinitionRecord;
+                return scopedCache.ContentDefinitionRecord;
             }
 
-            return holder.ContentDefinitionRecord = await GetContentDefinitionAsync();
+            return scopedCache.ContentDefinitionRecord = await GetContentDefinitionAsync();
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
@@ -1,9 +1,11 @@
 using System.IO;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using OrchardCore.ContentManagement.Metadata.Records;
 using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Scope;
 
 namespace OrchardCore.ContentManagement
 {
@@ -11,8 +13,6 @@ namespace OrchardCore.ContentManagement
     {
         private readonly IOptions<ShellOptions> _shellOptions;
         private readonly ShellSettings _shellSettings;
-
-        private ContentDefinitionRecord _contentDefinitionRecord;
 
         public FileContentDefinitionStore(IOptions<ShellOptions> shellOptions, ShellSettings shellSettings)
         {
@@ -25,12 +25,14 @@ namespace OrchardCore.ContentManagement
         /// </summary>
         public async Task<ContentDefinitionRecord> LoadContentDefinitionAsync()
         {
-            if (_contentDefinitionRecord != null)
+            var holder = ShellScope.Services.GetRequiredService<FileContentDefinitionScopedCache>();
+
+            if (holder.ContentDefinitionRecord != null)
             {
-                return _contentDefinitionRecord;
+                return holder.ContentDefinitionRecord;
             }
 
-            return _contentDefinitionRecord = await GetContentDefinitionAsync();
+            return holder.ContentDefinitionRecord = await GetContentDefinitionAsync();
         }
 
         /// <summary>
@@ -78,5 +80,10 @@ namespace OrchardCore.ContentManagement
             _shellOptions.Value.ShellsApplicationDataPath,
             _shellOptions.Value.ShellsContainerName,
             _shellSettings.Name, "ContentDefinition.json");
+    }
+
+    internal class FileContentDefinitionScopedCache
+    {
+        public ContentDefinitionRecord ContentDefinitionRecord { get; internal set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ namespace OrchardCore.ContentManagement
         {
             services.RemoveAll<IContentDefinitionStore>();
             services.AddSingleton<IContentDefinitionStore, FileContentDefinitionStore>();
+            services.AddScoped<FileContentDefinitionScopedCache>();
 
             return services;
         }


### PR DESCRIPTION
So we made `FileContentDefinitionStore` a singleton so that the locking on itself is useful.

But while it was a scoped service it was using a field as a scoped cache for the definition, we need this when there are multiple updates on the definition in the same shell scope.

The problem is that because it is now a singleton, **this scoped cache is now a singleton cache**. It works but now e.g we always mutate the same singleton object and we never reload it after updating.

So here this is the battle of a singleton that need a scoped cache OR a scoped service that need a tenant level cache ...

There are different solutions

- Make it again a scoped service but the lock will be useless. Then maybe use a tenant level named lock component as i did in another PR.

- Use an `IHttpContextAccessor` and then use `HttpContext.Items` or `.Features` for a scoped cache. Notice that in #4933 i introduced the ability to add `Items / Features` but on the `ShellScope` which is better in our case because a request scope may have different shell scopes.

- So right now, here i used the DI to register a `FileContentDefinitionScopedCache`, but that's okay for me.