### PR TITLE
Better query for ordering list items

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Controllers/OrderController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Controllers/OrderController.cs
@@ -63,7 +63,7 @@ namespace OrchardCore.Lists.Controllers
             {
                 if (!await _authorizationService.AuthorizeAsync(User, Permissions.PublishContent, pagedContentItem))
                 {
-                    return Unauthorized();
+                    return Forbid();
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Controllers/OrderController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Controllers/OrderController.cs
@@ -1,8 +1,10 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Admin;
 using OrchardCore.ContentManagement;
+using OrchardCore.Contents;
 using OrchardCore.Lists.Models;
 using OrchardCore.Lists.Services;
 using OrchardCore.Navigation;
@@ -13,10 +15,12 @@ namespace OrchardCore.Lists.Controllers
     public class OrderController : Controller
     {
         private readonly IContainerService _containerService;
+        private readonly IAuthorizationService _authorizationService;
 
-        public OrderController(IContainerService listPartQueryService)
+        public OrderController(IContainerService containerService, IAuthorizationService authorizationService)
         {
-            _containerService = listPartQueryService;
+            _containerService = containerService;
+            _authorizationService = authorizationService;
         }
 
         [HttpPost]
@@ -55,9 +59,18 @@ namespace OrchardCore.Lists.Controllers
                 return NotFound();
             }
 
+            foreach (var pagedContentItem in pageOfContentItems)
+            {
+                if (!await _authorizationService.AuthorizeAsync(User, Permissions.PublishContent, pagedContentItem))
+                {
+                    return Unauthorized();
+                }
+            }
+
             var currentOrderOfFirstItem = pageOfContentItems.FirstOrDefault().As<ContainedPart>().Order;
 
             var contentItem = pageOfContentItems[oldIndex];
+
             pageOfContentItems.Remove(contentItem);
             pageOfContentItems.Insert(newIndex, contentItem);
 

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Services/ContainerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Services/ContainerService.cs
@@ -9,6 +9,7 @@ using OrchardCore.Lists.Indexes;
 using OrchardCore.Lists.Models;
 using OrchardCore.Navigation;
 using YesSql;
+using YesSql.Services;
 
 namespace OrchardCore.Lists.Services
 {
@@ -64,29 +65,84 @@ namespace OrchardCore.Lists.Services
                     containedPart.Order = orderOfFirstItem + i;
                     containedPart.Apply();
 
-                    await _contentManager.UpdateAsync(contentItem);
-
                     // Keep the published and draft orders the same to avoid confusion in the admin list.
                     if (!contentItem.IsPublished())
                     {
                         var publishedItem = await _contentManager.GetAsync(contentItem.ContentItemId, VersionOptions.Published);
-                        publishedItem.Alter<ContainedPart>(x => x.Order = orderOfFirstItem + i);
-
-                        await _contentManager.UpdateAsync(publishedItem);
+                        if (publishedItem != null)
+                        {
+                            publishedItem.Alter<ContainedPart>(x => x.Order = orderOfFirstItem + i);
+                            await _contentManager.UpdateAsync(publishedItem);
+                        }
                     }
+
+                    await _contentManager.UpdateAsync(contentItem);
                 }
+
                 i++;
             }
         }
 
