### PR TITLE
Fixes RunningShellTable Remove.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/AdminController.cs
@@ -27,7 +27,6 @@ namespace OrchardCore.Tenants.Controllers
     public class AdminController : Controller
     {
         private readonly IShellHost _shellHost;
-        private readonly IRunningShellTable _runningShellTable;
         private readonly IShellSettingsManager _shellSettingsManager;
         private readonly IEnumerable<DatabaseProvider> _databaseProviders;
         private readonly IAuthorizationService _authorizationService;
@@ -42,7 +41,6 @@ namespace OrchardCore.Tenants.Controllers
 
         public AdminController(
             IShellHost shellHost,
-            IRunningShellTable runningShellTable,
             IShellSettingsManager shellSettingsManager,
             IEnumerable<DatabaseProvider> databaseProviders,
             IAuthorizationService authorizationService,
@@ -57,7 +55,6 @@ namespace OrchardCore.Tenants.Controllers
             IHtmlLocalizer<AdminController> htmlLocalizer)
         {
             _shellHost = shellHost;
-            _runningShellTable = runningShellTable;
             _authorizationService = authorizationService;
             _shellSettingsManager = shellSettingsManager;
             _databaseProviders = databaseProviders;
@@ -407,11 +404,6 @@ namespace OrchardCore.Tenants.Controllers
 
             if (ModelState.IsValid)
             {
-                if (!String.Equals(shellSettings.RequestUrlPrefix, model.RequestUrlPrefix, StringComparison.OrdinalIgnoreCase))
-                {
-                    _runningShellTable.Remove(shellSettings);
-                }
-
                 shellSettings.RequestUrlPrefix = model.RequestUrlPrefix;
                 shellSettings.RequestUrlHost = model.RequestUrlHost;
 

--- a/src/OrchardCore/OrchardCore/Environment/Shell/RunningShellTable.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/RunningShellTable.cs
@@ -17,8 +17,6 @@ namespace OrchardCore.Environment.Shell
 
         public void Add(ShellSettings settings)
         {
-            Remove(settings);
-
             if (ShellHelper.DefaultShellName == settings.Name)
             {
                 _default = settings;
@@ -47,12 +45,9 @@ namespace OrchardCore.Environment.Shell
                 .Select(kv => kv.Key)
                 .ToArray();
 
-            if (allHostsAndPrefix.Length > 0)
+            lock (this)
             {
-                lock (this)
-                {
-                    _shellsByHostAndPrefix = _shellsByHostAndPrefix.RemoveRange(allHostsAndPrefix);
-                }
+                _shellsByHostAndPrefix = _shellsByHostAndPrefix.RemoveRange(allHostsAndPrefix);
             }
 
             if (_default == settings)

--- a/src/OrchardCore/OrchardCore/Environment/Shell/RunningShellTable.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/RunningShellTable.cs
@@ -17,6 +17,8 @@ namespace OrchardCore.Environment.Shell
 
         public void Add(ShellSettings settings)
         {
+            Remove(settings);
+
             if (ShellHelper.DefaultShellName == settings.Name)
             {
                 _default = settings;
@@ -40,11 +42,17 @@ namespace OrchardCore.Environment.Shell
 
         public void Remove(ShellSettings settings)
         {
-            var allHostsAndPrefix = GetAllHostsAndPrefix(settings);
+            var allHostsAndPrefix = _shellsByHostAndPrefix
+                .Where(kv => kv.Value.Name == settings.Name)
+                .Select(kv => kv.Key)
+                .ToArray();
 
-            lock (this)
+            if (allHostsAndPrefix.Length > 0)
             {
-                _shellsByHostAndPrefix = _shellsByHostAndPrefix.RemoveRange(allHostsAndPrefix);
+                lock (this)
+                {
+                    _shellsByHostAndPrefix = _shellsByHostAndPrefix.RemoveRange(allHostsAndPrefix);
+                }
             }
 
             if (_default == settings)


### PR DESCRIPTION
- Really remove all entries related to a given tenant even if its prefix and / or hosts have changed.

    Doing so we don't have to do it explicitly e.g in the `OC.Tenants` admin controller.

- Also calls `Remove()` at the beginning of `Add()`. Maybe not necessary if, before calling `Add()` for an existing tenant, it is intended that we already have called `Remove()`, which is the case.

**Update**: Finally i did some simplification, e.g i reverted the calling of `Remove()` inside `Add()` as we are intended to do it explicitly. There are other use cases e.g if 2 tenants have the same prefix but for the same reason i don't check it as before, at least it is filtered by the admin controller.