### PR TITLE
Constraint admin controllers to mapped routes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraint.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraint.cs
@@ -1,21 +1,28 @@
-using System;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ActionConstraints;
 
 namespace OrchardCore.Admin
 {
     public class AdminActionConstraint : IActionConstraint
     {
+        private readonly PathString _adminUrlPrefix;
+
         public int Order => 0;
+
+        public AdminActionConstraint(PathString adminUrlPrefix)
+        {
+            _adminUrlPrefix = adminUrlPrefix;
+        }
 
         public bool Accept(ActionConstraintContext context)
         {
-            if (context.RouteContext.HttpContext.Request.Path.Value.StartsWith("/OrchardCore", StringComparison.OrdinalIgnoreCase))
+            if (context.RouteContext.HttpContext.Request.Path.StartsWithSegments(_adminUrlPrefix))
             {
-                return false;
+                return true;
             }
             else
             {
-                return true;
+                return false;
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraint.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraint.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+
+namespace OrchardCore.Admin
+{
+    public class AdminActionConstraint : IActionConstraint
+    {
+        public int Order => 0;
+
+        public bool Accept(ActionConstraintContext context)
+        {
+            if (context.RouteContext.HttpContext.Request.Path.Value.StartsWith("/OrchardCore", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraintFactory.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraintFactory.cs
@@ -1,0 +1,19 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace OrchardCore.Admin
+{
+    public class AdminActionConstraintFactory : IActionConstraintFactory
+    {
+        public bool IsReusable => true;
+
+        public IActionConstraint CreateInstance(IServiceProvider services)
+        {
+            var adminOptions = services.GetRequiredService<IOptions<AdminOptions>>();
+            return new AdminActionConstraint(new PathString('/' + adminOptions.Value.AdminUrlPrefix));
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionModelConvention.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionModelConvention.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace OrchardCore.Admin
+{
+    /// <summary>
+    /// Routing convention to apply admin constraint to mapped admin routes only.
+    /// </summary>
+    public class AdminActionModelConvention : IActionModelConvention
+    {
+        public void Apply(ActionModel action)
+        {
+            if (action.Controller.ControllerName.StartsWith("Admin", StringComparison.OrdinalIgnoreCase) ||
+                action.Controller.Attributes.OfType<AdminAttribute>().Any())
+            {
+                foreach (var selector in action.Selectors)
+                {
+                    selector.ActionConstraints.Add(new AdminActionConstraint());
+                }
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionModelConvention.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionModelConvention.cs
@@ -14,9 +14,10 @@ namespace OrchardCore.Admin
             if (action.Controller.ControllerName.StartsWith("Admin", StringComparison.OrdinalIgnoreCase) ||
                 action.Controller.Attributes.OfType<AdminAttribute>().Any())
             {
+                var factory = new AdminActionConstraintFactory();
                 foreach (var selector in action.Selectors)
                 {
-                    selector.ActionConstraints.Add(new AdminActionConstraint());
+                    selector.ActionConstraints.Add(factory);
                 }
             }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Admin/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/Startup.cs
@@ -36,6 +36,8 @@ namespace OrchardCore.Admin
 
                 // Ordered to be called before any global filter.
                 options.Filters.Add(typeof(AdminZoneFilter), -1000);
+
+                options.Conventions.Add(new AdminActionModelConvention());
             });
 
             services.AddScoped<IPermissionProvider, Permissions>();


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5162

Applies a convention that restraints all `AdminControllers` or `[Admin]` controllers to use the mapped route only, and not the default route applied by Mvc.

Guess this will tell us if we missed any route mappings