### PR TITLE
Render bagpart items with summary displaytype.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.cshtml
@@ -6,7 +6,7 @@
 <section class="flow">
     @foreach (var item in Model.BagPart.ContentItems)
     {
-        var itemContent = await ContentItemDisplayManager.BuildDisplayAsync(item, Model.BuildPartDisplayContext.Updater, Model.Settings.DisplayType ?? "Detail", Model.BuildPartDisplayContext.GroupId);
+        var itemContent = await ContentItemDisplayManager.BuildDisplayAsync(item, Model.BuildPartDisplayContext.Updater, Model.Settings.DisplayType ?? "Summary", Model.BuildPartDisplayContext.GroupId);
 
         @await DisplayAsync(itemContent)
     }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPartSettings.Edit.cshtml
@@ -9,7 +9,7 @@
 <div class="form-group">
     <div class="row col-sm-6">
         <label asp-for="DisplayType">@T["Display Type"]</label>
-        <input asp-for="DisplayType" placeholder="Detail" class="form-control medium" />
-        <span class="hint">@T["The display type to use when rendering the content items. Default is Detail."]</span>
+        <input asp-for="DisplayType" placeholder="Summary" class="form-control medium" />
+        <span class="hint">@T["The display type to use when rendering the content items. Default is Summary."]</span>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.Summary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.Summary.cshtml
@@ -1,0 +1,23 @@
+<div class="@String.Join(" ", Model.Classes.ToArray())">
+    @if (Model.Header != null || Model.Meta != null)
+    {
+        <div class="widget-header">
+            @await DisplayAsync(Model.Header)
+            @if (Model.Meta != null)
+            {
+                <div class="widget-metadata">
+                    @await DisplayAsync(Model.Meta)
+                </div>
+            }
+        </div>
+    }
+    <div class="widget-body">
+        @await DisplayAsync(Model.Content)
+    </div>
+    @if (Model.Footer != null)
+    {
+        <div class="widget-footer">
+            @await DisplayAsync(Model.Footer)
+        </div>
+    }
+</div>


### PR DESCRIPTION
@deanmarcussen New PR fixes #5700 that uses summary display type instead of detail.

Added Widget_Summary template to prevent issue #4372 when changing to summary display type.
 
A different solution was started in #5904 that provides 2 new alternates:
Content_Contained
Content_Contained__[ContentType]