### PR TITLE
Improve admin menu filter

### DIFF
--- a/src/OrchardCore.Themes/TheAdmin/Views/Navigation-admin.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Navigation-admin.cshtml
@@ -34,7 +34,14 @@
             return jQuery(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;
         };
     });
-
+    function isDisplayedLeaf(e) {
+      if ($(e).is(":visible") && $(e).children().length === 1) {
+        return true;
+      }
+      return false;
+    }
+    var lastLeafFound = null;
+    var nbLeavesFound = 0;
     function hasChild(list) {
         var filter = $('#filter').val();
         list.children('li').each(function () {
@@ -44,6 +51,7 @@
                     hasChild($(this).find('ul :first').parent());
                 } else {
                     $(this).show();
+                    nbLeavesFound += 1;
                 }
             } else {
                 $(this).hide();
@@ -54,9 +62,14 @@
         var list = $('#adminMenu');
         var filter = $('#filter').val();
         if (filter) {
+            nbLeavesFound = 0;
             hasChild(list);
         } else {
             list.find("li").show();
+        }
+
+        if (nbLeavesFound == 1) {
+            $('#adminMenu li:visible> ul').show();
         }
         return false;
     });


### PR DESCRIPTION
I would like to improve the admin menu filter:
If there is only one leaf menu item found, expand the nodes to its level.

![media](https://user-images.githubusercontent.com/703248/77228876-83da4480-6b8a-11ea-8996-1a4a4be4f6eb.gif)

I am not entirely satisfied of the result.
If someone can try, pleas help me to find the best behavior and improve the javascript code.

You can test different filters:
- 'con' for 'Content types', 'Content Definiton'
- 'imp' for 'Package Import'
- 'ty' for 'Content types' or 'Security'
- 'mi' for 'Admin' and 'Microsoft'