### PR TITLE
RetrieveContent workflow task added outcome and fixed parsing

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/ContentActivity.cs
@@ -96,6 +96,11 @@ namespace OrchardCore.Contents.Workflows.Activities
                 {
                     return contentItemId;
                 }
+                else if (contentItemIdResult is Newtonsoft.Json.Linq.JArray contentItemArray)
+                {
+                    if (contentItemArray.Count == 1)
+                        return contentItemArray.First.ToString();
+                }
             }
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Contents.Workflows.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Outcomes(S["Retrieved"]);
+            return Outcomes(S["Retrieved"], S["Not Found"]);
         }
 
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
@@ -29,7 +29,22 @@ namespace OrchardCore.Contents.Workflows.Activities
         public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
             var contentItemId = await GetContentItemIdAsync(workflowContext);
+
+            // Clean up return string if passed expression had a string add: variable + ""
+            contentItemId = contentItemId
+                .Replace("\r\n", string.Empty)
+                .Replace("\n", string.Empty)
+                .Replace("\r", string.Empty)
+                .Replace("\\", string.Empty)
+                .Replace("\"", string.Empty)
+                .Replace("[", string.Empty)
+                .Replace("]", string.Empty)
+                .Trim();
+
             var contentItem = await ContentManager.GetAsync(contentItemId, VersionOptions.Latest);
+            if (contentItem == null)
+                return Outcomes("Not Found");
+
             workflowContext.LastResult = contentItem;
 
             return Outcomes("Retrieved");

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Contents.Workflows.Activities
         {
             var contentItemId = await GetContentItemIdAsync(workflowContext);
 
-            // Clean up return string if passed expression had a string add: variable + ""
+            // Clean up return string if passed expression was malformed due to trying to add a string: variable + ""
             contentItemId = contentItemId
                 .Replace("\r\n", string.Empty)
                 .Replace("\n", string.Empty)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/RetrieveContentTask.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Contents.Workflows.Activities
         {
             var contentItemId = await GetContentItemIdAsync(workflowContext);
 
-            // Clean up return string if passed expression was malformed due to trying to add a string: variable + ""
+            // Clean up return string if parsed expression was malformed due to trying to add a string: variable + ""
             contentItemId = contentItemId
                 .Replace("\r\n", string.Empty)
                 .Replace("\n", string.Empty)


### PR DESCRIPTION
Thix PR fixes a couple of things:

1. The workflow task RetrieveContent was missing a "Not found" outcome instead of simply failing the workflow.
2. There were also problems when trying to parse a JObject property from requestFormAsJson(), where the JObject would return a JArray instead of a text string thus returning null.
3. In the RetrieveContent input if you for some reason need to append a text string such as `property("FormInput").ContentItemId + "GIG"`, it would return a malformed text string that had to be cleaned.