### PR TITLE
Update "Creating a modular ASP.NET Core application" guide

### DIFF
--- a/src/docs/guides/create-modular-application-mvc/README.md
+++ b/src/docs/guides/create-modular-application-mvc/README.md
@@ -66,10 +66,10 @@ We will change the route of the view in this module to handle the home page.
 In the `Startup.cs` file of `MyModule`, add this code in the `Configure()` method.
 
 ```csharp
-    routes.MapAreaRoute(
+    routes.MapAreaControllerRoute(
         name: "Home",
         areaName: "MyModule",
-        template: "",
+        pattern: "",
         defaults: new { controller = "Home", action = "Index" }
     );
 ```


### PR DESCRIPTION
Section "Registering a custom route" is out of date with code generation templates and implementation (probably since the upgrade to dotnet 3.0). Generation template creates a `Configure()` method which accepts an `IEndpointRouteBuilder` (formerly `IRouteBuilder`), which does not have a `MapAreaRoute()` method. `MapAreaControllerRoute()` seems to be the method to use here.