### PR TITLE
Fixing typos, a lot of them (Lombiq Technologies: OCORE-20)

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,7 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <!-- This feed should not be used when shipping on Nuget. It should just be used in the dev branch while dependencies are not available on NuGet.org -->
+    <!-- This feed should not be used when shipping on NuGet. It should just be used in the dev branch while dependencies are not available on NuGet.org -->
     <!--<add key="OrchardCore" value="https://www.myget.org/F/orchardcore-dev/api/v3/index.json" />-->
   </packageSources>
   <disabledPackageSources />

--- a/src/OrchardCore.Build/OrchardCore.Commons.props
+++ b/src/OrchardCore.Build/OrchardCore.Commons.props
@@ -16,7 +16,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <LangVersion>8.0</LangVersion>
 
-    <!-- Common Nuget properties-->
+    <!-- Common NuGet properties-->
     
     <!-- This is used by GitHub Repository to find which repository should contain the package when updloaded -->
     <RepositoryUrl>https://github.com/OrchardCMS/OrchardCore</RepositoryUrl>

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Services/IAdminMenuService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Services/IAdminMenuService.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.AdminMenu
     public interface IAdminMenuService
     {
         /// <summary>
-        /// Returns all the admin menus for udpate.
+        /// Returns all the admin menus for update.
         /// </summary>
         Task<Models.AdminMenuList> LoadAdminMenuListAsync();
 

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
@@ -122,7 +122,7 @@ namespace OrchardCore.Alias.Handlers
 
             while (true)
             {
-                // Unversioned length + seperator char + version length.
+                // Unversioned length + separator char + version length.
                 var quantityCharactersToTrim = unversionedAlias.Length + 1 + version.ToString().Length - AliasPartDisplayDriver.MaxAliasLength;
                 if (quantityCharactersToTrim > 0)
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -226,7 +226,8 @@ namespace OrchardCore.Autoroute.Handlers
                         var autoroutePart = contentItem.As<AutoroutePart>();
                         if (setHomepage && autoroutePart != null && autoroutePart.SetHomepage)
                         {
-                            await SetHomeRoute(autoroutePart, homeRoute => {
+                            await SetHomeRoute(autoroutePart, homeRoute =>
+                            {
                                 homeRoute[_options.ContentItemIdKey] = containerContentItemId;
                                 homeRoute[_options.JsonPathKey] = jItem.Path;
                             });
@@ -319,7 +320,7 @@ namespace OrchardCore.Autoroute.Handlers
 
             while (true)
             {
-                // Unversioned length + seperator char + version length.
+                // Unversioned length + separator char + version length.
                 var quantityCharactersToTrim = unversionedPath.Length + 1 + version.ToString().Length - AutoroutePartDisplay.MaxPathLength;
                 if (quantityCharactersToTrim > 0)
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.Autoroute.Services
             lock (this)
             {
                 // Evict all entries related to a container item from autoroute entries.
-                // This is necesary to account for deletions, disabling of an item, or disabling routing of contained items.
+                // This is necessary to account for deletions, disabling of an item, or disabling routing of contained items.
                 foreach (var entry in entries.Where(x => String.IsNullOrEmpty(x.ContainedContentItemId)))
                 {
                     var entriesToRemove = _paths.Values.Where(x => x.ContentItemId == entry.ContentItemId && !String.IsNullOrEmpty(x.ContainedContentItemId));
@@ -72,7 +72,7 @@ namespace OrchardCore.Autoroute.Services
         public void RemoveEntries(IEnumerable<AutorouteEntry> entries)
         {
             lock (this)
-            {        
+            {
                 foreach (var entry in entries)
                 {
                     // Evict all entries related to a container item from autoroute entries.

--- a/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Email
             builder
                 .Add(S["Configuration"], configuration => configuration
                     .Add(S["Settings"], settings => settings
-                       .Add(S["SMTP"], S["SMTP"].PrefixPosition(), entry => entry
+                       .Add(S["Smtp"], S["Smtp"].PrefixPosition(), entry => entry
                        .AddClass("email").Id("email")
                           .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = SmtpSettingsDisplayDriver.GroupId })
                           .Permission(Permissions.ManageEmailSettings)

--- a/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Email
             builder
                 .Add(S["Configuration"], configuration => configuration
                     .Add(S["Settings"], settings => settings
-                       .Add(S["Smtp"], S["Smtp"].PrefixPosition(), entry => entry
+                       .Add(S["SMTP"], S["SMTP"].PrefixPosition(), entry => entry
                        .AddClass("email").Id("email")
                           .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = SmtpSettingsDisplayDriver.GroupId })
                           .Permission(Permissions.ManageEmailSettings)

--- a/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpService.cs
@@ -43,7 +43,7 @@ namespace OrchardCore.Email.Services
 
             try
             {
-                // Set the MailMessage.From, to avoid the confusion between _options.DefaultSender (Author) and submittor (Sender)
+                // Set the MailMessage.From, to avoid the confusion between _options.DefaultSender (Author) and submitter (Sender)
                 message.From = String.IsNullOrWhiteSpace(message.From)
                     ? _options.DefaultSender
                     : message.From;

--- a/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpSettingsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpSettingsConfiguration.cs
@@ -50,7 +50,7 @@ namespace OrchardCore.Email.Services
                 }
                 catch
                 {
-                    _logger.LogError("The SMTP password could not be decrypted. It may have been encrypted using a different key.");
+                    _logger.LogError("The Smtp password could not be decrypted. It may have been encrypted using a different key.");
                 }
             }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpSettingsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpSettingsConfiguration.cs
@@ -50,7 +50,7 @@ namespace OrchardCore.Email.Services
                 }
                 catch
                 {
-                    _logger.LogError("The Smtp password could not be decrypted. It may have been encrypted using a different key.");
+                    _logger.LogError("The SMTP password could not be decrypted. It may have been encrypted using a different key.");
                 }
             }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/Admin/Index.cshtml
@@ -17,7 +17,7 @@
             <label asp-for="Sender">@T["Sender"]</label>
             <input asp-for="Sender" class="form-control" type="text" />
             <span asp-validation-for="Sender"></span>
-            <span class="hint">@T["The sender is optional, it is useful when the email author is different than the email submittor."]</span>
+            <span class="hint">@T["The sender is optional, it is useful when the email author is different than the email submitter."]</span>
         </div>
     </div>
     <div class="form-group">

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/NavigationItemText-email.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/NavigationItemText-email.Id.cshtml
@@ -1,1 +1,1 @@
-<span class="icon"><i class="fa fa-envelope" aria-hidden="true"></i></span><span class="title">@T["Smtp"]</span>
+<span class="icon"><i class="fa fa-envelope" aria-hidden="true"></i></span><span class="title">@T["SMTP"]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/NavigationItemText-email.Id.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/NavigationItemText-email.Id.cshtml
@@ -1,1 +1,1 @@
-<span class="icon"><i class="fa fa-envelope" aria-hidden="true"></i></span><span class="title">@T["SMTP"]</span>
+<span class="icon"><i class="fa fa-envelope" aria-hidden="true"></i></span><span class="title">@T["Smtp"]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Login/Configuration/FacebookLoginConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Login/Configuration/FacebookLoginConfiguration.cs
@@ -86,7 +86,7 @@ namespace OrchardCore.Facebook.Login.Configuration
             }
             catch
             {
-                _logger.LogError("The Facebook secret keycould not be decrypted. It may have been encrypted using a different key.");
+                _logger.LogError("The Facebook secret key could not be decrypted. It may have been encrypted using a different key.");
             }
 
             if (loginSettings.CallbackPath.HasValue)

--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -66,7 +66,7 @@ namespace OrchardCore.Localization
             // Load tenant-specific .po file from /App_Data/Sites/[Tenant]/Localization
             yield return new PhysicalFileInfo(new FileInfo(PathExtensions.Combine(_shellDataContainer, _resourcesContainer, poFileName)));
 
-            // Load each modules .po file for extending localization when using Orchard Core as a Nuget package
+            // Load each modules .po file for extending localization when using Orchard Core as a NuGet package
             foreach (var extension in extensions)
             {
                 // \src\OrchardCore.Cms.Web\Localization\OrchardCore.Cms.Web\fr-CA.po

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Permissions.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Localization
     public class Permissions : IPermissionProvider
     {
         /// <summary>
-        /// Gets a permession for managing the cultures.
+        /// Gets a permission for managing the cultures.
         /// </summary>
         public static readonly Permission ManageCultures = new Permission("ManageCultures", "Manage supported culture");
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/AttachedMediaFieldFileService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/AttachedMediaFieldFileService.cs
@@ -66,7 +66,7 @@ namespace OrchardCore.Media.Services
             await _fileStore.TryCreateDirectoryAsync(MediaFieldsTempSubFolder);
         }
 
-        // Files just uploaded and then inmediately discarded.
+        // Files just uploaded and then immediately discarded.
         private async Task RemoveTemporaryAsync(List<EditMediaFieldItemInfo> items)
         {
             foreach (var item in items.Where(i => i.IsRemoved && i.IsNew))

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
@@ -154,7 +154,7 @@ namespace OrchardCore.Menu.Controllers
             // Look for the target menu item in the hierarchy
             JObject menuItem = FindMenuItem(menu.Content, menuItemId);
 
-            // Couldn't find targetted menu item
+            // Couldn't find targeted menu item
             if (menuItem == null)
             {
                 return NotFound();
@@ -200,7 +200,7 @@ namespace OrchardCore.Menu.Controllers
             // Look for the target menu item in the hierarchy
             JObject menuItem = FindMenuItem(menu.Content, menuItemId);
 
-            // Couldn't find targetted menu item
+            // Couldn't find targeted menu item
             if (menuItem == null)
             {
                 return NotFound();
@@ -255,7 +255,7 @@ namespace OrchardCore.Menu.Controllers
             // Look for the target menu item in the hierarchy
             var menuItem = FindMenuItem(menu.Content, menuItemId);
 
-            // Couldn't find targetted menu item
+            // Couldn't find targeted menu item
             if (menuItem == null)
             {
                 return NotFound();

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.OpenId.ViewModels
                 {
                     if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || !uri.IsWellFormedOriginalString())
                     {
-                        yield return new ValidationResult(S["{0} is not wellformed", url], new[] { memberName });
+                        yield return new ValidationResult(S["{0} is not well-formed", url], new[] { memberName });
                     }
                 }
             }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
@@ -51,7 +51,7 @@ namespace OrchardCore.OpenId.ViewModels
                 {
                     if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) || !uri.IsWellFormedOriginalString())
                     {
-                        yield return new ValidationResult(S["{0} is not wellformed", url], new[] { memberName });
+                        yield return new ValidationResult(S["{0} is not well-formed", url], new[] { memberName });
                     }
                 }
             }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
@@ -119,7 +119,7 @@
                 <ul>
                     <li>When the consent is explicit, the authorization request must be approved by the end user. <strong>This is the recommended option.</strong></li>
                     <li>When the consent is implicit, the authorization request is assumed to be pre-approved and no consent form is displayed.</li>
-                    <li>When the consent is external, the authorization request is rejected unless a pre-existing authorization (granted programatically) already exists.</li>
+                    <li>When the consent is external, the authorization request is rejected unless a pre-existing authorization (granted programmatically) already exists.</li>
                 </ul>
             </div>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
@@ -121,7 +121,7 @@
                 <ul>
                     <li>When the consent is explicit, the authorization request must be approved by the end user. <strong>This is the recommended option.</strong></li>
                     <li>When the consent is implicit, the authorization request is assumed to be pre-approved and no consent form is displayed.</li>
-                    <li>When the consent is external, the authorization request is rejected unless a pre-existing authorization (granted programatically) already exists.</li>
+                    <li>When the consent is external, the authorization request is rejected unless a pre-existing authorization (granted programmatically) already exists.</li>
                 </ul>
             </div>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/GraphQL/SqlQueryFieldTypeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/GraphQL/SqlQueryFieldTypeProvider.cs
@@ -16,7 +16,7 @@ namespace OrchardCore.Queries.Sql.GraphQL.Queries
 {
     /// <summary>
     /// This implementation of <see cref="ISchemaBuilder"/> registers
-    /// all SQL Qeries as GraphQL queries.
+    /// all SQL Queries as GraphQL queries.
     /// </summary>
     public class SqlQueryFieldTypeProvider : ISchemaBuilder
     {

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlGrammar.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlGrammar.cs
@@ -135,7 +135,7 @@ namespace OrchardCore.Queries.Sql
             betweenExpr.Rule = expression + notOpt + "BETWEEN" + expression + "AND" + expression;
             inExpr.Rule = expression + notOpt + "IN" + "(" + functionArguments + ")";
             notOpt.Rule = Empty | NOT;
-            //funCall covers some psedo-operators and special forms like ANY(...), SOME(...), ALL(...), EXISTS(...), IN(...)
+            //funCall covers some pseudo-operators and special forms like ANY(...), SOME(...), ALL(...), EXISTS(...), IN(...)
             funCall.Rule = Id + "(" + functionArguments + ")";
             functionArguments.Rule = selectStatement | expressionList | "*";
             parameter.Rule = "@" + Id | "@" + Id + ":" + term;

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Controllers/AdminController.cs
@@ -159,7 +159,7 @@ namespace OrchardCore.Taxonomies.Controllers
             // Look for the target taxonomy item in the hierarchy
             JObject taxonomyItem = FindTaxonomyItem(taxonomy.As<TaxonomyPart>().Content, taxonomyItemId);
 
-            // Couldn't find targetted taxonomy item
+            // Couldn't find targeted taxonomy item
             if (taxonomyItem == null)
             {
                 return NotFound();
@@ -207,7 +207,7 @@ namespace OrchardCore.Taxonomies.Controllers
             // Look for the target taxonomy item in the hierarchy
             JObject taxonomyItem = FindTaxonomyItem(taxonomy.As<TaxonomyPart>().Content, taxonomyItemId);
 
-            // Couldn't find targetted taxonomy item
+            // Couldn't find targeted taxonomy item
             if (taxonomyItem == null)
             {
                 return NotFound();
@@ -270,7 +270,7 @@ namespace OrchardCore.Taxonomies.Controllers
             // Look for the target taxonomy item in the hierarchy
             var taxonomyItem = FindTaxonomyItem(taxonomy.As<TaxonomyPart>().Content, taxonomyItemId);
 
-            // Couldn't find targetted taxonomy item
+            // Couldn't find targeted taxonomy item
             if (taxonomyItem == null)
             {
                 return NotFound();

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Settings/TaxonomyFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Settings/TaxonomyFieldSettings.cs
@@ -15,17 +15,17 @@ namespace OrchardCore.Taxonomies.Settings
         public string TaxonomyContentItemId { get; set; }
 
         /// <summary>
-        /// Wether the user can select only one term or not
+        /// Whether the user can select only one term or not
         /// </summary>
         public bool Unique { get; set; }
 
         /// <summary>
-        /// Wether the user can only select leaves in the taxonomy
+        /// Whether the user can only select leaves in the taxonomy
         /// </summary>
         public bool LeavesOnly { get; set; }
 
         /// <summary>
-        /// Wether the field allows the user to add new Terms to the taxonomy (similar to tags)
+        /// Whether the field allows the user to add new Terms to the taxonomy (similar to tags)
         /// </summary>
         public bool Open { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Settings/TaxonomyFieldTagsEditorSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Settings/TaxonomyFieldTagsEditorSettings.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Taxonomies.Settings
     public class TaxonomyFieldTagsEditorSettings
     {
         /// <summary>
-        /// Wether the field allows the user to add new tags to the taxonomy
+        /// Whether the field allows the user to add new tags to the taxonomy
         /// </summary>
         [DefaultValue(true)]
         public bool Open { get; set; } = true;

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TermPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TermPart.cshtml
@@ -20,6 +20,6 @@ else
 
 @await DisplayAsync(Model.Pager)
 
-@* To render the hierachy of inherited terms use the Term shape here
+@* To render the hierarchy of inherited terms use the Term shape here
     <shape type="term" TaxonomyContentItemId="@Model.TaxonomyContentItemId" TermContentItemId="@Model.TermContentItemId" />
 *@

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -62,7 +62,7 @@
             }
         });
 
-        // override default behaviour of Bootstrap's. We only hide, not remove the alert.
+        // override default behavior of Bootstrap's. We only hide, not remove the alert.
         $('#close-warning').on('click', function () {
             $('#notConnectedWarning').hide();
         });

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
@@ -134,7 +134,7 @@ namespace OrchardCore.Users.Controllers
                     }
                     catch (Exception ex)
                     {
-                        _logger.LogError(ex, "An error occured while validating DefaultExternalLogin token");
+                        _logger.LogError(ex, "An error occurred while validating DefaultExternalLogin token");
                     }
                 }
             }
@@ -404,7 +404,7 @@ namespace OrchardCore.Users.Controllers
 
                 if (user != null)
                 {
-                    // Link external login to an axisting user
+                    // Link external login to an existing user
                     ViewData["UserName"] = user.UserName;
                     ViewData["Email"] = email;
 
@@ -447,7 +447,7 @@ namespace OrchardCore.Users.Controllers
                                 ConfirmPassword = null
                             }, S["Confirm your account"], _logger);
 
-                            // If the registration was successfull we can link the external provider and redirect the user
+                            // If the registration was successful we can link the external provider and redirect the user
                             if (user != null)
                             {
                                 var identityResult = await _signInManager.UserManager.AddLoginAsync(user, new UserLoginInfo(info.LoginProvider, info.ProviderKey, info.ProviderDisplayName));

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.Fields.Edit.cshtml
@@ -1,1 +1,1 @@
-@*Override this shape if needed to include hidden fields requred for edit shape*@
+@*Override this shape if needed to include hidden fields required for edit shape*@

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.cshtml
@@ -1,7 +1,7 @@
 @inject OrchardCore.ContentManagement.Display.IContentItemDisplayManager ContentItemDisplayManager
 
 @{
-    //Set Model (Current Shape) as Child content of Outher Frame, Later this Model is used to render other shapes
+    //Set Model (Current Shape) as Child content of Outer Frame, Later this Model is used to render other shapes
     dynamic contentCardFrame = await New.ContentCard_Frame();
 
     var contentItem = Model.ContentItem;

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Builder/OrchardCoreBuilder.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Builder/OrchardCoreBuilder.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// This method gets called for each tenant. Use this method to configure the request's pipeline.
         /// </summary>
-        /// <param name="configure">The action to execute when configuring the request's pipeling for a tenant.</param>
+        /// <param name="configure">The action to execute when configuring the request's pipeline for a tenant.</param>
         /// <param name="order">The order of the action to execute. Lower values will be executed first.</param>
         public OrchardCoreBuilder Configure(Action<IApplicationBuilder, IEndpointRouteBuilder, IServiceProvider> configure, int order = 0)
         {
@@ -78,7 +78,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// This method gets called for each tenant. Use this method to configure the request's pipeline.
         /// </summary>
-        /// <param name="configure">The action to execute when configuring the request's pipeling for a tenant.</param>
+        /// <param name="configure">The action to execute when configuring the request's pipeline for a tenant.</param>
         /// <param name="order">The order of the action to execute. Lower values will be executed first.</param>
         public OrchardCoreBuilder Configure(Action<IApplicationBuilder, IEndpointRouteBuilder> configure, int order = 0)
         {
@@ -88,7 +88,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// This method gets called for each tenant. Use this method to configure the request's pipeline.
         /// </summary>
-        /// <param name="configure">The action to execute when configuring the request's pipeling for a tenant.</param>
+        /// <param name="configure">The action to execute when configuring the request's pipeline for a tenant.</param>
         /// <param name="order">The order of the action to execute. Lower values will be executed first.</param>
         public OrchardCoreBuilder Configure(Action<IApplicationBuilder> configure, int order = 0)
         {

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/FeatureAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/FeatureAttribute.cs
@@ -16,7 +16,7 @@ namespace OrchardCore.Modules
         }
 
         /// <summary>
-        /// The name of the feaure to assign the component to.
+        /// The name of the feature to assign the component to.
         /// </summary>
         public string FeatureName { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/IClock.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/IClock.cs
@@ -3,14 +3,14 @@ using System;
 namespace OrchardCore.Modules
 {
     /// <summary>
-    /// Provides the current Utc <see cref="DateTime"/>, and timezone related methods.
+    /// Provides the current UTC <see cref="DateTime"/>, and timezone related methods.
     /// This service should be used whenever the current date and time are needed, instead of <seealso cref="DateTime"/> directly.
     /// If local date time and timezones are needed use <see cref="ILocalClock" /> instead.
     /// </summary>
     public interface IClock
     {
         /// <summary>
-        /// Gets the current <see cref="DateTime"/> of the system, expressed in Utc.!--
+        /// Gets the current <see cref="DateTime"/> of the system, expressed in UTC.
         /// </summary>
         /// <remarks>
         /// A <see cref="DateTime"/> as this property is usually used to store the current date time in UTC and a <see cref="DateTimeOffset" />

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ICompositionStrategy.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ICompositionStrategy.cs
@@ -5,7 +5,7 @@ using OrchardCore.Environment.Shell.Descriptor.Models;
 namespace OrchardCore.Environment.Shell.Builders
 {
     /// <summary>
-    /// Service at the host level to transform the cachable descriptor into the loadable blueprint.
+    /// Service at the host level to transform the cacheable descriptor into the loadable blueprint.
     /// </summary>
     public interface ICompositionStrategy
     {

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/TenantState.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/TenantState.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Environment.Shell.Models
     public enum TenantState
     {
         /// <summary>
-        /// The tenant is not yet intialized.
+        /// The tenant is not yet initialized.
         /// </summary>
         Uninitialized,
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/State/ShellState.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/State/ShellState.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Environment.Shell.State
     /// <summary>
     /// Represents the transitive list of features a tenant is made of at a specific moment.
     /// It's used to differentiate new features from existing ones in order to trigger events like
-    /// Installed/Unistalled compared to only Enabled/Disabled.
+    /// Installed/Uninstalled compared to only Enabled/Disabled.
     /// </summary>
     public class ShellState
     {

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Apis
             where TObjectType : InputObjectGraphType<TObject>
         {
             // Instances are registered as singletons as their constructor holds the logic to configure the type
-            // and doesn't need to run everytime
+            // and doesn't need to run every time
             services.AddSingleton<TObjectType>();
             services.AddSingleton<InputObjectGraphType<TObject>, TObjectType>(s => s.GetRequiredService<TObjectType>());
             services.AddSingleton<IInputObjectGraphType, TObjectType>(s => s.GetRequiredService<TObjectType>());
@@ -32,7 +32,7 @@ namespace OrchardCore.Apis
             where TInputType : ObjectGraphType<TInput>
         {
             // Instances are registered as singletons as their constructor holds the logic to configure the type
-            // and doesn't need to run everytime
+            // and doesn't need to run every time
             services.AddSingleton<TInputType>();
             services.AddSingleton<ObjectGraphType<TInput>, TInputType>(s => s.GetRequiredService<TInputType>());
             services.AddSingleton<IObjectGraphType, TInputType>(s => s.GetRequiredService<TInputType>());

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/IContentLocalizationManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/IContentLocalizationManager.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.ContentLocalization
         /// <returns>List of all items matching a localizationSet</returns>
         Task<IEnumerable<ContentItem>> GetItemsForSetAsync(string localizationSet);
         /// <summary>
-        /// Get the content item that matches the localizationSet / culture combinaison
+        /// Get the content item that matches the localizationSet / culture combination
         /// </summary>
         /// <returns>ContentItem or null if not found</returns>
         Task<ContentItem> GetContentItemAsync(string localizationSet, string culture);

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentItemBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentItemBuilder.cs
@@ -3,7 +3,7 @@ using OrchardCore.ContentManagement.Metadata.Models;
 namespace OrchardCore.ContentManagement.Handlers
 {
     /// <summary>
-    /// Builds a contentitem based on its the type definition (<seealso cref="ContentTypeDefinition"/>).
+    /// Builds a content item based on its the type definition (<seealso cref="ContentTypeDefinition"/>).
     /// </summary>
     public class ContentItemBuilder
     {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Records/ContentFieldDefinitionRecord.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Records/ContentFieldDefinitionRecord.cs
@@ -1,7 +1,7 @@
 namespace OrchardCore.ContentManagement.Metadata.Records
 {
     /// <summary>
-    /// Reprensents a field name.
+    /// Represents a field name.
     /// </summary>
     public class ContentFieldDefinitionRecord
     {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Records/ContentPartFieldDefinitionRecord.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Records/ContentPartFieldDefinitionRecord.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.ContentManagement.Metadata.Records
     public class ContentPartFieldDefinitionRecord
     {
         /// <summary>
-        /// Gets or set the field name, e.g. BooleanField.
+        /// Gets or sets the field name, e.g. BooleanField.
         /// </summary>
         public string FieldName { get; set; }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentPartFieldSettings.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentPartFieldSettings.cs
@@ -8,17 +8,17 @@ namespace OrchardCore.ContentManagement.Metadata.Settings
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Gest or set the description of the part field.
+        /// Gets or sets the description of the part field.
         /// </summary>
         public string Description { get; set; }
 
         /// <summary>
-        /// Gest or set the editor of the part field.
+        /// Gets or sets the editor of the part field.
         /// </summary>
         public string Editor { get; set; }
 
         /// <summary>
-        /// Gest or set the display mode of the part field.
+        /// Gets or sets the display mode of the part field.
         /// </summary>
         public string DisplayMode { get; set; }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentPartSettings.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentPartSettings.cs
@@ -18,12 +18,12 @@ namespace OrchardCore.ContentManagement.Metadata.Settings
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Gest or set the description of the part.
+        /// Gets or sets the description of the part.
         /// </summary>
         public string Description { get; set; }
 
         /// <summary>
-        /// Gest or set the default position of the part when attached to a type.
+        /// Gets or sets the default position of the part when attached to a type.
         /// </summary>
         public string DefaultPosition { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypePartSettings.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypePartSettings.cs
@@ -18,12 +18,12 @@ namespace OrchardCore.ContentManagement.Metadata.Settings
         public string Position { get; set; }
 
         /// <summary>
-        /// Gest or set the display mode of the type part.
+        /// Gets or sets the display mode of the type part.
         /// </summary>
         public string DisplayMode { get; set; }
 
         /// <summary>
-        /// Gest or set the editor of the type part.
+        /// Gets or sets the editor of the type part.
         /// </summary>
         public string Editor { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
@@ -49,12 +49,12 @@ namespace OrchardCore.ContentManagement.Display
 
             foreach (var element in partDisplayDrivers.Select(x => x.GetType()))
             {
-                logger.LogWarning("The content part display driver '{ContentPartDisplayDriver}' should not be registerd in DI. Use UseDisplayDriver<T> instead.", element);
+                logger.LogWarning("The content part display driver '{ContentPartDisplayDriver}' should not be registered in DI. Use UseDisplayDriver<T> instead.", element);
             }
 
             foreach (var element in fieldDisplayDrivers.Select(x => x.GetType()))
             {
-                logger.LogWarning("The content field display driver '{ContentFieldDisplayDriver}' should not be registerd in DI. Use UseDisplayDriver<T> instead.", element);
+                logger.LogWarning("The content field display driver '{ContentFieldDisplayDriver}' should not be registered in DI. Use UseDisplayDriver<T> instead.", element);
             }
 
             _logger = logger;
@@ -112,7 +112,7 @@ namespace OrchardCore.ContentManagement.Display
                         }
                     }
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
+                    // Iterate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
                     foreach (var displayDriver in _partDisplayDrivers)
                     {
                         try
@@ -191,7 +191,7 @@ namespace OrchardCore.ContentManagement.Display
                             }
                         }
                         // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                        // Iteratate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
+                        // Iterate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
                         foreach (var displayDriver in _fieldDisplayDrivers)
                         {
                             try
@@ -275,7 +275,7 @@ namespace OrchardCore.ContentManagement.Display
                     }
                 }, part, typePartDefinition, context, _logger);
                 // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                // Iteratate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
+                // Iterate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
                 await _partDisplayDrivers.InvokeAsync(async (driver, part, typePartDefinition, context) =>
                 {
                     var result = await driver.BuildEditorAsync(part, typePartDefinition, context);
@@ -301,7 +301,7 @@ namespace OrchardCore.ContentManagement.Display
                         }
                     }, part, partFieldDefinition, typePartDefinition, context, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
+                    // Iterate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
                     await _fieldDisplayDrivers.InvokeAsync(async (driver, part, partFieldDefinition, typePartDefinition, context) =>
                     {
                         var result = await driver.BuildEditorAsync(part, partFieldDefinition, typePartDefinition, context);
@@ -372,7 +372,7 @@ namespace OrchardCore.ContentManagement.Display
                     }
                 }, part, typePartDefinition, context, _logger);
                 // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                // Iteratate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
+                // Iterate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
                 await _partDisplayDrivers.InvokeAsync(async (driver, part, typePartDefinition, context) =>
                 {
                     var result = await driver.UpdateEditorAsync(part, typePartDefinition, context);
@@ -398,7 +398,7 @@ namespace OrchardCore.ContentManagement.Display
                         }
                     }, part, partFieldDefinition, typePartDefinition, context, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
+                    // Iterate existing driver registrations as multiple drivers maybe not be registered with ContentOptions.
                     await _fieldDisplayDrivers.InvokeAsync(async (driver, part, partFieldDefinition, typePartDefinition, context) =>
                     {
                         var result = await driver.UpdateEditorAsync(part, partFieldDefinition, typePartDefinition, context);

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.ContentManagement.Handlers
 
             foreach (var element in partHandlers.Select(x => x.GetType()))
             {
-                logger.LogWarning("The content part handler '{ContentPartHandler}' should not be registerd in DI. Use AddHandler<T> instead.", element);
+                logger.LogWarning("The content part handler '{ContentPartHandler}' should not be registered in DI. Use AddHandler<T> instead.", element);
             }
 
             _logger = logger;
@@ -59,7 +59,7 @@ namespace OrchardCore.ContentManagement.Handlers
                 var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                 await partHandlers.InvokeAsync((handler, context, part) => handler.ActivatingAsync(context, part), context, part, _logger);
                 // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                 await _partHandlers.InvokeAsync((handler, context, part) => handler.ActivatingAsync(context, part), context, part, _logger);
                 context.Builder.Weld(typePartDefinition.Name, part);
             }
@@ -82,7 +82,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.ActivatedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.ActivatedAsync(context, part), context, part, _logger);
                 }
             }
@@ -106,7 +106,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.CreatingAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.CreatingAsync(context, part), context, part, _logger);
                 }
             }
@@ -130,7 +130,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.CreatedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.CreatedAsync(context, part), context, part, _logger);
                 }
             }
@@ -153,7 +153,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.InitializingAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.InitializingAsync(context, part), context, part, _logger);
                 }
             }
@@ -177,7 +177,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.InitializedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.InitializedAsync(context, part), context, part, _logger);
                 }
             }
@@ -213,7 +213,7 @@ namespace OrchardCore.ContentManagement.Handlers
                 var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                 await partHandlers.InvokeAsync((handler, context, part) => handler.LoadingAsync(context, part), context, part, _logger);
                 // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                 await _partHandlers.InvokeAsync((handler, context, part) => handler.LoadingAsync(context, part), context, part, _logger);
                 foreach (var partFieldDefinition in typePartDefinition.PartDefinition.Fields)
                 {
@@ -246,7 +246,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.LoadedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.LoadedAsync(context, part), context, part, _logger);
                 }
             }
@@ -269,7 +269,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.PublishingAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.PublishingAsync(context, part), context, part, _logger);
                 }
             }
@@ -292,7 +292,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.PublishedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.PublishedAsync(context, part), context, part, _logger);
                 }
             }
@@ -315,7 +315,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.RemovingAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.RemovingAsync(context, part), context, part, _logger);
                 }
             }
@@ -338,7 +338,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.RemovedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.RemovedAsync(context, part), context, part, _logger);
                 }
             }
