### PR TITLE
Fixes #5921 shape table providers

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Manifest.cs
@@ -7,6 +7,7 @@ using OrchardCore.Modules.Manifest;
     Version = "2.0.0",
     Category = "Content Management"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.ContentFields",
     Name = "Content Fields",
@@ -19,5 +20,6 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.ContentFields.Indexing.SQL",
     Name = "Content Fields Indexing (SQL)",
     Category = "Content Management",
-    Description = "Content Fields Indexing module adds database indexing for content fields."
+    Description = "Content Fields Indexing module adds database indexing for content fields.",
+    Dependencies = new[] { "OrchardCore.ContentFields" }
 )]

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Manifest.cs
@@ -8,6 +8,7 @@ using OrchardCore.Modules.Manifest;
     Description = "Provides a part that allows to localize content items.",
     Category = "Internationalization"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.ContentLocalization",
     Name = "Content Localization",
@@ -28,6 +29,6 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.ContentLocalization.Sitemaps",
     Name = "Localized Content Item Sitemaps",
     Description = "Provides support for localized content item sitemaps.",
-    Dependencies = new[] { "OrchardCore.Sitemaps" },
+    Dependencies = new[] { "OrchardCore.ContentLocalization", "OrchardCore.Sitemaps" },
     Category = "Internationalization"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Manifest.cs
@@ -8,12 +8,14 @@ using OrchardCore.Facebook;
     Version = "2.0.0",
     Category = "Facebook"
 )]
+
 [assembly: Feature(
     Id = FacebookConstants.Features.Core,
     Name = "Facebook",
     Category = "Facebook",
     Description = "Registers the core components used by the Facebook features."
 )]
+
 [assembly: Feature(
     Id = FacebookConstants.Features.Login,
     Name = "Facebook Login",

--- a/src/OrchardCore.Modules/OrchardCore.Features/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Features",
     Name = "Features",

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Forms",
     Name = "Forms",

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Manifest.cs
@@ -8,6 +8,7 @@ using OrchardCore.GitHub;
     Version = "2.0.0",
     Category = "GitHub"
 )]
+
 [assembly: Feature(
     Id = GitHubConstants.Features.GitHubAuthentication,
     Name = "GitHub Authentication",

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Lists",
     Name = "Lists",

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Media.Azure.Storage",
     Name = "Azure Media Storage",

--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Media",
     Name = "Media",

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/MIcrosoftAuthenticationConstants.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/MIcrosoftAuthenticationConstants.cs
@@ -4,7 +4,6 @@ namespace OrchardCore.Microsoft.Authentication
     {
         public static class Features
         {
-            public const string MicrosoftAuthentication = "OrchardCore.Microsoft.Authentication";
             public const string MicrosoftAccount = "OrchardCore.Microsoft.Authentication.MicrosoftAccount";
             public const string AAD = "OrchardCore.Microsoft.Authentication.AzureAD";
         }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/MIcrosoftAuthenticationConstants.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/MIcrosoftAuthenticationConstants.cs
@@ -4,6 +4,7 @@ namespace OrchardCore.Microsoft.Authentication
     {
         public static class Features
         {
+            public const string MicrosoftAuthentication = "OrchardCore.Microsoft.Authentication";
             public const string MicrosoftAccount = "OrchardCore.Microsoft.Authentication.MicrosoftAccount";
             public const string AAD = "OrchardCore.Microsoft.Authentication.AzureAD";
         }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Manifest.cs
@@ -10,9 +10,17 @@ using OrchardCore.Microsoft.Authentication;
 )]
 
 [assembly: Feature(
+    Id = MicrosoftAuthenticationConstants.Features.MicrosoftAuthentication,
+    Name = "Microsoft Authentication",
+    Category = "Microsoft Authentication",
+    Description = "Manages Microsoft Authentication settings."
+)]
+
+[assembly: Feature(
     Id = MicrosoftAuthenticationConstants.Features.MicrosoftAccount,
     Name = "Microsoft Account Authentication",
     Category = "Microsoft Authentication",
+    Dependencies = new[] { MicrosoftAuthenticationConstants.Features.MicrosoftAuthentication },
     Description = "Authenticates users with their Microsoft Account."
 )]
 
@@ -20,5 +28,6 @@ using OrchardCore.Microsoft.Authentication;
     Id = MicrosoftAuthenticationConstants.Features.AAD,
     Name = "Microsoft Azure Active Directory Authentication",
     Category = "Microsoft Authentication",
+    Dependencies = new[] { MicrosoftAuthenticationConstants.Features.MicrosoftAuthentication },
     Description = "Authenticates users with their Azure Active Directory Account."
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Manifest.cs
@@ -10,17 +10,9 @@ using OrchardCore.Microsoft.Authentication;
 )]
 
 [assembly: Feature(
-    Id = MicrosoftAuthenticationConstants.Features.MicrosoftAuthentication,
-    Name = "Microsoft Authentication",
-    Category = "Microsoft Authentication",
-    Description = "Manages Microsoft Authentication settings."
-)]
-
-[assembly: Feature(
     Id = MicrosoftAuthenticationConstants.Features.MicrosoftAccount,
     Name = "Microsoft Account Authentication",
     Category = "Microsoft Authentication",
-    Dependencies = new[] { MicrosoftAuthenticationConstants.Features.MicrosoftAuthentication },
     Description = "Authenticates users with their Microsoft Account."
 )]
 
