### PR TITLE
Fix remaining routes to AdminUrlPrefix

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Startup.cs
@@ -122,6 +122,18 @@ namespace OrchardCore.AdminMenu
                 pattern: _adminOptions.AdminUrlPrefix + "/AdminMenu/Node/Edit",
                 defaults: new { controller = nodeControllerName, action = nameof(NodeController.Edit) }
             );
+            routes.MapAreaControllerRoute(
+                name: "AdminMenuNodeToggle",
+                areaName: "OrchardCore.AdminMenu",
+                pattern: _adminOptions.AdminUrlPrefix + "/AdminMenu/Node/Toggle",
+                defaults: new { controller = nodeControllerName, action = nameof(NodeController.Toggle) }
+            );
+            routes.MapAreaControllerRoute(
+                name: "AdminMenuNodeMoveNode",
+                areaName: "OrchardCore.AdminMenu",
+                pattern: _adminOptions.AdminUrlPrefix + "/AdminMenu/Node/MoveNode",
+                defaults: new { controller = nodeControllerName, action = nameof(NodeController.MoveNode) }
+            );
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Startup.cs
@@ -42,22 +42,28 @@ namespace OrchardCore.BackgroundTasks
                 defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Index) }
             );
             routes.MapAreaControllerRoute(
-                name: "BackgroundTasksDisable",
+                name: "BackgroundTasksCreate",
                 areaName: "OrchardCore.BackgroundTasks",
-                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Disable/{id}",
-                defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Disable) }
+                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Create",
+                defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Create) }
             );
             routes.MapAreaControllerRoute(
                 name: "BackgroundTasksEdit",
                 areaName: "OrchardCore.BackgroundTasks",
-                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Edit/{id}",
+                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Edit",
                 defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Edit) }
             );
             routes.MapAreaControllerRoute(
                 name: "BackgroundTasksEnable",
                 areaName: "OrchardCore.BackgroundTasks",
-                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Enable/{id}",
+                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Enable",
                 defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Enable) }
+            );
+            routes.MapAreaControllerRoute(
+                name: "BackgroundTasksDisable",
+                areaName: "OrchardCore.BackgroundTasks",
+                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Disable",
+                defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Disable) }
             );
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Startup.cs
@@ -44,25 +44,25 @@ namespace OrchardCore.BackgroundTasks
             routes.MapAreaControllerRoute(
                 name: "BackgroundTasksCreate",
                 areaName: "OrchardCore.BackgroundTasks",
-                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Create",
+                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Create/{name}",
                 defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Create) }
             );
             routes.MapAreaControllerRoute(
                 name: "BackgroundTasksEdit",
                 areaName: "OrchardCore.BackgroundTasks",
-                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Edit",
+                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Edit/{name}",
                 defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Edit) }
             );
             routes.MapAreaControllerRoute(
                 name: "BackgroundTasksEnable",
                 areaName: "OrchardCore.BackgroundTasks",
-                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Enable",
+                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Enable/{name}",
                 defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Enable) }
             );
             routes.MapAreaControllerRoute(
                 name: "BackgroundTasksDisable",
                 areaName: "OrchardCore.BackgroundTasks",
-                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Disable",
+                pattern: _adminOptions.AdminUrlPrefix + "/BackgroundTasks/Disable/{name}",
                 defaults: new { controller = backgroundTaskControllerName, action = nameof(BackgroundTaskController.Disable) }
             );
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
@@ -3,6 +3,9 @@ using Fluid;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
+using OrchardCore.ContentFields.Controllers;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentFields.Indexing;
 using OrchardCore.ContentFields.Indexing.SQL;
@@ -16,11 +19,13 @@ using OrchardCore.Data;
 using OrchardCore.Data.Migration;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
