### PR TITLE
Make ContentPicker default to displaying all content types when none are selected

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/ContentPickerAdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/ContentPickerAdminController.cs
@@ -52,6 +52,7 @@ namespace OrchardCore.ContentFields.Controllers
             var results = await resultProvider.Search(new ContentPickerSearchContext
             {
                 Query = query,
+                DisplayAllContentTypes = fieldSettings.DisplayAllContentTypes,
                 ContentTypes = fieldSettings.DisplayedContentTypes,
                 PartFieldDefinition = partFieldDefinition
             });

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.ContentFields.Services
         public async Task<IEnumerable<ContentPickerResult>> Search(ContentPickerSearchContext searchContext)
         {
             var contentTypes = searchContext.ContentTypes;
-            if (searchContext.DisplayAllContentTypes == true)
+            if (searchContext.DisplayAllContentTypes)
             {
                 contentTypes = _contentDefinitionManager
                     .ListTypeDefinitions()

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
@@ -28,11 +28,11 @@ namespace OrchardCore.ContentFields.Services
         public async Task<IEnumerable<ContentPickerResult>> Search(ContentPickerSearchContext searchContext)
         {
             var contentTypes = searchContext.ContentTypes;
-            if (contentTypes.Count() == 0)
+            if (searchContext.DisplayAllContentTypes == true)
             {
                 contentTypes = _contentDefinitionManager
                     .ListTypeDefinitions()
-                    .Where(ctd => string.IsNullOrEmpty(ctd.GetSettings<ContentTypeSettings>().Stereotype))
+                    .Where(x => string.IsNullOrEmpty(x.GetSettings<ContentTypeSettings>().Stereotype))
                     .Select(x => x.Name)
                     .AsEnumerable();
             }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Records;
 using YesSql;
 using YesSql.Services;
@@ -11,11 +12,13 @@ namespace OrchardCore.ContentFields.Services
     public class DefaultContentPickerResultProvider : IContentPickerResultProvider
     {
         private readonly IContentManager _contentManager;
+        private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ISession _session;
 
-        public DefaultContentPickerResultProvider(IContentManager contentManager, ISession session)
+        public DefaultContentPickerResultProvider(IContentManager contentManager, IContentDefinitionManager contentDefinitionManager, ISession session)
         {
             _contentManager = contentManager;
+            _contentDefinitionManager = contentDefinitionManager;
             _session = session;
         }
 
@@ -23,8 +26,17 @@ namespace OrchardCore.ContentFields.Services
 
         public async Task<IEnumerable<ContentPickerResult>> Search(ContentPickerSearchContext searchContext)
         {
+            var contentTypes = searchContext.ContentTypes;
+            if (contentTypes.Count() == 0)
+            {
+                contentTypes = _contentDefinitionManager
+                    .ListTypeDefinitions()
+                    .Select(x => x.Name)
+                    .AsEnumerable();
+            }
+
             var query = _session.Query<ContentItem, ContentItemIndex>()
-                .With<ContentItemIndex>(x => x.ContentType.IsIn(searchContext.ContentTypes) && x.Latest);
+                .With<ContentItemIndex>(x => x.ContentType.IsIn(contentTypes) && x.Latest);
 
             if (!string.IsNullOrEmpty(searchContext.Query))
             {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Services/DefaultContentPickerResultProvider.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Records;
 using YesSql;
 using YesSql.Services;
@@ -31,6 +32,7 @@ namespace OrchardCore.ContentFields.Services
             {
                 contentTypes = _contentDefinitionManager
                     .ListTypeDefinitions()
+                    .Where(ctd => string.IsNullOrEmpty(ctd.GetSettings<ContentTypeSettings>().Stereotype))
                     .Select(x => x.Name)
                     .AsEnumerable();
             }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettings.cs
@@ -5,6 +5,7 @@ namespace OrchardCore.ContentFields.Settings
         public string Hint { get; set; }
         public bool Required { get; set; }
         public bool Multiple { get; set; }
+        public bool DisplayAllContentTypes { get; set; }
         public string[] DisplayedContentTypes { get; set; } = new string[0];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettingsDriver.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.ContentFields.Settings
 
             if (model.DisplayAllContentTypes)
             {
-                model.DisplayedContentTypes = new string[0];
+                model.DisplayedContentTypes = Array.Empty<String>();
             }
 
             context.Builder.WithSettings(model);

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettingsDriver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement.Metadata.Models;

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettingsDriver.cs
@@ -20,6 +20,11 @@ namespace OrchardCore.ContentFields.Settings
 
             await context.Updater.TryUpdateModelAsync(model, Prefix);
 
+            if (model.DisplayAllContentTypes)
+            {
+                model.DisplayedContentTypes = new string[0];
+            }
+
             context.Builder.WithSettings(model);
 
             return Edit(partFieldDefinition);

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerFieldSettings.Edit.cshtml
@@ -11,6 +11,9 @@
     });
 }
 
+
+<script asp-name="vuejs" at="Foot"></script>
+
 <div class="form-group">
     <div class="custom-control custom-checkbox">
         <input asp-for="Required" type="checkbox" class="custom-control-input">
@@ -27,10 +30,19 @@
     </div>
 </div>
 
-<div class="form-group">
+<div id="contentTypesVue" class="form-group">
     <label asp-for="DisplayedContentTypes">@T["Content Types"]</label>
     <span class="hint">@T["The content types to display. Choose at least one."]</span>
-    @await Component.InvokeAsync("SelectContentTypes", new { selectedContentTypes = Model.DisplayedContentTypes, htmlName = Html.NameFor(m => m.DisplayedContentTypes) })
+
+    <div class="custom-control custom-checkbox">
+        <input asp-for="DisplayAllContentTypes" type="checkbox" class="custom-control-input" v-model="displayAllContentTypes">
+        <label class="custom-control-label" asp-for="DisplayAllContentTypes">@T["Display All Content Types"]</label>
+        <span class="hint">— @T["Whether to allow picker to display all content types."]</span>
+    </div>
+
+    <div v-show="!displayAllContentTypes">
+        @await Component.InvokeAsync("SelectContentTypes", new { selectedContentTypes = Model.DisplayedContentTypes, htmlName = Html.NameFor(m => m.DisplayedContentTypes) })
+    </div>
 </div>
 
 <div class="form-group">
@@ -48,3 +60,12 @@
             <span class="hint">@T["The search result provider to use when selecting content items."]</span>
         </div>
     </div>*@
+
+<script at="Foot" depends-on="vuejs">
+    var app = new Vue({
+        el: "#contentTypesVue",
+        data: {
+            displayAllContentTypes: @Model.DisplayAllContentTypes.ToString().ToLower()
+        }
+    });
+</script>

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentPickerResultProvider.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentPickerResultProvider.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.ContentManagement
     public class ContentPickerSearchContext
     {
         public string Query { get; set; }
+        public bool DisplayAllContentTypes { get; set; }
         public IEnumerable<string> ContentTypes { get; set; }
         public ContentPartFieldDefinition PartFieldDefinition { get; set; }
     }


### PR DESCRIPTION
There is no reasonable use-case for a content picker to be configured with no DisplayedContentTypes other than it just hasn't been configured yet. On the other hand, it seems reasonable that some circumstances may necessitate picking a content item of an undeterminable ContentType at setup.
