### PR TITLE
Add ability to restrict widgets within a flow part

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Models/FlowPartSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Models/FlowPartSettings.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace OrchardCore.Flows.Models
+{
+    public class FlowPartSettings
+    {
+        public string[] ContainedContentTypes { get; set; } = Array.Empty<string>();
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Settings/FlowPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Settings/FlowPartSettingsDisplayDriver.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentManagement.Metadata.Settings;
+using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Flows.Models;
+using OrchardCore.Flows.ViewModels;
+
+namespace OrchardCore.Flows.Settings
+{
+    public class FlowPartSettingsDisplayDriver : ContentTypePartDefinitionDisplayDriver
+    {
+        private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly IStringLocalizer S;
+
+        public FlowPartSettingsDisplayDriver(
+            IContentDefinitionManager contentDefinitionManager,
+            IStringLocalizer<FlowPartSettingsDisplayDriver> localizer)
+        {
+            _contentDefinitionManager = contentDefinitionManager;
+            S = localizer;
+        }
+
+        public override IDisplayResult Edit(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
+        {
+            if (!String.Equals(nameof(FlowPart), contentTypePartDefinition.PartDefinition.Name))
+            {
+                return null;
+            }
+
+            return Initialize<FlowPartSettingsViewModel>("FlowPartSettings_Edit", model =>
+            {
+                model.FlowPartSettings = contentTypePartDefinition.GetSettings<FlowPartSettings>();
+                model.ContainedContentTypes = model.FlowPartSettings.ContainedContentTypes;
+                model.ContentTypes = new NameValueCollection();
+
+                foreach (var contentTypeDefinition in _contentDefinitionManager.ListTypeDefinitions().Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget"))
+                {
+                    model.ContentTypes.Add(contentTypeDefinition.Name, contentTypeDefinition.DisplayName);
+                }
+            }).Location("Content");
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)
+        {
+            if (!String.Equals(nameof(FlowPart), contentTypePartDefinition.PartDefinition.Name))
+            {
+                return null;
+            }
+
+            var model = new FlowPartSettingsViewModel();
+
+            await context.Updater.TryUpdateModelAsync(model, Prefix, m => m.ContainedContentTypes);
+
+            context.Builder.WithSettings(new FlowPartSettings
+            {
+                ContainedContentTypes = model.ContainedContentTypes
+            });
+
+            return Edit(contentTypePartDefinition, context.Updater);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
@@ -44,6 +44,7 @@ namespace OrchardCore.Flows
             // Flow Part
             services.AddContentPart<FlowPart>()
                 .UseDisplayDriver<FlowPartDisplay>();
+            services.AddScoped<IContentTypePartDefinitionDisplayDriver, FlowPartSettingsDisplayDriver>();
 
             services.AddScoped<IContentDisplayDriver, FlowMetadataDisplay>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartEditViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartEditViewModel.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.Flows.Models;
 
@@ -20,5 +22,8 @@ namespace OrchardCore.Flows.ViewModels
 
         [BindNever]
         public IUpdateModel Updater { get; set; }
+
+        [BindNever]
+        public IEnumerable<ContentTypeDefinition> ContainedContentTypeDefinitions { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartSettingsViewModel.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Specialized;
+using OrchardCore.Flows.Models;
+
+namespace OrchardCore.Flows.ViewModels
+{
+    public class FlowPartSettingsViewModel
+    {
+        public FlowPartSettings FlowPartSettings { get; set; }
+        public NameValueCollection ContentTypes { get; set; }
+        public string[] ContainedContentTypes { get; set; } = Array.Empty<string>();
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -1,5 +1,4 @@
 @using OrchardCore.ContentManagement;
-@using OrchardCore.ContentManagement.Metadata.Settings;
 @using OrchardCore.Flows.Models;
 @using OrchardCore.Flows.ViewModels;
 @using OrchardCore.Mvc.Utilities;
@@ -7,11 +6,10 @@
 @model FlowPartEditViewModel
 
 @inject IContentManager ContentManager
-@inject OrchardCore.ContentManagement.Metadata.IContentDefinitionManager ContentDefinitionManager
 @inject OrchardCore.ContentManagement.Display.IContentItemDisplayManager ContentItemDisplayManager
 
 @{
-    var widgetContentTypes = ContentDefinitionManager.ListTypeDefinitions().Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
+    var widgetContentTypes = Model.ContainedContentTypeDefinitions;
     var widgetTemplatePlaceholderId = Html.Id("widgetTemplatePlaceholder");
     var parentContentType = Model.FlowPart.ContentItem.ContentType;
     string partName = ((dynamic)Model).Metadata.Name;

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPartSettings.Edit.cshtml
@@ -1,0 +1,7 @@
+@model OrchardCore.Flows.ViewModels.FlowPartSettingsViewModel
+
+<div class="form-group">
+    <label asp-for="ContainedContentTypes">@T["Restrict Content Types"]</label>
+    <span class="hint">@T["The content types that this flow can contain."]</span>
+    @await Component.InvokeAsync("SelectContentTypes", new { selectedContentTypes = Model.ContainedContentTypes, htmlName = Html.NameFor(m => m.ContainedContentTypes), stereotype = "Widget" })
+</div>


### PR DESCRIPTION
Add `FlowPartSettings` to give content managers the capability to restrict which widgets are available within the flow editor. If no widgets have been selected then all widgets will be available, as per the current implementation.

Implementation mimics how contained content types work within the `BagPart`.

Related to #5960.