### PR TITLE
YesSql Session Wrapper

### DIFF
--- a/src/OrchardCore/OrchardCore.Data/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data/OrchardCoreBuilderExtensions.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     return store;
                 });
 
-                services.AddScoped(sp =>
+                services.AddScoped<ISession>(sp =>
                 {
                     var store = sp.GetService<IStore>();
 
@@ -113,12 +113,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     session.RegisterIndexes(scopedServices.ToArray());
 
-                    ShellScope.RegisterBeforeDispose(scope =>
-                    {
-                        return session.CommitAsync();
-                    });
-
-                    return session;
+                    return new SessionWrapper(session);
                 });
 
                 services.AddScoped<ISessionHelper, SessionHelper>();

--- a/src/OrchardCore/OrchardCore.Data/SessionWrapper.cs
+++ b/src/OrchardCore/OrchardCore.Data/SessionWrapper.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.Data
 
             if (!_canceled)
             {
-                // A save followed by a query and then a mutation, needs another save to persist the last mutation.
+                // A save followed by a query, and then a mutation, needs another save to persist the last mutation.
                 foreach (var item in _saved)
                 {
                     _session.Save(item);

--- a/src/OrchardCore/OrchardCore.Data/SessionWrapper.cs
+++ b/src/OrchardCore/OrchardCore.Data/SessionWrapper.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Threading.Tasks;
+using OrchardCore.Environment.Shell.Scope;
+using YesSql;
+using YesSql.Indexes;
+
+namespace OrchardCore.Data
+{
+    public class SessionWrapper : ISession
+    {
+        private readonly ISession _session;
+
+        private readonly HashSet<object> _saved = new HashSet<object>();
+
+        private bool _canceled;
+
+        public SessionWrapper(ISession session)
+        {
+            _session = session;
+
+            ShellScope.RegisterBeforeDispose(scope => BeforeDisposeAsync());
+        }
+
+        public Task BeforeDisposeAsync()
+        {
+            if (_session == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            // TODO: See what to do when 'CommitAsync()' is called explicitly as in 'UserStore'.
+
+            if (!_canceled)
+            {
+                // A save followed by a query and then a mutation, needs another save to persist the last mutation.
+                foreach (var item in _saved)
+                {
+                    _session.Save(item);
+                }
+            }
+            else
+            {
+                // A cancel followed by a query, a mutation and then a save, needs another cancel to not persist the last mutation.
+                _session.Cancel();
+            }
+
+            return _session.CommitAsync();
+        }
+
+        public IStore Store => _session.Store;
+
+        public void Cancel()
+        {
+            _canceled = true;
+            _session.Cancel();
+        }
+
+        public Task CommitAsync() => _session.CommitAsync();
+
+        public void Delete(object item) => _session.Delete(item);
+
+        public Task<DbTransaction> DemandAsync() => _session.DemandAsync();
+
+        public void Detach(object item) => _session.Detach(item);
+
+        public void Dispose() => _session.Dispose();
+
+        public IQuery<T> ExecuteQuery<T>(ICompiledQuery<T> compiledQuery) where T : class => _session.ExecuteQuery<T>(compiledQuery);
+
+        public Task FlushAsync() => _session.FlushAsync();
+
+        public Task<IEnumerable<T>> GetAsync<T>(int[] ids) where T : class => _session.GetAsync<T>(ids);
+
+        public bool Import(object item, int id) => _session.Import(item, id);
+
+        public IQuery Query() => _session.Query();
+
+        public ISession RegisterIndexes(params IIndexProvider[] indexProviders) => _session.RegisterIndexes(indexProviders);
+
+        public void Save(object item, bool checkConcurrency = false)
+        {
+            _session.Save(item, checkConcurrency);
+            _saved.Add(item);
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Data/SessionWrapper.cs
+++ b/src/OrchardCore/OrchardCore.Data/SessionWrapper.cs
@@ -30,8 +30,6 @@ namespace OrchardCore.Data
                 return Task.CompletedTask;
             }
 
-            // TODO: See what to do when 'CommitAsync()' is called explicitly as in 'UserStore'.
-
             if (!_canceled)
             {
                 // A save followed by a query and then a mutation, needs another save to persist the last mutation.
@@ -45,6 +43,8 @@ namespace OrchardCore.Data
                 // A cancel followed by a query, a mutation and then a save, needs another cancel to not persist the last mutation.
                 _session.Cancel();
             }
+
+            // TODO: See what to do when 'CommitAsync()' is called explicitly as in 'UserStore'.
 
             return _session.CommitAsync();
         }


### PR DESCRIPTION
Just to describe 2 "issues" related to the session that i saw, if there are real issues maybe better to do it on YesSql side, at least this wrapper, quickly done and registered in place of the `ISession`, shows what i mean. I will need to focus on it again but as i remember the 2 concerns were

- A save followed by a query, and then a mutation, needs another save to persist the last mutation.

- A cancel followed by a query, a mutation and then a save, needs another cancel to not persist the last mutation.

- TODO: See what to do when `CommitAsync()` is called explicitly as in `UserStore`.