@@ -28,6 +20,5 @@ using OrchardCore.Microsoft.Authentication;
     Id = MicrosoftAuthenticationConstants.Features.AAD,
     Name = "Microsoft Azure Active Directory Authentication",
     Category = "Microsoft Authentication",
-    Dependencies = new[] { MicrosoftAuthenticationConstants.Features.MicrosoftAuthentication },
     Description = "Authenticates users with their Azure Active Directory Account."
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Manifest.cs
@@ -8,12 +8,14 @@ using OrchardCore.Microsoft.Authentication;
     Version = "2.0.0",
     Category = "Microsoft Authentication"
 )]
+
 [assembly: Feature(
     Id = MicrosoftAuthenticationConstants.Features.MicrosoftAccount,
     Name = "Microsoft Account Authentication",
     Category = "Microsoft Authentication",
     Description = "Authenticates users with their Microsoft Account."
 )]
+
 [assembly: Feature(
     Id = MicrosoftAuthenticationConstants.Features.AAD,
     Name = "Microsoft Azure Active Directory Authentication",

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Startup.cs
@@ -18,19 +18,13 @@ using OrchardCore.Settings;
 
 namespace OrchardCore.Microsoft.Authentication
 {
-    public class Startup : StartupBase
-    {
-        public override void ConfigureServices(IServiceCollection services)
-        {
-            services.AddScoped<IPermissionProvider, Permissions>();
-        }
-    }
-
     [Feature(MicrosoftAuthenticationConstants.Features.MicrosoftAccount)]
     public class MicrosoftAccountStartup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)
         {
+            services.TryAddEnumerable(new ServiceDescriptor(typeof(IPermissionProvider), typeof(Permissions), ServiceLifetime.Scoped));
+
             services.AddSingleton<IMicrosoftAccountService, MicrosoftAccountService>();
             services.AddScoped<IDisplayDriver<ISite>, MicrosoftAccountSettingsDisplayDriver>();
             services.AddScoped<INavigationProvider, AdminMenuMicrosoftAccount>();
@@ -52,6 +46,8 @@ namespace OrchardCore.Microsoft.Authentication
     {
         public override void ConfigureServices(IServiceCollection services)
         {
+            services.TryAddEnumerable(new ServiceDescriptor(typeof(IPermissionProvider), typeof(Permissions), ServiceLifetime.Scoped));
+
             services.AddSingleton<IAzureADService, AzureADService>();
             services.AddRecipeExecutionStep<AzureADSettingsStep>();
             services.AddScoped<IDisplayDriver<ISite>, AzureADSettingsDisplayDriver>();

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Manifest.cs
@@ -9,18 +9,18 @@ using OrchardCore.OpenId;
 )]
 
 [assembly: Feature(
+    Id = OpenIdConstants.Features.Core,
+    Name = "OpenID Core Components",
+    Category = "OpenID Connect",
+    Description = "Registers the core components used by the OpenID module."
+)]
+
+[assembly: Feature(
     Id = OpenIdConstants.Features.Client,
     Name = "OpenID Client",
     Category = "OpenID Connect",
     Description = "Authenticates users from an external OpenID Connect identity provider.",
     Dependencies = new[] { OpenIdConstants.Features.Core }
-)]
-
-[assembly: Feature(
-    Id = OpenIdConstants.Features.Core,
-    Name = "OpenID Core Components",
-    Category = "OpenID Connect",
-    Description = "Registers the core components used by the OpenID module."
 )]
 
 [assembly: Feature(

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Queries",
     Name = "Queries",

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Templates",
     Name = "Templates",

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Manifest.cs
@@ -18,6 +18,6 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.AdminTemplates",
     Name = "Admin Templates",
     Description = "The Admin Templates module provides a way to write custom admin shape templates.",
-    Dependencies = new[] { "OrchardCore.Liquid" },
+    Dependencies = new[] { "OrchardCore.Templates", "OrchardCore.Liquid" },
     Category = "Development"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Manifest.cs
@@ -8,16 +8,18 @@ using OrchardCore.Twitter;
     Version = "2.0.0",
     Category = "Twitter"
 )]
+
 [assembly: Feature(
     Id = TwitterConstants.Features.Twitter,
     Name = "Twitter Integration",
     Category = "Twitter",
     Description = "Provides a TwitterClient and Workflow Activities to integrate with twitter"
 )]
+
 [assembly: Feature(
     Id = TwitterConstants.Features.Signin,
     Name = "Sign in with Twitter",
     Category = "Twitter",
     Description = "Authenticates users with their Twitter Account.",
-    Dependencies = new[] { "OrchardCore.Twitter" }
+    Dependencies = new[] { TwitterConstants.Features.Twitter }
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Users/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Manifest.cs
@@ -6,12 +6,14 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Users",
     Name = "Users",
     Description = "The users module enables authentication UI and user management.",
     Category = "Security"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Users.ChangeEmail",
     Name = "Users Change Email",

--- a/src/OrchardCore.Modules/OrchardCore.Users/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Manifest.cs
@@ -42,5 +42,6 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.Users.TimeZone",
     Name = "User Time Zone",
     Description = "Provides a way to set the time zone per user.",
+    Dependencies = new[] { "OrchardCore.Users" },
     Category = "Settings"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Manifest.cs
@@ -6,6 +6,7 @@ using OrchardCore.Modules.Manifest;
     Website = "https://orchardproject.net",
     Version = "2.0.0"
 )]
+
 [assembly: Feature(
     Id = "OrchardCore.Widgets",
     Name = "Widgets",

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/DefaultShapeTableManager.cs
@@ -72,11 +72,6 @@ namespace OrchardCore.DisplayManagement.Descriptors
                 {
                     var strategyFeature = _typeFeatureProvider.GetFeatureForDependency(bindingStrategy.GetType());
 
-                    if (!(bindingStrategy is IShapeTableHarvester) && excludedFeatures.Contains(strategyFeature.Id))
-                    {
-                        continue;
-                    }
-
                     var builder = new ShapeTableBuilder(strategyFeature, excludedFeatures);
                     bindingStrategy.Discover(builder);
                     var builtAlterations = builder.BuildAlterations();

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
@@ -57,12 +57,11 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
                 .ToList();
 
             var enabledFeatures = _shellFeaturesManager.GetEnabledFeaturesAsync().GetAwaiter().GetResult();
+            var enabledFeatureIds = enabledFeatures.Select(f => f.Id).ToArray();
 
-            var enabledFeaturesIds = enabledFeatures.Select(f => f.Id).ToArray();
-
-            // Filter the extensions whose templates are already associated to an excluded feature that it is still enabled.
+            // Excludes the extensions whose templates are already associated to an excluded feature that is still enabled.
             var activeExtensions = Once(enabledFeatures)
-                .Where(e => !e.Features.Any(f => builder.ExcludedFeatureIds.Contains(f.Id) && enabledFeaturesIds.Contains(f.Id)))
+                .Where(e => !e.Features.Any(f => builder.ExcludedFeatureIds.Contains(f.Id) && enabledFeatureIds.Contains(f.Id)))
                 .ToArray();
 
             if (!_viewEnginesByExtension.Any())
@@ -133,9 +132,8 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
             {
                 var hit = iter;
 
-                // The template files of a given module or theme may be used by any of its features.
-                // So, we need to associate them at least to one feature that is currently enabled.
-                var feature = hit.extensionDescriptor.Features.First(f => enabledFeaturesIds.Contains(f.Id));
+                // The template files of an active module need to be associated to one of its enabled feature.
+                var feature = hit.extensionDescriptor.Features.First(f => enabledFeatureIds.Contains(f.Id));
 
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
@@ -3,10 +3,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Extensions.Features;
 using OrchardCore.Environment.Shell;
@@ -16,7 +14,6 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
 {
     public class ShapeTemplateBindingStrategy : IShapeTableHarvester
     {
-        private readonly string _shellName;
         private readonly IEnumerable<IShapeTemplateHarvester> _harvesters;
         private readonly IEnumerable<IShapeTemplateViewEngine> _shapeTemplateViewEngines;
         private readonly IShapeTemplateFileProviderAccessor _fileProviderAccessor;
@@ -27,15 +24,12 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
             new Dictionary<string, IShapeTemplateViewEngine>(StringComparer.OrdinalIgnoreCase);
 
         public ShapeTemplateBindingStrategy(
-            ShellSettings shellSettings,
             IEnumerable<IShapeTemplateHarvester> harvesters,
             IShellFeaturesManager shellFeaturesManager,
             IEnumerable<IShapeTemplateViewEngine> shapeTemplateViewEngines,
-            IOptions<MvcViewOptions> options,
             IShapeTemplateFileProviderAccessor fileProviderAccessor,
             ILogger<DefaultShapeTableManager> logger)
         {
-            _shellName = shellSettings.Name;
             _harvesters = harvesters;
             _shellFeaturesManager = shellFeaturesManager;
             _shapeTemplateViewEngines = shapeTemplateViewEngines;
@@ -135,7 +129,7 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
             {
                 var hit = iter;
 
-                // Template files need to be associated with all features of a given module or theme.
+                // Template files need to be associated to all features of a given module or theme.
                 // So we iterate on the main feature and any other feature that doesn't depend on it.
                 // Note: For performance reasons we only check the 1st level of the dependency graph.
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateBindingStrategy.cs
@@ -133,9 +133,19 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
 
             foreach (var iter in hits)
             {
-                // templates are always associated with the namesake feature of module or theme
                 var hit = iter;
-                foreach (var feature in hit.extensionDescriptor.Features)
+
+                // Template files need to be associated with all features of a given module or theme.
+                // So we iterate on the main feature and any other feature that doesn't depend on it.
+                // Note: For performance reasons we only check the 1st level of the dependency graph.
+
+                var mainId = hit.extensionDescriptor.Features.ElementAt(0).Id;
+
+                var features = hit.extensionDescriptor.Features
+                    .Where(f => !f.Dependencies.Contains(mainId))
+                    .ToArray();
+
+                foreach (var feature in features)
                 {
                     if (_logger.IsEnabled(LogLevel.Debug))
                     {

--- a/test/OrchardCore.Tests.Modules/ModuleSample/Manifest.cs
+++ b/test/OrchardCore.Tests.Modules/ModuleSample/Manifest.cs
@@ -7,6 +7,7 @@ using OrchardCore.Modules.Manifest;
     Version = "2.0.0",
     Category = "Test"
 )]
+
 [assembly: Feature(
     Id = "Sample1",
     Name = "Sample 1",


### PR DESCRIPTION
Fixes #5921 

- So we use `excludedFeatures` to not run twice (accross tenants) the providers of a given feature. The issue is that the one that harvests template files, associate the files of a given module to all of its features (we can't tie a file to a feature). So, if one of its feature defines an `IShapeTableProvider` and is enabled afterwards, it may be already excluded and its provider not executed.

- So the fix would just be to only associate the files of a given module to its main feature (the 1st). It works and doing this i could **reduce the `ShapeTable` entries from 921 to 525**.

- But it introduces a little constraint, we can't have a feature that is not the main one (the 1st), that needs at least a template file, and that doesn't depend on the main feature meaning that the feature can be enabled without the main one enabled.

- That's okay for 90% of the module manifests but, because of the remaining 10%, here we associate the files of a given module to its main feature (the 1st) and also to all of its features that doesn't depend on it. Here we can still **reduce the `ShapeTable` entries from 921 to 638**. Note: For perf we only check the 1st level of the dependency graph.

- But this re-introduces the original issue, only for 10% of the modules and only if they define an `IShapeTableProvider`, but still a potential issue.

- So finally, here the `excludedFeatures` is no more used to filter the execution of a given shape provider. This because before the main providers (the harversters e.g of template files) was not filtered, and the other ones are much more faster. But the `excludedFeatures` are still used by the harversters themselves, this is where there is the most perf gain So there is **no significant impact, e.g only 1ms for a whole around 80ms** to build a full table. And it fixes again the original issue.

**So here we fix the issue and we reduce the `ShapeTable` entries from 921 to 638**.

Note: To reduce again the shape entries to 525, we could try to update the 10% of manifests that don't follow the new constraint. But a good example is the Templates module where we can enable the Admin Templates but not enable the main feature being the front end Templates. **Update**: Bad example as it fails if we do that, so i added the missing dependency.

Hmm, maybe i have an idea.


