### PR TITLE
Allow .webmanifest file extension

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
@@ -42,6 +42,9 @@ namespace OrchardCore.Media.Services
             ".mpg",
             ".ogv", // (Ogg)
             ".3gp", // (3GPP)
+
+            // Web
+            ".webmanifest",
         };
 
         private const int DefaultMaxBrowserCacheDays = 30;


### PR DESCRIPTION
Allow by default .webmanifest in the allowed files extensions.

Fixes #2486