### PR TITLE
Fix typos in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
             - Lucene: docs/reference/modules/Lucene/README.md
             - Queries: docs/reference/modules/Queries/README.md
             - Media: docs/reference/modules/Media/README.md
+            - Media Azure: docs/reference/modules/Media.Azure/README.md
             - ReCaptcha: docs/reference/modules/ReCaptcha/README.md
             - Resources: docs/reference/modules/Resources/README.md
             - Menu: docs/reference/modules/Menu/README.md
@@ -120,7 +121,6 @@ nav:
             - Health Check: docs/reference/modules/HealthChecks/README.md
             - Localization: docs/reference/modules/Localize/README.md
             - Logging Serilog: docs/reference/core/Logging.Serilog/readme.md
-            - Media Azure: docs/reference/modules/Media.Azure/README.md
             - Modules: docs/reference/core/Modules/README.md
             - OpenId: docs/reference/modules/OpenId/README.md
             - Recipes: docs/reference/modules/Recipes/README.md

--- a/src/docs/reference/modules/DataProtection.Azure/README.md
+++ b/src/docs/reference/modules/DataProtection.Azure/README.md
@@ -54,7 +54,7 @@ If not supplied the `BlobName` will automatically default to a folder per tenant
 ```
 
 !!! note
-Only the default liquid filters and tags are available during parsing of the liquid template.
-Extra filters like `slugify` will not be available.
+    Only the default liquid filters and tags are available during parsing of the liquid template.
+    Extra filters like `slugify` will not be available.
 
 Refer also to the [Configuration Section](../../core/Configuration/README.md).

--- a/src/docs/reference/modules/Media.Azure/README.md
+++ b/src/docs/reference/modules/Media.Azure/README.md
@@ -85,8 +85,8 @@ The `ContainerName` property and the `BasePath` property are the only templatabl
 ```
 
 !!! note
-Only the default liquid filters and tags are available during parsing of the liquid template.
-Extra filters like `slugify` will not be available.
+    Only the default liquid filters and tags are available during parsing of the liquid template.
+    Extra filters like `slugify` will not be available.
 
 ## Media Cache
 
@@ -100,7 +100,6 @@ You might choose to use the Purging feature if you are fronting the media assets
 After allowing a long enough period of time for the CDN to have fetched a significant amount of
 Media assets, both resized, and full size, from the Media Cache you might consider purging the cache.
 
-!!! note
 However please bear in mind that your CDN provider will likely have multiple Points of Presence
 worldwide, and each of these will maintain their own cache, so while a local CDN PoP might have the asset
 another PoP may not, until it is requested. At this stage the Media Cache will, if necessary, refetch the
@@ -111,5 +110,5 @@ are a valuable caching and performance asset, it is important that they are alwa
 re-fetch the source file, as and when required, which the Media Cache Module will automatically handle.
 
 !!! note
-The Media Feature is designed to support one storage provider at a time, whether that is
-local File Storage, the default, or Azure Blob Storage.
+    The Media Feature is designed to support one storage provider at a time, whether that is
+    local File Storage, the default, or Azure Blob Storage.

--- a/src/docs/reference/modules/Resources/README.md
+++ b/src/docs/reference/modules/Resources/README.md
@@ -20,7 +20,7 @@ Resource Settings are configured through the site admin.
 
 ### AppendVersion
 
-Enabling ``AppendVersion` or Resources cache busting will automatically append a version hash to all local scripts and style sheets.
+Enabling `AppendVersion` or Resources cache busting will automatically append a version hash to all local scripts and style sheets.
 This is turned on by default.
 
 ### UseCdn
@@ -92,8 +92,8 @@ We set the Cdn Integrity Hashes and the version to `3.4.1`
 This script will then be available for the tag helper or API to register by name. 
 
 !!! note "Registration"
-   Make sure to register this `IResourceManifestProvider` in the `Startup` or your theme or module.
-   `serviceCollection.AddScoped<IResourceManifestProvider, ResourceManifest>();`
+    Make sure to register this `IResourceManifestProvider` in the `Startup` or your theme or module.
+    `serviceCollection.AddScoped<IResourceManifestProvider, ResourceManifest>();`
 
 ## Usage
 
@@ -245,8 +245,8 @@ Styles, however, are always injected in the header section of the HTML document.
 You can declare a new resource directly from a view, and it will be injected only once even if the view is called multiple time.
 
 ``` liquid tab="Liquid"
