### PR TITLE
Use SessionHelper for saving

### DIFF
--- a/src/OrchardCore/OrchardCore.Data.Abstractions/ISessionHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/ISessionHelper.cs
@@ -24,5 +24,15 @@ namespace OrchardCore.Data
         /// <param name="factory">A factory method to get or create a document for caching.</param>
         /// <returns></returns>
         Task<T> GetForCachingAsync<T>(Func<T> factory = null) where T : class, new();
+
+        /// <summary>
+        /// Saves the provided entity to the ambient session.
+        /// </summary>
+        void Save(object entity, bool checkConcurrency = false);
+
+        /// <summary>
+        /// Commits the ambient session.
+        /// </summary>
+        Task CommitAsync();
     }
 }

--- a/src/OrchardCore/OrchardCore.Data/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data/OrchardCoreBuilderExtensions.cs
@@ -115,7 +115,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     ShellScope.RegisterBeforeDispose(scope =>
                     {
-                        return session.CommitAsync();
+                        return scope.ServiceProvider
+                            .GetRequiredService<ISessionHelper>()
+                            .CommitAsync();
                     });
 
                     return session;

--- a/src/OrchardCore/OrchardCore.Data/SessionHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data/SessionHelper.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.Data
         private readonly ISession _session;
 
         private readonly Dictionary<Type, object> _loaded = new Dictionary<Type, object>();
+        private readonly HashSet<object> _saved = new HashSet<object>();
 
         /// <summary>
         /// Creates a new instance of <see cref="SessionHelper"/>.
@@ -55,6 +56,27 @@ namespace OrchardCore.Data
             }
 
             return factory?.Invoke() ?? new T();
+        }
+
+        public void Save(object entity, bool checkConcurrency = false)
+        {
+            _session.Save(entity);
+            _saved.Add(entity);
+        }
+
+        public Task CommitAsync()
+        {
+            if (_session == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            foreach(var entity in _saved)
+            {
+                _session.Save(entity);
+            }
+
+            return _session.CommitAsync();
         }
     }
 }


### PR DESCRIPTION
Fixes #6008, see my comments in the related issue

- So in the content manager we may need to call a session save before an handler so that it can retrieve the related item with a session query. But we also may need to call the session save after if an handler does a session query and also another mutation on the related item.

- So here the idea is to use the `ISessionHelper` to save items and commit the session, an item being saved to the session immediately and also cached so that it can be saved again before committing. This way we can always do `_sessionHelper.Save()` before the handlers.

- But part of the issue may be only related to Workflows (see below). So, as i assume that we will never have `ContentXXXingEvent` activities, only `ContentXXXedEvent` ones, here right now we call `_sessionHelper.Save()` between the "XXXing" and "XXXed" handlers (as mostly done before).

---

- **That said part of the issue may be only related to Workflow Content events / tasks**. I think that handlers are not intended to use the `ContentManager` that calls them, but for a Content event, this is a content handler that triggers the event, here meaning that it executes the related WF(s) activities that may use the `ContentManager` that may call handlers that may trigger WF(s).

- Also normally handlers use a context e.g `CreateContentContext` to retrieve the related item(s). When a WF Content event is triggered this context is not passed but the related content item is passed, so maybe some Content activities would have to retrieve this content item from the worflow context, this in place of using the `ContentManager` to retrieve it and also to upate it.

- Hmm, ATM my feeling is that when a WF is not triggered by a Content event, e.g a Request event, it can use Content activities **to behave e.g as a controller**. But when a WF is triggered by a Content event **it would have to behave as a content handler**.

Need to sleep, i will think about it tomorrow ;)


