### PR TITLE
Update ITagCache registration

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Cache/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Cache/OrchardCoreBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             builder.ConfigureServices(services =>
             {
-                services.AddTransient<ITagCache, DefaultTagCache>();
+                services.AddScoped<ITagCache, DefaultTagCache>();
                 services.AddSingleton<ISignal, Signal>();
                 services.AddScoped<ICacheContextManager, CacheContextManager>();
                 services.AddScoped<ICacheScopeManager, CacheScopeManager>();


### PR DESCRIPTION
`ITagCache` is a transient so it can be referenced e.g by a singleton. But `DefaultTagCache` reference all `ITagRemovedEventHandler` whose the only one current implementation is a scoped service.

So it is possible to have

    Singleton => Transient instance => Scoped service

Just tried, in fact it fails automatically as it is auto detected

But anyway this is not good, so i made `ITagCache` a scoped service