### PR TITLE
Fix Azure error when using TryCreateDirectory

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Drivers/MediaFieldDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Drivers/MediaFieldDriver.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
@@ -19,12 +20,15 @@ namespace OrchardCore.Media.Drivers
     public class MediaFieldDisplayDriver : ContentFieldDisplayDriver<MediaField>
     {
         private readonly AttachedMediaFieldFileService _attachedMediaFieldFileService;
+        private readonly ILogger _logger;
 
         public MediaFieldDisplayDriver(AttachedMediaFieldFileService attachedMediaFieldFileService,
-            IStringLocalizer<MediaFieldDisplayDriver> localizer)
+            IStringLocalizer<MediaFieldDisplayDriver> localizer,
+            ILogger<MediaFieldDisplayDriver> logger)
         {
             _attachedMediaFieldFileService = attachedMediaFieldFileService;
             S = localizer;
+            _logger = logger;
         }
 
         public IStringLocalizer S { get; }
@@ -73,9 +77,10 @@ namespace OrchardCore.Media.Drivers
                     {
                         await _attachedMediaFieldFileService.HandleFilesOnFieldUpdateAsync(items, context.ContentPart.ContentItem);
                     }
-                    catch (Exception)
+                    catch (Exception e)
                     {
                         updater.ModelState.AddModelError(Prefix, S["{0}: There was an error handling the files.", context.PartFieldDefinition.DisplayName()]);
+                        _logger.LogError(e, "Error handling attached media files for field '{Field}'", context.PartFieldDefinition.DisplayName());
                     }
                 }
 

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -134,14 +134,18 @@ namespace OrchardCore.FileStorage.AzureBlob
             // simply pretend like we created the directory, unless there is already
             // a blob with the same path.
 
-            var blob = GetBlobReference(path);
+            var blobFile = GetBlobReference(path);
 
-            if (await blob.ExistsAsync())
+            if (await blobFile.ExistsAsync())
             {
                 throw new FileStoreException($"Cannot create directory because the path '{path}' already exists and is a file.");
             }
 
-            await CreateDirectoryAsync(path);
+            var blobDirectory = await GetBlobDirectoryReference(path);
+            if (blobDirectory == null)
+            {
+                await CreateDirectoryAsync(path);
+            }
 
             return true;
         }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5694

Tests properly on `TryCreateDirectoryAsync` to see if either
- a file exists with the name of the directory, or
- the directory already exists

Also adds exception logging to the `MediaFieldDisplayDriver`