### PR TITLE
Validate Site Settings BaseUrl property

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
@@ -1,8 +1,11 @@
+using System;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Settings.ViewModels;
+using OrchardCore.Mvc.ModelBinding;
 
 namespace OrchardCore.Settings.Drivers
 {
@@ -12,14 +15,17 @@ namespace OrchardCore.Settings.Drivers
 
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly IStringLocalizer S;
 
         public DefaultSiteSettingsDisplayDriver(
             IShellHost shellHost,
-            ShellSettings shellSettings
+            ShellSettings shellSettings,
+            IStringLocalizer<DefaultSiteSettingsDisplayDriver> stringLocalizer
             )
         {
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            S = stringLocalizer;
         }
 
         public override IDisplayResult Edit(ISite site)
@@ -55,7 +61,15 @@ namespace OrchardCore.Settings.Drivers
                     site.CdnBaseUrl = model.CdnBaseUrl;
                     site.ResourceDebugMode = model.ResourceDebugMode;
                     site.AppendVersion = model.AppendVersion;
+                }
 
+                if (!String.IsNullOrEmpty(site.BaseUrl) && !Uri.TryCreate(site.BaseUrl, UriKind.Absolute, out var baseUrl))
+                {
+                    context.Updater.ModelState.AddModelError(Prefix, nameof(site.BaseUrl), S["The Base url must be a fully qualified URL."]);
+                }
+
+                if (context.Updater.ModelState.IsValid)
+                {
                     await _shellHost.ReloadShellContextAsync(_shellSettings);
                 }
             }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4836

Doesn't require a base url, but if provided, validates it