### PR TITLE
Get draft content item by alias

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
@@ -16,8 +16,8 @@ namespace OrchardCore.Alias.Drivers
 {
     public class AliasPartDisplayDriver : ContentPartDisplayDriver<AliasPart>
     {
-        // Match the AutoRoutePart Length
-        public const int MaxAliasLength = 1024;
+        // Maximum length that MySql can support in an index under utf8 collation.
+        public const int MaxAliasLength = 767;
 
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ISession _session;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Fluid;
+using OrchardCore.Alias.Drivers;
 using OrchardCore.Alias.Indexes;
 using OrchardCore.Alias.Models;
 using OrchardCore.Alias.Settings;
@@ -57,6 +58,11 @@ namespace OrchardCore.Alias.Handlers
                     scope => scope.SetValue("ContentItem", model.ContentItem));
 
                 part.Alias = part.Alias.Replace("\r", String.Empty).Replace("\n", String.Empty);
+
+                if (part.Alias?.Length > AliasPartDisplayDriver.MaxAliasLength)
+                {
+                    part.Alias = part.Alias.Substring(0, AliasPartDisplayDriver.MaxAliasLength);
+                }
 
                 if (!await IsAliasUniqueAsync(part.Alias, part))
                 {
@@ -116,6 +122,13 @@ namespace OrchardCore.Alias.Handlers
 
             while (true)
             {
+                // Unversioned length + seperator char + version length.
+                var quantityCharactersToTrim = unversionedAlias.Length + 1 + version.ToString().Length - AliasPartDisplayDriver.MaxAliasLength;
+                if (quantityCharactersToTrim > 0)
+                {
+                    unversionedAlias = unversionedAlias.Substring(0, unversionedAlias.Length - quantityCharactersToTrim);
+                }
+
                 var versionedAlias = $"{unversionedAlias}-{version++}";
                 if (await IsAliasUniqueAsync(versionedAlias, context))
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
@@ -1,6 +1,7 @@
-﻿using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement;
 using OrchardCore.Alias.Models;
 using YesSql.Indexes;
+using System;
 
 namespace OrchardCore.Alias.Indexes
 {
@@ -8,6 +9,7 @@ namespace OrchardCore.Alias.Indexes
     {
         public string ContentItemId { get; set; }
         public string Alias { get; set; }
+        public bool Published { get; set; }
     }
 
     public class AliasPartIndexProvider : IndexProvider<ContentItem>
@@ -17,23 +19,17 @@ namespace OrchardCore.Alias.Indexes
             context.For<AliasPartIndex>()
                 .Map(contentItem =>
                 {
-                    if (!contentItem.IsPublished())
+                    var alias = contentItem.As<AliasPart>()?.Alias;
+                    if (!String.IsNullOrEmpty(alias) && (contentItem.Published || contentItem.Latest))
                     {
-                        return null;
+                        return new AliasPartIndex
+                        {
+                            Alias = alias.ToLowerInvariant(),
+                            ContentItemId = contentItem.ContentItemId,
+                        };
                     }
 
-                    var aliasPart = contentItem.As<AliasPart>();
-
-                    if (aliasPart?.Alias == null)
-                    {
-                        return null;
-                    }
-
-                    return new AliasPartIndex
-                    {
-                        Alias = aliasPart.Alias.ToLowerInvariant(),
-                        ContentItemId = contentItem.ContentItemId,
-                    };
+                    return null;
                 });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
@@ -9,6 +9,7 @@ namespace OrchardCore.Alias.Indexes
     {
         public string ContentItemId { get; set; }
         public string Alias { get; set; }
+        public bool Latest { get; set; }
         public bool Published { get; set; }
     }
 
@@ -26,6 +27,8 @@ namespace OrchardCore.Alias.Indexes
                         {
                             Alias = alias.ToLowerInvariant(),
                             ContentItemId = contentItem.ContentItemId,
+                            Latest = contentItem.Latest,
+                            Published = contentItem.Published
                         };
                     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
@@ -9,6 +9,8 @@ namespace OrchardCore.Alias.Indexes
     {
         public string ContentItemId { get; set; }
         public string Alias { get; set; }
+        public bool Latest { get; set; }
+        public bool Published { get; set; }
     }
 
     public class AliasPartIndexProvider : IndexProvider<ContentItem>
@@ -24,7 +26,9 @@ namespace OrchardCore.Alias.Indexes
                         return new AliasPartIndex
                         {
                             Alias = alias.ToLowerInvariant(),
-                            ContentItemId = contentItem.ContentItemId
+                            ContentItemId = contentItem.ContentItemId,
+                            Latest = contentItem.Latest,
+                            Published = contentItem.Published
                         };
                     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
@@ -9,8 +9,6 @@ namespace OrchardCore.Alias.Indexes
     {
         public string ContentItemId { get; set; }
         public string Alias { get; set; }
-        public bool Latest { get; set; }
-        public bool Published { get; set; }
     }
 
     public class AliasPartIndexProvider : IndexProvider<ContentItem>
@@ -26,9 +24,7 @@ namespace OrchardCore.Alias.Indexes
                         return new AliasPartIndex
                         {
                             Alias = alias.ToLowerInvariant(),
-                            ContentItemId = contentItem.ContentItemId,
-                            Latest = contentItem.Latest,
-                            Published = contentItem.Published
+                            ContentItemId = contentItem.ContentItemId
                         };
                     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -27,13 +27,25 @@ namespace OrchardCore.Alias
             SchemaBuilder.CreateMapIndexTable(nameof(AliasPartIndex), table => table
                 .Column<string>("Alias", col => col.WithLength(AliasPartDisplayDriver.MaxAliasLength))
                 .Column<string>("ContentItemId", c => c.WithLength(26))
+                .Column<bool>("Published")
             );
 
             SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
                 .CreateIndex("IDX_AliasPartIndex_Alias", "Alias")
             );
 
-            return 1;
+            // Return 2 to shortcut the second migration on new content definition schemas.
+            return 2;
+        }
+
+        // This code can be removed in a later version as published is a recent addition.
+        public int UpdateFrom1()
+        {
+            SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
+                .AddColumn<bool>("Published")
+            );
+
+            return 2;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -22,17 +22,17 @@ namespace OrchardCore.Alias
                 .Attachable()
                 .WithDescription("Provides a way to define custom aliases for content items."));
 
-            // NOTE: The Alias Length has been upgraded from 64 characters to 1024.
+            // NOTE: The Alias Length has been upgraded from 64 characters to 767.
             // For existing SQL databases update the AliasPartIndex tables Alias column length manually. 
             SchemaBuilder.CreateMapIndexTable(nameof(AliasPartIndex), table => table
                 .Column<string>("Alias", col => col.WithLength(AliasPartDisplayDriver.MaxAliasLength))
                 .Column<string>("ContentItemId", c => c.WithLength(26))
-                .Column<bool>("Latest", c => c.WithDefault(true))
+                .Column<bool>("Latest", c => c.WithDefault(false))
                 .Column<bool>("Published", c => c.WithDefault(true))
             );
 
             SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
-                .CreateIndex("IDX_AliasPartIndex_Alias", "Alias")
+                .CreateIndex("IDX_AliasPartIndex_Alias", "Alias", "Published", "Latest")
             );
 
             // Return 2 to shortcut the second migration on new content definition schemas.
