### PR TITLE
Update session save usage

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/DefaultContentLocalizationManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/DefaultContentLocalizationManager.cs
@@ -105,7 +105,6 @@ namespace OrchardCore.ContentLocalization
             await Handlers.InvokeAsync((handler, context) => handler.LocalizingAsync(context), context, _logger);
             await ReversedHandlers.InvokeAsync((handler, context) => handler.LocalizedAsync(context), context, _logger);
 
-            _session.Save(cloned);
             return cloned;
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -119,8 +119,12 @@ namespace OrchardCore.Contents.Controllers
             if (!string.IsNullOrEmpty(model.Options.SelectedContentType))
             {
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.Options.SelectedContentType);
+
                 if (contentTypeDefinition == null)
+                {
                     return NotFound();
+                }
+
                 contentTypeDefinitions = contentTypeDefinitions.Append(contentTypeDefinition);
 
                 // We display a specific type even if it's not listable so that admin pages
@@ -449,7 +453,9 @@ namespace OrchardCore.Contents.Controllers
             var contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.Latest);
 
             if (contentItem == null)
+            {
                 return NotFound();
+            }
 
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.EditContent, contentItem))
             {
@@ -521,27 +527,12 @@ namespace OrchardCore.Contents.Controllers
                 return Forbid();
             }
 
-            //string previousRoute = null;
-            //if (contentItem.Has<IAliasAspect>() &&
-            //    !string.IsNullOrWhiteSpace(returnUrl)
-            //    && Request.IsLocalUrl(returnUrl)
-            //    // only if the original returnUrl is the content itself
-            //    && String.Equals(returnUrl, Url.ItemDisplayUrl(contentItem), StringComparison.OrdinalIgnoreCase)
-            //    )
-            //{
-            //    previousRoute = contentItem.As<IAliasAspect>().Path;
-            //}
-
             var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, _updateModelAccessor.ModelUpdater, false);
             if (!ModelState.IsValid)
             {
                 _session.Cancel();
                 return View("Edit", model);
             }
-
-            // The content item needs to be marked as saved in case the drivers or the handlers have
-            // executed some query which would flush the saved entities inside the above UpdateEditorAsync.
-            _session.Save(contentItem);
 
             await conditionallyPublish(contentItem);
 
@@ -565,7 +556,9 @@ namespace OrchardCore.Contents.Controllers
             var contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.Latest);
 
             if (contentItem == null)
+            {
                 return NotFound();
+            }
 
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.CloneContent, contentItem))
             {
@@ -733,12 +726,5 @@ namespace OrchardCore.Contents.Controllers
             }
             return listable;
         }
-
-        //ActionResult ListableTypeList(int? containerId)
-        //{
-        //    var viewModel = Shape.ViewModel(ContentTypes: GetListableTypes(containerId.HasValue), ContainerId: containerId);
-
-        //    return View("ListableTypeList", viewModel);
-        //}
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.DisplayManagement.ModelBinding;

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -803,16 +803,16 @@ namespace OrchardCore.ContentManagement
 
                 await Handlers.InvokeAsync((handler, context) => handler.PublishingAsync(context), publishContext, _logger);
                 await ReversedHandlers.InvokeAsync((handler, context) => handler.PublishedAsync(context), publishContext, _logger);
+            }
 
-                // Restore values that may have been altered by handlers.
-                if (modifiedUtc.HasValue)
-                {
-                    updatingVersion.ModifiedUtc = modifiedUtc;
-                }
-                if (publishedUtc.HasValue)
-                {
-                    updatingVersion.PublishedUtc = publishedUtc;
-                }
+            // Restore values that may have been altered by handlers.
+            if (modifiedUtc.HasValue)
+            {
+                updatingVersion.ModifiedUtc = modifiedUtc;
+            }
+            if (publishedUtc.HasValue)
+            {
+                updatingVersion.PublishedUtc = publishedUtc;
             }
 
             return result;

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -273,7 +273,6 @@ namespace OrchardCore.ContentManagement
             }
 
             contentItem.Published = true;
-
             _session.Save(contentItem);
 
             await ReversedHandlers.InvokeAsync((handler, context) => handler.PublishedAsync(context), context, _logger);
@@ -317,7 +316,6 @@ namespace OrchardCore.ContentManagement
 
             publishedItem.Published = false;
             publishedItem.ModifiedUtc = _clock.UtcNow;
-
             _session.Save(publishedItem);
 
             await ReversedHandlers.InvokeAsync((handler, context) => handler.UnpublishedAsync(context), context, _logger);
@@ -390,10 +388,10 @@ namespace OrchardCore.ContentManagement
             // invoke handlers to add information to persistent stores
             await Handlers.InvokeAsync((handler, context) => handler.CreatingAsync(context), context, _logger);
 
-            await ReversedHandlers.InvokeAsync((handler, context) => handler.CreatedAsync(context), context, _logger);
-
             _session.Save(contentItem);
             _contentManagerSession.Store(contentItem);
