### PR TITLE
Using ControllerModelUpdater on controller instead of implementing IUpdateModel 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Controllers/MenuController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Controllers/MenuController.cs
@@ -19,7 +19,7 @@ using OrchardCore.Settings;
 namespace OrchardCore.AdminMenu.Controllers
 {
     [Admin]
-    public class MenuController : Controller, IUpdateModel
+    public class MenuController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly IAdminMenuService _adminMenuService;

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Controllers/BackgroundTaskController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Controllers/BackgroundTaskController.cs
@@ -19,7 +19,7 @@ using OrchardCore.Settings;
 namespace OrchardCore.BackgroundTasks.Controllers
 {
     [Admin]
-    public class BackgroundTaskController : Controller, IUpdateModel
+    public class BackgroundTaskController : Controller
     {
         private readonly string _tenant;
         private readonly IAuthorizationService _authorizationService;
@@ -29,7 +29,7 @@ namespace OrchardCore.BackgroundTasks.Controllers
         private readonly INotifier _notifier;
         private readonly IStringLocalizer S;
         private readonly dynamic New;
-        
+
         public BackgroundTaskController(
             ShellSettings shellSettings,
             IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/AdminController.cs
@@ -11,7 +11,7 @@ using OrchardCore.DisplayManagement.Notify;
 
 namespace OrchardCore.ContentLocalization.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IContentLocalizationManager _contentLocalizationManager;

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/ContentCulturePickerController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/ContentCulturePickerController.cs
@@ -16,7 +16,7 @@ using OrchardCore.Settings;
 namespace OrchardCore.ContentLocalization.Controllers
 {
     [Feature("OrchardCore.ContentLocalization.ContentCulturePicker")]
-    public class ContentCulturePickerController : Controller, IUpdateModel
+    public class ContentCulturePickerController : Controller
     {
         private readonly ISiteService _siteService;
         private readonly ILocalizationService _locationService;

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Controllers/PreviewController.cs
@@ -17,7 +17,7 @@ using OrchardCore.Modules;
 
 namespace OrchardCore.ContentPreview.Controllers
 {
-    public class PreviewController : Controller, IUpdateModel
+    public class PreviewController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IContentManagerSession _contentManagerSession;
@@ -82,7 +82,7 @@ namespace OrchardCore.ContentPreview.Controllers
             contentItem.Published = true;
 
             // TODO: we should probably get this value from the main editor as it might impact validators
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, true);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, true);
 
             if (!ModelState.IsValid)
             {
@@ -117,9 +117,15 @@ namespace OrchardCore.ContentPreview.Controllers
                 return Ok();
             }
 
-            model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, this, "Detail");
+            model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, (ControllerModelUpdater)this, "Detail");
 
             return View(model);
+        }
+
+        public static explicit operator ControllerModelUpdater(PreviewController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Controllers/PreviewController.cs
@@ -24,6 +24,7 @@ namespace OrchardCore.ContentPreview.Controllers
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly IClock _clock;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly dynamic New;
 
         public PreviewController(
@@ -33,14 +34,15 @@ namespace OrchardCore.ContentPreview.Controllers
             IShapeFactory shapeFactory,
             ILogger<PreviewController> logger,
             IAuthorizationService authorizationService,
-            IClock clock
-            )
+            IClock clock,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _authorizationService = authorizationService;
             _clock = clock;
             _contentItemDisplayManager = contentItemDisplayManager;
             _contentManager = contentManager;
             _contentManagerSession = contentManagerSession;
+            _updateModelAccessor = updateModelAccessor;
             New = shapeFactory;
             Logger = logger;
         }
@@ -82,7 +84,7 @@ namespace OrchardCore.ContentPreview.Controllers
             contentItem.Published = true;
 
             // TODO: we should probably get this value from the main editor as it might impact validators
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, true);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, true);
 
             if (!ModelState.IsValid)
             {
@@ -117,15 +119,9 @@ namespace OrchardCore.ContentPreview.Controllers
                 return Ok();
             }
 
-            model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, (ControllerModelUpdater)this, "Detail");
+            model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, _updateModelAccessor.ModelUpdater, "Detail");
 
             return View(model);
-        }
-
-        public static explicit operator ControllerModelUpdater(PreviewController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -33,6 +33,7 @@ namespace OrchardCore.ContentTypes.Controllers
         private readonly IHtmlLocalizer<AdminController> H;
         private readonly IStringLocalizer<AdminController> S;
         private readonly INotifier _notifier;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public AdminController(
             IContentDefinitionDisplayManager contentDefinitionDisplayManager,
@@ -44,8 +45,8 @@ namespace OrchardCore.ContentTypes.Controllers
             ILogger<AdminController> logger,
             IHtmlLocalizer<AdminController> htmlLocalizer,
             IStringLocalizer<AdminController> stringLocalizer,
-            INotifier notifier
-            )
+            INotifier notifier,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _notifier = notifier;
             _contentDefinitionDisplayManager = contentDefinitionDisplayManager;
@@ -54,6 +55,7 @@ namespace OrchardCore.ContentTypes.Controllers
             _contentDefinitionService = contentDefinitionService;
             _contentDefinitionManager = contentDefinitionManager;
             _settings = settings;
+            _updateModelAccessor = updateModelAccessor;
 
             Logger = logger;
             H = htmlLocalizer;
@@ -159,7 +161,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 return NotFound();
             }
 
-            typeViewModel.Editor = await _contentDefinitionDisplayManager.BuildTypeEditorAsync(typeViewModel.TypeDefinition, (ControllerModelUpdater)this);
+            typeViewModel.Editor = await _contentDefinitionDisplayManager.BuildTypeEditorAsync(typeViewModel.TypeDefinition, _updateModelAccessor.ModelUpdater);
 
             return View(typeViewModel);
         }
@@ -183,7 +185,7 @@ namespace OrchardCore.ContentTypes.Controllers
             viewModel.Settings = contentTypeDefinition.Settings;
             viewModel.TypeDefinition = contentTypeDefinition;
             viewModel.DisplayName = contentTypeDefinition.DisplayName;
-            viewModel.Editor = await _contentDefinitionDisplayManager.UpdateTypeEditorAsync(contentTypeDefinition, (ControllerModelUpdater)this);
+            viewModel.Editor = await _contentDefinitionDisplayManager.UpdateTypeEditorAsync(contentTypeDefinition, _updateModelAccessor.ModelUpdater);
 
             if (!ModelState.IsValid)
             {
@@ -506,7 +508,7 @@ namespace OrchardCore.ContentTypes.Controllers
             }
 
             var viewModel = new EditPartViewModel(contentPartDefinition);
-            viewModel.Editor = await _contentDefinitionDisplayManager.BuildPartEditorAsync(contentPartDefinition, (ControllerModelUpdater)this);
+            viewModel.Editor = await _contentDefinitionDisplayManager.BuildPartEditorAsync(contentPartDefinition, _updateModelAccessor.ModelUpdater);
 
             return View(viewModel);
         }
@@ -528,7 +530,7 @@ namespace OrchardCore.ContentTypes.Controllers
             }
 
             var viewModel = new EditPartViewModel(contentPartDefinition);
-            viewModel.Editor = await _contentDefinitionDisplayManager.UpdatePartEditorAsync(contentPartDefinition, (ControllerModelUpdater)this);
+            viewModel.Editor = await _contentDefinitionDisplayManager.UpdatePartEditorAsync(contentPartDefinition, _updateModelAccessor.ModelUpdater);
 
             if (!ModelState.IsValid)
             {
@@ -694,7 +696,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 DisplayMode = partFieldDefinition.DisplayMode(),
                 DisplayName = partFieldDefinition.DisplayName(),
                 PartFieldDefinition = partFieldDefinition,
-                Shape = await _contentDefinitionDisplayManager.BuildPartFieldEditorAsync(partFieldDefinition, (ControllerModelUpdater)this)
+                Shape = await _contentDefinitionDisplayManager.BuildPartFieldEditorAsync(partFieldDefinition, _updateModelAccessor.ModelUpdater)
             };
 
             ViewData["ReturnUrl"] = returnUrl;
@@ -749,7 +751,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 if (!ModelState.IsValid)
                 {
                     // Calls update to build editor shape with the display name validation failures, and other validation errors.
-                    viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, (ControllerModelUpdater)this);
+                    viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, _updateModelAccessor.ModelUpdater);
                     _session.Cancel();
 
                     ViewData["ReturnUrl"] = returnUrl;
@@ -764,7 +766,7 @@ namespace OrchardCore.ContentTypes.Controllers
             // Refresh the local field variable in case it has been altered
             field = _contentDefinitionManager.LoadPartDefinition(id).Fields.FirstOrDefault(x => x.Name == viewModel.Name);
 
-            viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, (ControllerModelUpdater)this);
+            viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, _updateModelAccessor.ModelUpdater);
 
             if (!ModelState.IsValid)
             {
@@ -861,7 +863,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 DisplayName = typePartDefinition.DisplayName(),
                 Description = typePartDefinition.Description(),
                 TypePartDefinition = typePartDefinition,
-                Shape = await _contentDefinitionDisplayManager.BuildTypePartEditorAsync(typePartDefinition, (ControllerModelUpdater)this)
+                Shape = await _contentDefinitionDisplayManager.BuildTypePartEditorAsync(typePartDefinition, _updateModelAccessor.ModelUpdater)
             };
 
             return View(typePartViewModel);
@@ -916,7 +918,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
                     if (!ModelState.IsValid)
                     {
-                        viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, (ControllerModelUpdater)this);
+                        viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, _updateModelAccessor.ModelUpdater);
                         _session.Cancel();
                         return View(viewModel);
                     }
@@ -929,7 +931,7 @@ namespace OrchardCore.ContentTypes.Controllers
             // Refresh the local part variable in case it has been altered
             part = _contentDefinitionManager.LoadTypeDefinition(id).Parts.FirstOrDefault(x => x.Name == viewModel.Name);
 
