### PR TITLE
Set max width on activity/task span

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Assets/Styles/workflow-canvas.scss
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Assets/Styles/workflow-canvas.scss
@@ -68,6 +68,14 @@
                 }
             }
         }
+        
+        span {
+            display: inline-block;
+            max-width: 300px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 
     .jtk-connector {


### PR DESCRIPTION
Just some style updates to the activity block to prevent them from becoming super long (as seen below)

![image](https://user-images.githubusercontent.com/6050438/80213779-fc289f80-8639-11ea-8206-818673c8e564.png)

Now it looks like this 

![image](https://user-images.githubusercontent.com/6050438/80213922-3c881d80-863a-11ea-9428-ff63d379de5a.png)
