### PR TITLE
Graphql - fix max number of results validation when using variables

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/MaxNumberOfResultsValidationRule.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/MaxNumberOfResultsValidationRule.cs
@@ -28,10 +28,23 @@ namespace OrchardCore.Apis.GraphQL.ValidationRules
                     if ((arg.Name == "first" || arg.Name == "last") && arg.Value != null)
                     {
                         var context = (GraphQLContext)validationContext.UserContext;
+                       
 
-                        var value = (IntValue)arg.Value;
+                        int? value = null;
 
-                        if (value?.Value > _maxNumberOfResults)
+                        if (arg.Value is IntValue)
+                        {
+                            value = ((IntValue)arg.Value)?.Value;
+                        }
+                        else
+                        {
+                            if (validationContext.Inputs.TryGetValue(arg.Value.ToString(), out var input))
+                            {
+                                value = (int?)input;
+                            }
+                        }
+
+                        if (value.HasValue && value > _maxNumberOfResults)
                         {
                             var localizer = context.ServiceProvider.GetService<IStringLocalizer<MaxNumberOfResultsValidationRule>>();
                             var errorMessage = localizer["'{0}' exceeds the maximum number of results for '{1}' ({2})", value.Value, arg.Name, _maxNumberOfResults];

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/MaxNumberOfResultsValidationRule.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/MaxNumberOfResultsValidationRule.cs
@@ -29,7 +29,6 @@ namespace OrchardCore.Apis.GraphQL.ValidationRules
                     {
                         var context = (GraphQLContext)validationContext.UserContext;
                        
-
                         int? value = null;
 
                         if (arg.Value is IntValue)


### PR DESCRIPTION
Fixes #5024 (max number of results validations throws an error when using graphql variables)