### PR TITLE
Fixes autoroute trailing slash

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutoRouteTransformer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutoRouteTransformer.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.Autoroute.Routing
 
         public override ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
         {
-            if (_entries.TryGetContentItemId(httpContext.Request.Path.Value.TrimEnd('/'), out var contentItemId))
+            if (_entries.TryGetContentItemId(httpContext.Request.Path.Value, out var contentItemId))
             {
                 var routeValues = new RouteValueDictionary(_options.GlobalRouteValues);
                 routeValues[_options.ContentItemIdKey] = contentItemId;

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Autoroute.Services
 
         public bool TryGetContentItemId(string path, out string contentItemId)
         {
-            return _contentItemIds.TryGetValue(path, out contentItemId);
+            return _contentItemIds.TryGetValue(path.TrimEnd('/'), out contentItemId);
         }
 
         public bool TryGetPath(string contentItemId, out string path)
@@ -36,7 +36,7 @@ namespace OrchardCore.Autoroute.Services
                         _contentItemIds.Remove(previousPath);
                     }
 
-                    var requestPath = "/" + entry.Path.TrimStart('/');
+                    var requestPath = "/" + entry.Path.Trim('/');
                     _paths[entry.ContentItemId] = requestPath;
                     _contentItemIds[requestPath] = entry.ContentItemId;
                 }


### PR DESCRIPTION
For a given autoroute e.g `/about`, both routes `/about` and `/about/` work because we trim the trailing slash before asking to `AutorouteEntries` the related item.

But working on the content culture picker i had a little issue because `ContentCulturePickerService` doesn't trim the trailing slash. And i also saw that for a given content item we can save an autoroute with a trailing slash.

So here i just trim this trailing slash in `AutorouteEntries` itself, when we cache it and also when we lookup for a related item.