### PR TITLE
Add default edit display option to publish later

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.PublishLater/Views/PublishLaterPart.Option.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.PublishLater/Views/PublishLaterPart.Option.cshtml
@@ -1,0 +1,4 @@
+﻿@{
+    string currentEditor = Model.Editor;
+}
+<option value="" selected="@String.IsNullOrEmpty(currentEditor)">@T["Standard"]</option>


### PR DESCRIPTION
The default (standard) edit mode option needs to be added as a shape as well, or anytime someone creates a custom edit mode they are no longer able to select the `Standard` option as it has no shape.

/cc @Piedone I would have pushed this to your pr, but can't edit your prs 