### PR TITLE
Import recipe

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/ImportController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/ImportController.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Logging;
 using OrchardCore.Admin;
 using OrchardCore.Deployment.Services;
 using OrchardCore.DisplayManagement.Notify;
@@ -19,14 +18,12 @@ namespace OrchardCore.Deployment.Controllers
         private readonly IDeploymentManager _deploymentManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly INotifier _notifier;
-        private ILogger<ImportController> _logger;
 
         public ImportController(
             IDeploymentManager deploymentManager,
             IAuthorizationService authorizationService,
             INotifier notifier,
-            IHtmlLocalizer<ImportController> h,
-            ILogger<ImportController> logger
+            IHtmlLocalizer<ImportController> h
         )
         {
             _deploymentManager = deploymentManager;
@@ -34,7 +31,6 @@ namespace OrchardCore.Deployment.Controllers
             _notifier = notifier;
 
             H = h;
-            _logger = logger;
         }
         public IHtmlLocalizer H { get; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Import/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Import/Index.cshtml
@@ -4,7 +4,7 @@
     <nav class="admin-toolbar">
         <ul class="navbar-nav">
             <li class="nav-item">
-                <input type="file" name="importedPackage"/>
+                <input type="file" name="importedPackage"  accept=".zip,.json" />
                 <button class="btn btn-primary" type="submit">@T["Import"]</button>
             </li>
         </ul>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Import/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Import/Index.cshtml
@@ -4,7 +4,7 @@
     <nav class="admin-toolbar">
         <ul class="navbar-nav">
             <li class="nav-item">
-                <input type="file" name="importedPackage"  accept=".zip,.json" />
+                <input type="file" name="importedPackage" accept=".zip,.json" />
                 <button class="btn btn-primary" type="submit">@T["Import"]</button>
             </li>
         </ul>


### PR DESCRIPTION
Allow to import a .json file from the 'Package import' admin page, instead of only accepting allowing a .zip file with a recipe inside.

Fixes #5346