### PR TITLE
Add returnUrl for ListPart dropdown in ListPart.DetailAdmin.cshtml

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPart.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPart.DetailAdmin.cshtml
@@ -42,7 +42,7 @@ else
                     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
                         @foreach (var containedContentTypeDefinition in Model.ContainedContentTypeDefinitions)
                         {
-                            <a class="dropdown-item" asp-action="Create" asp-controller="Admin" asp-route-id="@containedContentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering">@containedContentTypeDefinition.DisplayName</a>
+                            <a class="dropdown-item" asp-action="Create" asp-controller="Admin" asp-route-id="@containedContentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">@containedContentTypeDefinition.DisplayName</a>
                         }
                     </div>
                 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPart.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPart.DetailAdmin.cshtml
@@ -24,7 +24,7 @@ else
         var contentTypeDefinition = Model.ContainedContentTypeDefinitions.FirstOrDefault();
         <div class="row">
             <div class="col form-group text-right">
-                <a class="btn btn-sm btn-success" asp-action="Create" asp-controller="Admin" asp-route-id="@contentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering">
+                <a class="btn btn-sm btn-success" asp-action="Create" asp-controller="Admin" asp-route-id="@contentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
                     @T["Create {0}", contentTypeDefinition.DisplayName]
                 </a>
             </div>
@@ -42,7 +42,9 @@ else
                     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
                         @foreach (var containedContentTypeDefinition in Model.ContainedContentTypeDefinitions)
                         {
-                            <a class="dropdown-item" asp-action="Create" asp-controller="Admin" asp-route-id="@containedContentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">@containedContentTypeDefinition.DisplayName</a>
+                            <a class="dropdown-item" asp-action="Create" asp-controller="Admin" asp-route-id="@containedContentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
+                                @containedContentTypeDefinition.DisplayName
+                            </a>
                         }
                     </div>
                 </div>


### PR DESCRIPTION
Many of the ContentItems I work with have an attached ListPart with multiple content items attached to the parent. 
e.g. I have course, with many lecture content items attached via list. Whenever I am adding new lectures to my course using the top right menu dropdown in the list part "Create" menu there is no return url attached. Each time I attach a new Lecture and click "Publish" I need to navigate back to the Course Content Item to continue attaching more lectures.

This is a major UX flaw for me.