### PR TITLE
Patch 1

### DIFF
--- a/src/docs/reference/modules/ContentFields/README.md
+++ b/src/docs/reference/modules/ContentFields/README.md
@@ -253,10 +253,10 @@ This template will need to render an `<option>` tag. Here is an example for a Wy
 <option value="Wysiwyg" selected="@(currentEditor == "Wysiwyg")">@T["Wysiwyg editor"]</option>
 ```
 
-Then you can create the editor shape by adding a file named `{FIELDTYPE}_Editor__{EDITORNAME}` which is
-represented by a template file named `{FIELDTYPE}-{EDITORNAME}.Editor.cshtml`.
+Then you can create the editor shape by adding a file named `{FIELDTYPE}_Edit__{EDITORNAME}` which is
+represented by a template file named `{FIELDTYPE}-{EDITORNAME}.Edit.cshtml`.
 
-For instance the filename for the Wysiwyg editor on the Html Field is named `HtmlField-Wysiwyg.Editor.cshtml`.
+For instance the filename for the Wysiwyg editor on the Html Field is named `HtmlField-Wysiwyg.Edit.cshtml`.
 
 ### Customising Display Driver Registration
 

--- a/src/docs/reference/modules/Markdown/README.md
+++ b/src/docs/reference/modules/Markdown/README.md
@@ -84,7 +84,7 @@ Sample content:
 #### HTML Editor
 
 To define what HTML to render when the editor is selected from the settings, a shape named 
-`Markdown_Editor__{Name}` corresponding to a file `Markdown-{Name}.Editor.cshtml` can be created.
+`Markdown_Edit__{Name}` corresponding to a file `Markdown-{Name}.Edit.cshtml` can be created.
 
 Sample content:
 
@@ -102,8 +102,8 @@ Sample content:
 ### Overriding the predefined editors
 
 You can override the HTML editor for the `Default` editor by creating a shape file named 
-`Markdown.Editor.cshtml`. The WYSIWYG editor is defined by using the file named 
-`Markdown-Wysiwyg.Editor.cshtml`.
+`Markdown.Edit.cshtml`. The WYSIWYG editor is defined by using the file named 
+`Markdown-Wysiwyg.Edit.cshtml`.
 
 ## Razor Helper
 


### PR DESCRIPTION
Found two more markdown docs that mislabeled as `.Editor.` I think this is all of them. I searched the repo source this time and found only three files that contained _Editor__. This PR contains two of them, and the other was already fixed in a previously merged PR.