### PR TITLE
Maintain content item id across BagPart.ContentItems

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
@@ -68,7 +68,7 @@ namespace OrchardCore.Flows.Drivers
             for (var i = 0; i < model.Prefixes.Length; i++)
             {
                 var contentItem = await _contentManager.NewAsync(model.ContentTypes[i]);
-                var existing = part.ContentItems.FirstOrDefault(x => x.ContentItemId == model.Prefixes[i]);
+                var existing = part.ContentItems.FirstOrDefault(x => String.Equals(x.ContentItemId, model.Prefixes[i], StringComparison.OrdinalIgnoreCase));
                 if (existing != null)
                 {
                     contentItem.ContentItemId = model.Prefixes[i];

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplay.cs
@@ -62,15 +62,24 @@ namespace OrchardCore.Flows.Drivers
 
             await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-            part.ContentItems.Clear();
+            //part.ContentItems.Clear();
+            var contentItems = new List<ContentItem>();
 
             for (var i = 0; i < model.Prefixes.Length; i++)
             {
                 var contentItem = await _contentManager.NewAsync(model.ContentTypes[i]);
+                var existing = part.ContentItems.FirstOrDefault(x => x.ContentItemId == model.Prefixes[i]);
+                if (existing != null)
+                {
+                    contentItem.ContentItemId = model.Prefixes[i];
+                }
+
                 var widgetModel = await contentItemDisplayManager.UpdateEditorAsync(contentItem, context.Updater, context.IsNew, htmlFieldPrefix: model.Prefixes[i]);
 
-                part.ContentItems.Add(contentItem);
+                contentItems.Add(contentItem);
             }
+
+            part.ContentItems = contentItems;
 
             return Edit(part, context);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Models/BagPart.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Models/BagPart.cs
@@ -7,6 +7,6 @@ namespace OrchardCore.Flows.Models
     public class BagPart : ContentPart
     {
         [BindNever]
-        public List<ContentItem> ContentItems { get; } = new List<ContentItem>();
+        public List<ContentItem> ContentItems { get; set; } = new List<ContentItem>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Edit.cshtml
@@ -39,6 +39,7 @@
                 CanDelete: true,
                 //Input hidden
                 //Prefixes
+                PrefixValue: widget.ContentItemId,
                 HtmlFieldPrefix: htmlFieldPrefix,
                 PrefixesId: Html.IdFor(x => x.Prefixes),
                 PrefixesName: Html.NameFor(x => x.Prefixes),

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.cshtml
@@ -13,11 +13,13 @@
     if (Model.BuildEditor == true)
     {
         //Assign prefix
-        var prefix = Guid.NewGuid().ToString("n");
-        Model.PrefixValue = prefix;
+        if (String.IsNullOrEmpty(Model.PrefixValue))
+        {
+            Model.PrefixValue = Guid.NewGuid().ToString("n");
+        }
 
         //Build Editor for Content Item
-        dynamic contentItemEditor = await ContentItemDisplayManager.BuildEditorAsync(contentItem, updater, false, "", prefix);
+        dynamic contentItemEditor = await ContentItemDisplayManager.BuildEditorAsync(contentItem, updater, false, "", Model.PrefixValue);
 
         //We don't show Actions and Side bar the parent editor has its own buttons.
         contentItemEditor.Actions = null;


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5633

Only done for BagParts, not Flows or WidgetList.

Necessary for contained content item routing.

Plus not hard to achieve.

For me, it makes sense for the content item id to either remain consistent, or not be there.

So as it is useful to have it...