### PR TITLE
Use PrefixPosition for Admin menus

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenu.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Admin
             builder
                 .Add(S["Configuration"], design => design
                     .Add(S["Settings"], settings => settings
-                        .Add(S["Admin"], "am-" + S["Admin"], admin => admin
+                        .Add(S["Admin"], S["Admin"].PrefixPosition(), admin => admin
                         .AddClass("admin").Id("admin")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = AdminSiteSettingsDisplayDriver.GroupId })
                             .Permission(PermissionsAdminSettings.ManageAdminSettings)

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminMenu.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.AdminMenu
 
             // Configuration and settings menus for the AdminMenu module
             builder.Add(S["Configuration"], configuration => configuration
-                    .Add(S["Admin Menus"], "am-" + S["Admin Menus"], admt => admt
+                    .Add(S["Admin Menus"], S["Admin Menus"].PrefixPosition(), admt => admt
                         .Permission(Permissions.ManageAdminMenu)
                         .Action("List", "Menu", new { area = "OrchardCore.AdminMenu" })
                         .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/AdminMenu.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Apis.GraphQL
             builder
                 .Add(S["Configuration"], NavigationConstants.AdminMenuConfigurationPosition, design => design
                     .AddClass("menu-configuration").Id("configuration")
-                    .Add(S["GraphiQL"], "am-" + S["GraphiQL"], deployment => deployment
+                    .Add(S["GraphiQL"], S["GraphiQL"].PrefixPosition(), deployment => deployment
                         .Action("Index", "Admin", new { area = "OrchardCore.Apis.GraphQL" })
                         .Permission(Permissions.ExecuteGraphQL)
                         .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/AdminMenu.cs
@@ -23,8 +23,8 @@ namespace OrchardCore.BackgroundTasks
 
             builder
                 .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Tasks"], "am-" + S["Tasks"], tasks => tasks
-                        .Add(S["Background Tasks"], "am-" + S["Background Tasks"], backgroundTasks => backgroundTasks
+                    .Add(S["Tasks"], S["Tasks"].PrefixPosition(), tasks => tasks
+                        .Add(S["Background Tasks"], S["Background Tasks"].PrefixPosition(), backgroundTasks => backgroundTasks
                             .Action("Index", "BackgroundTask", new { area = "OrchardCore.BackgroundTasks" })
                             .Permission(Permissions.ManageBackgroundTasks)
                             .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.ContentLocalization
             builder
                 .Add(S["Configuration"], localization => localization
                     .Add(S["Settings"], settings => settings
-                        .Add(S["Content Culture Picker"], "am-" + S["Content Culture Picker"], registration => registration
+                        .Add(S["Content Culture Picker"], S["Content Culture Picker"].PrefixPosition(), registration => registration
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = ContentCulturePickerSettingsDriver.GroupId })
                             .Permission(Permissions.ManageContentCulturePicker)
                             .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/AdminMenu.cs
@@ -26,12 +26,12 @@ namespace OrchardCore.ContentTypes
             var adminControllerName = typeof(AdminController).ControllerName();
 
             builder.Add(S["Content"], content => content
-                .Add(S["Content Definition"], "am-" + S["Content Definition"], contentDefinition => contentDefinition
-                    .Add(S["Content Types"], "am1-" + S["Content Types"], contentTypes => contentTypes
+                .Add(S["Content Definition"], S["Content Definition"].PrefixPosition("9"), contentDefinition => contentDefinition
+                    .Add(S["Content Types"], S["Content Types"].PrefixPosition("1"), contentTypes => contentTypes
                         .Action(nameof(AdminController.List), adminControllerName, new { area = "OrchardCore.ContentTypes" })
                         .Permission(Permissions.ViewContentTypes)
                         .LocalNav())
-                    .Add(S["Content Parts"], "am2-" + S["Content Parts"], contentParts => contentParts
+                    .Add(S["Content Parts"], S["Content Parts"].PrefixPosition("2"), contentParts => contentParts
                         .Action(nameof(AdminController.ListParts), adminControllerName, new { area = "OrchardCore.ContentTypes" })
                         .Permission(Permissions.ViewContentTypes)
                         .LocalNav())

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
@@ -39,7 +39,7 @@ namespace OrchardCore.Contents
 
             builder.Add(S["Content"], NavigationConstants.AdminMenuContentPosition, content => content
                 .AddClass("content").Id("content")
-                .Add(S["Content Items"], "am-" + S["Content Items"], contentItems => contentItems
+                .Add(S["Content Items"], S["Content Items"].PrefixPosition(), contentItems => contentItems
                     .Permission(Permissions.EditOwnContent)
                     .Action(nameof(AdminController.List), typeof(AdminController).ControllerName(), new { area = "OrchardCore.Contents" })
                     .LocalNav())

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
@@ -31,7 +31,7 @@ namespace OrchardCore.CustomSettings
                 builder
                     .Add(S["Configuration"], configuration => configuration
                         .Add(S["Settings"], settings => settings
-                            .Add(new LocalizedString(type.DisplayName, type.DisplayName), layers => layers
+                            .Add(new LocalizedString(type.DisplayName, type.DisplayName), type.DisplayName.PrefixPosition(), layers => layers
                                 .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = type.Name })
                                 .Permission(Permissions.CreatePermissionForType(type))
                                 .Resource(type.Name)

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/AdminMenu.cs
@@ -24,12 +24,12 @@ namespace OrchardCore.Deployment.Remote
             builder
                 .Add(S["Configuration"], configuration => configuration
                     .Add(S["Import/Export"], import => import
-                        .Add(S["Remote Instances"], "am-" + S["Remote Instances"], remote => remote
+                        .Add(S["Remote Instances"], S["Remote Instances"].PrefixPosition(), remote => remote
                             .Action("Index", "RemoteInstance", new { area = "OrchardCore.Deployment.Remote" })
                             .Permission(Permissions.ManageRemoteInstances)
                             .LocalNav()
                         )
-                        .Add(S["Remote Clients"], "am-" + S["Remote Clients"], remote => remote
+                        .Add(S["Remote Clients"], S["Remote Clients"].PrefixPosition(), remote => remote
                             .Action("Index", "RemoteClient", new { area = "OrchardCore.Deployment.Remote" })
                             .Permission(Permissions.ManageRemoteClients)
                             .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/AdminMenu.cs
@@ -23,13 +23,13 @@ namespace OrchardCore.Deployment
 
             builder
                 .Add(S["Configuration"], configuration => configuration
-                    .Add(S["Import/Export"], "am-" + S["Import/Export"], import => import
-                        .Add(S["Deployment Plans"], "am-" + S["Deployment Plans"], deployment => deployment
+                    .Add(S["Import/Export"], S["Import/Export"].PrefixPosition(), import => import
+                        .Add(S["Deployment Plans"], S["Deployment Plans"].PrefixPosition(), deployment => deployment
                             .Action("Index", "DeploymentPlan", new { area = "OrchardCore.Deployment" })
                             .Permission(Permissions.Export)
                             .LocalNav()
                         )
-                        .Add(S["Package Import"], "am-" + S["Package Import"], deployment => deployment
+                        .Add(S["Package Import"], S["Package Import"].PrefixPosition(), deployment => deployment
                             .Action("Index", "Import", new { area = "OrchardCore.Deployment" })
                             .Permission(Permissions.Import)
                             .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Email
             builder
                 .Add(S["Configuration"], configuration => configuration
                     .Add(S["Settings"], settings => settings
-                       .Add(S["Smtp"], "am-" + S["Smtp"], entry => entry
+                       .Add(S["Smtp"], S["Smtp"].PrefixPosition(), entry => entry
                        .AddClass("email").Id("email")
                           .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = SmtpSettingsDisplayDriver.GroupId })
                           .Permission(Permissions.ManageEmailSettings)

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/NavigationItemText-email.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/NavigationItemText-email.Id.cshtml
@@ -1,1 +1,1 @@
-<span class="icon"><i class="fa fa-envelope" aria-hidden="true"></i></span><span class="title">@T["Email"]</span>
+<span class="icon"><i class="fa fa-envelope" aria-hidden="true"></i></span><span class="title">@T["Smtp"]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenu.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Facebook
             {
                 builder.Add(S["Configuration"], configuration => configuration
                         .Add(S["Settings"], settings => settings
-                            .Add(S["Facebook App"], "am-" + S["Facebook App"], settings => settings
+                            .Add(S["Facebook App"], S["Facebook App"].PrefixPosition(), settings => settings
                             .AddClass("facebookApp").Id("facebookApp")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = FacebookConstants.Features.Core })
                             .Permission(Permissions.ManageFacebookApp)
@@ -58,7 +58,7 @@ namespace OrchardCore.Facebook
             {
                 builder.Add(S["Security"], security => security
                         .Add(S["Authentication"], authentication => authentication
-                        .Add(S["Facebook"], "am-" + S["Facebook"], settings => settings
+                        .Add(S["Facebook"], S["Facebook"].PrefixPosition(), settings => settings
                         .AddClass("facebook").Id("facebook")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = FacebookConstants.Features.Login })
                             .Permission(Permissions.ManageFacebookApp)

--- a/src/OrchardCore.Modules/OrchardCore.Features/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/AdminMenu.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Features
             builder
                 .Add(S["Configuration"], NavigationConstants.AdminMenuConfigurationPosition, configuration => configuration
                     .AddClass("menu-configuration").Id("configuration")
-                    .Add(S["Features"], "am-" + S["Features"], deployment => deployment
+                    .Add(S["Features"], S["Features"].PrefixPosition(), deployment => deployment
                         .Action("Features", "Admin", new { area = "OrchardCore.Features" })
                         .Permission(Permissions.ManageFeatures)
                         .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/AdminMenu.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.GitHub
             {
                 builder.Add(S["Security"], security => security
                         .Add(S["Authentication"], authentication => authentication
-                        .Add(S["GitHub"], "am-" + S["GitHub"], settings => settings
+                        .Add(S["GitHub"], S["GitHub"].PrefixPosition(), settings => settings
                         .AddClass("github").Id("github")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = GitHubConstants.Features.GitHubAuthentication })
                             .Permission(Permissions.ManageGitHubAuthentication)

--- a/src/OrchardCore.Modules/OrchardCore.Google/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/AdminMenu.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Google
             {
                 builder.Add(S["Security"], security => security
                         .Add(S["Authentication"], authentication => authentication
-                        .Add(S["Google"], "am-" + S["Google"], settings => settings
+                        .Add(S["Google"], S["Google"].PrefixPosition(), settings => settings
                         .AddClass("google").Id("google")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = GoogleConstants.Features.GoogleAuthentication })
                             .Permission(Permissions.ManageGoogleAuthentication)
@@ -54,7 +54,7 @@ namespace OrchardCore.Google
             {
                 builder.Add(S["Configuration"], configuration => configuration
                         .Add(S["Settings"], settings => settings
-                            .Add(S["Google Analytics"], "am-" + S["Google Analytics"], settings => settings
+                            .Add(S["Google Analytics"], S["Google Analytics"].PrefixPosition(), settings => settings
                             .AddClass("googleAnalytics").Id("googleAnalytics")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = GoogleConstants.Features.GoogleAnalytics })
                                 .Permission(Permissions.ManageGoogleAnalytics)

--- a/src/OrchardCore.Modules/OrchardCore.Https/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Https/AdminMenu.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Https
             builder
                 .Add(S["Security"], security => security
                     .Add(S["Settings"], settings => settings
-                        .Add(S["HTTPS"], "am-" + S["HTTPS"], entry => entry
+                        .Add(S["HTTPS"], S["HTTPS"].PrefixPosition(), entry => entry
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "Https" })
                             .Permission(Permissions.ManageHttps)
                             .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
@@ -25,12 +25,12 @@ namespace OrchardCore.Layers
             builder
                 .Add(S["Design"], design => design
                     .Add(S["Settings"], settings => settings
-                        .Add(S["Zones"], "am-" + S["Zones"], zones => zones
+                        .Add(S["Zones"], S["Zones"].PrefixPosition(), zones => zones
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = LayerSiteSettingsDisplayDriver.GroupId })
                             .Permission(Permissions.ManageLayers)
                             .LocalNav()
                         ))
-                    .Add(S["Widgets"], "am-" + S["Widgets"], widgets => widgets
+                    .Add(S["Widgets"], S["Widgets"].PrefixPosition(), widgets => widgets
                         .Permission(Permissions.ManageLayers)
                         .Action("Index", "Admin", new { area = "OrchardCore.Layers" })
                         .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Localization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/AdminMenu.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Localization
                 builder
                     .Add(S["Configuration"], NavigationConstants.AdminMenuConfigurationPosition, localization => localization
                         .Add(S["Settings"], settings => settings
-                            .Add(S["Cultures"], "am-" + S["Cultures"], entry => entry
+                            .Add(S["Cultures"], S["Cultures"].PrefixPosition(), entry => entry
                             .AddClass("cultures").Id("cultures")
                                 .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = LocalizationSettingsDisplayDriver.GroupId })
                                 .Permission(Permissions.ManageCultures)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/AdminMenu.cs
@@ -24,17 +24,17 @@ namespace OrchardCore.Lucene
             builder
                 .Add(S["Search"], NavigationConstants.AdminMenuSearchPosition, search => search
                     .AddClass("search").Id("search")
-                    .Add(S["Indexing"], "am-" + S["Indexing"], import => import
-                        .Add(S["Lucene Indices"], "am-" + S["Lucene Indices"], indexes => indexes
+                    .Add(S["Indexing"], S["Indexing"].PrefixPosition(), import => import
+                        .Add(S["Lucene Indices"], S["Lucene Indices"].PrefixPosition(), indexes => indexes
                             .Action("Index", "Admin", new { area = "OrchardCore.Lucene" })
                             .Permission(Permissions.ManageIndexes)
                             .LocalNav())
-                        .Add(S["Run Lucene Query"], "am-" + S["Run Lucene Query"], queries => queries
+                        .Add(S["Run Lucene Query"], S["Run Lucene Query"].PrefixPosition(), queries => queries
                             .Action("Query", "Admin", new { area = "OrchardCore.Lucene" })
                             .Permission(Permissions.ManageIndexes)
                             .LocalNav()))
                     .Add(S["Settings"], settings => settings
-                        .Add(S["Search"], "am-" + S["Search"], entry => entry
+                        .Add(S["Search"],S["Search"].PrefixPosition(), entry => entry
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "search" })
                             .Permission(Permissions.ManageIndexes)
                             .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Media
             builder
                 .Add(S["Content"], content => content
                     .AddClass("media").Id("media")
-                    .Add(S["Media Library"], "am-" + S["Media Library"], layers => layers
+                    .Add(S["Media Library"], S["Media Library"].PrefixPosition(), layers => layers
                         .Permission(Permissions.ManageOwnMedia)
                         .Action("Index", "Admin", new { area = "OrchardCore.Media" })
                         .LocalNav()
@@ -51,7 +51,7 @@ namespace OrchardCore.Media
             }
 
             builder.Add(S["Content"], content => content
-                .Add(S["Media Cache"], "am-" + S["Media Cache"], contentItems => contentItems
+                .Add(S["Media Cache"], S["Media Cache"].PrefixPosition(), contentItems => contentItems
                     .Action("Index", "MediaCache", new { area = "OrchardCore.Media" })
                     .Permission(MediaCachePermissions.ManageAssetCache)
                     .LocalNav())

--- a/src/OrchardCore.Modules/OrchardCore.Menu/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/AdminMenu.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Menu
             };
 
             builder.Add(S["Content"], design => design
-                    .Add(S["Menus"], "am-" + S["Menus"], menus => menus
+                    .Add(S["Menus"], S["Menus"].PrefixPosition(), menus => menus
                         .Permission(Permissions.ManageMenu)
                         .Action("List", "Admin", rvd)
                         .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenu.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Microsoft.Authentication
             {
                 builder.Add(S["Security"], security => security
                         .Add(S["Authentication"], authentication => authentication
-                        .Add(S["Microsoft"], "am-" + S["Microsoft"], client => client
+                        .Add(S["Microsoft"], S["Microsoft"].PrefixPosition(), client => client
                         .AddClass("microsoft").Id("microsoft")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = MicrosoftAuthenticationConstants.Features.MicrosoftAccount })
                             .Permission(Permissions.ManageMicrosoftAuthentication)
@@ -54,7 +54,7 @@ namespace OrchardCore.Microsoft.Authentication
             {
                 builder.Add(S["Security"], security => security
                         .Add(S["Authentication"], authentication => authentication
-                        .Add(S["Azure Active Directory"], "am-" + S["Azure Active Directory"], client => client
+                        .Add(S["Azure Active Directory"], S["Azure Active Directory"].PrefixPosition(), client => client
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = MicrosoftAuthenticationConstants.Features.AAD })
                             .Permission(Permissions.ManageMicrosoftAuthentication)
                             .LocalNav())

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/AdminMenu.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.OpenId
             }
 
             builder.Add(S["Security"], security => security
-            .Add(S["OpenID Connect"], "am-" + S["OpenID Connect"], category =>
+            .Add(S["OpenID Connect"], S["OpenID Connect"].PrefixPosition(), category =>
             {
                 category.AddClass("openid").Id("openid");
 

--- a/src/OrchardCore.Modules/OrchardCore.Queries/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/AdminMenu.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Queries
 
             builder.Add(S["Search"], NavigationConstants.AdminMenuSearchPosition, search => search
                     .AddClass("search").Id("search")
-                    .Add(S["Queries"], "am-" + S["Queries"], contentItems => contentItems
+                    .Add(S["Queries"], S["Queries"].PrefixPosition(), contentItems => contentItems
                     .Add(S["All queries"], "1", queries => queries
                         .Action("Index", "Admin", new { area = "OrchardCore.Queries" })
                         .Permission(Permissions.ManageQueries)

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/AdminMenu.cs
@@ -23,8 +23,8 @@ namespace OrchardCore.Queries.Sql
 
             builder
                 .Add(S["Search"], search => search
-                    .Add(S["Queries"], "am-" + S["Queries"], queries => queries
-                        .Add(S["Run SQL Query"], "am-" + S["Run SQL Query"], sql => sql
+                    .Add(S["Queries"], S["Queries"].PrefixPosition(), queries => queries
+                        .Add(S["Run SQL Query"],S["Run SQL Query"].PrefixPosition(), sql => sql
                             .Action("Query", "Admin", new { area = "OrchardCore.Queries" })
                             .Permission(Permissions.ManageSqlQueries)
                             .LocalNav())));

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/AdminMenu.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.ReCaptcha
             builder
                 .Add(S["Security"], security => security
                     .Add(S["Settings"], settings => settings
-                        .Add(S["reCaptcha"], "am-" + S["reCaptcha"], registration => registration
+                        .Add(S["reCaptcha"], S["reCaptcha"].PrefixPosition(), registration => registration
                             .Permission(Permissions.ManageReCaptchaSettings)
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = ReCaptchaSettingsDisplayDriver.GroupId })
                             .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/AdminMenu.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Recipes
 
             builder.Add(S["Configuration"], configuration => configuration
                 .AddClass("recipes").Id("recipes")
-                .Add(S["Recipes"], "am-" + S["Recipes"], recipes => recipes
+                .Add(S["Recipes"], S["Recipes"].PrefixPosition(), recipes => recipes
                     .Permission(StandardPermissions.SiteOwner)
                     .Action("Index", "Admin", new { area = "OrchardCore.Recipes" })
                     .LocalNav())

--- a/src/OrchardCore.Modules/OrchardCore.ReverseProxy/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReverseProxy/AdminMenu.cs
@@ -21,7 +21,7 @@ namespace OrchardCore.ReverseProxy
                 builder
                     .Add(S["Configuration"], configuration => configuration
                         .Add(S["Settings"], settings => settings
-                            .Add(S["Reverse Proxy"], "am-" + S["Reverse Proxy"], entry => entry
+                            .Add(S["Reverse Proxy"], S["Reverse Proxy"].PrefixPosition(), entry => entry
                             .AddClass("reverseproxy").Id("reverseproxy")
                                 .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "ReverseProxy" })
                                 .Permission(Permissions.ReverseProxySettings)

--- a/src/OrchardCore.Modules/OrchardCore.Roles/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/AdminMenu.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.Roles
             }
 
             builder.Add(S["Security"], security => security
-                        .Add(S["Roles"], "am-" + S["Roles"], roles => roles
+                        .Add(S["Roles"], S["Roles"].PrefixPosition(), roles => roles
                             .AddClass("roles").Id("roles")
                             .Action("Index", "Admin", "OrchardCore.Roles")
                             .Permission(Permissions.ManageRoles)

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/AdminMenu.cs
@@ -22,17 +22,17 @@ namespace OrchardCore.Sitemaps
             }
 
             builder.Add(S["Configuration"], NavigationConstants.AdminMenuConfigurationPosition, cfg => cfg
-                    .Add(S["SEO"], "am-" + S["SEO"], admt => admt
+                    .Add(S["SEO"], S["SEO"].PrefixPosition(), seo => seo
                         .Permission(Permissions.ManageSitemaps)
-                        .Add(S["Sitemaps"], "am1-" + S["Sitemaps"], sitemaps => sitemaps
+                        .Add(S["Sitemaps"], S["Sitemaps"].PrefixPosition("1"), sitemaps => sitemaps
                             .Action("List", "Admin", new { area = "OrchardCore.Sitemaps" })
                             .LocalNav()
                         )
-                        .Add(S["Sitemap Indexes"], "am2-" + S["Sitemap Indexes"], sitemaps => sitemaps
+                        .Add(S["Sitemap Indexes"], S["Sitemap Indexes"].PrefixPosition("2"), sitemaps => sitemaps
                             .Action("List", "SitemapIndex", new { area = "OrchardCore.Sitemaps" })
                             .LocalNav()
                         )
-                        .Add(S["Sitemaps Cache"], "am3-" + S["Sitemaps Cache"], sitemaps => sitemaps
+                        .Add(S["Sitemaps Cache"], S["Sitemaps Cache"].PrefixPosition("3"), sitemaps => sitemaps
                             .Action("List", "SitemapCache", new { area = "OrchardCore.Sitemaps" })
                             .LocalNav()
                         )

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenu.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.Twitter
             {
                 builder.Add(S["Security"], security => security
                         .Add(S["Authentication"], authentication => authentication
-                        .Add(S["Twitter"], "am-" + S["Twitter"], settings => settings
+                        .Add(S["Twitter"], S["Twitter"].PrefixPosition(), settings => settings
                         .AddClass("twitter").Id("twitter")
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = TwitterConstants.Features.Twitter })
                             .Permission(Permissions.ManageTwitter)
@@ -48,9 +48,9 @@ namespace OrchardCore.Twitter
             if (String.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
             {
                 builder.Add(S["Security"], security => security
-                        .Add(S["Twitter"], "am-" + S["Twitter"], settings => settings
+                        .Add(S["Twitter"], S["Twitter"].PrefixPosition(), settings => settings
                         .AddClass("twitter").Id("twitter")
-                        .Add(S["Sign in with Twitter"], "am-" + S["Sign in with Twitter"], client => client
+                        .Add(S["Sign in with Twitter"], S["Sign in with Twitter"].PrefixPosition(), client => client
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = TwitterConstants.Features.Signin })
                             .Permission(Permissions.ManageTwitterSignin)
                             .LocalNav())

--- a/src/OrchardCore.Modules/OrchardCore.Users/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/AdminMenu.cs
@@ -25,14 +25,14 @@ namespace OrchardCore.Users
 
             builder.Add(S["Security"], NavigationConstants.AdminMenuSecurityPosition, security => security
                     .AddClass("security").Id("security")
-                        .Add(S["Users"], "am-" + S["Users"], users => users
+                        .Add(S["Users"], S["Users"].PrefixPosition(), users => users
                             .AddClass("users").Id("users")
                             .Action("Index", "Admin", "OrchardCore.Users")
                             .Permission(Permissions.ManageUsers)
                             .LocalNav()
                          )
                         .Add(S["Settings"], settings => settings
-                            .Add(S["Login"], "am-" + S["Login"], login => login
+                            .Add(S["Login"], S["Login"].PrefixPosition(), login => login
                                 .Permission(Permissions.ManageUsers)
                                 .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = LoginSettingsDisplayDriver.GroupId })
                                 .LocalNav()
@@ -64,7 +64,7 @@ namespace OrchardCore.Users
             builder
                 .Add(S["Security"], security => security
                     .Add(S["Settings"], settings => settings
-                        .Add(S["Email"], "am-" + S["Email"], registration => registration
+                        .Add(S["Email"], S["Email"].PrefixPosition(), registration => registration
                             .Permission(Permissions.ManageUsers)
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = ChangeEmailSettingsDisplayDriver.GroupId })
                             .LocalNav()
@@ -94,7 +94,7 @@ namespace OrchardCore.Users
             builder
                 .Add(S["Security"], security => security
                     .Add(S["Settings"], settings => settings
-                        .Add(S["Registration"], "am-" + S["Registration"], registration => registration
+                        .Add(S["Registration"], S["Registration"].PrefixPosition(), registration => registration
                             .Permission(Permissions.ManageUsers)
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = RegistrationSettingsDisplayDriver.GroupId })
                             .LocalNav()
@@ -124,7 +124,7 @@ namespace OrchardCore.Users
             builder
                 .Add(S["Security"], security => security
                     .Add(S["Settings"], settings => settings
-                        .Add(S["Reset password"], "am-" + S["Reset password"], password => password
+                        .Add(S["Reset password"], S["Reset password"].PrefixPosition(), password => password
                             .Permission(Permissions.ManageUsers)
                             .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = ResetPasswordSettingsDisplayDriver.GroupId })
                             .LocalNav()

--- a/src/OrchardCore/OrchardCore.Navigation.Core/NavigationExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/NavigationExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Localization;
+
+namespace OrchardCore.Navigation
+{
+    public static class NavigationExtensions
+    {
+        public const string AdminMenuPositionPrefix = "am";
+        public const string Separator = "-";
+
+        public static string PrefixPosition(this string position, string sublevel = "", string prefix = AdminMenuPositionPrefix, string separator = Separator)
+        {
+            return prefix + sublevel + separator + position;
+        }
+
+        public static string PrefixPosition(this LocalizedString position, string sublevel = "", string prefix = AdminMenuPositionPrefix, string separator = Separator)
+        {
+            return position.ToString().PrefixPosition(sublevel, prefix, separator);
+        }
+    }
+}


### PR DESCRIPTION
Add `PrefixPosition` extension method and use it to generate the positions in admin menus.

Ex:
`.Add(S["Admin"], S["Admin"].PrefixPosition(), admin => admin`

Ex with sublevels menus:

>             builder.Add(S["Content"], content => content
>                 .Add(S["Content Definition"], S["Content Definition"].PrefixPosition("9"), contentDefinition => contentDefinition
>                     .Add(S["Content Types"], S["Content Types"].PrefixPosition("1"), contentTypes => contentTypes
>                         .Action(nameof(AdminController.List), adminControllerName, new { area = "OrchardCore.ContentTypes" })
>                         .Permission(Permissions.ViewContentTypes)
>                         .LocalNav())
>                     .Add(S["Content Parts"], S["Content Parts"].PrefixPosition("2"), contentParts => contentParts
>                         .Action(nameof(AdminController.ListParts), adminControllerName, new { area = "OrchardCore.ContentTypes" })
>                         .Permission(Permissions.ViewContentTypes)
>                         .LocalNav())
>                     ));
> 