### PR TITLE
Remove font awesome pseudoSearch config

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/ContentCard-FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/ContentCard-FlowPart.Edit.cshtml
@@ -28,7 +28,8 @@
                 @if (Model.CanInsert != false)
                 {
                     <div class="btn-group">
-                        <button class="toggleAll btn btn-secondary btn-sm" onclick="toggleWidgets(); return false;" title="@T["Toggle all widgets"]"></button>
+                        <button class="toggleAll btn btn-secondary btn-sm" onclick="toggleWidgets(); return false;" title="@T["Toggle all widgets"]">
+                            <i class="fa fa-angle-double-up" aria-hidden="true"></i></button>
                         <button type="button" title="@T["Insert Widget"]" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fa fa-plus" aria-hidden="true"></i>
                         </button>

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -98,7 +98,7 @@
 
 <script at="Foot">
     function toggleWidgets(){
-        $(this).find('i').toggleClass('fa-angle-double-up fa-angle-double-down');
+        $('.toggleAll > svg').toggleClass('fa-angle-double-up fa-angle-double-down');
         $('.toggleAll').toggleClass('collapsed');        
         $('.widget.widget-editor.card').toggleClass('collapsed');
     }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -98,7 +98,8 @@
 
 <script at="Foot">
     function toggleWidgets(){
-        $('.toggleAll').toggleClass('collapsed');
+        $(this).find('i').toggleClass('fa-angle-double-up fa-angle-double-down');
+        $('.toggleAll').toggleClass('collapsed');        
         $('.widget.widget-editor.card').toggleClass('collapsed');
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -99,7 +99,6 @@
 <script at="Foot">
     function toggleWidgets(){
         $('.toggleAll > svg').toggleClass('fa-angle-double-up fa-angle-double-down');
-        $('.toggleAll').toggleClass('collapsed');        
         $('.widget.widget-editor.card').toggleClass('collapsed');
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Assets.json
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Assets.json
@@ -239,12 +239,5 @@
       "node_modules/@fortawesome/fontawesome-free/webfonts/*"
     ],
     "output": "wwwroot/Vendor/fontawesome-free/webfonts/@"
-  },
-  {
-    "copy": true,
-    "inputs": [
-      "Assets/fontawesome/js/config.js"
-    ],
-    "output": "wwwroot/Scripts/fontawesome-config.js"
   }
 ]

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Assets/fontawesome/js/config.js
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Assets/fontawesome/js/config.js
@@ -1,1 +1,0 @@
-FontAwesomeConfig = { searchPseudoElements: true };

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -194,11 +194,6 @@ namespace OrchardCore.Resources
                 .SetVersion("5.13.0");
 
             manifest
-                .DefineScript("font-awesome-config")
-                .SetUrl("~/OrchardCore.Resources/Scripts/fontawesome-config.js")
-                .SetVersion("5.13.0");
-
-            manifest
                 .DefineScript("font-awesome")
                 .SetDependencies("font-awesome-config")
                 .SetUrl("~/OrchardCore.Resources/Vendor/fontawesome-free/js/all.min.js", "~/OrchardCore.Resources/Vendor/fontawesome-free/js/all.js")

--- a/src/OrchardCore.Modules/OrchardCore.Resources/wwwroot/Scripts/fontawesome-config.js
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/wwwroot/Scripts/fontawesome-config.js
@@ -1,1 +1,0 @@
-FontAwesomeConfig = { searchPseudoElements: true };


### PR DESCRIPTION
Do not use 'search pseudo elements' in font awesome anymore because it slows the pages.

Fixes #5864