### PR TITLE
Bearer Token GraphQL Content Permissions Support

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
@@ -50,16 +50,14 @@ namespace OrchardCore.Apis.GraphQL
             }
             else
             {
-                var principal = context.User;
-
                 var authenticateResult = await authenticationService.AuthenticateAsync(context, "Api");
 
                 if (authenticateResult.Succeeded)
                 {
-                    principal = authenticateResult.Principal;
+                    context.User = authenticateResult.Principal;
                 }
 
-                var authorized = await authorizationService.AuthorizeAsync(principal, Permissions.ExecuteGraphQL);
+                var authorized = await authorizationService.AuthorizeAsync(context.User, Permissions.ExecuteGraphQL);
 
                 if (authorized)
                 {


### PR DESCRIPTION
Updating context.User to the Principal from API authentication process as authenticate user is needed in downstream validation.