### PR TITLE
Returning null in case of not finding the entry in Workflow's dictionaries

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Scripting/WorkflowMethodsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Scripting/WorkflowMethodsProvider.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.Workflows.Scripting
             _inputMethod = new GlobalMethod
             {
                 Name = "input",
-                Method = serviceProvider => (Func<string, object>)(name => workflowContext.Input[name])
+                Method = serviceProvider => (Func<string, object>)((name) => workflowContext.Input.ContainsKey(name) ? workflowContext.Input[name] : null)
             };
 
             _outputMethod = new GlobalMethod
@@ -45,7 +45,7 @@ namespace OrchardCore.Workflows.Scripting
             _propertyMethod = new GlobalMethod
             {
                 Name = "property",
-                Method = serviceProvider => (Func<string, object>)((name) => workflowContext.Properties[name])
+                Method = serviceProvider => (Func<string, object>)((name) => workflowContext.Properties.ContainsKey(name) ? workflowContext.Properties[name] : null)
             };
 
             _setPropertyMethod = new GlobalMethod


### PR DESCRIPTION
Since in Javascript, we don't have a method to check availability of an input entry or property entry, in case of not having the value in the dictionary, we got an exception. A simple solution is
returning null in case of not having the item there.