### PR TITLE
Validate consecutive slashes in autoroute path

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Drivers/AutoroutePartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Drivers/AutoroutePartDisplay.cs
@@ -126,10 +126,10 @@ namespace OrchardCore.Autoroute.Drivers
                 updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), S["Your permalink can't be set to the homepage, please use the homepage option instead."]);
             }
 
-            if (autoroute.Path?.IndexOfAny(InvalidCharactersForPath) > -1 || autoroute.Path?.IndexOf(' ') > -1)
+            if (autoroute.Path?.IndexOfAny(InvalidCharactersForPath) > -1 || autoroute.Path?.IndexOf(' ') > -1 || autoroute.Path?.IndexOf("//") > -1)
             {
                 var invalidCharactersForMessage = string.Join(", ", InvalidCharactersForPath.Select(c => $"\"{c}\""));
-                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), S["Please do not use any of the following characters in your permalink: {0}. No spaces are allowed (please use dashes or underscores instead).", invalidCharactersForMessage]);
+                updater.ModelState.AddModelError(Prefix, nameof(autoroute.Path), S["Please do not use any of the following characters in your permalink: {0}. No spaces are allowed, or consecutive slashes (please use dashes or underscores instead).", invalidCharactersForMessage]);
             }
 
             if (autoroute.Path?.Length > MaxPathLength)

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Services/SitemapHelperService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Services/SitemapHelperService.cs
@@ -39,10 +39,10 @@ namespace OrchardCore.Sitemaps.Services
                 updater.ModelState.AddModelError(Prefix, Path, S["Your permalink can't be set to the homepage"]);
             }
 
-            if (path.IndexOfAny(InvalidCharactersForPath) > -1 || path.IndexOf(' ') > -1)
+            if (path.IndexOfAny(InvalidCharactersForPath) > -1 || path.IndexOf(' ') > -1 || path.IndexOf("//") > -1)
             {
                 var invalidCharactersForMessage = string.Join(", ", InvalidCharactersForPath.Select(c => $"\"{c}\""));
-                updater.ModelState.AddModelError(Prefix, Path, S["Please do not use any of the following characters in your permalink: {0}. No spaces are allowed (please use dashes or underscores instead).", invalidCharactersForMessage]);
+                updater.ModelState.AddModelError(Prefix, Path, S["Please do not use any of the following characters in your permalink: {0}. No spaces are allowed (please use dashes or underscores instead), or consecutive slashes.", invalidCharactersForMessage]);
             }
 
             // Precludes possibility of collision with Autoroute as Autoroute excludes . as a valid path character.


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5928

Also done for sitemap paths as well.

Note to self: Also do for new validate handler methods in recipe idempotancy