### PR TITLE
Fixes AntiforgeryValidationException

### DIFF
--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -245,8 +245,9 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.ConfigureServices((services, serviceProvider) =>
             {
                 var settings = serviceProvider.GetRequiredService<ShellSettings>();
+                var environment = serviceProvider.GetRequiredService<IHostEnvironment>();
 
-                var cookieName = "orchantiforgery_" + settings.Name;
+                var cookieName = "orchantiforgery_" + settings.Name + environment.ContentRootPath;
 
                 // If uninitialized, we use the host services.
                 if (settings.State == TenantState.Uninitialized)

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
@@ -247,7 +248,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var settings = serviceProvider.GetRequiredService<ShellSettings>();
                 var environment = serviceProvider.GetRequiredService<IHostEnvironment>();
 
-                var cookieName = "orchantiforgery_" + settings.Name + environment.ContentRootPath;
+                var cookieName = "orchantiforgery_" + HttpUtility.UrlEncode(settings.Name + environment.ContentRootPath);
 
                 // If uninitialized, we use the host services.
                 if (settings.State == TenantState.Uninitialized)


### PR DESCRIPTION
Fixes #3293

We fixed it on a new setup but we still have errors logged when we run an application from a given location and login to the admin, and then do the same from another application location but same url.

Using this in the startup seems to fix the issue but then you get a new cookie on each startup

    var cookieName = "orchantiforgery_" + settings.Name + Guid.NewGuid().ToString();

So i suggest the following that only add a cookie per application location and that also works

    var cookieName = "orchantiforgery_" + settings.Name + env.ContentRootPath;