+using OrchardCore.Mvc.Core.Utilities;
 
 namespace OrchardCore.ContentFields
 {
     public class Startup : StartupBase
     {
+        private readonly AdminOptions _adminOptions;
         static Startup()
         {
             // Registering both field types and shape types are necessary as they can 
@@ -42,6 +47,11 @@ namespace OrchardCore.ContentFields
             TemplateContext.GlobalMemberAccessStrategy.Register<DisplayDateFieldViewModel>();
             TemplateContext.GlobalMemberAccessStrategy.Register<TimeField>();
             TemplateContext.GlobalMemberAccessStrategy.Register<DisplayTimeFieldViewModel>();
+        }
+
+        public Startup(IOptions<AdminOptions> adminOptions)
+        {
+            _adminOptions = adminOptions.Value;
         }
 
         public override void ConfigureServices(IServiceCollection services)
@@ -119,8 +129,8 @@ namespace OrchardCore.ContentFields
             routes.MapAreaControllerRoute(
                 name: "ContentPicker",
                 areaName: "OrchardCore.ContentFields",
-                pattern: "ContentFields/SearchContentItems",
-                defaults: new { controller = "ContentPickerAdmin", action = "SearchContentItems" }
+                pattern: _adminOptions.AdminUrlPrefix + "/ContentFields/SearchContentItems",
+                defaults: new { controller = typeof(ContentPickerAdminController).ControllerName(), action = nameof(ContentPickerAdminController.SearchContentItems) }
             );
         }
     }
@@ -128,6 +138,13 @@ namespace OrchardCore.ContentFields
     [RequireFeatures("OrchardCore.ContentLocalization")]
     public class LocalizationSetContentPickerStartup : StartupBase
     {
+        private readonly AdminOptions _adminOptions;
+
+        public LocalizationSetContentPickerStartup(IOptions<AdminOptions> adminOptions)
+        {
+            _adminOptions = adminOptions.Value;
+        }
+
         public override void ConfigureServices(IServiceCollection services)
         {
             services.AddContentField<LocalizationSetContentPickerField>();
@@ -141,8 +158,8 @@ namespace OrchardCore.ContentFields
             routes.MapAreaControllerRoute(
                 name: "SearchLocalizationSets",
                 areaName: "OrchardCore.ContentFields",
-                pattern: "ContentFields/SearchLocalizationSets",
-                defaults: new { controller = "LocalizationSetContentPickerAdmin", action = "SearchLocalizationSets" }
+                pattern: _adminOptions.AdminUrlPrefix + "/ContentFields/SearchLocalizationSets",
+                defaults: new { controller = typeof(LocalizationSetContentPickerAdminController).ControllerName(), action = nameof(LocalizationSetContentPickerAdminController.SearchLocalizationSets) }
             );
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -162,6 +162,41 @@ namespace OrchardCore.Contents
                 pattern: _adminOptions.AdminUrlPrefix + "/Contents/ContentItems/{contentTypeId?}",
                 defaults: new {controller = adminControllerName, action = nameof(AdminController.List) }
             );
+
+            routes.MapAreaControllerRoute(
+                name: "AdminPublishContentItem",
+                areaName: "OrchardCore.Contents",
+                pattern: _adminOptions.AdminUrlPrefix + "/Contents/ContentItems/{contentItemId}/Publish",
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.Publish) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "AdminDiscardDraftContentItem",
+                areaName: "OrchardCore.Contents",
+                pattern: _adminOptions.AdminUrlPrefix + "/Contents/ContentItems/{contentItemId}/DiscardDraft",
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.DiscardDraft) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "AdminDeleteContentItem",
+                areaName: "OrchardCore.Contents",
+                pattern: _adminOptions.AdminUrlPrefix + "/Contents/ContentItems/{contentItemId}/Delete",
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.Remove) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "AdminCloneContentItem",
+                areaName: "OrchardCore.Contents",
+                pattern: _adminOptions.AdminUrlPrefix + "/Contents/ContentItems/{contentItemId}/Clone",
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.Clone) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "AdminUnpublishContentItem",
+                areaName: "OrchardCore.Contents",
+                pattern: _adminOptions.AdminUrlPrefix + "/Contents/ContentItems/{contentItemId}/Unpublish",
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.Unpublish) }
+            );
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Startup.cs
@@ -12,6 +12,7 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.Data.Migration;
 using OrchardCore.Demo.Commands;
 using OrchardCore.Demo.ContentElementDisplays;
