### PR TITLE
Moved SameSite.None to OpenId Module at startup

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -82,7 +82,9 @@ namespace OrchardCore.OpenId
                     // protected by antiforgery checks, that are enforced with or without this setting being changed.
                     // 2020-03-23; Moved the SameSiteNode.None here, this will require that the site runs on HTTPS;
                     if (cookieContext.CookieName.StartsWith("orchauth_"))
+                    {
                         cookieContext.CookieOptions.SameSite = SameSiteMode.None;
+                    }
                 };
             });
         }
@@ -92,7 +94,7 @@ namespace OrchardCore.OpenId
             var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
             if (!httpContextAccessor.HttpContext.Request.IsHttps)
             {
-                _logger.LogCritical("OpenId module requires a site that runs on Https, Http sites may not function correctly.");
+                _logger.LogCritical("OpenId module requires a site that runs on https.");
             }
 
             // Application

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -7,9 +7,11 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenIddict.Mvc;
 using OpenIddict.Server;
@@ -43,9 +45,13 @@ namespace OrchardCore.OpenId
     public class Startup : StartupBase
     {
         private readonly AdminOptions _adminOptions;
+        private readonly ILogger _logger;
 
-        public Startup(IOptions<AdminOptions> adminOptions)
-            => _adminOptions = adminOptions.Value;
+        public Startup(IOptions<AdminOptions> adminOptions, ILogger<Startup> logger)
+        {
+            _adminOptions = adminOptions.Value;
+            _logger = logger;
+        }
 
         public override void ConfigureServices(IServiceCollection services)
         {
@@ -66,10 +72,29 @@ namespace OrchardCore.OpenId
                 ServiceDescriptor.Scoped<IPermissionProvider, Permissions>(),
                 ServiceDescriptor.Scoped<INavigationProvider, AdminMenu>(),
             });
+
+            services.Configure<CookiePolicyOptions>(options =>
+            {
+                options.OnAppendCookie = cookieContext =>
+                {
+                    // Disabling same-site is required for OpenID's module prompt=none support to work correctly.
+                    // Note: it has no practical impact on the security of the site since all endpoints are always
+                    // protected by antiforgery checks, that are enforced with or without this setting being changed.
+                    // 2020-03-23; Moved the SameSiteNode.None here, this will require that the site runs on HTTPS;
+                    if (cookieContext.CookieName.StartsWith("orchauth_"))
+                        cookieContext.CookieOptions.SameSite = SameSiteMode.None;
+                };
+            });
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
         {
+            var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
+            if (!httpContextAccessor.HttpContext.Request.IsHttps)
+            {
+                _logger.LogCritical("OpenId module requires a site that runs on Https, Http sites may not function correctly.");
+            }
+
             // Application
             var applicationControllerName = typeof(ApplicationController).ControllerName();
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -136,7 +136,7 @@ namespace OrchardCore.Users
             services.ConfigureApplicationCookie(options =>
             {
                 options.Cookie.Name = "orchauth_" + HttpUtility.UrlEncode(_tenantName);
-
+                
                 // Don't set the cookie builder 'Path' so that it uses the 'IAuthenticationFeature' value
                 // set by the pipeline and comming from the request 'PathBase' which already ends with the
                 // tenant prefix but may also start by a path related e.g to a virtual folder.
@@ -149,7 +149,8 @@ namespace OrchardCore.Users
                 // protected by antiforgery checks, that are enforced with or without this setting being changed.
                 // 2019-12-10; Removed, since https://github.com/aspnet/Announcements/issues/390
                 // 2020-02-17; Reenabled since we have compensation logic for backwardscompatibility
-                options.Cookie.SameSite = SameSiteMode.None;
+                // 2020-03-23; Moved the SameSiteNode.None to the Startup of the OIDC Server
+                options.Cookie.SameSite = SameSiteMode.Strict;
             });
 
             services.AddSingleton<IIndexProvider, UserIndexProvider>();


### PR DESCRIPTION
PR for https://github.com/OrchardCMS/OrchardCore/issues/5712

Since we need SameSite cookie behavior set to None to support the OpenId prompt feature, the default setting should be Strict and None when OpenId Server feature is turned on.

I've added a critical log statement that you definitely must run your OpenId server on Https, otherwise Chrome will reject the cookie.