### PR TITLE
Fixes Workflow Singleton

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Controllers/HttpWorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Controllers/HttpWorkflowController.cs
@@ -91,7 +91,7 @@ namespace OrchardCore.Workflows.Http.Controllers
                 return NotFound();
             }
 
-            if(!workflowType.IsEnabled)
+            if (!workflowType.IsEnabled)
             {
                 if (_logger.IsEnabled(LogLevel.Warning))
                 {
@@ -137,14 +137,14 @@ namespace OrchardCore.Workflows.Http.Controllers
             // If the activity is a start activity, start a new workflow.
             if (startActivity.IsStart)
             {
-                if (_logger.IsEnabled(LogLevel.Debug))
-                {
-                    _logger.LogDebug("Invoking new workflow of type '{WorkflowTypeId}' with start activity '{ActivityId}'", workflowType.WorkflowTypeId, startActivity.ActivityId);
-                }
-
                 // If this is not a singleton workflow or there is not already an halted instance, start a new workflow.
                 if (!workflowType.IsSingleton || !await _workflowStore.HasHaltedInstanceAsync(workflowType.WorkflowTypeId))
                 {
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Invoking new workflow of type '{WorkflowTypeId}' with start activity '{ActivityId}'", workflowType.WorkflowTypeId, startActivity.ActivityId);
+                    }
+
                     await _workflowManager.StartWorkflowAsync(workflowType, startActivity);
                 }
             }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Filters/WorkflowActionFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Filters/WorkflowActionFilter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Filters;
+using OrchardCore.Workflows.Helpers;
 using OrchardCore.Workflows.Http.Services;
 using OrchardCore.Workflows.Services;
 
@@ -13,18 +14,21 @@ namespace OrchardCore.Workflows.Http.Filters
         private readonly IWorkflowTypeRouteEntries _workflowTypeRouteEntries;
         private readonly IWorkflowInstanceRouteEntries _workflowRouteEntries;
         private readonly IWorkflowTypeStore _workflowTypeStore;
+        private readonly IWorkflowStore _workflowStore;
 
         public WorkflowActionFilter(
             IWorkflowManager workflowManager,
             IWorkflowTypeRouteEntries workflowTypeRouteEntries,
             IWorkflowInstanceRouteEntries workflowRouteEntries,
-            IWorkflowTypeStore workflowTypeStore
+            IWorkflowTypeStore workflowTypeStore,
+            IWorkflowStore workflowStore
         )
         {
             _workflowManager = workflowManager;
             _workflowTypeRouteEntries = workflowTypeRouteEntries;
             _workflowRouteEntries = workflowRouteEntries;
             _workflowTypeStore = workflowTypeStore;
+            _workflowStore = workflowStore;
         }
 
         public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
@@ -38,12 +42,41 @@ namespace OrchardCore.Workflows.Http.Filters
             {
                 var workflowTypeIds = workflowTypeEntries.Select(x => Int32.Parse(x.WorkflowId)).ToList();
                 var workflowTypes = (await _workflowTypeStore.GetAsync(workflowTypeIds)).ToDictionary(x => x.Id);
+                var correlationId = routeValues.GetValue<string>("correlationid");
 
                 foreach (var entry in workflowTypeEntries)
                 {
-                    var workflowType = workflowTypes[Int32.Parse(entry.WorkflowId)];
-                    var activity = workflowType.Activities.Single(x => x.ActivityId == entry.ActivityId);
-                    await _workflowManager.StartWorkflowAsync(workflowType, activity);
+                    if (workflowTypes.TryGetValue(Int32.Parse(entry.WorkflowId), out var workflowType))
+                    {
+                        var activity = workflowType.Activities.Single(x => x.ActivityId == entry.ActivityId);
+
+                        if (activity.IsStart)
+                        {
+                            // If this is not a singleton workflow or there is not already an halted instance, start a new workflow.
+                            if (!workflowType.IsSingleton || !await _workflowStore.HasHaltedInstanceAsync(workflowType.WorkflowTypeId))
+                            {
+                                await _workflowManager.StartWorkflowAsync(workflowType, activity, null, correlationId);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (workflowEntries.Any())
+            {
+                var workflowIds = workflowEntries.Select(x => x.WorkflowId).ToList();
+                var workflows = (await _workflowStore.GetAsync(workflowIds)).ToDictionary(x => x.WorkflowId);
+                var correlationId = routeValues.GetValue<string>("correlationid");
+
+                foreach (var entry in workflowEntries)
+                {
+                    if (workflows.TryGetValue(entry.WorkflowId, out var workflow) &&
+                        (String.IsNullOrWhiteSpace(correlationId) ||
+                        workflow.CorrelationId == correlationId))
+                    {
+                        var blockingActivity = workflow.BlockingActivities.Single(x => x.ActivityId == entry.ActivityId);
+                        await _workflowManager.ResumeWorkflowAsync(workflow, blockingActivity);
+                    }
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowManager.cs
@@ -127,8 +127,14 @@ namespace OrchardCore.Workflows.Services
             // Start new workflows.
             foreach (var workflowType in workflowTypesToStart)
             {
-                // If this is a singleton workflow or if the event is exclusive, and there's already an instance, then skip.
-                if ((workflowType.IsSingleton || isExclusive) && haltedWorkflows.Any(x => x.WorkflowTypeId == workflowType.WorkflowTypeId))
+                // If this is a singleton workflow and there's already an halted instance, then skip.
+                if (workflowType.IsSingleton && await _workflowStore.HasHaltedInstanceAsync(workflowType.WorkflowTypeId))
+                {
+                    continue;
+                }
+
+                // If the event is exclusive and there's already an instance halted on this activity type, then skip.
+                if (isExclusive && haltedWorkflows.Any(x => x.WorkflowTypeId == workflowType.WorkflowTypeId))
                 {
                     continue;
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowStore.cs
@@ -28,6 +28,11 @@ namespace OrchardCore.Workflows.Services
             return FilterByWorkflowTypeId(_session.Query<Workflow, WorkflowIndex>(), workflowTypeId).CountAsync();
         }
 
+        public async Task<bool> HasHaltedInstanceAsync(string workflowTypeId)
+        {
+            return (await _session.Query<Workflow, WorkflowBlockingActivitiesIndex>(x => x.WorkflowTypeId == workflowTypeId).FirstOrDefaultAsync()) != null;
+        }
+
         public Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId = null, int? skip = null, int? take = null)
         {
             var query = (IQuery<Workflow>)FilterByWorkflowTypeId(_session.Query<Workflow, WorkflowIndex>(), workflowTypeId)
@@ -63,8 +68,7 @@ namespace OrchardCore.Workflows.Services
 
         public Task<IEnumerable<Workflow>> GetAsync(IEnumerable<string> workflowIds)
         {
-            var workflowIdList = workflowIds.ToList();
-            return _session.Query<Workflow, WorkflowBlockingActivitiesIndex>(x => x.WorkflowCorrelationId.IsIn(workflowIdList)).ListAsync();
+            return _session.Query<Workflow, WorkflowBlockingActivitiesIndex>(x => x.WorkflowId.IsIn(workflowIds)).ListAsync();
         }
 
         public Task<IEnumerable<Workflow>> GetAsync(IEnumerable<int> ids)

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowStore.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowStore.cs
@@ -7,6 +7,7 @@ namespace OrchardCore.Workflows.Services
     public interface IWorkflowStore
     {
         Task<int> CountAsync(string workflowTypeId = null);
+        Task<bool> HasHaltedInstanceAsync(string workflowTypeId);
         Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId = null, int? skip = null, int? take = null);
         Task<IEnumerable<Workflow>> ListAsync(IEnumerable<string> workflowTypeIds);
         Task<IEnumerable<Workflow>> ListAsync(string workflowTypeId, IEnumerable<string> blockingActivityIds);


### PR DESCRIPTION
Fixes #5997

- On a starting activity event, if the WF type is a `Singleton`, we don't start a new WF instance if there is already an halted instance, but only if this instance is halted on an activity of the same type as the above starting activity. Now, we check that the existing instance is halted on any activity type.

- There is still the "issue" if multiple events occur before having stored any WF instance, multiple WF instances will be created even if the worflow is a `Singleton`. Maybe we don't want to support this, anyway it would be done through another PR.

- Now, the WF type Singleton property is checked on an `HttpRequestFilterEvent`.

- Now, the WF type Singleton property is checked on an `HttpRequestEvent`.