+using OrchardCore.Demo.Controllers;
 using OrchardCore.Demo.Drivers;
 using OrchardCore.Demo.Models;
 using OrchardCore.Demo.Services;
@@ -20,6 +21,7 @@ using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Environment.Commands;
 using OrchardCore.Modules;
+using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Navigation;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Users.Models;
@@ -38,31 +40,42 @@ namespace OrchardCore.Demo
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
         {
             routes.MapAreaControllerRoute(
-                name: "Home",
+                name: "Demo.Home.Index",
                 areaName: "OrchardCore.Demo",
                 pattern: "Home/Index",
                 defaults: new { controller = "Home", action = "Index" }
             );
 
             routes.MapAreaControllerRoute(
-                name: "Display",
+                name: "Demo.Home.Display",
                 areaName: "OrchardCore.Demo",
                 pattern: "Home/Display/{contentItemId}",
                 defaults: new { controller = "Home", action = "Display" }
             );
 
             routes.MapAreaControllerRoute(
-                name: "Error",
+                name: "Demo.Home.Error",
                 areaName: "OrchardCore.Demo",
                 pattern: "Home/IndexError",
                 defaults: new { controller = "Home", action = "IndexError" }
             );
 
+            var demoAdminControllerName = typeof(AdminController).ControllerName();
+
             routes.MapAreaControllerRoute(
-                name: "AdminDemo",
+                name: "Demo.Admin",
                 areaName: "OrchardCore.Demo",
-                pattern: _adminOptions.AdminUrlPrefix + "/Demo/Index",
-                defaults: new { controller = "Admin", action = "Index" }
+                pattern: _adminOptions.AdminUrlPrefix + "/Demo/Admin",
+                defaults: new { controller = demoAdminControllerName, action = nameof(AdminController.Index) }
+            );
+
+            var demoContentControllerName = typeof(ContentController).ControllerName();
+
+            routes.MapAreaControllerRoute(
+                name: "Demo.Content.Edit",
+                areaName: "OrchardCore.Demo",
+                pattern: _adminOptions.AdminUrlPrefix + "/Demo/Content/Edit",
+                defaults: new { controller = demoContentControllerName, action = nameof(ContentController.Edit) }
             );
 
             builder.UseMiddleware<NonBlockingMiddleware>();

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Startup.cs
@@ -87,6 +87,14 @@ namespace OrchardCore.Deployment
                 pattern: _adminOptions.AdminUrlPrefix + "/Deployment/RemoteInstance/Edit/{id}",
                 defaults: new { controller = remoteInstanceControllerName, action = nameof(RemoteInstanceController.Edit) }
             );
+
+            //ExportRemoteInstance
+            routes.MapAreaControllerRoute(
+                name: "DeploymentExportRemoteInstanceExecute",
+                areaName: "OrchardCore.Deployment.Remote",
+                pattern: _adminOptions.AdminUrlPrefix + "/Deployment/ExportRemoteInstance/Execute",
+                defaults: new { controller = typeof(ExportRemoteInstanceController).ControllerName(), action = nameof(ExportRemoteInstanceController.Execute) }
+            );
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -19,7 +19,6 @@ using OrchardCore.Routing;
 
 namespace OrchardCore.Features.Controllers
 {
-    [Admin]
     public class AdminController : Controller
     {
         private readonly IModuleService _moduleService;
@@ -34,7 +33,6 @@ namespace OrchardCore.Features.Controllers
             IModuleService moduleService,
             IExtensionManager extensionManager,
             IHtmlLocalizer<AdminController> localizer,
-            IShellDescriptorManager shellDescriptorManager,
             IShellFeaturesManager shellFeaturesManager,
             IAuthorizationService authorizationService,
             ShellSettings shellSettings,
@@ -51,7 +49,7 @@ namespace OrchardCore.Features.Controllers
 
         public async Task<ActionResult> Features()
         {
-            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageFeatures)) // , H["Not allowed to manage features."]
+            if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageFeatures))
             {
                 return Unauthorized();
             }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/OrchardCore.Flows.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/OrchardCore.Flows.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Indexing.Abstractions\OrchardCore.Indexing.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Liquid.Abstractions\OrchardCore.Liquid.Abstractions.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