-            viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, (ControllerModelUpdater)this);
+            viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, _updateModelAccessor.ModelUpdater);
 
             if (!ModelState.IsValid)
             {
@@ -945,12 +947,6 @@ namespace OrchardCore.ContentTypes.Controllers
         }
 
         #endregion
-
-        public static explicit operator ControllerModelUpdater(AdminController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
-        }
     }
 
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -22,7 +22,7 @@ using YesSql;
 
 namespace OrchardCore.ContentTypes.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IContentDefinitionService _contentDefinitionService;
         private readonly IContentDefinitionManager _contentDefinitionManager;
@@ -159,7 +159,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 return NotFound();
             }
 
-            typeViewModel.Editor = await _contentDefinitionDisplayManager.BuildTypeEditorAsync(typeViewModel.TypeDefinition, this);
+            typeViewModel.Editor = await _contentDefinitionDisplayManager.BuildTypeEditorAsync(typeViewModel.TypeDefinition, (ControllerModelUpdater)this);
 
             return View(typeViewModel);
         }
@@ -183,7 +183,7 @@ namespace OrchardCore.ContentTypes.Controllers
             viewModel.Settings = contentTypeDefinition.Settings;
             viewModel.TypeDefinition = contentTypeDefinition;
             viewModel.DisplayName = contentTypeDefinition.DisplayName;
-            viewModel.Editor = await _contentDefinitionDisplayManager.UpdateTypeEditorAsync(contentTypeDefinition, this);
+            viewModel.Editor = await _contentDefinitionDisplayManager.UpdateTypeEditorAsync(contentTypeDefinition, (ControllerModelUpdater)this);
 
             if (!ModelState.IsValid)
             {
@@ -506,7 +506,7 @@ namespace OrchardCore.ContentTypes.Controllers
             }
 
             var viewModel = new EditPartViewModel(contentPartDefinition);
-            viewModel.Editor = await _contentDefinitionDisplayManager.BuildPartEditorAsync(contentPartDefinition, this);
+            viewModel.Editor = await _contentDefinitionDisplayManager.BuildPartEditorAsync(contentPartDefinition, (ControllerModelUpdater)this);
 
             return View(viewModel);
         }
@@ -528,7 +528,7 @@ namespace OrchardCore.ContentTypes.Controllers
             }
 
             var viewModel = new EditPartViewModel(contentPartDefinition);
-            viewModel.Editor = await _contentDefinitionDisplayManager.UpdatePartEditorAsync(contentPartDefinition, this);
+            viewModel.Editor = await _contentDefinitionDisplayManager.UpdatePartEditorAsync(contentPartDefinition, (ControllerModelUpdater)this);
 
             if (!ModelState.IsValid)
             {
@@ -694,7 +694,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 DisplayMode = partFieldDefinition.DisplayMode(),
                 DisplayName = partFieldDefinition.DisplayName(),
                 PartFieldDefinition = partFieldDefinition,
-                Shape = await _contentDefinitionDisplayManager.BuildPartFieldEditorAsync(partFieldDefinition, this)
+                Shape = await _contentDefinitionDisplayManager.BuildPartFieldEditorAsync(partFieldDefinition, (ControllerModelUpdater)this)
             };
 
             ViewData["ReturnUrl"] = returnUrl;
@@ -749,7 +749,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 if (!ModelState.IsValid)
                 {
                     // Calls update to build editor shape with the display name validation failures, and other validation errors.
-                    viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, this);
+                    viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, (ControllerModelUpdater)this);
                     _session.Cancel();
 
                     ViewData["ReturnUrl"] = returnUrl;
@@ -764,7 +764,7 @@ namespace OrchardCore.ContentTypes.Controllers
             // Refresh the local field variable in case it has been altered
             field = _contentDefinitionManager.LoadPartDefinition(id).Fields.FirstOrDefault(x => x.Name == viewModel.Name);
 
-            viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, this);
+            viewModel.Shape = await _contentDefinitionDisplayManager.UpdatePartFieldEditorAsync(field, (ControllerModelUpdater)this);
 
             if (!ModelState.IsValid)
             {
@@ -861,7 +861,7 @@ namespace OrchardCore.ContentTypes.Controllers
                 DisplayName = typePartDefinition.DisplayName(),
                 Description = typePartDefinition.Description(),
                 TypePartDefinition = typePartDefinition,
-                Shape = await _contentDefinitionDisplayManager.BuildTypePartEditorAsync(typePartDefinition, this)
+                Shape = await _contentDefinitionDisplayManager.BuildTypePartEditorAsync(typePartDefinition, (ControllerModelUpdater)this)
             };
 
             return View(typePartViewModel);
@@ -916,7 +916,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
                     if (!ModelState.IsValid)
                     {
-                        viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, this);
+                        viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, (ControllerModelUpdater)this);
                         _session.Cancel();
                         return View(viewModel);
                     }
@@ -929,7 +929,7 @@ namespace OrchardCore.ContentTypes.Controllers
             // Refresh the local part variable in case it has been altered
             part = _contentDefinitionManager.LoadTypeDefinition(id).Parts.FirstOrDefault(x => x.Name == viewModel.Name);
 
-            viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, this);
+            viewModel.Shape = await _contentDefinitionDisplayManager.UpdateTypePartEditorAsync(part, (ControllerModelUpdater)this);
 
             if (!ModelState.IsValid)
             {
@@ -945,5 +945,12 @@ namespace OrchardCore.ContentTypes.Controllers
         }
 
         #endregion
+
+        public static explicit operator ControllerModelUpdater(AdminController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
+        }
     }
+
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace OrchardCore.Contents.Controllers
 {
-    public class ItemController : Controller, IUpdateModel
+    public class ItemController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
@@ -38,7 +38,7 @@ namespace OrchardCore.Contents.Controllers
                 return User.Identity.IsAuthenticated ? (IActionResult)Forbid() : Challenge();
             }
 
-            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, this);
+            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, (ControllerModelUpdater)this);
 
             return View(model);
         }
@@ -64,9 +64,15 @@ namespace OrchardCore.Contents.Controllers
                 return User.Identity.IsAuthenticated ? (IActionResult)Forbid() : Challenge();
             }
 
-            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, this);
+            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, (ControllerModelUpdater)this);
 
             return View(model);
+        }
+
+        public static explicit operator ControllerModelUpdater(ItemController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
@@ -12,16 +12,18 @@ namespace OrchardCore.Contents.Controllers
         private readonly IContentManager _contentManager;
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
         private readonly IAuthorizationService _authorizationService;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public ItemController(
             IContentManager contentManager,
             IContentItemDisplayManager contentItemDisplayManager,
-            IAuthorizationService authorizationService
-            )
+            IAuthorizationService authorizationService,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _authorizationService = authorizationService;
             _contentItemDisplayManager = contentItemDisplayManager;
             _contentManager = contentManager;
+            _updateModelAccessor = updateModelAccessor;
         }
 
         public async Task<IActionResult> Display(string contentItemId)
@@ -38,7 +40,7 @@ namespace OrchardCore.Contents.Controllers
                 return User.Identity.IsAuthenticated ? (IActionResult)Forbid() : Challenge();
             }
 
-            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, (ControllerModelUpdater)this);
+            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, _updateModelAccessor.ModelUpdater);
 
             return View(model);
         }
@@ -64,15 +66,9 @@ namespace OrchardCore.Contents.Controllers
                 return User.Identity.IsAuthenticated ? (IActionResult)Forbid() : Challenge();
             }
 
-            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, (ControllerModelUpdater)this);
+            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, _updateModelAccessor.ModelUpdater);
 
             return View(model);
-        }
-
-        public static explicit operator ControllerModelUpdater(ItemController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentController.cs
@@ -13,15 +13,18 @@ namespace OrchardCore.Demo.Controllers
         private readonly IContentItemDisplayManager _contentDisplay;
         private readonly IContentManager _contentManager;
         private readonly ISession _session;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public ContentController(
             IContentManager contentManager,
             IContentItemDisplayManager contentDisplay,
-            ISession session)
+            ISession session,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _contentManager = contentManager;
             _contentDisplay = contentDisplay;
             _session = session;
+            _updateModelAccessor = updateModelAccessor;
         }
 
         public async Task<ActionResult> Display(string contentItemId)
@@ -33,7 +36,7 @@ namespace OrchardCore.Demo.Controllers
                 return NotFound();
             }
 
-            var shape = await _contentDisplay.BuildDisplayAsync(contentItem, (IUpdateModel)this);
+            var shape = await _contentDisplay.BuildDisplayAsync(contentItem, _updateModelAccessor.ModelUpdater);
             return View(shape);
         }
 
@@ -47,7 +50,7 @@ namespace OrchardCore.Demo.Controllers
                 return NotFound();
             }
 
-            var shape = await _contentDisplay.BuildEditorAsync(contentItem, (IUpdateModel)this, false);
+            var shape = await _contentDisplay.BuildEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, false);
             return View(shape);
         }
 
@@ -61,7 +64,7 @@ namespace OrchardCore.Demo.Controllers
                 return NotFound();
             }
 
-            var shape = await _contentDisplay.UpdateEditorAsync(contentItem, (IUpdateModel)this, false);
+            var shape = await _contentDisplay.UpdateEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, false);
 
             if (!ModelState.IsValid)
             {
@@ -72,13 +75,6 @@ namespace OrchardCore.Demo.Controllers
             _session.Save(contentItem);
             return RedirectToAction("Edit", contentItemId);
 
-
-        }
-
-        public static explicit operator ControllerModelUpdater(ContentController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentController.cs
@@ -8,7 +8,7 @@ using YesSql;
 
 namespace OrchardCore.Demo.Controllers
 {
-    public class ContentController : Controller, IUpdateModel
+    public class ContentController : Controller
     {
         private readonly IContentItemDisplayManager _contentDisplay;
         private readonly IContentManager _contentManager;
@@ -33,7 +33,7 @@ namespace OrchardCore.Demo.Controllers
                 return NotFound();
             }
 
-            var shape = await _contentDisplay.BuildDisplayAsync(contentItem, this);
+            var shape = await _contentDisplay.BuildDisplayAsync(contentItem, (IUpdateModel)this);
             return View(shape);
         }
 
@@ -47,7 +47,7 @@ namespace OrchardCore.Demo.Controllers
                 return NotFound();
             }
 
