### PR TITLE
Fix null error when rendering html part in flow editor

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
@@ -23,12 +23,14 @@
 <script at="Foot">
     $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
-        var editor = CodeMirror.fromTextArea(optionsTextArea, {
-            autoRefresh: true,
-            lineNumbers: false,
-            lineWrapping: true,
-            matchBrackets: true,
-            mode: { name: "htmlmixed" }
-        });
+        if (optionsTextArea) {
+            var editor = CodeMirror.fromTextArea(optionsTextArea, {
+                autoRefresh: true,
+                lineNumbers: false,
+                lineWrapping: true,
+                matchBrackets: true,
+                mode: { name: "htmlmixed" }
+            });
+        }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
@@ -23,6 +23,7 @@
 <script at="Foot">
     $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
+        // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (optionsTextArea) {
             var editor = CodeMirror.fromTextArea(optionsTextArea, {
                 autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
@@ -23,12 +23,14 @@
 <script at="Foot">
     $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Text)');
-        var editor = CodeMirror.fromTextArea(optionsTextArea, {
-            autoRefresh: true,
-            lineNumbers: false,
-            lineWrapping: true,
-            matchBrackets: true,
-            mode: { name: "htmlmixed" }
-        });
+        if (optionsTextArea) {
+            var editor = CodeMirror.fromTextArea(optionsTextArea, {
+                autoRefresh: true,
+                lineNumbers: false,
+                lineWrapping: true,
+                matchBrackets: true,
+                mode: { name: "htmlmixed" }
+            });
+        }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
@@ -23,6 +23,7 @@
 <script at="Foot">
     $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Text)');
+        // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (optionsTextArea) {
             var editor = CodeMirror.fromTextArea(optionsTextArea, {
                 autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart.Edit.cshtml
@@ -25,6 +25,7 @@
 <script at="Foot">
     $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
+        // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (optionsTextArea) {
             var editor = CodeMirror.fromTextArea(optionsTextArea, {
                 autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart.Edit.cshtml
@@ -25,12 +25,14 @@
 <script at="Foot">
     $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
-        var editor = CodeMirror.fromTextArea(optionsTextArea, {
-            autoRefresh: true,
-            lineNumbers: false,
-            lineWrapping: true,
-            matchBrackets: true,
-            mode: { name: "htmlmixed" }
-        });
+        if (optionsTextArea) {
+            var editor = CodeMirror.fromTextArea(optionsTextArea, {
+                autoRefresh: true,
+                lineNumbers: false,
+                lineWrapping: true,
+                matchBrackets: true,
+                mode: { name: "htmlmixed" }
+            });
+        }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
@@ -20,21 +20,24 @@
 
 <script at="Foot">
     $(function () {
-        var simplemde = new SimpleMDE({
-            element: document.getElementById("@Html.IdFor(m => m.Markdown)"),
-            forceSync: true,
-            toolbar: simplemdeToolbar,
-            autoDownloadFontAwesome: false
-        });
+        var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
+        if (markdownElement) {
+            var simplemde = new SimpleMDE({
+                element: document.getElementById("@Html.IdFor(m => m.Markdown)"),
+                forceSync: true,
+                toolbar: simplemdeToolbar,
+                autoDownloadFontAwesome: false
+            });
 
-        simplemde.codemirror.on('change', function () {
-            $(document).trigger('contentpreview:render');
-        });
+            simplemde.codemirror.on('change', function () {
+                $(document).trigger('contentpreview:render');
+            });
 
-        @if(culture.IsRightToLeft())
-        {
-            <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
-$('.CodeMirror').attr('style', 'text-align:right');</text>
+            @if(culture.IsRightToLeft())
+            {
+                <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
+                $('.CodeMirror').attr('style', 'text-align:right');</text>
+            }
         }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
@@ -21,9 +21,10 @@
 <script at="Foot">
     $(function () {
         var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
+        // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (markdownElement) {
             var simplemde = new SimpleMDE({
-                element: document.getElementById("@Html.IdFor(m => m.Markdown)"),
+                element: markdownElement,
                 forceSync: true,
                 toolbar: simplemdeToolbar,
                 autoDownloadFontAwesome: false

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -22,21 +22,24 @@
 
 <script at="Foot">
     $(function () {
-        var simplemde = new SimpleMDE({
-            element: document.getElementById("@Html.IdFor(m => m.Markdown)"),
-            forceSync: true,
-            toolbar: simplemdeToolbar,
-            autoDownloadFontAwesome: false
-        });
+        var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
+        if (markdownElement) {
+            var simplemde = new SimpleMDE({
+                element: document.getElementById("@Html.IdFor(m => m.Markdown)"),
+                forceSync: true,
+                toolbar: simplemdeToolbar,
+                autoDownloadFontAwesome: false
+            });
 
-        simplemde.codemirror.on('change', function () {
-            $(document).trigger('contentpreview:render');
-        });
+            simplemde.codemirror.on('change', function () {
+                $(document).trigger('contentpreview:render');
+            });
 
-        @if(culture.IsRightToLeft())
-        {
-            <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
-$('.CodeMirror').attr('style', 'text-align:right');</text>
+            @if(culture.IsRightToLeft())
+            {
+                <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
+                $('.CodeMirror').attr('style', 'text-align:right');</text>
+            }
         }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -23,9 +23,10 @@
 <script at="Foot">
     $(function () {
         var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
+        // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist. 
         if (markdownElement) {
             var simplemde = new SimpleMDE({
-                element: document.getElementById("@Html.IdFor(m => m.Markdown)"),
+                element: markdownElement,
                 forceSync: true,
                 toolbar: simplemdeToolbar,
                 autoDownloadFontAwesome: false


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6013

Because the Flow editor renders shapes for items to get the scripts injected, when the script is intended to work with an elements id from the shape, that isn't rendered to html, there is a javascript error in the browser console.

@ns8482e I think I got all the places where this is done, if I've missed any, and you see the error again refer back to this
