### PR TITLE
Reduce length of indexes for Content Fields Indexing

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/LinkFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/LinkFieldIndexProvider.cs
@@ -12,8 +12,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 {
     public class LinkFieldIndex : ContentFieldIndex
     {
+        // Maximum length that MySql can support in an index under utf8 collation.
+        public const int MaxUrlSize = 768;
+        public const int MaxTextSize = 768;
+
         public string Url { get; set; }
+        public string BigUrl { get; set; }
         public string Text { get; set; }
+        public string BigText { get; set; }
     }
 
     public class LinkFieldIndexProvider : ContentFieldIndexProvider
@@ -81,8 +87,10 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                             ContentType = contentItem.ContentType,
                             ContentPart = fieldDefinition.PartDefinition.Name,
                             ContentField = fieldDefinition.Name,
-                            Url = field.Url?.Substring(0, Math.Min(field.Url.Length, 4000)),
-                            Text = field.Text?.Substring(0, Math.Min(field.Text.Length, 4000))
+                            Url = field.Url?.Substring(0, Math.Min(field.Url.Length, LinkFieldIndex.MaxUrlSize)),
+                            BigUrl = field.Url,
+                            Text = field.Text?.Substring(0, Math.Min(field.Text.Length, LinkFieldIndex.MaxTextSize)),
+                            BigText = field.Text
                         });
                     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
@@ -8,6 +8,8 @@ namespace OrchardCore.ContentFields.Indexing.SQL
     {
         public int Create()
         {
+            // NOTE: The Text Length has been decreased from 4000 characters to 768.
+            // For existing SQL databases update the TextFieldIndex tables Text column length manually. 
             SchemaBuilder.CreateMapIndexTable(nameof(TextFieldIndex), table => table
                 .Column<string>("ContentItemId", column => column.WithLength(26))
                 .Column<string>("ContentItemVersionId", column => column.WithLength(26))
@@ -16,7 +18,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                 .Column<string>("ContentField", column => column.WithLength(ContentItemIndex.MaxContentFieldSize))
                 .Column<bool>("Published", column => column.Nullable())
                 .Column<bool>("Latest", column => column.Nullable())
-                .Column<string>("Text", column => column.Nullable().WithLength(4000))
+                .Column<string>("Text", column => column.Nullable().WithLength(TextFieldIndex.MaxTextSize))
                 .Column<string>("BigText", column => column.Nullable().Unlimited())
             );
 
@@ -310,6 +312,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                 .CreateIndex("IDX_TimeFieldIndex_Time", "Time")
             );
 
+            // NOTE: The Url and Text Length has been decreased from 4000 characters to 768.
+            // For existing SQL databases update the LinkFieldIndex tables Url and Text column length manually.
+            // The BigText and BigUrl columns are new additions so will not be populated until the content item is republished.
             SchemaBuilder.CreateMapIndexTable(nameof(LinkFieldIndex), table => table
                 .Column<string>("ContentItemId", column => column.WithLength(26))
                 .Column<string>("ContentItemVersionId", column => column.WithLength(26))
@@ -318,8 +323,10 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                 .Column<string>("ContentField", column => column.WithLength(ContentItemIndex.MaxContentFieldSize))
                 .Column<bool>("Published", column => column.Nullable())
                 .Column<bool>("Latest", column => column.Nullable())
-                .Column<string>("Url", column => column.Nullable().WithLength(4000))
-                .Column<string>("Text", column => column.Nullable().WithLength(4000))
+                .Column<string>("Url", column => column.Nullable().WithLength(LinkFieldIndex.MaxUrlSize))
+                .Column<string>("BigUrl", column => column.Nullable().Unlimited())
+                .Column<string>("Text", column => column.Nullable().WithLength(LinkFieldIndex.MaxTextSize))
+                .Column<string>("BigText", column => column.Nullable().Unlimited())
             );
 
             SchemaBuilder.AlterTable(nameof(LinkFieldIndex), table => table
@@ -397,7 +404,19 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                 .CreateIndex("IDX_HtmlFieldIndex_Latest", "Latest")
             );
 
-            return 1;
+            // Return 2 to shorcut migrations on new installations.
+            return 2;
+        }
+
+        public int UpdateFrom1()
+        {
+            SchemaBuilder.AlterTable(nameof(LinkFieldIndex), table => table
+                .AddColumn<string>("BigUrl", column => column.Nullable().Unlimited()));
+
+            SchemaBuilder.AlterTable(nameof(LinkFieldIndex), table => table
+                .AddColumn<string>("BigText", column => column.Nullable().Unlimited()));
+
+            return 2;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/TextFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/TextFieldIndexProvider.cs
@@ -12,6 +12,8 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 {
     public class TextFieldIndex : ContentFieldIndex
     {
+        // Maximum length that MySql can support in an index under utf8 collation.
+        public const int MaxTextSize = 768;
         public string Text { get; set; }
         public string BigText { get; set; }
     }
@@ -81,7 +83,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                             ContentType = contentItem.ContentType,
                             ContentPart = fieldDefinition.PartDefinition.Name,
                             ContentField = fieldDefinition.Name,
-                            Text = field.Text?.Substring(0, Math.Min(field.Text.Length, 4000)),
+                            Text = field.Text?.Substring(0, Math.Min(field.Text.Length, TextFieldIndex.MaxTextSize)),
                             BigText = field.Text
                         });
                     }

--- a/src/OrchardCore/OrchardCore.Data/Migration/DataMigrationManager.cs
+++ b/src/OrchardCore/OrchardCore.Data/Migration/DataMigrationManager.cs
@@ -178,7 +178,8 @@ namespace OrchardCore.Data.Migration
                 var current = 0;
                 if (dataMigrationRecord != null)
                 {
-                    current = dataMigrationRecord.Version.Value;
+                    // This can be null if a failed create migration has occured and the data migration record was saved.
+                    current = dataMigrationRecord.Version.HasValue ? dataMigrationRecord.Version.Value : current;
                 }
                 else
                 {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5196 and fixes https://github.com/OrchardCMS/OrchardCore/issues/4753

Reduce length to maximum MySql can support (768) and add BigText columns that were missing to LinkField

Also fixes a null ref that can occur when a `Create()` migration fails

Still to test on MySql just to make sure the install completes ok