@@ -43,7 +43,7 @@ namespace OrchardCore.Alias
         public int UpdateFrom1()
         {
             SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
-                .AddColumn<bool>("Latest", c => c.WithDefault(true))
+                .AddColumn<bool>("Latest", c => c.WithDefault(false))
             );
 
             SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -27,13 +27,30 @@ namespace OrchardCore.Alias
             SchemaBuilder.CreateMapIndexTable(nameof(AliasPartIndex), table => table
                 .Column<string>("Alias", col => col.WithLength(AliasPartDisplayDriver.MaxAliasLength))
                 .Column<string>("ContentItemId", c => c.WithLength(26))
+                .Column<bool>("Latest", c => c.WithDefault(true))
+                .Column<bool>("Published", c => c.WithDefault(true))
             );
 
             SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
                 .CreateIndex("IDX_AliasPartIndex_Alias", "Alias")
             );
 
-            return 1;
+            // Return 2 to shortcut the second migration on new content definition schemas.
+            return 2;
+        }
+
+        // This code can be removed in a later version as Latest and Published are alterations.
+        public int UpdateFrom1()
+        {
+            SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
+                .AddColumn<bool>("Latest", c => c.WithDefault(true))
+            );
+
+            SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
+                .AddColumn<bool>("Published", c => c.WithDefault(true))
+            );
+
+            return 2;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -27,7 +27,8 @@ namespace OrchardCore.Alias
             SchemaBuilder.CreateMapIndexTable(nameof(AliasPartIndex), table => table
                 .Column<string>("Alias", col => col.WithLength(AliasPartDisplayDriver.MaxAliasLength))
                 .Column<string>("ContentItemId", c => c.WithLength(26))
-                .Column<bool>("Published")
+                .Column<bool>("Latest", c => c.WithDefault(true))
+                .Column<bool>("Published", c => c.WithDefault(true))
             );
 
             SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
