### PR TITLE
Trim leading slash on AdminUrlPrefix

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraintFactory.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraintFactory.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.Admin
         public IActionConstraint CreateInstance(IServiceProvider services)
         {
             var adminOptions = services.GetRequiredService<IOptions<AdminOptions>>();
+
             return new AdminActionConstraint(new PathString('/' + adminOptions.Value.AdminUrlPrefix.TrimStart('/')));
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraintFactory.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraintFactory.cs
@@ -13,8 +13,7 @@ namespace OrchardCore.Admin
         public IActionConstraint CreateInstance(IServiceProvider services)
         {
             var adminOptions = services.GetRequiredService<IOptions<AdminOptions>>();
-
-            return new AdminActionConstraint(new PathString('/' + adminOptions.Value.AdminUrlPrefix.TrimStart('/')));
+            return new AdminActionConstraint(new PathString('/' + adminOptions.Value.AdminUrlPrefix));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraintFactory.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminActionConstraintFactory.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Admin
         public IActionConstraint CreateInstance(IServiceProvider services)
         {
             var adminOptions = services.GetRequiredService<IOptions<AdminOptions>>();
-            return new AdminActionConstraint(new PathString('/' + adminOptions.Value.AdminUrlPrefix));
+            return new AdminActionConstraint(new PathString('/' + adminOptions.Value.AdminUrlPrefix.TrimStart('/')));
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/AdminOptions.cs
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/AdminOptions.cs
@@ -2,6 +2,12 @@ namespace OrchardCore.Admin
 {
     public class AdminOptions
     {
-        public string AdminUrlPrefix { get; set; } = "Admin";
+        private string _adminUrlPrefix = "Admin";
+
+        public string AdminUrlPrefix
+        {
+            get => _adminUrlPrefix;
+            set => _adminUrlPrefix = value.Trim(' ', '/');
+        }
     }
 }


### PR DESCRIPTION
Following from @jtkech comment https://github.com/OrchardCMS/OrchardCore/pull/5177#discussion_r362651309

Trims a possible leading slash from the `AdminUrlPrefix` when we make the `AdminActionConstraint`

I tested it @jtkech and how we build the routes will work if `AdminUrlPrefix` has a leading slash, but not a trailing slash. So as you suggest it is better to trim the leading slash to make sure the `PathString` is made correctly.