### PR TITLE
Fixes changing tenant prefix

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/AdminController.cs
@@ -27,6 +27,7 @@ namespace OrchardCore.Tenants.Controllers
     public class AdminController : Controller
     {
         private readonly IShellHost _shellHost;
+        private readonly IRunningShellTable _runningShellTable;
         private readonly IShellSettingsManager _shellSettingsManager;
         private readonly IEnumerable<DatabaseProvider> _databaseProviders;
         private readonly IAuthorizationService _authorizationService;
@@ -41,27 +42,29 @@ namespace OrchardCore.Tenants.Controllers
 
         public AdminController(
             IShellHost shellHost,
-            ShellSettings currentShellSettings,
-            IAuthorizationService authorizationService,
+            IRunningShellTable runningShellTable,
             IShellSettingsManager shellSettingsManager,
             IEnumerable<DatabaseProvider> databaseProviders,
+            IAuthorizationService authorizationService,
+            ShellSettings currentShellSettings,
+            IEnumerable<IRecipeHarvester> recipeHarvesters,
             IDataProtectionProvider dataProtectorProvider,
             IClock clock,
             INotifier notifier,
-            IEnumerable<IRecipeHarvester> recipeHarvesters,
             ISiteService siteService,
             IShapeFactory shapeFactory,
             IStringLocalizer<AdminController> stringLocalizer,
             IHtmlLocalizer<AdminController> htmlLocalizer)
         {
-            _dataProtectorProvider = dataProtectorProvider;
-            _clock = clock;
-            _recipeHarvesters = recipeHarvesters;
             _shellHost = shellHost;
+            _runningShellTable = runningShellTable;
             _authorizationService = authorizationService;
             _shellSettingsManager = shellSettingsManager;
             _databaseProviders = databaseProviders;
             _currentShellSettings = currentShellSettings;
+            _dataProtectorProvider = dataProtectorProvider;
+            _recipeHarvesters = recipeHarvesters;
+            _clock = clock;
             _notifier = notifier;
             _siteService = siteService;
 
@@ -404,6 +407,11 @@ namespace OrchardCore.Tenants.Controllers
 
             if (ModelState.IsValid)
             {
+                if (!String.Equals(shellSettings.RequestUrlPrefix, model.RequestUrlPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    _runningShellTable.Remove(shellSettings);
+                }
+
                 shellSettings.RequestUrlPrefix = model.RequestUrlPrefix;
                 shellSettings.RequestUrlHost = model.RequestUrlHost;
 


### PR DESCRIPTION
Fixes #5491 

So here, to not complicate things we don't check if a new tenant prefix is in conflict with an exixting content item slug. Otherwise, each time we save an item we would also need to check the opposite. So, we just have to know that the tenant prefix takes precedence which makes sense, and that we can still change the item url or the tenant prefix to solve the conflict.

The main issue was that, when changing a tenant prefix, the old prefix was still working, and if you change it n times, the n previous ones were still reacheable until you restart the application.

So here, if we change a tenant prefix, the previous one is removed from the running shell table.