@@ -38,11 +39,15 @@ namespace OrchardCore.Alias
             return 2;
         }
 
-        // This code can be removed in a later version as published is a recent addition.
+        // This code can be removed in a later version as Latest and Published are alterations.
         public int UpdateFrom1()
         {
             SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
-                .AddColumn<bool>("Published")
+                .AddColumn<bool>("Latest", c => c.WithDefault(true))
+            );
+
+            SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
+                .AddColumn<bool>("Published", c => c.WithDefault(true))
             );
 
             return 2;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -27,30 +27,13 @@ namespace OrchardCore.Alias
             SchemaBuilder.CreateMapIndexTable(nameof(AliasPartIndex), table => table
                 .Column<string>("Alias", col => col.WithLength(AliasPartDisplayDriver.MaxAliasLength))
                 .Column<string>("ContentItemId", c => c.WithLength(26))
-                .Column<bool>("Latest", c => c.WithDefault(true))
-                .Column<bool>("Published", c => c.WithDefault(true))
             );
 
             SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
                 .CreateIndex("IDX_AliasPartIndex_Alias", "Alias")
             );
 
-            // Return 2 to shortcut the second migration on new content definition schemas.
-            return 2;
-        }
-
-        // This code can be removed in a later version as Latest and Published are alterations.
-        public int UpdateFrom1()
-        {
-            SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
-                .AddColumn<bool>("Latest", c => c.WithDefault(true))
-            );
-
-            SchemaBuilder.AlterTable(nameof(AliasPartIndex), table => table
-                .AddColumn<bool>("Published", c => c.WithDefault(true))
-            );
-
-            return 2;
+            return 1;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteAliasProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteAliasProvider.cs
@@ -1,25 +1,21 @@
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
-using OrchardCore.ContentManagement.Records;
 using OrchardCore.ContentManagement.Routing;
