### PR TITLE
Update ContentLinkTagHelper for general actions

### DIFF
--- a/src/OrchardCore/OrchardCore.Contents.TagHelpers/ContentLinkTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.TagHelpers/ContentLinkTagHelper.cs
@@ -15,6 +15,7 @@ namespace OrchardCore.Contents.TagHelpers
     [HtmlTargetElement("a", Attributes = ContentLinkEdit)]
     [HtmlTargetElement("a", Attributes = ContentLinkRemove)]
     [HtmlTargetElement("a", Attributes = ContentLinkCreate)]
+    [HtmlTargetElement("a")]
     public class ContentLinkTagHelper : TagHelper
     {
         private const string ContentLinkAdmin = "admin-for";
@@ -148,6 +149,14 @@ namespace OrchardCore.Contents.TagHelpers
                 ApplyRouteValues(tagHelperContext, metadata.CreateRouteValues);
 
                 output.Attributes.SetAttribute("href", urlHelper.Action(metadata.CreateRouteValues["action"].ToString(), metadata.CreateRouteValues));
+            } else
+            {
+                var routeDictionary = new RouteValueDictionary();
+                ApplyRouteValues(tagHelperContext, routeDictionary);
+                if (routeDictionary.Keys.Contains("action"))
+                {
+                    output.Attributes.SetAttribute("href", urlHelper.Action(routeDictionary["action"].ToString(), routeDictionary));
+                }
             }
 
             // A self closing anchor tag will be rendered using the display text


### PR DESCRIPTION
Added option to ContentLinkTagHelper to be called by liquid without any of the following options: edit_for, create_for, remove_for, display_for, or admin_for. Currently the {% a ... %} option can't be used in Liquid pages without one of the content item options. However, the "a" tag helper supports options for "asp-route-" attributes, and these are unusable from Liquid without this update.