### PR TITLE
Docs contrib guide (Lombiq Technologies: OCORE-26)

### DIFF
--- a/OrchardCore.sln
+++ b/OrchardCore.sln
@@ -249,7 +249,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{68F6113F-2F08-4412-B5E7-41B7164A0C7F}"
 	ProjectSection(SolutionItems) = preProject
 		gulpfile.js = gulpfile.js
-		mkdocs.yml = mkdocs.yml
 		package.json = package.json
 		README.md = README.md
 	EndProjectSection

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,10 @@ markdown_extensions:
 plugins:
   - search
   - git-revision-date-localized
+  - exclude:
+      glob:
+        # Excluding the large node folder with all its MD files. We can't exclude everything apart from docs because there are links to e.g. C# files too.
+        - "*node_modules*"
   
 # Page tree
 nav:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,10 +86,10 @@ nav:
         - Navigate between pages: docs/topics/navigation/README.md
         - Query and Search data: docs/topics/search/README.md
         - Secure your application: docs/topics/security/README.md
-        - Contributing to the docs: docs/topics/docs-contributions/README.md
 #        - Data: docs/topics/data/README.md
 #        - Configuration: docs/topics/configuration/README.md
         - Workflows: docs/topics/workflows/README.md
+        - Contributing to the docs: docs/topics/docs-contributions/README.md
     - Reference: 
         - CMS Modules: 
             - Content Types: docs/reference/modules/ContentTypes/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,4 +162,5 @@ nav:
     - Resources: 
         - Learning: docs/resources/README.md
         - Workshops: docs/resources/workshops/README.md
+        - Branding: docs/resources/branding/README.md
     

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
         - Navigate between pages: docs/topics/navigation/README.md
         - Query and Search data: docs/topics/search/README.md
         - Secure your application: docs/topics/security/README.md
+        - Contributing to the docs: docs/topics/docs-contributions/README.md
 #        - Data: docs/topics/data/README.md
 #        - Configuration: docs/topics/configuration/README.md
         - Workflows: docs/topics/workflows/README.md
@@ -162,5 +163,4 @@ nav:
     - Resources: 
         - Learning: docs/resources/README.md
         - Workshops: docs/resources/workshops/README.md
-        - Branding: docs/resources/branding/README.md
     

--- a/src/docs/getting-started/theme.md
+++ b/src/docs/getting-started/theme.md
@@ -1,6 +1,6 @@
 # Getting started with an Orchard Core Theme
 
-In this article, we are going to create an Orchard Core Theme by adding it to an existing Orchard Core CMS application [created previously](../README.md).
+In this article, we are going to create an Orchard Core Theme by adding it to an existing Orchard Core CMS application [created previously](README.md).
 
 ## Create an Orchard Core Theme
 

--- a/src/docs/reference/core/Configuration/README.md
+++ b/src/docs/reference/core/Configuration/README.md
@@ -122,7 +122,17 @@ services
     });
 ```
 
-This will thus make the SMTP port use this configuration despite any other value defined from site settings. 
+This will thus make the SMTP port use this configuration despite any other value defined from site settings. The second example's configuration value can come from e.g. an `appsettings.json` file like below:
+
+```
+{
+  "OrchardCore": {
+    "SmtpSettings": {
+      "Password":  "password"
+    }
+  }
+}
+```
 
 !!! note 
     On the admin there will be no indication that this override happened, and the value displayed there will still be 

--- a/src/docs/reference/core/Configuration/README.md
+++ b/src/docs/reference/core/Configuration/README.md
@@ -110,7 +110,7 @@ services
         // Instead of IShellConfiguration you could fetch the configuration 
         // values from an injected IConfiguration instance here too. While that 
         // would also allow you to access standard ASP.NET Core configuration 
-        // keys it wouldn't have support for all the hierarchical sources 
+        // keys it won't have support for all the hierarchical sources 
         // detailed above.
         var shellConfiguration = serviceProvider.GetRequiredService<IShellConfiguration>();
         var password = shellConfiguration.GetValue<string>("SmtpSettings:Password");

--- a/src/docs/reference/core/Configuration/README.md
+++ b/src/docs/reference/core/Configuration/README.md
@@ -77,7 +77,7 @@ without having to provide a state value.
   "OrchardCore": {
     "Default": {
       "OrchardCore_Media": {
-        ... specific tenant configuration configuration ...
+        ... specific tenant configuration ...
       }
     }
   }
@@ -146,7 +146,7 @@ Additionally these `appsettings.json` files do not need the `OrchardCore` sectio
 ```
 {
   "OrchardCore_Media": {
-    ... specific tenant configuration configuration ...
+    ... specific tenant configuration ...
   }
 }
 ```
@@ -164,8 +164,8 @@ OrchardCore__MyTenant__OrchardCore_Media__MaxFileSize
 ```
 
 !!! note
