### PR TITLE
Provide new AddOrchardCms/AddOrchardCore overloads

### DIFF
--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/ServiceExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/ServiceExtensions.cs
@@ -8,17 +8,13 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds Orchard CMS services to the application. 
         /// </summary>
-        public static IServiceCollection AddOrchardCms(this IServiceCollection services)
+        public static OrchardCoreBuilder AddOrchardCms(this IServiceCollection services)
         {
-            return AddOrchardCms(services, null);
-        }
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
 
-        /// <summary>
-        /// Adds Orchard CMS services to the application and let the app change the
-        /// default tenant behavior and set of features through a configure action.
-        /// </summary>
-        public static IServiceCollection AddOrchardCms(this IServiceCollection services, Action<OrchardCoreBuilder> configure)
-        {
             var builder = services.AddOrchardCore()
 
                 .AddCommands()
@@ -46,6 +42,17 @@ namespace Microsoft.Extensions.DependencyInjection
                 s.AddTagHelpers<ScriptTagHelper>();
                 s.AddTagHelpers<StyleTagHelper>();
             });
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds Orchard CMS services to the application and let the app change the
+        /// default tenant behavior and set of features through a configure action.
+        /// </summary>
+        public static IServiceCollection AddOrchardCms(this IServiceCollection services, Action<OrchardCoreBuilder> configure)
+        {
+            var builder = services.AddOrchardCms();
 
             configure?.Invoke(builder);
 

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -38,6 +38,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         public static OrchardCoreBuilder AddOrchardCore(this IServiceCollection services)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             // If an instance of OrchardCoreBuilder exists reuse it,
             // so we can call AddOrchardCore several times.
             var builder = services
@@ -64,6 +69,19 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             return builder;
+        }
+
+        /// <summary>
+        /// Adds OrchardCore services to the host service collection and let the app change
+        /// the default behavior and set of features through a configure action.
+        /// </summary>
+        public static IServiceCollection AddOrchardCore(this IServiceCollection services, Action<OrchardCoreBuilder> configure)
+        {
+            var builder = services.AddOrchardCore();
+
+            configure?.Invoke(builder);
+
+            return services;
         }
 
         private static void AddDefaultServices(IServiceCollection services)


### PR DESCRIPTION
`AddOrchardCms` and `AddOrchardCore` currently have inconsistent signatures: the first one accepts a `configure` delegate while the second one returns the builder so you can chain calls using a fluent API.

This PR fixes that inconsistency by adding new extensions to support both styles.

Note: one of the API changes is technically binary (and potentially source) breaking - as it returns a different type - but I believe it's worth it.