@@ -61,7 +61,7 @@ namespace OrchardCore.Flows
             routes.MapAreaControllerRoute(
                 name: "Flows.BuildEditor",
                 areaName: "OrchardCore.Flows",
-                pattern: _adminOptions.AdminUrlPrefix + "/BuildEditor",
+                pattern: _adminOptions.AdminUrlPrefix + "/Flows/BuildEditor",
                 defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.BuildEditor) }
             );
         }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
@@ -1,9 +1,15 @@
+using System;
 using Fluid;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
+using OrchardCore.Flows.Controllers;
 using OrchardCore.Flows.Drivers;
 using OrchardCore.Flows.Indexing;
 using OrchardCore.Flows.Models;
@@ -11,17 +17,25 @@ using OrchardCore.Flows.Settings;
 using OrchardCore.Flows.ViewModels;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
+using OrchardCore.Mvc.Core.Utilities;
 
 namespace OrchardCore.Flows
 {
     public class Startup : StartupBase
     {
+        private readonly AdminOptions _adminOptions;
+
         static Startup()
         {
             TemplateContext.GlobalMemberAccessStrategy.Register<BagPartViewModel>();
             TemplateContext.GlobalMemberAccessStrategy.Register<FlowPartViewModel>();
             TemplateContext.GlobalMemberAccessStrategy.Register<FlowMetadata>();
             TemplateContext.GlobalMemberAccessStrategy.Register<FlowPart>();
+        }
+
+        public Startup(IOptions<AdminOptions> adminOptions)
+        {
+            _adminOptions = adminOptions.Value;
         }
 
         public override void ConfigureServices(IServiceCollection services)
@@ -40,6 +54,16 @@ namespace OrchardCore.Flows
             services.AddContentPart<FlowMetadata>();
 
             services.AddScoped<IDataMigration, Migrations>();
+        }
+
+        public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
+        {
+            routes.MapAreaControllerRoute(
+                name: "Flows.BuildEditor",
+                areaName: "OrchardCore.Flows",
+                pattern: _adminOptions.AdminUrlPrefix + "/BuildEditor",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.BuildEditor) }
+            );
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -192,6 +192,83 @@ namespace OrchardCore.Media
             );
 
             routes.MapAreaControllerRoute(
+                name: "Media.MediaApplication",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/MediaApplication",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.MediaApplication) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.GetFolders",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/GetFolders",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.GetFolders) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.GetMediaItems",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/GetMediaItems",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.GetMediaItems) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.GetMediaItem",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/GetMediaItem",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.GetMediaItem) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.Upload",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/Upload",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.Upload) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.DeleteFolder",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/DeleteFolder",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.DeleteFolder) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.DeleteMedia",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/DeleteMedia",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.DeleteMedia) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.MoveMedia",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/MoveMedia",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.MoveMedia) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.DeleteMediaList",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/DeleteMediaList",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.DeleteMediaList) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.MoveMediaList",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/MoveMediaList",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.MoveMediaList) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Media.CreateFolder",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/CreateFolder",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.CreateFolder) }
+            );
+
+            routes.MapAreaControllerRoute(
                 name: "MediaCache.Index",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/MediaCache",

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -184,60 +184,62 @@ namespace OrchardCore.Media
                 }
             });
 
