### PR TITLE
Fixing the file naming convention - Edit.cshtml not Editor.cshtml

### DIFF
--- a/src/docs/reference/modules/Html/README.md
+++ b/src/docs/reference/modules/Html/README.md
@@ -68,7 +68,7 @@ Sample content:
 
 #### HTML Editor
 
-To define what HTML to render when the editor is selected from the settings, a shape named `HtmlBody_Editor__{Name}` corresponding to a file `Body-{Name}.Editor.cshtml` can be created.
+To define what HTML to render when the editor is selected from the settings, a shape named `HtmlBody_Edit__{Name}` corresponding to a file `Body-{Name}.Edit.cshtml` can be created.
 
 Sample content:
 
@@ -86,8 +86,8 @@ Sample content:
 ### Overriding the predefined editors
 
 You can override the HTML editor for the `Default` editor by creating a shape file named  
-`HtmlBody.Editor.cshtml`. The Wysiwyg editor is defined by using the file named  
-`HtmlBody-Wysiwyg.Editor.cshtml`.
+`HtmlBody.Edit.cshtml`. The Wysiwyg editor is defined by using the file named  
+`HtmlBody-Wysiwyg.Edit.cshtml`.
 
 ## CREDITS
 

--- a/src/docs/reference/modules/Html/README.md
+++ b/src/docs/reference/modules/Html/README.md
@@ -54,8 +54,8 @@ render the actual HTML for the editor.
 
 #### Declaration
 
-To declare a new editor, create a shape named `HtmlBody_Option__{Name}` where `{Name}` is a value 
-of your choosing. This will be represented by a file named `HtmlBody-{Name}.Option.cshtml`.
+To declare a new editor, create a shape named `HtmlBodyPart_Option__{Name}` where `{Name}` is a value 
+of your choosing. This will be represented by a file named `HtmlBodyPart-{Name}.Option.cshtml`.
 
 Sample content:
 
@@ -68,7 +68,7 @@ Sample content:
 
 #### HTML Editor
 
-To define what HTML to render when the editor is selected from the settings, a shape named `HtmlBody_Edit__{Name}` corresponding to a file `Body-{Name}.Edit.cshtml` can be created.
+To define what HTML to render when the editor is selected from the settings, a shape named `HtmlBodyPart_Edit__{Name}` corresponding to a file `HtmlBodyPart-{Name}.Edit.cshtml` can be created.
 
 Sample content:
 
@@ -86,8 +86,8 @@ Sample content:
 ### Overriding the predefined editors
 
 You can override the HTML editor for the `Default` editor by creating a shape file named  
-`HtmlBody.Edit.cshtml`. The Wysiwyg editor is defined by using the file named  
-`HtmlBody-Wysiwyg.Edit.cshtml`.
+`HtmlBodyPart.Edit.cshtml`. The Wysiwyg editor is defined by using the file named  
+`HtmlBodyPart-Wysiwyg.Edit.cshtml`.
 
 ## CREDITS
 


### PR DESCRIPTION
Looking at the source, and having just run through an example, looks like editor templates should end it `.Edit.cshtml` not `.Editor.cshtml`