### PR TITLE
Reverting setup cultures appsettings changes and update docs

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -7,44 +7,6 @@
     }
   },
   "OrchardCore": {
-    "OrchardCore.Setup": {
-      "DefaultCulture": "", // When using "" the system OS culture will be used
-      "SupportedCultures": [
-        "ar",
-        "cs",
-        "da",
-        "de",
-        "el",
-        "en",
-        "es",
-        "fa",
-        "fi",
-        "fr",
-        "he",
-        "hr",
-        "hu",
-        "id",
-        "it",
-        "ja",
-        "ko",
-        "lt",
-        "mk",
-        "nl",
-        "pl",
-        "pt",
-        "ru",
-        "sk",
-        "sl",
-        "sr-cyrl-rs",
-        "sr-latn-rs",
-        "sv",
-        "tr",
-        "uk",
-        "vi",
-        "zh-CN",
-        "zh-TW"
-      ] // "" value (InvariantCulture) is not supported for these
-    }
     // Uncomment to configure shell and tenant configuration in Azure Blob Storage.
     // Add a reference to the OrchardCore.Shells.Azure NuGet package.
     // Add '.AddAzureShellsConfiguration()' to your Host Startup AddOrchardCms() section.

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/appsettings.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/appsettings.json
@@ -36,44 +36,6 @@
         }
       }
     ]
-  },
-  //#endif
-  "OrchardCore": {
-    "OrchardCore.Setup": {
-      "DefaultCulture": "", // When using "" the system OS culture will be used
-      "SupportedCultures": [
-        "ar",
-        "cs",
-        "da",
-        "de",
-        "el",
-        "en",
-        "es",
-        "fa",
-        "fi",
-        "fr",
-        "he",
-        "hr",
-        "hu",
-        "id",
-        "it",
-        "ja",
-        "ko",
-        "lt",
-        "mk",
-        "nl",
-        "pl",
-        "pt",
-        "ru",
-        "sk",
-        "sl",
-        "sv",
-        "tr",
-        "uk",
-        "vi",
-        "zh-CN",
-        "zh-TW"
-      ] // "" value (InvariantCulture) is not supported for these
-    }
   }
+  //#endif
 }

--- a/src/docs/reference/modules/Setup/README.md
+++ b/src/docs/reference/modules/Setup/README.md
@@ -33,12 +33,46 @@ The value will be retrieved from the `appsettings.json` tenant file.
 
 ## Configuration
 
-`OrchardCore.Setup` can be configured through `appsettings.json` as follows:
+The following configuration values are used by default and can be customized:
 
 ```json
     "OrchardCore.Setup": {
-        "DefaultCulture": "",
-        "SupportedCultures": [ "en" ]
+      "DefaultCulture": "", // When using "" the system OS culture will be used
+      "SupportedCultures": [
+        "ar", 
+        "cs", 
+        "da", 
+        "de", 
+        "el", 
+        "en", 
+        "es", 
+        "fa", 
+        "fi", 
+        "fr", 
+        "he", 
+        "hr", 
+        "hu", 
+        "id", 
+        "it", 
+        "ja", 
+        "ko", 
+        "lt", 
+        "mk", 
+        "nl", 
+        "pl", 
+        "pt", 
+        "ru", 
+        "sk", 
+        "sl", 
+        "sr-cyrl-rs", 
+        "sr-latn-rs", 
+        "sv", 
+        "tr", 
+        "uk", 
+        "vi", 
+        "zh-CN", 
+        "zh-TW"
+      ] // "" value (InvariantCulture) is not supported for these
     }
 ```
 


### PR DESCRIPTION
As discussed as these are in code now it is better not to have them in `appsettings.json` by default.

Worth noting that already the list in `appsettings.json was already out of sync with the default settings defined in the `Startup.cs`