### PR TITLE
Rendering zones before rendering layout

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/RenderSectionTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/RenderSectionTag.cs
@@ -6,6 +6,7 @@ using Fluid;
 using Fluid.Ast;
 using Fluid.Tags;
 using Microsoft.AspNetCore.Html;
+using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.Liquid.Ast;
 
 namespace OrchardCore.DisplayManagement.Liquid.Tags
@@ -30,7 +31,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
             var required = arguments.HasNamed("required") && Convert.ToBoolean(arguments["required"].ToStringValue());
             var zone = layout[name];
 
-            if (required && zone != null && zone.Items.Count == 0)
+            if (required && zone != null && zone is Shape && zone.Items.Count == 0)
             {
                 throw new InvalidOperationException("Zone not found while invoking 'render_section': " + name);
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -335,7 +335,7 @@ namespace OrchardCore.DisplayManagement.Razor
 
             var zone = ThemeLayout[name];
 
-            if (required && zone != null && zone.Items.Count == 0)
+            if (required && zone != null && zone is Shape && zone.Items.Count == 0)
             {
                 throw new InvalidOperationException("Zone not found: " + name);
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Localization;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -57,7 +57,7 @@ namespace OrchardCore.DisplayManagement.Theming
                     }
                 }
                 // Finally we render the Layout Shape's HTML to the page's output
-                Write(await DisplayAsync(ThemeLayout);
+                Write(await DisplayAsync(ThemeLayout));
             }
             else
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.DisplayManagement.Theming
                 // Then is added to the Content zone of the Layout shape
                 ThemeLayout.Content.Add(body);
 
-                //Render Shapes in Content
+                // Render Shapes in Content
                 var htmlContent = await DisplayAsync(ThemeLayout.Content);
                 var content = ((Shape)ThemeLayout.Content);
 
