### PR TITLE
Fixes #5233 database locking issue

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexManager.cs
@@ -293,7 +293,7 @@ namespace OrchardCore.Lucene
         {
             if (!_writers.TryGetValue(indexName, out var writer))
             {
-                var indexAnalyzer = await _luceneIndexSettingsService.LoaIndexAnalyzerAsync(indexName);
+                var indexAnalyzer = await _luceneIndexSettingsService.LoadIndexAnalyzerAsync(indexName);
                 lock (this)
                 {
                     if (!_writers.TryGetValue(indexName, out writer))

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexManager.cs
@@ -293,7 +293,7 @@ namespace OrchardCore.Lucene
         {
             if (!_writers.TryGetValue(indexName, out var writer))
             {
-                var indexAnalyzer = await _luceneIndexSettingsService.GetIndexAnalyzerAsync(indexName);
+                var indexAnalyzer = await _luceneIndexSettingsService.LoaIndexAnalyzerAsync(indexName);
                 lock (this)
                 {
                     if (!_writers.TryGetValue(indexName, out writer))

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexSettingsService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexSettingsService.cs
@@ -87,7 +87,7 @@ namespace OrchardCore.Lucene
             return LuceneSettings.StandardAnalyzer;
         }
 
-        public async Task<string> LoaIndexAnalyzerAsync(string indexName)
+        public async Task<string> LoadIndexAnalyzerAsync(string indexName)
         {
             var document = await LoadDocumentAsync();
 

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexSettingsService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexSettingsService.cs
@@ -87,6 +87,18 @@ namespace OrchardCore.Lucene
             return LuceneSettings.StandardAnalyzer;
         }
 
+        public async Task<string> LoaIndexAnalyzerAsync(string indexName)
+        {
+            var document = await LoadDocumentAsync();
+
+            if (document.LuceneIndexSettings.TryGetValue(indexName, out var settings))
+            {
+                return settings.AnalyzerName;
+            }
+
+            return LuceneSettings.StandardAnalyzer;
+        }
+
         public async Task UpdateIndexAsync(LuceneIndexSettings settings)
         {
             if (settings.IsReadonly)


### PR DESCRIPTION
Fixes #5233 

So, to fix the database locking issue, i kept `LuceneIndexSettingsService` as a singleton (because used by `LuceneIndexManager` that is a singleton) but here we resolve the scoped `ISession` in place of using the `IStore` singleton, as we do in `SiteService`.