### PR TITLE
Don't pre-create the DataProtection directory

### DIFF
--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -370,7 +370,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 var settings = serviceProvider.GetRequiredService<ShellSettings>();
                 var options = serviceProvider.GetRequiredService<IOptions<ShellOptions>>();
 
-                var directory = Directory.CreateDirectory(Path.Combine(
+                // The 'FileSystemXmlRepository' will create the directory, but only if it is not overridden.
+                var directory = new DirectoryInfo(Path.Combine(
                     options.Value.ShellsApplicationDataPath,
                     options.Value.ShellsContainerName,
                     settings.Name, "DataProtection-Keys"));


### PR DESCRIPTION
Working on a Redis DataProtection i saw that the related directory is still created on the file system.

Here, if the `FileSystemXmlRepository` is not used the `DataProtection-Keys` directory is not created