### PR TITLE
Fixes OC.ContentLocalization dependencies

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Manifest.cs
@@ -20,7 +20,7 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.ContentLocalization.ContentCulturePicker",
     Name = "Content Culture Picker",
     Description = "Provides a culture picker shape for the frontend.",
-    Dependencies = new[] { "OrchardCore.ContentLocalization" },
+    Dependencies = new[] { "OrchardCore.ContentLocalization", "OrchardCore.Autoroute" },
     Category = "Internationalization"
 )]
 

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.HomeRoute",
     Name = "Home Route",


### PR DESCRIPTION
Fixes #5833 

The only 2 modules that inject `IAutorouteEntries` is `OC.Autoroute` itself and `OC.ContentLocalization`.