-{% script name:"bar", src:"~/TheTheme/js/bar.min.js", debug_src:"~/TheTheme/js/bar.js", depends_on:"jQuery", version:"1.0" %}
-{% script name:"foo", src:"~/TheTheme/js/foo.min.js", debug_src:"~/TheTheme/js/foo.js", depends_on:"bar:1.0", version:"1.0" %}
+{% script name:"foo", src:"~/TheTheme/js/foo.min.js", debug_src:"~/TheTheme/js/foo.js", depends_on:"jQuery", version:"1.0" %}
+{% script name:"bar", src:"~/TheTheme/js/bar.min.js", debug_src:"~/TheTheme/js/bar.js", depends_on:"foo:1.0", version:"1.0" %}
 ```
 
 ``` html tab="Razor"
@@ -255,9 +255,13 @@ You can declare a new resource directly from a view, and it will be injected onl
 ```
 
 We define a script named `foo` with a dependency on `jQuery` with the version `1.0`. 
+
 We then define a script named `bar` which also takes a dependency on version `1.0` of the `foo` script.
+
 If the version was not set the one with the highest number would be used.
+
 When rendering the scripts the resource manager will order the output based on the dependencies, regardless of the order they are written to:
+
 1. `jQuery`
 2. `foo`
 3. `bar`
@@ -265,19 +269,21 @@ When rendering the scripts the resource manager will order the output based on t
 You can also do the same for a stylesheet:
 
 ``` liquid tab="Liquid"
-{% style name="bar", src:"~/TheTheme/css/bar.min.css", debug_src:"~/TheTheme/css/bar.css", depends_on="foo:1.0" %}
-{% style name="foo", src:"~/TheTheme/css/foo.min.css", debug_src:"~/TheTheme/css/foo.css", depends_on="bootstrap" version="1.0" %}
+{% style name:"bar", src:"~/TheTheme/css/bar.min.css", debug_src:"~/TheTheme/css/bar.css", depends_on:"foo" %}
+{% style name:"foo", src:"~/TheTheme/css/foo.min.css", debug_src:"~/TheTheme/css/foo.css", depends_on:"bootstrap" %}
 ```
 
 ``` html tab="Razor"
-<style asp-name="bar" asp-src="~/TheTheme/css/bar.min.css" debug-src="~/TheTheme/css/bar.css" depends-on="foo:1.0"></style>
-<style asp-name="foo" asp-src="~/TheTheme/css/foo.min.css" debug-src="~/TheTheme/css/foo.css" depends-on="bootstrap" version="1.0"></style>
+<style asp-name="bar" asp-src="~/TheTheme/css/bar.min.css" debug-src="~/TheTheme/css/bar.css" depends-on="foo"></style>
+<style asp-name="foo" asp-src="~/TheTheme/css/foo.min.css" debug-src="~/TheTheme/css/foo.css" depends-on="bootstrap"></style>
 ```
 
-In this example define a style named `bar` with a dependency on the style named `foo` with the version `1.0`
-We then define the style named `foo` with the version of `1.0`
-If the version was not set the one with the highest number will be used.
+In this example define a style named `bar` with a dependency on the style named `foo`
+
+We then define the style named `foo`
+
 When rendering the scripts the resource manager will order the output based on the dependencies, regardless of the order they are written to:
+
 1. `bootstrap`
 2. `foo`
 3. `bar`
@@ -366,7 +372,6 @@ These should be rendered at the bottom of the `<body>` section.
     <resources type="FootScript" />
 </body>
 ```
-{% resources type: "FootScript" %}
 
 ### Logging
 


### PR DESCRIPTION
Fixes some typos from yesterday and previous.

Also simplifies one liquid style example because mkdocs didn't format the liquid syntax correctly.

Actually makes the example easier and more normal use.

Plus moved Media.Azure out of core into cms - back to being beside Media
