### PR TITLE
Return null if home route has no values

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteTransformer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteTransformer.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -19,7 +18,7 @@ namespace OrchardCore.HomeRoute.Routing
         public override async ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
         {
             var homeRoute = (await _siteService.GetSiteSettingsAsync()).HomeRoute;
-            if (homeRoute.Any())
+            if (homeRoute.Count > 0)
             {
                 return new RouteValueDictionary(homeRoute);
             } else

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteTransformer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteTransformer.cs
@@ -18,10 +18,12 @@ namespace OrchardCore.HomeRoute.Routing
         public override async ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
         {
             var homeRoute = (await _siteService.GetSiteSettingsAsync()).HomeRoute;
+            
             if (homeRoute.Count > 0)
             {
                 return new RouteValueDictionary(homeRoute);
-            } else
+            } 
+            else
             {
                 return null;
             }

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteTransformer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/Routing/HomeRouteTransformer.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -17,7 +18,14 @@ namespace OrchardCore.HomeRoute.Routing
 
         public override async ValueTask<RouteValueDictionary> TransformAsync(HttpContext httpContext, RouteValueDictionary values)
         {
-            return new RouteValueDictionary((await _siteService.GetSiteSettingsAsync()).HomeRoute);
+            var homeRoute = (await _siteService.GetSiteSettingsAsync()).HomeRoute;
+            if (homeRoute.Any())
+            {
+                return new RouteValueDictionary(homeRoute);
+            } else
+            {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
Following on from the issue https://github.com/OrchardCMS/OrchardCore/issues/5400

this just updates the `HomeRouteTransformer` to return null, if there are no route values set for the `HomeRoute`.

This allows the framework to handle the NotFound, rather than the itemcontroller.
