### PR TITLE
GraphQL Settings

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/OrchardCore.ContentManagement.GraphQL.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/OrchardCore.ContentManagement.GraphQL.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Apis.GraphQL.Abstractions\OrchardCore.Apis.GraphQL.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.CustomSettings\OrchardCore.CustomSettings.csproj" />
+    <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Settings\OrchardCore.Settings.csproj" />
     <ProjectReference Include="..\OrchardCore.ContentManagement.Abstractions\OrchardCore.ContentManagement.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.ContentManagement.Display\OrchardCore.ContentManagement.Display.csproj" />
     <ProjectReference Include="..\OrchardCore.ContentManagement\OrchardCore.ContentManagement.csproj" />

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/SiteQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/SiteQuery.cs
@@ -1,0 +1,70 @@
+using System.Linq;
+using System.Threading.Tasks;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.ContentManagement.GraphQL.Options;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Settings;
+
+namespace OrchardCore.ContentManagement.GraphQL.Queries
+{
+    /// <summary>
+    /// Registers all Content Types as queries.
+    /// </summary>
+    public class SiteQuery : ISchemaBuilder
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IOptions<GraphQLContentOptions> _contentOptionsAccessor;
+        private readonly ISiteService _siteService;
+        private readonly IStringLocalizer S;
+
+        public SiteQuery(IHttpContextAccessor httpContextAccessor,
+            IOptions<GraphQLContentOptions> contentOptionsAccessor,
+            ISiteService siteService,
+            IStringLocalizer<SiteQuery> localizer)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _contentOptionsAccessor = contentOptionsAccessor;
+            _siteService = siteService;
+            S = localizer;
+        }
+
+        public Task<IChangeToken> BuildAsync(ISchema schema)
+        {
+            var typetype = new SiteGraphType(_contentOptionsAccessor);
+            var field = new FieldType {
+                Name = "Site",
+                Description = S["Site Metadata including Settings and CustomSettings."],
+                ResolvedType = typetype,
+                Resolver = new AsyncFieldResolver<ISite>(ResolveAsync)
+            };
+
+            field.RequirePermission(OrchardCore.Settings.Permissions.ManageSettings);
+
+            var serviceProvider = _httpContextAccessor.HttpContext.RequestServices;
+            var siteBuilders = serviceProvider.GetServices<ISiteGraphBuilder>().ToList();
+
+            foreach (var siteBuilder in siteBuilders)
+            {
+                siteBuilder.Build(typetype);
+            }
+
+            schema.Query.AddField(field);
+
+            var contentDefinitionManager = serviceProvider.GetService<IContentDefinitionManager>();
+
+            return Task.FromResult(contentDefinitionManager.ChangeToken);
+        }
+
+        private Task<ISite> ResolveAsync(ResolveFieldContext context)
+        {
+            return _siteService.GetSiteSettingsAsync();
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/ContentItemType.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/ContentItemType.cs
@@ -15,6 +15,12 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
     {
         private readonly GraphQLContentOptions _options;
 
+        /// <summary>
+        /// Allow a GraphQL type name to be different from the ContentType,
+        /// so it can be a field on another query like `Site__MyCustomSetting`
+        /// </summary>
+        public string ContentType { get; set; }
+
         public ContentItemType(IOptions<GraphQLContentOptions> optionsAccessor)
         {
             _options = optionsAccessor.Value;
@@ -68,7 +74,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
 
         private bool IsContentType(object obj)
         {
-            return obj is ContentItem item && item.ContentType == Name;
+            return obj is ContentItem item && item.ContentType == (ContentType ?? Name);
         }
 
         public override FieldType AddField(FieldType fieldType)

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/CustomSettingsSiteGraphBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/CustomSettingsSiteGraphBuilder.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using GraphQL.Resolvers;
+using GraphQL.Types;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.ContentManagement.GraphQL.Options;
+using OrchardCore.ContentManagement.GraphQL.Queries.Types;
+using OrchardCore.Contents;
+using OrchardCore.CustomSettings.Services;
+
+namespace OrchardCore.ContentManagement.GraphQL.Queries
+{
+    public sealed class CustomSettingsSiteGraphBuilder : ISiteGraphBuilder
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IOptions<GraphQLContentOptions> _contentOptionsAccessor;
+        private readonly CustomSettingsService _customSettings;
+        private readonly IStringLocalizer S;
+
+        public CustomSettingsSiteGraphBuilder(
+            IOptions<GraphQLContentOptions> contentOptionsAccessor,
+            IHttpContextAccessor httpContextAccessor,
+            CustomSettingsService customSettings,
+            IStringLocalizer<DynamicContentTypeBuilder> localizer
+        ) {
+            _httpContextAccessor = httpContextAccessor;
+            _contentOptionsAccessor = contentOptionsAccessor;
+            _customSettings = customSettings;
+
+            S = localizer;
+        }
+
+        public void Build(SiteGraphType siteType)
+        {
+            var serviceProvider = _httpContextAccessor.HttpContext.RequestServices;
+            var contentTypeBuilders = serviceProvider.GetServices<IContentTypeBuilder>().ToList();
+            var settingsTypes = _customSettings.GetAllSettingsTypes();
+
+            foreach (var typeDefinition in settingsTypes)
+            {
+                var typeType = new ContentItemType(_contentOptionsAccessor)
+                {
+                    ContentType = typeDefinition.Name,
+                    Name = $"Site__{typeDefinition.Name}",
+                    Description = S["Represents a {0}.", typeDefinition.DisplayName]
+                };
+
+                var query = new FieldType
+                {
+                    Name = typeDefinition.Name,
+                    Description = S["Represents a {0}.", typeDefinition.DisplayName],
+                    ResolvedType = typeType,
+                    Resolver = new AsyncFieldResolver<ContentItem>(async context =>
+                    {
+                        var customSetting = await _customSettings.GetSettingsAsync(typeDefinition.Name);
+
+                        return customSetting;
+                    })
+                };
+
+                query.RequirePermission(CommonPermissions.ViewContent, typeDefinition.Name);
+
+                foreach (var builder in contentTypeBuilders)
+                {
+                    builder.Build(query, typeDefinition, typeType);
+                }
+
+                siteType.AddField(query);
+            }
+
+            foreach (var builder in contentTypeBuilders)
+            {
+                builder.Clear();
+            }
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/ISiteGraphBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/ISiteGraphBuilder.cs
@@ -1,0 +1,9 @@
+using GraphQL.Types;
+
+namespace OrchardCore.ContentManagement.GraphQL.Queries
+{
+    public interface ISiteGraphBuilder
+    {
+        void Build(SiteGraphType siteType);
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/SiteGraphType.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/SiteGraphType.cs
@@ -1,0 +1,50 @@
+using GraphQL.Types;
+using Microsoft.Extensions.Options;
+using OrchardCore.ContentManagement.GraphQL.Options;
+using OrchardCore.Settings;
+
+namespace OrchardCore.ContentManagement.GraphQL.Queries
+{
+    public class SiteGraphType : ObjectGraphType<ISite>
+    {
+        private readonly GraphQLContentOptions _options;
+
+        public SiteGraphType(IOptions<GraphQLContentOptions> optionsAccessor) {
+            _options = optionsAccessor.Value;
+
+            Name = "Site";
+
+            Field(si => si.SiteName);
+            Field(si => si.PageTitleFormat);
+
+            // these seem bad to expose
+            // Field(si => si.SiteSalt);
+            // Field(si => si.SuperUser);
+
+            Field(si => si.Calendar);
+            Field(si => si.TimeZoneId);
+
+            // IDK
+            // Field(si => si.ResourceDebugMode);
+
+            Field(si => si.UseCdn);
+            Field(si => si.CdnBaseUrl);
+            Field(si => si.PageSize);
+            Field(si => si.MaxPageSize);
+            Field(si => si.MaxPagedCount);
+            Field(si => si.BaseUrl);
+
+            // should not expose
+            // Field(si => si.HomeRoute);
+
+            Field(si => si.AppendVersion);
+
+            IsTypeOf = IsContentType;
+        }
+
+        private bool IsContentType(object obj)
+        {
+            return obj is ISite;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/ServiceCollectionExtensions.cs
@@ -13,15 +13,20 @@ namespace OrchardCore.ContentManagement.GraphQL
         {
             services.AddSingleton<ISchemaBuilder, ContentItemQuery>();
             services.AddSingleton<ISchemaBuilder, ContentTypeQuery>();
+            services.AddSingleton<ISchemaBuilder, SiteQuery>();
+
             services.AddSingleton<ContentItemInterface>();
 
             services.AddTransient<ContentItemType>();
+            services.AddTransient<SiteGraphType>();
 
             services.AddScoped<IPermissionProvider, Permissions>();
 
             services.AddTransient<DynamicPartGraphType>();
             services.AddScoped<IContentTypeBuilder, TypedContentTypeBuilder>();
             services.AddScoped<IContentTypeBuilder, DynamicContentTypeBuilder>();
+
+            services.AddScoped<ISiteGraphBuilder, CustomSettingsSiteGraphBuilder>();
 
             services.AddOptions<GraphQLContentOptions>();
 


### PR DESCRIPTION
closes #5668 

![image](https://user-images.githubusercontent.com/1881482/76124474-bbf95900-5fc8-11ea-8fbf-b172bb30370e.png)

### Thoughts

I'm not sure a normal ContentItemType is the proper field type to instantiate here, since there's no need to have some fields on CustomSettings, like `render`.

I also used OP permissions on the site root (`ManageSettings`), and skipped some items which should probably never be exposed by the API. (think, `SiteSalt`, `SuperAdmin`). Direction here is welcome.

There's one thing I couldn't figure out. In order to use a ContentItem as a Field, it needs to be prefixed. So `{ site: { myCustomSettings } }` becomes the types: `Site.Site__MyCustomSettings`. When creating this new `ContentItemType`, it automatically gets registered to the ContentItem and Bag queries, as shown below. I'm sure there's a way to filter these out, but I was unable to find it in the time I had today.

![image](https://user-images.githubusercontent.com/1881482/76124085-f0b8e080-5fc7-11ea-8b9f-12ce420d6fb3.png)
