### PR TITLE
Add boolean valueType for email_verified claim

### DIFF
--- a/src/OrchardCore/OrchardCore.Users.Core/Services/DefaultUserClaimsPrincipalFactory.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/DefaultUserClaimsPrincipalFactory.cs
@@ -11,30 +11,24 @@ namespace OrchardCore.Users.Services
     /// </summary>
     public class DefaultUserClaimsPrincipalFactory : UserClaimsPrincipalFactory<IUser, IRole>
     {
-        private readonly UserManager<IUser> _userManager;
-        private readonly IOptions<IdentityOptions> _identityOptions;
-
         public DefaultUserClaimsPrincipalFactory(
             UserManager<IUser> userManager,
             RoleManager<IRole> roleManager,
             IOptions<IdentityOptions> identityOptions) : base(userManager, roleManager, identityOptions)
         {
-            _userManager = userManager;
-            _identityOptions = identityOptions;
         }
 
         protected override async Task<ClaimsIdentity> GenerateClaimsAsync(IUser user)
         {
             var claims = await base.GenerateClaimsAsync(user);
 
-            var email = await _userManager.GetEmailAsync(user);
-
+            var email = await UserManager.GetEmailAsync(user);
             if (email != null)
             {
                 claims.AddClaim(new Claim("email", email));
 
-                var confirmed = await _userManager.IsEmailConfirmedAsync(user);
-                claims.AddClaim(new Claim("email_verified", confirmed ? bool.TrueString : bool.FalseString));
+                var confirmed = await UserManager.IsEmailConfirmedAsync(user);
+                claims.AddClaim(new Claim("email_verified", confirmed ? bool.TrueString : bool.FalseString, ClaimValueTypes.Boolean));
             }
 
             return claims;

--- a/test/OrchardCore.Tests/OrchardCore.Users/OrchardCore.Users.Core/DefaultUserClaimsPrincipalFactoryTests.cs
+++ b/test/OrchardCore.Tests/OrchardCore.Users/OrchardCore.Users.Core/DefaultUserClaimsPrincipalFactoryTests.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Moq;
+using OrchardCore.Security;
+using OrchardCore.Users;
+using OrchardCore.Users.Models;
+using OrchardCore.Users.Services;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace OrchardCore.Tests.OrchardCore.Users.Core
+{
+    public class DefaultUserClaimsPrincipalFactoryTests
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task EnsurePrincipalHasExpectedClaims(bool emailVerified)
+        {
+            //Arrange
+            var userManager = UsersMockHelper.MockUserManager<IUser>();
+            var user = new User { Id = new Random().Next(), UserName = "Foo", Email = "foo@foo.com" };
+            userManager.Setup(m => m.GetUserIdAsync(user)).ReturnsAsync(user.Id.ToString());
+            userManager.Setup(m => m.GetUserNameAsync(user)).ReturnsAsync(user.UserName);
+            userManager.Setup(m => m.GetEmailAsync(user)).ReturnsAsync(user.Email);
+            if (emailVerified)
+            {
+                userManager.Setup(m => m.IsEmailConfirmedAsync(user)).ReturnsAsync(emailVerified);
+            }
+
+            var roleManager = UsersMockHelper.MockRoleManager<IRole>().Object;
+
+            var options = new Mock<IOptions<IdentityOptions>>();
+            options.Setup(a => a.Value).Returns(new IdentityOptions());
+            
+            var factory = new DefaultUserClaimsPrincipalFactory(userManager.Object, roleManager, options.Object);
+
+            //Act
+            var principal = await factory.CreateAsync(user);
+
+            //Assert
+            var identity = principal.Identities.First();
+            Assert.NotNull(identity);
+
+            var claims = identity.Claims.ToList();
+            Assert.NotNull(claims);
+
+            var emailClaim = claims.FirstOrDefault(c => c.Type == "email");
+            Assert.NotNull(emailClaim);
+            Assert.Equal(user.Email, emailClaim.Value);
+
+            var emailVerifiedClaim = claims.FirstOrDefault(c => c.Type == "email_verified");
+            Assert.NotNull(emailVerifiedClaim);
+            Assert.Equal(ClaimValueTypes.Boolean, emailVerifiedClaim.ValueType);
+            Assert.Equal(emailVerified.ToString(), emailVerifiedClaim.Value); 
+        }
+    }
+
+}

--- a/test/OrchardCore.Tests/OrchardCore.Users/RegistrationControllerTests.cs
+++ b/test/OrchardCore.Tests/OrchardCore.Users/RegistrationControllerTests.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Tests.OrchardCore.Users
         [Fact]
         public async Task UsersShouldNotBeAbleToRegisterIfNotAllowed()
         {
-            var mockUserManager = MockUserManager<IUser>().Object;
+            var mockUserManager = UsersMockHelper.MockUserManager<IUser>().Object;
             var settings = new RegistrationSettings { UsersCanRegister = UserRegistrationType.NoRegistration };
             var mockSiteService = Mock.Of<ISiteService>(ss =>
                 ss.GetSiteSettingsAsync() == Task.FromResult(
@@ -59,7 +59,7 @@ namespace OrchardCore.Tests.OrchardCore.Users
         [Fact]
         public async Task UsersShouldBeAbleToRegisterIfAllowed()
         {
-            var mockUserManager = MockUserManager<IUser>().Object;
+            var mockUserManager = UsersMockHelper.MockUserManager<IUser>().Object;
             var settings = new RegistrationSettings { UsersCanRegister = UserRegistrationType.AllowRegistration };
             var mockSiteService = Mock.Of<ISiteService>(ss =>
                 ss.GetSiteSettingsAsync() == Task.FromResult(
@@ -118,7 +118,7 @@ namespace OrchardCore.Tests.OrchardCore.Users
         public static Mock<SignInManager<TUser>> MockSignInManager<TUser>(UserManager<TUser> userManager = null) where TUser : class
         {
             var context = new Mock<HttpContext>();
-            var manager = userManager ?? MockUserManager<TUser>().Object;
+            var manager = userManager ?? UsersMockHelper.MockUserManager<TUser>().Object;
             return new Mock<SignInManager<TUser>>(
                 manager,
                 new HttpContextAccessor { HttpContext = context.Object },
@@ -128,26 +128,6 @@ namespace OrchardCore.Tests.OrchardCore.Users
                 null,
                 null)
             { CallBase = true };
-        }
-
-        public static Mock<UserManager<TUser>> MockUserManager<TUser>() where TUser : class
-        {
-            IList<IUserValidator<TUser>> UserValidators = new List<IUserValidator<TUser>>();
-            IList<IPasswordValidator<TUser>> PasswordValidators = new List<IPasswordValidator<TUser>>();
-
-            var store = new Mock<IUserStore<TUser>>();
-            UserValidators.Add(new UserValidator<TUser>());
-            PasswordValidators.Add(new PasswordValidator<TUser>());
-            var mgr = new Mock<UserManager<TUser>>(store.Object,
-                null,
-                null,
-                UserValidators,
-                PasswordValidators,
-                null,
-                null,
-                null,
-                null);
-            return mgr;
         }
     }
 }

--- a/test/OrchardCore.Tests/OrchardCore.Users/UsersMockHelper.cs
+++ b/test/OrchardCore.Tests/OrchardCore.Users/UsersMockHelper.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+
+namespace OrchardCore.Tests.OrchardCore.Users
+{
+    public static class UsersMockHelper
+    {
+        public static Mock<UserManager<TUser>> MockUserManager<TUser>() where TUser : class
+        {
+            var store = new Mock<IUserStore<TUser>>();
+            var mgr = new Mock<UserManager<TUser>>(store.Object, null, null, null, null, null, null, null, null);
+            mgr.Object.UserValidators.Add(new UserValidator<TUser>());
+            mgr.Object.PasswordValidators.Add(new PasswordValidator<TUser>());
+
+            return mgr;
+        }
+
+        public static Mock<RoleManager<TRole>> MockRoleManager<TRole>() where TRole : class
+        {
+            var store = new Mock<IRoleStore<TRole>>().Object;
+            var roles = new List<IRoleValidator<TRole>>();
+            roles.Add(new RoleValidator<TRole>());
+
+            return new Mock<RoleManager<TRole>>(store, roles, new UpperInvariantLookupNormalizer(), new IdentityErrorDescriber(), null);
+        }
+    }
+}


### PR DESCRIPTION
Fix for #5307
- Tidy up DefaultUserClaimsPrincipalFactory constructor initialisation
- Remove UserManager and IOptions field to use UserClaimsPrincipalFactory public interface
- Add ClaimValueTypes.Boolean to email_verified Claim constructor
- Add unit test for DefaultUserClaimsPrincipalFactory
- Move UserManager and RoleManager to static UsersMockHelper
- Refactor RegistrationControllerTests to use UsersMockHelper