### PR TITLE
Add constructor overload to CultureDictionaryRecord

### DIFF
--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/CultureDictionaryRecord.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/CultureDictionaryRecord.cs
@@ -11,9 +11,20 @@ namespace OrchardCore.Localization
         /// Creates new instance of <see cref="CultureDictionaryRecord"/>.
         /// </summary>
         /// <param name="messageId">The message Id.</param>
+        /// <param name="translations">a list of translations</param>
+        public CultureDictionaryRecord(string messageId, params string[] translations)
+            : this(messageId, null, translations)
+        {
+
+        }
+
+        /// <summary>
+        /// Creates new instance of <see cref="CultureDictionaryRecord"/>.
+        /// </summary>
+        /// <param name="messageId">The message Id.</param>
         /// <param name="context">The message context.</param>
         /// <param name="translations">a list of translations</param>
-        public CultureDictionaryRecord(string messageId, string context, string[] translations)
+        public CultureDictionaryRecord(string messageId, string context, params string[] translations)
         {
             Key = GetKey(messageId, context);
             Translations = translations;

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/CultureDictionaryRecord.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/CultureDictionaryRecord.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Localization
         /// <param name="messageId">The message Id.</param>
         /// <param name="context">The message context.</param>
         /// <param name="translations">a list of translations</param>
-        public CultureDictionaryRecord(string messageId, string context, params string[] translations)
+        public CultureDictionaryRecord(string messageId, string context, string[] translations)
         {
             Key = GetKey(messageId, context);
             Translations = translations;

--- a/test/OrchardCore.Tests/Localization/CultureDictionaryTests.cs
+++ b/test/OrchardCore.Tests/Localization/CultureDictionaryTests.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Tests.Localization
         public void MergeAddsRecordToEmptyDictionary()
         {
             var dictionary = new CultureDictionary("cs", _csPluralRule);
-            var record = new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" });
+            var record = new CultureDictionaryRecord("ball", "míč", "míče", "míčů");
 
             dictionary.MergeTranslations(new[] { record });
 
@@ -22,8 +22,8 @@ namespace OrchardCore.Tests.Localization
         public void MergeOverwritesTranslationsForSameKeys()
         {
             var dictionary = new CultureDictionary("cs", _csPluralRule);
-            var record = new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" });
-            var record2 = new CultureDictionaryRecord("ball", null, new[] { "balón", "balóny", "balónů" });
+            var record = new CultureDictionaryRecord("ball","míč", "míče", "míčů");
+            var record2 = new CultureDictionaryRecord("ball", "balón", "balóny", "balónů");
 
             dictionary.MergeTranslations(new[] { record });
             dictionary.MergeTranslations(new[] { record2 });
@@ -45,7 +45,7 @@ namespace OrchardCore.Tests.Localization
         public void IntexerThrowsPluralFormNotFoundExceptionIfSpecifiedPluralFormDoesntExist()
         {
             var dictionary = new CultureDictionary("cs", _csPluralRule);
-            var record = new CultureDictionaryRecord("ball", null, new[] { "míč", "míče" });
+            var record = new CultureDictionaryRecord("ball", "míč", "míče");
             dictionary.MergeTranslations(new[] { record });
 
             Assert.Throws<PluralFormNotFoundException>(() => dictionary["ball", 5]);

--- a/test/OrchardCore.Tests/Localization/LocalizationManagerTests.cs
+++ b/test/OrchardCore.Tests/Localization/LocalizationManagerTests.cs
@@ -41,7 +41,7 @@ namespace OrchardCore.Tests.Localization
         [Fact]
         public void GetDictionaryReturnsDictionaryWithTranslationsFromProvider()
         {
-            var dictionaryRecord = new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" });
+            var dictionaryRecord = new CultureDictionaryRecord("ball", "míč", "míče", "míčů");
             _translationProvider
                 .Setup(o => o.LoadTranslations(It.Is<string>(culture => culture == "cs"), It.IsAny<CultureDictionary>()))
                 .Callback<string, CultureDictionary>((culture, dictioanry) => dictioanry.MergeTranslations(new[] { dictionaryRecord }));

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -37,7 +37,7 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsTranslationsFromProvidedDictionary()
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" })
+                new CultureDictionaryRecord("ball", "míč", "míče", "míčů")
             });
 
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
@@ -53,7 +53,7 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsOriginalTextIfTranslationsDoesntExistInProvidedDictionary()
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" })
+                new CultureDictionaryRecord("ball", "míč", "míče", "míčů")
             });
 
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
@@ -83,10 +83,10 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerFallbacksToParentCultureIfTranslationDoesntExistInSpecificCulture()
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" })
+                new CultureDictionaryRecord("ball", "míč", "míče", "míčů")
             });
             SetupDictionary("cs-CZ", new[] {
-                new CultureDictionaryRecord("car", null, new[] { "auto", "auta", "aut" })
+                new CultureDictionaryRecord("car", "auto", "auta", "aut")
             });
 
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
@@ -102,10 +102,10 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsTranslationFromSpecificCultureIfItExists()
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" })
+                new CultureDictionaryRecord("ball", "míč", "míče", "míčů")
             });
             SetupDictionary("cs-CZ", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "balón", "balóny", "balónů" })
