### PR TITLE
Make Import Data a security critical permission

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Permissions.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Deployment
     {
         public static readonly Permission ManageDeploymentPlan = new Permission("ManageDeploymentPlan", "Manage deployment plan");
         public static readonly Permission Export = new Permission("Export", "Export Data");
-        public static readonly Permission Import = new Permission("Import", "Import Data");
+        public static readonly Permission Import = new Permission("Import", "Import Data", isSecurityCritical: true);
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6085

Because role elevation is possible.

Hmm, I have to check, this probably needs to be Export, as Export allows you to run a deployment plan on a remote server.