### PR TITLE
Fixed routing issue with setting up a Remote Instance

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Startup.cs
@@ -72,19 +72,19 @@ namespace OrchardCore.Deployment
             routes.MapAreaControllerRoute(
                 name: "DeploymentRemoteInstancesCreate",
                 areaName: "OrchardCore.Deployment.Remote",
-                pattern: _adminOptions.AdminUrlPrefix + "/Deployment/RemoteClient/Create",
+                pattern: _adminOptions.AdminUrlPrefix + "/Deployment/RemoteInstance/Create",
                 defaults: new { controller = remoteInstanceControllerName, action = nameof(RemoteInstanceController.Create) }
             );
             routes.MapAreaControllerRoute(
                 name: "DeploymentRemoteInstancesDelete",
                 areaName: "OrchardCore.Deployment.Remote",
-                pattern: _adminOptions.AdminUrlPrefix + "/Deployment/RemoteClient/Delete/{id}",
+                pattern: _adminOptions.AdminUrlPrefix + "/Deployment/RemoteInstance/Delete/{id}",
                 defaults: new { controller = remoteInstanceControllerName, action = nameof(RemoteClientController.Delete) }
             );
             routes.MapAreaControllerRoute(
                 name: "DeploymentRemoteInstancesEdit",
                 areaName: "OrchardCore.Deployment.Remote",
-                pattern: _adminOptions.AdminUrlPrefix + "/Deployment/RemoteClient/Edit/{id}",
+                pattern: _adminOptions.AdminUrlPrefix + "/Deployment/RemoteInstance/Edit/{id}",
                 defaults: new { controller = remoteInstanceControllerName, action = nameof(RemoteInstanceController.Edit) }
             );
         }


### PR DESCRIPTION
Remote instances were incorrect for the following actions:  Create, Delete and Edit.  