### PR TITLE
Remove unnecessary code from LuceneSettings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Model/LuceneSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Model/LuceneSettings.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Lucene.Net.Util;
 using OrchardCore.Contents.Indexing;
 
@@ -15,10 +14,5 @@ namespace OrchardCore.Lucene.Model
         public string SearchIndex { get; set; }
 
         public string[] DefaultSearchFields { get; set; } = FullTextField;
-
-        /// <summary>
-        /// Gets the list of indices and their settings.
-        /// </summary>
-        public Dictionary<string, LuceneIndexSettings> IndexSettings { get; } = new Dictionary<string, LuceneIndexSettings>();
     }
 }


### PR DESCRIPTION
LuceneSettings are global settings and are an extension of the SiteSettings properties. But the LuceneIndexSettings are saved in a single row in the document table separatly.