-            var shape = await _contentDisplay.BuildEditorAsync(contentItem, this, false);
+            var shape = await _contentDisplay.BuildEditorAsync(contentItem, (IUpdateModel)this, false);
             return View(shape);
         }
 
@@ -61,7 +61,7 @@ namespace OrchardCore.Demo.Controllers
                 return NotFound();
             }
 
-            var shape = await _contentDisplay.UpdateEditorAsync(contentItem, this, false);
+            var shape = await _contentDisplay.UpdateEditorAsync(contentItem, (IUpdateModel)this, false);
 
             if (!ModelState.IsValid)
             {
@@ -73,6 +73,12 @@ namespace OrchardCore.Demo.Controllers
             return RedirectToAction("Edit", contentItemId);
 
 
+        }
+
+        public static explicit operator ControllerModelUpdater(ContentController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
@@ -28,6 +28,7 @@ namespace OrchardCore.Deployment.Controllers
         private readonly ISession _session;
         private readonly ISiteService _siteService;
         private readonly INotifier _notifier;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly IStringLocalizer S;
         private readonly IHtmlLocalizer H;
         private readonly dynamic New;
@@ -41,15 +42,17 @@ namespace OrchardCore.Deployment.Controllers
             IShapeFactory shapeFactory,
             IStringLocalizer<DeploymentPlanController> stringLocalizer,
             IHtmlLocalizer<DeploymentPlanController> htmlLocalizer,
-            INotifier notifier)
+            INotifier notifier,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _displayManager = displayManager;
             _factories = factories;
             _authorizationService = authorizationService;
             _session = session;
             _siteService = siteService;
-            New = shapeFactory;
             _notifier = notifier;
+            _updateModelAccessor = updateModelAccessor;
+            New = shapeFactory;
             S = stringLocalizer;
             H = htmlLocalizer;
         }
@@ -122,7 +125,7 @@ namespace OrchardCore.Deployment.Controllers
             var items = new List<dynamic>();
             foreach (var step in deploymentPlan.DeploymentSteps)
             {
-                dynamic item = await _displayManager.BuildDisplayAsync(step, (ControllerModelUpdater)this, "Summary");
+                dynamic item = await _displayManager.BuildDisplayAsync(step, _updateModelAccessor.ModelUpdater, "Summary");
                 item.DeploymentStep = step;
                 items.Add(item);
             }
@@ -131,7 +134,7 @@ namespace OrchardCore.Deployment.Controllers
             foreach (var factory in _factories)
             {
                 var step = factory.Create();
-                dynamic thumbnail = await _displayManager.BuildDisplayAsync(step, (ControllerModelUpdater)this, "Thumbnail");
+                dynamic thumbnail = await _displayManager.BuildDisplayAsync(step, _updateModelAccessor.ModelUpdater, "Thumbnail");
                 thumbnail.DeploymentStep = step;
                 thumbnails.Add(factory.Name, thumbnail);
             }
@@ -268,12 +271,6 @@ namespace OrchardCore.Deployment.Controllers
             _notifier.Success(H["Deployment plan deleted successfully"]);
 
             return RedirectToAction(nameof(Index));
-        }
-
-        public static explicit operator ControllerModelUpdater(DeploymentPlanController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
@@ -20,7 +20,7 @@ using YesSql;
 namespace OrchardCore.Deployment.Controllers
 {
     [Admin]
-    public class DeploymentPlanController : Controller, IUpdateModel
+    public class DeploymentPlanController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly IDisplayManager<DeploymentStep> _displayManager;
@@ -31,7 +31,7 @@ namespace OrchardCore.Deployment.Controllers
         private readonly IStringLocalizer S;
         private readonly IHtmlLocalizer H;
         private readonly dynamic New;
-        
+
         public DeploymentPlanController(
             IAuthorizationService authorizationService,
             IDisplayManager<DeploymentStep> displayManager,
@@ -122,7 +122,7 @@ namespace OrchardCore.Deployment.Controllers
             var items = new List<dynamic>();
             foreach (var step in deploymentPlan.DeploymentSteps)
             {
-                dynamic item = await _displayManager.BuildDisplayAsync(step, this, "Summary");
+                dynamic item = await _displayManager.BuildDisplayAsync(step, (ControllerModelUpdater)this, "Summary");
                 item.DeploymentStep = step;
                 items.Add(item);
             }
@@ -131,7 +131,7 @@ namespace OrchardCore.Deployment.Controllers
             foreach (var factory in _factories)
             {
                 var step = factory.Create();
-                dynamic thumbnail = await _displayManager.BuildDisplayAsync(step, this, "Thumbnail");
+                dynamic thumbnail = await _displayManager.BuildDisplayAsync(step, (ControllerModelUpdater)this, "Thumbnail");
                 thumbnail.DeploymentStep = step;
                 thumbnails.Add(factory.Name, thumbnail);
             }
@@ -197,7 +197,7 @@ namespace OrchardCore.Deployment.Controllers
             var deploymentPlan = await _session.GetAsync<DeploymentPlan>(id);
 
             if (deploymentPlan == null)
-            { 
+            {
                 return NotFound();
             }
 
@@ -266,8 +266,14 @@ namespace OrchardCore.Deployment.Controllers
             _session.Delete(deploymentPlan);
 
             _notifier.Success(H["Deployment plan deleted successfully"]);
-            
+
             return RedirectToAction(nameof(Index));
+        }
+
+        public static explicit operator ControllerModelUpdater(DeploymentPlanController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/StepController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/StepController.cs
@@ -17,7 +17,7 @@ using YesSql;
 namespace OrchardCore.Deployment.Controllers
 {
     [Admin]
-    public class StepController : Controller, IUpdateModel
+    public class StepController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly IDisplayManager<DeploymentStep> _displayManager;
@@ -77,7 +77,7 @@ namespace OrchardCore.Deployment.Controllers
                 DeploymentStep = step,
                 DeploymentStepId = step.Id,
                 DeploymentStepType = type,
-                Editor = await _displayManager.BuildEditorAsync(step, updater: this, isNew: true)
+                Editor = await _displayManager.BuildEditorAsync(step, updater: (ControllerModelUpdater)this, isNew: true)
             };
 
             model.Editor.DeploymentStep = step;
@@ -107,7 +107,7 @@ namespace OrchardCore.Deployment.Controllers
                 return NotFound();
             }
 
-            dynamic editor = await _displayManager.UpdateEditorAsync(step, updater: this, isNew: true);
+            dynamic editor = await _displayManager.UpdateEditorAsync(step, updater: (ControllerModelUpdater)this, isNew: true);
             editor.DeploymentStep = step;
 
             if (ModelState.IsValid)
@@ -153,7 +153,7 @@ namespace OrchardCore.Deployment.Controllers
                 DeploymentStep = step,
                 DeploymentStepId = step.Id,
                 DeploymentStepType = step.GetType().Name,
-                Editor = await _displayManager.BuildEditorAsync(step, updater: this, isNew: false)
+                Editor = await _displayManager.BuildEditorAsync(step, updater: (ControllerModelUpdater)this, isNew: false)
             };
 
             model.Editor.DeploymentStep = step;
@@ -183,7 +183,7 @@ namespace OrchardCore.Deployment.Controllers
                 return NotFound();
             }
 
-            var editor = await _displayManager.UpdateEditorAsync(step, updater: this, isNew: false);
+            var editor = await _displayManager.UpdateEditorAsync(step, updater: (ControllerModelUpdater)this, isNew: false);
 
             if (ModelState.IsValid)
             {
@@ -228,6 +228,12 @@ namespace OrchardCore.Deployment.Controllers
             _notifier.Success(H["Deployment step deleted successfully"]);
 
             return RedirectToAction("Display", "DeploymentPlan", new { id });
+        }
+
+        public static explicit operator ControllerModelUpdater(StepController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/StepController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/StepController.cs
@@ -25,6 +25,7 @@ namespace OrchardCore.Deployment.Controllers
         private readonly ISession _session;
         private readonly ISiteService _siteService;
         private readonly INotifier _notifier;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly IHtmlLocalizer H;
         private readonly dynamic New;
 
@@ -36,15 +37,17 @@ namespace OrchardCore.Deployment.Controllers
             ISiteService siteService,
             IShapeFactory shapeFactory,
             IHtmlLocalizer<StepController> htmlLocalizer,
-            INotifier notifier)
+            INotifier notifier,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _displayManager = displayManager;
             _factories = factories;
             _authorizationService = authorizationService;
             _session = session;
             _siteService = siteService;
-            New = shapeFactory;
             _notifier = notifier;
+            _updateModelAccessor = updateModelAccessor;
+            New = shapeFactory;            
             H = htmlLocalizer;
         }
 
@@ -77,7 +80,7 @@ namespace OrchardCore.Deployment.Controllers
                 DeploymentStep = step,
                 DeploymentStepId = step.Id,
                 DeploymentStepType = type,
-                Editor = await _displayManager.BuildEditorAsync(step, updater: (ControllerModelUpdater)this, isNew: true)
+                Editor = await _displayManager.BuildEditorAsync(step, updater: _updateModelAccessor.ModelUpdater, isNew: true)
             };
 
             model.Editor.DeploymentStep = step;
@@ -107,7 +110,7 @@ namespace OrchardCore.Deployment.Controllers
                 return NotFound();
             }
 
