### PR TITLE
Remove INavigationManager from AdminMenuFilter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenuFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenuFilter.cs
@@ -6,7 +6,6 @@ using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Layout;
 using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.DisplayManagement.Zones;
-using OrchardCore.Navigation;
 
 namespace OrchardCore.Admin
 {
@@ -16,15 +15,12 @@ namespace OrchardCore.Admin
     /// </summary>
     public class AdminMenuFilter : IAsyncResultFilter
     {
-        private readonly INavigationManager _navigationManager;
         private readonly ILayoutAccessor _layoutAccessor;
         private readonly IShapeFactory _shapeFactory;
 
-        public AdminMenuFilter(INavigationManager navigationManager,
-            ILayoutAccessor layoutAccessor,
+        public AdminMenuFilter(ILayoutAccessor layoutAccessor,
             IShapeFactory shapeFactory)
         {
-            _navigationManager = navigationManager;
             _layoutAccessor = layoutAccessor;
             _shapeFactory = shapeFactory;
         }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5532

Replaces https://github.com/OrchardCMS/OrchardCore/pull/5600

Didn't feel like there was enough of a win to be worth creating a filter aggregator, so am just removing the unused `INavigationManager` dependency from the `AdminMenuFilter`, which in turns creates all the `INavigationProviders` unnecessarily on general front end requests