### PR TITLE
Fix login redirect for external providers

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -72,21 +72,6 @@ namespace OrchardCore.OpenId
                 ServiceDescriptor.Scoped<IPermissionProvider, Permissions>(),
                 ServiceDescriptor.Scoped<INavigationProvider, AdminMenu>(),
             });
-
-            services.Configure<CookiePolicyOptions>(options =>
-            {
-                options.OnAppendCookie = cookieContext =>
-                {
-                    // Disabling same-site is required for OpenID's module prompt=none support to work correctly.
-                    // Note: it has no practical impact on the security of the site since all endpoints are always
-                    // protected by antiforgery checks, that are enforced with or without this setting being changed.
-                    // 2020-03-23; Moved the SameSiteNode.None here, this will require that the site runs on HTTPS;
-                    if (cookieContext.CookieName.StartsWith("orchauth_"))
-                    {
-                        cookieContext.CookieOptions.SameSite = SameSiteMode.None;
-                    }
-                };
-            });
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -160,7 +160,8 @@ namespace OrchardCore.Users
                 // 2019-12-10; Removed, since https://github.com/aspnet/Announcements/issues/390
                 // 2020-02-17; Reenabled since we have compensation logic for backwardscompatibility
                 // 2020-03-23; Moved the SameSiteNode.None to the Startup of the OIDC Server
-                options.Cookie.SameSite = SameSiteMode.Strict;
+                // 2020-05-05; Removed to fix external login providers
+                // options.Cookie.SameSite = SameSiteMode.Strict;
             });
 
             services.AddSingleton<IIndexProvider, UserIndexProvider>();

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -153,15 +153,6 @@ namespace OrchardCore.Users
 
                 options.LoginPath = "/" + userOptions.Value.LoginPath;
                 options.AccessDeniedPath = "/Error/403";
-
-                // Disabling same-site is required for OpenID's module prompt=none support to work correctly.
-                // Note: it has no practical impact on the security of the site since all endpoints are always
-                // protected by antiforgery checks, that are enforced with or without this setting being changed.
-                // 2019-12-10; Removed, since https://github.com/aspnet/Announcements/issues/390
-                // 2020-02-17; Reenabled since we have compensation logic for backwardscompatibility
-                // 2020-03-23; Moved the SameSiteNode.None to the Startup of the OIDC Server
-                // 2020-05-05; Removed to fix external login providers
-                // options.Cookie.SameSite = SameSiteMode.Strict;
             });
 
             services.AddSingleton<IIndexProvider, UserIndexProvider>();


### PR DESCRIPTION
fixes #6049

I tested this with AAD on port 5001 and everything worked as expected. I removed the SameSiteMode.None from the OpenId Module but I did not test that. I assume it would work.

/cc @kevinchalet @deanmarcussen 