-    To support Linux the underscore `_` is used as a seperator, e.g. `OrchardCore_Media`
-    `OrchardCore.Media` is supported for backwards compatability, but users should migrate to the `_` pattern.
+    To support Linux the underscore `_` is used as a separator, e.g. `OrchardCore_Media`
+    `OrchardCore.Media` is supported for backwards compatibility, but users should migrate to the `_` pattern.
 
 ### Order of hierarchy
 

--- a/src/docs/reference/core/Configuration/README.md
+++ b/src/docs/reference/core/Configuration/README.md
@@ -19,7 +19,7 @@ Orchard Core supports a hierarchy of Configuration Sources
 The Configuration Sources are loaded in the above order, and settings lower in the hierarchy will override values configured higher up, i.e. an Global Tenant value will always be overridden by an Environment Variable.
 
 !!! note 
-    Not all modules, even if they expose `IOptions`-based configuration, have built-in support for `IShellConfiguration` keys. So the patterns in the `appsettings.json` examples below won't necessarily work for just any module out of the box. Keep reading on how you can combine the two.
+    The `IShellConfiguration` patterns in the `appsettings.json` examples below will only work for modules that specifically support such configuration. You can check out the given module's code or documentation to see if this is the case.
 
 ### `IShellConfiguration` in the `OrchardCore.Cms.Web.csproj` Startup Project
 
@@ -84,11 +84,11 @@ without having to provide a state value.
 }
 ```
 
-### IOptions Configuration
+### `IOptions` Configuration
 
 You can also configure `IOptions` from code in the web project's `Startup` class as explained in the [ASP.NET documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options). 
 
-A lot of Orchard Core features are configured through the admin UI with site settings stored in the database. If you wish to override the site settings, you can do this with your own configuration code.
+A lot of Orchard Core features are configured through the admin UI with site settings stored in the database and/or expose configuration via `IOptions`. If you wish to override the site settings or default settings, you can do this with your own configuration code.
 
 For example, the Email module allows SMTP configuration via the `SmtpSettings` class which by default is populated from the given tenant's site settings, as set on the admin. 
 However, you can override the site settings from the `Startup` class like this (note that we use `PostConfigure` to override the site settings values but if the module doesn't use site settings you can just use `Configure`):

--- a/src/docs/reference/core/Configuration/README.md
+++ b/src/docs/reference/core/Configuration/README.md
@@ -18,6 +18,9 @@ Orchard Core supports a hierarchy of Configuration Sources
 
 The Configuration Sources are loaded in the above order, and settings lower in the hierarchy will override values configured higher up, i.e. an Global Tenant value will always be overridden by an Environment Variable.
 
+!!! note 
+    Modules can expose configuration via `IOptions` objects, `IShellConfiguration` keys (like the ones supplied in `appsettings.json` files) or both. However, one is not guarantee for the other. For example, the Email module allows SMTP configuration via the `SmtpSettings` class exposed via `IOptions` but to supply those settings from an `appsettings.json` file you'll need read out `IShellConfiguration` keys in your own app's code, see below.
+
 ### `IShellConfiguration` in the `OrchardCore.Cms.Web.csproj` Startup Project
 
 Orchard Core stores all Configuration data under the `OrchardCore` section in `appsettings.json` files:
@@ -99,6 +102,7 @@ public void ConfigureServices(IServiceCollection services)
             tenantServices.PostConfigure<SmtpSettings>(settings =>
             {
                 // You could e.g. fetch the configuration values from an injected IShellConfiguration instance here.
+                // That in turn can then load configuration from e.g. appsettings.json files.
                 settings.Port = 255;
             }));
 }

--- a/src/docs/reference/core/Configuration/README.md
+++ b/src/docs/reference/core/Configuration/README.md
@@ -108,7 +108,7 @@ services
     .ConfigureServices((tenantServices, serviceProvider) =>
     {
         // Instead of IShellConfiguration you could fetch the configuration 
-        // values from an injected Configuration instance here too. While that 
+        // values from an injected IConfiguration instance here too. While that 
         // would also allow you to access standard ASP.NET Core configuration 
         // keys it wouldn't have support for all the hierarchical sources 
         // detailed above.
@@ -215,4 +215,3 @@ If building with the nightly dev builds from the preview package feed, the CI/CD
 The `IShellConfiguration` values stored in the `App_Data` folder, and individual tenants `appsettings.json` files, can also be stored in alternate locations.
 
 Refer to the [Shells Section](../Shells/README.md) for more details on this.
-

--- a/src/docs/reference/core/Configuration/README.md
+++ b/src/docs/reference/core/Configuration/README.md
@@ -122,7 +122,7 @@ services
     });
 ```
 
