### PR TITLE
Prevent array duplication when merging existing content

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ApiController.cs
@@ -16,6 +16,8 @@ namespace OrchardCore.Content.Controllers
     [Authorize(AuthenticationSchemes = "Api"), IgnoreAntiforgeryToken, AllowAnonymous]
     public class ApiController : Controller
     {
+        private static readonly JsonMergeSettings UpdateJsonMergeSettings = new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace };
+
         private readonly IContentManager _contentManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly IStringLocalizer S;
@@ -122,7 +124,7 @@ namespace OrchardCore.Content.Controllers
                     return this.ChallengeOrForbid();
                 }
 
-                contentItem.Merge(model, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
+                contentItem.Merge(model, UpdateJsonMergeSettings);
 
                 await _contentManager.UpdateAsync(contentItem);
                 var result = await _contentManager.ValidateAsync(contentItem);

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ApiController.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
+using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.Contents;
 using OrchardCore.Mvc.Utilities;
@@ -121,7 +122,7 @@ namespace OrchardCore.Content.Controllers
                     return this.ChallengeOrForbid();
                 }
 
-                contentItem.Merge(model);
+                contentItem.Merge(model, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
 
                 await _contentManager.UpdateAsync(contentItem);
                 var result = await _contentManager.ValidateAsync(contentItem);

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -783,7 +783,7 @@ namespace OrchardCore.ContentManagement
                 await RemovePublishedVersionAsync(updatingVersion, evictionVersions);
             }
 
-            updatingVersion.Merge(updatedVersion);
+            updatingVersion.Merge(updatedVersion, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
             updatingVersion.Latest = importingLatest;
             updatingVersion.Published = importingPublished;
 

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -21,6 +21,7 @@ namespace OrchardCore.ContentManagement
     public class DefaultContentManager : IContentManager
     {
         private const int ImportBatchSize = 500;
+        private static readonly JsonMergeSettings UpdateJsonMergeSettings = new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace };
 
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ISession _session;
@@ -783,7 +784,7 @@ namespace OrchardCore.ContentManagement
                 await RemovePublishedVersionAsync(updatingVersion, evictionVersions);
             }
 
-            updatingVersion.Merge(updatedVersion, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
+            updatingVersion.Merge(updatedVersion, UpdateJsonMergeSettings);
             updatingVersion.Latest = importingLatest;
             updatingVersion.Published = importingPublished;
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6312

This fixes the issue, but I wonder if this behaviour should not be the default when merging content items?