### PR TITLE
Remove permission check on custom settings recipe step

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/Recipes/CustomSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/Recipes/CustomSettingsStep.cs
@@ -37,19 +37,6 @@ namespace OrchardCore.CustomSettings.Recipes
                                       where property.Name != "name"
                                       select property).ToArray();
 
-            var customSettingsNames = (from customSettings in customSettingsList
-                                       select customSettings.Name).ToArray();
-
-            var customSettingsTypes = _customSettingsService.GetSettingsTypes(customSettingsNames).ToArray();
-
-            foreach (var customSettingsType in customSettingsTypes)
-            {
-                if (!await _customSettingsService.CanUserCreateSettingsAsync(customSettingsType))
-                {
-                    return;
-                }
-            }
-
             var siteSettings = await _siteService.LoadSiteSettingsAsync();
 
             foreach (var customSettings in customSettingsList)


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6083

No other step asks for permission, and this causes `DataMigration` using a recipe migration to fail