-        public async Task<IEnumerable<ContentItem>> GetContainedItemsAsync(string contentItemId)
+        public async Task SetInitialOrder(IEnumerable<string> containerContentItemIds)
         {
             var query = _session.Query<ContentItem>()
-                .With<ContainedPartIndex>(x => x.ListContentItemId == contentItemId)
-                .With<ContentItemIndex>(CreateDefaultContentIndexFilter(null, null, false))
+                .With<ContainedPartIndex>(x => x.ListContentItemId.IsIn(containerContentItemIds))
+                .With<ContentItemIndex>(ci => ci.Latest == true || ci.Published == true)
                 .OrderByDescending(x => x.CreatedUtc);
 
-            return await query.ListAsync();
+            var contentItemGroups = (await query.ListAsync()).ToLookup(l => l.As<ContainedPart>()?.ListContentItemId);
+             
+            foreach (var contentItemGroup in contentItemGroups)
+            {
+                var i = 0;
+                foreach (var contentItem in contentItemGroup)
+                {
+                    var containedPart = contentItem.As<ContainedPart>();
+                    if (containedPart != null)
+                    {
+                        if (contentItem.Published && contentItem.Latest)
+                        {
+                            containedPart.Order = i;
+                            containedPart.Apply();
+                        }
+                        else if (contentItem.Latest && !contentItem.Published)
+                        {
+                            // Update the latest order.
+                            containedPart.Order = i;
+                            containedPart.Apply();
+
+                            // If a published version exists, find it, and set it to the same order as the draft.
+                            var publishedItem = contentItemGroup.FirstOrDefault(p => p.Published == true && p.ContentItemId == contentItem.ContentItemId);
+                            var publishedContainedPart = publishedItem?.As<ContainedPart>();
+                            if (publishedContainedPart != null)
+                            {
+                                publishedContainedPart.Order = i;
+                                publishedContainedPart.Apply();
+                            }
+                        }
+                        else if (contentItem.Published && !contentItem.Latest)
+                        {
+                            // If a latest version exists, it will handle updating the order.
+                            var latestItem = contentItemGroup.FirstOrDefault(l => l.Latest == true && l.ContentItemId == contentItem.ContentItemId);
+                            if (latestItem == null)
+                            {
+                                // Apply order to the published item.
+                                containedPart.Order = i;
+                                containedPart.Apply();
+                            }
+                            else
+                            {
+                                // Order of this item will be updated when latest is iterated.
+                                continue;
+                            }
+                        }
+
+                        _session.Save(contentItem);
+                    }
+
+                    i++;
+                }
+            }
         }
 
         public async Task<IEnumerable<ContentItem>> QueryContainedItemsAsync(string contentItemId, bool enableOrdering, PagerSlim pager, bool publishedOnly)

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Services/IContainerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Services/IContainerService.cs
@@ -16,12 +16,7 @@ namespace OrchardCore.Lists.Services
         /// Update the orders of the content items.
         /// </summary>
         Task UpdateContentItemOrdersAsync(IEnumerable<ContentItem> contentItems, int orderOfFirstItem);
-
-        /// <summary>
-        /// Get the container content items for the specified content type.
-        /// </summary>
-        Task<IEnumerable<ContentItem>> GetContainerItemsAsync(string contentType);
-
+        
         /// <summary>
         /// Get the next order number.
         /// New or cloned content items are added to the bottom of the list.
@@ -31,6 +26,6 @@ namespace OrchardCore.Lists.Services
         /// <summary>
         /// Update order of the content items when ordering is enabled.
         /// </summary>
