### PR TITLE
Switch buttons Events and Tasks in Workflow Edit

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Edit.cshtml
@@ -13,11 +13,11 @@
 <nav class="admin-toolbar">
     <ul class="navbar-nav mr-auto">
         <li class="nav-item">
-            <button type="button" id="add-task-button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#activity-picker" data-picker-title="@T["Available Tasks"]" data-activity-type="Task">
-                @T["Add Task"]
-            </button>
             <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#activity-picker" data-picker-title="@T["Available Events"]" data-activity-type="Event">
                 @T["Add Event"]
+            </button>
+            <button type="button" id="add-task-button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#activity-picker" data-picker-title="@T["Available Tasks"]" data-activity-type="Task">
+                @T["Add Task"]
             </button>
         </li>
     </ul>


### PR DESCRIPTION
Show `Add Event` before `Add Task` because when you start from an empty Workflow, you will probably add the original event before the tasks.