### PR TITLE
Upgrade to ASP.NET 3.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ os:
   - osx
 osx_image: xcode10.1
 script:
-  - curl https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version 3.1.100
+  - curl https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh | bash /dev/stdin --version 3.1.101
   - if test "$TRAVIS_OS_NAME" == "linux"; then export PATH="/home/travis/.dotnet":"$PATH"; fi
   - if test "$TRAVIS_OS_NAME" == "osx"; then export PATH="/Users/travis/.dotnet":"$PATH"; fi
   - dotnet --info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
   - ps: $IsDevBranch = ($env:APPVEYOR_REPO_BRANCH -eq "dev" -And -not $env:APPVEYOR_PULL_REQUEST_NUMBER)
 # Uncomment to download a specific version of dotnet
 #  - ps: Invoke-WebRequest "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1" -OutFile "dotnet-install.ps1" 
-# - ps: .\dotnet-install.ps1 --Version 3.1.100
+# - ps: .\dotnet-install.ps1 --Version 3.1.101
 
 build_script:
   - dotnet build -c Release

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
+    <AspNetCoreVersion>3.1.1</AspNetCoreVersion>
+    <AspNetCoreLtsVersion>3.1.0</AspNetCoreLtsVersion>
     <AspNetCoreTargetFramework>netcoreapp3.1</AspNetCoreTargetFramework>
   </PropertyGroup>
   <ItemGroup>
@@ -16,6 +17,6 @@
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Owin" Version="$(AspNetCoreVersion)" />
-    <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="$(AspNetCoreVersion)" />
+    <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="$(AspNetCoreLtsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup>
     <AspNetCoreVersion>3.1.1</AspNetCoreVersion>
-    <AspNetCoreLtsVersion>3.1.0</AspNetCoreLtsVersion>
     <AspNetCoreTargetFramework>netcoreapp3.1</AspNetCoreTargetFramework>
   </PropertyGroup>
   <ItemGroup>
@@ -17,6 +16,6 @@
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Owin" Version="$(AspNetCoreVersion)" />
-    <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="$(AspNetCoreLtsVersion)" />
+    <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
If we want to update to .NET 3.1.1

I don't know if the download of a specific version of dotnet has to be uncommented in appveyor.yml