### PR TITLE
Disable feature confirmation messages

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -71,7 +71,7 @@ namespace OrchardCore.Features.Controllers
                     IsAlwaysEnabled = alwaysEnabledFeatures.Contains(moduleFeatureInfo),
                     //IsRecentlyInstalled = _moduleService.IsRecentlyInstalled(f.Extension),
                     //NeedsUpdate = featuresThatNeedUpdate.Contains(f.Id),
-                    DependentFeatures = dependentFeatures.Where(x => x.Id != moduleFeatureInfo.Id).ToList(),
+                    EnabledDependentFeatures = dependentFeatures.Where(x => x.Id != moduleFeatureInfo.Id && enabledFeatures.Contains(x)).ToList(),
                     FeatureDependencies = featureDependencies.Where(d => d.Id != moduleFeatureInfo.Id).ToList()
                 };
 

--- a/src/OrchardCore.Modules/OrchardCore.Features/Models/ModuleFeature.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Models/ModuleFeature.cs
@@ -39,9 +39,9 @@ namespace OrchardCore.Features.Models
         public bool IsRecentlyInstalled { get; set; }
 
         /// <summary>
-        /// List of features that depend on this feature.
+        /// List of enabled features that depend on this feature.
         /// </summary>
-        public IEnumerable<IFeatureInfo> DependentFeatures { get; set; }
+        public IEnumerable<IFeatureInfo> EnabledDependentFeatures { get; set; }
 
         /// <summary>
         /// List of features that this feature depends on.

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -130,11 +130,11 @@
                                         }
                                         @if (showDisable && feature.IsEnabled)
                                         {
-                                            var confirmationMessage = T["Are you sure you want to disable this feature? Continue?"];
-                                            if (feature.DependentFeatures.Any())
+                                            var confirmationMessage = T["Are you sure you want to disable the {0} feature? Continue?", feature.Descriptor.Name];
+                                            if (feature.EnabledDependentFeatures.Any())
                                             {
-                                                var dependentFeatures = new HtmlString($"<ul>{String.Join("", feature.DependentFeatures.Select(f => $"<li>{f.Name}</li>"))}</ul>");
-                                                confirmationMessage = T["Disabling this feature will also disable the following dependent features:{0}Continue?", dependentFeatures];
+                                                var enabledDependentFeatures = new HtmlString($"<ul>{String.Join("", feature.EnabledDependentFeatures.Select(f => $"<li>{f.Name}</li>"))}</ul>");
+                                                confirmationMessage = T["Disabling the {0} feature will also disable the following dependent features:{1}Continue?", feature.Descriptor.Name, enabledDependentFeatures];
                                             }
                                             <a asp-action="Disable" asp-route-id="@feature.Descriptor.Id" class="btn btn-danger btn-sm" data-title="@T["Disable Feature"]" data-message="@confirmationMessage" data-ok-text="@T["Yes"]" data-cancel-text="@T["No"]" itemprop="UnsafeUrl RemoveUrl">@T["Disable"]</a>
                                         }


### PR DESCRIPTION
Fixes #5508 

1. Changed confirmation message to only show dependent features if they are enabled.
2. Added the name of the feature being disabled to the confirmation message.