### PR TITLE
Fix ContentItemIndex and apply better length checking to autoroute part

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Fluid;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
+using OrchardCore.Autoroute.Drivers;
 using OrchardCore.Autoroute.Models;
 using OrchardCore.Autoroute.ViewModels;
 using OrchardCore.ContentManagement;
@@ -130,6 +131,11 @@ namespace OrchardCore.Autoroute.Handlers
 
                 part.Path = part.Path.Replace("\r", String.Empty).Replace("\n", String.Empty);
 
+                if (part.Path?.Length > AutoroutePartDisplay.MaxPathLength)
+                {
+                    part.Path = part.Path.Substring(0, AutoroutePartDisplay.MaxPathLength);
+                }
+
                 if (!await IsPathUniqueAsync(part.Path, part))
                 {
                     part.Path = await GenerateUniquePathAsync(part.Path, part);
@@ -177,6 +183,13 @@ namespace OrchardCore.Autoroute.Handlers
 
             while (true)
             {
+                // Unversioned length + seperator char + version length.
+                var quantityCharactersToTrim = unversionedPath.Length + 1 + version.ToString().Length - AutoroutePartDisplay.MaxPathLength;
+                if (quantityCharactersToTrim > 0)
+                {
+                    unversionedPath = unversionedPath.Substring(0, unversionedPath.Length - quantityCharactersToTrim);
+                }
+
                 var versionedPath = $"{unversionedPath}-{version++}";
                 if (await IsPathUniqueAsync(versionedPath, context))
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Migrations.cs
@@ -32,8 +32,12 @@ namespace OrchardCore.Autoroute
                 .CreateIndex("IDX_AutoroutePartIndex_ContentItemId", "ContentItemId")
             );
 
-            // Return 2 to shortcut the second migration on new content definition schemas.
-            return 2;
+            SchemaBuilder.AlterTable(nameof(AutoroutePartIndex), table => table
+                .CreateIndex("IDX_AutoroutePartIndex_Published", "Published")
+            );
+
+            // Return 3 to shortcut the second migration on new content definition schemas.
+            return 3;
         }
 
         // Migrate PartSettings. This only needs to run on old content definition schemas.
@@ -43,6 +47,16 @@ namespace OrchardCore.Autoroute
             _contentDefinitionManager.MigratePartSettings<AutoroutePart, AutoroutePartSettings>();
 
             return 2;
+        }
+
+        // This code can be removed in a later version.
+        public int UpdateFrom2()
+        {
+            SchemaBuilder.AlterTable(nameof(AutoroutePartIndex), table => table
+                .CreateIndex("IDX_AutoroutePartIndex_Published", "Published")
+            );
+
+            return 3;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement/Records/ContentItemIndex.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Records/ContentItemIndex.cs
@@ -49,22 +49,22 @@ namespace OrchardCore.ContentManagement.Records
 
                     if (contentItemIndex.ContentType?.Length > ContentItemIndex.MaxContentTypeSize)
                     {
-                        contentItem.ContentType = contentItem.ContentType.Substring(ContentItemIndex.MaxContentTypeSize);
+                        contentItem.ContentType = contentItem.ContentType.Substring(0, ContentItemIndex.MaxContentTypeSize);
                     }
 
                     if (contentItemIndex.Owner?.Length > ContentItemIndex.MaxOwnerSize)
                     {
-                        contentItem.Owner = contentItem.Owner.Substring(ContentItemIndex.MaxOwnerSize);
+                        contentItem.Owner = contentItem.Owner.Substring(0, ContentItemIndex.MaxOwnerSize);
                     }
 
                     if (contentItemIndex.Author?.Length > ContentItemIndex.MaxAuthorSize)
                     {
-                        contentItem.Author = contentItem.Author.Substring(ContentItemIndex.MaxAuthorSize);
+                        contentItem.Author = contentItem.Author.Substring(0, ContentItemIndex.MaxAuthorSize);
                     }
 
                     if (contentItemIndex.DisplayText?.Length > ContentItemIndex.MaxDisplayTextSize)
                     {
-                        contentItem.DisplayText = contentItem.DisplayText.Substring(ContentItemIndex.MaxDisplayTextSize);
+                        contentItem.DisplayText = contentItem.DisplayText.Substring(0, ContentItemIndex.MaxDisplayTextSize);
                     }
 
                     return contentItemIndex;


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5318

Applies same checking as was done for the alias part in https://github.com/OrchardCMS/OrchardCore/pull/5195

Fixes the way the Content Item Index would truncate values when too long.

And adds the `Published` value to a separate key index for Autoroute as this is the `.Where clause` used when starting the site, and reading from the index into `IAutorouteEntries`

We also query on the path during handlers, but the path will not fit in a MS SQL or MySql Index so not indexing that field.