@@ -361,7 +361,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.UnpublishingAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.UnpublishingAsync(context, part), context, part, _logger);
                 }
             }
@@ -384,7 +384,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.UnpublishedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.UnpublishedAsync(context, part), context, part, _logger);
                 }
             }
@@ -407,7 +407,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.UpdatingAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.UpdatingAsync(context, part), context, part, _logger);
                 }
             }
@@ -430,7 +430,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.UpdatedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.UpdatedAsync(context, part), context, part, _logger);
                 }
             }
@@ -455,7 +455,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, existingPart, buildingPart) => handler.VersioningAsync(context, existingPart, buildingPart), context, existingPart, buildingPart, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, existingPart, buildingPart) => handler.VersioningAsync(context, existingPart, buildingPart), context, existingPart, buildingPart, _logger);
                 }
             }
@@ -480,7 +480,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, existingPart, buildingPart) => handler.VersionedAsync(context, existingPart, buildingPart), context, existingPart, buildingPart, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, existingPart, buildingPart) => handler.VersionedAsync(context, existingPart, buildingPart), context, existingPart, buildingPart, _logger);
                 }
             }
@@ -503,7 +503,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.GetContentItemAspectAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.GetContentItemAspectAsync(context, part), context, part, _logger);
                 }
             }
@@ -525,7 +525,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.ClonedAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.ClonedAsync(context, part), context, part, _logger);
                 }
             }