+            var adminControllerName = typeof(AdminController).ControllerName();
+
             routes.MapAreaControllerRoute(
                 name: "Media.Index",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.Index) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.Index) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.MediaApplication",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/MediaApplication",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.MediaApplication) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.MediaApplication) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.GetFolders",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/GetFolders",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.GetFolders) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.GetFolders) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.GetMediaItems",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/GetMediaItems",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.GetMediaItems) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.GetMediaItems) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.GetMediaItem",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/GetMediaItem",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.GetMediaItem) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.GetMediaItem) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.Upload",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/Upload",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.Upload) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.Upload) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.DeleteFolder",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/DeleteFolder",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.DeleteFolder) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.DeleteFolder) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.DeleteMedia",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/DeleteMedia",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.DeleteMedia) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.DeleteMedia) }
             );
 
             routes.MapAreaControllerRoute(
@@ -251,28 +253,37 @@ namespace OrchardCore.Media
                 name: "Media.DeleteMediaList",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/DeleteMediaList",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.DeleteMediaList) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.DeleteMediaList) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.MoveMediaList",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/MoveMediaList",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.MoveMediaList) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.MoveMediaList) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Media.CreateFolder",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/CreateFolder",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.CreateFolder) }
+                defaults: new { controller = adminControllerName, action = nameof(AdminController.CreateFolder) }
             );
