### PR TITLE
Fixes bulk actions filtering

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -149,16 +149,16 @@
                 return $(this).data("action");
             })
             .one("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({...$this.data(), callback: function(r) {
-                    if (r) {
-                        $("[name='Options.BulkAction']").val($this.data("action"));
-                        $("[name='submit.BulkAction']").click();
-                    }
-                }});
-            }
-        });
+                if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                    var $this = $(this);
+                    confirmDialog({...$this.data(), callback: function(r) {
+                        if (r) {
+                            $("[name='Options.BulkAction']").val($this.data("action"));
+                            $("[name='submit.BulkAction']").click();
+                        }
+                    }});
+                }
+            });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -144,7 +144,11 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item").on("click", function () {
+        $(".dropdown-menu .dropdown-item")
+            .filter(function() {
+                return $(this).data("action");
+            })
+            .one("click", function () {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {
                 var $this = $(this);
                 confirmDialog({...$this.data(), callback: function(r) {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -144,21 +144,20 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item")
-            .filter(function() {
-                return $(this).data("action");
-            })
-            .one("click", function () {
-                if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                    var $this = $(this);
-                    confirmDialog({...$this.data(), callback: function(r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }});
-                }
-            });
+        $(".dropdown-menu .dropdown-item").filter(function() {
+            return $(this).data("action");
+        })
+        .one("click", function () {
+            if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                var $this = $(this);
+                confirmDialog({...$this.data(), callback: function(r) {
+                    if (r) {
+                        $("[name='Options.BulkAction']").val($this.data("action"));
+                        $("[name='submit.BulkAction']").click();
+                    }
+                }});
+            }
+        });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Admin/List.cshtml
@@ -146,8 +146,7 @@
 
         $(".dropdown-menu .dropdown-item").filter(function() {
             return $(this).data("action");
-        })
-        .one("click", function () {
+        }).one("click", function () {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {
                 var $this = $(this);
                 confirmDialog({...$this.data(), callback: function(r) {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
@@ -100,17 +100,21 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item").on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({...$this.data(), callback: function(r) {
-                    if (r) {
-                        $("[name='Options.BulkAction']").val($this.data("action"));
-                        $("[name='submit.BulkAction']").click();
-                    }
-                }});
-            }
-        });
+        $(".dropdown-menu .dropdown-item")
+            .filter(function() {
+                return $(this).data("action");
+            })
+            .one("click", function () {
+                if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                    var $this = $(this);
+                    confirmDialog({...$this.data(), callback: function(r) {
+                        if (r) {
+                            $("[name='Options.BulkAction']").val($this.data("action"));
+                            $("[name='submit.BulkAction']").click();
+                        }
+                    }});
+                }
+            });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
@@ -100,21 +100,19 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item")
-            .filter(function() {
-                return $(this).data("action");
-            })
-            .one("click", function () {
-                if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                    var $this = $(this);
-                    confirmDialog({...$this.data(), callback: function(r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }});
-                }
-            });
+        $(".dropdown-menu .dropdown-item").filter(function() {
+            return $(this).data("action");
+        }).one("click", function () {
+            if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                var $this = $(this);
+                confirmDialog({...$this.data(), callback: function(r) {
+                    if (r) {
+                        $("[name='Options.BulkAction']").val($this.data("action"));
+                        $("[name='submit.BulkAction']").click();
+                    }
+                }});
+            }
+        });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -190,7 +190,9 @@
             }
         });
 
-        $(".dropdown-menu a").on('click', function () {
+        $(".dropdown-menu a").filter(function() {
+            return $(this).data("action");
+        }).one('click', function () {
             $("[name='BulkAction']").val($(this).data('action'));
             $("[name='submit.BulkAction']").click();
         });

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Index.cshtml
@@ -106,17 +106,21 @@
             }
         }
 
-        $(".dropdown-menu .dropdown-item").on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({...$this.data(), callback: function(r) {
-                    if (r) {
-                        $("[name='Options.BulkAction']").val($this.data("action"));
-                        $("[name='submit.BulkAction']").click();
-                    }
-                }});
-            }
-        });
+        $(".dropdown-menu .dropdown-item")
+            .filter(function() {
+                return $(this).data("action");
+            })
+            .one("click", function () {
+                if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                    var $this = $(this);
+                    confirmDialog({...$this.data(), callback: function(r) {
+                        if (r) {
+                            $("[name='Options.BulkAction']").val($this.data("action"));
+                            $("[name='submit.BulkAction']").click();
+                        }
+                    }});
+                }
+            });
 
         selectAllCtrl.click(function(){
             itemsCheckboxes.not(this).prop("checked", this.checked);

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Admin/Index.cshtml
@@ -106,21 +106,19 @@
             }
         }
 