-This will thus make the SMTP port use this configuration despite any other value defined from site settings. The second example's configuration value can come from e.g. an `appsettings.json` file like below:
+This will make the SMTP port use this configuration despite any other value defined in site settings. The second example's configuration value can come from e.g. an `appsettings.json` file like below:
 
 ```
 {

--- a/src/docs/reference/core/Razor/README.md
+++ b/src/docs/reference/core/Razor/README.md
@@ -18,20 +18,20 @@ Many extensions methods are available in Razor with `@Orchard`.
 | `GetContentItemByVersionIdAsync(string contentItemVersionId)` | OrchardCore.Contents | Loads a content item by its version id. |
 | `QueryContentItemsAsync(Func<IQuery<ContentItem, ContentItemIndex>, IQuery<ContentItem>> query)` | OrchardCore.Contents | Query content items. |
 | `GetRecentContentItemsByContentTypeAsync(string contentType, int maxContentItems = 10)` | OrchardCore.Contents | Loads content items of a specific type. |
-| `LiquidToHtmlAsync(string liquid)` | [OrchardCore.Liquid](../../Modules/Liquid/README.md#razor-helpers) | Parses a liquid string to HTML. |
-| `LiquidToHtmlAsync(string liquid, object model)` | [OrchardCore.Liquid](../../Modules/Liquid/README.md#razor-helpers) | Parses a liquid string to HTML. |
+| `LiquidToHtmlAsync(string liquid)` | [OrchardCore.Liquid](../../modules/Liquid/README.md#razor-helpers) | Parses a liquid string to HTML. |
+| `LiquidToHtmlAsync(string liquid, object model)` | [OrchardCore.Liquid](../../modules/Liquid/README.md#razor-helpers) | Parses a liquid string to HTML. |
 | `QueryListItemsCountAsync(string listContentItemId, Expression<Func<ContentItemIndex, bool>> itemPredicate = null)` | OrchardCore.Lists | Returns list count. |
-| `QueryListItemsAsync(string listContentItemId, Expression<Func<ContentItemIndex, bool>> itemPredicate = null)` | [OrchardCore.List](../../Modules/List/README.md#orchard-helpers) | Returns list items. |
-| `MarkdownToHtmlAsync(string listContentItemId, Expression<Func<ContentItemIndex, bool>> itemPredicate = null)` | [OrchardCore.Markdown](../../Modules/Markdown/README.md#razor-helper) | Converts Markdown string to HTML. |
-| `AssetUrl(string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, bool appendVersion = false)` | [OrchardCore.Media](../../Modules/Media/README.md#razor-helpers) | Returns the relative URL of the specifier asset path with optional resizing parameters. |
-| `ImageResizeUrl(string imagePath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)` | [OrchardCore.Media](../../Modules/Media/README.md#razor-helpers) | Returns a URL with custom resizing parameters for an existing image path. |
-| `ContentQueryAsync(string queryName)` | [OrchardCore.Queries](../../Modules/Queries/README.md#razor-helpers) | Returns a List of Content items |
-| `ContentQueryAsync(string queryName, IDictionary<string, object> parameters)` | [OrchardCore.Queries](../../Modules/Queries/README.md#razor-helpers) | Returns a List of Content items |
-| `QueryAsync(string liquid, object model)` | [OrchardCore.Queries](../../Modules/Queries/README.md#razor-helpers) | Returns a List of objects |
-| `QueryAsync(string queryName, IDictionary<string, object> parameters)` | [OrchardCore.Queries](../../Modules/Queries/README.md#razor-helpers) | Returns a List of objects |
-| `GetTaxonomyTermAsync(string taxonomyContentItemId, string termContentItemId)` | [OrchardCore.Taxonomies](../../Modules/Taxonomies/README.md#orchard-helpers) | Returns a the term from its content item id and taxonomy. |
-| `GetInheritedTermsAsync(string taxonomyContentItemId, string termContentItemId)` | [OrchardCore.Taxonomies](../../Modules/Taxonomies/README.md#orchard-helpers) | Returns the list of terms including their parents. |
-| `QueryCategorizedContentItemsAsync(string taxonomy(Func<IQuery<ContentItem, TaxonomyIndex>, IQuery<ContentItem>> query)` | [OrchardCore.Taxonomies](../../Modules/Taxonomies/README.md#orchard-helpers) | Query content items. |
+| `QueryListItemsAsync(string listContentItemId, Expression<Func<ContentItemIndex, bool>> itemPredicate = null)` | [OrchardCore.List](../../modules/List/README.md#orchard-helpers) | Returns list items. |
+| `MarkdownToHtmlAsync(string listContentItemId, Expression<Func<ContentItemIndex, bool>> itemPredicate = null)` | [OrchardCore.Markdown](../../modules/Markdown/README.md#razor-helper) | Converts Markdown string to HTML. |
+| `AssetUrl(string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, bool appendVersion = false)` | [OrchardCore.Media](../../modules/Media/README.md#razor-helpers) | Returns the relative URL of the specifier asset path with optional resizing parameters. |
+| `ImageResizeUrl(string imagePath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)` | [OrchardCore.Media](../../modules/Media/README.md#razor-helpers) | Returns a URL with custom resizing parameters for an existing image path. |
+| `ContentQueryAsync(string queryName)` | [OrchardCore.Queries](../../modules/Queries/README.md#razor-helpers) | Returns a List of Content items |
+| `ContentQueryAsync(string queryName, IDictionary<string, object> parameters)` | [OrchardCore.Queries](../../modules/Queries/README.md#razor-helpers) | Returns a List of Content items |
+| `QueryAsync(string liquid, object model)` | [OrchardCore.Queries](../../modules/Queries/README.md#razor-helpers) | Returns a List of objects |
+| `QueryAsync(string queryName, IDictionary<string, object> parameters)` | [OrchardCore.Queries](../../modules/Queries/README.md#razor-helpers) | Returns a List of objects |
+| `GetTaxonomyTermAsync(string taxonomyContentItemId, string termContentItemId)` | [OrchardCore.Taxonomies](../../modules/Taxonomies/README.md#orchard-helpers) | Returns a the term from its content item id and taxonomy. |
+| `GetInheritedTermsAsync(string taxonomyContentItemId, string termContentItemId)` | [OrchardCore.Taxonomies](../../modules/Taxonomies/README.md#orchard-helpers) | Returns the list of terms including their parents. |
+| `QueryCategorizedContentItemsAsync(string taxonomy(Func<IQuery<ContentItem, TaxonomyIndex>, IQuery<ContentItem>> query)` | [OrchardCore.Taxonomies](../../modules/Taxonomies/README.md#orchard-helpers) | Query content items. |
 
 ## How to use
 

--- a/src/docs/reference/modules/MiniProfiler/README.md
+++ b/src/docs/reference/modules/MiniProfiler/README.md
@@ -2,4 +2,4 @@
 
 The module lets you use [Mini Profiler](https://miniprofiler.com/) to troubleshoot performance issues and generally to profile the performance of the application. Just enable the corresponding feature.
 
-By default, the module will display the Mini Profiler performance widget on the frontend only. If you want to enable it for the admin too then use the `AllowMiniProfilerOnAdmin()` extension method to set the `MiniProfilerOptions.EnableOnAdmin` option (see the [documentation on configuration](../../core/Configuration/README.MD)).
+By default, the module will display the Mini Profiler performance widget on the frontend only. If you want to enable it for the admin too then use the `AllowMiniProfilerOnAdmin()` extension method to set the `MiniProfilerOptions.EnableOnAdmin` option (see the [documentation on configuration](../../core/Configuration/README.md)).

--- a/src/docs/requirements.txt
+++ b/src/docs/requirements.txt
@@ -2,3 +2,4 @@ mkdocs>=1.1.1
 mkdocs-material>=5.2.0
 mkdocs-git-revision-date-localized-plugin>=0.5.2
 pymdown-extensions>=7.1
+mkdocs-exclude>=1.0.2

--- a/src/docs/topics/docs-contributions/README.md
+++ b/src/docs/topics/docs-contributions/README.md
@@ -1,0 +1,20 @@
+# Contributing to the Orchard Core documentation
+
+First of all, thank you for thinking about contributing to the docs! This is especially valuable while you're still new to Orchard because your experiences and revelations can help other newcomers a lot.
+
+The [Orchard Core documentation site](https://docs.orchardcore.net/) is built with [MkDocs](https://www.mkdocs.org/) and served from [Read the docs](https://readthedocs.org/projects/orchardcore/).
+
+## Editing documentation pages
+
+On every documentation page, including this one, you'll see an editor icon in the top right corner. If you click that you'll be able to do quick edits right within GitHub.
+
+Alternatively, you can clone the whole [Orchard Core repository](https://github.com/OrchardCMS/OrchardCore) and edit any documentation file there. These you can find under the *src/docs* folder. If you open the Orchard Core solution (*OrchardCore.sln* in the root) in Visual Studio or another IDE then you'll be able to browse the files in the `OrchardCore.Docs` project under the *docs* solution folder. If you use a Markdown editor like the [Markdown Editor VS extension](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.MarkdownEditor) then you'll see all the Markdown formatting and embedded images in a WYSIWYG manner, and links will work too.
+
+## Running the documentation site locally
+
+With MkDocs you can get the full docs.orchardcore.net experience locally too. If you are looking to contribute substantial amount of docs then please do run the site locally to make sure what you write will actually look like it should.
+
+1. Follow the [MkDocs installation guide](https://www.mkdocs.org/#installation). If you're on Windows we recommend doing this via chocolatey. In that case also be sure to check all the notes about adding Python and the MkDocs scripts to `PATH` otherwise none of the `mkdocs` commands will be found.
+2. Open a command line in the root of the repository.
+3. Run `pip install -r src\docs\requirements.txt` to install dependencies.
+4. Run `mkdocs serve` to start the site. You'll then be able to browse the site under http://127.0.0.1:8000.

--- a/src/docs/topics/docs-contributions/README.md
+++ b/src/docs/topics/docs-contributions/README.md
@@ -16,5 +16,5 @@ With MkDocs you can get the full docs.orchardcore.net experience locally too. If
 
 1. Follow the [MkDocs installation guide](https://www.mkdocs.org/#installation) to install Python. once you have Python installed you won't need to install MkDocs by hand, we'll do that in a next step. If you're on Windows be sure to add the Python *Scripts* folder to the `PATH` as noted there, otherwise none of the `mkdocs` commands will be found.
 2. Open a command line in the root of the repository.
-3. Run `pip3 install -r src\docs\requirements.txt` to install dependencies.
-4. Run `mkdocs serve` to start the site. You'll then be able to browse the site under http://127.0.0.1:8000.
+3. Run `pip3 install -r src/docs/requirements.txt` to install dependencies.
+4. Run `mkdocs serve` to start the site. You'll then be able to browse the it under http://127.0.0.1:8000.

--- a/src/docs/topics/docs-contributions/README.md
+++ b/src/docs/topics/docs-contributions/README.md
@@ -14,7 +14,7 @@ Alternatively, you can clone the whole [Orchard Core repository](https://github.
 
 With MkDocs you can get the full docs.orchardcore.net experience locally too. If you are looking to contribute substantial amount of docs then please do run the site locally to make sure what you write will actually look like it should.
 
-1. Follow the [MkDocs installation guide](https://www.mkdocs.org/#installation). If you're on Windows we recommend doing this via chocolatey. In that case also be sure to check all the notes about adding Python and the MkDocs scripts to `PATH` otherwise none of the `mkdocs` commands will be found.
+1. Follow the [MkDocs installation guide](https://www.mkdocs.org/#installation) to install Python. once you have Python installed you won't need to install MkDocs by hand, we'll do that in a next step. If you're on Windows be sure to add the Python *Scripts* folder to the `PATH` as noted there, otherwise none of the `mkdocs` commands will be found.
 2. Open a command line in the root of the repository.
-3. Run `pip install -r src\docs\requirements.txt` to install dependencies.
+3. Run `pip3 install -r src\docs\requirements.txt` to install dependencies.
 4. Run `mkdocs serve` to start the site. You'll then be able to browse the site under http://127.0.0.1:8000.

--- a/src/docs/topics/docs-contributions/README.md
+++ b/src/docs/topics/docs-contributions/README.md
@@ -17,4 +17,4 @@ With MkDocs you can get the full docs.orchardcore.net experience locally too. If
 1. Follow the [MkDocs installation guide](https://www.mkdocs.org/#installation) to install Python. once you have Python installed you won't need to install MkDocs by hand, we'll do that in a next step. If you're on Windows be sure to add the Python `Scripts` folder to the `PATH` as noted there, otherwise none of the `mkdocs` commands will be found.
 2. Open a command line in the root of the repository.
 3. Run `pip3 install -r src/docs/requirements.txt` to install dependencies.
-4. Run `mkdocs serve` to start the site. You'll then be able to browse the it under http://127.0.0.1:8000.
+4. Run `mkdocs serve` to start the site. You'll then be able to browse it under http://127.0.0.1:8000.

--- a/src/docs/topics/docs-contributions/README.md
+++ b/src/docs/topics/docs-contributions/README.md
@@ -8,13 +8,13 @@ The [Orchard Core documentation site](https://docs.orchardcore.net/) is built wi
 
 On every documentation page, including this one, you'll see an editor icon in the top right corner. If you click that you'll be able to do quick edits right within GitHub.
 
-Alternatively, you can clone the whole [Orchard Core repository](https://github.com/OrchardCMS/OrchardCore) and edit any documentation file there. These you can find under the *src/docs* folder. If you open the Orchard Core solution (*OrchardCore.sln* in the root) in Visual Studio or another IDE then you'll be able to browse the files in the `OrchardCore.Docs` project under the *docs* solution folder. If you use a Markdown editor like the [Markdown Editor VS extension](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.MarkdownEditor) then you'll see all the Markdown formatting and embedded images in a WYSIWYG manner, and links will work too.
+Alternatively, you can clone the whole [Orchard Core repository](https://github.com/OrchardCMS/OrchardCore) and edit any documentation file there. These you can find under the `src/docs` folder. If you open the Orchard Core solution (`OrchardCore.sln` in the root) in Visual Studio or another IDE then you'll be able to browse the files in the `OrchardCore.Docs` project under the `docs` solution folder. If you use a Markdown editor like the [Markdown Editor VS extension](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.MarkdownEditor) then you'll see all the Markdown formatting and embedded images in a WYSIWYG manner, and links will work too.
 
 ## Running the documentation site locally
 
 With MkDocs you can get the full docs.orchardcore.net experience locally too. If you are looking to contribute substantial amount of docs then please do run the site locally to make sure what you write will actually look like it should.
 
-1. Follow the [MkDocs installation guide](https://www.mkdocs.org/#installation) to install Python. once you have Python installed you won't need to install MkDocs by hand, we'll do that in a next step. If you're on Windows be sure to add the Python *Scripts* folder to the `PATH` as noted there, otherwise none of the `mkdocs` commands will be found.
+1. Follow the [MkDocs installation guide](https://www.mkdocs.org/#installation) to install Python. once you have Python installed you won't need to install MkDocs by hand, we'll do that in a next step. If you're on Windows be sure to add the Python `Scripts` folder to the `PATH` as noted there, otherwise none of the `mkdocs` commands will be found.
 2. Open a command line in the root of the repository.
 3. Run `pip3 install -r src/docs/requirements.txt` to install dependencies.
 4. Run `mkdocs serve` to start the site. You'll then be able to browse the it under http://127.0.0.1:8000.

--- a/src/docs/topics/localize/README.md
+++ b/src/docs/topics/localize/README.md
@@ -4,6 +4,6 @@ Orchard Core allows you to translate your strings with .po files and your conten
 
 ## Localize your Site
 
-- [Install localization files](../../guides/install-localization-files/README.MD)
+- [Install localization files](../../guides/install-localization-files/README.md)
 - [Localization](../../reference/modules/Localize/README.md)
 - [Content Localization](../../reference/modules/ContentLocalization/README.md)

--- a/src/docs/topics/localize/README.md
+++ b/src/docs/topics/localize/README.md
@@ -1,6 +1,5 @@
 # Localization
 
-[root](../../../../README.md#status)
 Orchard Core allows you to translate your strings with .po files and your contents in different cultures.
 
 ## Localize your Site


### PR DESCRIPTION
After some epic yak shaving with the MkDocs setup I've managed to compile this guide. Also included:

- MkDocs now won't build node_modules folders which slows it down incredibly. So you can work on the docs in the same clone as you work on Orchard normally (or you can open the solution in VS and let it restore NPM packages, and still be able to run the MkDocs server).
- Fixing broken links uncovered by the MkDocs build.
- Options clarification related to https://github.com/OrchardCMS/OrchardCore/issues/6264.