### PR TITLE
Lucene indexing small fixes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
@@ -184,6 +184,7 @@ namespace OrchardCore.Lucene
                                 //We index only if we actually found a content item in the database
                                 if (context == null)
                                 {
+                                    //TODO purge these content items from IndexingTask table
                                     continue;
                                 }
 

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
@@ -188,7 +188,7 @@ namespace OrchardCore.Lucene
                                     continue;
                                 }
 
-                                bool ignoreIndexedCulture = settings?.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != settings?.Culture;
+                                bool ignoreIndexedCulture = settings.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != settings.Culture;
 
                                 // Ignore if the content item content type or culture is not indexed in this index
                                 if (!settings.IndexedContentTypes.Contains(context.ContentItem.ContentType) || ignoreIndexedCulture)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
@@ -171,29 +171,33 @@ namespace OrchardCore.Lucene
                                 }
                             }
 
-                            //We index only if we actually found a content item in the database
-                            if (publishedIndexContext != null || latestIndexContext != null)
+                            // Update the document from the index if its lastIndexId is smaller than the current task id. 
+                            foreach (var index in allIndices)
                             {
-                                // Update the document from the index if its lastIndexId is smaller than the current task id. 
-                                foreach (var index in allIndices)
+                                if (index.Value >= task.Id || !settingsByIndex.TryGetValue(index.Key, out var settings))
                                 {
-                                    if (index.Value >= task.Id || !settingsByIndex.TryGetValue(index.Key, out var settings))
-                                    {
-                                        continue;
-                                    }
-
-                                    var context = !settings.IndexLatest ? publishedIndexContext : latestIndexContext;
-                                    bool ignoreIndexedCulture = settings?.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != settings?.Culture;
-
-                                    // Ignore if the content item content type or culture is not indexed in this index
-                                    if (context.ContentItem == null || !settings.IndexedContentTypes.Contains(context.ContentItem.ContentType) || ignoreIndexedCulture)
-                                    {
-                                        continue;
-                                    }
-
-                                    updatedDocumentsByIndex[index.Key].Add(context.DocumentIndex);
+                                    continue;
                                 }
+
+                                var context = !settings.IndexLatest ? publishedIndexContext : latestIndexContext;
+
+                                //We index only if we actually found a content item in the database
+                                if (context == null)
+                                {
+                                    continue;
+                                }
+
+                                bool ignoreIndexedCulture = settings?.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != settings?.Culture;
+
+                                // Ignore if the content item content type or culture is not indexed in this index
+                                if (!settings.IndexedContentTypes.Contains(context.ContentItem.ContentType) || ignoreIndexedCulture)
+                                {
+                                    continue;
+                                }
+
+                                updatedDocumentsByIndex[index.Key].Add(context.DocumentIndex);
                             }
+
                         }
                     }
 


### PR DESCRIPTION
Don't index if we do not find the item in the db.
Make sure there is always a LuceneSettings set.

Fixes #5173