### PR TITLE
Fixes AdminOptions resolution

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/Startup.cs
@@ -11,6 +11,7 @@ using OrchardCore.Admin.Drivers;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.Environment.Shell.Scope;
 using OrchardCore.Modules;
 using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Mvc.Routing;
@@ -69,20 +70,14 @@ namespace OrchardCore.Admin
 
     public class AdminPagesStartup : StartupBase
     {
-        private readonly AdminOptions _adminOptions;
-
-        public AdminPagesStartup(IOptions<AdminOptions> adminOptions)
-        {
-            _adminOptions = adminOptions.Value;
-        }
-
         public override int Order => 1000;
 
         public override void ConfigureServices(IServiceCollection services)
         {
             services.Configure<RazorPagesOptions>((options) =>
             {
-                options.Conventions.Add(new AdminPageRouteModelConvention(_adminOptions.AdminUrlPrefix));
+                var adminOptions = ShellScope.Services.GetRequiredService<IOptions<AdminOptions>>().Value;
+                options.Conventions.Add(new AdminPageRouteModelConvention(adminOptions.AdminUrlPrefix));
             });
         }
     }


### PR DESCRIPTION
`AdminOptions` are configured in the `OC.Admin` startup `ConfigureServices`.

    services.Configure<AdminOptions>(_configuration.GetSection("OrchardCore_Admin"));

So we can inject `IOptions<AdminOptions>` in a startup class when it is instanciated to execute its `Configure()` method, but not when created to execute its `ConfigureServices()`, here we get the default value not the one coming from the config.

So in `ConfigureServices` we can't use the following

    services.Configure<SomeOtherOptions>((options) =>
    {
        // here we can't use the injected _adminOptions
    });

So here we resolve explicitly `IOptions<AdminOptions>` in the configure delegate.
