### PR TITLE
Validate content type names

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/ContentDefinitionService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/ContentDefinitionService.cs
@@ -115,6 +115,10 @@ namespace OrchardCore.ContentTypes.Services
                 {
                     throw new ArgumentException("Content type name must start with a letter", "name");
                 }
+                if (!String.Equals(name, name.ToSafeName(), StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ArgumentException("Content type name contains invalid characters", "name");
+                }
             }
 
             while (_contentDefinitionManager.LoadTypeDefinition(name) != null)

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentManagement.Utilities;
 
 namespace OrchardCore.ContentManagement.Metadata.Builders
 {
@@ -40,6 +41,15 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
 
         public ContentPartDefinition Build()
         {
+            if (!Name[0].IsLetter())
+            {
+                throw new ArgumentException("Content type name must start with a letter", "name");
+            }
+            if (!String.Equals(Name, Name.ToSafeName(), StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Content type name contains invalid characters", "name");
+            }
+
             return new ContentPartDefinition(Name, _fields, _settings);
         }
 
@@ -143,6 +153,15 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
 
             public override ContentPartFieldDefinition Build()
             {
+                if (!_fieldName[0].IsLetter())
+                {
+                    throw new ArgumentException("Content field name must start with a letter", "name");
+                }
+                if (!String.Equals(_fieldName, _fieldName.ToSafeName(), StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ArgumentException("Content field name contains invalid characters", "name");
+                }
+
                 return new ContentPartFieldDefinition(_fieldDefinition, _fieldName, _settings);
             }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentManagement.Utilities;
 
 namespace OrchardCore.ContentManagement.Metadata.Builders
 {
@@ -40,6 +41,14 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
 
         public ContentTypeDefinition Build()
         {
+            if (!_name[0].IsLetter())
+            {
+                throw new ArgumentException("Content type name must start with a letter", "name");
+            }
+            if (!String.Equals(_name, _name.ToSafeName(), StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ArgumentException("Content type name contains invalid characters", "name");
+            }
             return new ContentTypeDefinition(_name, _displayName, _parts, _settings);
         }
 
@@ -159,6 +168,15 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
 
             public override ContentTypePartDefinition Build()
             {
+                if (!Current.Name[0].IsLetter())
+                {
+                    throw new ArgumentException("Content part name must start with a letter", "name");
+                }
+                if (!String.Equals(Current.Name, Current.Name.ToSafeName(), StringComparison.OrdinalIgnoreCase))
+                {
+                    throw new ArgumentException("Content part name contains invalid characters", "name");
+                }
+
                 return new ContentTypePartDefinition(Current.Name, _partDefinition, _settings)
                 {
                     ContentTypeDefinition = Current.ContentTypeDefinition,


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/2322
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5251

Throws exceptions when part or field names don't pass the `.ToSafeName()` tests

Issue can only occur when importing from a recipe or via migration, so easiest just to throw the exception in the builders
