### PR TITLE
[doc] Correct shape tags usage with arrays

### DIFF
--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -483,8 +483,10 @@ Adds alternates to a shape.
 Input
 
 ```liquid
-{% shape_add_alternates my_shape "alternate1", "alternate2" %}
 {% shape_add_alternates my_shape "alternate1 alternate2" %}
+
+{% assign my_alternates = "alternate1,alternate2" | split: "," %}
+{% shape_add_alternates my_shape my_alternates %}
 ```
 
 ### `shape_clear_wrappers`
@@ -504,8 +506,10 @@ Adds wrappers to a shape.
 Input
 
 ```liquid
-{% shape_add_wrappers my_shape "wrapper1", "wrapper2" %}
 {% shape_add_wrappers my_shape "wrapper1 wrapper2" %}
+
+{% assign my_wrappers = "wrapper1,wrapper2" | split: "," %}
+{% shape_add_wrappers my_shape my_wrappers %}
 ```
 
 ### `shape_clear_classes`
@@ -526,7 +530,9 @@ Input
 
 ```liquid
 {% shape_add_classes my_shape "class1 class2" %}
-{% shape_add_classes my_shape "class1", "class2" %}
+
+{% assign my_classes "class1,class2" | split: "," %}
+{% shape_add_classes my_shape my_classes %}
 ```
 
 ### `shape_clear_attributes`


### PR DESCRIPTION
`shape_add_alternates`, `shape_add_wrappers` and `shape_add_classes` support one argument only.