### PR TITLE
GetDictionary() should be called once per culture

### DIFF
--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizer.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizer.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace OrchardCore.Localization.PortableObject
 {
@@ -174,35 +172,54 @@ namespace OrchardCore.Localization.PortableObject
 
         private string GetTranslation(string name, string context, CultureInfo culture, int? count)
         {
-            var key = CultureDictionaryRecord.GetKey(name, context);
+            string translation = null;
             try
             {
-                var dictionary = _localizationManager.GetDictionary(culture);
-                var translation = dictionary[key, count];
-                if (translation == null && _fallBackToParentCulture && culture.Parent != CultureInfo.InvariantCulture && culture.Parent != culture)
+                if (_fallBackToParentCulture)
                 {
-                    dictionary = _localizationManager.GetDictionary(culture.Parent);
+                    do
+                    {
+                        if(ExtractTranslation() != null)
+                        {
+                            break;
+                        }
+
+                        culture = culture.Parent;
+                    }
+                    while (culture != CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    ExtractTranslation();
+                }
+
+                string ExtractTranslation()
+                {
+                    var dictionary = _localizationManager.GetDictionary(culture);
 
                     if (dictionary != null)
                     {
-                        translation = dictionary[key, count]; // fallback to the parent culture
+                        // Extract translation with context
+                        var key = CultureDictionaryRecord.GetKey(name, context);
+                        translation = dictionary[key, count];
+
+                        if (context != null && translation == null)
+                        {
+                            // Extract translation without context
+                            key = CultureDictionaryRecord.GetKey(name, null);
+                            translation = dictionary[key, count];
+                        }
                     }
-                }
 
-                // No exact translation found, search without context
-                if (translation == null && context != null)
-                {
-                    translation = GetTranslation(name, null, culture, count);
+                    return translation;
                 }
-
-                return translation;
             }
             catch (PluralFormNotFoundException ex)
             {
                 _logger.LogWarning(ex.Message);
             }
 
-            return null;
+            return translation;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizer.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizer.cs
@@ -178,10 +178,7 @@ namespace OrchardCore.Localization.PortableObject
             try
             {
                 var dictionary = _localizationManager.GetDictionary(culture);
-
                 var translation = dictionary[key, count];
-
-                // Should we search in the parent culture?
                 if (translation == null && _fallBackToParentCulture && culture.Parent != CultureInfo.InvariantCulture && culture.Parent != culture)
                 {
                     dictionary = _localizationManager.GetDictionary(culture.Parent);

--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizer.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizer.cs
@@ -182,7 +182,7 @@ namespace OrchardCore.Localization.PortableObject
                 var translation = dictionary[key, count];
 
                 // Should we search in the parent culture?
-                if (translation == null && _fallBackToParentCulture && culture.Parent != null && culture.Parent != culture)
+                if (translation == null && _fallBackToParentCulture && culture.Parent != CultureInfo.InvariantCulture && culture.Parent != culture)
                 {
                     dictionary = _localizationManager.GetDictionary(culture.Parent);
 

--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizer.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PortableObjectStringLocalizer.cs
@@ -179,7 +179,7 @@ namespace OrchardCore.Localization.PortableObject
                 {
                     do
                     {
-                        if(ExtractTranslation() != null)
+                        if (ExtractTranslation() != null)
                         {
                             break;
                         }

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -316,6 +316,8 @@ namespace OrchardCore.Tests.Localization
         [Theory]
         [InlineData("ar", 1)]
         [InlineData("ar-YE", 2)]
+        [InlineData("zh-CN", 3)]
+        [InlineData("zh-TW", 3)]
         public void LocalizerWithContextShouldCallGetDictionaryOncePerCulture(string culture, int expectedCalls)
         {
             // Arrange

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -316,8 +316,8 @@ namespace OrchardCore.Tests.Localization
         [Theory]
         [InlineData("ar", 1)]
         [InlineData("ar-YE", 2)]
-        [InlineData("zh-CN", 3)]
-        [InlineData("zh-TW", 3)]
+        [InlineData("zh-Hans-CN", 3)]
+        [InlineData("zh-Hant-TW", 3)]
         public void LocalizerWithContextShouldCallGetDictionaryOncePerCulture(string culture, int expectedCalls)
         {
             // Arrange

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -314,9 +314,9 @@ namespace OrchardCore.Tests.Localization
             => await StartupRunner.Run(typeof(PortableObjectLocalizationStartup),"en", "Hello");
 
         [Theory]
-        [InlineData("ar", 2)]
-        [InlineData("ar-YE", 4)]
-        public void LocalizerWithContextShouldCallGetDictionaryTwicePerCulture(string culture, int expectedCalls)
+        [InlineData("ar", 1)]
+        [InlineData("ar-YE", 2)]
+        public void LocalizerWithContextShouldCallGetDictionaryOncePerCulture(string culture, int expectedCalls)
         {
             // Arrange
             SetupDictionary(culture, Array.Empty<CultureDictionaryRecord>());

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -311,6 +312,25 @@ namespace OrchardCore.Tests.Localization
         [Fact]
         public async Task PortableObjectStringLocalizerShouldRegisterIStringLocalizerOfT()
             => await StartupRunner.Run(typeof(PortableObjectLocalizationStartup),"en", "Hello");
+
+        [Theory]
+        [InlineData("ar", 2)]
+        [InlineData("ar-YE", 4)]
+        public void LocalizerWithContextShouldCallGetDictionaryTwicePerCulture(string culture, int expectedCalls)
+        {
+            // Arrange
+            SetupDictionary(culture, Array.Empty<CultureDictionaryRecord>());
+
+            var localizer = new PortableObjectStringLocalizer("context", _localizationManager.Object, true, _logger.Object);
+            CultureInfo.CurrentUICulture = new CultureInfo(culture);
+
+            // Act
+            var translation = localizer["Hello"];
+
+            // Assert
+            _localizationManager.Verify(lm => lm.GetDictionary(It.IsAny<CultureInfo>()), Times.Exactly(expectedCalls));
+            Assert.Equal("Hello", translation);
+        }
 
         private void SetupDictionary(string cultureName, IEnumerable<CultureDictionaryRecord> records)
         {


### PR DESCRIPTION
The issue is `GetDirctionary()` called more than expected, because the culture is fallback until it's parent is `null` which is wrong, it should fallback unit the culture parent is empty aka `InvariantCulture`