+
+            await ReversedHandlers.InvokeAsync((handler, context) => handler.CreatedAsync(context), context, _logger);
 
             if (options.IsPublished)
             {
@@ -479,9 +477,6 @@ namespace OrchardCore.ContentManagement
                         // Imported handlers will only be fired if the validation has been successful.
                         // Consumers should implement validated handlers to alter the success of that operation.
                         await ReversedHandlers.InvokeAsync((handler, context) => handler.ImportedAsync(context), context, _logger);
-
-                        // Re-enlist content item here in case of session queries.
-                        _session.Save(importingItem);
                     }
                     else
                     {
@@ -533,9 +528,6 @@ namespace OrchardCore.ContentManagement
                         // Imported handlers will only be fired if the validation has been successful.
                         // Consumers should implement validated handlers to alter the success of that operation.
                         await ReversedHandlers.InvokeAsync((handler, context) => handler.ImportedAsync(context), context, _logger);
-
-                        // Re-enlist content item here in case of session queries.
-                        _session.Save(originalVersion);
                     }
                 }
 
@@ -550,9 +542,10 @@ namespace OrchardCore.ContentManagement
             var context = new UpdateContentContext(contentItem);
 
             await Handlers.InvokeAsync((handler, context) => handler.UpdatingAsync(context), context, _logger);
-            await ReversedHandlers.InvokeAsync((handler, context) => handler.UpdatedAsync(context), context, _logger);
 
             _session.Save(contentItem);
+
+            await ReversedHandlers.InvokeAsync((handler, context) => handler.UpdatedAsync(context), context, _logger);
         }
 
         public async Task<ContentValidateResult> ValidateAsync(ContentItem contentItem)
@@ -646,9 +639,11 @@ namespace OrchardCore.ContentManagement
             context.CloneContentItem.DisplayText = contentItem.DisplayText;
 
             await Handlers.InvokeAsync((handler, context) => handler.CloningAsync(context), context, _logger);
-            await ReversedHandlers.InvokeAsync((handler, context) => handler.ClonedAsync(context), context, _logger);
 
             _session.Save(context.CloneContentItem);
+
+            await ReversedHandlers.InvokeAsync((handler, context) => handler.ClonedAsync(context), context, _logger);
+
             return context.CloneContentItem;
         }
 
@@ -693,12 +688,13 @@ namespace OrchardCore.ContentManagement
             // Invoked create handlers.
             var context = new CreateContentContext(contentItem);
             await Handlers.InvokeAsync((handler, context) => handler.CreatingAsync(context), context, _logger);
-            await ReversedHandlers.InvokeAsync((handler, context) => handler.CreatedAsync(context), context, _logger);
 
             // The content item should be placed in the session store so that further calls
             // to ContentManager.Get by a scoped index provider will resolve the imported item correctly.
             _session.Save(contentItem);
             _contentManagerSession.Store(contentItem);
+
+            await ReversedHandlers.InvokeAsync((handler, context) => handler.CreatedAsync(context), context, _logger);
 
             await UpdateAsync(contentItem);
 
@@ -738,9 +734,6 @@ namespace OrchardCore.ContentManagement
             {
                 contentItem.Author = author;
             }
-
-            // Re-enlist content item here in case of session queries.
-            _session.Save(contentItem);
 
             return result;
         }
@@ -814,16 +807,13 @@ namespace OrchardCore.ContentManagement
                 // Restore values that may have been altered by handlers.
                 if (modifiedUtc.HasValue)
                 {
-                    updatedVersion.ModifiedUtc = modifiedUtc;
+                    updatingVersion.ModifiedUtc = modifiedUtc;
                 }
                 if (publishedUtc.HasValue)
                 {
-                    updatedVersion.PublishedUtc = publishedUtc;
+                    updatingVersion.PublishedUtc = publishedUtc;
                 }
             }
-
-            // Re-enlist content item here in case of session queries.
-            _session.Save(updatingVersion);
 
             return result;
         }
@@ -849,8 +839,10 @@ namespace OrchardCore.ContentManagement
                 var removeContext = new RemoveContentContext(contentItem, publishedVersion == null);
 
                 await Handlers.InvokeAsync((handler, context) => handler.RemovingAsync(context), removeContext, _logger);
+
                 latestVersion.Latest = false;
                 _session.Save(latestVersion);
+
                 await ReversedHandlers.InvokeAsync((handler, context) => handler.RemovedAsync(context), removeContext, _logger);
             }
         }
@@ -874,8 +866,10 @@ namespace OrchardCore.ContentManagement
                 var removeContext = new RemoveContentContext(contentItem, true);
 
                 await Handlers.InvokeAsync((handler, context) => handler.RemovingAsync(context), removeContext, _logger);
+
                 publishedVersion.Published = false;
                 _session.Save(publishedVersion);
+
                 await ReversedHandlers.InvokeAsync((handler, context) => handler.RemovedAsync(context), removeContext, _logger);
             }
         }


### PR DESCRIPTION
@sebastienros 

- We saw that now a session save can be done before / after handlers, but it may be still useful to do it before, at least before the `Xxxed` handlers, when the content item has not be queried, so not yet in the entity map, e.g. when cloning / creating a new one.

- **So here we do it between `Xxxing` and `Xxxed` handlers as it was already done most of the time**.

- **And i removed some session save calls that are now useless**.

- Note: There are some places where some mutations are done between handlers, and some other places where there are done before all handlers, but i let it as it is to not break anything.