@@ -547,7 +547,7 @@ namespace OrchardCore.ContentManagement.Handlers
                     var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
                     await partHandlers.InvokeAsync((handler, context, part) => handler.CloningAsync(context, part), context, part, _logger);
                     // TODO: This can be removed in a future release as the recommended way is to use ContentOptions.
-                    // Iteratate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.=
+                    // Iterate existing handler registrations as multiple handlers maybe not be registered with ContentOptions.=
                     await _partHandlers.InvokeAsync((handler, context, part) => handler.CloningAsync(context, part), context, part, _logger);
                 }
             }

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/IDbConnectionAccessor.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/IDbConnectionAccessor.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Data
     public interface IDbConnectionAccessor
     {
         /// <summary>
-        /// Creats a database connection.
+        /// Creates a database connection.
         /// </summary>
         DbConnection CreateConnection();
     }

--- a/src/OrchardCore/OrchardCore.Data/Migration/DataMigrationManager.cs
+++ b/src/OrchardCore/OrchardCore.Data/Migration/DataMigrationManager.cs
@@ -178,7 +178,7 @@ namespace OrchardCore.Data.Migration
                 var current = 0;
                 if (dataMigrationRecord != null)
                 {
-                    // This can be null if a failed create migration has occured and the data migration record was saved.
+                    // This can be null if a failed create migration has occurred and the data migration record was saved.
                     current = dataMigrationRecord.Version.HasValue ? dataMigrationRecord.Version.Value : current;
                 }
                 else

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
@@ -93,7 +93,7 @@ namespace OrchardCore.DisplayManagement.Implementation
                 // invoking ShapeMetadata displaying events
                 shapeMetadata.Displaying.Invoke(action => action(displayContext), _logger);
 