-            dynamic editor = await _displayManager.UpdateEditorAsync(step, updater: (ControllerModelUpdater)this, isNew: true);
+            dynamic editor = await _displayManager.UpdateEditorAsync(step, updater: _updateModelAccessor.ModelUpdater, isNew: true);
             editor.DeploymentStep = step;
 
             if (ModelState.IsValid)
@@ -153,7 +156,7 @@ namespace OrchardCore.Deployment.Controllers
                 DeploymentStep = step,
                 DeploymentStepId = step.Id,
                 DeploymentStepType = step.GetType().Name,
-                Editor = await _displayManager.BuildEditorAsync(step, updater: (ControllerModelUpdater)this, isNew: false)
+                Editor = await _displayManager.BuildEditorAsync(step, updater: _updateModelAccessor.ModelUpdater, isNew: false)
             };
 
             model.Editor.DeploymentStep = step;
@@ -183,7 +186,7 @@ namespace OrchardCore.Deployment.Controllers
                 return NotFound();
             }
 
-            var editor = await _displayManager.UpdateEditorAsync(step, updater: (ControllerModelUpdater)this, isNew: false);
+            var editor = await _displayManager.UpdateEditorAsync(step, updater: _updateModelAccessor.ModelUpdater, isNew: false);
 
             if (ModelState.IsValid)
             {
@@ -228,12 +231,6 @@ namespace OrchardCore.Deployment.Controllers
             _notifier.Success(H["Deployment step deleted successfully"]);
 
             return RedirectToAction("Display", "DeploymentPlan", new { id });
-        }
-
-        public static explicit operator ControllerModelUpdater(StepController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
@@ -13,7 +13,7 @@ using OrchardCore.Email.ViewModels;
 
 namespace OrchardCore.Email.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly INotifier _notifier;

--- a/src/OrchardCore.Modules/OrchardCore.Feeds/Controllers/FeedController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Feeds/Controllers/FeedController.cs
@@ -9,7 +9,7 @@ using OrchardCore.Feeds.Models;
 
 namespace OrchardCore.Feeds.Controllers
 {
-    public class FeedController : Controller, IUpdateModel
+    public class FeedController : Controller
     {
         private readonly IEnumerable<IFeedBuilderProvider> _feedFormatProviders;
         private readonly IEnumerable<IFeedQueryProvider> _feedQueryProviders;
@@ -34,7 +34,7 @@ namespace OrchardCore.Feeds.Controllers
 
         public async Task<ActionResult> Index(string format)
         {
-            var context = new FeedContext(this, format);
+            var context = new FeedContext((ControllerModelUpdater)this, format);
 
             var bestFormatterMatch = _feedFormatProviders
                 .Select(provider => provider.Match(context))
@@ -86,6 +86,12 @@ namespace OrchardCore.Feeds.Controllers
            });
 
             return Content(document.ToString(), "text/xml");
+        }
+
+        public static explicit operator ControllerModelUpdater(FeedController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Feeds/OrchardCore.Feeds.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Feeds/OrchardCore.Feeds.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Feeds.Core\OrchardCore.Feeds.Core.csproj" />
   </ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
@@ -12,7 +12,7 @@ using OrchardCore.Flows.ViewModels;
 
 namespace OrchardCore.Flows.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IContentItemDisplayManager _contentItemDisplayManager;

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
@@ -17,18 +17,20 @@ namespace OrchardCore.Flows.Controllers
         private readonly IContentManager _contentManager;
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
         private readonly IShapeFactory _shapeFactory;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public AdminController(
             IContentManager contentManager,
             IContentItemDisplayManager contentItemDisplayManager,
             IShapeFactory shapeFactory,
             ILogger<AdminController> logger,
-            IHtmlLocalizer<AdminController> localizer
-            )
+            IHtmlLocalizer<AdminController> localizer,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _contentItemDisplayManager = contentItemDisplayManager;
             _contentManager = contentManager;
             _shapeFactory = shapeFactory;
+            _updateModelAccessor = updateModelAccessor;
 
             T = localizer;
             Logger = logger;
@@ -66,7 +68,7 @@ namespace OrchardCore.Flows.Controllers
             //Create a Card Shape
             dynamic contentCard = await _shapeFactory.New.ContentCard(
                 //Updater is the controller for AJAX Requests
-                Updater: this,
+                Updater: _updateModelAccessor.ModelUpdater,
                 //Shape Specific
                 CollectionShapeType: cardCollectionType,
                 ContentItem: contentItem,

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
@@ -31,6 +31,7 @@ namespace OrchardCore.Layers.Controllers
         private readonly ISession _session;
         private readonly ISignal _signal;
         private readonly INotifier _notifier;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public AdminController(
             ISignal signal,
@@ -42,8 +43,8 @@ namespace OrchardCore.Layers.Controllers
             ISiteService siteService,
             IStringLocalizer<AdminController> s,
             IHtmlLocalizer<AdminController> h,
-            INotifier notifier
-            )
+            INotifier notifier,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _signal = signal;
             _authorizationService = authorizationService;
@@ -52,9 +53,10 @@ namespace OrchardCore.Layers.Controllers
             _contentManager = contentManager;
             _contentItemDisplayManager = contentItemDisplayManager;
             _siteService = siteService;
+            _notifier = notifier;
+            _updateModelAccessor = updateModelAccessor;
             S = s;
             H = h;
-            _notifier = notifier;
         }
 
         public IStringLocalizer S { get; }
@@ -86,7 +88,7 @@ namespace OrchardCore.Layers.Controllers
                     model.Widgets.Add(zone, list = new List<dynamic>());
                 }
 
-                list.Add(await _contentItemDisplayManager.BuildDisplayAsync(widget.ContentItem, (ControllerModelUpdater)this, "SummaryAdmin"));
+                list.Add(await _contentItemDisplayManager.BuildDisplayAsync(widget.ContentItem, _updateModelAccessor.ModelUpdater, "SummaryAdmin"));
             }
 
             return View(model);
@@ -315,12 +317,6 @@ namespace OrchardCore.Layers.Controllers
             {
                 ModelState.AddModelError(nameof(LayerEditViewModel.Rule), S["The rule is required."]);
             }
-        }
-
-        public static explicit operator ControllerModelUpdater(AdminController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
@@ -21,7 +21,7 @@ using YesSql;
 
 namespace OrchardCore.Layers.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
@@ -86,7 +86,7 @@ namespace OrchardCore.Layers.Controllers
                     model.Widgets.Add(zone, list = new List<dynamic>());
                 }
 
-                list.Add(await _contentItemDisplayManager.BuildDisplayAsync(widget.ContentItem, this, "SummaryAdmin"));
+                list.Add(await _contentItemDisplayManager.BuildDisplayAsync(widget.ContentItem, (ControllerModelUpdater)this, "SummaryAdmin"));
             }
 
             return View(model);
@@ -315,6 +315,12 @@ namespace OrchardCore.Layers.Controllers
             {
                 ModelState.AddModelError(nameof(LayerEditViewModel.Rule), S["The rule is required."]);
             }
+        }
+
+        public static explicit operator ControllerModelUpdater(AdminController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
@@ -15,7 +15,7 @@ using YesSql;
 
 namespace OrchardCore.Menu.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IAuthorizationService _authorizationService;
@@ -58,7 +58,7 @@ namespace OrchardCore.Menu.Controllers
 
             var contentItem = await _contentManager.NewAsync(id);
 
-            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, this, true);
+            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, (ControllerModelUpdater)this, true);
 
             model.MenuContentItemId = menuContentItemId;
             model.MenuItemId = menuItemId;
@@ -95,7 +95,7 @@ namespace OrchardCore.Menu.Controllers
 
             var contentItem = await _contentManager.NewAsync(id);
 
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, true);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, true);
 
             if (!ModelState.IsValid)
             {
@@ -160,7 +160,7 @@ namespace OrchardCore.Menu.Controllers
 
             var contentItem = menuItem.ToObject<ContentItem>();
 
-            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, this, false);
+            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, (ControllerModelUpdater)this, false);
 
             model.MenuContentItemId = menuContentItemId;
             model.MenuItemId = menuItemId;
@@ -206,7 +206,7 @@ namespace OrchardCore.Menu.Controllers
 
             var contentItem = menuItem.ToObject<ContentItem>();
 
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, false);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, false);
 
             if (!ModelState.IsValid)
             {
@@ -295,6 +295,12 @@ namespace OrchardCore.Menu.Controllers
             }
 
             return null;
+        }
+
+        public static explicit operator ControllerModelUpdater(AdminController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
@@ -23,6 +23,7 @@ namespace OrchardCore.Menu.Controllers
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ISession _session;
         private readonly INotifier _notifier;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public AdminController(
             ISession session,
@@ -31,7 +32,8 @@ namespace OrchardCore.Menu.Controllers
             IContentItemDisplayManager contentItemDisplayManager,
             IContentDefinitionManager contentDefinitionManager,
             INotifier notifier,
-            IHtmlLocalizer<AdminController> h)
+            IHtmlLocalizer<AdminController> h,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _contentManager = contentManager;
             _authorizationService = authorizationService;
@@ -39,6 +41,7 @@ namespace OrchardCore.Menu.Controllers
             _contentDefinitionManager = contentDefinitionManager;
             _session = session;
             _notifier = notifier;
+            _updateModelAccessor = updateModelAccessor;
             H = h;
         }
 
@@ -58,7 +61,7 @@ namespace OrchardCore.Menu.Controllers
 
             var contentItem = await _contentManager.NewAsync(id);
 
-            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, (ControllerModelUpdater)this, true);
+            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, true);
 
             model.MenuContentItemId = menuContentItemId;
             model.MenuItemId = menuItemId;
@@ -95,7 +98,7 @@ namespace OrchardCore.Menu.Controllers
 
             var contentItem = await _contentManager.NewAsync(id);
 
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, true);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, true);
 
             if (!ModelState.IsValid)
             {
@@ -160,7 +163,7 @@ namespace OrchardCore.Menu.Controllers
 
             var contentItem = menuItem.ToObject<ContentItem>();
 
-            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, (ControllerModelUpdater)this, false);
+            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, false);
 
             model.MenuContentItemId = menuContentItemId;
             model.MenuItemId = menuItemId;