+                new CultureDictionaryRecord("ball", "balón", "balóny", "balónů")
             });
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
 
@@ -120,8 +120,8 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsTranslationWithSpecificContext()
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" }),
-                new CultureDictionaryRecord("ball", "small", new[] { "míček", "míčky", "míčků" })
+                new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
+                new CultureDictionaryRecord("ball", "small", "míček", "míčky", "míčků")
             });
             var localizer = new PortableObjectStringLocalizer("small", _localizationManager.Object, true, _logger.Object);
 
@@ -136,8 +136,8 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsTranslationWithoutContextIfTranslationWithContextDoesntExist()
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" }),
-                new CultureDictionaryRecord("ball", "big", new[] { "míček", "míčky", "míčků" })
+                new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
+                new CultureDictionaryRecord("ball", "big", "míček", "míčky", "míčků")
             });
             var localizer = new PortableObjectStringLocalizer("small", _localizationManager.Object, true, _logger.Object);
 
@@ -152,7 +152,7 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsFormattedTranslation()
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("The page (ID:{0}) was deleted.", null, new[] { "Stránka (ID:{0}) byla smazána." })
+                new CultureDictionaryRecord("The page (ID:{0}) was deleted.", "Stránka (ID:{0}) byla smazána.")
             });
             var localizer = new PortableObjectStringLocalizer("small", _localizationManager.Object, true, _logger.Object);
 
@@ -167,7 +167,7 @@ namespace OrchardCore.Tests.Localization
         public void HtmlLocalizerDoesNotFormatTwiceIfFormattedTranslationContainsCurlyBraces()
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("The page (ID:{0}) was deleted.", null, new[] { "Stránka (ID:{0}) byla smazána." })
+                new CultureDictionaryRecord("The page (ID:{0}) was deleted.", "Stránka (ID:{0}) byla smazána.")
             });
             var localizer = new PortableObjectStringLocalizer("small", _localizationManager.Object, true, _logger.Object);
             CultureInfo.CurrentUICulture = new CultureInfo("cs");
@@ -197,7 +197,7 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsOriginalTextForPluralIfTranslationDoesntExist(string expected, int count)
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "míč", "míče", "míčů" }),
+                new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
             });
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
             CultureInfo.CurrentUICulture = new CultureInfo("cs");
@@ -218,7 +218,7 @@ namespace OrchardCore.Tests.Localization
             TryGetRuleFromDefaultPluralRuleProvider(currentCulture, out var rule);
             Assert.NotNull(rule);
 
-            SetupDictionary(culture, new[] { new CultureDictionaryRecord("ball", null, translations), }, rule);
+            SetupDictionary(culture, new[] { new CultureDictionaryRecord("ball", translations), }, rule);
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
             var translation = localizer.Plural(count, "ball", "{0} balls", count);
 
