### PR TITLE
Produce cleaner image resize query string

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.WebUtilities;
 using Fluid;
 using Fluid.Values;
-using Microsoft.AspNetCore.WebUtilities;
 using OrchardCore.Liquid;
 
 namespace OrchardCore.Media.Filters

--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
@@ -1,6 +1,8 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
+using Microsoft.AspNetCore.WebUtilities;
 using OrchardCore.Liquid;
 
 namespace OrchardCore.Media.Filters
@@ -48,10 +50,7 @@ namespace OrchardCore.Media.Filters
         {
             var url = input.ToStringValue();
 
-            if (!url.Contains('?'))
-            {
-                url += "?";
-            }
+            var queryStringParams = new Dictionary<string, string>();
 
             var width = arguments["width"].Or(arguments.At(0));
             var height = arguments["height"].Or(arguments.At(1));
@@ -59,20 +58,20 @@ namespace OrchardCore.Media.Filters
 
             if (!width.IsNil())
             {
-                url += "&width=" + width.ToStringValue();
+                queryStringParams.Add("width", width.ToStringValue());
             }
 
             if (!height.IsNil())
             {
-                url += "&height=" + height.ToStringValue();
+                queryStringParams.Add("height", height.ToStringValue());
             }
 
             if (!mode.IsNil())
             {
-                url += "&rmode=" + mode.ToStringValue();
+                queryStringParams.Add("rmode", mode.ToStringValue());
             }
 
-            return new ValueTask<FluidValue>(new StringValue(url));
+            return new ValueTask<FluidValue>(new StringValue(QueryHelpers.AddQueryString(url, queryStringParams)));
         }
     }
 }


### PR DESCRIPTION
While working on something else realised that the `resize` liquid filter is producing quite an ugly query string

`media/about/2.jpg?&width=160&height=160&rmode=stretch` with an ampersand directly after the `?`, which works, but is unnecessary, and ugly.

This just uses the Mvc `QueryHelper` to add it in a cleaner way so you get
`media/about/2.jpg?width=160&height=160&rmode=stretch`
