### PR TITLE
Sort Shape.Items list

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/Shape.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/Shape.cs
@@ -25,7 +25,20 @@ namespace OrchardCore.DisplayManagement.Shapes
         public string TagName { get; set; }
         public IList<string> Classes => _classes ??= new List<string>();
         public IDictionary<string, string> Attributes => _attributes ??= new Dictionary<string, string>();
-        public IEnumerable<dynamic> Items => _items;
+        public IEnumerable<dynamic> Items
+        {
+            get
+            {
+                if (!_sorted)
+                {
+                    _items.Sort(FlatPositionComparer.Instance);
+                    _sorted = true;
+                }
+
+                return _items;
+            }
+        }
+
         public bool HasItems => _items.Count > 0;
 
         public string Position


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5967

Sort it when accessing through `Shape.Items` as well as when just enumerating `Shape`