### PR TITLE
Themes standardization

### DIFF
--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>{{ "PageTitle" | shape_new | shape_stringify }}</title>
     {% render_section "HeadMeta", required: false %}
-    <title>{% page_title Site.SiteName %}</title>
     {% resources type: "Meta" %}
 
     <!-- Bootstrap core CSS -->

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>{{ "PageTitle" | shape_new | shape_stringify }}</title>
-
+    <title>{{ "PageTitle" | shape_new | shape_stringify }}</title>    
+    {% render_section "HeadMeta", required: false %}
     {% resources type: "Meta" %}
 
     <!-- Bootstrap core CSS -->
@@ -32,7 +32,6 @@
     {% resources type: "HeadScript" %}
     {% resources type: "HeadLink" %}
     {% resources type: "Stylesheet" %}
-
 </head>
 <body dir="{{ Culture.Dir }}">
     <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">

--- a/src/OrchardCore.Themes/TheComingSoonTheme/Views/layout.liquid
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/Views/layout.liquid
@@ -1,16 +1,10 @@
 <!DOCTYPE html>
 <html lang="{{ Culture.Name }}">
-
   <head>
-
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="">
-    <meta name="author" content="">
-
+    <title>{{ "PageTitle" | shape_new | shape_stringify }}</title>    
     {% render_section "HeadMeta", required:false %}
-
-    <title>{% page_title Site.SiteName %}</title>
 
     <!-- Bootstrap core CSS -->
     {% style name:"thecomingsoontheme-vendor-bootstrap", version:"4" %}
@@ -27,9 +21,7 @@
     {% resources type: "Stylesheet" %}
     {% resources type: "HeadScript" %}
   </head>
-
   <body dir={{ Culture.Dir }}>
-
     <div class="overlay"></div>
     <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
       <source src="{{ "~/TheComingSoonTheme/mp4/bg.mp4" | href }}" type="video/mp4">
@@ -48,5 +40,4 @@
 
     {% resources type: "FootScript" %}
   </body>
-
 </html>

--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -1,4 +1,3 @@
-﻿@* Based on https://getbootstrap.com/docs/4.0/examples/sticky-footer-navbar/ *@
 <!DOCTYPE html>
 <html lang="@Orchard.CultureName()">
 <head>
@@ -6,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@RenderTitleSegments(Site.SiteName, "before")</title>
     <link type="image/x-icon" rel="shortcut icon" href="~/TheTheme/favicon.ico" />
+    @await RenderSectionAsync("HeadMeta", required: false)
     <script asp-name="bootstrap" version="4" at="Foot"></script>
     <style asp-name="thetheme-bootstrap-oc" version="1"></style>
     <style asp-name="font-awesome" version="5"></style>


### PR DESCRIPTION
Add missing HeadMeta section in all themes

I would like to configure the zones by default in all themes and add to this one this kind of meta in a RawHtml widget:
`<link type="image/x-icon" rel="shortcut icon" href="/TheAgencyTheme/favicon.ico">`
but it would require to remove the wrappers around the widget in that zone.