@@ -206,7 +209,7 @@ namespace OrchardCore.Menu.Controllers
 
             var contentItem = menuItem.ToObject<ContentItem>();
 
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, false);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, false);
 
             if (!ModelState.IsValid)
             {
@@ -295,12 +298,6 @@ namespace OrchardCore.Menu.Controllers
             }
 
             return null;
-        }
-
-        public static explicit operator ControllerModelUpdater(AdminController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ServerConfigurationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ServerConfigurationController.cs
@@ -16,7 +16,7 @@ using OrchardCore.OpenId.Settings;
 namespace OrchardCore.OpenId.Controllers
 {
     [Admin, Feature(OpenIdConstants.Features.Server)]
-    public class ServerConfigurationController : Controller, IUpdateModel
+    public class ServerConfigurationController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly INotifier _notifier;
@@ -52,7 +52,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var settings = await _serverService.GetSettingsAsync();
-            var shape = await _serverSettingsDisplayManager.BuildEditorAsync(settings, updater: this, isNew: false);
+            var shape = await _serverSettingsDisplayManager.BuildEditorAsync(settings, updater: (ControllerModelUpdater)this, isNew: false);
 
             return View(shape);
         }
@@ -67,7 +67,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var settings = await _serverService.GetSettingsAsync();
-            var shape = await _serverSettingsDisplayManager.UpdateEditorAsync(settings, updater: this, isNew: false);
+            var shape = await _serverSettingsDisplayManager.UpdateEditorAsync(settings, updater: (ControllerModelUpdater)this, isNew: false);
 
             if (!ModelState.IsValid)
             {
@@ -95,6 +95,12 @@ namespace OrchardCore.OpenId.Controllers
             await _shellHost.ReloadShellContextAsync(_shellSettings);
 
             return RedirectToAction(nameof(Index));
+        }
+
+        public static explicit operator ControllerModelUpdater(ServerConfigurationController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ServerConfigurationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ServerConfigurationController.cs
@@ -24,6 +24,7 @@ namespace OrchardCore.OpenId.Controllers
         private readonly IDisplayManager<OpenIdServerSettings> _serverSettingsDisplayManager;
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly IHtmlLocalizer<ServerConfigurationController> H;
 
         public ServerConfigurationController(
@@ -33,7 +34,8 @@ namespace OrchardCore.OpenId.Controllers
             IOpenIdServerService serverService,
             IDisplayManager<OpenIdServerSettings> serverSettingsDisplayManager,
             IShellHost shellHost,
-            ShellSettings shellSettings)
+            ShellSettings shellSettings,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _authorizationService = authorizationService;
             H = htmlLocalizer;
@@ -42,6 +44,7 @@ namespace OrchardCore.OpenId.Controllers
             _serverSettingsDisplayManager = serverSettingsDisplayManager;
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            _updateModelAccessor = updateModelAccessor;
         }
 
         public async Task<IActionResult> Index()
@@ -52,7 +55,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var settings = await _serverService.GetSettingsAsync();
-            var shape = await _serverSettingsDisplayManager.BuildEditorAsync(settings, updater: (ControllerModelUpdater)this, isNew: false);
+            var shape = await _serverSettingsDisplayManager.BuildEditorAsync(settings, updater: _updateModelAccessor.ModelUpdater, isNew: false);
 
             return View(shape);
         }
@@ -67,7 +70,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var settings = await _serverService.GetSettingsAsync();
-            var shape = await _serverSettingsDisplayManager.UpdateEditorAsync(settings, updater: (ControllerModelUpdater)this, isNew: false);
+            var shape = await _serverSettingsDisplayManager.UpdateEditorAsync(settings, updater: _updateModelAccessor.ModelUpdater, isNew: false);
 
             if (!ModelState.IsValid)
             {
@@ -95,12 +98,6 @@ namespace OrchardCore.OpenId.Controllers
             await _shellHost.ReloadShellContextAsync(_shellSettings);
 
             return RedirectToAction(nameof(Index));
-        }
-
-        public static explicit operator ControllerModelUpdater(ServerConfigurationController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ValidationConfigurationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ValidationConfigurationController.cs
@@ -24,6 +24,7 @@ namespace OrchardCore.OpenId.Controllers
         private readonly IDisplayManager<OpenIdValidationSettings> _validationSettingsDisplayManager;
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly IHtmlLocalizer<ValidationConfigurationController> H;
 
         public ValidationConfigurationController(
@@ -33,7 +34,8 @@ namespace OrchardCore.OpenId.Controllers
             IOpenIdValidationService validationService,
             IDisplayManager<OpenIdValidationSettings> validationSettingsDisplayManager,
             IShellHost shellHost,
-            ShellSettings shellSettings)
+            ShellSettings shellSettings,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _authorizationService = authorizationService;
             H = htmlLocalizer;
@@ -42,6 +44,7 @@ namespace OrchardCore.OpenId.Controllers
             _validationSettingsDisplayManager = validationSettingsDisplayManager;
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            _updateModelAccessor = updateModelAccessor;
         }
 
         public async Task<IActionResult> Index()
@@ -52,7 +55,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var settings = await _validationService.GetSettingsAsync();
-            var shape = await _validationSettingsDisplayManager.BuildEditorAsync(settings, updater: (ControllerModelUpdater)this, isNew: false);
+            var shape = await _validationSettingsDisplayManager.BuildEditorAsync(settings, updater: _updateModelAccessor.ModelUpdater, isNew: false);
 
             return View(shape);
         }
@@ -67,7 +70,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var settings = await _validationService.GetSettingsAsync();
-            var shape = await _validationSettingsDisplayManager.UpdateEditorAsync(settings, updater: (ControllerModelUpdater)this, isNew: false);
+            var shape = await _validationSettingsDisplayManager.UpdateEditorAsync(settings, updater: _updateModelAccessor.ModelUpdater, isNew: false);
 
             if (!ModelState.IsValid)
             {
@@ -95,12 +98,6 @@ namespace OrchardCore.OpenId.Controllers
             await _shellHost.ReloadShellContextAsync(_shellSettings);
 
             return RedirectToAction(nameof(Index));
-        }
-
-        public static explicit operator ControllerModelUpdater(ValidationConfigurationController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ValidationConfigurationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ValidationConfigurationController.cs
@@ -16,7 +16,7 @@ using OrchardCore.OpenId.Settings;
 namespace OrchardCore.OpenId.Controllers
 {
     [Admin, Feature(OpenIdConstants.Features.Validation)]
-    public class ValidationConfigurationController : Controller, IUpdateModel
+    public class ValidationConfigurationController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly INotifier _notifier;
@@ -52,7 +52,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var settings = await _validationService.GetSettingsAsync();
-            var shape = await _validationSettingsDisplayManager.BuildEditorAsync(settings, updater: this, isNew: false);
+            var shape = await _validationSettingsDisplayManager.BuildEditorAsync(settings, updater: (ControllerModelUpdater)this, isNew: false);
 
             return View(shape);
         }
@@ -67,7 +67,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var settings = await _validationService.GetSettingsAsync();
-            var shape = await _validationSettingsDisplayManager.UpdateEditorAsync(settings, updater: this, isNew: false);
+            var shape = await _validationSettingsDisplayManager.UpdateEditorAsync(settings, updater: (ControllerModelUpdater)this, isNew: false);
 
             if (!ModelState.IsValid)
             {
@@ -95,6 +95,12 @@ namespace OrchardCore.OpenId.Controllers
             await _shellHost.ReloadShellContextAsync(_shellSettings);
 
             return RedirectToAction(nameof(Index));
+        }
+
+        public static explicit operator ControllerModelUpdater(ValidationConfigurationController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/AdminController.cs
@@ -27,6 +27,7 @@ namespace OrchardCore.Queries.Controllers
         private readonly IEnumerable<IQuerySource> _querySources;
         private readonly IDisplayManager<Query> _displayManager;
         private readonly ISession _session;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly IHtmlLocalizer H;
         private readonly dynamic New;
 
@@ -39,7 +40,8 @@ namespace OrchardCore.Queries.Controllers
             INotifier notifier,
             IQueryManager queryManager,
             IEnumerable<IQuerySource> querySources,
-            ISession session)
+            ISession session,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _session = session;
             _displayManager = displayManager;
@@ -47,6 +49,7 @@ namespace OrchardCore.Queries.Controllers
             _siteService = siteService;
             _queryManager = queryManager;
             _querySources = querySources;
+            _updateModelAccessor = updateModelAccessor;
             New = shapeFactory;
             _notifier = notifier;
             H = htmlLocalizer;
@@ -100,7 +103,7 @@ namespace OrchardCore.Queries.Controllers
                 model.Queries.Add(new QueryEntry
                 {
                     Query = query,
-                    Shape = await _displayManager.BuildDisplayAsync(query, (ControllerModelUpdater)this, "SummaryAdmin")
+                    Shape = await _displayManager.BuildDisplayAsync(query, _updateModelAccessor.ModelUpdater, "SummaryAdmin")
                 });
             }
 
@@ -132,7 +135,7 @@ namespace OrchardCore.Queries.Controllers
 
             var model = new QueriesCreateViewModel
             {
-                Editor = await _displayManager.BuildEditorAsync(query, updater: (ControllerModelUpdater)this, isNew: true),
+                Editor = await _displayManager.BuildEditorAsync(query, updater: _updateModelAccessor.ModelUpdater, isNew: true),
                 SourceName = id
             };
 
@@ -154,7 +157,7 @@ namespace OrchardCore.Queries.Controllers
                 return NotFound();
             }
 
