### PR TITLE
Fix links for "content types" and "content items" glossary definitions

### DIFF
--- a/src/docs/topics/content-management/README.md
+++ b/src/docs/topics/content-management/README.md
@@ -1,6 +1,6 @@
 # Content Management
 
-Orchard Core allows you to define your [content types](../glossary/#Content-Type) and manage your [content items](../glossary/#Content-Item) dynamically.
+Orchard Core allows you to define your [content types](../../glossary/#Content-Type) and manage your [content items](../../glossary/#Content-Item) dynamically.
 
 ## How to Create Contents
 


### PR DESCRIPTION
Links are currently dev/docs/topics/glossary/#Content-Type and dev/docs/topics/glossary/#Content-Item but should not have the "topics" directory in them