### PR TITLE
Fixes #5129: Preserve query string in language switcher

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
@@ -6,7 +6,9 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
+using OrchardCore.ContentLocalization.Controllers;
 using OrchardCore.ContentLocalization.Drivers;
 using OrchardCore.ContentLocalization.Handlers;
 using OrchardCore.ContentLocalization.Indexing;
@@ -22,6 +24,7 @@ using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Indexing;
 using OrchardCore.Liquid;
 using OrchardCore.Modules;
+using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Settings;
@@ -31,9 +34,16 @@ namespace OrchardCore.ContentLocalization
 {
     public class Startup : StartupBase
     {
+        private readonly AdminOptions _adminOptions;
+
         static Startup()
         {
             TemplateContext.GlobalMemberAccessStrategy.Register<LocalizationPartViewModel>();
+        }
+
+        public Startup(IOptions<AdminOptions> adminOptions)
+        {
+            _adminOptions = adminOptions.Value;
         }
 
         public override void ConfigureServices(IServiceCollection services)
@@ -46,6 +56,16 @@ namespace OrchardCore.ContentLocalization
 
             services.AddScoped<IPermissionProvider, Permissions>();
             services.AddScoped<IAuthorizationHandler, LocalizeContentAuthorizationHandler>();
+        }
+
+        public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
+        {
+            routes.MapAreaControllerRoute(
+                name: "ContentLocalization.Localize",
+                areaName: "OrchardCore.ContentLocalization",
+                pattern: _adminOptions.AdminUrlPrefix + "/ContentLocalization",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.Localize) }
+            );
         }
     }
 
@@ -93,6 +113,7 @@ namespace OrchardCore.ContentLocalization
         {
             TemplateContext.GlobalMemberAccessStrategy.Register<CultureInfo>();
         }
+
         public override void ConfigureServices(IServiceCollection services)
         {
             services.AddLiquidFilter<ContentLocalizationFilter>("localization_set");

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePickerContainer.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePickerContainer.cshtml
@@ -2,15 +2,25 @@
     <li class="nav-item dropdown">
         <a class="nav-link dropdown-toggle" href="#" id="oc-culture-picker" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">@Model.CurrentCulture.DisplayName</a>
         <div class="dropdown-menu" aria-labelledby="oc-culture-picker">
-            @foreach (var culture in Model.SupportedCultures)
-            {
-                if (culture.Name != Model.CurrentCulture.Name)
+            @{
+                var routeData = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var culture in Model.SupportedCultures)
                 {
-                    <a asp-route="RedirectToLocalizedContent"
-                       asp-route-area="OrchardCore.ContentLocalization"
-                       asp-route-targetculture="@culture.Name"
-                       asp-route-contentItemUrl="@Context.Request.Path.Value"
-                       class="dropdown-item">@culture.DisplayName</a>
+                    if (culture.Name != Model.CurrentCulture.Name)
+                    {
+                        routeData.Clear();
+                        routeData.Add("area", "OrchardCore.ContentLocalization");
+                        routeData.Add("targetCulture", culture.Name);
+                        routeData.Add("contentItemUrl", Context.Request.Path.Value);
+
+                        foreach (var kv in Context.Request.Query)
+                        {
+                            routeData.TryAdd(kv.Key, kv.Value.ToString());
+                        }
+
+                        <a asp-route="RedirectToLocalizedContent" asp-all-route-data=@routeData class="dropdown-item">@culture.DisplayName</a>
+                    }
                 }
             }
         </div>

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -49,6 +49,7 @@
         <div class="row">
             <div class="col-lg-8 col-md-10 mx-auto">
 				{% render_section "Messages", required: false %}
+                {% shape "ContentCulturePicker" %}
                 {% render_body %}
             </div>
         </div>


### PR DESCRIPTION
Fixes #5129 

@hishamco i started working on this one so i needed to include what you did in #5197.

Hmm, not so obvious

- In `ContentCulturePickerController.RedirectToLocalizedContent()` we preserve query parameters before redirecting but not the `targetCulture` and `contentItemUrl` ones that are also passed through the query string for this controller action that uses them.

- In `ContentCulturePickerContainer.cshtml` the generated link preserve the ambient query parameters that will be taking into account by the above controller.

- As i have time, i think tomorrow, i will need to do the same kind of things in the `switch_culture_url` liquid filter.