### PR TITLE
Failsafe for absent or duplicated 'database' tag

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
@@ -95,12 +95,9 @@ namespace OrchardCore.Setup.Controllers
 
             var selectedProvider = model.DatabaseProviders.FirstOrDefault(x => x.Value == model.DatabaseProvider);
 
-            if (!model.DatabaseConfigurationPreset)
+            if (!model.DatabaseConfigurationPreset && selectedProvider != null && selectedProvider.HasConnectionString && String.IsNullOrWhiteSpace(model.ConnectionString))
             {
-                if (selectedProvider != null && selectedProvider.HasConnectionString && String.IsNullOrWhiteSpace(model.ConnectionString))
-                {
-                    ModelState.AddModelError(nameof(model.ConnectionString), S["The connection string is mandatory for this provider."]);
-                }
+                ModelState.AddModelError(nameof(model.ConnectionString), S["The connection string is mandatory for this provider."]);
                 var aux = model.ConnectionString.Replace(" ", "");
                 var database = aux.Split(";").Where(i => i.StartsWith("database=", StringComparison.CurrentCultureIgnoreCase));
                 if (database.Count() != 1)

--- a/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
@@ -101,6 +101,12 @@ namespace OrchardCore.Setup.Controllers
                 {
                     ModelState.AddModelError(nameof(model.ConnectionString), S["The connection string is mandatory for this provider."]);
                 }
+                var aux = model.ConnectionString.Replace(" ", "");
+                var database = aux.Split(";").Where(i => i.StartsWith("database=", StringComparison.CurrentCultureIgnoreCase));
+                if (database.Count() != 1)
+                {
+                    ModelState.AddModelError(nameof(model.ConnectionString), S["Invalid amount of 'database' entries defined on the connection string."]);
+                }
             }
 
             if (String.IsNullOrEmpty(model.Password))


### PR DESCRIPTION
If the database tag is not specified, the default database (master for Sql Server) is used. This prevents it.