### PR TITLE
Add closing tags to taxonomy field editor

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
@@ -5,10 +5,11 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TaxonomyFieldSettings>();
     int previousLevel = 0;
+    int closingDivs = 0;
 }
 
 <label>@Model.PartFieldDefinition.DisplayName()</label>
-    
+
 @if (!String.IsNullOrEmpty(settings.Hint))
 {
     <span class="hint">— @settings.Hint</span>
@@ -22,69 +23,75 @@
 }
 
 <div class="form-group">
-@for (var i = 0; i < Model.TermEntries.Count; i++)
-{
-    var entry = Model.TermEntries[i];
-    var term = entry.Term;
+    @for (var i = 0; i < Model.TermEntries.Count; i++)
+    {
+        var entry = Model.TermEntries[i];
+        var term = entry.Term;
 
-    if (entry.Level == previousLevel + 1)
-    {
-        WriteLiteral("<div class=\"pl-3\">");
-    }
-    
-    for (var e = entry.Level; e < previousLevel; e++)
-    {
-        WriteLiteral("</div>");
-    }
-
-    @if (!settings.Unique)
-    {
-        <div class="custom-control custom-checkbox">
-        @if (!settings.LeavesOnly || Model.TermEntries[i].IsLeaf)
+        if (entry.Level == previousLevel + 1)
         {
-            <input asp-for="@Model.TermEntries[i].Selected" type="checkbox" class="custom-control-input" /> 
+            WriteLiteral("<div class=\"pl-3\">");
+            closingDivs = entry.Level;
+        }
+        for (var e = entry.Level; e < previousLevel; e++)
+        {
+            WriteLiteral("</div>");
+            closingDivs = 0;
+        }
+
+        @if (!settings.Unique)
+        {
+            <div class="custom-control custom-checkbox">
+                @if (!settings.LeavesOnly || Model.TermEntries[i].IsLeaf)
+                {
+                    <input asp-for="@Model.TermEntries[i].Selected" type="checkbox" class="custom-control-input" />
+                }
+                else
+                {
+                    <input asp-for="@Model.TermEntries[i].Selected" type="checkbox" disabled="disabled" class="custom-control-input" />
+                }
+
+                <label class="custom-control-label" asp-for="@Model.TermEntries[i].Selected">
+                    @term
+                </label>
+                <input asp-for="@Model.TermEntries[i].ContentItemId" type="hidden" />
+            </div>
         }
         else
         {
-            <input asp-for="@Model.TermEntries[i].Selected" type="checkbox" disabled="disabled" class="custom-control-input" /> 
+            <div class="custom-control custom-radio">
+                @if (!settings.LeavesOnly || Model.TermEntries[i].IsLeaf)
+                {
+                    <input id="@Html.IdFor(x => x.TermEntries[i].Selected)"
+                           name="@Html.NameFor(m => m.UniqueValue)"
+                           type="radio"
+                           value="@Model.TermEntries[i].ContentItemId"
+                           checked="@(Model.TermEntries[i].Selected ? "checked" : null)"
+                           class="custom-control-input" />
+                }
+                else
+                {
+                    <input id="@Html.IdFor(x => x.TermEntries[i].Selected)"
+                           name="@Html.NameFor(m => m.UniqueValue)"
+                           type="radio"
+                           value="@Model.TermEntries[i].ContentItemId"
+                           disabled="disabled"
+                           checked="@(Model.TermEntries[i].Selected ? "checked" : null)"
+                           class="custom-control-input" />
+                }
+                <label class="custom-control-label" asp-for="@Model.TermEntries[i].Selected">
+                    @term
+                </label>
+            </div>
         }
 
-        <label class="custom-control-label" asp-for="@Model.TermEntries[i].Selected">
-            @term
-        </label>
-        <input asp-for="@Model.TermEntries[i].ContentItemId" type="hidden" /> 
-    </div>
+        previousLevel = entry.Level;
     }
-    else
+    @if (closingDivs > 0)
     {
-        <div class="custom-control custom-radio">
-        @if (!settings.LeavesOnly || Model.TermEntries[i].IsLeaf)
+        for (var e = 0; e < closingDivs; e++)
         {
-            <input 
-                id="@Html.IdFor(x => x.TermEntries[i].Selected)" 
-                name="@Html.NameFor(m => m.UniqueValue)" 
-                type="radio" 
-                value="@Model.TermEntries[i].ContentItemId" 
-                checked="@(Model.TermEntries[i].Selected ? "checked" : null)"
-                class="custom-control-input" /> 
+            WriteLiteral("</div>");
         }
-        else
-        {
-            <input 
-                id="@Html.IdFor(x => x.TermEntries[i].Selected)" 
-                name="@Html.NameFor(m => m.UniqueValue)" 
-                type="radio" 
-                value="@Model.TermEntries[i].ContentItemId" 
-                disabled="disabled" 
-                checked="@(Model.TermEntries[i].Selected ? "checked" : null)"
-                class="custom-control-input" /> 
-        }
-        <label class="custom-control-label" asp-for="@Model.TermEntries[i].Selected">
-            @term
-        </label>
-    </div>
     }
-
-    previousLevel = entry.Level;
-}
 </div>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4965

Just needed to have closing tags added after the entries were rendered, as the loop had finished by then.

Most changes are just formatting.

Keep the issue open if you want the prettier vue tree editor at some stage ;)