+
+            var mediaCacheControllerName = typeof(MediaCacheController).ControllerName();
 
             routes.MapAreaControllerRoute(
                 name: "MediaCache.Index",
                 areaName: "OrchardCore.Media",
                 pattern: _adminOptions.AdminUrlPrefix + "/MediaCache",
-                defaults: new { controller = typeof(MediaCacheController).ControllerName(), action = nameof(MediaCacheController.Index) }
+                defaults: new { controller = mediaCacheControllerName, action = nameof(MediaCacheController.Index) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "MediaCache.Purge",
+                areaName: "OrchardCore.Media",
+                pattern: _adminOptions.AdminUrlPrefix + "/MediaCache/Purge",
+                defaults: new { controller = mediaCacheControllerName, action = nameof(MediaCacheController.Purge) }
             );
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -196,7 +196,7 @@ namespace OrchardCore.Media
             routes.MapAreaControllerRoute(
                 name: "Media.MediaApplication",
                 areaName: "OrchardCore.Media",
-                pattern: _adminOptions.AdminUrlPrefix + "/MediaApplication",
+                pattern: _adminOptions.AdminUrlPrefix + "/Media/MediaApplication",
                 defaults: new { controller = adminControllerName, action = nameof(AdminController.MediaApplication) }
             );
 

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -18,7 +18,6 @@ using OrchardCore.Settings;
 
 namespace OrchardCore.Recipes.Controllers
 {
-    [Admin]
     public class AdminController : Controller
     {
         private readonly ShellSettings _shellSettings;
@@ -33,7 +32,6 @@ namespace OrchardCore.Recipes.Controllers
         public AdminController(
             ShellSettings shellSettings,
             ISiteService siteService,
-            IAdminThemeService adminThemeService,
             IExtensionManager extensionManager,
             IHtmlLocalizer<AdminController> localizer,
             IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/OrchardCore.Taxonomies.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/OrchardCore.Taxonomies.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Apis.GraphQL.Abstractions\OrchardCore.Apis.GraphQL.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Abstractions\OrchardCore.ContentManagement.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Startup.cs
@@ -1,5 +1,10 @@
+using System;
 using Fluid;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
 using OrchardCore.Apis;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
@@ -9,7 +14,9 @@ using OrchardCore.Data.Migration;
 using OrchardCore.Indexing;
 using OrchardCore.Liquid;
 using OrchardCore.Modules;
+using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Security.Permissions;
+using OrchardCore.Taxonomies.Controllers;
 using OrchardCore.Taxonomies.Drivers;
 using OrchardCore.Taxonomies.Fields;
 using OrchardCore.Taxonomies.GraphQL;
@@ -23,6 +30,8 @@ namespace OrchardCore.Taxonomies
 {
     public class Startup : StartupBase
     {
+        private readonly AdminOptions _adminOptions;
+
         static Startup()
         {
             // Registering both field types and shape types are necessary as they can 
@@ -30,6 +39,11 @@ namespace OrchardCore.Taxonomies
 
             TemplateContext.GlobalMemberAccessStrategy.Register<TaxonomyField>();
             TemplateContext.GlobalMemberAccessStrategy.Register<DisplayTaxonomyFieldViewModel>();
+        }
+
+        public Startup(IOptions<AdminOptions> adminOptions)
+        {
+            _adminOptions = adminOptions.Value;
         }
 
         public override void ConfigureServices(IServiceCollection services)
@@ -48,6 +62,32 @@ namespace OrchardCore.Taxonomies
             services.AddScoped<IContentFieldIndexHandler, TaxonomyFieldIndexHandler>();
 
             services.AddScoped<IScopedIndexProvider, TaxonomyIndexProvider>();
+        }
+
+        public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
+        {
+            var taxonomyControllerName = typeof(AdminController).ControllerName();
+
+            routes.MapAreaControllerRoute(
+                name: "Taxonomies.Create",
+                areaName: "OrchardCore.Taxonomies",
+                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Create",
+                defaults: new { controller = taxonomyControllerName, action = nameof(AdminController.Create) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Taxonomies.Edit",
+                areaName: "OrchardCore.Taxonomies",
+                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Edit",
+                defaults: new { controller = taxonomyControllerName, action = nameof(AdminController.Edit) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Taxonomies.Delete",
+                areaName: "OrchardCore.Taxonomies",
+                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Delete",
+                defaults: new { controller = taxonomyControllerName, action = nameof(AdminController.Delete) }
+            );
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Startup.cs
@@ -71,21 +71,21 @@ namespace OrchardCore.Taxonomies
             routes.MapAreaControllerRoute(
                 name: "Taxonomies.Create",
                 areaName: "OrchardCore.Taxonomies",
-                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Create",
+                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Create/{id}",
                 defaults: new { controller = taxonomyControllerName, action = nameof(AdminController.Create) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Taxonomies.Edit",
                 areaName: "OrchardCore.Taxonomies",
-                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Edit",
+                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Edit/{taxonomyContentItemId}/{taxonomyItemId}",
                 defaults: new { controller = taxonomyControllerName, action = nameof(AdminController.Edit) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Taxonomies.Delete",
                 areaName: "OrchardCore.Taxonomies",
-                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Delete",
+                pattern: _adminOptions.AdminUrlPrefix + "/Taxonomies/Delete/{taxonomyContentItemId}/{taxonomyItemId}",
                 defaults: new { controller = taxonomyControllerName, action = nameof(AdminController.Delete) }
             );
         }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Startup.cs
@@ -64,6 +64,13 @@ namespace OrchardCore.Templates
             );
 
             routes.MapAreaControllerRoute(
+                name: "Templates.Admin",
+                areaName: "OrchardCore.Templates",
+                pattern: _adminOptions.AdminUrlPrefix + "/Templates/Admin",
+                defaults: new { controller = templateControllerName, action = nameof(TemplateController.Admin) }
+            );
+
+            routes.MapAreaControllerRoute(
                 name: "Templates.Create",
                 areaName: "OrchardCore.Templates",
                 pattern: _adminOptions.AdminUrlPrefix + "/Templates/Create",

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -16,15 +16,11 @@ using OrchardCore.Themes.Services;
 
 namespace OrchardCore.Themes.Controllers
 {
-    [Admin]
     public class AdminController : Controller
     {
         private readonly ISiteThemeService _siteThemeService;
         private readonly IAdminThemeService _adminThemeService;
-        private readonly IThemeService _themeService;
-        private readonly ShellSettings _shellSettings;
         private readonly IExtensionManager _extensionManager;
-        private readonly IShellDescriptorManager _shellDescriptorManager;
         private readonly IShellFeaturesManager _shellFeaturesManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly INotifier _notifier;
@@ -44,10 +40,7 @@ namespace OrchardCore.Themes.Controllers
         {
             _siteThemeService = siteThemeService;
             _adminThemeService = adminThemeService;
-            _themeService = themeService;
-            _shellSettings = shellSettings;
             _extensionManager = extensionManager;
-            _shellDescriptorManager = shellDescriptorManager;
             _shellFeaturesManager = shellFeaturesManager;
             _authorizationService = authorizationService;
             _notifier = notifier;

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
@@ -47,11 +47,48 @@ namespace OrchardCore.Themes
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
         {
+            var themeControllerName = typeof(AdminController).ControllerName();
+
             routes.MapAreaControllerRoute(
                 name: "Themes.Index",
                 areaName: "OrchardCore.Themes",
                 pattern: _adminOptions.AdminUrlPrefix + "/Themes",
-                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.Index) }
+                defaults: new { controller = themeControllerName, action = nameof(AdminController.Index) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Themes.SetCurrentTheme",
+                areaName: "OrchardCore.Themes",
+                pattern: _adminOptions.AdminUrlPrefix + "/Themes/SetCurrentTheme",
+                defaults: new { controller = themeControllerName, action = nameof(AdminController.SetCurrentTheme) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Themes.ResetSiteTheme",
+                areaName: "OrchardCore.Themes",
+                pattern: _adminOptions.AdminUrlPrefix + "/Themes/ResetSiteTheme",
+                defaults: new { controller = themeControllerName, action = nameof(AdminController.ResetSiteTheme) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Themes.ResetAdminTheme",
+                areaName: "OrchardCore.Themes",
+                pattern: _adminOptions.AdminUrlPrefix + "/Themes/ResetAdminTheme",
+                defaults: new { controller = themeControllerName, action = nameof(AdminController.ResetAdminTheme) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Themes.Disable",
+                areaName: "OrchardCore.Themes",
+                pattern: _adminOptions.AdminUrlPrefix + "/Themes/Disable",
+                defaults: new { controller = themeControllerName, action = nameof(AdminController.Disable) }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "Themes.Enable",
+                areaName: "OrchardCore.Themes",
+                pattern: _adminOptions.AdminUrlPrefix + "/Themes/Enable",
+                defaults: new { controller = themeControllerName, action = nameof(AdminController.Enable) }
             );
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
@@ -59,7 +59,7 @@ namespace OrchardCore.Themes
             routes.MapAreaControllerRoute(
                 name: "Themes.SetCurrentTheme",
                 areaName: "OrchardCore.Themes",
-                pattern: _adminOptions.AdminUrlPrefix + "/Themes/SetCurrentTheme",
+                pattern: _adminOptions.AdminUrlPrefix + "/Themes/SetCurrentTheme/{id}",
                 defaults: new { controller = themeControllerName, action = nameof(AdminController.SetCurrentTheme) }
             );
 
@@ -80,14 +80,14 @@ namespace OrchardCore.Themes
             routes.MapAreaControllerRoute(
                 name: "Themes.Disable",
                 areaName: "OrchardCore.Themes",
-                pattern: _adminOptions.AdminUrlPrefix + "/Themes/Disable",
+                pattern: _adminOptions.AdminUrlPrefix + "/Themes/Disable/{id}",
                 defaults: new { controller = themeControllerName, action = nameof(AdminController.Disable) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "Themes.Enable",
                 areaName: "OrchardCore.Themes",
-                pattern: _adminOptions.AdminUrlPrefix + "/Themes/Enable",
+                pattern: _adminOptions.AdminUrlPrefix + "/Themes/Enable/{id}",
                 defaults: new { controller = themeControllerName, action = nameof(AdminController.Enable) }
             );
         }

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/OrchardCore.Widgets.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/OrchardCore.Widgets.csproj
@@ -10,6 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Abstractions\OrchardCore.ContentManagement.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Display\OrchardCore.ContentManagement.Display.csproj" />
@@ -17,7 +18,6 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
 
-    <ProjectReference Include="..\OrchardCore.Contents\OrchardCore.Contents.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Startup.cs
@@ -8,11 +8,25 @@ using OrchardCore.Widgets.Drivers;
 using OrchardCore.Widgets.Models;
 using OrchardCore.Widgets.Settings;
 using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.Admin;
+using Microsoft.Extensions.Options;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Routing;
+using System;
+using OrchardCore.Widgets.Controllers;
+using OrchardCore.Mvc.Core.Utilities;
 
 namespace OrchardCore.Widgets
 {
     public class Startup : StartupBase
     {
+        private readonly AdminOptions _adminOptions;
+
+        public Startup(IOptions<AdminOptions> adminOptions)
+        {
+            _adminOptions = adminOptions.Value;
+        }
+
         public override void ConfigureServices(IServiceCollection services)
         {
             //Add Widget Card Shapes
@@ -24,6 +38,16 @@ namespace OrchardCore.Widgets
             services.AddScoped<IContentTypePartDefinitionDisplayDriver, WidgetsListPartSettingsDisplayDriver>();
             services.AddContentPart<WidgetMetadata>();
             services.AddScoped<IDataMigration, Migrations>();
+        }
+
+        public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
+        {
+            routes.MapAreaControllerRoute(
+                name: "Widgets.BuildEditor",
+                areaName: "OrchardCore.Widgets",
+                pattern: _adminOptions.AdminUrlPrefix + "/Widgets/BuildEditor",
+                defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.BuildEditor) }
+            );
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
@@ -9,10 +9,12 @@ using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Entities;
 using OrchardCore.Modules;
+using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Workflows.Activities;
+using OrchardCore.Workflows.Controllers;
 using OrchardCore.Workflows.Deployment;
 using OrchardCore.Workflows.Drivers;
 using OrchardCore.Workflows.Evaluators;
@@ -80,32 +82,35 @@ namespace OrchardCore.Workflows
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
         {
+            var activityControllerName = typeof(ActivityController).ControllerName();
             routes.MapAreaControllerRoute(
                 name: "AddActivity",
                 areaName: "OrchardCore.Workflows",
                 pattern: _adminOptions.AdminUrlPrefix + "/Workflows/Types/{workflowTypeId}/Activity/{activityName}/Add",
-                defaults: new { controller = "Activity", action = "Create" }
+                defaults: new { controller = activityControllerName, action = nameof(ActivityController.Create) }
             );
 
             routes.MapAreaControllerRoute(
                 name: "EditActivity",
                 areaName: "OrchardCore.Workflows",
                 pattern: _adminOptions.AdminUrlPrefix + "/Workflows/Types/{workflowTypeId}/Activity/{activityId}/Edit",
-                defaults: new { controller = "Activity", action = "Edit" }
+                defaults: new { controller = activityControllerName, action = nameof(ActivityController.Edit) }
             );
 
+            var workflowControllerName = typeof(WorkflowController).ControllerName();
             routes.MapAreaControllerRoute(
                 name: "Workflows",
                 areaName: "OrchardCore.Workflows",
                 pattern: _adminOptions.AdminUrlPrefix + "/Workflows/Types/{workflowTypeId}/Instances/{action}",
-                defaults: new { controller = "Workflow", action = "Index" }
+                defaults: new { controller = workflowControllerName, action = nameof(WorkflowController.Index) }
             );
 
+            var workflowTypeControllerName = typeof(WorkflowTypeController).ControllerName();
             routes.MapAreaControllerRoute(
                 name: "WorkflowTypes",
                 areaName: "OrchardCore.Workflows",
                 pattern: _adminOptions.AdminUrlPrefix + "/Workflows/Types/{action}/{id?}",
-                defaults: new { controller = "WorkflowType", action = "Index" }
+                defaults: new { controller = workflowTypeControllerName, action = nameof(WorkflowTypeController.Index) }
             );
         }
     }


### PR DESCRIPTION
Routed to `/Admin/Feature` and/or tested (and was already good) the following

- Media
- Media Cache
- Content Picker
- Localized Content Picked
- Email
- Flows
- Menus
- Queries
- Themes
- Taxonomies 
- Widgets
- Features
- Recipes
- Background Tasks
- Demo Controller
- Remote Instance
- Templates
- Workflows
- Content list publish /delete/clone/unpublish and bulk actions