### PR TITLE
fix: Cloning removes LocalizationSet

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Handlers/LocalizationPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Handlers/LocalizationPartHandler.cs
@@ -3,8 +3,8 @@ using System.Globalization;
 using System.Threading.Tasks;
 using OrchardCore.ContentLocalization.Models;
 using OrchardCore.ContentLocalization.Services;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
-using OrchardCore.Localization;
 
 namespace OrchardCore.ContentLocalization.Handlers
 {
@@ -66,6 +66,14 @@ namespace OrchardCore.ContentLocalization.Handlers
                 Culture = part.Culture.ToLowerInvariant()
             });
 
+            return Task.CompletedTask;
+        }
+
+        public override Task CloningAsync(CloneContentContext context, LocalizationPart part)
+        {
+            var clonedPart = context.CloneContentItem.As<LocalizationPart>();
+            clonedPart.LocalizationSet = string.Empty;
+            clonedPart.Apply();
             return Task.CompletedTask;
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/LocalizationPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/LocalizationPart.Edit.cshtml
@@ -19,7 +19,7 @@
                 @if (!Model.ContentItemCultures.Any())
                 {
                     <p>@T["Your site does not have any cultures. Current System culture is {1} | {0}", CultureInfo.InstalledUICulture.Name, CultureInfo.InstalledUICulture.DisplayName]</p>
-                    <p><a asp-route-area="OrchardCore.Settings" asp-controller="Admin" asp-action="Index" asp-route-groupId = "localization">T["Add or remove supported cultures for the site"]</a></p>
+                    <p><a asp-route-area="OrchardCore.Settings" asp-controller="Admin" asp-action="Index" asp-route-groupId = "localization">@T["Add or remove supported cultures for the site"]</a></p>
                 }
                 else
                 {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/CloneContentContext.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/CloneContentContext.cs
@@ -3,6 +3,7 @@ namespace OrchardCore.ContentManagement.Handlers
     public class CloneContentContext : ContentContextBase
     {
         public ContentItem CloneContentItem { get; set; }
+
         public CloneContentContext(ContentItem contentItem, ContentItem cloneContentItem)
             : base(contentItem)
         {


### PR DESCRIPTION
LocalizationSet was not being cleared when cloning so a duplicate entry
would be created for a locale when cloning

fix #5096