-            var editor = await _displayManager.UpdateEditorAsync(query, updater: (ControllerModelUpdater)this, isNew: true);
+            var editor = await _displayManager.UpdateEditorAsync(query, updater: _updateModelAccessor.ModelUpdater, isNew: true);
 
             if (ModelState.IsValid)
             {
@@ -189,7 +192,7 @@ namespace OrchardCore.Queries.Controllers
                 SourceName = query.Source,
                 Name = query.Name,
                 Schema = query.Schema,
-                Editor = await _displayManager.BuildEditorAsync(query, updater: (ControllerModelUpdater)this, isNew: false)
+                Editor = await _displayManager.BuildEditorAsync(query, updater: _updateModelAccessor.ModelUpdater, isNew: false)
             };
 
             return View(model);
@@ -210,7 +213,7 @@ namespace OrchardCore.Queries.Controllers
                 return NotFound();
             }
 
-            var editor = await _displayManager.UpdateEditorAsync(query, updater: (ControllerModelUpdater)this, isNew: false);
+            var editor = await _displayManager.UpdateEditorAsync(query, updater: _updateModelAccessor.ModelUpdater, isNew: false);
 
             if (ModelState.IsValid)
             {
@@ -246,12 +249,6 @@ namespace OrchardCore.Queries.Controllers
             _notifier.Success(H["Query deleted successfully"]);
 
             return RedirectToAction("Index");
-        }
-
-        public static explicit operator ControllerModelUpdater(AdminController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/AdminController.cs
@@ -18,7 +18,7 @@ using YesSql;
 
 namespace OrchardCore.Queries.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly ISiteService _siteService;
@@ -100,7 +100,7 @@ namespace OrchardCore.Queries.Controllers
                 model.Queries.Add(new QueryEntry
                 {
                     Query = query,
-                    Shape = await _displayManager.BuildDisplayAsync(query, this, "SummaryAdmin")
+                    Shape = await _displayManager.BuildDisplayAsync(query, (ControllerModelUpdater)this, "SummaryAdmin")
                 });
             }
 
@@ -132,7 +132,7 @@ namespace OrchardCore.Queries.Controllers
 
             var model = new QueriesCreateViewModel
             {
-                Editor = await _displayManager.BuildEditorAsync(query, updater: this, isNew: true),
+                Editor = await _displayManager.BuildEditorAsync(query, updater: (ControllerModelUpdater)this, isNew: true),
                 SourceName = id
             };
 
@@ -154,7 +154,7 @@ namespace OrchardCore.Queries.Controllers
                 return NotFound();
             }
 
-            var editor = await _displayManager.UpdateEditorAsync(query, updater: this, isNew: true);
+            var editor = await _displayManager.UpdateEditorAsync(query, updater: (ControllerModelUpdater)this, isNew: true);
 
             if (ModelState.IsValid)
             {
@@ -189,7 +189,7 @@ namespace OrchardCore.Queries.Controllers
                 SourceName = query.Source,
                 Name = query.Name,
                 Schema = query.Schema,
-                Editor = await _displayManager.BuildEditorAsync(query, updater: this, isNew: false)
+                Editor = await _displayManager.BuildEditorAsync(query, updater: (ControllerModelUpdater)this, isNew: false)
             };
 
             return View(model);
@@ -210,7 +210,7 @@ namespace OrchardCore.Queries.Controllers
                 return NotFound();
             }
 
-            var editor = await _displayManager.UpdateEditorAsync(query, updater: this, isNew: false);
+            var editor = await _displayManager.UpdateEditorAsync(query, updater: (ControllerModelUpdater)this, isNew: false);
 
             if (ModelState.IsValid)
             {
@@ -246,6 +246,12 @@ namespace OrchardCore.Queries.Controllers
             _notifier.Success(H["Query deleted successfully"]);
 
             return RedirectToAction("Index");
+        }
+
+        public static explicit operator ControllerModelUpdater(AdminController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
@@ -10,7 +10,7 @@ using OrchardCore.Settings.ViewModels;
 
 namespace OrchardCore.Settings.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IDisplayManager<ISite> _siteSettingsDisplayManager;
         private readonly ISiteService _siteService;
@@ -49,7 +49,7 @@ namespace OrchardCore.Settings.Controllers
             var viewModel = new AdminIndexViewModel
             {
                 GroupId = groupId,
-                Shape = await _siteSettingsDisplayManager.BuildEditorAsync(site, this, false, groupId)
+                Shape = await _siteSettingsDisplayManager.BuildEditorAsync(site, (IUpdateModel)this, false, groupId)
             };
 
             return View(viewModel);
@@ -69,7 +69,7 @@ namespace OrchardCore.Settings.Controllers
             var viewModel = new AdminIndexViewModel
             {
                 GroupId = groupId,
-                Shape = await _siteSettingsDisplayManager.UpdateEditorAsync(site, this, false, groupId)
+                Shape = await _siteSettingsDisplayManager.UpdateEditorAsync(site, (IUpdateModel)this, false, groupId)
             };
 
             if (ModelState.IsValid)
@@ -82,6 +82,12 @@ namespace OrchardCore.Settings.Controllers
             }
 
             return View(viewModel);
+        }
+
+        public static explicit operator ControllerModelUpdater(AdminController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
@@ -16,6 +16,7 @@ namespace OrchardCore.Settings.Controllers
         private readonly ISiteService _siteService;
         private readonly INotifier _notifier;
         private readonly IAuthorizationService _authorizationService;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public AdminController(
             ISiteService siteService,
@@ -23,13 +24,14 @@ namespace OrchardCore.Settings.Controllers
             IAuthorizationService authorizationService,
             INotifier notifier,
             IHtmlLocalizer<AdminController> h,
-            IStringLocalizer<AdminController> s
-            )
+            IStringLocalizer<AdminController> s,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _siteSettingsDisplayManager = siteSettingsDisplayManager;
             _siteService = siteService;
             _notifier = notifier;
             _authorizationService = authorizationService;
+            _updateModelAccessor = updateModelAccessor;
             H = h;
             S = s;
         }
@@ -49,7 +51,7 @@ namespace OrchardCore.Settings.Controllers
             var viewModel = new AdminIndexViewModel
             {
                 GroupId = groupId,
-                Shape = await _siteSettingsDisplayManager.BuildEditorAsync(site, (IUpdateModel)this, false, groupId)
+                Shape = await _siteSettingsDisplayManager.BuildEditorAsync(site, _updateModelAccessor.ModelUpdater, false, groupId)
             };
 
             return View(viewModel);
@@ -69,7 +71,7 @@ namespace OrchardCore.Settings.Controllers
             var viewModel = new AdminIndexViewModel
             {
                 GroupId = groupId,
-                Shape = await _siteSettingsDisplayManager.UpdateEditorAsync(site, (IUpdateModel)this, false, groupId)
+                Shape = await _siteSettingsDisplayManager.UpdateEditorAsync(site, _updateModelAccessor.ModelUpdater, false, groupId)
             };
 
             if (ModelState.IsValid)
@@ -82,12 +84,6 @@ namespace OrchardCore.Settings.Controllers
             }
 
             return View(viewModel);
-        }
-
-        public static explicit operator ControllerModelUpdater(AdminController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Controllers/AdminController.cs
@@ -23,6 +23,7 @@ namespace OrchardCore.Taxonomies.Controllers
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ISession _session;
         private readonly INotifier _notifier;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public AdminController(
             ISession session,
@@ -31,7 +32,8 @@ namespace OrchardCore.Taxonomies.Controllers
             IContentItemDisplayManager contentItemDisplayManager,
             IContentDefinitionManager contentDefinitionManager,
             INotifier notifier,
-            IHtmlLocalizer<AdminController> h)
+            IHtmlLocalizer<AdminController> h,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _contentManager = contentManager;
             _authorizationService = authorizationService;
@@ -39,6 +41,7 @@ namespace OrchardCore.Taxonomies.Controllers
             _contentDefinitionManager = contentDefinitionManager;
             _session = session;
             _notifier = notifier;
+            _updateModelAccessor = updateModelAccessor;
             H = h;
         }
 
@@ -58,7 +61,7 @@ namespace OrchardCore.Taxonomies.Controllers
 
             var contentItem = await _contentManager.NewAsync(id);
 
-            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, (ControllerModelUpdater)this, true);
+            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, true);
 
             model.TaxonomyContentItemId = taxonomyContentItemId;
             model.TaxonomyItemId = taxonomyItemId;
@@ -95,7 +98,7 @@ namespace OrchardCore.Taxonomies.Controllers
 
             var contentItem = await _contentManager.NewAsync(id);
 
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, true);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, true);
 
             if (!ModelState.IsValid)
             {
@@ -158,7 +161,7 @@ namespace OrchardCore.Taxonomies.Controllers
 
             var contentItem = taxonomyItem.ToObject<ContentItem>();
 
-            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, (ControllerModelUpdater)this, false);
+            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, false);
 
             model.TaxonomyContentItemId = taxonomyContentItemId;
             model.TaxonomyItemId = taxonomyItemId;
@@ -204,7 +207,7 @@ namespace OrchardCore.Taxonomies.Controllers
 
             var contentItem = taxonomyItem.ToObject<ContentItem>();
 
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, false);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, false);
 
             if (!ModelState.IsValid)
             {
@@ -296,12 +299,6 @@ namespace OrchardCore.Taxonomies.Controllers
             }
 
             return null;
-        }
-
-        public static explicit operator ControllerModelUpdater(AdminController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Controllers/AdminController.cs
@@ -15,7 +15,7 @@ using YesSql;
 
 namespace OrchardCore.Taxonomies.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IAuthorizationService _authorizationService;
@@ -58,7 +58,7 @@ namespace OrchardCore.Taxonomies.Controllers
 
             var contentItem = await _contentManager.NewAsync(id);
 
-            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, this, true);
+            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, (ControllerModelUpdater)this, true);
 
             model.TaxonomyContentItemId = taxonomyContentItemId;
             model.TaxonomyItemId = taxonomyItemId;
