### PR TITLE
GraphQL: fixes name clash issue when using dynamic parts on multiple types

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
@@ -82,6 +82,11 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
                 }
             }
 
+            foreach (var builder in contentTypeBuilders)
+            {
+                builder.Clear();
+            }
+
             return Task.FromResult(changeToken);
         }
     }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
@@ -89,5 +89,10 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                 }
             }
         }
+
+        public void Clear()
+        {
+            _dynamicPartFields.Clear();
+        }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Linq;
 using GraphQL.Types;
 using Microsoft.AspNetCore.Http;
@@ -14,6 +15,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly GraphQLContentOptions _contentOptions;
         private readonly IStringLocalizer S;
+        private readonly Dictionary<string, FieldType> _dynamicPartFields;
 
         public DynamicContentTypeBuilder(IHttpContextAccessor httpContextAccessor,
             IOptions<GraphQLContentOptions> contentOptionsAccessor,
@@ -21,6 +23,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
         {
             _httpContextAccessor = httpContextAccessor;
             _contentOptions = contentOptionsAccessor.Value;
+            _dynamicPartFields = new Dictionary<string, FieldType>();
 
             S = localizer;
         }
@@ -62,19 +65,27 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                 }
                 else
                 {
-                    var field = contentItemType.Field(
-                        typeof(DynamicPartGraphType),
-                        partName.ToFieldName(),
-                        description: S["Represents a {0}.", part.PartDefinition.Name],
-                        resolve: context =>
-                        {
-                            var nameToResolve = partName;
-                            var typeToResolve = context.ReturnType.GetType().BaseType.GetGenericArguments().First();
+                    if (_dynamicPartFields.TryGetValue(partName, out var fieldType))
+                    {
+                        contentItemType.AddField(fieldType);
+                    }
+                    else
+                    {
+                        var field = contentItemType.Field(
+                            typeof(DynamicPartGraphType),
+                            partName.ToFieldName(),
+                            description: S["Represents a {0}.", part.PartDefinition.Name],
+                            resolve: context =>
+                            {
+                                var nameToResolve = partName;
+                                var typeToResolve = context.ReturnType.GetType().BaseType.GetGenericArguments().First();
 
-                            return context.Source.Get(typeToResolve, nameToResolve);
-                        });
+                                return context.Source.Get(typeToResolve, nameToResolve);
+                            });
 
-                    field.ResolvedType = new DynamicPartGraphType(_httpContextAccessor, part);
+                        field.ResolvedType = new DynamicPartGraphType(_httpContextAccessor, part);
+                        _dynamicPartFields[partName] = field;
+                    }
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/IContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/IContentTypeBuilder.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using GraphQL.Types;
 using OrchardCore.ContentManagement.Metadata.Models;
 
@@ -7,5 +6,6 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
     public interface IContentTypeBuilder
     {
         void Build(FieldType contentQuery, ContentTypeDefinition contentTypeDefinition, ContentItemType contentItemType);
+        void Clear() { }
     }
 }


### PR DESCRIPTION
fixes #5250 

The dynamic builder is trying to register the same field definition for a dynamic part twice (and succeeding as technically that is fine) but it always tries to resolve the first one which is incorrect.

This doesn't happen in strongly-typed parts as they are registered via DI and always the correct one is returned.

I've fixed these by having the schema builder cache them in a dictionary so each type uses the same field definition; also had to add a method to the builder that says the schema build is complete, so it can be cleared for if those change on content definition change and to free memory after schema build.

(builders are singleton)

/cc @jeffolmstead @jptissot 