-                // use pre-fectched content if available (e.g. coming from specific cache implementation)
+                // use pre-fetched content if available (e.g. coming from specific cache implementation)
                 if (displayContext.ChildContent != null)
                 {
                     shape.Metadata.ChildContent = displayContext.ChildContent;
@@ -181,7 +181,7 @@ namespace OrchardCore.DisplayManagement.Implementation
         {
             // Note: The shape type of a descriptor is a fundamental shape type that never contains
             // any '__' separator. If a shape type contains some '__' separators, its fundamental
-            // shape type is the left part just before the 1st occurence of the '__' separator.
+            // shape type is the left part just before the 1st occurrence of the '__' separator.
 
             // As a fast path we 1st use the shapeType as is but it may contain some '__'.
             if (!shapeTable.Descriptors.TryGetValue(shapeType, out var shapeDescriptor))

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/FlatPositionComparer.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/FlatPositionComparer.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.DisplayManagement.Zones
 
             // null == "before"; "" == "0"
             x = x == null
-                ? "before." // in order to have before < null when 'before' is explicitely defined
+                ? "before." // in order to have before < null when 'before' is explicitly defined
                 : x.Trim().Length == 0 ? "0" : x.Trim(':').TrimEnd('.'); // ':' is _sometimes_ used as a partition identifier
             y = y == null
                 ? "before."

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/MailMessage.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/MailMessage.cs
@@ -31,10 +31,10 @@ namespace OrchardCore.Email
         public string ReplyTo { get; set; }
 
         /// <summary>
-        /// Gets or sets the actual submittor of the email.
+        /// Gets or sets the actual submitter of the email.
         /// </summary>
         /// <remark>
-        /// This property is required if not the same as <see cref="From"/>, for more informaton please refer to https://ietf.org/rfc/rfc822.txt.
+        /// This property is required if not the same as <see cref="From"/>, for more information please refer to https://ietf.org/rfc/rfc822.txt.
         /// </remark>
         public string Sender { get; set; }
 

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpResult.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpResult.cs
@@ -9,12 +9,12 @@ namespace OrchardCore.Email
     public class SmtpResult
     {
         /// <summary>
-        /// Returns an <see cref="SmtpResult"/>indicating a successful Smtp operation.
+        /// Returns an <see cref="SmtpResult"/>indicating a successful SMTP operation.
         /// </summary>
         public static SmtpResult Success { get; } = new SmtpResult { Succeeded = true };
 
         /// <summary>
-        /// An <see cref="IEnumerable{LocalizedString}"/> containing an errors that occurred during the Smtp operation.
+        /// An <see cref="IEnumerable{LocalizedString}"/> containing an errors that occurred during the SMTP operation.
         /// </summary>
         public IEnumerable<LocalizedString> Errors { get; protected set; }
 
@@ -24,7 +24,7 @@ namespace OrchardCore.Email
         public bool Succeeded { get; protected set; }
 
         /// <summary>
-        /// Creates an <see cref="SmtpResult"/> indicating a failed Smtp operation, with a list of errors if applicable.
+        /// Creates an <see cref="SmtpResult"/> indicating a failed SMTP operation, with a list of errors if applicable.
         /// </summary>
         /// <param name="errors">An optional array of <see cref="LocalizedString"/> which caused the operation to fail.</param>
         public static SmtpResult Failed(params LocalizedString[] errors) => new SmtpResult { Succeeded = false, Errors = errors };

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpResult.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpResult.cs
@@ -9,12 +9,12 @@ namespace OrchardCore.Email
     public class SmtpResult
     {
         /// <summary>
-        /// Returns an <see cref="SmtpResult"/>indicating a successful SMTP operation.
+        /// Returns an <see cref="SmtpResult"/>indicating a successful Smtp operation.
         /// </summary>
         public static SmtpResult Success { get; } = new SmtpResult { Succeeded = true };
 
         /// <summary>
-        /// An <see cref="IEnumerable{LocalizedString}"/> containing an errors that occurred during the SMTP operation.
+        /// An <see cref="IEnumerable{LocalizedString}"/> containing an errors that occurred during the Smtp operation.
         /// </summary>
         public IEnumerable<LocalizedString> Errors { get; protected set; }
 
@@ -24,7 +24,7 @@ namespace OrchardCore.Email
         public bool Succeeded { get; protected set; }
 
         /// <summary>
-        /// Creates an <see cref="SmtpResult"/> indicating a failed SMTP operation, with a list of errors if applicable.
+        /// Creates an <see cref="SmtpResult"/> indicating a failed Smtp operation, with a list of errors if applicable.
         /// </summary>
         /// <param name="errors">An optional array of <see cref="LocalizedString"/> which caused the operation to fail.</param>
         public static SmtpResult Failed(params LocalizedString[] errors) => new SmtpResult { Succeeded = false, Errors = errors };

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobDirectory.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobDirectory.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.FileStorage.AzureBlob
         {
             _path = path;
             _lastModifiedUtc = lastModifiedUtc;
-            // Use GetFileName rather than GetDirectoryName as GetDirectoryName requires a delimeter
+            // Use GetFileName rather than GetDirectoryName as GetDirectoryName requires a delimiter
             _name = System.IO.Path.GetFileName(path);
             _directoryPath = _path.Length > _name.Length ? _path.Substring(0, _path.Length - _name.Length - 1) : "";
         }

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IGlobalMethodProvider.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IGlobalMethodProvider.cs
@@ -4,7 +4,7 @@ namespace OrchardCore.Scripting
 {
     /// <summary>
     /// An implementation of <see cref="IGlobalMethodProvider"/> provides custom methods for
-    /// an <see cref="IScriptingManager"/> intance.
+    /// an <see cref="IScriptingManager"/> instance.
     /// </summary>
     public interface IGlobalMethodProvider
     {

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/Extensions/HtmlLocalizerExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/Extensions/HtmlLocalizerExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization
         {
             if (plural == null)
             {
-                throw new ArgumentNullException(nameof(plural), "Plural text can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentNullException(nameof(plural), "Plural text can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             return localizer[singular, new PluralizationArgument { Count = count, Forms = new[] { singular, plural }, Arguments = arguments }];
@@ -37,12 +37,12 @@ namespace Microsoft.AspNetCore.Mvc.Localization
         {
             if (pluralForms == null)
             {
-                throw new ArgumentNullException(nameof(pluralForms), "PluralForms array can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentNullException(nameof(pluralForms), "PluralForms array can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             if (pluralForms.Length == 0)
             {
-                throw new ArgumentException(nameof(pluralForms), "PluralForms array can't be empty, it must contain at least one element. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentException(nameof(pluralForms), "PluralForms array can't be empty, it must contain at least one element. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             var name = pluralForms[0];

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/Extensions/StringLocalizerExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/Extensions/StringLocalizerExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.Localization
         {
             if (plural == null)
             {
-                throw new ArgumentNullException(nameof(plural), "Plural text can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentNullException(nameof(plural), "Plural text can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             return localizer[singular, new PluralizationArgument { Count = count, Forms = new[] { singular, plural }, Arguments = arguments }];
@@ -37,12 +37,12 @@ namespace Microsoft.Extensions.Localization
         {
             if (pluralForms == null)
             {
-                throw new ArgumentNullException(nameof(pluralForms), "PluralForms array can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentNullException(nameof(pluralForms), "PluralForms array can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             if (pluralForms.Length == 0)
             {
-                throw new ArgumentException(nameof(pluralForms), "PluralForms array can't be empty, it must contain at least one element. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentException(nameof(pluralForms), "PluralForms array can't be empty, it must contain at least one element. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             return localizer[pluralForms[0], new PluralizationArgument { Count = count, Forms = pluralForms, Arguments = arguments }];

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/Extensions/ViewLocalizerExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/Extensions/ViewLocalizerExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Mvc.Localization
         {
             if (plural == null)
             {
-                throw new ArgumentNullException(nameof(plural), "Plural text can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentNullException(nameof(plural), "Plural text can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             return localizer[singular, new PluralizationArgument { Count = count, Forms = new[] { singular, plural }, Arguments = arguments }];
@@ -38,12 +38,12 @@ namespace Microsoft.AspNetCore.Mvc.Localization
         {
             if (pluralForms == null)
             {
-                throw new ArgumentNullException(nameof(pluralForms), "PluralForms array can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentNullException(nameof(pluralForms), "PluralForms array can't be null. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             if (pluralForms.Length == 0)
             {
-                throw new ArgumentException(nameof(pluralForms), "PluralForms array can't be empty, it must contain at least one element. If you don't want to specify the plural text, use IStringLocalizer without Plural extention.");
+                throw new ArgumentException(nameof(pluralForms), "PluralForms array can't be empty, it must contain at least one element. If you don't want to specify the plural text, use IStringLocalizer without Plural extension.");
             }
 
             return localizer[pluralForms[0], new PluralizationArgument { Count = count, Forms = pluralForms, Arguments = arguments }];

--- a/src/OrchardCore/OrchardCore.Lucene.Abstractions/Indexing/Mapping.cs
+++ b/src/OrchardCore/OrchardCore.Lucene.Abstractions/Indexing/Mapping.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace OrchardCore.Lucene.Indexing
 {
     /// <summary>
-    /// Reprensents the information of a content type in a Lucene index.
+    /// Represents the information of a content type in a Lucene index.
     /// </summary>
     public class Mapping
     {

--- a/src/OrchardCore/OrchardCore.Module.Targets/Package.Build.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/Package.Build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   
   <!-- 
-    This file is included in the Nuget packages as "build\$(TargetFramework)\$(AssemblyName).props" file.
+    This file is included in the NuGet packages as "build\$(TargetFramework)\$(AssemblyName).props" file.
     It contains the logic to be referenced as a module by the main application.
   -->
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Navigation.Core/MenuItem.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/MenuItem.cs
@@ -6,8 +6,8 @@ using OrchardCore.Security.Permissions;
 namespace OrchardCore.Navigation
 {
     /// <summary>
-    /// Represents a menu item descrbibed by an <see cref="INavigationProvider"/> implementation.
-    /// A menu item can desbribe child menu items.
+    /// Represents a menu item described by an <see cref="INavigationProvider"/> implementation.
+    /// A menu item can describe child menu items.
     /// </summary>
     public class MenuItem
     {

--- a/src/OrchardCore/OrchardCore.Queries.Abstractions/IQueryManager.cs
+++ b/src/OrchardCore/OrchardCore.Queries.Abstractions/IQueryManager.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Queries
         Task DeleteQueryAsync(string name);
 
         /// <summary>
-        /// Returns the <see cref="Query"/> instance with the specified name for udpate.
+        /// Returns the <see cref="Query"/> instance with the specified name for update.
         /// </summary>
         Task<Query> LoadQueryAsync(string name);
 

--- a/src/OrchardCore/OrchardCore.Queries.Abstractions/Query.cs
+++ b/src/OrchardCore/OrchardCore.Queries.Abstractions/Query.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Queries
         public string Source { get; }
 
         /// <summary>
-        /// Gets or sets the retun schema of the query.
+        /// Gets or sets the return schema of the query.
         /// This is used runtime determination of the results returned when Content Items are not returned.
         /// </summary>
         public string Schema { get; set; }

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/Services/IRecipeExecutionStep.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/Services/IRecipeExecutionStep.cs
@@ -4,8 +4,8 @@ using OrchardCore.Recipes.Models;
 namespace OrchardCore.Recipes.Services
 {
     /// <summary>
-    /// An implementation of this interface will be used everytime a recipe step is processed.
-    /// Each implementation is reponsible for processing only the steps that it targets.
+    /// An implementation of this interface will be used every time a recipe step is processed.
+    /// Each implementation is responsible for processing only the steps that it targets.
     /// </summary>
     public interface IRecipeStepHandler
     {

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ResourcesTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ResourcesTagHelper.cs
@@ -74,7 +74,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "An error occured while rendering {Type} resource.", Type);
+                _logger.LogError(ex, "An error occurred while rendering {Type} resource.", Type);
             }
             finally
             {

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/Services/IUserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/Services/IUserService.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.Users.Services
         /// </summary>
         /// <param name="userName">The username.</param>
         /// <param name="password">The user password.</param>
-        /// <param name="reportError">The error reported in case failure happened during the authntication process.</param>
+        /// <param name="reportError">The error reported in case failure happened during the authentication process.</param>
         /// <returns>A <see cref="IUser"/> that represents an authenticated user.</returns>
         Task<IUser> AuthenticateAsync(string userName, string password, Action<string, string> reportError);
 

--- a/src/OrchardCore/OrchardCore/Localization/NullHtmlLocalizerFactory.cs
+++ b/src/OrchardCore/OrchardCore/Localization/NullHtmlLocalizerFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Localization;
 
 namespace OrchardCore.Localization
 {
-    /// Represensts a null <see cref="IHtmlLocalizerFactory"/> which is used by default when the localization module is disabled.
+    /// Represents a null <see cref="IHtmlLocalizerFactory"/> which is used by default when the localization module is disabled.
     /// <remarks>
     /// LocalizedHtmlString's arguments will be HTML encoded and not the main string. So the result
     /// should just contain the localized string containing the formatting placeholders {0...} as is.

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/PoweredByOrchardCoreExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/PoweredByOrchardCoreExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Builder
         }
 
         /// <summary>
-        /// Configures wethere use or not the Header X-Powered-By and its value.
+        /// Configures whether use or not the Header X-Powered-By and its value.
         /// Default value is OrchardCore.
         /// </summary>
         /// <param name="app">The modular application builder</param>

--- a/src/OrchardCore/OrchardCore/Shell/Builders/Extensions/ServiceProviderExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/Extensions/ServiceProviderExtensions.cs
@@ -41,7 +41,7 @@ namespace OrchardCore.Environment.Shell.Builders
 
                     if (service.Lifetime == ServiceLifetime.Singleton)
                     {
-                        // An host singleton is shared accross tenant containers but only registered instances are not disposed
+                        // An host singleton is shared across tenant containers but only registered instances are not disposed
                         // by the DI, so we check if it is disposable or if it uses a factory which may return a different type.
 
                         if (typeof(IDisposable).IsAssignableFrom(service.GetImplementationType()) || service.ImplementationFactory != null)

--- a/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
@@ -16,7 +16,7 @@ namespace OrchardCore.Environment.Shell
     /// <summary>
     /// All <see cref="ShellContext"/> are pre-created when <see cref="InitializeAsync"/> is called on startup and where we first load
     /// all <see cref="ShellSettings"/> that we also need to register in the <see cref="IRunningShellTable"/> to serve incoming requests.
-    /// For each <see cref="ShellContext"/> a service container and then a request pilpeline are only built on the first matching request.
+    /// For each <see cref="ShellContext"/> a service container and then a request pipeline are only built on the first matching request.
     /// </summary>
     public class ShellHost : IShellHost, IDisposable
     {


### PR DESCRIPTION
This fixes about 200 typos in the codebase.

The overwhelming majority of fixes are in "safe" places, in comments and in user-facing strings. I didn't touch strings used as identifiers or any other purely technical value. I didn't look into anything other than spelling errors, so no grammatical or stylistic ones.

Included only crystal clean misspellings and didn't change ones where there's a factor of opinion. Since Orchard's codebase uses US English everywhere I've changed a single UK spelling, then dumped some tea into the sink.

For localized strings, this will break PO translations. I don't think, however, that this can be prevented (apart from leaving the typos in place).

I recommend everyone to install [the VS Spell Checker](https://marketplace.visualstudio.com/items?itemName=EWoodruff.VisualStudioSpellCheckerVS2017andLater) :).