@@ -95,7 +95,7 @@ namespace OrchardCore.Taxonomies.Controllers
 
             var contentItem = await _contentManager.NewAsync(id);
 
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, true);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, true);
 
             if (!ModelState.IsValid)
             {
@@ -158,7 +158,7 @@ namespace OrchardCore.Taxonomies.Controllers
 
             var contentItem = taxonomyItem.ToObject<ContentItem>();
 
-            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, this, false);
+            dynamic model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, (ControllerModelUpdater)this, false);
 
             model.TaxonomyContentItemId = taxonomyContentItemId;
             model.TaxonomyItemId = taxonomyItemId;
@@ -204,7 +204,7 @@ namespace OrchardCore.Taxonomies.Controllers
 
             var contentItem = taxonomyItem.ToObject<ContentItem>();
 
-            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, false);
+            var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, (ControllerModelUpdater)this, false);
 
             if (!ModelState.IsValid)
             {
@@ -296,6 +296,12 @@ namespace OrchardCore.Taxonomies.Controllers
             }
 
             return null;
+        }
+
+        public static explicit operator ControllerModelUpdater(AdminController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -10,7 +10,7 @@ using OrchardCore.Templates.ViewModels;
 
 namespace OrchardCore.Templates.Controllers
 {
-    public class PreviewController : Controller, IUpdateModel
+    public class PreviewController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IContentAliasManager _contentAliasManager;
@@ -84,9 +84,15 @@ namespace OrchardCore.Templates.Controllers
                 return NotFound();
             }
 
-            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, this, "Detail");
+            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, (ControllerModelUpdater)this, "Detail");
 
             return View(model);
+        }
+
+        public static explicit operator ControllerModelUpdater(PreviewController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -17,6 +17,7 @@ namespace OrchardCore.Templates.Controllers
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly ISiteService _siteService;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly string _homeUrl;
 
         public PreviewController(
@@ -25,13 +26,15 @@ namespace OrchardCore.Templates.Controllers
             IContentItemDisplayManager contentItemDisplayManager,
             IAuthorizationService authorizationService,
             ISiteService siteService,
-            ShellSettings shellSettings)
+            ShellSettings shellSettings,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _contentManager = contentManager;
             _contentAliasManager = contentAliasManager;
             _contentItemDisplayManager = contentItemDisplayManager;
             _authorizationService = authorizationService;
             _siteService = siteService;
+            _updateModelAccessor = updateModelAccessor;
             _homeUrl = ('/' + (shellSettings.RequestUrlPrefix ?? string.Empty)).TrimEnd('/') + '/';
         }
 
@@ -84,15 +87,9 @@ namespace OrchardCore.Templates.Controllers
                 return NotFound();
             }
 
-            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, (ControllerModelUpdater)this, "Detail");
+            var model = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, _updateModelAccessor.ModelUpdater, "Detail");
 
             return View(model);
-        }
-
-        public static explicit operator ControllerModelUpdater(PreviewController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/TemplateController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/TemplateController.cs
@@ -18,7 +18,7 @@ using OrchardCore.Templates.ViewModels;
 namespace OrchardCore.Templates.Controllers
 {
     [Admin]
-    public class TemplateController : Controller, IUpdateModel
+    public class TemplateController : Controller
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly TemplatesManager _templatesManager;
@@ -28,7 +28,7 @@ namespace OrchardCore.Templates.Controllers
         private readonly IStringLocalizer S;
         private readonly IHtmlLocalizer H;
         private readonly dynamic New;
-        
+
         public TemplateController(
             IAuthorizationService authorizationService,
             TemplatesManager templatesManager,
@@ -254,7 +254,7 @@ namespace OrchardCore.Templates.Controllers
                 if (submit != "SaveAndContinue")
                 {
                     return RedirectToReturnUrlOrIndex(returnUrl);
-                }                
+                }
             }
 
             // If we got this far, something failed, redisplay form
@@ -291,7 +291,7 @@ namespace OrchardCore.Templates.Controllers
                     );
 
             _notifier.Success(H["Template deleted successfully"]);
-            
+
             return RedirectToReturnUrlOrIndex(returnUrl);
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
@@ -32,6 +32,7 @@ namespace OrchardCore.Users.Controllers
         private readonly IDisplayManager<User> _userDisplayManager;
         private readonly INotifier _notifier;
         private readonly IUserService _userService;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         private readonly dynamic New;
         private readonly IHtmlLocalizer H;
@@ -45,8 +46,8 @@ namespace OrchardCore.Users.Controllers
             INotifier notifier,
             ISiteService siteService,
             IShapeFactory shapeFactory,
-            IHtmlLocalizer<AdminController> htmlLocalizer
-            )
+            IHtmlLocalizer<AdminController> htmlLocalizer,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _userDisplayManager = userDisplayManager;
             _authorizationService = authorizationService;
@@ -55,6 +56,7 @@ namespace OrchardCore.Users.Controllers
             _notifier = notifier;
             _siteService = siteService;
             _userService = userService;
+            _updateModelAccessor = updateModelAccessor;
 
             New = shapeFactory;
             H = htmlLocalizer;
@@ -136,7 +138,7 @@ namespace OrchardCore.Users.Controllers
                 userEntries.Add(new UserEntry
                     {
                         Id = user.Id,
-                        Shape = await _userDisplayManager.BuildDisplayAsync(user, updater: (ControllerModelUpdater)this, displayType: "SummaryAdmin")
+                        Shape = await _userDisplayManager.BuildDisplayAsync(user, updater: _updateModelAccessor.ModelUpdater, displayType: "SummaryAdmin")
                     }
                 );
             }
@@ -239,7 +241,7 @@ namespace OrchardCore.Users.Controllers
                 return Unauthorized();
             }
 
-            var shape = await _userDisplayManager.BuildEditorAsync(new User(), updater: (ControllerModelUpdater)this, isNew: true);
+            var shape = await _userDisplayManager.BuildEditorAsync(new User(), updater: _updateModelAccessor.ModelUpdater, isNew: true);
 
             return View(shape);
         }
@@ -255,7 +257,7 @@ namespace OrchardCore.Users.Controllers
 
             var user = new User();
 
-            var shape = await _userDisplayManager.UpdateEditorAsync(user, updater: (ControllerModelUpdater)this, isNew: true);
+            var shape = await _userDisplayManager.UpdateEditorAsync(user, updater: _updateModelAccessor.ModelUpdater, isNew: true);
 
             if (!ModelState.IsValid)
             {
@@ -287,7 +289,7 @@ namespace OrchardCore.Users.Controllers
                 return NotFound();
             }
 
-            var shape = await _userDisplayManager.BuildEditorAsync(user, updater: (ControllerModelUpdater)this, isNew: false);
+            var shape = await _userDisplayManager.BuildEditorAsync(user, updater: _updateModelAccessor.ModelUpdater, isNew: false);
 
             return View(shape);
         }
@@ -307,7 +309,7 @@ namespace OrchardCore.Users.Controllers
                 return NotFound();
             }
 
-            var shape = await _userDisplayManager.UpdateEditorAsync(user, updater: (ControllerModelUpdater)this, isNew: false);
+            var shape = await _userDisplayManager.UpdateEditorAsync(user, updater: _updateModelAccessor.ModelUpdater, isNew: false);
 
             if (!ModelState.IsValid)
             {
@@ -414,12 +416,6 @@ namespace OrchardCore.Users.Controllers
             }
 
             return View(model);
-        }
-
-        public static explicit operator ControllerModelUpdater(AdminController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
@@ -23,7 +23,7 @@ using YesSql.Services;
 
 namespace OrchardCore.Users.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly UserManager<IUser> _userManager;
         private readonly ISession _session;
@@ -136,7 +136,7 @@ namespace OrchardCore.Users.Controllers
                 userEntries.Add(new UserEntry
                     {
                         Id = user.Id,
-                        Shape = await _userDisplayManager.BuildDisplayAsync(user, updater: this, displayType: "SummaryAdmin")
+                        Shape = await _userDisplayManager.BuildDisplayAsync(user, updater: (ControllerModelUpdater)this, displayType: "SummaryAdmin")
                     }
                 );
             }
@@ -239,7 +239,7 @@ namespace OrchardCore.Users.Controllers
                 return Unauthorized();
             }
 
-            var shape = await _userDisplayManager.BuildEditorAsync(new User(), updater: this, isNew: true);
+            var shape = await _userDisplayManager.BuildEditorAsync(new User(), updater: (ControllerModelUpdater)this, isNew: true);
 
             return View(shape);
         }
@@ -255,7 +255,7 @@ namespace OrchardCore.Users.Controllers
 
             var user = new User();
 
-            var shape = await _userDisplayManager.UpdateEditorAsync(user, updater: this, isNew: true);
+            var shape = await _userDisplayManager.UpdateEditorAsync(user, updater: (ControllerModelUpdater)this, isNew: true);
 
             if (!ModelState.IsValid)
             {
@@ -287,7 +287,7 @@ namespace OrchardCore.Users.Controllers
                 return NotFound();
             }
 
-            var shape = await _userDisplayManager.BuildEditorAsync(user, updater: this, isNew: false);
+            var shape = await _userDisplayManager.BuildEditorAsync(user, updater: (ControllerModelUpdater)this, isNew: false);
 
             return View(shape);
         }
@@ -307,7 +307,7 @@ namespace OrchardCore.Users.Controllers
                 return NotFound();
             }
 
-            var shape = await _userDisplayManager.UpdateEditorAsync(user, updater: this, isNew: false);
+            var shape = await _userDisplayManager.UpdateEditorAsync(user, updater: (ControllerModelUpdater)this, isNew: false);
 
             if (!ModelState.IsValid)
             {
@@ -414,6 +414,12 @@ namespace OrchardCore.Users.Controllers
             }
 
             return View(model);
