### PR TITLE
Move HeadMeta section

### DIFF
--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{{ "PageTitle" | shape_new | shape_stringify }}</title>
-    {% render_section "HeadMeta", required: false %}
     {% resources type: "Meta" %}
     <link type="image/x-icon" rel="shortcut icon" href="/TheAgencyTheme/favicon.ico">
 
@@ -37,7 +36,7 @@
     {% resources type: "HeadScript" %}
     {% resources type: "HeadLink" %}
     {% resources type: "Stylesheet" %}
-
+    {% render_section "HeadMeta", required: false %}
 </head>
 <body id="page-top" dir="{{ Culture.Dir }}">
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{{ "PageTitle" | shape_new | shape_stringify }}</title>
-    {% render_section "HeadMeta", required: false %}
     {% resources type: "Meta" %}
     <link type="image/x-icon" rel="shortcut icon" href="/TheBlogTheme/favicon.ico">
 
@@ -33,6 +32,7 @@
     {% resources type: "HeadScript" %}
     {% resources type: "HeadLink" %}
     {% resources type: "Stylesheet" %}
+    {% render_section "HeadMeta", required: false %}
 </head>
 <body dir="{{ Culture.Dir }}">
     <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="mainNav">

--- a/src/OrchardCore.Themes/TheComingSoonTheme/Views/layout.liquid
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/Views/layout.liquid
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{{ "PageTitle" | shape_new | shape_stringify }}</title> 
-    {% render_section "HeadMeta", required:false %}
     {% resources type: "Meta" %}
     <link type="image/x-icon" rel="shortcut icon" href="/TheComingSoonTheme/favicon.ico">
 
@@ -21,6 +20,7 @@
     {% resources type: "HeadLink" %}
     {% resources type: "Stylesheet" %}
     {% resources type: "HeadScript" %}
+    {% render_section "HeadMeta", required:false %}
   </head>
   <body dir={{ Culture.Dir }}>
     <div class="overlay"></div>

--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -1,10 +1,9 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="@Orchard.CultureName()">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@RenderTitleSegments(Site.SiteName, "before")</title>
-    @await RenderSectionAsync("HeadMeta", required: false)
     <link type="image/x-icon" rel="shortcut icon" href="/TheTheme/favicon.ico">
     <script asp-name="bootstrap" version="4" at="Foot"></script>
     <style asp-name="thetheme-bootstrap-oc" version="1"></style>
@@ -14,6 +13,7 @@
     <resources type="HeadLink" />
     <resources type="Stylesheet" />
     <resources type="HeadScript" />
+    @await RenderSectionAsync("HeadMeta", required: false)
 </head>
 <body dir="@Orchard.CultureDir()">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">


### PR DESCRIPTION
> {% render_section "HeadMeta", required: false %} should be the last line just before </head> as in Admin and must be after all {% resources type: "XXX" %} entries

https://github.com/OrchardCMS/OrchardCore/pull/5852#issuecomment-616291880

/cc @ns8482e 