### PR TITLE
Fixed string localiser reference.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CommitTransactionTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/CommitTransactionTask.cs
@@ -18,7 +18,6 @@ namespace OrchardCore.Workflows.Activities
             S = localizer;
         }
 
-        private IStringLocalizer T { get; }
         public override string Name => nameof(CommitTransactionTask);
 
         public override LocalizedString DisplayText => S["Commit Transaction Task"];

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEvent.cs
@@ -21,8 +21,6 @@ namespace OrchardCore.Workflows.Timers
             S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => EventName;
 
         public override LocalizedString DisplayText => S["Timer Event"];

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
@@ -16,7 +16,6 @@ namespace OrchardCore.Workflows.UserTasks.Activities
             S = localizer;
         }
 
-
         public override string Name => nameof(UserTaskEvent);
         public override LocalizedString DisplayText => S["User Task Event"];
         public override LocalizedString Category => S["Content"];

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
@@ -16,6 +16,7 @@ namespace OrchardCore.Workflows.UserTasks.Activities
             S = localizer;
         }
 
+
         public override string Name => nameof(UserTaskEvent);
         public override LocalizedString DisplayText => S["User Task Event"];
         public override LocalizedString Category => S["Content"];

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Activities/UserTaskEvent.cs
@@ -16,8 +16,6 @@ namespace OrchardCore.Workflows.UserTasks.Activities
             S = localizer;
         }
 
-        private IStringLocalizer T { get; }
-
         public override string Name => nameof(UserTaskEvent);
         public override LocalizedString DisplayText => S["User Task Event"];
         public override LocalizedString Category => S["Content"];
@@ -42,7 +40,7 @@ namespace OrchardCore.Workflows.UserTasks.Activities
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
-            return Actions.Select(x => Outcome(T[x]));
+            return Actions.Select(x => Outcome(S[x]));
         }
 
         public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)


### PR DESCRIPTION
Looks like the reference to the string localiser was never swapped for the UserTaskEvent.
There may be more of these, but this is a blocker on a project at the moment.
#5662 