### PR TITLE
Proposal of new extension method ContentElement.OfType

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement.Metadata.Builders;
 
@@ -232,6 +233,24 @@ namespace OrchardCore.ContentManagement
         public static bool HasDraft(this IContent content)
         {
             return content.ContentItem != null && (!content.ContentItem.Published || !content.ContentItem.Latest);
+        }
+
+        /// <summary>
+        /// Gets all content elements of a specific type.
+        /// </summary>
+        /// <typeparam name="TElement">The expected type of the content elements.</typeparam>
+        /// <returns>The content element instances or empty sequence if no entries exist.</returns>
+        public static IEnumerable<TElement> OfType<TElement>(this ContentElement contentElement) where TElement : ContentElement
+        {
+            foreach (var part in contentElement.Elements)
+            {
+                var result = part.Value as TElement;
+
+                if (result != null)
+                {
+                    yield return result;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Proposal of a new extension method to make it easier to work with named parts.

Today we have code like the following:

```csharp
        public IEnumerable<TPart> PartsOfType<TPart>(ContentItem contentItem) where TPart : ContentPart
        {
            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);

            foreach (var contentTypePartDefinition in contentTypeDefinition.Parts)
            {
                var partName = contentTypePartDefinition.Name;
                var partTypeName = contentTypePartDefinition.PartDefinition.Name;
                var partActivator = _contentPartFactory.GetTypeActivator(partTypeName);
                var part = contentItem.Get(partActivator.Type, partName) as TPart;

                if (part != null)
                {
                    yield return part;
                }
            }
        }
```

It's called like the following:
```csharp
foreach (var pricePart in PartsOfType<PricePart>(contentItem))
{
    // Other logic
}
```

It would then be possible to call like the following without the local support function:
```csharp
foreach (var pricePart in contentItem.OfType<PricePart>())
{
    // Other logic
}
```