-        Task SetInitialOrder(IEnumerable<string> containerContentItemIds);
+        Task SetInitialOrder(string containerContentType);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Services/IContainerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Services/IContainerService.cs
@@ -7,10 +7,30 @@ namespace OrchardCore.Lists.Services
 {
     public interface IContainerService
     {
+        /// <summary>
+        /// Query contained items by page either order by the created utc or order value.
+        /// </summary>
         Task<IEnumerable<ContentItem>> QueryContainedItemsAsync(string contentItemId, bool enableOrdering, PagerSlim pager, bool publishedOnly);
+
+        /// <summary>
+        /// Update the orders of the content items.
+        /// </summary>
         Task UpdateContentItemOrdersAsync(IEnumerable<ContentItem> contentItems, int orderOfFirstItem);
-        Task<IEnumerable<ContentItem>> GetContainedItemsAsync(string contentItemId);
+
+        /// <summary>
+        /// Get the container content items for the specified content type.
+        /// </summary>
         Task<IEnumerable<ContentItem>> GetContainerItemsAsync(string contentType);
+
+        /// <summary>
+        /// Get the next order number.
+        /// New or cloned content items are added to the bottom of the list.
+        /// </summary>
         Task<int> GetNextOrderNumberAsync(string contentItemId);
+
+        /// <summary>
+        /// Update order of the content items when ordering is enabled.
+        /// </summary>
+        Task SetInitialOrder(IEnumerable<string> containerContentItemIds);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Settings/ListPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Settings/ListPartSettingsDisplayDriver.cs
@@ -80,11 +80,7 @@ namespace OrchardCore.Lists.Settings
                 // Update order of existing content if enable ordering has been turned on
                 if (settings.EnableOrdering != model.EnableOrdering && model.EnableOrdering == true)
                 {
-                    var containerItems = await _containerService.GetContainerItemsAsync(contentTypePartDefinition.ContentTypeDefinition.Name);
-                    if (containerItems.Any())
-                    {
-                        await _containerService.SetInitialOrder(containerItems.Select(items => items.ContentItemId));
-                    }
+                    await _containerService.SetInitialOrder(contentTypePartDefinition.ContentTypeDefinition.Name);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Settings/ListPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Settings/ListPartSettingsDisplayDriver.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement.Metadata;
@@ -72,7 +73,7 @@ namespace OrchardCore.Lists.Settings
                 context.Builder.WithSettings(new ListPartSettings
                 {
                     PageSize = model.PageSize,
-		            EnableOrdering = model.EnableOrdering,
+                    EnableOrdering = model.EnableOrdering,
                     ContainedContentTypes = model.ContainedContentTypes
                 });
 
@@ -80,10 +81,9 @@ namespace OrchardCore.Lists.Settings
                 if (settings.EnableOrdering != model.EnableOrdering && model.EnableOrdering == true)
                 {
                     var containerItems = await _containerService.GetContainerItemsAsync(contentTypePartDefinition.ContentTypeDefinition.Name);
-                    foreach (var containerItem in containerItems)
+                    if (containerItems.Any())
                     {
-                        var containedItems = await _containerService.GetContainedItemsAsync(containerItem.ContentItemId);
-                        await _containerService.UpdateContentItemOrdersAsync(containedItems, 0);
+                        await _containerService.SetInitialOrder(containerItems.Select(items => items.ContentItemId));
                     }
                 }
             }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
@@ -3,6 +3,8 @@ using Fluid;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OrchardCore.Admin;
 using OrchardCore.AdminMenu.Services;
 using OrchardCore.ContentLocalization.Handlers;
 using OrchardCore.ContentManagement;
@@ -33,9 +35,16 @@ namespace OrchardCore.Lists
 {
     public class Startup : StartupBase
     {
+        private readonly AdminOptions _adminOptions;
+
         static Startup()
         {
             TemplateContext.GlobalMemberAccessStrategy.Register<ListPartViewModel>();
+        }
+
+        public Startup(IOptions<AdminOptions> adminOptions)
+        {
+            _adminOptions = adminOptions.Value;
         }
 
         public override void ConfigureServices(IServiceCollection services)
@@ -68,7 +77,14 @@ namespace OrchardCore.Lists
                 name: "ListFeed",
                 areaName: "OrchardCore.Feeds",
                 pattern: "Contents/Lists/{contentItemId}/rss",
-                defaults: new { controller = "Feed", action = "Index", format = "rss"}
+                defaults: new { controller = "Feed", action = "Index", format = "rss" }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: "ListOrder",
+                areaName: "OrchardCore.Lists",
+                pattern: _adminOptions.AdminUrlPrefix + "/Lists/Order/{containerId?}",
+                defaults: new { controller = "Order", action = "UpdateContentItemOrders" }
             );
         }
     }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5428

@jtkech thanks for your advise on this.

I've adapted the query for the initial ordering of items to be much more efficient and retrieve all items that it needs to order, inc published, and non published, in one query.

The null ref is also exactly where you suggested, and I've moved that as per suggestion.

One question, as I didn't totally understand the potential issues around flushing.

The calls to `_contentManager.Get()` are in a loop for the published version if multiple items are drafts.

If that query is called a couple of times in the loop, is there this same issue around flushing?

I'm asking because I wasn't able to repro the original issue