### PR TITLE
Placement documentation small fixes

### DIFF
--- a/src/docs/reference/core/Placement/README.md
+++ b/src/docs/reference/core/Placement/README.md
@@ -24,10 +24,8 @@ In the following example, we describe the placement for the `TextField` and `Par
 
 A placement rule contains two sets of data:
 
-- Filters
-  - Defines what specific shapes are targeted.
-- Placement information
-  - The placement information to apply when the filter is matched.
+- **Filters** - defines what specific shapes are targeted.
+- **Placement** information - the placement information to apply when the filter is matched.
 
 Currently you can filter shapes by:
 
@@ -73,8 +71,8 @@ Placement information consists of:
 
 Fields have a custom differentiator as their shape is used in many places.  
 It is built using the `Part` it's contained in, and the name of the field.  
-For instance, if a field named `MyField` would be added to an `Article` content type, its differentiator would be `Article.MyField`.  
-If a field named `City` was added to an `Address` part then its differentiator would be `Address.City`.
+For instance, if a field named `MyField` would be added to an `Article` content type, its differentiator would be `Article-MyField`.  
+If a field named `City` was added to an `Address` part then its differentiator would be `Address-City`.
 
 ## Shapes
 

--- a/src/docs/reference/core/Placement/README.md
+++ b/src/docs/reference/core/Placement/README.md
@@ -25,7 +25,7 @@ In the following example, we describe the placement for the `TextField` and `Par
 A placement rule contains two sets of data:
 
 - **Filters** - defines what specific shapes are targeted.
-- **Placement** information - the placement information to apply when the filter is matched.
+- **Placement information** - the placement information to apply when the filter is matched.
 
 Currently you can filter shapes by:
 


### PR DESCRIPTION
Fix incorrect field differentiator format needs - (dash) instead of . (dot)
Make the placement rules definition a little clearer.