### PR TITLE
Allow classes by default with the html sanitizer

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Services/DefaultMarkdownService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Services/DefaultMarkdownService.cs
@@ -10,9 +10,9 @@ namespace OrchardCore.Markdown.Services
         public DefaultMarkdownService(IOptions<MarkdownPipelineOptions> options)
         {
             var builder = new MarkdownPipelineBuilder();
-            if (options.Value.Configure != null)
+            foreach (var action in options.Value.Configure2)
             {
-                options.Value.Configure.Invoke(builder);
+                action.Invoke(builder);
             }
             _markdownPipeline = builder.Build();
         }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Services/DefaultMarkdownService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Services/DefaultMarkdownService.cs
@@ -10,9 +10,9 @@ namespace OrchardCore.Markdown.Services
         public DefaultMarkdownService(IOptions<MarkdownPipelineOptions> options)
         {
             var builder = new MarkdownPipelineBuilder();
-            foreach (var action in options.Value.Configure2)
+            foreach (var action in options.Value.Configure)
             {
-                action.Invoke(builder);
+                action?.Invoke(builder);
             }
             _markdownPipeline = builder.Build();
         }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptions.cs
@@ -6,7 +6,6 @@ namespace OrchardCore.Markdown.Services
 {
     public class MarkdownPipelineOptions
     {
-        public Action<MarkdownPipelineBuilder> Configure { get; set; }
-        public IList<Action<MarkdownPipelineBuilder>> Configure2 { get; set; } = new List<Action<MarkdownPipelineBuilder>>();
+        public IList<Action<MarkdownPipelineBuilder>> Configure { get; } = new List<Action<MarkdownPipelineBuilder>>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Markdig;
 
 namespace OrchardCore.Markdown.Services
@@ -6,5 +7,6 @@ namespace OrchardCore.Markdown.Services
     public class MarkdownPipelineOptions
     {
         public Action<MarkdownPipelineBuilder> Configure { get; set; }
+        public IList<Action<MarkdownPipelineBuilder>> Configure2 { get; set; } = new List<Action<MarkdownPipelineBuilder>>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptions.cs
@@ -6,6 +6,6 @@ namespace OrchardCore.Markdown.Services
 {
     public class MarkdownPipelineOptions
     {
-        public IList<Action<MarkdownPipelineBuilder>> Configure { get; } = new List<Action<MarkdownPipelineBuilder>>();
+        public List<Action<MarkdownPipelineBuilder>> Configure { get; } = new List<Action<MarkdownPipelineBuilder>>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptionsExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptionsExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             services.Configure<MarkdownPipelineOptions>(o =>
             {
-                o.Configure2.Add(action);
+                o.Configure.Add(action);
             });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptionsExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Services/MarkdownPipelineOptionsExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using Markdig;
+using OrchardCore.Markdown.Services;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class MarkdownPipelineOptionsExtensions
+    {
+        /// <summary>
+        /// Adds a configuration action to the markdown pipeline builder.
+        /// </summary>
+        public static void ConfigureMarkdownPipeline(this IServiceCollection services, Action<MarkdownPipelineBuilder> action)
+        {
+            services.Configure<MarkdownPipelineOptions>(o =>
+            {
+                o.Configure2.Add(action);
+            });
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Startup.cs
@@ -48,10 +48,8 @@ namespace OrchardCore.Markdown
 
             services.AddLiquidFilter<Markdownify>("markdownify");
 
-            services.Configure<MarkdownPipelineOptions>(o =>
-            {
-                o.Configure = (pipeline) => pipeline.DisableHtml();
-            });
+            services.AddOptions<MarkdownPipelineOptions>();
+            services.ConfigureMarkdownPipeline((pipeline) => pipeline.DisableHtml());
 
             services.AddScoped<IMarkdownService, DefaultMarkdownService>();
         }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptions.cs
@@ -6,6 +6,6 @@ namespace OrchardCore.Infrastructure.Html
 {
     public class HtmlSanitizerOptions
     {
-        public IList<Action<HtmlSanitizer>> Configure { get; } = new List<Action<HtmlSanitizer>>();
+        public List<Action<HtmlSanitizer>> Configure { get; } = new List<Action<HtmlSanitizer>>();
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptions.cs
@@ -6,6 +6,6 @@ namespace OrchardCore.Infrastructure.Html
 {
     public class HtmlSanitizerOptions
     {
-        public IList<Action<HtmlSanitizer>> Configure { get; set; } = new List<Action<HtmlSanitizer>>();
+        public IList<Action<HtmlSanitizer>> Configure { get; } = new List<Action<HtmlSanitizer>>();
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptions.cs
@@ -1,10 +1,11 @@
 using System;
+using System.Collections.Generic;
 using Ganss.XSS;
 
 namespace OrchardCore.Infrastructure.Html
 {
     public class HtmlSanitizerOptions
     {
-        public Action<HtmlSanitizer> Configure { get; set; }
+        public IList<Action<HtmlSanitizer>> Configure { get; set; } = new List<Action<HtmlSanitizer>>();
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptions.cs
@@ -5,6 +5,6 @@ namespace OrchardCore.Infrastructure.Html
 {
     public class HtmlSanitizerOptions
     {
-        public Action<Ganss.XSS.HtmlSanitizer> Configure { get; set; }
+        public Action<HtmlSanitizer> Configure { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptionsExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerOptionsExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using Ganss.XSS;
+using OrchardCore.Infrastructure.Html;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    public static class HtmlSanitizerOptionsExtensions
+    {
+        /// <summary>
+        /// Adds a configuration action to the html sanitizer.
+        /// </summary>
+        public static void ConfigureHtmlSanitizer(this IServiceCollection services, Action<HtmlSanitizer> action)
+        {
+            services.Configure<HtmlSanitizerOptions>(o =>
+            {
+                o.Configure.Add(action);
+            });
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerRazorExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerRazorExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OrchardCore;
 using OrchardCore.Infrastructure.Html;
 
-public static class HtmlSanitizerExtensions
+public static class HtmlSanitizerRazorExtensions
 {
     /// <summary>
     /// Sanitizes a string of html.

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerService.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerService.cs
@@ -9,9 +9,9 @@ namespace OrchardCore.Infrastructure.Html
 
         public HtmlSanitizerService(IOptions<HtmlSanitizerOptions> options)
         {
-            if (options.Value.Configure != null)
+            foreach(var action in options.Value.Configure)
             {
-                options.Value.Configure.Invoke(_sanitizer);
+                action.Invoke(_sanitizer);
             }
         }
 

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerService.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerService.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Infrastructure.Html
         {
             foreach(var action in options.Value.Configure)
             {
-                action.Invoke(_sanitizer);
+                action?.Invoke(_sanitizer);
             }
         }
 

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/OrchardCoreBuilderExtensions.cs
@@ -12,6 +12,13 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             builder.ConfigureServices(services =>
             {
+                services.Configure<HtmlSanitizerOptions>(o =>
+                {
+                    o.Configure = (sanitizer) =>
+                    {
+                        sanitizer.AllowedAttributes.Add("class");
+                    };
+                });
                 services.AddScoped<IHtmlSanitizerService, HtmlSanitizerService>();
             });
 

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/OrchardCoreBuilderExtensions.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             builder.ConfigureServices(services =>
             {
-                services.Configure<HtmlSanitizerOptions>(o =>
+                services.AddOptions<HtmlSanitizerOptions>();
+
+                services.ConfigureHtmlSanitizer((sanitizer) =>
                 {
-                    o.Configure = (sanitizer) =>
-                    {
-                        sanitizer.AllowedAttributes.Add("class");
-                    };
+                    sanitizer.AllowedAttributes.Add("class");
                 });
+
                 services.AddScoped<IHtmlSanitizerService, HtmlSanitizerService>();
             });
 

--- a/test/OrchardCore.Tests/Html/HtmlSanitizerTests.cs
+++ b/test/OrchardCore.Tests/Html/HtmlSanitizerTests.cs
@@ -27,12 +27,10 @@ namespace OrchardCore.Tests.Html
         public void ShouldConfigureSanitizer()
         {
             var services = new ServiceCollection();
-            services.Configure<HtmlSanitizerOptions>(o =>
+            services.AddOptions<HtmlSanitizerOptions>();
+            services.ConfigureHtmlSanitizer((sanitizer) =>
             {
-                o.Configure = (sanitizer) =>
-                {
-                    sanitizer.AllowedAttributes.Add("class");
-                };
+                sanitizer.AllowedAttributes.Add("class");
             });
 
             services.AddScoped<IHtmlSanitizerService, HtmlSanitizerService>();

--- a/test/OrchardCore.Tests/Html/HtmlSanitizerTests.cs
+++ b/test/OrchardCore.Tests/Html/HtmlSanitizerTests.cs
@@ -41,5 +41,31 @@ namespace OrchardCore.Tests.Html
             var sanitized = sanitizer.Sanitize(input);
             Assert.Equal(input, sanitized);
         }
+
+        [Fact]
+        public void ShouldReconfigureSanitizer()
+        {
+            // Setup. With defaults.
+            var services = new ServiceCollection();
+            services.AddOptions<HtmlSanitizerOptions>();
+            services.ConfigureHtmlSanitizer((sanitizer) =>
+            {
+                sanitizer.AllowedAttributes.Add("class");
+            });
+
+            // Act. Reconfigure to remove defaults.
+            services.Configure<HtmlSanitizerOptions>(o => {
+                o.Configure.Clear();
+            });
+
+            // Test.
+            services.AddScoped<IHtmlSanitizerService, HtmlSanitizerService>();
+
+            var sanitizer = services.BuildServiceProvider().GetService<IHtmlSanitizerService>();
+
+            var input = @"<a href=""bar"" class=""foo"">baz</a>";
+            var sanitized = sanitizer.Sanitize(input);
+            Assert.Equal(@"<a href=""bar"">baz</a>", sanitized);
+        }
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Markdown/MarkdownTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Markdown/MarkdownTests.cs
@@ -27,16 +27,22 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Markdown
         }
 
         [Fact]
-        public void ShouldDisabledHtmlEntityEscaping()
+        public void ShouldReconfigureMarkdownPipeline()
         {
+            // Setup. With defaults.
             var services = new ServiceCollection();
-            services.Configure<MarkdownPipelineOptions>(o =>
-            {
-                o.Configure2 = new List<Action<MarkdownPipelineBuilder>>();
-            });
+            services.AddOptions<MarkdownPipelineOptions>();
+            services.ConfigureMarkdownPipeline((pipeline) => pipeline.DisableHtml());
 
             services.AddScoped<IMarkdownService, DefaultMarkdownService>();
 
+            // Act. Clear configuration
+            services.Configure<MarkdownPipelineOptions>(o =>
+            {
+                o.Configure.Clear();
+            });
+
+            // Test.
             var markdownService = services.BuildServiceProvider().GetService<IMarkdownService>();
 
             var markdown = @"<h1>foo</h1>";

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Markdown/MarkdownTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Markdown/MarkdownTests.cs
@@ -1,3 +1,5 @@
+using System;
+using J2N.Collections.Generic;
 using Markdig;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Markdown.Services;
@@ -11,13 +13,8 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Markdown
         public void ShouldConfigureMarkdownPipeline()
         {
             var services = new ServiceCollection();
-            services.Configure<MarkdownPipelineOptions>(o =>
-            {
-                o.Configure = (pipeline) =>
-                {
-                    pipeline.DisableHtml();
-                };
-            });
+            services.AddOptions<MarkdownPipelineOptions>();
+            services.ConfigureMarkdownPipeline((pipeline) => pipeline.DisableHtml());
 
             services.AddScoped<IMarkdownService, DefaultMarkdownService>();
 
@@ -35,7 +32,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Markdown
             var services = new ServiceCollection();
             services.Configure<MarkdownPipelineOptions>(o =>
             {
-                o.Configure = null;
+                o.Configure2 = new List<Action<MarkdownPipelineBuilder>>();
             });
 
             services.AddScoped<IMarkdownService, DefaultMarkdownService>();


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6260

We should just give this a couple of days to make sure it's a good idea

Anyone can still alter the options, by using `Configure` to register a different `Action` to be invoked against the sanitizer.

A new registration would cancel the old `Action`. We could have a list of `Actions` and add to them, so it is progressive, rather than replacing.