-using YesSql;
 
 namespace OrchardCore.Autoroute.Services
 {
     public class AutorouteAliasProvider : IContentAliasProvider
     {
         private readonly IAutorouteEntries _autorouteEntries;
-        private readonly ISession _session;
 
-        public AutorouteAliasProvider(IAutorouteEntries autorouteEntries, ISession session)
+        public AutorouteAliasProvider(IAutorouteEntries autorouteEntries)
         {
             _autorouteEntries = autorouteEntries;
-            _session = session;
         }
 
         public int Order => 10;
 
-        public async Task<string> GetContentItemIdAsync(string alias)
+        public Task<string> GetContentItemIdAsync(string alias)
         {
             if (alias.StartsWith("slug:", System.StringComparison.OrdinalIgnoreCase))
             {
@@ -30,18 +26,14 @@ namespace OrchardCore.Autoroute.Services
                     alias = "/" + alias;
                 }
 
-                // This only contains published items.
-                if (_autorouteEntries.TryGetContentItemId(alias, out var contentItemId))
+                string contentItemId;
+                if (_autorouteEntries.TryGetContentItemId(alias, out contentItemId))
                 {
-                    return contentItemId;
-                } else // Not relevant to check against published here as we are only querying for the content item id for the path / alias provided.
-                {
-                    var autoroutePartIndex = await _session.Query<ContentItem, AutoroutePartIndex>(x => x.Path == alias.ToLowerInvariant()).FirstOrDefaultAsync();
-                    return autoroutePartIndex?.ContentItemId;
+                    return Task.FromResult(contentItemId);
                 }
             }
 
-            return null;
+            return Task.FromResult<string>(null);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteAliasProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteAliasProvider.cs
@@ -1,21 +1,25 @@
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Records;
 using OrchardCore.ContentManagement.Routing;
+using YesSql;
 
 namespace OrchardCore.Autoroute.Services
 {
     public class AutorouteAliasProvider : IContentAliasProvider
     {
         private readonly IAutorouteEntries _autorouteEntries;
+        private readonly ISession _session;
 
-        public AutorouteAliasProvider(IAutorouteEntries autorouteEntries)
+        public AutorouteAliasProvider(IAutorouteEntries autorouteEntries, ISession session)
         {
             _autorouteEntries = autorouteEntries;
+            _session = session;
         }
 
         public int Order => 10;
 
-        public Task<string> GetContentItemIdAsync(string alias)
+        public async Task<string> GetContentItemIdAsync(string alias)
         {
             if (alias.StartsWith("slug:", System.StringComparison.OrdinalIgnoreCase))
             {
@@ -26,14 +30,18 @@ namespace OrchardCore.Autoroute.Services
                     alias = "/" + alias;
                 }
 
-                string contentItemId;
-                if (_autorouteEntries.TryGetContentItemId(alias, out contentItemId))
+                // This only contains published items.
+                if (_autorouteEntries.TryGetContentItemId(alias, out var contentItemId))
                 {
-                    return Task.FromResult(contentItemId);
+                    return contentItemId;
+                } else // Not relevant to check against published here as we are only querying for the content item id for the path / alias provided.
+                {
+                    var autoroutePartIndex = await _session.Query<ContentItem, AutoroutePartIndex>(x => x.Path == alias.ToLowerInvariant()).FirstOrDefaultAsync();
+                    return autoroutePartIndex?.ContentItemId;
                 }
             }
 
-            return Task.FromResult<string>(null);
+            return null;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Razor/ContentRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Razor/ContentRazorHelperExtensions.cs
@@ -14,7 +14,7 @@ public static class ContentRazorHelperExtensions
     /// </summary>
     /// <param name="alias">The alias.</param>
     /// <example>GetContentItemIdByAliasAsync("alias:carousel")</example>
-    /// <example>GetContentItemIdByAliasAsync("autoroute:myblog/my-blog-post")</example>
+    /// <example>GetContentItemIdByAliasAsync("slug:myblog/my-blog-post")</example>
     /// <returns>A content item id or <c>null</c> if it was not found.</returns>
     public static Task<string> GetContentItemIdByAliasAsync(this IOrchardHelper orchardHelper, string alias)
     {
@@ -28,7 +28,7 @@ public static class ContentRazorHelperExtensions
     /// <param name="alias">The alias to load.</param>
     /// <param name="latest">Whether a draft should be loaded if available. <c>false</c> by default.</param>
     /// <example>GetContentItemByAliasAsync("alias:carousel")</example>
-    /// <example>GetContentItemByAliasAsync("autoroute:myblog/my-blog-post", true)</example>
+    /// <example>GetContentItemByAliasAsync("slug:myblog/my-blog-post", true)</example>
     /// <returns>A content item with the specific alias, or <c>null</c> if it doesn't exist.</returns>
     public static async Task<ContentItem> GetContentItemByAliasAsync(this IOrchardHelper orchardHelper, string alias, bool latest = false)
     {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5186

Looked like the best option was to add the published column as per autoroute.

Also allows now for getting an autoroute alias `{slug:path}` that is a draft only (or changes between draft and published)

I still need to test this properly