### PR TITLE
Update ShellHost Registrations

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/IShellHost.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/IShellHost.cs
@@ -5,7 +5,7 @@ using OrchardCore.Environment.Shell.Scope;
 
 namespace OrchardCore.Environment.Shell
 {
-    public interface IShellHost
+    public interface IShellHost : IShellDescriptorManagerEventHandler
     {
         /// <summary>
         /// Ensure that all the <see cref="ShellContext"/> are pre-created and available to process requests.

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ServiceCollectionExtensions.cs
@@ -12,10 +12,8 @@ namespace OrchardCore.Environment.Shell
     {
         public static IServiceCollection AddHostingShellServices(this IServiceCollection services)
         {
-            // Register the type as it's implementing two interfaces which can be resolved independently
-            services.AddSingleton<ShellHost>();
-            services.AddSingleton<IShellHost>(sp => sp.GetRequiredService<ShellHost>());
-            services.AddSingleton<IShellDescriptorManagerEventHandler>(sp => sp.GetRequiredService<ShellHost>());
+            services.AddSingleton<IShellHost, ShellHost>();
+            services.AddSingleton<IShellDescriptorManagerEventHandler>(sp => sp.GetRequiredService<IShellHost>());
 
             {
                 // Use a single default site by default, i.e. if WithTenants hasn't been called before

--- a/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Environment/Shell/ShellHost.cs
@@ -18,7 +18,7 @@ namespace OrchardCore.Environment.Shell
     /// tenant is removed, but are necessary to match an incoming request, even if they are not initialized.
     /// Each <see cref="ShellContext"/> is activated (its service provider is built) on the first request.
     /// </summary>
-    public class ShellHost : IShellHost, IShellDescriptorManagerEventHandler, IDisposable
+    public class ShellHost : IShellHost, IDisposable
     {
         private readonly IShellSettingsManager _shellSettingsManager;
         private readonly IShellContextFactory _shellContextFactory;
@@ -293,7 +293,7 @@ namespace OrchardCore.Environment.Shell
         /// <summary>
         /// A feature is enabled / disabled, the tenant needs to be restarted
         /// </summary>
-        Task IShellDescriptorManagerEventHandler.Changed(ShellDescriptor descriptor, string tenant)
+        public Task Changed(ShellDescriptor descriptor, string tenant)
         {
             if (_logger.IsEnabled(LogLevel.Information))
             {


### PR DESCRIPTION
**Currently we have**

    services.AddSingleton<ShellHost>();
    services.AddSingleton<IShellHost>(sp => sp.GetRequiredService<ShellHost>());
    services.AddSingleton<IShellDescriptorManagerEventHandler>(sp => sp.GetRequiredService<ShellHost>());


So here if someone overrides `IShellHost`, when we resolve `<IShellDescriptorManagerEventHandler>` as an `IEnumerable` **the `ShellHost` implementation is still used**.

**By using this with one less registration and that i tried**

    public interface IShellHost : IShellDescriptorManagerEventHandler

    services.AddSingleton<IShellHost, ShellHost>();
    services.AddSingleton<IShellDescriptorManagerEventHandler>(sp => sp.GetRequiredService<IShellHost>());

Now it forces the one that overides `IShellHost` to also implements `<IShellDescriptorManagerEventHandler>` and when all `<IShellDescriptorManagerEventHandler>` are resolved as an `IEnumerable`, **the right instance is used**

I also tried this pattern for other services in another branch