@@ -232,7 +232,7 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsTranslationInCorrectPluralForm(string expected, int count)
         {
             SetupDictionary("cs", new[] {
-                new CultureDictionaryRecord("ball", null, new[] { "míč", "{0} míče", "{0} míčů" }),
+                new CultureDictionaryRecord("ball", "míč", "{0} míče", "{0} míčů"),
             });
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
             CultureInfo.CurrentUICulture = new CultureInfo("cs");
@@ -261,7 +261,7 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsCorrectPluralFormIfMultiplePluraflFormsAreSpecified(string expected, int count)
         {
             SetupDictionary("en", new CultureDictionaryRecord[] {
-                new CultureDictionaryRecord("míč", null, new[] { "ball", "{0} balls" })
+                new CultureDictionaryRecord("míč", "ball", "{0} balls")
             }, _enPluralRule);
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
             CultureInfo.CurrentUICulture = new CultureInfo("en");
@@ -276,7 +276,7 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerFallBackToParentCultureIfFallBackToParentUICulturesIsTrue(bool fallBackToParentCulture, string resourceKey, string expected)
         {
             SetupDictionary("ar", new CultureDictionaryRecord[] {
-                new CultureDictionaryRecord("hello", null, new[] { "مرحبا" })
+                new CultureDictionaryRecord("hello", "مرحبا")
             }, _arPluralRule);
             SetupDictionary("ar-YE", new CultureDictionaryRecord[] { }, _arPluralRule);
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, fallBackToParentCulture, _logger.Object);
@@ -292,14 +292,14 @@ namespace OrchardCore.Tests.Localization
         public void LocalizerReturnsGetAllStrings(bool includeParentCultures, string[] expected)
         {
             SetupDictionary("ar", new CultureDictionaryRecord[] {
-                new CultureDictionaryRecord("Blog", null, new[] { "مدونة" }),
-                new CultureDictionaryRecord("Menu", null, new[] { "قائمة" }),
-                new CultureDictionaryRecord("Page", null, new[] { "صفحة" }),
-                new CultureDictionaryRecord("Article", null, new[] { "مقالة" })
+                new CultureDictionaryRecord("Blog", "مدونة"),
+                new CultureDictionaryRecord("Menu", "قائمة"),
+                new CultureDictionaryRecord("Page", "صفحة"),
+                new CultureDictionaryRecord("Article", "مقالة")
             }, _arPluralRule);
             SetupDictionary("ar-YE", new CultureDictionaryRecord[] {
-                new CultureDictionaryRecord("Blog", null, new[] { "مدونة" }),
-                new CultureDictionaryRecord("Product", null, new[] { "منتج" })
+                new CultureDictionaryRecord("Blog", "مدونة"),
+                new CultureDictionaryRecord("Product", "منتج")
             }, _arPluralRule);
 
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, false, _logger.Object);

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -121,7 +121,7 @@ namespace OrchardCore.Tests.Localization
         {
             SetupDictionary("cs", new[] {
                 new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
-                new CultureDictionaryRecord("ball", "small", "míček", "míčky", "míčků")
+                new CultureDictionaryRecord("ball", "small",  new [] { "míček", "míčky", "míčků" })
             });
             var localizer = new PortableObjectStringLocalizer("small", _localizationManager.Object, true, _logger.Object);
 
@@ -137,7 +137,7 @@ namespace OrchardCore.Tests.Localization
         {
             SetupDictionary("cs", new[] {
                 new CultureDictionaryRecord("ball", "míč", "míče", "míčů"),
-                new CultureDictionaryRecord("ball", "big", "míček", "míčky", "míčků")
+                new CultureDictionaryRecord("ball", "big", new [] { "míček", "míčky", "míčků" })
             });
             var localizer = new PortableObjectStringLocalizer("small", _localizationManager.Object, true, _logger.Object);
 


### PR DESCRIPTION
Add additional overload to `CultureDictionaryRecord` that accept `messageId` and `translations` parameter could be useful for some cases:

- When there's no context is required, like in my case in `JsonStringLocalizer` [here](https://github.com/OrchardCoreContrib/OrchardCoreContrib/blob/dev/src/OrchardCoreContrib.Localization.Abstractions/CultureDictionaryRecordWrapper.cs), so the workaround that I did is to subclass the `CultureDictionaryRecord`

- Adding `params` also useful to
    - Avoid creating new array in the caller
    - Make `CultureDictionaryRecord` works fine for localizers that doesn't support pluralization