@@ -44,9 +44,9 @@ namespace OrchardCore.DisplayManagement.Theming
                 {
                     foreach (var key in zoneKeys)
                     {
-                        //Render each layout zone
+                        // Render each layout zone
                         var zone = ThemeLayout[key];
-                        var htmlZone= DisplayAsync(zone);
+                        var htmlZone = await DisplayAsync(zone);
 
                         foreach (var item in zone.Items.ToArray())
                         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -7,9 +7,9 @@ using OrchardCore.DisplayManagement.Shapes;
 namespace OrchardCore.DisplayManagement.Theming
 {
     /// <summary>
-    /// This class represents a precompiled _Layout.cshtml view that renders a 
+    /// This class represents a precompiled _Layout.cshtml view that renders a
     /// Layout shape and the View's body in its Content zone.
-    /// 
+    ///
     /// 1- Views look for any _ViewStart.cshtml
     /// 2- <see cref="ThemingViewsFeatureProvider"/> has registered <see cref="ThemeViewStart"/> as the top one
     /// 3- <see cref="ThemeViewStart"/> then set a special Layout filename as the default View's Layout.
@@ -20,7 +20,7 @@ namespace OrchardCore.DisplayManagement.Theming
     {
         public override async Task ExecuteAsync()
         {
-            // The View's body is rendered 
+            // The View's body is rendered
             var body = RenderLayoutBody();
 
             if (ThemeLayout != null)
@@ -28,9 +28,8 @@ namespace OrchardCore.DisplayManagement.Theming
                 // Then is added to the Content zone of the Layout shape
                 ThemeLayout.Content.Add(body);
 
-                //Render Shapes in Content 
+                //Render Shapes in Content
                 var htmlContent = await DisplayAsync(ThemeLayout.Content);
-
                 var content = ((Shape)ThemeLayout.Content);
 
                 foreach (var item in content.Items.ToArray())
@@ -39,8 +38,8 @@ namespace OrchardCore.DisplayManagement.Theming
                 }
 
                 content.Add(htmlContent);
-
                 var zoneKeys = ((Zones.ZoneHolding)ThemeLayout).Properties.Keys.ToArray();
+
                 if(zoneKeys != null && zoneKeys.Count() > 0)
                 {
                     foreach (var key in zoneKeys)
@@ -56,10 +55,9 @@ namespace OrchardCore.DisplayManagement.Theming
 
                         zone.Add(htmlZone);
                     }
-                }                
+                }
                 // Finally we render the Layout Shape's HTML to the page's output
-                var layout = await DisplayAsync(ThemeLayout);                
-                Write(layout);
+                Write(await DisplayAsync(ThemeLayout);
             }
             else
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.DisplayManagement.Theming
                 ThemeLayout.Content.Add(body);
 
                 // Render Shapes in Content
-                if(ThemeLayout.Content is Shape content)
+                if(ThemeLayout.Content is IShape content)
                 {
                     var htmlContent = await DisplayAsync(content);
                     ThemeLayout.Content = htmlContent;
@@ -39,8 +39,7 @@ namespace OrchardCore.DisplayManagement.Theming
                 {
                     foreach (var zone in layout.Properties.ToArray())
                     {
-                        if((zone.Value is Shape shape) &&
-                        !string.Equals(zone.Key,"Content", StringComparison.OrdinalIgnoreCase))
+                        if(zone.Value is IShape shape)
                         {
                             // Render each layout zone
                             var htmlZone = await DisplayAsync(shape);

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Html;
+using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.DisplayManagement.Theming
 {
@@ -24,8 +28,38 @@ namespace OrchardCore.DisplayManagement.Theming
                 // Then is added to the Content zone of the Layout shape
                 ThemeLayout.Content.Add(body);
 
-                // Finally we render the Shape's HTML to the page's output
-                Write(await DisplayAsync(ThemeLayout));
+                //Render Shapes in Content 
+                var htmlContent = await DisplayAsync(ThemeLayout.Content);
+
+                var content = ((Shape)ThemeLayout.Content);
+
+                foreach (var item in content.Items.ToArray())
+                {
+                    content.Remove(((IShape)item).Metadata.Name);
+                }
+
+                content.Add(htmlContent);
+
+                var zoneKeys = ((Zones.ZoneHolding)ThemeLayout).Properties.Keys.ToArray();
+                if(zoneKeys != null && zoneKeys.Count() > 0)
+                {
+                    foreach (var key in zoneKeys)
+                    {
+                        //Render each layout zone
+                        var zone = ThemeLayout[key];
+                        var htmlZone= DisplayAsync(zone);
+
+                        foreach (var item in zone.Items.ToArray())
+                        {
+                            zone.Remove(((IShape)item).Metadata.Name);
+                        }
+
+                        zone.Add(htmlZone);
+                    }
+                }                
+                // Finally we render the Layout Shape's HTML to the page's output
+                var layout = await DisplayAsync(ThemeLayout);                
+                Write(layout);
             }
             else
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
-using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.DisplayManagement.Zones;
 
 namespace OrchardCore.DisplayManagement.Theming
@@ -29,7 +27,7 @@ namespace OrchardCore.DisplayManagement.Theming
                 ThemeLayout.Content.Add(body);
 
                 // Render Shapes in Content
-                if(ThemeLayout.Content is IShape content)
+                if (ThemeLayout.Content is IShape content)
                 {
                     var htmlContent = await DisplayAsync(content);
                     ThemeLayout.Content = htmlContent;
@@ -39,7 +37,7 @@ namespace OrchardCore.DisplayManagement.Theming
                 {
                     foreach (var zone in layout.Properties.ToArray())
                     {
-                        if(zone.Value is IShape shape)
+                        if (zone.Value is IShape shape)
                         {
                             // Render each layout zone
                             var htmlZone = await DisplayAsync(shape);


### PR DESCRIPTION
Fixes #3947, #1994, #993

Rendering zones before Layout allow zones to register resources to ResourceManager. 