-        $(".dropdown-menu .dropdown-item")
-            .filter(function() {
-                return $(this).data("action");
-            })
-            .one("click", function () {
-                if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                    var $this = $(this);
-                    confirmDialog({...$this.data(), callback: function(r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }});
-                }
-            });
+        $(".dropdown-menu .dropdown-item").filter(function() {
+            return $(this).data("action");
+        }).one("click", function () {
+            if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                var $this = $(this);
+                confirmDialog({...$this.data(), callback: function(r) {
+                    if (r) {
+                        $("[name='Options.BulkAction']").val($this.data("action"));
+                        $("[name='submit.BulkAction']").click();
+                    }
+                }});
+            }
+        });
 
         selectAllCtrl.click(function(){
             itemsCheckboxes.not(this).prop("checked", this.checked);

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
@@ -221,21 +221,19 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item")
-            .filter(function() {
-                return $(this).data("action");
-            })
-            .one("click", function () {
-                if ($(":checkbox[name='tenantNames']:checked").length > 1) {
-                    var $this = $(this);
-                    confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {
-                        if (r) {
-                            $("[name='BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }});
-                }
-            });
+        $(".dropdown-menu .dropdown-item").filter(function() {
+            return $(this).data("action");
+        }).one("click", function () {
+            if ($(":checkbox[name='tenantNames']:checked").length > 1) {
+                var $this = $(this);
+                confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {
+                    if (r) {
+                        $("[name='BulkAction']").val($this.data("action"));
+                        $("[name='submit.BulkAction']").click();
+                    }
+                }});
+            }
+        });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='tenantNames']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
@@ -221,17 +221,21 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item").on("click", function () {
-            if ($(":checkbox[name='tenantNames']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {
-                    if (r) {
-                        $("[name='BulkAction']").val($this.data("action"));
-                        $("[name='submit.BulkAction']").click();
-                    }
-                }});
-            }
-        });
+        $(".dropdown-menu .dropdown-item")
+            .filter(function() {
+                return $(this).data("action");
+            })
+            .one("click", function () {
+                if ($(":checkbox[name='tenantNames']:checked").length > 1) {
+                    var $this = $(this);
+                    confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {
+                        if (r) {
+                            $("[name='BulkAction']").val($this.data("action"));
+                            $("[name='submit.BulkAction']").click();
+                        }
+                    }});
+                }
+            });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='tenantNames']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Admin/Index.cshtml
@@ -104,17 +104,21 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item").on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({...$this.data(), callback: function(r) {
-                    if (r) {
-                        $("[name='Options.BulkAction']").val($this.data("action"));
-                        $("[name='submit.BulkAction']").click();
-                    }
-                }});
-            }
-        });
+        $(".dropdown-menu .dropdown-item")
+            .filter(function() {
+                return $(this).data("action");
+            })
+            .one("click", function () {
+                if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                    var $this = $(this);
+                    confirmDialog({...$this.data(), callback: function(r) {
+                        if (r) {
+                            $("[name='Options.BulkAction']").val($this.data("action"));
+                            $("[name='submit.BulkAction']").click();
+                        }
+                    }});
+                }
+            });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Admin/Index.cshtml
@@ -104,21 +104,19 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item")
-            .filter(function() {
-                return $(this).data("action");
-            })
-            .one("click", function () {
-                if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                    var $this = $(this);
-                    confirmDialog({...$this.data(), callback: function(r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }});
-                }
-            });
+        $(".dropdown-menu .dropdown-item").filter(function() {
+            return $(this).data("action");
+        }).one("click", function () {
+            if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                var $this = $(this);
+                confirmDialog({...$this.data(), callback: function(r) {
+                    if (r) {
+                        $("[name='Options.BulkAction']").val($this.data("action"));
+                        $("[name='submit.BulkAction']").click();
+                    }
+                }});
+            }
+        });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
@@ -148,21 +148,19 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item")
-            .filter(function() {
-                return $(this).data("action");
-            })
-            .one("click", function () {
-                if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                    var $this = $(this);
-                    confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {
-                        if (r) {
-                            $("[name='Options.BulkAction']").val($this.data("action"));
-                            $("[name='submit.BulkAction']").click();
-                        }
-                    }});
-                }
-            });
+        $(".dropdown-menu .dropdown-item").filter(function() {
+            return $(this).data("action");
+        }).one("click", function () {
+            if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                var $this = $(this);
+                confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {
+                    if (r) {
+                        $("[name='Options.BulkAction']").val($this.data("action"));
+                        $("[name='submit.BulkAction']").click();
+                    }
+                }});
+            }
+        });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
@@ -148,17 +148,21 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item").on("click", function () {
-            if ($(":checkbox[name='itemIds']:checked").length > 1) {
-                var $this = $(this);
-                confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {
-                    if (r) {
-                        $("[name='Options.BulkAction']").val($this.data("action"));
-                        $("[name='submit.BulkAction']").click();
-                    }
-                }});
-            }
-        });
+        $(".dropdown-menu .dropdown-item")
+            .filter(function() {
+                return $(this).data("action");
+            })
+            .one("click", function () {
+                if ($(":checkbox[name='itemIds']:checked").length > 1) {
+                    var $this = $(this);
+                    confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {
+                        if (r) {
+                            $("[name='Options.BulkAction']").val($this.data("action"));
+                            $("[name='submit.BulkAction']").click();
+                        }
+                    }});
+                }
+            });
 
         function displayActionsOrFilters() {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
@@ -115,7 +115,9 @@
             $("[name='submit.Filter']").click();
         });
 
-        $(".dropdown-menu .dropdown-item").on("click", function () {
+        $(".dropdown-menu .dropdown-item").filter(function() {
+            return $(this).data("action");
+        }).one("click", function () {
             if ($(":checkbox[name='itemIds']:checked").length > 1) {
                 var $this = $(this);
                 confirmDialog({title: $this.data('title'), message: $this.data('message'), callback: function(r) {


### PR DESCRIPTION
In the admin content items index page script, bulk actions are selected by their `".dropdown-menu .dropdown-item"` classes, the problem is that there are other items with the same classes, e.g. the filter actions, the actions of a given item and so on.

So as soon as you have selected multiple items, even if you are not cliking on a bulk action, but on another action, this action is posted **but also the bulk one, with no action but posted**, the first one is done and redirect first, but because of the 2nd one you may have some disconnected errors, a flashing confirm dialog and so on.

**So here i filtered the items to only retrieve those that have a `data-action` attribute.**

Todo: **There are many other index pages to update**

**Update**: Done