### PR TITLE
Don't release a disabled shell still in use

### DIFF
--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -328,6 +328,7 @@ namespace OrchardCore.Environment.Shell
                 if (_shellContexts.TryGetValue(settings.Name, out var value) && value.ActiveScopes > 0)
                 {
                     _runningShellTable.Remove(settings);
+                    return;
                 }
             }
 


### PR DESCRIPTION
As said in the code comments

    // If a disabled shell is still in use it will be released and then disposed by its last scope.
    // Knowing that it is still removed from the running shell table, so that it is no more served.
    if (_shellContexts.TryGetValue(settings.Name, out var value) && value.ActiveScopes > 0)
    {
        _runningShellTable.Remove(settings);

        // missing return
        // return;
    }

But afterwards we were still releasing this disabled shell because of the above missing return.