### PR TITLE
Resolve asyncfilter scoped services lazily

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenuFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenuFilter.cs
@@ -16,8 +16,8 @@ namespace OrchardCore.Admin
     /// </summary>
     public class AdminMenuFilter : IAsyncResultFilter
     {
-        private IShapeFactory shapeFactory;
-        private ILayoutAccessor layoutAccessor;
+        private IShapeFactory _shapeFactory;
+        private ILayoutAccessor _layoutAccessor;
 
         public async Task OnResultExecutionAsync(ResultExecutingContext filterContext, ResultExecutionDelegate next)
         {
@@ -51,18 +51,18 @@ namespace OrchardCore.Admin
             }
 
             // Resolve services lazy if we got this far.
-            shapeFactory ??= filterContext.HttpContext.RequestServices.GetRequiredService<IShapeFactory>();
-            layoutAccessor ??= filterContext.HttpContext.RequestServices.GetRequiredService<ILayoutAccessor>();
+            _shapeFactory ??= filterContext.HttpContext.RequestServices.GetRequiredService<IShapeFactory>();
+            _layoutAccessor ??= filterContext.HttpContext.RequestServices.GetRequiredService<ILayoutAccessor>();
 
             // Populate main nav
-            var menuShape = await shapeFactory.CreateAsync("Navigation",
+            var menuShape = await _shapeFactory.CreateAsync("Navigation",
                 Arguments.From(new
                 {
                     MenuName = "admin",
                     RouteData = filterContext.RouteData,
                 }));
 
-            dynamic layout = await layoutAccessor.GetLayoutAsync();
+            dynamic layout = await _layoutAccessor.GetLayoutAsync();
 
             if (layout.Navigation is ZoneOnDemand zoneOnDemand)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Filters/FBInitFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Filters/FBInitFilter.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Admin;
 using OrchardCore.Entities;
 using OrchardCore.Facebook.Settings;
@@ -12,34 +13,33 @@ namespace OrchardCore.Facebook.Filters
 {
     public class FBInitFilter : IAsyncResultFilter
     {
-        private readonly IResourceManager _resourceManager;
-        private readonly ISiteService _siteService;
-
-        public FBInitFilter(
-            IResourceManager resourceManager,
-            ISiteService siteService)
-        {
-            _resourceManager = resourceManager;
-            _siteService = siteService;
-        }
-
+        private IResourceManager _resourceManager;
+        private ISiteService _siteService;
+        
         public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
         {
             // Should only run on the front-end for a full view
             if ((context.Result is ViewResult || context.Result is PageResult) &&
                 !AdminAttribute.IsApplied(context.HttpContext))
             {
+                // Resolve scoped services lazy if we got this far.
+                _siteService ??= context.HttpContext.RequestServices.GetRequiredService<ISiteService>();
+
                 var site = (await _siteService.GetSiteSettingsAsync());
                 var settings = site.As<FacebookSettings>();
                 if (!string.IsNullOrWhiteSpace(settings?.AppId))
                 {
                     if (settings.FBInit)
                     {
+                        // Resolve scoped services lazy if we got this far.
+                        _resourceManager ??= context.HttpContext.RequestServices.GetRequiredService<IResourceManager>();
+
                         var setting = _resourceManager.RegisterResource("script", "fb");
                         setting.AtLocation(ResourceLocation.Foot);
                     }
                 }
             }
+
             await next.Invoke();
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.Layers.Services
         private ILayerService _layerService;
         private ILayoutAccessor _layoutAccessor;
         private IContentItemDisplayManager _contentItemDisplayManager;
-        private IUpdateModel _updater;
+        private IUpdateModelAccessor _updateModelAccessor;
 
         public LayerFilter(
             IScriptingManager scriptingManager,
@@ -71,7 +71,7 @@ namespace OrchardCore.Layers.Services
                 _layerService ??= context.HttpContext.RequestServices.GetRequiredService<ILayerService>();
                 _layoutAccessor ??= context.HttpContext.RequestServices.GetRequiredService<ILayoutAccessor>();
                 _contentItemDisplayManager ??= context.HttpContext.RequestServices.GetRequiredService<IContentItemDisplayManager>();
-                _updater ??= context.HttpContext.RequestServices.GetRequiredService<IUpdateModelAccessor>().ModelUpdater;
+                _updateModelAccessor ??= context.HttpContext.RequestServices.GetRequiredService<IUpdateModelAccessor>();
 
                 var widgets = await _memoryCache.GetOrCreateAsync("OrchardCore.Layers.LayerFilter:AllWidgets", entry =>
                 {
@@ -86,6 +86,7 @@ namespace OrchardCore.Layers.Services
                 var engine = _scriptingManager.GetScriptingEngine("js");
                 var scope = engine.CreateScope(_scriptingManager.GlobalMethodProviders.SelectMany(x => x.GetMethods()), ShellScope.Services, null, null);
 
+                var updater = _updateModelAccessor.ModelUpdater;
                 var layersCache = new Dictionary<string, bool>();
 
                 foreach (var widget in widgets)
@@ -117,7 +118,7 @@ namespace OrchardCore.Layers.Services
                         continue;
                     }
 
-                    var widgetContent = await _contentItemDisplayManager.BuildDisplayAsync(widget.ContentItem, _updater);
+                    var widgetContent = await _contentItemDisplayManager.BuildDisplayAsync(widget.ContentItem, updater);
 
                     widgetContent.Classes.Add("widget");
                     widgetContent.Classes.Add("widget-" + widget.ContentItem.ContentType.HtmlClassify());

--- a/src/OrchardCore.Modules/OrchardCore.MiniProfiler/MiniProfilerFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.MiniProfiler/MiniProfilerFilter.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Admin;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Layout;
@@ -10,16 +11,8 @@ namespace OrchardCore.MiniProfiler
 {
     public class MiniProfilerFilter : IAsyncResultFilter
     {
-        private readonly ILayoutAccessor _layoutAccessor;
-        private readonly IShapeFactory _shapeFactory;
-
-        public MiniProfilerFilter(
-            ILayoutAccessor layoutAccessor,
-            IShapeFactory shapeFactory)
-        {
-            _layoutAccessor = layoutAccessor;
-            _shapeFactory = shapeFactory;
-        }
+        private ILayoutAccessor _layoutAccessor;
+        private IShapeFactory _shapeFactory;
 
         public async Task OnResultExecutionAsync(ResultExecutingContext context, ResultExecutionDelegate next)
         {
@@ -27,6 +20,10 @@ namespace OrchardCore.MiniProfiler
             if ((context.Result is ViewResult || context.Result is PageResult) &&
                 !AdminAttribute.IsApplied(context.HttpContext))
             {
+                // Resolve scoped services lazy if we got this far.
+                _layoutAccessor ??= context.HttpContext.RequestServices.GetRequiredService<ILayoutAccessor>();
+                _shapeFactory ??= context.HttpContext.RequestServices.GetRequiredService<IShapeFactory>();
+
                 dynamic layout = await _layoutAccessor.GetLayoutAsync();
                 var footerZone = layout.Zones["Footer"];
                 footerZone.Add(await _shapeFactory.CreateAsync("MiniProfiler"));


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5532

Probably the biggest win here is actually on the `AdminMenuFilter` which was resolving the `INavigationManager` for no reason at all on all requests, not just admin.

@jtkech just resolved through the filter context services, assume that is best?