+        }
+
+        public static explicit operator ControllerModelUpdater(AdminController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Controllers/AdminController.cs
@@ -17,18 +17,20 @@ namespace OrchardCore.Widgets.Controllers
         private readonly IContentManager _contentManager;
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
         private readonly IShapeFactory _shapeFactory;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public AdminController(
             IContentManager contentManager,
             IContentItemDisplayManager contentItemDisplayManager,
             IShapeFactory shapeFactory,
-            ILogger<AdminController> logger
-            )
+            ILogger<AdminController> logger,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _contentItemDisplayManager = contentItemDisplayManager;
             _contentManager = contentManager;
             _shapeFactory = shapeFactory;
             Logger = logger;
+            _updateModelAccessor = updateModelAccessor;
         }
 
         public ILogger Logger { get; set; }
@@ -49,7 +51,7 @@ namespace OrchardCore.Widgets.Controllers
             //Create a Card Shape
             dynamic contentCard = await _shapeFactory.New.ContentCard(
                 //Updater is the controller for AJAX Requests
-                Updater: this,
+                Updater: _updateModelAccessor.ModelUpdater,
                 //Shape Specific
                 CollectionShapeType: cardCollectionType,
                 ContentItem: contentItem,

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Controllers/AdminController.cs
@@ -12,7 +12,7 @@ using OrchardCore.Widgets.ViewModels;
 
 namespace OrchardCore.Widgets.Controllers
 {
-    public class AdminController : Controller, IUpdateModel
+    public class AdminController : Controller
     {
         private readonly IContentManager _contentManager;
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
@@ -56,7 +56,7 @@ namespace OrchardCore.Widgets.Controllers
                 BuildEditor: true,
                 ParentContentType: parentContentType,
                 CollectionPartName: partName,
-                //WidgetListPart Specific 
+                //WidgetListPart Specific
                 ZoneValue: zone,
                 //Card Specific Properties
                 TargetId: targetId,

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -28,7 +28,7 @@ using YesSql.Services;
 namespace OrchardCore.Workflows.Controllers
 {
     [Admin]
-    public class WorkflowController : Controller, IUpdateModel
+    public class WorkflowController : Controller
     {
         private readonly ISiteService _siteService;
         private readonly ISession _session;
@@ -262,13 +262,19 @@ namespace OrchardCore.Workflows.Controllers
 
         private async Task<dynamic> BuildActivityDisplayAsync(ActivityContext activityContext, int workflowTypeId, bool isBlocking, string displayType)
         {
-            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activityContext.Activity, this, displayType);
+            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activityContext.Activity, (ControllerModelUpdater)this, displayType);
             activityShape.Metadata.Type = $"Activity_{displayType}ReadOnly";
             activityShape.Activity = activityContext.Activity;
             activityShape.ActivityRecord = activityContext.ActivityRecord;
             activityShape.WorkflowTypeId = workflowTypeId;
             activityShape.IsBlocking = isBlocking;
             return activityShape;
+        }
+
+        public static explicit operator ControllerModelUpdater(WorkflowController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -39,6 +39,7 @@ namespace OrchardCore.Workflows.Controllers
         private readonly IActivityDisplayManager _activityDisplayManager;
         private readonly INotifier _notifier;
         private readonly ILogger<WorkflowController> _logger;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
         private readonly IHtmlLocalizer<WorkflowController> H;
 
         public WorkflowController(
@@ -52,8 +53,8 @@ namespace OrchardCore.Workflows.Controllers
             IShapeFactory shapeFactory,
             INotifier notifier,
             IHtmlLocalizer<WorkflowController> localizer,
-            ILogger<WorkflowController> logger
-        )
+            ILogger<WorkflowController> logger,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _siteService = siteService;
             _session = session;
@@ -64,6 +65,7 @@ namespace OrchardCore.Workflows.Controllers
             _activityDisplayManager = activityDisplayManager;
             _notifier = notifier;
             _logger = logger;
+            _updateModelAccessor = updateModelAccessor;
             New = shapeFactory;
             H = localizer;
         }
@@ -262,19 +264,13 @@ namespace OrchardCore.Workflows.Controllers
 
         private async Task<dynamic> BuildActivityDisplayAsync(ActivityContext activityContext, int workflowTypeId, bool isBlocking, string displayType)
         {
-            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activityContext.Activity, (ControllerModelUpdater)this, displayType);
+            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activityContext.Activity, _updateModelAccessor.ModelUpdater, displayType);
             activityShape.Metadata.Type = $"Activity_{displayType}ReadOnly";
             activityShape.Activity = activityContext.Activity;
             activityShape.ActivityRecord = activityContext.ActivityRecord;
             activityShape.WorkflowTypeId = workflowTypeId;
             activityShape.IsBlocking = isBlocking;
             return activityShape;
-        }
-
-        public static explicit operator ControllerModelUpdater(WorkflowController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
@@ -42,6 +42,7 @@ namespace OrchardCore.Workflows.Controllers
         private readonly IActivityDisplayManager _activityDisplayManager;
         private readonly INotifier _notifier;
         private readonly ISecurityTokenService _securityTokenService;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
 
         private dynamic New { get; }
         private IStringLocalizer S { get; }
@@ -61,8 +62,8 @@ namespace OrchardCore.Workflows.Controllers
             INotifier notifier,
             ISecurityTokenService securityTokenService,
             IStringLocalizer<WorkflowTypeController> s,
-            IHtmlLocalizer<WorkflowTypeController> h
-        )
+            IHtmlLocalizer<WorkflowTypeController> h,
+            IUpdateModelAccessor updateModelAccessor)
         {
             _siteService = siteService;
             _session = session;
@@ -74,6 +75,7 @@ namespace OrchardCore.Workflows.Controllers
             _activityDisplayManager = activityDisplayManager;
             _notifier = notifier;
             _securityTokenService = securityTokenService;
+            _updateModelAccessor = updateModelAccessor;
 
             New = shapeFactory;
             S = s;
@@ -479,7 +481,7 @@ namespace OrchardCore.Workflows.Controllers
 
         private async Task<dynamic> BuildActivityDisplay(IActivity activity, int index, int workflowTypeId, string localId, string displayType)
         {
-            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activity, (ControllerModelUpdater)this, displayType);
+            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activity, _updateModelAccessor.ModelUpdater, displayType);
             activityShape.Metadata.Type = $"Activity_{displayType}";
             activityShape.Activity = activity;
             activityShape.WorkflowTypeId = workflowTypeId;
@@ -490,7 +492,7 @@ namespace OrchardCore.Workflows.Controllers
 
         private async Task<dynamic> BuildActivityDisplay(ActivityContext activityContext, int index, int workflowTypeId, string localId, string displayType)
         {
-            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activityContext.Activity, (ControllerModelUpdater)this, displayType);
+            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activityContext.Activity, _updateModelAccessor.ModelUpdater, displayType);
             activityShape.Metadata.Type = $"Activity_{displayType}";
             activityShape.Activity = activityContext.Activity;
             activityShape.ActivityRecord = activityContext.ActivityRecord;
@@ -498,12 +500,6 @@ namespace OrchardCore.Workflows.Controllers
             activityShape.Index = index;
             activityShape.ReturnUrl = Url.Action(nameof(Edit), new { id = workflowTypeId, localId = localId });
             return activityShape;
-        }
-
-        public static explicit operator ControllerModelUpdater(WorkflowTypeController controller)
-        {
-            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
-            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
@@ -30,7 +30,7 @@ using YesSql.Services;
 namespace OrchardCore.Workflows.Controllers
 {
     [Admin]
-    public class WorkflowTypeController : Controller, IUpdateModel
+    public class WorkflowTypeController : Controller
     {
         private readonly ISiteService _siteService;
         private readonly ISession _session;
@@ -176,7 +176,7 @@ namespace OrchardCore.Workflows.Controllers
             {
                 return Unauthorized();
             }
-            
+
             if (itemIds?.Count() > 0)
             {
                 var checkedEntries = await _session.Query<WorkflowType, WorkflowTypeIndex>().Where(x => x.DocumentId.IsIn(itemIds)).ListAsync();
@@ -479,7 +479,7 @@ namespace OrchardCore.Workflows.Controllers
 
         private async Task<dynamic> BuildActivityDisplay(IActivity activity, int index, int workflowTypeId, string localId, string displayType)
         {
-            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activity, this, displayType);
+            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activity, (ControllerModelUpdater)this, displayType);
             activityShape.Metadata.Type = $"Activity_{displayType}";
             activityShape.Activity = activity;
             activityShape.WorkflowTypeId = workflowTypeId;
@@ -490,7 +490,7 @@ namespace OrchardCore.Workflows.Controllers
 
         private async Task<dynamic> BuildActivityDisplay(ActivityContext activityContext, int index, int workflowTypeId, string localId, string displayType)
         {
-            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activityContext.Activity, this, displayType);
+            dynamic activityShape = await _activityDisplayManager.BuildDisplayAsync(activityContext.Activity, (ControllerModelUpdater)this, displayType);
             activityShape.Metadata.Type = $"Activity_{displayType}";
             activityShape.Activity = activityContext.Activity;
             activityShape.ActivityRecord = activityContext.ActivityRecord;
@@ -498,6 +498,12 @@ namespace OrchardCore.Workflows.Controllers
             activityShape.Index = index;
             activityShape.ReturnUrl = Url.Action(nameof(Edit), new { id = workflowTypeId, localId = localId });
             return activityShape;
+        }
+
+        public static explicit operator ControllerModelUpdater(WorkflowTypeController controller)
+        {
+            var updater = (IUpdateModelAccessor)controller.HttpContext.RequestServices.GetService(typeof(IUpdateModelAccessor));
+            return (ControllerModelUpdater)updater.ModelUpdater;
         }
     }
 }


### PR DESCRIPTION
Fixes #5253 

1. Removed `IUpdateModel` from controllers
2. Inject `IUpdateModelAccessor` 
3. BuildEditorAsync

 In place of 
`var model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, this, true);`
changed to
`var model = await _contentItemDisplayManager.BuildEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, true);`
