### PR TITLE
Fix localization accessors names

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
@@ -21,7 +21,7 @@ namespace OrchardCore.Alias.Drivers
 
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ISession _session;
-        private readonly IStringLocalizer<AliasPartDisplayDriver> T;
+        private readonly IStringLocalizer<AliasPartDisplayDriver> S;
 
         public AliasPartDisplayDriver(
             IContentDefinitionManager contentDefinitionManager,
@@ -30,7 +30,7 @@ namespace OrchardCore.Alias.Drivers
         {
             _contentDefinitionManager = contentDefinitionManager;
             _session = session;
-            T = localizer;
+            S = localizer;
         }
 
         public override IDisplayResult Edit(AliasPart aliasPart)
@@ -71,12 +71,12 @@ namespace OrchardCore.Alias.Drivers
         {
             if (alias.Alias?.Length > MaxAliasLength)
             {
-                updater.ModelState.AddModelError(Prefix, nameof(alias.Alias), T["Your alias is too long. The alias can only be up to {0} characters.", MaxAliasLength]);
+                updater.ModelState.AddModelError(Prefix, nameof(alias.Alias), S["Your alias is too long. The alias can only be up to {0} characters.", MaxAliasLength]);
             }
 
             if (alias.Alias != null && (await _session.QueryIndex<AliasPartIndex>(o => o.Alias == alias.Alias && o.ContentItemId != alias.ContentItem.ContentItemId).CountAsync()) > 0)
             {
-                updater.ModelState.AddModelError(Prefix, nameof(alias.Alias), T["Your alias is already in use."]);
+                updater.ModelState.AddModelError(Prefix, nameof(alias.Alias), S["Your alias is already in use."]);
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/GraphQL/AliasInputObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/GraphQL/AliasInputObjectType.cs
@@ -7,12 +7,12 @@ namespace OrchardCore.Alias.GraphQL
 {
     public class AliasInputObjectType : WhereInputObjectGraphType<AliasPart>
     {
-        public AliasInputObjectType(IStringLocalizer<AliasInputObjectType> T)
+        public AliasInputObjectType(IStringLocalizer<AliasInputObjectType> S)
         {
             Name = "AliasPartInput";
-            Description = T["the alias part of the content item"];
+            Description = S["the alias part of the content item"];
 
-            AddScalarFilterFields<StringGraphType>("alias", T["the alias of the content item"]);
+            AddScalarFilterFields<StringGraphType>("alias", S["the alias of the content item"]);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/GraphQL/AliasQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/GraphQL/AliasQueryObjectType.cs
@@ -6,10 +6,10 @@ namespace OrchardCore.Alias.GraphQL
 {
     public class AliasQueryObjectType : ObjectGraphType<AliasPart>
     {
-        public AliasQueryObjectType(IStringLocalizer<AliasQueryObjectType> T)
+        public AliasQueryObjectType(IStringLocalizer<AliasQueryObjectType> S)
         {
             Name = "AliasPart";
-            Description = T["Alternative path for the content item"];
+            Description = S["Alternative path for the content item"];
 
             Field("alias", x => x.Alias, true);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Settings/AliasPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Settings/AliasPartSettingsDisplayDriver.cs
@@ -13,14 +13,13 @@ namespace OrchardCore.Alias.Settings
     public class AliasPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
         private readonly ILiquidTemplateManager _templateManager;
+        private readonly IStringLocalizer<AliasPartSettingsDisplayDriver> S;
 
         public AliasPartSettingsDisplayDriver(ILiquidTemplateManager templateManager, IStringLocalizer<AliasPartSettingsDisplayDriver> localizer)
         {
             _templateManager = templateManager;
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
@@ -51,7 +50,7 @@ namespace OrchardCore.Alias.Settings
             {
                 if (!string.IsNullOrEmpty(model.Pattern) && !_templateManager.Validate(model.Pattern, out var errors))
                 {
-                    context.Updater.ModelState.AddModelError(nameof(model.Pattern), T["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                    context.Updater.ModelState.AddModelError(nameof(model.Pattern), S["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Drivers/AutoroutePartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Drivers/AutoroutePartDisplay.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Autoroute.Drivers
         private readonly IAuthorizationService _authorizationService;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly YesSql.ISession _session;
-        private readonly IStringLocalizer<AutoroutePartDisplay> T;
+        private readonly IStringLocalizer<AutoroutePartDisplay> S;
 
         public AutoroutePartDisplay(
             IOptions<AutorouteOptions> options,
@@ -48,7 +48,7 @@ namespace OrchardCore.Autoroute.Drivers
             _authorizationService = authorizationService;
             _httpContextAccessor = httpContextAccessor;
             _session = session;
-            T = localizer;
+            S = localizer;
         }
 
         public override IDisplayResult Edit(AutoroutePart autoroutePart)
@@ -113,23 +113,23 @@ namespace OrchardCore.Autoroute.Drivers
         {
             if (autoroute.Path == "/")
             {
-                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), T["Your permalink can't be set to the homepage, please use the homepage option instead."]);
+                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), S["Your permalink can't be set to the homepage, please use the homepage option instead."]);
             }
 
             if (autoroute.Path?.IndexOfAny(InvalidCharactersForPath) > -1 || autoroute.Path?.IndexOf(' ') > -1)
             {
                 var invalidCharactersForMessage = string.Join(", ", InvalidCharactersForPath.Select(c => $"\"{c}\""));
-                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), T["Please do not use any of the following characters in your permalink: {0}. No spaces are allowed (please use dashes or underscores instead).", invalidCharactersForMessage]);
+                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), S["Please do not use any of the following characters in your permalink: {0}. No spaces are allowed (please use dashes or underscores instead).", invalidCharactersForMessage]);
             }
 
             if (autoroute.Path?.Length > MaxPathLength)
             {
-                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), T["Your permalink is too long. The permalink can only be up to {0} characters.", MaxPathLength]);
+                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), S["Your permalink is too long. The permalink can only be up to {0} characters.", MaxPathLength]);
             }
 
             if (autoroute.Path != null && (await _session.QueryIndex<AutoroutePartIndex>(o => o.Path == autoroute.Path && o.ContentItemId != autoroute.ContentItem.ContentItemId).CountAsync()) > 0)
             {
-                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), T["Your permalink is already in use."]);
+                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), S["Your permalink is already in use."]);
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/GraphQL/AutorouteInputObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/GraphQL/AutorouteInputObjectType.cs
@@ -7,12 +7,12 @@ namespace OrchardCore.Autoroute.GraphQL
 {
     public class AutorouteInputObjectType : WhereInputObjectGraphType<AutoroutePart>
     {
-        public AutorouteInputObjectType(IStringLocalizer<AutorouteInputObjectType> T)
+        public AutorouteInputObjectType(IStringLocalizer<AutorouteInputObjectType> S)
         {
             Name = "AutoroutePartInput";
-            Description = T["the custom URL part of the content item"];
+            Description = S["the custom URL part of the content item"];
 
-            AddScalarFilterFields<StringGraphType>("path", T["the path of the content item to filter"]);
+            AddScalarFilterFields<StringGraphType>("path", S["the path of the content item to filter"]);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/GraphQL/AutorouteQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/GraphQL/AutorouteQueryObjectType.cs
@@ -6,12 +6,12 @@ namespace OrchardCore.Autoroute.GraphQL
 {
     public class AutorouteQueryObjectType : ObjectGraphType<AutoroutePart>
     {
-        public AutorouteQueryObjectType(IStringLocalizer<AutorouteQueryObjectType> T)
+        public AutorouteQueryObjectType(IStringLocalizer<AutorouteQueryObjectType> S)
         {
             Name = "AutoroutePart";
-            Description = T["Custom URLs (permalinks) for your content item."];
+            Description = S["Custom URLs (permalinks) for your content item."];
 
-            Field(x => x.Path).Description(T["The permalinks for your content item."]);
+            Field(x => x.Path).Description(S["The permalinks for your content item."]);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Settings/AutoroutePartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Settings/AutoroutePartSettingsDisplayDriver.cs
@@ -14,14 +14,13 @@ namespace OrchardCore.Autoroute.Settings
     public class AutoroutePartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
         private readonly ILiquidTemplateManager _templateManager;
+        private readonly IStringLocalizer<AutoroutePartSettingsDisplayDriver> S;
 
         public AutoroutePartSettingsDisplayDriver(ILiquidTemplateManager templateManager, IStringLocalizer<AutoroutePartSettingsDisplayDriver> localizer)
         {
             _templateManager = templateManager;
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
@@ -59,7 +58,7 @@ namespace OrchardCore.Autoroute.Settings
 
             if (!string.IsNullOrEmpty(model.Pattern) && !_templateManager.Validate(model.Pattern, out var errors))
             {
-                context.Updater.ModelState.AddModelError(nameof(model.Pattern), T["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                context.Updater.ModelState.AddModelError(nameof(model.Pattern), S["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/HtmlFieldDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/HtmlFieldDriver.cs
@@ -15,15 +15,14 @@ namespace OrchardCore.ContentFields.Fields
     {
         private readonly ILiquidTemplateManager _liquidTemplateManager;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly IStringLocalizer<HtmlFieldDisplayDriver> S;
 
         public HtmlFieldDisplayDriver(ILiquidTemplateManager liquidTemplateManager, IStringLocalizer<HtmlFieldDisplayDriver> localizer, HtmlEncoder htmlEncoder)
         {
             _liquidTemplateManager = liquidTemplateManager;
-            T = localizer;
+            S = localizer;
             _htmlEncoder = htmlEncoder;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Display(HtmlField field, BuildFieldDisplayContext context)
         {
@@ -60,7 +59,7 @@ namespace OrchardCore.ContentFields.Fields
                 if (!string.IsNullOrEmpty(viewModel.Html) && !_liquidTemplateManager.Validate(viewModel.Html, out var errors))
                 {
                     var fieldName = context.PartFieldDefinition.DisplayName();
-                    context.Updater.ModelState.AddModelError(nameof(field.Html), T["{0} doesn't contain a valid Liquid expression. Details: {1}", fieldName, string.Join(" ", errors)]);
+                    context.Updater.ModelState.AddModelError(nameof(field.Html), S["{0} doesn't contain a valid Liquid expression. Details: {1}", fieldName, string.Join(" ", errors)]);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/HtmlFieldTrumbowygEditorSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/HtmlFieldTrumbowygEditorSettingsDriver.cs
@@ -11,12 +11,12 @@ namespace OrchardCore.ContentFields.Settings
 {
     public class HtmlFieldTrumbowygEditorSettingsDriver : ContentPartFieldDefinitionDisplayDriver<HtmlField>
     {
+        private readonly IStringLocalizer<HtmlFieldTrumbowygEditorSettingsDriver> S;
+
         public HtmlFieldTrumbowygEditorSettingsDriver(IStringLocalizer<HtmlFieldTrumbowygEditorSettingsDriver> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; set; }
 
         public override IDisplayResult Edit(ContentPartFieldDefinition partFieldDefinition)
         {
@@ -47,7 +47,7 @@ namespace OrchardCore.ContentFields.Settings
                 }
                 catch
                 {
-                    context.Updater.ModelState.AddModelError(Prefix, T["The options are written in an incorrect format."]);
+                    context.Updater.ModelState.AddModelError(Prefix, S["The options are written in an incorrect format."]);
                     return Edit(partFieldDefinition);
                 }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/AdminController.cs
@@ -16,10 +16,8 @@ namespace OrchardCore.ContentLocalization.Controllers
         private readonly IContentManager _contentManager;
         private readonly IContentLocalizationManager _contentLocalizationManager;
         private readonly INotifier _notifier;
-        private readonly IHtmlLocalizer<AdminController> _localizer;
         private readonly IAuthorizationService _authorizationService;
-
-        public IHtmlLocalizer T { get; }
+        private readonly IHtmlLocalizer<AdminController> H;
 
         public AdminController(
             IContentManager contentManager,
@@ -30,10 +28,9 @@ namespace OrchardCore.ContentLocalization.Controllers
         {
             _contentManager = contentManager;
             _notifier = notifier;
-            _localizer = localizer;
             _authorizationService = authorizationService;
             _contentLocalizationManager = localizationManager;
-            T = localizer;
+            H = localizer;
         }
 
         [HttpPost]
@@ -75,19 +72,19 @@ namespace OrchardCore.ContentLocalization.Controllers
 
             if (alreadyLocalizedContent != null)
             {
-                _notifier.Warning(T["A localization already exist for '{0}'", targetCulture]);
+                _notifier.Warning(H["A localization already exist for '{0}'", targetCulture]);
                 return RedirectToAction("Edit", "Admin", new { area = "OrchardCore.Contents", contentItemId = contentItemId });
             }
 
             try
             {
                 var newContent = await _contentLocalizationManager.LocalizeAsync(contentItem, targetCulture);
-                _notifier.Information(T["Successfully created localized version of the content."]);
+                _notifier.Information(H["Successfully created localized version of the content."]);
                 return RedirectToAction("Edit", "Admin", new { area = "OrchardCore.Contents", contentItemId = newContent.ContentItemId });
             }
             catch (InvalidOperationException)
             {
-                _notifier.Warning(T["Could not create localized version of the content item"]);
+                _notifier.Warning(H["Could not create localized version of the content item"]);
                 return RedirectToAction("Edit", "Admin", new { area = "OrchardCore.Contents", contentItemId = contentItem.ContentItemId });
             }
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/GraphQL/LocalizationInputObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/GraphQL/LocalizationInputObjectType.cs
@@ -7,12 +7,12 @@ namespace OrchardCore.ContentLocalization.GraphQL
 {
     public class LocalizationInputObjectType : WhereInputObjectGraphType<LocalizationPart>
     {
-        public LocalizationInputObjectType(IStringLocalizer<LocalizationInputObjectType> T)
+        public LocalizationInputObjectType(IStringLocalizer<LocalizationInputObjectType> S)
         {
             Name = "LocalizationInputObjectType";
-            Description = T["the localization part of the content item"];
+            Description = S["the localization part of the content item"];
 
-            AddScalarFilterFields<StringGraphType>("culture", T["the culture of the content item to filter"]);
+            AddScalarFilterFields<StringGraphType>("culture", S["the culture of the content item to filter"]);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/GraphQL/LocalizationQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/GraphQL/LocalizationQueryObjectType.cs
@@ -6,13 +6,13 @@ namespace OrchardCore.ContentLocalization.GraphQL
 {
     public class LocalizationQueryObjectType : ObjectGraphType<LocalizationPart>
     {
-        public LocalizationQueryObjectType(IStringLocalizer<LocalizationQueryObjectType> T)
+        public LocalizationQueryObjectType(IStringLocalizer<LocalizationQueryObjectType> S)
         {
             Name = "LocalizationPart";
-            Description = T["Localization cultures for your content item."];
+            Description = S["Localization cultures for your content item."];
 
-            Field(x => x.Culture).Description(T["The culture for your content item."]);
-            Field(x => x.LocalizationSet).Description(T["The localization set for your content item."]);
+            Field(x => x.Culture).Description(S["The culture for your content item."]);
+            Field(x => x.LocalizationSet).Description(S["The localization set for your content item."]);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Settings/PreviewPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Settings/PreviewPartSettingsDisplayDriver.cs
@@ -14,14 +14,13 @@ namespace OrchardCore.ContentPreview.Settings
     public class PreviewPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
         private readonly ILiquidTemplateManager _templateManager;
+        private readonly IStringLocalizer<PreviewPartSettingsDisplayDriver> S;
 
         public PreviewPartSettingsDisplayDriver(ILiquidTemplateManager templateManager, IStringLocalizer<PreviewPartSettingsDisplayDriver> localizer)
         {
             _templateManager = templateManager;
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
@@ -54,7 +53,7 @@ namespace OrchardCore.ContentPreview.Settings
 
             if (!string.IsNullOrEmpty(model.Pattern) && !_templateManager.Validate(model.Pattern, out var errors))
             {
-                context.Updater.ModelState.AddModelError(nameof(model.Pattern), T["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                context.Updater.ModelState.AddModelError(nameof(model.Pattern), S["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -30,6 +30,8 @@ namespace OrchardCore.ContentTypes.Controllers
         private readonly IAuthorizationService _authorizationService;
         private readonly ISession _session;
         private readonly IContentDefinitionDisplayManager _contentDefinitionDisplayManager;
+        private readonly IHtmlLocalizer<AdminController> H;
+        private readonly IStringLocalizer<AdminController> S;
         private readonly INotifier _notifier;
 
         public AdminController(
@@ -40,8 +42,8 @@ namespace OrchardCore.ContentTypes.Controllers
             IAuthorizationService authorizationService,
             ISession session,
             ILogger<AdminController> logger,
-            IHtmlLocalizer<AdminMenu> htmlLocalizer,
-            IStringLocalizer<AdminMenu> stringLocalizer,
+            IHtmlLocalizer<AdminController> htmlLocalizer,
+            IStringLocalizer<AdminController> stringLocalizer,
             INotifier notifier
             )
         {
@@ -54,12 +56,10 @@ namespace OrchardCore.ContentTypes.Controllers
             _settings = settings;
 
             Logger = logger;
-            T = htmlLocalizer;
+            H = htmlLocalizer;
             S = stringLocalizer;
         }
 
-        public IHtmlLocalizer T { get; }
-        public IStringLocalizer S { get; }
         public ILogger Logger { get; }
         public Task<ActionResult> Index() { return List(); }
 
@@ -140,7 +140,7 @@ namespace OrchardCore.ContentTypes.Controllers
             var typeViewModel = new EditTypeViewModel(contentTypeDefinition);
 
 
-            _notifier.Success(T["The \"{0}\" content type has been created.", typeViewModel.DisplayName]);
+            _notifier.Success(H["The \"{0}\" content type has been created.", typeViewModel.DisplayName]);
 
             return RedirectToAction("AddPartsTo", new { id = typeViewModel.Name });
         }
@@ -199,7 +199,7 @@ namespace OrchardCore.ContentTypes.Controllers
                     _contentDefinitionService.AlterPartFieldsOrder(ownedPartDefinition, viewModel.OrderedFieldNames);
                 }
                 _contentDefinitionService.AlterTypePartsOrder(contentTypeDefinition, viewModel.OrderedPartNames);
-                _notifier.Success(T["\"{0}\" settings have been saved.", contentTypeDefinition.Name]);
+                _notifier.Success(H["\"{0}\" settings have been saved.", contentTypeDefinition.Name]);
             }
 
             return RedirectToAction("Edit", new { id });
@@ -223,7 +223,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
             _contentDefinitionService.RemoveType(id, true);
 
-            _notifier.Success(T["\"{0}\" has been removed.", typeViewModel.DisplayName]);
+            _notifier.Success(H["\"{0}\" has been removed.", typeViewModel.DisplayName]);
 
             return RedirectToAction("List");
         }
@@ -312,7 +312,7 @@ namespace OrchardCore.ContentTypes.Controllers
             foreach (var partToAdd in partsToAdd)
             {
                 _contentDefinitionService.AddPartToType(partToAdd, typeViewModel.Name);
-                _notifier.Success(T["The \"{0}\" part has been added.", partToAdd]);
+                _notifier.Success(H["The \"{0}\" part has been added.", partToAdd]);
             }
 
             if (!ModelState.IsValid)
@@ -388,7 +388,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
             _contentDefinitionService.AddReusablePartToType(viewModel.Name, viewModel.DisplayName, viewModel.Description, partToAdd, typeViewModel.Name);
 
-            _notifier.Success(T["The \"{0}\" part has been added.", partToAdd]);
+            _notifier.Success(H["The \"{0}\" part has been added.", partToAdd]);
 
             return RedirectToAction("Edit", new { id });
         }
@@ -410,7 +410,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
             _contentDefinitionService.RemovePartFromType(name, id);
 
-            _notifier.Success(T["The \"{0}\" part has been removed.", name]);
+            _notifier.Success(H["The \"{0}\" part has been removed.", name]);
 
             return RedirectToAction("Edit", new { id });
         }
@@ -482,11 +482,11 @@ namespace OrchardCore.ContentTypes.Controllers
 
             if (partViewModel == null)
             {
-                _notifier.Information(T["The content part could not be created."]);
+                _notifier.Information(H["The content part could not be created."]);
                 return View(viewModel);
             }
 
-            _notifier.Success(T["The \"{0}\" content part has been created.", partViewModel.Name]);
+            _notifier.Success(H["The \"{0}\" content part has been created.", partViewModel.Name]);
 
             return RedirectToAction("EditPart", new { id = partViewModel.Name });
         }
@@ -538,7 +538,7 @@ namespace OrchardCore.ContentTypes.Controllers
             else
             {
                 _contentDefinitionService.AlterPartFieldsOrder(contentPartDefinition, orderedFieldNames);
-                _notifier.Success(T["The settings of \"{0}\" have been saved.", contentPartDefinition.Name]);
+                _notifier.Success(H["The settings of \"{0}\" have been saved.", contentPartDefinition.Name]);
             }
 
             return RedirectToAction("EditPart", new { id });
@@ -562,7 +562,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
             _contentDefinitionService.RemovePart(id);
 
-            _notifier.Information(T["\"{0}\" has been removed.", partViewModel.DisplayName]);
+            _notifier.Information(H["\"{0}\" has been removed.", partViewModel.DisplayName]);
 
             return RedirectToAction("ListParts");
         }
@@ -654,7 +654,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
             _contentDefinitionService.AddFieldToPart(viewModel.Name, viewModel.DisplayName, viewModel.FieldTypeName, partDefinition.Name);
 
-            _notifier.Success(T["The field \"{0}\" has been added.", viewModel.DisplayName]);
+            _notifier.Success(H["The field \"{0}\" has been added.", viewModel.DisplayName]);
 
             if (!String.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
             {
@@ -756,7 +756,7 @@ namespace OrchardCore.ContentTypes.Controllers
                     return View(viewModel);
                 }
 
-                _notifier.Information(T["Display name changed to {0}.", viewModel.DisplayName]);
+                _notifier.Information(H["Display name changed to {0}.", viewModel.DisplayName]);
             }
 
             _contentDefinitionService.AlterField(partViewModel, viewModel);
@@ -775,7 +775,7 @@ namespace OrchardCore.ContentTypes.Controllers
             }
             else
             {
-                _notifier.Success(T["The \"{0}\" field settings have been saved.", field.DisplayName()]);
+                _notifier.Success(H["The \"{0}\" field settings have been saved.", field.DisplayName()]);
             }
 
 
@@ -820,7 +820,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
             _contentDefinitionService.RemoveFieldFromPart(name, partViewModel.Name);
 
-            _notifier.Success(T["The \"{0}\" field has been removed.", field.DisplayName()]);
+            _notifier.Success(H["The \"{0}\" field has been removed.", field.DisplayName()]);
 
             if (_contentDefinitionService.LoadType(id) != null)
             {
@@ -935,7 +935,7 @@ namespace OrchardCore.ContentTypes.Controllers
             }
             else
             {
-                _notifier.Success(T["The \"{0}\" part settings have been saved.", part.DisplayName()]);
+                _notifier.Success(H["The \"{0}\" part settings have been saved.", part.DisplayName()]);
             }
 
             return RedirectToAction("Edit", new { id });

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/DefaultContentTypeDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/DefaultContentTypeDisplayDriver.cs
@@ -9,12 +9,12 @@ namespace OrchardCore.ContentTypes.Editors
 {
     public class DefaultContentTypeDisplayDriver : ContentTypeDefinitionDisplayDriver
     {
+        private readonly IStringLocalizer<DefaultContentTypeDisplayDriver> S;
+
         public DefaultContentTypeDisplayDriver(IStringLocalizer<DefaultContentTypeDisplayDriver> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Edit(ContentTypeDefinition contentTypeDefinition)
         {
@@ -34,7 +34,7 @@ namespace OrchardCore.ContentTypes.Editors
 
             if (String.IsNullOrWhiteSpace(model.DisplayName))
             {
-                context.Updater.ModelState.AddModelError("DisplayName", T["The Content Type name can't be empty."]);
+                context.Updater.ModelState.AddModelError("DisplayName", S["The Content Type name can't be empty."]);
             }
 
             return Edit(contentTypeDefinition);

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/OwnerEditorDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/OwnerEditorDriver.cs
@@ -21,7 +21,7 @@ namespace OrchardCore.Contents.Drivers
         private readonly IAuthorizationService _authorizationService;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IUserService _userService;
-        private readonly IStringLocalizer T;
+        private readonly IStringLocalizer<OwnerEditorDriver> S;
 
         public OwnerEditorDriver(
             IContentDefinitionManager contentDefinitionManager,
@@ -34,7 +34,7 @@ namespace OrchardCore.Contents.Drivers
             _authorizationService = authorizationService;
             _httpContextAccessor = httpContextAccessor;
             _userService = userService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public override async Task<IDisplayResult> EditAsync(CommonPart part, BuildPartEditorContext context)
@@ -95,7 +95,7 @@ namespace OrchardCore.Contents.Drivers
 
                     if (newOwner == null)
                     {
-                        context.Updater.ModelState.AddModelError("CommonPart.Owner", T["Invalid user name"]);
+                        context.Updater.ModelState.AddModelError("CommonPart.Owner", S["Invalid user name"]);
                     }
                     else
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Settings/CommonPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Settings/CommonPartSettingsDisplayDriver.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.Contents.Models;
 using OrchardCore.Contents.ViewModels;
@@ -12,13 +11,6 @@ namespace OrchardCore.Lists.Settings
 {
     public class CommonPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
-        public CommonPartSettingsDisplayDriver(IStringLocalizer<CommonPartSettingsDisplayDriver> localizer)
-        {
-            TS = localizer;
-        }
-
-        public IStringLocalizer TS { get; }
-
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
             if (!String.Equals(nameof(CommonPart), contentTypePartDefinition.PartDefinition.Name))

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Settings/FullTextAspectSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Settings/FullTextAspectSettingsDisplayDriver.cs
@@ -11,18 +11,16 @@ namespace OrchardCore.Contents.Settings
 {
     public class FullTextAspectSettingsDisplayDriver : ContentTypeDefinitionDisplayDriver
     {
-
         private readonly ILiquidTemplateManager _templateManager;
+        private readonly IStringLocalizer<FullTextAspectSettingsDisplayDriver> S;
 
         public FullTextAspectSettingsDisplayDriver(
             ILiquidTemplateManager templateManager,
             IStringLocalizer<FullTextAspectSettingsDisplayDriver> localizer)
         {
             _templateManager = templateManager;
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Edit(ContentTypeDefinition contentTypeDefinition)
         {
@@ -49,7 +47,7 @@ namespace OrchardCore.Contents.Settings
 
             if (!string.IsNullOrEmpty(model.FullTextTemplate) && !_templateManager.Validate(model.FullTextTemplate, out var errors))
             {
-                context.Updater.ModelState.AddModelError(nameof(model.FullTextTemplate), T["Full-text doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                context.Updater.ModelState.AddModelError(nameof(model.FullTextTemplate), S["Full-text doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
@@ -14,17 +14,20 @@ namespace OrchardCore.Contents.Workflows.Activities
 {
     public abstract class ContentActivity : Activity
     {
+        protected readonly IStringLocalizer S;
+
         protected ContentActivity(IContentManager contentManager, IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer localizer)
         {
             ContentManager = contentManager;
             ScriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
         protected IContentManager ContentManager { get; }
+
         protected IWorkflowScriptEvaluator ScriptEvaluator { get; }
-        protected IStringLocalizer T { get; }
-        public override LocalizedString Category => T["Content"];
+
+        public override LocalizedString Category => S["Content"];
 
         /// <summary>
         /// An expression that evaluates to an <see cref="IContent"/> item.
@@ -37,7 +40,7 @@ namespace OrchardCore.Contents.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentCreatedEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentCreatedEvent.cs
@@ -8,9 +8,11 @@ namespace OrchardCore.Contents.Workflows.Activities
     {
         public ContentCreatedEvent(IContentManager contentManager, IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<ContentCreatedEvent> localizer) : base(contentManager, scriptEvaluator, localizer)
         {
+
         }
 
         public override string Name => nameof(ContentCreatedEvent);
-        public override LocalizedString DisplayText => T["Content Created Event"];
+        
+        public override LocalizedString DisplayText => S["Content Created Event"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentDeletedEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentDeletedEvent.cs
@@ -8,9 +8,11 @@ namespace OrchardCore.Contents.Workflows.Activities
     {
         public ContentDeletedEvent(IContentManager contentManager, IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<ContentCreatedEvent> localizer) : base(contentManager, scriptEvaluator, localizer)
         {
+
         }
 
         public override string Name => nameof(ContentDeletedEvent);
-        public override LocalizedString DisplayText => T["Content Deleted Event"];
+        
+        public override LocalizedString DisplayText => S["Content Deleted Event"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentPublishedEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentPublishedEvent.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(ContentPublishedEvent);
-        public override LocalizedString DisplayText => T["Content Published Event"];
+        
+        public override LocalizedString DisplayText => S["Content Published Event"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentUnpublishedEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentUnpublishedEvent.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(ContentUnpublishedEvent);
-        public override LocalizedString DisplayText => T["Content Unpublished Event"];
+        
+        public override LocalizedString DisplayText => S["Content Unpublished Event"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentUpdatedEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentUpdatedEvent.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(ContentUpdatedEvent);
-        public override LocalizedString DisplayText => T["Content Updated Event"];
+        
+        public override LocalizedString DisplayText => S["Content Updated Event"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentVersionedEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentVersionedEvent.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(ContentVersionedEvent);
-        public override LocalizedString DisplayText => T["Content Versioned Event"];
+        
+        public override LocalizedString DisplayText => S["Content Versioned Event"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/CreateContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/CreateContentTask.cs
@@ -23,8 +23,10 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(CreateContentTask);
-        public override LocalizedString Category => T["Content"];
-        public override LocalizedString DisplayText => T["Create Content Task"];
+        
+        public override LocalizedString Category => S["Content"];
+        
+        public override LocalizedString DisplayText => S["Create Content Task"];
 
         public string ContentType
         {
@@ -40,7 +42,7 @@ namespace OrchardCore.Contents.Workflows.Activities
 
         public WorkflowExpression<string> ContentProperties
         {
-            get => GetProperty(() => new WorkflowExpression<string>(JsonConvert.SerializeObject(new { DisplayText = T["Enter a title"].Value }, Formatting.Indented)));
+            get => GetProperty(() => new WorkflowExpression<string>(JsonConvert.SerializeObject(new { DisplayText = S["Enter a title"].Value }, Formatting.Indented)));
             set => SetProperty(value);
         }
 
@@ -51,7 +53,7 @@ namespace OrchardCore.Contents.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public async override Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/DeleteContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/DeleteContentTask.cs
@@ -16,18 +16,21 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(DeleteContentTask);
-        public override LocalizedString DisplayText => T["Delete Content Task"];
-        public override LocalizedString Category => T["Content"];
+        
+        public override LocalizedString DisplayText => S["Delete Content Task"];
+        
+        public override LocalizedString Category => S["Content"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Deleted"]);
+            return Outcomes(S["Deleted"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
             var content = await GetContentAsync(workflowContext);
             await ContentManager.RemoveAsync(content.ContentItem);
+            
             return Outcomes("Deleted");
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/PublishContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/PublishContentTask.cs
@@ -16,12 +16,14 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(PublishContentTask);
-        public override LocalizedString DisplayText => T["Publish Content Task"];
-        public override LocalizedString Category => T["Content"];
+        
+        public override LocalizedString DisplayText => S["Publish Content Task"];
+        
+        public override LocalizedString Category => S["Content"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Published"]);
+            return Outcomes(S["Published"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
@@ -16,12 +16,14 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(RetrieveContentTask);
-        public override LocalizedString DisplayText => T["Retrieve Content Task"];
-        public override LocalizedString Category => T["Content"];
+        
+        public override LocalizedString DisplayText => S["Retrieve Content Task"];
+        
+        public override LocalizedString Category => S["Content"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Retrieved"]);
+            return Outcomes(S["Retrieved"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
@@ -29,6 +31,7 @@ namespace OrchardCore.Contents.Workflows.Activities
             var contentItemId = await GetContentItemIdAsync(workflowContext);
             var contentItem = await ContentManager.GetAsync(contentItemId, VersionOptions.Latest);
             workflowContext.LastResult = contentItem;
+
             return Outcomes("Retrieved");
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/UnpublishContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/UnpublishContentTask.cs
@@ -16,18 +16,21 @@ namespace OrchardCore.Contents.Workflows.Activities
         }
 
         public override string Name => nameof(UnpublishContentTask);
-        public override LocalizedString DisplayText => T["Unpublish Content Task"];
-        public override LocalizedString Category => T["Content"];
+        
+        public override LocalizedString DisplayText => S["Unpublish Content Task"];
+        
+        public override LocalizedString Category => S["Content"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Unpublished"]);
+            return Outcomes(S["Unpublished"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
             var content = await GetContentAsync(workflowContext);
             await ContentManager.UnpublishAsync(content.ContentItem);
+            
             return Outcomes("Unpublished");
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Services/RemoteInstanceDeploymentTargetProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Services/RemoteInstanceDeploymentTargetProvider.cs
@@ -10,16 +10,15 @@ namespace OrchardCore.Deployment
     public class RemoteInstanceDeploymentTargetProvider : IDeploymentTargetProvider
     {
         private readonly RemoteInstanceService _service;
+        private readonly IStringLocalizer<RemoteInstanceDeploymentTargetProvider> S;
 
         public RemoteInstanceDeploymentTargetProvider(
             IStringLocalizer<RemoteInstanceDeploymentTargetProvider> stringLocalizer,
             RemoteInstanceService service)
         {
             _service = service;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public async Task<IEnumerable<DeploymentTarget>> GetDeploymentTargetsAsync()
         {
@@ -28,7 +27,7 @@ namespace OrchardCore.Deployment
             return remoteInstanceList.RemoteInstances.Select(x =>
                     new DeploymentTarget(
                         name: new LocalizedString(x.Name, x.Name, false),
-                        description: T["Sends the deployment plan to a remote instance."],
+                        description: S["Sends the deployment plan to a remote instance."],
                         route: new RouteValueDictionary(new
                         {
                             area = "OrchardCore.Deployment.Remote",

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Services/FileDownloadDeploymentTargetProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Services/FileDownloadDeploymentTargetProvider.cs
@@ -7,20 +7,20 @@ namespace OrchardCore.Deployment
 {
     public class FileDownloadDeploymentTargetProvider : IDeploymentTargetProvider
     {
+        private readonly IStringLocalizer<FileDownloadDeploymentTargetProvider> S;
+
         public FileDownloadDeploymentTargetProvider(IStringLocalizer<FileDownloadDeploymentTargetProvider> stringLocalizer)
         {
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public Task<IEnumerable<DeploymentTarget>> GetDeploymentTargetsAsync()
         {
             return Task.FromResult<IEnumerable<DeploymentTarget>>(
                 new [] {
                     new DeploymentTarget(
-                        name: T["File Download"],
-                        description: T["Download a deployment plan locally."],
+                        name: S["File Download"],
+                        description: S["Download a deployment plan locally."],
                         route: new RouteValueDictionary(new
                         {
                             area = "OrchardCore.Deployment",

--- a/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
@@ -8,11 +8,11 @@ namespace OrchardCore.Email
 {
     public class AdminMenu : INavigationProvider
     {
-        private readonly IStringLocalizer<AdminMenu> T;
+        private readonly IStringLocalizer<AdminMenu> S;
 
         public AdminMenu(IStringLocalizer<AdminMenu> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
 
         public Task BuildNavigationAsync(string name, NavigationBuilder builder)
@@ -21,9 +21,9 @@ namespace OrchardCore.Email
                 return Task.CompletedTask;
 
             builder
-                .Add(T["Configuration"], configuration => configuration
-                    .Add(T["Settings"], settings => settings
-                       .Add(T["Smtp"], T["Smtp"], entry => entry
+                .Add(S["Configuration"], configuration => configuration
+                    .Add(S["Settings"], settings => settings
+                       .Add(S["Smtp"], S["Smtp"], entry => entry
                           .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = SmtpSettingsDisplayDriver.GroupId })
                           .Permission(Permissions.ManageEmailSettings)
                           .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Activities/EmailTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Activities/EmailTask.cs
@@ -12,7 +12,8 @@ namespace OrchardCore.Email.Workflows.Activities
     {
         private readonly ISmtpService _smtpService;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
-        
+        private readonly IStringLocalizer<EmailTask> S;
+
         public EmailTask(
             ISmtpService smtpService,
             IWorkflowExpressionEvaluator expressionEvaluator,
@@ -21,13 +22,12 @@ namespace OrchardCore.Email.Workflows.Activities
         {
             _smtpService = smtpService;
             _expressionEvaluator = expressionEvaluator;           
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
         public override string Name => nameof(EmailTask);
-        public override LocalizedString DisplayText => T["Email Task"];
-        public override LocalizedString Category => T["Messaging"];
+        public override LocalizedString DisplayText => S["Email Task"];
+        public override LocalizedString Category => S["Messaging"];
 
         public WorkflowExpression<string> Sender
         {
@@ -62,7 +62,7 @@ namespace OrchardCore.Email.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"], T["Failed"]);
+            return Outcomes(S["Done"], S["Failed"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Services/FacebookService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Services/FacebookService.cs
@@ -13,14 +13,14 @@ namespace OrchardCore.Facebook.Services
     public class FacebookService : IFacebookService
     {
         private readonly ISiteService _siteService;
-        private readonly IStringLocalizer<FacebookService> T;
+        private readonly IStringLocalizer<FacebookService> S;
 
         public FacebookService(
             ISiteService siteService,
             IStringLocalizer<FacebookService> stringLocalizer)
         {
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<FacebookSettings> GetSettingsAsync()
@@ -52,7 +52,7 @@ namespace OrchardCore.Facebook.Services
 
             if (string.IsNullOrEmpty(settings.AppId))
             {
-                results.Add(new ValidationResult(T["The AppId is required."], new[]
+                results.Add(new ValidationResult(S["The AppId is required."], new[]
                 {
                     nameof(settings.AppId)
                 }));
@@ -60,7 +60,7 @@ namespace OrchardCore.Facebook.Services
 
             if (string.IsNullOrEmpty(settings.AppSecret))
             {
-                results.Add(new ValidationResult(T["The App Secret is required."], new[]
+                results.Add(new ValidationResult(S["The App Secret is required."], new[]
                 {
                     nameof(settings.AppSecret)
                 }));

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Widgets/Drivers/FacebookPluginPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Widgets/Drivers/FacebookPluginPartDisplayDriver.cs
@@ -17,6 +17,7 @@ namespace OrchardCore.Facebook.Widgets.Drivers
     {
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ILiquidTemplateManager _liquidTemplatemanager;
+        private readonly IStringLocalizer<FacebookPluginPartDisplayDriver> S;
 
         public FacebookPluginPartDisplayDriver(
             IContentDefinitionManager contentDefinitionManager,
@@ -25,10 +26,8 @@ namespace OrchardCore.Facebook.Widgets.Drivers
         {
             _contentDefinitionManager = contentDefinitionManager;
             _liquidTemplatemanager = liquidTemplatemanager;
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Display(FacebookPluginPart part)
         {
@@ -83,7 +82,7 @@ namespace OrchardCore.Facebook.Widgets.Drivers
             {
                 if (!string.IsNullOrEmpty(viewModel.Liquid) && !_liquidTemplatemanager.Validate(viewModel.Liquid, out var errors))
                 {
-                    updater.ModelState.AddModelError(nameof(model.Liquid), T["The FaceBook Body doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                    updater.ModelState.AddModelError(nameof(model.Liquid), S["The FaceBook Body doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Widgets/Settings/FacebookPluginPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Widgets/Settings/FacebookPluginPartSettingsDisplayDriver.cs
@@ -14,14 +14,13 @@ namespace OrchardCore.Facebook.Widgets.Settings
     public class FacebookPluginPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
         private readonly ILiquidTemplateManager _templateManager;
+        private readonly IStringLocalizer<FacebookPluginPartSettingsDisplayDriver> S;
 
         public FacebookPluginPartSettingsDisplayDriver(ILiquidTemplateManager templateManager, IStringLocalizer<FacebookPluginPartSettingsDisplayDriver> localizer)
         {
             _templateManager = templateManager;
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
@@ -51,7 +50,7 @@ namespace OrchardCore.Facebook.Widgets.Settings
 
             if (!string.IsNullOrEmpty(model.Liquid) && !_templateManager.Validate(model.Liquid, out var errors))
             {
-                context.Updater.ModelState.AddModelError(nameof(model.Liquid), T["The Body doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                context.Updater.ModelState.AddModelError(nameof(model.Liquid), S["The Body doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -28,6 +28,7 @@ namespace OrchardCore.Features.Controllers
         private readonly IAuthorizationService _authorizationService;
         private readonly ShellSettings _shellSettings;
         private readonly INotifier _notifier;
+        private readonly IHtmlLocalizer<AdminController> H;
 
         public AdminController(
             IModuleService moduleService,
@@ -45,15 +46,12 @@ namespace OrchardCore.Features.Controllers
             _authorizationService = authorizationService;
             _shellSettings = shellSettings;
             _notifier = notifier;
-
-            T = localizer;
+            H = localizer;
         }
-
-        public IHtmlLocalizer T { get; }
 
         public async Task<ActionResult> Features()
         {
-            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageFeatures)) // , T["Not allowed to manage features."]
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageFeatures)) // , H["Not allowed to manage features."]
             {
                 return Unauthorized();
             }
@@ -101,7 +99,7 @@ namespace OrchardCore.Features.Controllers
 
             if (model.FeatureIds == null || !model.FeatureIds.Any())
             {
-                ModelState.AddModelError("featureIds", T["Please select one or more features."].ToString());
+                ModelState.AddModelError("featureIds", H["Please select one or more features."].ToString());
             }
 
             if (ModelState.IsValid)
@@ -201,7 +199,7 @@ namespace OrchardCore.Features.Controllers
         {
             foreach (var feature in features)
             {
-                _notifier.Success(T["{0} was {1}", feature.Name ?? feature.Id, enabled ? "enabled" : "disabled"]);
+                _notifier.Success(H["{0} was {1}", feature.Name ?? feature.Id, enabled ? "enabled" : "disabled"]);
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Features/Services/ModuleService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Services/ModuleService.cs
@@ -17,23 +17,21 @@ namespace OrchardCore.Features.Services
         private readonly IShellDescriptorManager _shellDescriptorManager;
         private readonly IShellFeaturesManager _shellFeaturesManager;
         private readonly INotifier _notifier;
+        private readonly IHtmlLocalizer<ModuleService> H;
 
         public ModuleService(
                 IExtensionManager extensionManager,
                 IShellDescriptorManager shellDescriptorManager,
                 IShellFeaturesManager shellFeaturesManager,
-                IHtmlLocalizer<AdminMenu> htmlLocalizer,
+                IHtmlLocalizer<ModuleService> htmlLocalizer,
                 INotifier notifier)
         {
             _notifier = notifier;
             _extensionManager = extensionManager;
             _shellDescriptorManager = shellDescriptorManager;
             _shellFeaturesManager = shellFeaturesManager;
-
-            T = htmlLocalizer;
+            H = htmlLocalizer;
         }
-
-        public IHtmlLocalizer T { get; set; }
 
         /// <summary>
         /// Retrieves an enumeration of the available features together with its state (enabled / disabled).
@@ -74,7 +72,7 @@ namespace OrchardCore.Features.Services
             var enabledFeatures = await _shellFeaturesManager.EnableFeaturesAsync(featuresToEnable, force);
             foreach (var enabledFeature in enabledFeatures)
             {
-                _notifier.Success(T["{0} was enabled", enabledFeature.Name]);
+                _notifier.Success(H["{0} was enabled", enabledFeature.Name]);
             }
         }
 
@@ -101,7 +99,7 @@ namespace OrchardCore.Features.Services
             var features = await _shellFeaturesManager.DisableFeaturesAsync(featuresToDisable, force);
             foreach (var feature in features)
             {
-                _notifier.Success(T["{0} was disabled", feature.Name]);
+                _notifier.Success(H["{0} was disabled", feature.Name]);
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/GraphQL/BagPartQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/GraphQL/BagPartQueryObjectType.cs
@@ -10,10 +10,10 @@ namespace OrchardCore.Flows.GraphQL
 {
     public class BagPartQueryObjectType : ObjectGraphType<BagPart>
     {
-        public BagPartQueryObjectType(IStringLocalizer<BagPartQueryObjectType> T)
+        public BagPartQueryObjectType(IStringLocalizer<BagPartQueryObjectType> S)
         {
             Name = "BagPart";
-            Description = T["A BagPart allows to add content items directly within another content item"];
+            Description = S["A BagPart allows to add content items directly within another content item"];
 
             Field<ListGraphType<ContentItemInterface>, IEnumerable<ContentItem>>()
                 .Name("contentItems")

--- a/src/OrchardCore.Modules/OrchardCore.Flows/GraphQL/FlowPartQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/GraphQL/FlowPartQueryObjectType.cs
@@ -7,10 +7,10 @@ namespace OrchardCore.Flows.GraphQL
 {
     public class FlowPartQueryObjectType : ObjectGraphType<FlowPart>
     {
-        public FlowPartQueryObjectType(IStringLocalizer<FlowPartQueryObjectType> T)
+        public FlowPartQueryObjectType(IStringLocalizer<FlowPartQueryObjectType> S)
         {
             Name = "FlowPart";
-            Description = T["A FlowPart allows to add content items directly within another content item"];
+            Description = S["A FlowPart allows to add content items directly within another content item"];
 
             Field<ListGraphType<ContentItemInterface>>(
                 "widgets",

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/AddModelValidationErrorTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/AddModelValidationErrorTask.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.Forms.Workflows.Activities
     public class AddModelValidationErrorTask : TaskActivity
     {
         private readonly IUpdateModelAccessor _updateModelAccessor;
+        private readonly IStringLocalizer<AddModelValidationErrorTask> S;
 
         public AddModelValidationErrorTask(
             IUpdateModelAccessor updateModelAccessor,
@@ -18,13 +19,14 @@ namespace OrchardCore.Forms.Workflows.Activities
         )
         {
             _updateModelAccessor = updateModelAccessor;
-            T = localizer;
+            S = localizer;
         }
 
         public override string Name => nameof(AddModelValidationErrorTask);
-        public override LocalizedString DisplayText => T["Add Model Validation Error Task"];
-        public override LocalizedString Category => T["Validation"];
-        private IStringLocalizer T { get; set; }
+        
+        public override LocalizedString DisplayText => S["Add Model Validation Error Task"];
+        
+        public override LocalizedString Category => S["Validation"];
 
         public string Key
         {
@@ -40,7 +42,7 @@ namespace OrchardCore.Forms.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/BindModelStateTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/BindModelStateTask.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.Forms.Workflows.Activities
     {
         private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IStringLocalizer<BindModelStateTask> S;
 
         public BindModelStateTask(
             IHttpContextAccessor httpContextAccessor,
@@ -22,17 +23,18 @@ namespace OrchardCore.Forms.Workflows.Activities
         {
             _updateModelAccessor = updateModelAccessor;
             _httpContextAccessor = httpContextAccessor;
-            T = localizer;
+            S = localizer;
         }
 
         public override string Name => nameof(BindModelStateTask);
-        public override LocalizedString DisplayText => T["Bind Model State Task"];
-        public override LocalizedString Category => T["Validation"];
-        private IStringLocalizer T { get; set; }
+        
+        public override LocalizedString DisplayText => S["Bind Model State Task"];
+        
+        public override LocalizedString Category => S["Validation"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateAntiforgeryTokenTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateAntiforgeryTokenTask.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.Forms.Workflows.Activities
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IAntiforgery _antiforgery;
+        private readonly IStringLocalizer<ValidateAntiforgeryTokenTask> S;
 
         public ValidateAntiforgeryTokenTask(
             IHttpContextAccessor httpContextAccessor,
@@ -22,19 +23,20 @@ namespace OrchardCore.Forms.Workflows.Activities
         {
             _httpContextAccessor = httpContextAccessor;
             _antiforgery = antiforgery;
-            T = localizer;
+            S = localizer;
         }
 
         public override string Name => nameof(ValidateAntiforgeryTokenTask);
-        public override LocalizedString DisplayText => T["Validate Antiforgery Token Task"];
-        public override LocalizedString Category => T["Validation"];
+        
+        public override LocalizedString DisplayText => S["Validate Antiforgery Token Task"];
+        
+        public override LocalizedString Category => S["Validation"];
+        
         public override bool HasEditor => false;
-
-        private IStringLocalizer T { get; set; }
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"], T["Valid"], T["Invalid"]);
+            return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormFieldTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormFieldTask.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.Forms.Workflows.Activities
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IUpdateModelAccessor _updateModelAccessor;
+        private readonly IStringLocalizer<ValidateFormFieldTask> S;
 
         public ValidateFormFieldTask(
             IHttpContextAccessor httpContextAccessor,
@@ -22,14 +23,14 @@ namespace OrchardCore.Forms.Workflows.Activities
         {
             _httpContextAccessor = httpContextAccessor;
             _updateModelAccessor = updateModelAccessor;
-            T = localizer;
+            S = localizer;
         }
 
         public override string Name => nameof(ValidateFormFieldTask);
-        public override LocalizedString DisplayText => T["Validate Form Field Task"];
-        public override LocalizedString Category => T["Validation"];
-
-        private IStringLocalizer T { get; set; }
+        
+        public override LocalizedString DisplayText => S["Validate Form Field Task"];
+        
+        public override LocalizedString Category => S["Validation"];
 
         public string FieldName
         {
@@ -45,7 +46,7 @@ namespace OrchardCore.Forms.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"], T["Valid"], T["Invalid"]);
+            return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/ValidateFormTask.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.Forms.Workflows.Activities
     public class ValidateFormTask : TaskActivity
     {
         private readonly IUpdateModelAccessor _updateModelAccessor;
+        private readonly IStringLocalizer<ValidateFormTask> S;
 
         public ValidateFormTask(
             IUpdateModelAccessor updateModelAccessor,
@@ -18,20 +19,20 @@ namespace OrchardCore.Forms.Workflows.Activities
         )
         {
             _updateModelAccessor = updateModelAccessor;
-            T = localizer;
+            S = localizer;
         }
 
         public override string Name => nameof(ValidateFormTask);
-        public override LocalizedString DisplayText => T["Validate Form Task"];
-        public override LocalizedString Category => T["Validation"];
+        
+        public override LocalizedString DisplayText => S["Validate Form Task"];
+        
+        public override LocalizedString Category => S["Validation"];
+        
         public override bool HasEditor => false;
-
-        private IStringLocalizer T { get; set; }
-
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Valid"], T["Invalid"]);
+            return Outcomes(S["Valid"], S["Invalid"]);
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Services/GithubAuthenticationService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Services/GithubAuthenticationService.cs
@@ -12,14 +12,14 @@ namespace OrchardCore.GitHub.Services
     public class GitHubAuthenticationService : IGitHubAuthenticationService
     {
         private readonly ISiteService _siteService;
-        private readonly IStringLocalizer<GitHubAuthenticationService> T;
+        private readonly IStringLocalizer<GitHubAuthenticationService> S;
 
         public GitHubAuthenticationService(
             ISiteService siteService,
             IStringLocalizer<GitHubAuthenticationService> stringLocalizer)
         {
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<GitHubAuthenticationSettings> GetSettingsAsync()
@@ -53,12 +53,12 @@ namespace OrchardCore.GitHub.Services
 
             if (string.IsNullOrWhiteSpace(settings.ClientID))
             {
-                yield return new ValidationResult(T["ClientID is required"], new string[] { nameof(settings.ClientID) });
+                yield return new ValidationResult(S["ClientID is required"], new string[] { nameof(settings.ClientID) });
             }
 
             if (string.IsNullOrWhiteSpace(settings.ClientSecret))
             {
-                yield return new ValidationResult(T["ClientSecret is required"], new string[] { nameof(settings.ClientSecret) });
+                yield return new ValidationResult(S["ClientSecret is required"], new string[] { nameof(settings.ClientSecret) });
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Html/Drivers/HtmlBodyPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Drivers/HtmlBodyPartDisplay.cs
@@ -16,15 +16,14 @@ namespace OrchardCore.Html.Drivers
     {
         private readonly ILiquidTemplateManager _liquidTemplateManager;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly IStringLocalizer<HtmlBodyPartDisplay> S;
 
         public HtmlBodyPartDisplay(ILiquidTemplateManager liquidTemplateManager, IStringLocalizer<HtmlBodyPartDisplay> localizer, HtmlEncoder htmlEncoder)
         {
             _liquidTemplateManager = liquidTemplateManager;
-            T = localizer;
             _htmlEncoder = htmlEncoder;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Display(HtmlBodyPart HtmlBodyPart, BuildPartDisplayContext context)
         {
@@ -53,7 +52,7 @@ namespace OrchardCore.Html.Drivers
                 if (!string.IsNullOrEmpty(viewModel.Html) && !_liquidTemplateManager.Validate(viewModel.Html, out var errors))
                 {
                     var partName = context.TypePartDefinition.DisplayName();
-                    context.Updater.ModelState.AddModelError(nameof(model.Html), T["{0} doesn't contain a valid Liquid expression. Details: {1}", partName, string.Join(" ", errors)]);
+                    context.Updater.ModelState.AddModelError(nameof(model.Html), S["{0} doesn't contain a valid Liquid expression. Details: {1}", partName, string.Join(" ", errors)]);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Html/GraphQL/HtmlBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/GraphQL/HtmlBodyQueryObjectType.cs
@@ -12,14 +12,14 @@ namespace OrchardCore.Html.GraphQL
 {
     public class HtmlBodyQueryObjectType : ObjectGraphType<HtmlBodyPart>
     {
-        public HtmlBodyQueryObjectType(IStringLocalizer<HtmlBodyQueryObjectType> T)
+        public HtmlBodyQueryObjectType(IStringLocalizer<HtmlBodyQueryObjectType> S)
         {
             Name = "HtmlBodyPart";
-            Description = T["Content stored as HTML."];
+            Description = S["Content stored as HTML."];
 
             Field<StringGraphType>()
                 .Name("html")
-                .Description(T["the HTML content"])
+                .Description(S["the HTML content"])
                 .ResolveLockedAsync(RenderHtml);
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Html/Settings/HtmlBodyPartTrumbowygEditorSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Settings/HtmlBodyPartTrumbowygEditorSettingsDriver.cs
@@ -13,12 +13,12 @@ namespace OrchardCore.Html.Settings
 {
     public class HtmlBodyPartTrumbowygEditorSettingsDriver : ContentTypePartDefinitionDisplayDriver
     {
+        private readonly IStringLocalizer<HtmlBodyPartTrumbowygEditorSettingsDriver> S;
+
         public HtmlBodyPartTrumbowygEditorSettingsDriver(IStringLocalizer<HtmlBodyPartTrumbowygEditorSettingsDriver> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; set; }
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
@@ -57,7 +57,7 @@ namespace OrchardCore.Html.Settings
             }
             catch
             {
-                context.Updater.ModelState.AddModelError(Prefix, T["The options are written in an incorrect format."]);
+                context.Updater.ModelState.AddModelError(Prefix, S["The options are written in an incorrect format."]);
                 return Edit(contentTypePartDefinition, context.Updater);
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Https/Drivers/HttpsSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Https/Drivers/HttpsSettingsDisplayDriver.cs
@@ -22,21 +22,21 @@ namespace OrchardCore.Https.Drivers
         private readonly INotifier _notifier;
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
-        private readonly IHtmlLocalizer T;
+        private readonly IHtmlLocalizer<HttpsSettingsDisplayDriver> H;
 
         public HttpsSettingsDisplayDriver(IHttpContextAccessor httpContextAccessor,
             IAuthorizationService authorizationService,
             INotifier notifier,
             IShellHost shellHost,
             ShellSettings shellSettings,
-            IHtmlLocalizer<HttpsSettingsDisplayDriver> stringLocalizer)
+            IHtmlLocalizer<HttpsSettingsDisplayDriver> htmlLocalizer)
         {
             _httpContextAccessor = httpContextAccessor;
             _authorizationService = authorizationService;
             _notifier = notifier;
             _shellHost = shellHost;
             _shellSettings = shellSettings;
-            T = stringLocalizer;
+            H = htmlLocalizer;
         }
 
         public override async Task<IDisplayResult> EditAsync(HttpsSettings settings, BuildEditorContext context)
@@ -52,7 +52,7 @@ namespace OrchardCore.Https.Drivers
                 var isHttpsRequest = _httpContextAccessor.HttpContext.Request.IsHttps;
 
                 if (!isHttpsRequest)
-                    _notifier.Warning(T["For safety, Enabling require HTTPS over HTTP has been prevented."]);
+                    _notifier.Warning(H["For safety, Enabling require HTTPS over HTTP has been prevented."]);
 
                 model.EnableStrictTransportSecurity = settings.EnableStrictTransportSecurity;
                 model.IsHttpsRequest = isHttpsRequest;

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Drivers/LiquidPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Drivers/LiquidPartDisplay.cs
@@ -12,14 +12,13 @@ namespace OrchardCore.Liquid.Drivers
     public class LiquidPartDisplay : ContentPartDisplayDriver<LiquidPart>
     {
         private readonly ILiquidTemplateManager _liquidTemplatemanager;
+        private readonly IStringLocalizer<LiquidPartDisplay> S;
 
         public LiquidPartDisplay(ILiquidTemplateManager liquidTemplatemanager, IStringLocalizer<LiquidPartDisplay> localizer)
         {
             _liquidTemplatemanager = liquidTemplatemanager;
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Display(LiquidPart liquidPart)
         {
@@ -44,7 +43,7 @@ namespace OrchardCore.Liquid.Drivers
             {
                 if (!string.IsNullOrEmpty(viewModel.Liquid) && !_liquidTemplatemanager.Validate(viewModel.Liquid, out var errors))
                 {
-                    updater.ModelState.AddModelError(nameof(model.Liquid), T["The Liquid Body doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                    updater.ModelState.AddModelError(nameof(model.Liquid), S["The Liquid Body doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ContainedInputObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ContainedInputObjectType.cs
@@ -7,12 +7,12 @@ namespace OrchardCore.Lists.GraphQL
 {
     public class ContainedInputObjectType : WhereInputObjectGraphType<ContainedPart>
     {
-        public ContainedInputObjectType(IStringLocalizer<ContainedPart> T)
+        public ContainedInputObjectType(IStringLocalizer<ContainedPart> S)
         {
             Name = "ContainedPartInput";
-            Description = T["the list part of the content item"];
+            Description = S["the list part of the content item"];
 
-            AddScalarFilterFields<IdGraphType>("listContentItemId", T["the content item id of the parent list of the content item to filter"]);
+            AddScalarFilterFields<IdGraphType>("listContentItemId", S["the content item id of the parent list of the content item to filter"]);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ContainedQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ContainedQueryObjectType.cs
@@ -6,10 +6,10 @@ namespace OrchardCore.Lists.GraphQL
 {
     public class ContainedQueryObjectType : ObjectGraphType<ContainedPart>
     {
-        public ContainedQueryObjectType(IStringLocalizer<ContainedQueryObjectType> T)
+        public ContainedQueryObjectType(IStringLocalizer<ContainedQueryObjectType> S)
         {
             Name = "ContainedPart";
-            Description = T["Represents a link to the parent content item, and the order that content item is represented."];
+            Description = S["Represents a link to the parent content item, and the order that content item is represented."];
 
             Field(x => x.ListContentItemId);
             Field(x => x.Order);

--- a/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ListQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/GraphQL/ListQueryObjectType.cs
@@ -18,10 +18,10 @@ namespace OrchardCore.Lists.GraphQL
 {
     public class ListQueryObjectType : ObjectGraphType<ListPart>
     {
-        public ListQueryObjectType(IStringLocalizer<ListQueryObjectType> T)
+        public ListQueryObjectType(IStringLocalizer<ListQueryObjectType> S)
         {
             Name = "ListPart";
-            Description = T["Represents a collection of content items."];
+            Description = S["Represents a collection of content items."];
 
             Field<ListGraphType<ContentItemInterface>, IEnumerable<ContentItem>>()
                 .Name("contentItems")

--- a/src/OrchardCore.Modules/OrchardCore.Lists/RemotePublishing/MetaWeblogHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/RemotePublishing/MetaWeblogHandler.cs
@@ -40,6 +40,7 @@ namespace OrchardCore.Lists.RemotePublishing
         private readonly IMembershipService _membershipService;
         private readonly IEnumerable<IMetaWeblogDriver> _metaWeblogDrivers;
         private readonly ISession _session;
+        private readonly IStringLocalizer<MetaWeblogHandler> S;
 
         public MetaWeblogHandler(IContentManager contentManager,
             IAuthorizationService authorizationService,
@@ -61,11 +62,10 @@ namespace OrchardCore.Lists.RemotePublishing
             _mediaFileStore = mediaFileStore;
             _membershipService = membershipService;
             Logger = logger;
-            T = localizer;
+            S = localizer;
         }
 
         ILogger Logger { get; }
-        IStringLocalizer T { get; }
 
         public void SetCapabilities(XElement options)
         {
@@ -365,7 +365,7 @@ namespace OrchardCore.Lists.RemotePublishing
 
             if (contentItem == null)
             {
-                throw new Exception(T["The specified Blog Post doesn't exist anymore. Please create a new Blog Post."]);
+                throw new Exception(S["The specified Blog Post doesn't exist anymore. Please create a new Blog Post."]);
             }
 
             await CheckAccessAsync(publish ? Permissions.PublishContent : Permissions.EditContent, user, contentItem);
@@ -422,7 +422,7 @@ namespace OrchardCore.Lists.RemotePublishing
 
             if (!await _authorizationService.AuthorizeAsync(user, Permissions.DeleteContent, contentItem))
             {
-                throw new InvalidOperationException(T["Not authorized to delete this content"].Value);
+                throw new InvalidOperationException(S["Not authorized to delete this content"].Value);
             }
 
             foreach (var driver in drivers)
@@ -438,7 +438,7 @@ namespace OrchardCore.Lists.RemotePublishing
         {
             if (!await _membershipService.CheckPasswordAsync(userName, password))
             {
-                throw new InvalidOperationException(T["The username or e-mail or password provided is incorrect."].Value);
+                throw new InvalidOperationException(S["The username or e-mail or password provided is incorrect."].Value);
             }
 
             var storeUser = await _membershipService.GetUserAsync(userName);
@@ -489,7 +489,7 @@ namespace OrchardCore.Lists.RemotePublishing
         {
             if (!await _authorizationService.AuthorizeAsync(user, permission, contentItem))
             {
-                throw new InvalidOperationException(T["Not authorized to delete this content"].Value);
+                throw new InvalidOperationException(S["Not authorized to delete this content"].Value);
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Settings/ListPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Settings/ListPartSettingsDisplayDriver.cs
@@ -15,16 +15,15 @@ namespace OrchardCore.Lists.Settings
     public class ListPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
         private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly IStringLocalizer S;
 
         public ListPartSettingsDisplayDriver(
             IContentDefinitionManager contentDefinitionManager,
             IStringLocalizer<ListPartSettingsDisplayDriver> localizer)
         {
             _contentDefinitionManager = contentDefinitionManager;
-            TS = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer TS { get; }
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
@@ -60,7 +59,7 @@ namespace OrchardCore.Lists.Settings
 
             if (model.ContainedContentTypes == null || model.ContainedContentTypes.Length == 0)
             {
-                context.Updater.ModelState.AddModelError(nameof(model.ContainedContentTypes), TS["At least one content type must be selected."]);
+                context.Updater.ModelState.AddModelError(nameof(model.ContainedContentTypes), S["At least one content type must be selected."]);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.Localization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/AdminMenu.cs
@@ -8,22 +8,22 @@ namespace OrchardCore.Localization
 {
     public class AdminMenu : INavigationProvider
     {
+        private readonly IStringLocalizer<AdminMenu> S;
+
         public AdminMenu(IStringLocalizer<AdminMenu> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
-
-        IStringLocalizer T { get; }
 
         public Task BuildNavigationAsync(string name, NavigationBuilder builder)
         {
             if (String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
                 builder
-                    .Add(T["Configuration"], NavigationConstants.AdminMenuConfigurationPosition, localization => localization
+                    .Add(S["Configuration"], NavigationConstants.AdminMenuConfigurationPosition, localization => localization
                     .AddClass("localization").Id("localization")
-                        .Add(T["Settings"], settings => settings
-                            .Add(T["Cultures"], T["Cultures"], entry => entry
+                        .Add(S["Settings"], settings => settings
+                            .Add(S["Cultures"], S["Cultures"], entry => entry
                                 .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = LocalizationSettingsDisplayDriver.GroupId })
                                 .Permission(Permissions.ManageCultures)
                                 .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Shapes/LuceneContentPickerShapeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Shapes/LuceneContentPickerShapeProvider.cs
@@ -8,12 +8,12 @@ namespace OrchardCore.Lucene
 {
     public class LuceneContentPickerShapeProvider : IShapeAttributeProvider
     {
+        private readonly IStringLocalizer<LuceneContentPickerShapeProvider> S;
+
         public LuceneContentPickerShapeProvider(IStringLocalizer<LuceneContentPickerShapeProvider> stringLocalizer)
         {
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
-
-        private IStringLocalizer T { get; }
 
         [Shape]
         public IHtmlContent ContentPickerField_Option__Lucene(dynamic shape)
@@ -21,9 +21,9 @@ namespace OrchardCore.Lucene
             var selected = shape.Editor == "Lucene";
             if (selected)
             {
-                return new HtmlString($"<option value=\"Lucene\" selected=\"selected\">{T["Lucene"]}</option>");
+                return new HtmlString($"<option value=\"Lucene\" selected=\"selected\">{S["Lucene"]}</option>");
             }
-            return new HtmlString($"<option value=\"Lucene\">{T["Lucene"]}</option>");
+            return new HtmlString($"<option value=\"Lucene\">{S["Lucene"]}</option>");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Drivers/MarkdownBodyPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Drivers/MarkdownBodyPartDisplay.cs
@@ -16,15 +16,14 @@ namespace OrchardCore.Markdown.Drivers
     {
         private readonly ILiquidTemplateManager _liquidTemplateManager;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly IStringLocalizer<MarkdownBodyPartDisplay> S;
 
         public MarkdownBodyPartDisplay(ILiquidTemplateManager liquidTemplateManager, IStringLocalizer<MarkdownBodyPartDisplay> localizer, HtmlEncoder htmlEncoder)
         {
             _liquidTemplateManager = liquidTemplateManager;
-            T = localizer;
             _htmlEncoder = htmlEncoder;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Display(MarkdownBodyPart MarkdownBodyPart, BuildPartDisplayContext context)
         {
@@ -53,7 +52,7 @@ namespace OrchardCore.Markdown.Drivers
                 if (!string.IsNullOrEmpty(viewModel.Markdown) && !_liquidTemplateManager.Validate(viewModel.Markdown, out var errors))
                 {
                     var partName = context.TypePartDefinition.DisplayName();
-                    context.Updater.ModelState.AddModelError(nameof(model.Markdown), T["{0} doesn't contain a valid Liquid expression. Details: {1}", partName, string.Join(" ", errors)]);
+                    context.Updater.ModelState.AddModelError(nameof(model.Markdown), S["{0} doesn't contain a valid Liquid expression. Details: {1}", partName, string.Join(" ", errors)]);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Drivers/MarkdownFieldDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Drivers/MarkdownFieldDriver.cs
@@ -16,15 +16,14 @@ namespace OrchardCore.Markdown.Drivers
     {
         private readonly ILiquidTemplateManager _liquidTemplateManager;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly IStringLocalizer<MarkdownFieldDisplayDriver> S;
 
         public MarkdownFieldDisplayDriver(ILiquidTemplateManager liquidTemplateManager, IStringLocalizer<MarkdownFieldDisplayDriver> localizer, HtmlEncoder htmlEncoder)
         {
             _liquidTemplateManager = liquidTemplateManager;
-            T = localizer;
             _htmlEncoder = htmlEncoder;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Display(MarkdownField field, BuildFieldDisplayContext context)
         {
@@ -62,7 +61,7 @@ namespace OrchardCore.Markdown.Drivers
                 if (!string.IsNullOrEmpty(viewModel.Markdown) && !_liquidTemplateManager.Validate(viewModel.Markdown, out var errors))
                 {
                     var fieldName = context.PartFieldDefinition.DisplayName();
-                    context.Updater.ModelState.AddModelError(nameof(field.Markdown), T["{0} field doesn't contain a valid Liquid expression. Details: {1}", fieldName, string.Join(" ", errors)]);
+                    context.Updater.ModelState.AddModelError(nameof(field.Markdown), S["{0} field doesn't contain a valid Liquid expression. Details: {1}", fieldName, string.Join(" ", errors)]);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
@@ -13,18 +13,18 @@ namespace OrchardCore.Markdown.GraphQL
 {
     public class MarkdownBodyQueryObjectType : ObjectGraphType<MarkdownBodyPart>
     {
-        public MarkdownBodyQueryObjectType(IStringLocalizer<MarkdownBodyQueryObjectType> T)
+        public MarkdownBodyQueryObjectType(IStringLocalizer<MarkdownBodyQueryObjectType> S)
         {
             Name = nameof(MarkdownBodyPart);
-            Description = T["Content stored as Markdown. You can also query the HTML interpreted version of Markdown."];
+            Description = S["Content stored as Markdown. You can also query the HTML interpreted version of Markdown."];
 
             Field("markdown", x => x.Markdown, nullable: true)
-                .Description(T["the markdown value"])
+                .Description(S["the markdown value"])
                 .Type(new StringGraphType());
 
             Field<StringGraphType>()
                 .Name("html")
-                .Description(T["the HTML representation of the markdown content"])
+                .Description(S["the HTML representation of the markdown content"])
                 .ResolveLockedAsync(ToHtml);
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownFieldQueryObjectType.cs
@@ -11,18 +11,18 @@ namespace OrchardCore.Markdown.GraphQL
 {
     public class MarkdownFieldQueryObjectType : ObjectGraphType<MarkdownField>
     {
-        public MarkdownFieldQueryObjectType(IStringLocalizer<MarkdownFieldQueryObjectType> T)
+        public MarkdownFieldQueryObjectType(IStringLocalizer<MarkdownFieldQueryObjectType> S)
         {
             Name = nameof(MarkdownField);
-            Description = T["Content stored as Markdown. You can also query the HTML interpreted version of Markdown."];
+            Description = S["Content stored as Markdown. You can also query the HTML interpreted version of Markdown."];
 
             Field("markdown", x => x.Markdown, nullable: true)
-                .Description(T["the markdown value"])
+                .Description(S["the markdown value"])
                 .Type(new StringGraphType());
 
             Field<StringGraphType>()
                 .Name("html")
-                .Description(T["the HTML representation of the markdown content"])
+                .Description(S["the HTML representation of the markdown content"])
                 .ResolveLockedAsync(ToHtml);
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.Media.Controllers
         private readonly IAuthorizationService _authorizationService;
         private readonly IContentTypeProvider _contentTypeProvider;
         private readonly ILogger _logger;
-        private readonly IStringLocalizer<AdminController> T;
+        private readonly IStringLocalizer<AdminController> S;
 
         public AdminController(
             IMediaFileStore mediaFileStore,
@@ -38,7 +38,7 @@ namespace OrchardCore.Media.Controllers
             _contentTypeProvider = contentTypeProvider;
             _allowedFileExtensions = options.Value.AllowedFileExtensions;
             _logger = logger;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<IActionResult> Index()
@@ -168,7 +168,7 @@ namespace OrchardCore.Media.Controllers
                         name = file.FileName,
                         size = file.Length,
                         folder = path,
-                        error = T["This file extension is not allowed: {0}", Path.GetExtension(file.FileName)].ToString()
+                        error = S["This file extension is not allowed: {0}", Path.GetExtension(file.FileName)].ToString()
                     });
 
                     _logger.LogInformation("File extension not allowed: '{0}'", file.FileName);
@@ -217,13 +217,13 @@ namespace OrchardCore.Media.Controllers
 
             if (string.IsNullOrEmpty(path))
             {
-                return StatusCode(StatusCodes.Status403Forbidden, T["Cannot delete root media folder"]);
+                return StatusCode(StatusCodes.Status403Forbidden, S["Cannot delete root media folder"]);
             }
 
             var mediaFolder = await _mediaFileStore.GetDirectoryInfoAsync(path);
             if (mediaFolder != null && !mediaFolder.IsDirectory)
             {
-                return StatusCode(StatusCodes.Status403Forbidden, T["Cannot delete path because it is not a directory"]);
+                return StatusCode(StatusCodes.Status403Forbidden, S["Cannot delete path because it is not a directory"]);
             }
 
             if (await _mediaFileStore.TryDeleteDirectoryAsync(path) == false)
@@ -273,12 +273,12 @@ namespace OrchardCore.Media.Controllers
 
             if (!_allowedFileExtensions.Contains(Path.GetExtension(newPath), StringComparer.OrdinalIgnoreCase))
             {
-                return StatusCode(StatusCodes.Status403Forbidden, T["This file extension is not allowed: {0}", Path.GetExtension(newPath)]);
+                return StatusCode(StatusCodes.Status403Forbidden, S["This file extension is not allowed: {0}", Path.GetExtension(newPath)]);
             }
 
             if (await _mediaFileStore.GetFileInfoAsync(newPath) != null)
             {
-                return StatusCode(StatusCodes.Status403Forbidden, T["Cannot move media because a file already exists with the same name"]);
+                return StatusCode(StatusCodes.Status403Forbidden, S["Cannot move media because a file already exists with the same name"]);
             }
 
             await _mediaFileStore.MoveFileAsync(oldPath, newPath);
@@ -354,7 +354,7 @@ namespace OrchardCore.Media.Controllers
 
             if (filesOnError.Count > 0)
             {
-                return BadRequest(T["Error when moving files. Maybe they already exist on the target folder? Files on error: {0}", string.Join(",", filesOnError)].ToString());
+                return BadRequest(S["Error when moving files. Maybe they already exist on the target folder? Files on error: {0}", string.Join(",", filesOnError)].ToString());
             }
             else
             {
@@ -383,13 +383,13 @@ namespace OrchardCore.Media.Controllers
             var mediaFolder = await _mediaFileStore.GetDirectoryInfoAsync(newPath);
             if (mediaFolder != null)
             {
-                return StatusCode(StatusCodes.Status403Forbidden, T["Cannot create folder because a folder already exists with the same name"]);
+                return StatusCode(StatusCodes.Status403Forbidden, S["Cannot create folder because a folder already exists with the same name"]);
             }
 
             var existingFile = await _mediaFileStore.GetFileInfoAsync(newPath);
             if (existingFile != null)
             {
-                return StatusCode(StatusCodes.Status403Forbidden, T["Cannot create folder because a file already exists with the same name"]);
+                return StatusCode(StatusCodes.Status403Forbidden, S["Cannot create folder because a file already exists with the same name"]);
             }
 
             await _mediaFileStore.TryCreateDirectoryAsync(newPath);

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Services/AzureADService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Services/AzureADService.cs
@@ -12,14 +12,14 @@ namespace OrchardCore.Microsoft.Authentication.Services
     public class AzureADService : IAzureADService
     {
         private readonly ISiteService _siteService;
-        private readonly IStringLocalizer<AzureADService> T;
+        private readonly IStringLocalizer<AzureADService> S;
 
         public AzureADService(
             ISiteService siteService,
             IStringLocalizer<AzureADService> stringLocalizer)
         {
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<AzureADSettings> GetSettingsAsync()
@@ -55,17 +55,17 @@ namespace OrchardCore.Microsoft.Authentication.Services
 
             if (string.IsNullOrWhiteSpace(settings.DisplayName))
             {
-                yield return new ValidationResult(T["DisplayName is required"], new string[] { nameof(settings.DisplayName) });
+                yield return new ValidationResult(S["DisplayName is required"], new string[] { nameof(settings.DisplayName) });
             }
 
             if (string.IsNullOrWhiteSpace(settings.AppId))
             {
-                yield return new ValidationResult(T["AppId is required"], new string[] { nameof(settings.AppId) });
+                yield return new ValidationResult(S["AppId is required"], new string[] { nameof(settings.AppId) });
             }
 
             if (string.IsNullOrWhiteSpace(settings.TenantId))
             {
-                yield return new ValidationResult(T["TenantId is required"], new string[] { nameof(settings.TenantId) });
+                yield return new ValidationResult(S["TenantId is required"], new string[] { nameof(settings.TenantId) });
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Services/MicrosoftAccountService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Services/MicrosoftAccountService.cs
@@ -12,14 +12,14 @@ namespace OrchardCore.Microsoft.Authentication.Services
     public class MicrosoftAccountService : IMicrosoftAccountService
     {
         private readonly ISiteService _siteService;
-        private readonly IStringLocalizer<MicrosoftAccountService> T;
+        private readonly IStringLocalizer<MicrosoftAccountService> S;
 
         public MicrosoftAccountService(
             ISiteService siteService,
             IStringLocalizer<MicrosoftAccountService> stringLocalizer)
         {
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<MicrosoftAccountSettings> GetSettingsAsync()
@@ -53,12 +53,12 @@ namespace OrchardCore.Microsoft.Authentication.Services
 
             if (string.IsNullOrWhiteSpace(settings.AppId))
             {
-                yield return new ValidationResult(T["AppId is required"], new string[] { nameof(settings.AppId) });
+                yield return new ValidationResult(S["AppId is required"], new string[] { nameof(settings.AppId) });
             }
 
             if (string.IsNullOrWhiteSpace(settings.AppSecret))
             {
-                yield return new ValidationResult(T["AppSecret is required"], new string[] { nameof(settings.AppSecret) });
+                yield return new ValidationResult(S["AppSecret is required"], new string[] { nameof(settings.AppSecret) });
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.OpenId.Controllers
         private readonly IOpenIdAuthorizationManager _authorizationManager;
         private readonly IOpenIdScopeManager _scopeManager;
         private readonly ShellSettings _shellSettings;
-        private readonly IStringLocalizer<AccessController> T;
+        private readonly IStringLocalizer<AccessController> S;
 
         public AccessController(
             IOpenIdApplicationManager applicationManager,
@@ -45,7 +45,7 @@ namespace OrchardCore.OpenId.Controllers
             ShellSettings shellSettings,
             IOpenIdServerService serverService)
         {
-            T = localizer;
+            S = localizer;
             _applicationManager = applicationManager;
             _authorizationManager = authorizationManager;
             _scopeManager = scopeManager;
@@ -77,7 +77,7 @@ namespace OrchardCore.OpenId.Controllers
                 return View("Error", new ErrorViewModel
                 {
                     Error = OpenIddictConstants.Errors.InvalidClient,
-                    ErrorDescription = T["The specified 'client_id' parameter is invalid."]
+                    ErrorDescription = S["The specified 'client_id' parameter is invalid."]
                 });
             }
 
@@ -94,7 +94,7 @@ namespace OrchardCore.OpenId.Controllers
                     return RedirectToClient(new OpenIdConnectResponse
                     {
                         Error = OpenIddictConstants.Errors.ConsentRequired,
-                        ErrorDescription = T["The logged in user is not allowed to access this client application."]
+                        ErrorDescription = S["The logged in user is not allowed to access this client application."]
                     });
 
                 case OpenIddictConstants.ConsentTypes.Implicit:
@@ -110,7 +110,7 @@ namespace OrchardCore.OpenId.Controllers
                     return RedirectToClient(new OpenIdConnectResponse
                     {
                         Error = OpenIddictConstants.Errors.ConsentRequired,
-                        ErrorDescription = T["Interactive user consent is required."]
+                        ErrorDescription = S["Interactive user consent is required."]
                     });
 
                 default:
@@ -138,7 +138,7 @@ namespace OrchardCore.OpenId.Controllers
                 return View("Error", new ErrorViewModel
                 {
                     Error = OpenIddictConstants.Errors.InvalidClient,
-                    ErrorDescription = T["The specified 'client_id' parameter is invalid."]
+                    ErrorDescription = S["The specified 'client_id' parameter is invalid."]
                 });
             }
 
@@ -158,7 +158,7 @@ namespace OrchardCore.OpenId.Controllers
                     return RedirectToClient(new OpenIdConnectResponse
                     {
                         Error = OpenIddictConstants.Errors.ConsentRequired,
-                        ErrorDescription = T["The logged in user is not allowed to access this client application."]
+                        ErrorDescription = S["The logged in user is not allowed to access this client application."]
                     });
 
                 default:
@@ -256,7 +256,7 @@ namespace OrchardCore.OpenId.Controllers
                 return BadRequest(new OpenIdConnectResponse
                 {
                     Error = OpenIddictConstants.Errors.InvalidClient,
-                    ErrorDescription = T["The specified 'client_id' parameter is invalid."]
+                    ErrorDescription = S["The specified 'client_id' parameter is invalid."]
                 });
             }
 
@@ -317,7 +317,7 @@ namespace OrchardCore.OpenId.Controllers
                 return BadRequest(new OpenIdConnectResponse
                 {
                     Error = OpenIddictConstants.Errors.InvalidClient,
-                    ErrorDescription = T["The specified 'client_id' parameter is invalid."]
+                    ErrorDescription = S["The specified 'client_id' parameter is invalid."]
                 });
             }
 
@@ -329,7 +329,7 @@ namespace OrchardCore.OpenId.Controllers
                 return BadRequest(new OpenIdConnectResponse
                 {
                     Error = OpenIdConnectConstants.Errors.UnsupportedGrantType,
-                    ErrorDescription = T["The resource owner password credentials grant is not supported."]
+                    ErrorDescription = S["The resource owner password credentials grant is not supported."]
                 });
             }
 
@@ -362,7 +362,7 @@ namespace OrchardCore.OpenId.Controllers
                     return BadRequest(new OpenIdConnectResponse
                     {
                         Error = OpenIddictConstants.Errors.ConsentRequired,
-                        ErrorDescription = T["The logged in user is not allowed to access this client application."]
+                        ErrorDescription = S["The logged in user is not allowed to access this client application."]
                     });
             }
 
@@ -379,7 +379,7 @@ namespace OrchardCore.OpenId.Controllers
                 return BadRequest(new OpenIdConnectResponse
                 {
                     Error = OpenIddictConstants.Errors.InvalidClient,
-                    ErrorDescription = T["The specified 'client_id' parameter is invalid."]
+                    ErrorDescription = S["The specified 'client_id' parameter is invalid."]
                 });
             }
 
@@ -395,7 +395,7 @@ namespace OrchardCore.OpenId.Controllers
                     return BadRequest(new OpenIdConnectResponse
                     {
                         Error = OpenIddictConstants.Errors.UnauthorizedClient,
-                        ErrorDescription = T["The refresh token grant type is not allowed for refresh " +
+                        ErrorDescription = S["The refresh token grant type is not allowed for refresh " +
                                              "tokens retrieved using the client credentials flow."]
                     });
                 }
@@ -549,7 +549,7 @@ namespace OrchardCore.OpenId.Controllers
                 return RedirectToClient(new OpenIdConnectResponse
                 {
                     Error = OpenIddictConstants.Errors.LoginRequired,
-                    ErrorDescription = T["The user is not logged in."]
+                    ErrorDescription = S["The user is not logged in."]
                 });
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.OpenId.Controllers
     public class ApplicationController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
-        private readonly IStringLocalizer<ApplicationController> T;
+        private readonly IStringLocalizer<ApplicationController> S;
         private readonly IHtmlLocalizer<ApplicationController> H;
         private readonly ISiteService _siteService;
         private readonly IOpenIdApplicationManager _applicationManager;
@@ -48,7 +48,7 @@ namespace OrchardCore.OpenId.Controllers
         {
             New = shapeFactory;
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
             H = htmlLocalizer;
             _authorizationService = authorizationService;
             _applicationManager = applicationManager;
@@ -126,17 +126,17 @@ namespace OrchardCore.OpenId.Controllers
             if (!string.IsNullOrEmpty(model.ClientSecret) &&
                  string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
             {
-                ModelState.AddModelError(nameof(model.ClientSecret), T["No client secret can be set for public applications."]);
+                ModelState.AddModelError(nameof(model.ClientSecret), S["No client secret can be set for public applications."]);
             }
             else if (string.IsNullOrEmpty(model.ClientSecret) &&
                      string.Equals(model.Type, OpenIddictConstants.ClientTypes.Confidential, StringComparison.OrdinalIgnoreCase))
             {
-                ModelState.AddModelError(nameof(model.ClientSecret), T["The client secret is required for confidential applications."]);
+                ModelState.AddModelError(nameof(model.ClientSecret), S["The client secret is required for confidential applications."]);
             }
 
             if (!string.IsNullOrEmpty(model.ClientId) && await _applicationManager.FindByClientIdAsync(model.ClientId) != null)
             {
-                ModelState.AddModelError(nameof(model.ClientId), T["The client identifier is already taken by another application."]);
+                ModelState.AddModelError(nameof(model.ClientId), S["The client identifier is already taken by another application."]);
             }
 
             if (!ModelState.IsValid)
@@ -289,13 +289,13 @@ namespace OrchardCore.OpenId.Controllers
                !string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase) &&
                 await _applicationManager.IsPublicAsync(application))
             {
-                ModelState.AddModelError(nameof(model.ClientSecret), T["Setting a new client secret is required."]);
+                ModelState.AddModelError(nameof(model.ClientSecret), S["Setting a new client secret is required."]);
             }
 
             if (!string.IsNullOrEmpty(model.ClientSecret) &&
                  string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
             {
-                ModelState.AddModelError(nameof(model.ClientSecret), T["No client secret can be set for public applications."]);
+                ModelState.AddModelError(nameof(model.ClientSecret), S["No client secret can be set for public applications."]);
             }
 
             if (ModelState.IsValid)
@@ -305,7 +305,7 @@ namespace OrchardCore.OpenId.Controllers
                     await _applicationManager.GetIdAsync(other),
                     await _applicationManager.GetIdAsync(application), StringComparison.Ordinal))
                 {
-                    ModelState.AddModelError(nameof(model.ClientId), T["The client identifier is already taken by another application."]);
+                    ModelState.AddModelError(nameof(model.ClientId), S["The client identifier is already taken by another application."]);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ScopeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ScopeController.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.OpenId.Controllers
     public class ScopeController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
-        private readonly IStringLocalizer<ScopeController> T;
+        private readonly IStringLocalizer<ScopeController> S;
         private readonly IHtmlLocalizer<ScopeController> H;
         private readonly IOpenIdScopeManager _scopeManager;
         private readonly ISiteService _siteService;
@@ -49,7 +49,7 @@ namespace OrchardCore.OpenId.Controllers
             _scopeManager = scopeManager;
             New = shapeFactory;
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
             H = htmlLocalizer;
             _authorizationService = authorizationService;
             _notifier = notifier;
@@ -121,7 +121,7 @@ namespace OrchardCore.OpenId.Controllers
 
             if (await _scopeManager.FindByNameAsync(model.Name) != null)
             {
-                ModelState.AddModelError(nameof(model.Name), T["The name is already taken by another scope."]);
+                ModelState.AddModelError(nameof(model.Name), S["The name is already taken by another scope."]);
             }
 
             if (!ModelState.IsValid)
@@ -220,7 +220,7 @@ namespace OrchardCore.OpenId.Controllers
                     await _scopeManager.GetIdAsync(other),
                     await _scopeManager.GetIdAsync(scope)))
                 {
-                    ModelState.AddModelError(nameof(model.Name), T["The name is already taken by another scope."]);
+                    ModelState.AddModelError(nameof(model.Name), S["The name is already taken by another scope."]);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/UserInfoController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/UserInfoController.cs
@@ -16,10 +16,10 @@ namespace OrchardCore.OpenId.Controllers
     [OpenIdController, SkipStatusCodePages]
     public class UserInfoController : Controller
     {
-        private readonly IStringLocalizer<UserInfoController> T;
+        private readonly IStringLocalizer<UserInfoController> S;
 
         public UserInfoController(IStringLocalizer<UserInfoController> localizer)
-            => T = localizer;
+            => S = localizer;
 
         // GET/POST: /connect/userinfo
         [AcceptVerbs("GET", "POST")]
@@ -49,7 +49,7 @@ namespace OrchardCore.OpenId.Controllers
                 return BadRequest(new OpenIdConnectResponse
                 {
                     Error = OpenIddictConstants.Errors.InvalidRequest,
-                    ErrorDescription = T["The userinfo endpoint can only be used with access tokens representing users."]
+                    ErrorDescription = S["The userinfo endpoint can only be used with access tokens representing users."]
                 });
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdClientService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdClientService.cs
@@ -14,14 +14,14 @@ namespace OrchardCore.OpenId.Services
     public class OpenIdClientService : IOpenIdClientService
     {
         private readonly ISiteService _siteService;
-        private readonly IStringLocalizer<OpenIdClientService> T;
+        private readonly IStringLocalizer<OpenIdClientService> S;
 
         public OpenIdClientService(
             ISiteService siteService,
             IStringLocalizer<OpenIdClientService> stringLocalizer)
         {
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<OpenIdClientSettings> GetSettingsAsync()
@@ -53,21 +53,21 @@ namespace OrchardCore.OpenId.Services
 
             if (settings.Authority == null)
             {
-                results.Add(new ValidationResult(T["The authority cannot be null or empty."], new[]
+                results.Add(new ValidationResult(S["The authority cannot be null or empty."], new[]
                 {
                     nameof(settings.Authority)
                 }));
             }
             else if (!settings.Authority.IsAbsoluteUri || !settings.Authority.IsWellFormedOriginalString())
             {
-                results.Add(new ValidationResult(T["The authority must be a valid absolute URL."], new[]
+                results.Add(new ValidationResult(S["The authority must be a valid absolute URL."], new[]
                 {
                     nameof(settings.Authority)
                 }));
             }
             else if (!string.IsNullOrEmpty(settings.Authority.Query) || !string.IsNullOrEmpty(settings.Authority.Fragment))
             {
-                results.Add(new ValidationResult(T["The authority cannot contain a query string or a fragment."], new[]
+                results.Add(new ValidationResult(S["The authority cannot contain a query string or a fragment."], new[]
                 {
                     nameof(settings.Authority)
                 }));
@@ -75,7 +75,7 @@ namespace OrchardCore.OpenId.Services
 
             if (string.IsNullOrEmpty(settings.ResponseType))
             {
-                results.Add(new ValidationResult(T["The response type cannot be null or empty."], new[]
+                results.Add(new ValidationResult(S["The response type cannot be null or empty."], new[]
                 {
                     nameof(settings.ResponseType)
                 }));
@@ -84,7 +84,7 @@ namespace OrchardCore.OpenId.Services
                 settings.ResponseType != OpenIdConnectResponseType.CodeIdTokenToken && settings.ResponseType != OpenIdConnectResponseType.CodeToken &&
                 settings.ResponseType != OpenIdConnectResponseType.IdToken && settings.ResponseType != OpenIdConnectResponseType.IdTokenToken)
             {
-                results.Add(new ValidationResult(T["Unknown response type ."], new[]
+                results.Add(new ValidationResult(S["Unknown response type ."], new[]
                 {
                     nameof(settings.ResponseType)
                 }));
@@ -92,7 +92,7 @@ namespace OrchardCore.OpenId.Services
 
             if (string.IsNullOrEmpty(settings.ResponseMode))
             {
-                results.Add(new ValidationResult(T["The response mode cannot be null or empty."], new[]
+                results.Add(new ValidationResult(S["The response mode cannot be null or empty."], new[]
                 {
                     nameof(settings.ResponseMode)
                 }));
@@ -100,7 +100,7 @@ namespace OrchardCore.OpenId.Services
             else if (settings.ResponseMode != OpenIdConnectResponseMode.FormPost && settings.ResponseMode != OpenIdConnectResponseMode.Fragment &&
                 settings.ResponseMode != OpenIdConnectResponseMode.Query)
             {
-                results.Add(new ValidationResult(T["Unknown response mode."], new[]
+                results.Add(new ValidationResult(S["Unknown response mode."], new[]
                 {
                     nameof(settings.ResponseMode)
                 }));

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.OpenId.Services
         private readonly IOptionsMonitor<ShellOptions> _shellOptions;
         private readonly ShellSettings _shellSettings;
         private readonly ISiteService _siteService;
-        private readonly IStringLocalizer<OpenIdServerService> T;
+        private readonly IStringLocalizer<OpenIdServerService> S;
 
         public OpenIdServerService(
             IDataProtectionProvider dataProtectionProvider,
@@ -47,7 +47,7 @@ namespace OrchardCore.OpenId.Services
             _shellOptions = shellOptions;
             _shellSettings = shellSettings;
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<OpenIdServerSettings> GetSettingsAsync()
@@ -94,14 +94,14 @@ namespace OrchardCore.OpenId.Services
 
             if (settings.GrantTypes.Count == 0)
             {
-                results.Add(new ValidationResult(T["At least one OpenID Connect flow must be enabled."]));
+                results.Add(new ValidationResult(S["At least one OpenID Connect flow must be enabled."]));
             }
 
             if (settings.Authority != null)
             {
                 if (!settings.Authority.IsAbsoluteUri || !settings.Authority.IsWellFormedOriginalString())
                 {
-                    results.Add(new ValidationResult(T["The authority must be a valid absolute URL."], new[]
+                    results.Add(new ValidationResult(S["The authority must be a valid absolute URL."], new[]
                     {
                         nameof(settings.Authority)
                     }));
@@ -109,7 +109,7 @@ namespace OrchardCore.OpenId.Services
 
                 if (!string.IsNullOrEmpty(settings.Authority.Query) || !string.IsNullOrEmpty(settings.Authority.Fragment))
                 {
-                    results.Add(new ValidationResult(T["The authority cannot contain a query string or a fragment."], new[]
+                    results.Add(new ValidationResult(S["The authority cannot contain a query string or a fragment."], new[]
                     {
                         nameof(settings.Authority)
                     }));
@@ -126,7 +126,7 @@ namespace OrchardCore.OpenId.Services
 
                 if (certificate == null)
                 {
-                    results.Add(new ValidationResult(T["The certificate cannot be found."], new[]
+                    results.Add(new ValidationResult(S["The certificate cannot be found."], new[]
                     {
                         nameof(settings.CertificateThumbprint)
                     }));
@@ -134,7 +134,7 @@ namespace OrchardCore.OpenId.Services
 
                 else if (!certificate.HasPrivateKey)
                 {
-                    results.Add(new ValidationResult(T["The certificate doesn't contain the required private key."], new[]
+                    results.Add(new ValidationResult(S["The certificate doesn't contain the required private key."], new[]
                     {
                         nameof(settings.CertificateThumbprint)
                     }));
@@ -142,7 +142,7 @@ namespace OrchardCore.OpenId.Services
 
                 else if (certificate.Archived)
                 {
-                    results.Add(new ValidationResult(T["The certificate is not valid because it is marked as archived."], new[]
+                    results.Add(new ValidationResult(S["The certificate is not valid because it is marked as archived."], new[]
                     {
                         nameof(settings.CertificateThumbprint)
                     }));
@@ -150,7 +150,7 @@ namespace OrchardCore.OpenId.Services
 
                 else if (certificate.NotBefore > DateTime.Now || certificate.NotAfter < DateTime.Now)
                 {
-                    results.Add(new ValidationResult(T["The certificate is not valid for current date."], new[]
+                    results.Add(new ValidationResult(S["The certificate is not valid for current date."], new[]
                     {
                         nameof(settings.CertificateThumbprint)
                     }));
@@ -159,7 +159,7 @@ namespace OrchardCore.OpenId.Services
 
             if (settings.GrantTypes.Contains(GrantTypes.Password) && !settings.TokenEndpointPath.HasValue)
             {
-                results.Add(new ValidationResult(T["The password flow cannot be enabled when the token endpoint is disabled."], new[]
+                results.Add(new ValidationResult(S["The password flow cannot be enabled when the token endpoint is disabled."], new[]
                 {
                     nameof(settings.GrantTypes)
                 }));
@@ -167,7 +167,7 @@ namespace OrchardCore.OpenId.Services
 
             if (settings.GrantTypes.Contains(GrantTypes.ClientCredentials) && !settings.TokenEndpointPath.HasValue)
             {
-                results.Add(new ValidationResult(T["The client credentials flow cannot be enabled when the token endpoint is disabled."], new[]
+                results.Add(new ValidationResult(S["The client credentials flow cannot be enabled when the token endpoint is disabled."], new[]
                 {
                     nameof(settings.GrantTypes)
                 }));
@@ -176,7 +176,7 @@ namespace OrchardCore.OpenId.Services
             if (settings.GrantTypes.Contains(GrantTypes.AuthorizationCode) &&
                (!settings.AuthorizationEndpointPath.HasValue || !settings.TokenEndpointPath.HasValue))
             {
-                results.Add(new ValidationResult(T["The authorization code flow cannot be enabled when the authorization and token endpoints are disabled."], new[]
+                results.Add(new ValidationResult(S["The authorization code flow cannot be enabled when the authorization and token endpoints are disabled."], new[]
                 {
                     nameof(settings.GrantTypes)
                 }));
@@ -186,7 +186,7 @@ namespace OrchardCore.OpenId.Services
             {
                 if (!settings.TokenEndpointPath.HasValue)
                 {
-                    results.Add(new ValidationResult(T["The refresh token flow cannot be enabled when the token endpoint is disabled."], new[]
+                    results.Add(new ValidationResult(S["The refresh token flow cannot be enabled when the token endpoint is disabled."], new[]
                     {
                         nameof(settings.GrantTypes)
                     }));
@@ -194,7 +194,7 @@ namespace OrchardCore.OpenId.Services
 
                 if (!settings.GrantTypes.Contains(GrantTypes.Password) && !settings.GrantTypes.Contains(GrantTypes.AuthorizationCode))
                 {
-                    results.Add(new ValidationResult(T["The refresh token flow can only be enabled if the password, authorization code or hybrid flows are enabled."], new[]
+                    results.Add(new ValidationResult(S["The refresh token flow can only be enabled if the password, authorization code or hybrid flows are enabled."], new[]
                     {
                         nameof(settings.GrantTypes)
                     }));
@@ -203,7 +203,7 @@ namespace OrchardCore.OpenId.Services
 
             if (settings.GrantTypes.Contains(GrantTypes.Implicit) && !settings.AuthorizationEndpointPath.HasValue)
             {
-                results.Add(new ValidationResult(T["The implicit flow cannot be enabled when the authorization endpoint is disabled."], new[]
+                results.Add(new ValidationResult(S["The implicit flow cannot be enabled when the authorization endpoint is disabled."], new[]
                 {
                     nameof(settings.GrantTypes)
                 }));

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdValidationService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdValidationService.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.OpenId.Services
         private readonly ShellSettings _shellSettings;
         private readonly IShellHost _shellHost;
         private readonly ISiteService _siteService;
-        private readonly IStringLocalizer<OpenIdValidationService> T;
+        private readonly IStringLocalizer<OpenIdValidationService> S;
 
         public OpenIdValidationService(
             ShellDescriptor shellDescriptor,
@@ -33,7 +33,7 @@ namespace OrchardCore.OpenId.Services
             _shellSettings = shellSettings;
             _shellHost = shellHost;
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<OpenIdValidationSettings> GetSettingsAsync()
@@ -80,7 +80,7 @@ namespace OrchardCore.OpenId.Services
 
             if (!(settings.Authority == null ^ string.IsNullOrEmpty(settings.Tenant)))
             {
-                results.Add(new ValidationResult(T["Either a tenant or an authority must be registered."], new[]
+                results.Add(new ValidationResult(S["Either a tenant or an authority must be registered."], new[]
                 {
                     nameof(settings.Authority),
                     nameof(settings.Tenant)
@@ -91,7 +91,7 @@ namespace OrchardCore.OpenId.Services
             {
                 if (!settings.Authority.IsAbsoluteUri || !settings.Authority.IsWellFormedOriginalString())
                 {
-                    results.Add(new ValidationResult(T["The specified authority is not valid."], new[]
+                    results.Add(new ValidationResult(S["The specified authority is not valid."], new[]
                     {
                         nameof(settings.Authority)
                     }));
@@ -99,7 +99,7 @@ namespace OrchardCore.OpenId.Services
 
                 if (!string.IsNullOrEmpty(settings.Authority.Query) || !string.IsNullOrEmpty(settings.Authority.Fragment))
                 {
-                    results.Add(new ValidationResult(T["The authority cannot contain a query string or a fragment."], new[]
+                    results.Add(new ValidationResult(S["The authority cannot contain a query string or a fragment."], new[]
                     {
                         nameof(settings.Authority)
                     }));
@@ -108,7 +108,7 @@ namespace OrchardCore.OpenId.Services
 
             if (!string.IsNullOrEmpty(settings.Tenant) && !string.IsNullOrEmpty(settings.Audience))
             {
-                results.Add(new ValidationResult(T["No audience can be set when using another tenant."], new[]
+                results.Add(new ValidationResult(S["No audience can be set when using another tenant."], new[]
                 {
                     nameof(settings.Audience)
                 }));
@@ -116,7 +116,7 @@ namespace OrchardCore.OpenId.Services
 
             if (settings.Authority != null && string.IsNullOrEmpty(settings.Audience))
             {
-                results.Add(new ValidationResult(T["An audience must be set when configuring the authority."], new[]
+                results.Add(new ValidationResult(S["An audience must be set when configuring the authority."], new[]
                 {
                     nameof(settings.Audience)
                 }));
@@ -125,7 +125,7 @@ namespace OrchardCore.OpenId.Services
             if (!string.IsNullOrEmpty(settings.Audience) &&
                 settings.Audience.StartsWith(OpenIdConstants.Prefixes.Tenant, StringComparison.OrdinalIgnoreCase))
             {
-                results.Add(new ValidationResult(T["The audience cannot start with the special 'oct:' prefix."], new[]
+                results.Add(new ValidationResult(S["The audience cannot start with the special 'oct:' prefix."], new[]
                 {
                     nameof(settings.Audience)
                 }));
@@ -138,7 +138,7 @@ namespace OrchardCore.OpenId.Services
             {
                 if (!_shellHost.TryGetSettings(settings.Tenant, out var shellSettings))
                 {
-                    results.Add(new ValidationResult(T["The specified tenant is not valid."]));
+                    results.Add(new ValidationResult(S["The specified tenant is not valid."]));
                 }
                 else
                 {
@@ -149,7 +149,7 @@ namespace OrchardCore.OpenId.Services
                         var manager = scope.ServiceProvider.GetService<IOpenIdScopeManager>();
                         if (manager == null)
                         {
-                            results.Add(new ValidationResult(T["The specified tenant is not valid."], new[]
+                            results.Add(new ValidationResult(S["The specified tenant is not valid."], new[]
                             {
                                 nameof(settings.Tenant)
                             }));
@@ -160,7 +160,7 @@ namespace OrchardCore.OpenId.Services
                             var scopes = await manager.FindByResourceAsync(resource);
                             if (scopes.IsDefaultOrEmpty)
                             {
-                                results.Add(new ValidationResult(T["No appropriate scope was found."], new[]
+                                results.Add(new ValidationResult(S["No appropriate scope was found."], new[]
                                 {
                                     nameof(settings.Tenant)
                                 }));

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Workflows/ValidateReCaptchaTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Workflows/ValidateReCaptchaTask.cs
@@ -14,6 +14,7 @@ namespace OrchardCore.ReCaptcha.Workflows
     {
         private readonly ReCaptchaService _reCaptchaService;
         private readonly IUpdateModelAccessor _updateModelAccessor;
+        private readonly IStringLocalizer<ValidateReCaptchaTask> S;
 
         public ValidateReCaptchaTask(
             ReCaptchaService reCaptchaService,
@@ -23,19 +24,20 @@ namespace OrchardCore.ReCaptcha.Workflows
         {
             _reCaptchaService = reCaptchaService;
             _updateModelAccessor = updateModelAccessor;
-            T = localizer;
+            S = localizer;
         }
 
         public override string Name => nameof(ValidateReCaptchaTask);
-        public override LocalizedString DisplayText => T["Validate ReCaptcha Task"];
-        public override LocalizedString Category => T["Validation"];
+        
+        public override LocalizedString DisplayText => S["Validate ReCaptcha Task"];
+        
+        public override LocalizedString Category => S["Validation"];
+        
         public override bool HasEditor => false;
-
-        private IStringLocalizer T { get; set; }
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"], T["Valid"], T["Invalid"]);
+            return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
@@ -48,7 +50,7 @@ namespace OrchardCore.ReCaptcha.Workflows
                 outcome = "Invalid";
                 if (updater != null)
                 {
-                    updater.ModelState.TryAddModelError(Constants.ReCaptchaServerResponseHeaderName, T["Captcha validation failed. Try again."]);
+                    updater.ModelState.TryAddModelError(Constants.ReCaptchaServerResponseHeaderName, S["Captcha validation failed. Try again."]);
                 }
             });
 

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -28,6 +28,7 @@ namespace OrchardCore.Recipes.Controllers
         private readonly INotifier _notifier;
         private readonly IRecipeExecutor _recipeExecutor;
         private readonly ISiteService _siteService;
+        private readonly IHtmlLocalizer<AdminController> H;
 
         public AdminController(
             ShellSettings shellSettings,
@@ -47,11 +48,8 @@ namespace OrchardCore.Recipes.Controllers
             _authorizationService = authorizationService;
             _recipeHarvesters = recipeHarvesters;
             _notifier = notifier;
-
-            T = localizer;
+            H = localizer;
         }
-
-        public IHtmlLocalizer T { get; }
 
         public async Task<ActionResult> Index()
         {
@@ -96,7 +94,7 @@ namespace OrchardCore.Recipes.Controllers
 
             if (recipe == null)
             {
-                _notifier.Error(T["Recipe was not found"]);
+                _notifier.Error(H["Recipe was not found"]);
                 return RedirectToAction("Index");
             }
 
@@ -123,7 +121,7 @@ namespace OrchardCore.Recipes.Controllers
                 _shellSettings.State = TenantState.Running;
             }
 
-            _notifier.Success(T["The recipe '{0}' has been run successfully", recipe.Name]);
+            _notifier.Success(H["The recipe '{0}' has been run successfully", recipe.Name]);
             return RedirectToAction("Index");
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Roles.Controllers
     {
         private readonly ISession _session;
         private readonly IAuthorizationService _authorizationService;
-        private readonly IStringLocalizer T;
+        private readonly IStringLocalizer S;
         private readonly ISiteService _siteService;
         private readonly IShapeFactory _shapeFactory;
         private readonly RoleManager<IRole> _roleManager;
@@ -32,7 +32,7 @@ namespace OrchardCore.Roles.Controllers
         private readonly ITypeFeatureProvider _typeFeatureProvider;
         private readonly IRoleService _roleService;
         private readonly INotifier _notifier;
-        private readonly IHtmlLocalizer<AdminController> TH;
+        private readonly IHtmlLocalizer<AdminController> H;
 
         public AdminController(
             IAuthorizationService authorizationService,
@@ -48,7 +48,7 @@ namespace OrchardCore.Roles.Controllers
             IEnumerable<IPermissionProvider> permissionProviders
             )
         {
-            TH = htmlLocalizer;
+            H = htmlLocalizer;
             _notifier = notifier;
             _roleService = roleService;
             _typeFeatureProvider = typeFeatureProvider;
@@ -56,7 +56,7 @@ namespace OrchardCore.Roles.Controllers
             _roleManager = roleManager;
             _shapeFactory = shapeFactory;
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
             _authorizationService = authorizationService;
             _session = session;
         }
@@ -100,12 +100,12 @@ namespace OrchardCore.Roles.Controllers
 
                 if (model.RoleName.Contains('/'))
                 {
-                    ModelState.AddModelError(string.Empty, T["Invalid role name."]);
+                    ModelState.AddModelError(string.Empty, S["Invalid role name."]);
                 }
                 
                 if (await _roleManager.FindByNameAsync(_roleManager.NormalizeKey(model.RoleName)) != null)
                 {
-                    ModelState.AddModelError(string.Empty, T["The role is already used."]);
+                    ModelState.AddModelError(string.Empty, S["The role is already used."]);
                 }
             }
 
@@ -115,7 +115,7 @@ namespace OrchardCore.Roles.Controllers
                 var result = await _roleManager.CreateAsync(role);
                 if (result.Succeeded)
                 {
-                    _notifier.Success(TH["Role created successfully"]);
+                    _notifier.Success(H["Role created successfully"]);
                     return RedirectToAction(nameof(Index));
                 }
 
@@ -151,13 +151,13 @@ namespace OrchardCore.Roles.Controllers
 
             if (result.Succeeded)
             {
-                _notifier.Success(TH["Role deleted successfully"]);
+                _notifier.Success(H["Role deleted successfully"]);
             }
             else
             {
                 _session.Cancel();
 
-                _notifier.Error(TH["Could not delete this role"]);
+                _notifier.Error(H["Could not delete this role"]);
 
                 foreach (var error in result.Errors)
                 {
@@ -229,7 +229,7 @@ namespace OrchardCore.Roles.Controllers
 
             await _roleManager.UpdateAsync(role);
 
-            _notifier.Success(TH["Role updated successfully."]);
+            _notifier.Success(H["Role updated successfully."]);
 
             return RedirectToAction(nameof(Index));
         }
@@ -258,7 +258,7 @@ namespace OrchardCore.Roles.Controllers
                 {
                     var category = permission.Category;
 
-                    string title = String.IsNullOrWhiteSpace(category) ? T["{0} Feature", featureName] : category;
+                    string title = String.IsNullOrWhiteSpace(category) ? S["{0} Feature", featureName] : category;
 
                     if (installedPermissions.ContainsKey(title))
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
@@ -161,7 +161,7 @@ namespace OrchardCore.Roles.Controllers
 
                 foreach (var error in result.Errors)
                 {
-                    _notifier.Error(TH[error.Description]);
+                    _notifier.Error(H[error.Description]);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleStore.cs
@@ -27,6 +27,7 @@ namespace OrchardCore.Roles.Services
         private readonly ISessionHelper _sessionHelper;
         private readonly IMemoryCache _memoryCache;
         private readonly IServiceProvider _serviceProvider;
+        private readonly IStringLocalizer<RoleStore> S;
 
         public RoleStore(
             ISignal signal,
@@ -42,13 +43,11 @@ namespace OrchardCore.Roles.Services
             _sessionHelper = sessionHelper;
             _memoryCache = memoryCache;
             _serviceProvider = serviceProvider;
-            T = stringLocalizer;
+            S = stringLocalizer;
             Logger = logger;
         }
 
         public ILogger Logger { get; }
-
-        public IStringLocalizer T { get; }
 
         public void Dispose()
         {
@@ -122,7 +121,7 @@ namespace OrchardCore.Roles.Services
             if (String.Equals(roleToRemove.NormalizedRoleName, "ANONYMOUS") ||
                 String.Equals(roleToRemove.NormalizedRoleName, "AUTHENTICATED"))
             {
-                return IdentityResult.Failed(new IdentityError { Description = T["Can't delete system roles."] });
+                return IdentityResult.Failed(new IdentityError { Description = S["Can't delete system roles."] });
             }
 
             var roleRemovedEventHandlers = _serviceProvider.GetRequiredService<IEnumerable<IRoleRemovedEventHandler>>();

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/CreateTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/CreateTenantTask.cs
@@ -22,8 +22,10 @@ namespace OrchardCore.Tenants.Workflows.Activities
         }
 
         public override string Name => nameof(CreateTenantTask);
-        public override LocalizedString Category => T["Tenant"];
-        public override LocalizedString DisplayText => T["Create Tenant Task"];
+
+        public override LocalizedString Category => S["Tenant"];
+
+        public override LocalizedString DisplayText => S["Create Tenant Task"];
 
         public string ContentType
         {
@@ -69,7 +71,7 @@ namespace OrchardCore.Tenants.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public async override Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/DisableTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/DisableTenantTask.cs
@@ -18,12 +18,14 @@ namespace OrchardCore.Tenants.Workflows.Activities
         }
 
         public override string Name => nameof(DisableTenantTask);
-        public override LocalizedString Category => T["Tenant"];
-        public override LocalizedString DisplayText => T["Disable Tenant Task"];
+        
+        public override LocalizedString Category => S["Tenant"];
+        
+        public override LocalizedString DisplayText => S["Disable Tenant Task"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Disabled"]);
+            return Outcomes(S["Disabled"]);
         }
 
         //public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/EnableTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/EnableTenantTask.cs
@@ -18,12 +18,14 @@ namespace OrchardCore.Tenants.Workflows.Activities
         }
 
         public override string Name => nameof(EnableTenantTask);
-        public override LocalizedString Category => T["Tenant"];
-        public override LocalizedString DisplayText => T["Enable Tenant Task"];
+        
+        public override LocalizedString Category => S["Tenant"];
+        
+        public override LocalizedString DisplayText => S["Enable Tenant Task"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Enabled"]);
+            return Outcomes(S["Enabled"]);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/SetupTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/SetupTenantTask.cs
@@ -33,8 +33,10 @@ namespace OrchardCore.Tenants.Workflows.Activities
         protected ISetupService SetupService { get; }
 
         public override string Name => nameof(SetupTenantTask);
-        public override LocalizedString Category => T["Tenant"];
-        public override LocalizedString DisplayText => T["Setup Tenant Task"];
+        
+        public override LocalizedString Category => S["Tenant"];
+        
+        public override LocalizedString DisplayText => S["Setup Tenant Task"];
 
         public WorkflowExpression<string> SiteName
         {
@@ -86,7 +88,7 @@ namespace OrchardCore.Tenants.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"], T["Failed"]);
+            return Outcomes(S["Done"], S["Failed"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/TenantActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/TenantActivity.cs
@@ -12,12 +12,14 @@ namespace OrchardCore.Tenants.Workflows.Activities
 {
     public abstract class TenantActivity : Activity
     {
+        protected readonly IStringLocalizer S;
+
         protected TenantActivity(IShellSettingsManager shellSettingsManager, IShellHost shellHost, IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer localizer)
         {
             ShellSettingsManager = shellSettingsManager;
             ShellHost = shellHost;
             ScriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
         public WorkflowExpression<string> TenantName
@@ -29,12 +31,12 @@ namespace OrchardCore.Tenants.Workflows.Activities
         protected IShellSettingsManager ShellSettingsManager { get; }
         protected IShellHost ShellHost { get; }
         protected IWorkflowScriptEvaluator ScriptEvaluator { get; }
-        protected IStringLocalizer T { get; }
-        public override LocalizedString Category => T["Tenant"];
+
+        public override LocalizedString Category => S["Tenant"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -28,6 +28,7 @@ namespace OrchardCore.Themes.Controllers
         private readonly IShellFeaturesManager _shellFeaturesManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly INotifier _notifier;
+        private readonly IHtmlLocalizer<AdminController> H;
 
         public AdminController(
             ISiteThemeService siteThemeService,
@@ -51,10 +52,8 @@ namespace OrchardCore.Themes.Controllers
             _authorizationService = authorizationService;
             _notifier = notifier;
 
-            T = localizer;
+            H = localizer;
         }
-
-        public IHtmlLocalizer T { get; }
 
         public async Task<ActionResult> Index()
         {
@@ -160,10 +159,10 @@ namespace OrchardCore.Themes.Controllers
                     if (!isEnabled)
                     {
                         await _shellFeaturesManager.EnableFeaturesAsync(new[] { feature }, force: true);
-                        _notifier.Success(T["{0} was enabled", feature.Name ?? feature.Id]);
+                        _notifier.Success(H["{0} was enabled", feature.Name ?? feature.Id]);
                     }
 
-                    _notifier.Success(T["{0} was set as the default {1} theme", feature.Name ?? feature.Id, isAdmin ? "Admin" : "Site"]);
+                    _notifier.Success(H["{0} was set as the default {1} theme", feature.Name ?? feature.Id, isAdmin ? "Admin" : "Site"]);
                 }
             }
 
@@ -180,7 +179,7 @@ namespace OrchardCore.Themes.Controllers
 
             await _siteThemeService.SetSiteThemeAsync("");
 
-            _notifier.Success(T["The Site theme was reset."]);
+            _notifier.Success(H["The Site theme was reset."]);
 
             return RedirectToAction("Index");
         }
@@ -195,7 +194,7 @@ namespace OrchardCore.Themes.Controllers
 
             await _adminThemeService.SetAdminThemeAsync("");
 
-            _notifier.Success(T["The Admin theme was reset."]);
+            _notifier.Success(H["The Admin theme was reset."]);
 
             return RedirectToAction("Index");
         }
@@ -217,7 +216,7 @@ namespace OrchardCore.Themes.Controllers
 
             await _shellFeaturesManager.DisableFeaturesAsync(new[] { feature }, force: true);
 
-            _notifier.Success(T["{0} was disabled", feature.Name ?? feature.Id]);
+            _notifier.Success(H["{0} was disabled", feature.Name ?? feature.Id]);
 
             return RedirectToAction("Index");
         }
@@ -225,7 +224,7 @@ namespace OrchardCore.Themes.Controllers
         [HttpPost]
         public async Task<IActionResult> Enable(string id)
         {
-            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ApplyTheme)) // , T["Not allowed to apply theme."]
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ApplyTheme)) // , H["Not allowed to apply theme."]
             {
                 return Unauthorized();
             }
@@ -239,7 +238,7 @@ namespace OrchardCore.Themes.Controllers
 
             await _shellFeaturesManager.EnableFeaturesAsync(new[] { feature }, force: true);
 
-            _notifier.Success(T["{0} was enabled", feature.Name ?? feature.Id]);
+            _notifier.Success(H["{0} was enabled", feature.Name ?? feature.Id]);
 
             return RedirectToAction("Index");
         }

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Services/ThemeService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Services/ThemeService.cs
@@ -18,13 +18,14 @@ namespace OrchardCore.Themes.Services
         private readonly ILogger _logger;
         private readonly INotifier _notifier;
         private readonly ISiteThemeService _siteThemeService;
+        private readonly IHtmlLocalizer<ThemeService> H;
 
         public ThemeService(
             IExtensionManager extensionManager,
             IShellFeaturesManager shellFeaturesManager,
             ISiteThemeService siteThemeService,
             ILogger<ThemeService> logger,
-            IHtmlLocalizer<AdminMenu> htmlLocalizer,
+            IHtmlLocalizer<ThemeService> htmlLocalizer,
             INotifier notifier)
         {
             _extensionManager = extensionManager;
@@ -33,10 +34,8 @@ namespace OrchardCore.Themes.Services
             
             _logger = logger;
             _notifier = notifier;
-            T = htmlLocalizer;
+            H = htmlLocalizer;
         }
-
-        public IHtmlLocalizer T { get; }
 
         public async Task DisableThemeFeaturesAsync(string themeName)
         {
@@ -44,7 +43,7 @@ namespace OrchardCore.Themes.Services
             while (themeName != null)
             {
                 if (themes.Contains(themeName))
-                    throw new InvalidOperationException(T["The theme \"{0}\" is already in the stack of themes that need features disabled.", themeName].ToString());
+                    throw new InvalidOperationException(H["The theme \"{0}\" is already in the stack of themes that need features disabled.", themeName].ToString());
                 var theme = _extensionManager.GetExtension(themeName);
                 if (theme == null)
                     break;
@@ -75,7 +74,7 @@ namespace OrchardCore.Themes.Services
             while (themeName != null)
             {
                 if (themes.Contains(themeName))
-                    throw new InvalidOperationException(T["The theme \"{0}\" is already in the stack of themes that need features enabled.", themeName].ToString());
+                    throw new InvalidOperationException(H["The theme \"{0}\" is already in the stack of themes that need features enabled.", themeName].ToString());
                 themes.Push(themeName);
 
                 var extensionInfo = _extensionManager.GetExtension(themeName);
@@ -116,7 +115,7 @@ namespace OrchardCore.Themes.Services
             var enabledFeatures = await _shellFeaturesManager.EnableFeaturesAsync(featuresToEnable, force);
             foreach (var enabledFeature in enabledFeatures)
             {
-                _notifier.Success(T["{0} was enabled.", enabledFeature.Name]);
+                _notifier.Success(H["{0} was enabled.", enabledFeature.Name]);
             }
         }
 
@@ -143,7 +142,7 @@ namespace OrchardCore.Themes.Services
             var features = await _shellFeaturesManager.DisableFeaturesAsync(featuresToDisable, force);
             foreach (var feature in features)
             {
-                _notifier.Success(T["{0} was disabled.", feature.Name]);
+                _notifier.Success(H["{0} was disabled.", feature.Name]);
             }
         }        
     }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Settings/TitlePartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Settings/TitlePartSettingsDisplayDriver.cs
@@ -14,14 +14,13 @@ namespace OrchardCore.Title.Settings
     public class TitlePartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
     {
         private readonly ILiquidTemplateManager _templateManager;
+        private readonly IStringLocalizer<TitlePartSettingsDisplayDriver> S;
 
         public TitlePartSettingsDisplayDriver(ILiquidTemplateManager templateManager, IStringLocalizer<TitlePartSettingsDisplayDriver> localizer)
         {
             _templateManager = templateManager;
-            T = localizer;
+            S = localizer;
         }
-
-        public IStringLocalizer T { get; }
 
         public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
         {
@@ -55,7 +54,7 @@ namespace OrchardCore.Title.Settings
 
             if (!string.IsNullOrEmpty(model.Pattern) && !_templateManager.Validate(model.Pattern, out var errors))
             {
-                context.Updater.ModelState.AddModelError(nameof(model.Pattern), T["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                context.Updater.ModelState.AddModelError(nameof(model.Pattern), S["Pattern doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Services/TwitterSettingsService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Services/TwitterSettingsService.cs
@@ -12,14 +12,14 @@ namespace OrchardCore.Twitter.Services
     public class TwitterSettingsService : ITwitterSettingsService
     {
         private readonly ISiteService _siteService;
-        private readonly IStringLocalizer<TwitterSettingsService> T;
+        private readonly IStringLocalizer<TwitterSettingsService> S;
 
         public TwitterSettingsService(
             ISiteService siteService,
             IStringLocalizer<TwitterSettingsService> stringLocalizer)
         {
             _siteService = siteService;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<TwitterSettings> GetSettingsAsync()
@@ -54,22 +54,22 @@ namespace OrchardCore.Twitter.Services
 
             if (string.IsNullOrWhiteSpace(settings.ConsumerKey))
             {
-                yield return new ValidationResult(T["ConsumerKey is required"], new string[] { nameof(settings.ConsumerKey) });
+                yield return new ValidationResult(S["ConsumerKey is required"], new string[] { nameof(settings.ConsumerKey) });
             }
 
             if (string.IsNullOrWhiteSpace(settings.ConsumerSecret))
             {
-                yield return new ValidationResult(T["ConsumerSecret is required"], new string[] { nameof(settings.ConsumerSecret) });
+                yield return new ValidationResult(S["ConsumerSecret is required"], new string[] { nameof(settings.ConsumerSecret) });
             }
 
             if (string.IsNullOrWhiteSpace(settings.AccessToken))
             {
-                yield return new ValidationResult(T["Access Token is required"], new string[] { nameof(settings.AccessToken) });
+                yield return new ValidationResult(S["Access Token is required"], new string[] { nameof(settings.AccessToken) });
             }
 
             if (string.IsNullOrWhiteSpace(settings.AccessTokenSecret))
             {
-                yield return new ValidationResult(T["Access Token Secret is required"], new string[] { nameof(settings.AccessTokenSecret) });
+                yield return new ValidationResult(S["Access Token Secret is required"], new string[] { nameof(settings.AccessTokenSecret) });
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Workflows/Activities/UpdateTwitterStatusTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Workflows/Activities/UpdateTwitterStatusTask.cs
@@ -20,25 +20,25 @@ namespace OrchardCore.Twitter.Workflows.Activities
     {
         private readonly TwitterClient _twitterClient;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
-        private readonly IStringLocalizer T;
+        private readonly IStringLocalizer<UpdateTwitterStatusTask> S;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IUpdateModelAccessor _updateModelAccessor;
 
-        public UpdateTwitterStatusTask(TwitterClient twitterClient, IWorkflowExpressionEvaluator expressionEvaluator, IHttpContextAccessor httpContextAccessor, IUpdateModelAccessor updateModelAccessor, IStringLocalizer<UpdateTwitterStatusTask> t)
+        public UpdateTwitterStatusTask(TwitterClient twitterClient, IWorkflowExpressionEvaluator expressionEvaluator, IHttpContextAccessor httpContextAccessor, IUpdateModelAccessor updateModelAccessor, IStringLocalizer<UpdateTwitterStatusTask> localizer)
         {
             _twitterClient = twitterClient;
             _expressionEvaluator = expressionEvaluator;
             _httpContextAccessor = httpContextAccessor;
             _updateModelAccessor = updateModelAccessor;
-            T = t;
+            S = localizer;
         }
 
         // The technical name of the activity. Activities on a workflow definition reference this name.
         public override string Name => nameof(UpdateTwitterStatusTask);
-        public override LocalizedString DisplayText => T["Update Twitter Status Task"];
+        public override LocalizedString DisplayText => S["Update Twitter Status Task"];
 
         // The category to which this activity belongs. The activity picker groups activities by this category.
-        public override LocalizedString Category => T["Social"];
+        public override LocalizedString Category => S["Social"];
 
         // The message to display.
         public WorkflowExpression<string> StatusTemplate
@@ -50,7 +50,7 @@ namespace OrchardCore.Twitter.Workflows.Activities
         // Returns the possible outcomes of this activity.
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"], T["Failed"]);
+            return Outcomes(S["Done"], S["Failed"]);
         }
 
         // This is the heart of the activity and actually performs the work to be done.

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
@@ -43,6 +43,7 @@ namespace OrchardCore.Users.Controllers
         private readonly IClock _clock;
         private readonly IDistributedCache _distributedCache;
         private readonly IEnumerable<IExternalLoginEventHandler> _externalLoginHandlers;
+        private readonly IStringLocalizer<AccountController> S;
 
         public AccountController(
             IUserService userService,
@@ -69,10 +70,8 @@ namespace OrchardCore.Users.Controllers
             _distributedCache = distributedCache;
             _dataProtectionProvider = dataProtectionProvider;
             _externalLoginHandlers = externalLoginHandlers;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
-
-        IStringLocalizer T { get; set; }
 
         [HttpGet]
         [AllowAnonymous]
@@ -151,7 +150,7 @@ namespace OrchardCore.Users.Controllers
                 // Require that the users have a confirmed email before they can log on.
                 if (!await _userManager.IsEmailConfirmedAsync(user))
                 {
-                    ModelState.AddModelError(string.Empty, T["You must confirm your email."]);
+                    ModelState.AddModelError(string.Empty, S["You must confirm your email."]);
                     return true;
                 }
             }
@@ -165,7 +164,7 @@ namespace OrchardCore.Users.Controllers
 
             if (localUser == null || !localUser.IsEnabled)
             {
-                ModelState.AddModelError(String.Empty, T["Your account is disabled. Please contact an administrator."]);
+                ModelState.AddModelError(String.Empty, S["Your account is disabled. Please contact an administrator."]);
                 return true;
             }
             
@@ -187,7 +186,7 @@ namespace OrchardCore.Users.Controllers
                 var disableLocalLogin = (await _siteService.GetSiteSettingsAsync()).As<LoginSettings>().DisableLocalLogin;
                 if (disableLocalLogin)
                 {
-                    ModelState.AddModelError("", T["Local login is disabled."]);
+                    ModelState.AddModelError("", S["Local login is disabled."]);
                 }
                 else
                 {
@@ -213,7 +212,7 @@ namespace OrchardCore.Users.Controllers
                             }
                         }
                     }
-                    ModelState.AddModelError(string.Empty, T["Invalid login attempt."]);
+                    ModelState.AddModelError(string.Empty, S["Invalid login attempt."]);
                     await _accountEvents.InvokeAsync((e, model) => e.LoggingInFailedAsync(model.UserName), model, _logger);
                 }
             }
@@ -391,7 +390,7 @@ namespace OrchardCore.Users.Controllers
                     }
                     else
                     {
-                        ModelState.AddModelError(string.Empty, T["Invalid login attempt."]);
+                        ModelState.AddModelError(string.Empty, S["Invalid login attempt."]);
                     }
                 }
             }
@@ -419,7 +418,7 @@ namespace OrchardCore.Users.Controllers
                     // no user could be matched, check if a new user can register
                     if (registrationSettings.UsersCanRegister == UserRegistrationType.NoRegistration)
                     {
-                        string message = T["Site does not allow user registration."];
+                        string message = S["Site does not allow user registration."];
                         _logger.LogWarning(message);
                         ModelState.AddModelError("", message);
                     }
@@ -449,7 +448,7 @@ namespace OrchardCore.Users.Controllers
                                 Email = externalLoginViewModel.Email,
                                 Password = null,
                                 ConfirmPassword = null
-                            }, T["Confirm your account"], _logger);
+                            }, S["Confirm your account"], _logger);
 
                             // If the registration was successfull we can link the external provider and redirect the user
                             if (user != null)
@@ -468,7 +467,7 @@ namespace OrchardCore.Users.Controllers
                                     }
                                     else
                                     {
-                                        ModelState.AddModelError(string.Empty, T["Invalid login attempt."]);
+                                        ModelState.AddModelError(string.Empty, S["Invalid login attempt."]);
                                         return View(nameof(Login));
                                     }
                                 }
@@ -533,7 +532,7 @@ namespace OrchardCore.Users.Controllers
 
             if (TryValidateModel(model) && ModelState.IsValid)
             {
-                user = await this.RegisterUser(new RegisterViewModel() { UserName = model.UserName, Email = model.Email, Password = model.Password, ConfirmPassword = model.ConfirmPassword }, T["Confirm your account"], _logger);
+                user = await this.RegisterUser(new RegisterViewModel() { UserName = model.UserName, Email = model.Email, Password = model.Password, ConfirmPassword = model.ConfirmPassword }, S["Confirm your account"], _logger);
                 if (user is null)
                 {
                     ModelState.AddModelError(string.Empty, "Registration Failed.");
@@ -592,7 +591,7 @@ namespace OrchardCore.Users.Controllers
             if (!signInResult.Succeeded)
             {
                 user = null;
-                ModelState.AddModelError(string.Empty, T["Invalid login attempt."]);
+                ModelState.AddModelError(string.Empty, S["Invalid login attempt."]);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
@@ -360,7 +360,7 @@ namespace OrchardCore.Users.Controllers
 
                 foreach (var error in result.Errors)
                 {
-                    _notifier.Error(TH[error.Description]);
+                    _notifier.Error(H[error.Description]);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.Users.Controllers
         private readonly IUserService _userService;
 
         private readonly dynamic New;
-        private readonly IHtmlLocalizer TH;
+        private readonly IHtmlLocalizer H;
 
         public AdminController(
             IDisplayManager<User> userDisplayManager,
@@ -57,7 +57,7 @@ namespace OrchardCore.Users.Controllers
             _userService = userService;
 
             New = shapeFactory;
-            TH = htmlLocalizer;
+            H = htmlLocalizer;
         }
         public async Task<ActionResult> Index(UserIndexOptions options, PagerParameters pagerParameters)
         {
@@ -149,24 +149,24 @@ namespace OrchardCore.Users.Controllers
             };
 
             model.Options.UserFilters = new List<SelectListItem>() {
-                new SelectListItem() { Text = TH["All"].Value, Value = nameof(UsersFilter.All) },
-                //new SelectListItem() { Text = TH["Approved"].Value, Value = nameof(UsersFilter.Approved) },
-                //new SelectListItem() { Text = TH["Email pending"].Value, Value = nameof(UsersFilter.EmailPending) },
-                //new SelectListItem() { Text = TH["Pending"].Value, Value = nameof(UsersFilter.Pending) }
+                new SelectListItem() { Text = H["All"].Value, Value = nameof(UsersFilter.All) },
+                //new SelectListItem() { Text = H["Approved"].Value, Value = nameof(UsersFilter.Approved) },
+                //new SelectListItem() { Text = H["Email pending"].Value, Value = nameof(UsersFilter.EmailPending) },
+                //new SelectListItem() { Text = H["Pending"].Value, Value = nameof(UsersFilter.Pending) }
             };
 
             model.Options.UserSorts = new List<SelectListItem>() {
-                new SelectListItem() { Text = TH["Name"].Value, Value = nameof(UsersOrder.Name) },
-                new SelectListItem() { Text = TH["Email"].Value, Value = nameof(UsersOrder.Email) },
-                //new SelectListItem() { Text = TH["Created date"].Value, Value = nameof(UsersOrder.CreatedUtc) },
-                //new SelectListItem() { Text = TH["Last Login date"].Value, Value = nameof(UsersOrder.LastLoginUtc) }
+                new SelectListItem() { Text = H["Name"].Value, Value = nameof(UsersOrder.Name) },
+                new SelectListItem() { Text = H["Email"].Value, Value = nameof(UsersOrder.Email) },
+                //new SelectListItem() { Text = H["Created date"].Value, Value = nameof(UsersOrder.CreatedUtc) },
+                //new SelectListItem() { Text = H["Last Login date"].Value, Value = nameof(UsersOrder.LastLoginUtc) }
             };
 
             model.Options.UsersBulkAction = new List<SelectListItem>() {
-                new SelectListItem() { Text = TH["Approve"].Value, Value = nameof(UsersBulkAction.Approve) },
-                new SelectListItem() { Text = TH["Enable"].Value, Value = nameof(UsersBulkAction.Enable) },
-                new SelectListItem() { Text = TH["Disable"].Value, Value = nameof(UsersBulkAction.Disable) },
-                new SelectListItem() { Text = TH["Delete"].Value, Value = nameof(UsersBulkAction.Delete) }
+                new SelectListItem() { Text = H["Approve"].Value, Value = nameof(UsersBulkAction.Approve) },
+                new SelectListItem() { Text = H["Enable"].Value, Value = nameof(UsersBulkAction.Enable) },
+                new SelectListItem() { Text = H["Disable"].Value, Value = nameof(UsersBulkAction.Disable) },
+                new SelectListItem() { Text = H["Delete"].Value, Value = nameof(UsersBulkAction.Delete) }
             };
 
             return View(model);
@@ -199,14 +199,14 @@ namespace OrchardCore.Users.Controllers
                         {
                             var token = await _userManager.GenerateEmailConfirmationTokenAsync(item);
                             await _userManager.ConfirmEmailAsync(item, token);
-                            _notifier.Success(TH["User {0} successfully approved.", item.UserName]);
+                            _notifier.Success(H["User {0} successfully approved.", item.UserName]);
                         }
                         break;
                     case UsersBulkAction.Delete:
                         foreach (var item in checkedContentItems)
                         {
                             await _userManager.DeleteAsync(item);
-                            _notifier.Success(TH["User {0} successfully deleted.", item.UserName]);
+                            _notifier.Success(H["User {0} successfully deleted.", item.UserName]);
                         }
                         break;
                     case UsersBulkAction.Disable:
@@ -214,7 +214,7 @@ namespace OrchardCore.Users.Controllers
                         {
                             item.IsEnabled = false;
                             await _userManager.UpdateAsync(item);
-                            _notifier.Success(TH["User {0} successfully disabled.", item.UserName]);
+                            _notifier.Success(H["User {0} successfully disabled.", item.UserName]);
                         }
                         break;
                     case UsersBulkAction.Enable:
@@ -222,7 +222,7 @@ namespace OrchardCore.Users.Controllers
                         {
                             item.IsEnabled = true;
                             await _userManager.UpdateAsync(item);
-                            _notifier.Success(TH["User {0} successfully enabled.", item.UserName]);
+                            _notifier.Success(H["User {0} successfully enabled.", item.UserName]);
                         }
                         break;
                     default:
@@ -269,7 +269,7 @@ namespace OrchardCore.Users.Controllers
                 return View(shape);
             }
 
-            _notifier.Success(TH["User created successfully"]);
+            _notifier.Success(H["User created successfully"]);
 
             return RedirectToAction(nameof(Index));
         }
@@ -326,7 +326,7 @@ namespace OrchardCore.Users.Controllers
                 return View(shape);
             }
 
-            _notifier.Success(TH["User updated successfully"]);
+            _notifier.Success(H["User updated successfully"]);
 
             return RedirectToAction(nameof(Index));
         }
@@ -350,13 +350,13 @@ namespace OrchardCore.Users.Controllers
 
             if (result.Succeeded)
             {
-                _notifier.Success(TH["User deleted successfully"]);
+                _notifier.Success(H["User deleted successfully"]);
             }
             else
             {
                 _session.Cancel();
 
-                _notifier.Error(TH["Could not delete the user"]);
+                _notifier.Error(H["Could not delete the user"]);
 
                 foreach (var error in result.Errors)
                 {
@@ -407,7 +407,7 @@ namespace OrchardCore.Users.Controllers
 
                 if (await _userService.ResetPasswordAsync(model.Email, token, model.NewPassword, ModelState.AddModelError))
                 {
-                    _notifier.Success(TH["Password updated correctly."]);
+                    _notifier.Success(H["Password updated correctly."]);
 
                     return RedirectToAction(nameof(Index));
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/RegistrationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/RegistrationController.cs
@@ -20,8 +20,10 @@ namespace OrchardCore.Users.Controllers
         private readonly UserManager<IUser> _userManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly ISiteService _siteService;
-
         private readonly INotifier _notifier;
+        private readonly ILogger _logger;
+        private readonly IStringLocalizer<RegistrationController> S;
+        private readonly IHtmlLocalizer<RegistrationController> H;
 
         public RegistrationController(
             UserManager<IUser> userManager,
@@ -36,15 +38,10 @@ namespace OrchardCore.Users.Controllers
             _authorizationService = authorizationService;
             _siteService = siteService;
             _notifier = notifier;
-
             _logger = logger;
-            TH = htmlLocalizer;
-            T = stringLocalizer;
+            H = htmlLocalizer;
+            S = stringLocalizer;
         }
-
-        ILogger _logger;
-        IHtmlLocalizer TH { get; set; }
-        IStringLocalizer T { get; set; }
 
         [HttpGet]
         [AllowAnonymous]
@@ -75,7 +72,7 @@ namespace OrchardCore.Users.Controllers
             ViewData["ReturnUrl"] = returnUrl;
 
             // If we get a user, redirect to returnUrl
-            if (await this.RegisterUser(model, T["Confirm your account"], _logger) != null)
+            if (await this.RegisterUser(model, S["Confirm your account"], _logger) != null)
             {
                 return RedirectToLocal(returnUrl);
             }
@@ -123,9 +120,9 @@ namespace OrchardCore.Users.Controllers
             var user = await _userManager.FindByIdAsync(id) as User;
             if (user != null)
             {
-                await this.SendEmailConfirmationTokenAsync(user, T["Confirm your account"]);
+                await this.SendEmailConfirmationTokenAsync(user, S["Confirm your account"]);
 
-                _notifier.Success(TH["Verification email sent."]);
+                _notifier.Success(H["Verification email sent."]);
             }
 
             return RedirectToAction(nameof(AdminController.Index), "Admin");

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ResetPasswordController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ResetPasswordController.cs
@@ -27,6 +27,7 @@ namespace OrchardCore.Users.Controllers
         private readonly ISiteService _siteService;
         private readonly IEnumerable<IPasswordRecoveryFormEvents> _passwordRecoveryFormEvents;
         private readonly ILogger<ResetPasswordController> _logger;
+        private readonly IStringLocalizer<ResetPasswordController> S;
 
         public ResetPasswordController(
             IUserService userService,
@@ -42,12 +43,10 @@ namespace OrchardCore.Users.Controllers
             _userManager = userManager;
             _siteService = siteService;
 
-            T = stringLocalizer;
+            S = stringLocalizer;
             _logger = logger;
             _passwordRecoveryFormEvents = passwordRecoveryFormEvents;
         }
-
-        IStringLocalizer T { get; set; }
 
         [HttpGet]
         [AllowAnonymous]
@@ -87,7 +86,7 @@ namespace OrchardCore.Users.Controllers
                 user.ResetToken = Convert.ToBase64String(Encoding.UTF8.GetBytes(user.ResetToken));
                 var resetPasswordUrl = Url.Action("ResetPassword", "ResetPassword", new { code = user.ResetToken }, HttpContext.Request.Scheme);
                 // send email with callback link
-                await this.SendEmailAsync(user.Email, T["Reset your password"], new LostPasswordViewModel() { User = user, LostPasswordUrl = resetPasswordUrl });
+                await this.SendEmailAsync(user.Email, S["Reset your password"], new LostPasswordViewModel() { User = user, LostPasswordUrl = resetPasswordUrl });
 
                 await _passwordRecoveryFormEvents.InvokeAsync(i => i.PasswordRecoveredAsync(), _logger);
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -18,7 +18,7 @@ namespace OrchardCore.Users.Drivers
         private readonly UserManager<IUser> _userManager;
         private readonly IRoleService _roleService;
         private readonly IUserRoleStore<IUser> _userRoleStore;
-        private readonly IStringLocalizer T;
+        private readonly IStringLocalizer<UserDisplayDriver> S;
 
         public UserDisplayDriver(
             UserManager<IUser> userManager,
@@ -29,7 +29,7 @@ namespace OrchardCore.Users.Drivers
             _userManager = userManager;
             _roleService = roleService;
             _userRoleStore = userRoleStore;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public override IDisplayResult Display(User user)
@@ -72,12 +72,12 @@ namespace OrchardCore.Users.Drivers
 
             if (string.IsNullOrWhiteSpace(model.UserName))
             {
-                context.Updater.ModelState.AddModelError("UserName", T["A user name is required."]);
+                context.Updater.ModelState.AddModelError("UserName", S["A user name is required."]);
             }
 
             if (string.IsNullOrWhiteSpace(model.Email))
             {
-                context.Updater.ModelState.AddModelError("Email", T["An email is required."]);
+                context.Updater.ModelState.AddModelError("Email", S["An email is required."]);
             }
 
             var userWithSameName = await _userManager.FindByNameAsync(model.UserName);
@@ -86,7 +86,7 @@ namespace OrchardCore.Users.Drivers
                 var userWithSameNameId = await _userManager.GetUserIdAsync(userWithSameName);
                 if (userWithSameNameId != model.Id)
                 {
-                    context.Updater.ModelState.AddModelError(string.Empty, T["The user name is already used."]);
+                    context.Updater.ModelState.AddModelError(string.Empty, S["The user name is already used."]);
                 }
             }
 
@@ -96,7 +96,7 @@ namespace OrchardCore.Users.Drivers
                 var userWithSameEmailId = await _userManager.GetUserIdAsync(userWithSameEmail);
                 if (userWithSameEmailId != model.Id)
                 {
-                    context.Updater.ModelState.AddModelError(string.Empty, T["The email is already used."]);
+                    context.Updater.ModelState.AddModelError(string.Empty, S["The email is already used."]);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/AssignUserRoleTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/AssignUserRoleTask.cs
@@ -19,18 +19,21 @@ namespace OrchardCore.Users.Workflows.Activities
         private readonly IUserService _userService;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
 
-        public AssignUserRoleTask(UserManager<IUser> userManager, IUserService userService, IWorkflowExpressionEvaluator expressionvaluator, IStringLocalizer<AssignUserRoleTask> t)
+        private readonly IStringLocalizer<AssignUserRoleTask> S;
+        
+        public AssignUserRoleTask(UserManager<IUser> userManager, IUserService userService, IWorkflowExpressionEvaluator expressionvaluator, IStringLocalizer<AssignUserRoleTask> localizer)
         {
             _userManager = userManager;
             _userService = userService;
             _expressionEvaluator = expressionvaluator;
-            T = t;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; set; }
         public override string Name => nameof(AssignUserRoleTask);
-        public override LocalizedString DisplayText => T["Assign User Role Task"];
-        public override LocalizedString Category => T["User"];
+        
+        public override LocalizedString DisplayText => S["Assign User Role Task"];
+        
+        public override LocalizedString Category => S["User"];
 
         public WorkflowExpression<string> UserName
         {
@@ -46,7 +49,7 @@ namespace OrchardCore.Users.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"], T["Failed"]);
+            return Outcomes(S["Done"], S["Failed"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Users.Workflows.Activities
         private readonly LinkGenerator _linkGenerator;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IUpdateModelAccessor _updateModelAccessor;
-        private readonly IStringLocalizer T;
+        private readonly IStringLocalizer<RegisterUserTask> S;
 
         public RegisterUserTask(
             IUserService userService,
@@ -34,7 +34,7 @@ namespace OrchardCore.Users.Workflows.Activities
             LinkGenerator linkGenerator,
             IHttpContextAccessor httpContextAccessor,
             IUpdateModelAccessor updateModelAccessor,
-            IStringLocalizer<RegisterUserTask> t)
+            IStringLocalizer<RegisterUserTask> localizer)
         {
             _userService = userService;
             _userManager = userManager;
@@ -42,15 +42,16 @@ namespace OrchardCore.Users.Workflows.Activities
             _linkGenerator = linkGenerator;
             _httpContextAccessor = httpContextAccessor;
             _updateModelAccessor = updateModelAccessor;
-            T = t;
+            S = localizer;
         }
 
         // The technical name of the activity. Activities on a workflow definition reference this name.
         public override string Name => nameof(RegisterUserTask);
-        public override LocalizedString DisplayText => T["Register User Task"];
+        
+        public override LocalizedString DisplayText => S["Register User Task"];
 
         // The category to which this activity belongs. The activity picker groups activities by this category.
-        public override LocalizedString Category => T["Content"];
+        public override LocalizedString Category => S["Content"];
 
         // The message to display.
         public bool SendConfirmationEmail
@@ -76,7 +77,7 @@ namespace OrchardCore.Users.Workflows.Activities
         // Returns the possible outcomes of this activity.
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"], T["Valid"], T["Invalid"]);
+            return Outcomes(S["Done"], S["Valid"], S["Invalid"]);
         }
 
         // This is the heart of the activity and actually performs the work to be done.
@@ -109,7 +110,7 @@ namespace OrchardCore.Users.Workflows.Activities
                     {
                         foreach (var item in errors)
                         {
-                            updater.ModelState.TryAddModelError(item.Key, T[item.Value]);
+                            updater.ModelState.TryAddModelError(item.Key, S[item.Value]);
                         }
                     }
                     outcome = "Invalid";
@@ -142,7 +143,7 @@ namespace OrchardCore.Users.Workflows.Activities
                         var updater = _updateModelAccessor.ModelUpdater;
                         if (updater != null)
                         {
-                            updater.ModelState.TryAddModelError("", T["No email service is available"]);
+                            updater.ModelState.TryAddModelError("", S["No email service is available"]);
                         }
                         outcome = "Invalid";
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/UserActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/UserActivity.cs
@@ -11,17 +11,20 @@ namespace OrchardCore.Users.Workflows.Activities
 {
     public abstract class UserActivity : Activity
     {
+        protected readonly IStringLocalizer S;
+        
         protected UserActivity(IUserService userService, IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer localizer)
         {
             UserService = userService;
             ScriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
         protected IUserService UserService { get; }
+
         protected IWorkflowScriptEvaluator ScriptEvaluator { get; }
-        protected IStringLocalizer T { get; }
-        public override LocalizedString Category => T["User"];
+
+        public override LocalizedString Category => S["User"];
 
         /// <summary>
         /// An expression that evaluates to an <see cref="User"/> item.
@@ -34,7 +37,7 @@ namespace OrchardCore.Users.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/UserCreatedEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/UserCreatedEvent.cs
@@ -12,6 +12,7 @@ namespace OrchardCore.Users.Workflows.Activities
         }
 
         public override string Name => nameof(UserCreatedEvent);
-        public override LocalizedString DisplayText => T["User Created Event"];
+        
+        public override LocalizedString DisplayText => S["User Created Event"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/UserLoggedInEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/UserLoggedInEvent.cs
@@ -12,6 +12,7 @@ namespace OrchardCore.Users.Workflows.Activities
         }
 
         public override string Name => nameof(UserLoggedInEvent);
-        public override LocalizedString DisplayText => T["User Loggedin Event"];
+        
+        public override LocalizedString DisplayText => S["User Loggedin Event"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CommitTransactionTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CommitTransactionTask.cs
@@ -11,19 +11,23 @@ namespace OrchardCore.Workflows.Activities
 {
     public class CommitTransactionTask : TaskActivity
     {
+        private readonly IStringLocalizer<CommitTransactionTask> S;
+        
         public CommitTransactionTask(IStringLocalizer<CommitTransactionTask> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
 
         private IStringLocalizer T { get; }
         public override string Name => nameof(CommitTransactionTask);
-        public override LocalizedString DisplayText => T["Commit Transaction Task"];
-        public override LocalizedString Category => T["Primitives"];
+        
+        public override LocalizedString DisplayText => S["Commit Transaction Task"];
+        
+        public override LocalizedString Category => S["Primitives"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CorrelateTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CorrelateTask.cs
@@ -10,18 +10,19 @@ namespace OrchardCore.Workflows.Activities
     public class CorrelateTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<CorrelateTask> S;
 
         public CorrelateTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<CorrelateTask> localizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(CorrelateTask);
-        public override LocalizedString DisplayText => T["Correlate Task"];
-        public override LocalizedString Category => T["Primitives"];
+        
+        public override LocalizedString DisplayText => S["Correlate Task"];
+        
+        public override LocalizedString Category => S["Primitives"];
 
         public WorkflowExpression<string> Value
         {
@@ -31,7 +32,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForEachTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForEachTask.cs
@@ -11,18 +11,18 @@ namespace OrchardCore.Workflows.Activities
     public class ForEachTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<ForEachTask> S;
 
         public ForEachTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<ForEachTask> localizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
-
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(ForEachTask);
-        public override LocalizedString DisplayText => T["For Each Task"];
-        public override LocalizedString Category => T["Control Flow"];
+        
+        public override LocalizedString DisplayText => S["For Each Task"];
+        
+        public override LocalizedString Category => S["Control Flow"];
 
         /// <summary>
         /// An expression evaluating to an enumerable object to iterate over.
@@ -62,7 +62,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Iterate"], T["Done"]);
+            return Outcomes(S["Iterate"], S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForLoopTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForLoopTask.cs
@@ -10,18 +10,19 @@ namespace OrchardCore.Workflows.Activities
     public class ForLoopTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<ForLoopTask> S;
 
         public ForLoopTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<ForLoopTask> localizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(ForLoopTask);
-        public override LocalizedString DisplayText => T["For Loop Task"];
-        public override LocalizedString Category => T["Control Flow"];
+        
+        public override LocalizedString DisplayText => S["For Loop Task"];
+        
+        public override LocalizedString Category => S["Control Flow"];
 
         /// <summary>
         /// An expression evaluating to the start value.
@@ -70,7 +71,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Iterate"], T["Done"]);
+            return Outcomes(S["Iterate"], S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForkTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ForkTask.cs
@@ -8,16 +8,18 @@ namespace OrchardCore.Workflows.Activities
 {
     public class ForkTask : TaskActivity
     {
+        private readonly IStringLocalizer<ForkTask> S;
+
         public ForkTask(IStringLocalizer<ForkTask> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(ForkTask);
-        public override LocalizedString DisplayText => T["Fork Task"];
-        public override LocalizedString Category => T["Control Flow"];
+        
+        public override LocalizedString DisplayText => S["Fork Task"];
+        
+        public override LocalizedString Category => S["Control Flow"];
 
         public IList<string> Forks
         {
@@ -27,7 +29,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Forks.Select(x => Outcome(T[x]));
+            return Forks.Select(x => Outcome(S[x]));
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/IfElseTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/IfElseTask.cs
@@ -10,18 +10,18 @@ namespace OrchardCore.Workflows.Activities
     public class IfElseTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<IfElseTask> S;
 
         public IfElseTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<IfElseTask> localizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
-
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(IfElseTask);
-        public override LocalizedString DisplayText => T["If Else Task"];
-        public override LocalizedString Category => T["Control Flow"];
+        
+        public override LocalizedString DisplayText => S["If Else Task"];
+        
+        public override LocalizedString Category => S["Control Flow"];
 
         /// <summary>
         /// A script evaluating to either true or false.
@@ -34,7 +34,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["True"], T["False"]);
+            return Outcomes(S["True"], S["False"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/JoinTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/JoinTask.cs
@@ -9,6 +9,8 @@ namespace OrchardCore.Workflows.Activities
 {
     public class JoinTask : TaskActivity
     {
+        private readonly IStringLocalizer<JoinTask> S;
+        
         public enum JoinMode
         {
             WaitAll,
@@ -17,14 +19,14 @@ namespace OrchardCore.Workflows.Activities
 
         public JoinTask(IStringLocalizer<JoinTask> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(JoinTask);
-        public override LocalizedString DisplayText => T["Join Task"];
-        public override LocalizedString Category => T["Control Flow"];
+        
+        public override LocalizedString DisplayText => S["Join Task"];
+        
+        public override LocalizedString Category => S["Control Flow"];
 
         public JoinMode Mode
         {
@@ -40,7 +42,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Joined"]);
+            return Outcomes(S["Joined"]);
         }
 
         public override ActivityExecutionResult Execute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/LogTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/LogTask.cs
@@ -12,18 +12,19 @@ namespace OrchardCore.Workflows.Activities
     {
         private readonly ILogger<LogTask> _logger;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
-
-        public LogTask(ILogger<LogTask> logger, IWorkflowExpressionEvaluator expressionEvaluator, IStringLocalizer<NotifyTask> localizer)
+        private readonly IStringLocalizer<LogTask> S;
+        
+        public LogTask(ILogger<LogTask> logger, IWorkflowExpressionEvaluator expressionEvaluator, IStringLocalizer<LogTask> localizer)
         {
             _logger = logger;
             _expressionEvaluator = expressionEvaluator;
-            T = localizer;
+            S = localizer;
         }
-
-        private IStringLocalizer T { get; }
         public override string Name => nameof(LogTask);
-        public override LocalizedString DisplayText => T["Log Task"];
-        public override LocalizedString Category => T["Primitives"];
+        
+        public override LocalizedString DisplayText => S["Log Task"];
+        
+        public override LocalizedString Category => S["Primitives"];
 
         public LogLevel LogLevel
         {
@@ -39,7 +40,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/MissingActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/MissingActivity.cs
@@ -12,19 +12,20 @@ namespace OrchardCore.Workflows.Activities
     public class MissingActivity : Activity
     {
         private readonly ILogger<MissingActivity> _logger;
+        private readonly IStringLocalizer<MissingActivity> S;
 
         public MissingActivity(IStringLocalizer<MissingActivity> localizer, ILogger<MissingActivity> logger, ActivityRecord missingActivityRecord)
         {
-            T = localizer;
+            S = localizer;
             _logger = logger;
             MissingActivityRecord = missingActivityRecord;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(MissingActivity);
-        public override LocalizedString DisplayText => T["Missing Activity"];
-        public override LocalizedString Category => T["Exceptions"];
+        
+        public override LocalizedString DisplayText => S["Missing Activity"];
+        
+        public override LocalizedString Category => S["Exceptions"];
 
         public ActivityRecord MissingActivityRecord { get; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/NotifyTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/NotifyTask.cs
@@ -13,18 +13,20 @@ namespace OrchardCore.Workflows.Activities
     {
         private readonly INotifier _notifier;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
+        private readonly IStringLocalizer<NotifyTask> S;
 
-        public NotifyTask(INotifier notifier, IWorkflowExpressionEvaluator expressionvaluator, IStringLocalizer<NotifyTask> t)
+        public NotifyTask(INotifier notifier, IWorkflowExpressionEvaluator expressionvaluator, IStringLocalizer<NotifyTask> localizer)
         {
             _notifier = notifier;
             _expressionEvaluator = expressionvaluator;
-            T = t;
+            S = localizer;
         }
         
-        private IStringLocalizer T { get; set; }
         public override string Name => nameof(NotifyTask);
-        public override LocalizedString DisplayText => T["Notify Task"];
-        public override LocalizedString Category => T["UI"];
+        
+        public override LocalizedString DisplayText => S["Notify Task"];
+        
+        public override LocalizedString Category => S["UI"];
 
         public NotifyType NotificationType
         {
@@ -40,7 +42,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ScriptTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/ScriptTask.cs
@@ -12,18 +12,19 @@ namespace OrchardCore.Workflows.Activities
     public class ScriptTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<ScriptTask> S;
 
         public ScriptTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<ScriptTask> localizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(ScriptTask);
-        public override LocalizedString DisplayText => T["Script Task"];
-        public override LocalizedString Category => T["Control Flow"];
+        
+        public override LocalizedString DisplayText => S["Script Task"];
+        
+        public override LocalizedString Category => S["Control Flow"];
 
         public IList<string> AvailableOutcomes
         {
@@ -42,7 +43,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(AvailableOutcomes.Select(x => T[x]).ToArray());
+            return Outcomes(AvailableOutcomes.Select(x => S[x]).ToArray());
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SetOutputTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SetOutputTask.cs
@@ -10,18 +10,19 @@ namespace OrchardCore.Workflows.Activities
     public class SetOutputTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<SetOutputTask> S;
 
         public SetOutputTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<SetOutputTask> localizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(SetOutputTask);
-        public override LocalizedString DisplayText => T["Set Output Task"];
-        public override LocalizedString Category => T["Primitives"];
+        
+        public override LocalizedString DisplayText => S["Set Output Task"];
+        
+        public override LocalizedString Category => S["Primitives"];
 
         public string OutputName
         {
@@ -37,7 +38,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SetPropertyTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SetPropertyTask.cs
@@ -10,18 +10,19 @@ namespace OrchardCore.Workflows.Activities
     public class SetPropertyTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<SetPropertyTask> S;
 
         public SetPropertyTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<SetPropertyTask> localizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(SetPropertyTask);
-        public override LocalizedString DisplayText => T["Set Property Task"];
-        public override LocalizedString Category => T["Primitives"];
+        
+        public override LocalizedString DisplayText => S["Set Property Task"];
+        
+        public override LocalizedString Category => S["Primitives"];
 
         public string PropertyName
         {
@@ -37,7 +38,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/WhileLoopTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/WhileLoopTask.cs
@@ -10,18 +10,19 @@ namespace OrchardCore.Workflows.Activities
     public class WhileLoopTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<WhileLoopTask> S;
 
         public WhileLoopTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<WhileLoopTask> localizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = localizer;
+            S = localizer;
         }
-        
-        private IStringLocalizer T { get; }
 
         public override string Name => nameof(WhileLoopTask);
-        public override LocalizedString DisplayText => T["While Loop Task"];
-        public override LocalizedString Category => T["Control Flow"];
+        
+        public override LocalizedString DisplayText => S["While Loop Task"];
+        
+        public override LocalizedString Category => S["Control Flow"];
 
         /// <summary>
         /// An expression evaluating to true or false.
@@ -34,7 +35,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Iterate"], T["Done"]);
+            return Outcomes(S["Iterate"], S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -39,6 +39,7 @@ namespace OrchardCore.Workflows.Controllers
         private readonly IActivityDisplayManager _activityDisplayManager;
         private readonly INotifier _notifier;
         private readonly ILogger<WorkflowController> _logger;
+        private readonly IHtmlLocalizer<WorkflowController> H;
 
         public WorkflowController(
             ISiteService siteService,
@@ -63,13 +64,11 @@ namespace OrchardCore.Workflows.Controllers
             _activityDisplayManager = activityDisplayManager;
             _notifier = notifier;
             _logger = logger;
-
             New = shapeFactory;
-            T = localizer;
+            H = localizer;
         }
 
         private dynamic New { get; }
-        private IHtmlLocalizer<WorkflowController> T { get; }
 
         public async Task<IActionResult> Index(int workflowTypeId, WorkflowIndexViewModel model, PagerParameters pagerParameters, string returnUrl = null)
         {
@@ -124,13 +123,13 @@ namespace OrchardCore.Workflows.Controllers
             };
 
             model.Options.WorkflowsStatuses = new List<SelectListItem>() {
-                new SelectListItem() { Text = T["All"].Value, Value = nameof(WorkflowFilter.All) },
-                new SelectListItem() { Text = T["Faulted"].Value, Value = nameof(WorkflowFilter.Faulted) },
-                new SelectListItem() { Text = T["Finished"].Value, Value = nameof(WorkflowFilter.Finished) }
+                new SelectListItem() { Text = H["All"].Value, Value = nameof(WorkflowFilter.All) },
+                new SelectListItem() { Text = H["Faulted"].Value, Value = nameof(WorkflowFilter.Faulted) },
+                new SelectListItem() { Text = H["Finished"].Value, Value = nameof(WorkflowFilter.Finished) }
             };
 
             viewModel.Options.WorkflowsBulkAction = new List<SelectListItem>() {
-                new SelectListItem() { Text = T["Delete"].Value, Value = nameof(WorkflowBulkAction.Delete) }
+                new SelectListItem() { Text = H["Delete"].Value, Value = nameof(WorkflowBulkAction.Delete) }
             };
 
             return View(viewModel);
@@ -220,7 +219,7 @@ namespace OrchardCore.Workflows.Controllers
 
             var workflowType = await _workflowTypeStore.GetAsync(workflow.WorkflowTypeId);
             await _workflowStore.DeleteAsync(workflow);
-            _notifier.Success(T["Workflow {0} has been deleted.", id]);
+            _notifier.Success(H["Workflow {0} has been deleted.", id]);
             return RedirectToAction("Index", new { workflowTypeId = workflowType.Id });
         }
 
@@ -249,7 +248,7 @@ namespace OrchardCore.Workflows.Controllers
                             if (workflow != null)
                             {
                                 await _workflowStore.DeleteAsync(workflow);
-                                _notifier.Success(T["Workflow {0} has been deleted.", workflow.Id]);
+                                _notifier.Success(H["Workflow {0} has been deleted.", workflow.Id]);
                             }
                         }
                         break;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRedirectTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRedirectTask.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.Workflows.Http.Activities
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
+        private readonly IStringLocalizer<HttpRedirectTask> S;
 
         public HttpRedirectTask(
             IStringLocalizer<HttpRedirectTask> localizer,
@@ -20,16 +21,16 @@ namespace OrchardCore.Workflows.Http.Activities
             IWorkflowExpressionEvaluator expressionEvaluator
         )
         {
-            T = localizer;
+            S = localizer;
             _httpContextAccessor = httpContextAccessor;
             _expressionEvaluator = expressionEvaluator;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(HttpRedirectTask);
-        public override LocalizedString DisplayText => T["Http Redirect Task"];
-        public override LocalizedString Category => T["HTTP"];
+        
+        public override LocalizedString DisplayText => S["Http Redirect Task"];
+        
+        public override LocalizedString Category => S["HTTP"];
 
         public WorkflowExpression<string> Location
         {
@@ -45,7 +46,7 @@ namespace OrchardCore.Workflows.Http.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestEvent.cs
@@ -12,21 +12,20 @@ namespace OrchardCore.Workflows.Http.Activities
         public static string EventName => nameof(HttpRequestEvent);        
 
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IStringLocalizer<HttpRequestEvent> S;
 
         public HttpRequestEvent(
             IStringLocalizer<HttpRequestEvent> localizer,
             IHttpContextAccessor httpContextAccessor
         )
         {
-            T = localizer;
+            S = localizer;
             _httpContextAccessor = httpContextAccessor;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => EventName;
-        public override LocalizedString DisplayText => T["Http Request Event"];
-        public override LocalizedString Category => T["HTTP"];
+        public override LocalizedString DisplayText => S["Http Request Event"];
+        public override LocalizedString Category => S["HTTP"];
 
         public string HttpMethod
         {
@@ -63,7 +62,7 @@ namespace OrchardCore.Workflows.Http.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestFilterEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestFilterEvent.cs
@@ -13,20 +13,20 @@ namespace OrchardCore.Workflows.Http.Activities
     public class HttpRequestFilterEvent : EventActivity
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IStringLocalizer<HttpRequestFilterEvent> S;
+        
         public static string EventName => nameof(HttpRequestFilterEvent);
 
         public HttpRequestFilterEvent(IStringLocalizer<HttpRequestFilterEvent> localizer, IHttpContextAccessor httpContextAccessor)
         {
-            T = localizer;
+            S = localizer;
             _httpContextAccessor = httpContextAccessor;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => EventName;
-        public override LocalizedString DisplayText => T["Http Request Filter Event"];
+        public override LocalizedString DisplayText => S["Http Request Filter Event"];
 
-        public override LocalizedString Category => T["HTTP"];
+        public override LocalizedString Category => S["HTTP"];
 
         public string HttpMethod
         {
@@ -79,7 +79,7 @@ namespace OrchardCore.Workflows.Http.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Matched"]);
+            return Outcomes(S["Matched"]);
         }
 
         public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpRequestTask.cs
@@ -17,23 +17,24 @@ namespace OrchardCore.Workflows.Http.Activities
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
-
+        private readonly IStringLocalizer<HttpRequestTask> S;
+        
         public HttpRequestTask(
             IStringLocalizer<HttpRequestTask> localizer,
             IHttpContextAccessor httpContextAccessor,
             IWorkflowExpressionEvaluator expressionEvaluator
         )
         {
-            T = localizer;
+            S = localizer;
             _httpContextAccessor = httpContextAccessor;
             _expressionEvaluator = expressionEvaluator;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(HttpRequestTask);
-        public override LocalizedString DisplayText => T["Http Request Task"];
-        public override LocalizedString Category => T["HTTP"];
+        
+        public override LocalizedString DisplayText => S["Http Request Task"];
+        
+        public override LocalizedString Category => S["HTTP"];
 
         public WorkflowExpression<string> Url
         {
@@ -144,10 +145,10 @@ namespace OrchardCore.Workflows.Http.Activities
                 {
                     var status = int.Parse(x.Trim());
                     var description = httpStatusCodeDictionary.ContainsKey(status) ? $"{status} {httpStatusCodeDictionary[status]}" : status.ToString();
-                    return new Outcome(status.ToString(), T[description]);
+                    return new Outcome(status.ToString(), S[description]);
                 }).ToList()
                 : new List<Outcome>();
-            outcomes.Add(new Outcome("UnhandledHttpStatus", T["Unhandled Http Status"]));
+            outcomes.Add(new Outcome("UnhandledHttpStatus", S["Unhandled Http Status"]));
 
             return outcomes;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
@@ -16,23 +16,24 @@ namespace OrchardCore.Workflows.Http.Activities
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
-
+        private readonly IStringLocalizer<HttpResponseTask> S;
+        
         public HttpResponseTask(
             IStringLocalizer<HttpResponseTask> localizer,
             IHttpContextAccessor httpContextAccessor,
             IWorkflowExpressionEvaluator expressionEvaluator
         )
         {
-            T = localizer;
+            S = localizer;
             _httpContextAccessor = httpContextAccessor;
             _expressionEvaluator = expressionEvaluator;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(HttpResponseTask);
-        public override LocalizedString DisplayText => T["Http Response Task"];
-        public override LocalizedString Category => T["HTTP"];
+        
+        public override LocalizedString DisplayText => S["Http Response Task"];
+        
+        public override LocalizedString Category => S["HTTP"];
 
         public WorkflowExpression<string> Content
         {
@@ -60,7 +61,7 @@ namespace OrchardCore.Workflows.Http.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/SignalEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/SignalEvent.cs
@@ -14,18 +14,17 @@ namespace OrchardCore.Workflows.Http.Activities
     {
         public static string EventName => nameof(SignalEvent);
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
-
+        private readonly IStringLocalizer<SignalEvent> S;
+        
         public SignalEvent(IWorkflowExpressionEvaluator expressionEvaluator, IStringLocalizer<SignalEvent> localizer)
         {
             _expressionEvaluator = expressionEvaluator;
-            T = localizer;
+            S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => EventName;
-        public override LocalizedString DisplayText => T["Signal Event"];
-        public override LocalizedString Category => T["HTTP"];
+        public override LocalizedString DisplayText => S["Signal Event"];
+        public override LocalizedString Category => S["HTTP"];
 
         public WorkflowExpression<string> SignalName
         {
@@ -41,7 +40,7 @@ namespace OrchardCore.Workflows.Http.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEvent.cs
@@ -13,19 +13,21 @@ namespace OrchardCore.Workflows.Timers
     {
         public static string EventName => nameof(TimerEvent);
         private readonly IClock _clock;
+        private readonly IStringLocalizer<TimerEvent> S;
 
         public TimerEvent(IClock clock, IStringLocalizer<TimerEvent> localizer)
         {
             _clock = clock;
-            T = localizer;
+            S = localizer;
         }
 
         private IStringLocalizer T { get; }
 
         public override string Name => EventName;
-        public override LocalizedString DisplayText => T["Timer Event"];
+        
+        public override LocalizedString DisplayText => S["Timer Event"];
 
-        public override LocalizedString Category => T["Background"];
+        public override LocalizedString Category => S["Background"];
 
         public string CronExpression
         {
@@ -52,7 +54,7 @@ namespace OrchardCore.Workflows.Timers
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
@@ -9,16 +9,18 @@ namespace OrchardCore.Workflows.UserTasks.Activities
 {
     public class UserTaskEvent : EventActivity
     {
+        private readonly IStringLocalizer<UserTaskEvent> S;
+
         public UserTaskEvent(IStringLocalizer<UserTaskEvent> localizer)
         {
-            T = localizer;
+            S = localizer;
         }
 
         private IStringLocalizer T { get; }
 
         public override string Name => nameof(UserTaskEvent);
-        public override LocalizedString DisplayText => T["User Task Event"];
-        public override LocalizedString Category => T["Content"];
+        public override LocalizedString DisplayText => S["User Task Event"];
+        public override LocalizedString Category => S["Content"];
 
         public IList<string> Actions
         {

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/ActionFilters/ValidateReCaptchaAttribute.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/ActionFilters/ValidateReCaptchaAttribute.cs
@@ -12,7 +12,6 @@ namespace OrchardCore.ReCaptcha.ActionFilters
     {
         private readonly ReCaptchaMode _mode;
 
-
         public ValidateReCaptchaAttribute(ReCaptchaMode mode = ReCaptchaMode.AlwaysShow)
         {
             _mode = mode;
@@ -21,7 +20,7 @@ namespace OrchardCore.ReCaptcha.ActionFilters
         public override async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
         {
             var recaptchaService = context.HttpContext.RequestServices.GetService<ReCaptchaService>();
-            var T = context.HttpContext.RequestServices.GetService<IStringLocalizer<ReCaptchaService>>();
+            var S = context.HttpContext.RequestServices.GetService<IStringLocalizer<ReCaptchaService>>();
             var isValidCaptcha = false;
             var reCaptchaResponse = context.HttpContext.Request?.Form?[Constants.ReCaptchaServerResponseHeaderName].ToString();
 
@@ -43,7 +42,7 @@ namespace OrchardCore.ReCaptcha.ActionFilters
 
             if (isRobot && !isValidCaptcha)
             {
-                context.ModelState.AddModelError("ReCaptcha", T["Failed to validate captcha"]);
+                context.ModelState.AddModelError("ReCaptcha", S["Failed to validate captcha"]);
             }
 
             await next();

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaService.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaService.cs
@@ -19,6 +19,7 @@ namespace OrchardCore.ReCaptcha.Services
         private readonly IEnumerable<IDetectRobots> _robotDetectors;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly ILogger<ReCaptchaService> _logger;
+        private readonly IStringLocalizer<ReCaptchaService> S;
 
         public ReCaptchaService(ReCaptchaClient reCaptchaClient, IOptions<ReCaptchaSettings> optionsAccessor, IEnumerable<IDetectRobots> robotDetectors, IHttpContextAccessor httpContextAccessor, ILogger<ReCaptchaService> logger, IStringLocalizer<ReCaptchaService> stringLocalizer)    
         {
@@ -27,10 +28,8 @@ namespace OrchardCore.ReCaptcha.Services
             _robotDetectors = robotDetectors;
             _httpContextAccessor = httpContextAccessor;
             _logger = logger;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
-
-        private IStringLocalizer T { get; }
 
         /// <summary>
         /// Flags the behavior as that of a robot 
@@ -81,7 +80,7 @@ namespace OrchardCore.ReCaptcha.Services
 
             if (!isValid)
             {
-                reportError("ReCaptcha", T["Failed to validate captcha"]);
+                reportError("ReCaptcha", S["Failed to validate captcha"]);
             }
 
             return isValid;

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/TagHelpers/ReCaptchaTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/TagHelpers/ReCaptchaTagHelper.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.ReCaptcha.TagHelpers
         private readonly ReCaptchaSettings _settings;
         private readonly ILogger<ReCaptchaTagHelper> _logger;
         private readonly ILocalizationService _localizationService;
-        private readonly IStringLocalizer T;
+        private readonly IStringLocalizer<ReCaptchaTagHelper> S;
 
         public ReCaptchaTagHelper(IOptions<ReCaptchaSettings> optionsAccessor, IResourceManager resourceManager, ILocalizationService localizationService, IHttpContextAccessor httpContextAccessor, ILogger<ReCaptchaTagHelper> logger, IStringLocalizer<ReCaptchaTagHelper> localizer)
         {
@@ -36,7 +36,7 @@ namespace OrchardCore.ReCaptcha.TagHelpers
             Mode = ReCaptchaMode.PreventRobots;
             _logger = logger;
             _localizationService = localizationService;
-            T = localizer;
+            S = localizer;
         }
 
         [HtmlAttributeName("mode")]
@@ -96,7 +96,7 @@ namespace OrchardCore.ReCaptcha.TagHelpers
             }
             catch (CultureNotFoundException)
             {
-                _logger.LogWarning(T["Language with name {0} not found", language]);
+                _logger.LogWarning(S["Language with name {0} not found", language]);
             }
 
             return culture;

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.Setup.Services
         private readonly IShellContextFactory _shellContextFactory;
         private readonly IEnumerable<IRecipeHarvester> _recipeHarvesters;
         private readonly ILogger _logger;
-        private readonly IStringLocalizer T;
+        private readonly IStringLocalizer<SetupService> S;
         private readonly IHostApplicationLifetime _applicationLifetime;
         private readonly string _applicationName;
         private IEnumerable<RecipeDescriptor> _recipes;
@@ -60,7 +60,7 @@ namespace OrchardCore.Setup.Services
             _shellContextFactory = shellContextFactory;
             _recipeHarvesters = recipeHarvesters;
             _logger = logger;
-            T = stringLocalizer;
+            S = stringLocalizer;
             _applicationLifetime = applicationLifetime;
         }
 
@@ -165,7 +165,7 @@ namespace OrchardCore.Setup.Services
                         // unless the recipe is executing?
 
                         _logger.LogError(e, "An error occurred while initializing the datastore.");
-                        context.Errors.Add("DatabaseProvider", T["An error occurred while initializing the datastore: {0}", e.Message]);
+                        context.Errors.Add("DatabaseProvider", S["An error occurred while initializing the datastore: {0}", e.Message]);
                         return;
                     }
 

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Users.Services
         private readonly SignInManager<IUser> _signInManager;
         private readonly UserManager<IUser> _userManager;
         private readonly IOptions<IdentityOptions> _identityOptions;
-        private readonly IStringLocalizer<UserService> T;
+        private readonly IStringLocalizer<UserService> S;
 
         public UserService(
             SignInManager<IUser> signInManager,
@@ -28,44 +28,44 @@ namespace OrchardCore.Users.Services
             _signInManager = signInManager;
             _userManager = userManager;
             _identityOptions = identityOptions;
-            T = stringLocalizer;
+            S = stringLocalizer;
         }
 
         public async Task<IUser> AuthenticateAsync(string userName, string password, Action<string, string> reportError)
         {
             if (string.IsNullOrWhiteSpace(userName))
             {
-                reportError("UserName", T["A user name is required."]);
+                reportError("UserName", S["A user name is required."]);
                 return null;
             }
 
             if (string.IsNullOrWhiteSpace(password))
             {
-                reportError("Password", T["A password is required."]);
+                reportError("Password", S["A password is required."]);
                 return null;
             }
 
             var user = await _userManager.FindByNameAsync(userName);
             if (user == null)
             {
-                reportError(string.Empty, T["The specified username/password couple is invalid."]);
+                reportError(string.Empty, S["The specified username/password couple is invalid."]);
                 return null;
             }
 
             var result = await _signInManager.CheckPasswordSignInAsync(user, password, lockoutOnFailure: true);
             if (result.IsNotAllowed)
             {
-                reportError(string.Empty, T["The specified user is not allowed to sign in."]);
+                reportError(string.Empty, S["The specified user is not allowed to sign in."]);
                 return null;
             }
             else if (result.RequiresTwoFactor)
             {
-                reportError(string.Empty, T["The specified user is not allowed to sign in using password authentication."]);
+                reportError(string.Empty, S["The specified user is not allowed to sign in using password authentication."]);
                 return null;
             }
             else if (!result.Succeeded)
             {
-                reportError(string.Empty, T["The specified username/password couple is invalid."]);
+                reportError(string.Empty, S["The specified username/password couple is invalid."]);
                 return null;
             }
 
@@ -138,19 +138,19 @@ namespace OrchardCore.Users.Services
             var result = true;
             if (string.IsNullOrWhiteSpace(userIdentifier))
             {
-                reportError("UserName", T["A user name or email is required."]);
+                reportError("UserName", S["A user name or email is required."]);
                 result = false;
             }
 
             if (string.IsNullOrWhiteSpace(newPassword))
             {
-                reportError("Password", T["A password is required."]);
+                reportError("Password", S["A password is required."]);
                 result = false;
             }
 
             if (string.IsNullOrWhiteSpace(resetToken))
             {
-                reportError("Token", T["A token is required."]);
+                reportError("Token", S["A token is required."]);
                 result = false;
             }
 
@@ -206,43 +206,43 @@ namespace OrchardCore.Users.Services
                 {
                     // Password
                     case "PasswordRequiresDigit":
-                        reportError("Password", T["Passwords must have at least one digit character ('0'-'9')."]);
+                        reportError("Password", S["Passwords must have at least one digit character ('0'-'9')."]);
                         break;
                     case "PasswordRequiresLower":
-                        reportError("Password", T["Passwords must have at least one lowercase character ('a'-'z')."]);
+                        reportError("Password", S["Passwords must have at least one lowercase character ('a'-'z')."]);
                         break;
                     case "PasswordRequiresUpper":
-                        reportError("Password", T["Passwords must have at least one uppercase character ('A'-'Z')."]);
+                        reportError("Password", S["Passwords must have at least one uppercase character ('A'-'Z')."]);
                         break;
                     case "PasswordRequiresNonAlphanumeric":
-                        reportError("Password", T["Passwords must have at least one non letter or digit character."]);
+                        reportError("Password", S["Passwords must have at least one non letter or digit character."]);
                         break;
                     case "PasswordTooShort":
-                        reportError("Password", T["Passwords must be at least {0} characters.", _identityOptions.Value.Password.RequiredLength]);
+                        reportError("Password", S["Passwords must be at least {0} characters.", _identityOptions.Value.Password.RequiredLength]);
                         break;
                     case "PasswordRequiresUniqueChars":
-                        reportError("Password", T["Passwords must contain at least {0} unique characters.", _identityOptions.Value.Password.RequiredUniqueChars]);
+                        reportError("Password", S["Passwords must contain at least {0} unique characters.", _identityOptions.Value.Password.RequiredUniqueChars]);
                         break;
 
                     // CurrentPassword
                     case "PasswordMismatch":
-                        reportError("CurrentPassword", T["Incorrect password."]);
+                        reportError("CurrentPassword", S["Incorrect password."]);
                         break;
 
                     // User name
                     case "InvalidUserName":
-                        reportError("UserName", T["User name '{0}' is invalid, can only contain letters or digits.", user.UserName]);
+                        reportError("UserName", S["User name '{0}' is invalid, can only contain letters or digits.", user.UserName]);
                         break;
                     case "DuplicateUserName":
-                        reportError("UserName", T["User name '{0}' is already used.", user.UserName]);
+                        reportError("UserName", S["User name '{0}' is already used.", user.UserName]);
                         break;
 
                     // Email
                     case "InvalidEmail":
-                        reportError("Email", T["Email '{0}' is invalid.", user.Email]);
+                        reportError("Email", S["Email '{0}' is invalid.", user.Email]);
                         break;
                     default:
-                        reportError(string.Empty, T["Unexpected error: '{0}'.", error.Code]);
+                        reportError(string.Empty, S["Unexpected error: '{0}'.", error.Code]);
                         break;
                 }
             }

--- a/test/OrchardCore.Tests/Workflows/Activities/AddTask.cs
+++ b/test/OrchardCore.Tests/Workflows/Activities/AddTask.cs
@@ -11,17 +11,19 @@ namespace OrchardCore.Tests.Workflows.Activities
     public class AddTask : TaskActivity
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
+        private readonly IStringLocalizer<AddTask> S;
 
-        public AddTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<AddTask> t)
+        public AddTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<AddTask> stringLocalizer)
         {
             _scriptEvaluator = scriptEvaluator;
-            T = t;
+            S = stringLocalizer;
         }
 
-        private IStringLocalizer T { get; }
         public override string Name => nameof(AddTask);
-        public override LocalizedString DisplayText => T["Add Task"];
-        public override LocalizedString Category => T["Test"];
+        
+        public override LocalizedString DisplayText => S["Add Task"];
+        
+        public override LocalizedString Category => S["Test"];
 
         public WorkflowExpression<double> A
         {
@@ -37,7 +39,7 @@ namespace OrchardCore.Tests.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/test/OrchardCore.Tests/Workflows/Activities/WriteLineTask.cs
+++ b/test/OrchardCore.Tests/Workflows/Activities/WriteLineTask.cs
@@ -15,16 +15,17 @@ namespace OrchardCore.Tests.Workflows.Activities
         private readonly TextWriter _output;
         private readonly IStringLocalizer<WriteLineTask> S;
 
-        public WriteLineTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer stringLocalizer, TextWriter output)
+        public WriteLineTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<WriteLineTask> stringLocalizer, TextWriter output)
         {
             _scriptEvaluator = scriptEvaluator;
             _output = output;
             S = stringLocalizer;
         }
 
-        private IStringLocalizer T { get; }
         public override string Name => nameof(WriteLineTask);
+        
         public override LocalizedString DisplayText => S["Write Line Task"];
+        
         public override LocalizedString Category => S["Test"];
 
         public WorkflowExpression<string> Text

--- a/test/OrchardCore.Tests/Workflows/Activities/WriteLineTask.cs
+++ b/test/OrchardCore.Tests/Workflows/Activities/WriteLineTask.cs
@@ -13,18 +13,19 @@ namespace OrchardCore.Tests.Workflows.Activities
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
         private readonly TextWriter _output;
+        private readonly IStringLocalizer<WriteLineTask> S;
 
-        public WriteLineTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer t, TextWriter output)
+        public WriteLineTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer stringLocalizer, TextWriter output)
         {
             _scriptEvaluator = scriptEvaluator;
             _output = output;
-            T = t;
+            S = stringLocalizer;
         }
 
         private IStringLocalizer T { get; }
         public override string Name => nameof(WriteLineTask);
-        public override LocalizedString DisplayText => T["Write Line Task"];
-        public override LocalizedString Category => T["Test"];
+        public override LocalizedString DisplayText => S["Write Line Task"];
+        public override LocalizedString Category => S["Test"];
 
         public WorkflowExpression<string> Text
         {
@@ -34,7 +35,7 @@ namespace OrchardCore.Tests.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(T["Done"]);
+            return Outcomes(S["Done"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/test/OrchardCore.Tests/Workflows/Activities/WriteLineTask.cs
+++ b/test/OrchardCore.Tests/Workflows/Activities/WriteLineTask.cs
@@ -13,9 +13,9 @@ namespace OrchardCore.Tests.Workflows.Activities
     {
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
         private readonly TextWriter _output;
-        private readonly IStringLocalizer<WriteLineTask> S;
+        private readonly IStringLocalizer S;
 
-        public WriteLineTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer<WriteLineTask> stringLocalizer, TextWriter output)
+        public WriteLineTask(IWorkflowScriptEvaluator scriptEvaluator, IStringLocalizer stringLocalizer, TextWriter output)
         {
             _scriptEvaluator = scriptEvaluator;
             _output = output;


### PR DESCRIPTION
- Localization accessor conventions
- Remove unnecessary localizers
- Fix localizers generic types

@jtkech please merge if you don't have any comments

@agriffard is there a docs describing what are the conventions are used to get translations generated from `PoExtractor` in the docs? If not this a reminder for us