### PR TITLE
Fix alias and autoroute defaults

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Settings/AliasPartSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Settings/AliasPartSettings.cs
@@ -4,7 +4,7 @@ namespace OrchardCore.Alias.Settings
 {
     public class AliasPartSettings
     {
-        [DefaultValue("{{ ContentItem.DisplayText | slugify }}")]
-        public string Pattern { get; set; } = "{{ ContentItem.DisplayText | slugify }}";
+        [DefaultValue("{{ Model.ContentItem.DisplayText | slugify }}")]
+        public string Pattern { get; set; } = "{{ Model.ContentItem.DisplayText | slugify }}";
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartSettings.cs
@@ -12,8 +12,8 @@ namespace OrchardCore.Autoroute.Models
         /// <summary>
         /// The pattern used to build the Path.
         /// </summary>
-        [DefaultValue("{{ ContentItem.DisplayText | slugify }}")]
-        public string Pattern { get; set; } = "{{ ContentItem.DisplayText | slugify }}";
+        [DefaultValue("{{ Model.ContentItem.DisplayText | slugify }}")]
+        public string Pattern { get; set; } = "{{ Model.ContentItem.DisplayText | slugify }}";
 
         /// <summary>
         /// Whether to display an option to set the content item as the homepage.


### PR DESCRIPTION
Follow on from https://github.com/OrchardCMS/OrchardCore/pull/4933 

just updates the defaults to use the `Model` property