### PR TITLE
Refactor blog recipe to have less required fields

### DIFF
--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -115,7 +115,7 @@
               "Name": "Article",
               "Settings": {
                 "ContentTypePartSettings": {
-                  "Position": "2"
+                  "Position": "3"
                 }
               }
             },
@@ -139,7 +139,7 @@
               "Settings": {
                 "ContentTypePartSettings": {
                   "Editor": "Wysiwyg",
-                  "Position": "3"
+                  "Position": "2"
                 }
               }
             },
@@ -249,7 +249,7 @@
               "Name": "BlogPost",
               "Settings": {
                 "ContentTypePartSettings": {
-                  "Position": "2"
+                  "Position": "3"
                 }
               }
             },
@@ -259,7 +259,7 @@
               "Settings": {
                 "ContentTypePartSettings": {
                   "Editor": "Wysiwyg",
-                  "Position": "3"
+                  "Position": "2"
                 }
               }
             }
@@ -315,7 +315,7 @@
               "Name": "Blog",
               "Settings": {
                 "ContentTypePartSettings": {
-                  "Position": "2"
+                  "Position": "3"
                 }
               }
             },
@@ -324,7 +324,7 @@
               "Name": "HtmlBodyPart",
               "Settings": {
                 "ContentTypePartSettings": {
-                  "Position": "3"
+                  "Position": "2"
                 }
               }
             },
@@ -685,7 +685,6 @@
                   "Template": null
                 },
                 "MediaFieldSettings": {
-                  "Required": true,
                   "Multiple": false
                 }
               }
@@ -723,7 +722,6 @@
                   "Template": null
                 },
                 "MediaFieldSettings": {
-                  "Required": true,
                   "Multiple": false
                 }
               }  
@@ -740,7 +738,6 @@
                 },
                 "ContentIndexSettings": {},
                 "TaxonomyFieldSettings": {
-                  "Required": true,
                   "TaxonomyContentItemId": "[js: variables('tagsContentItemId')]"
                 },
                 "TaxonomyFieldTagsEditorSettings": {}
@@ -756,7 +753,6 @@
                 },
                 "ContentIndexSettings": {},
                 "TaxonomyFieldSettings": {
-                  "Required": true,
                   "TaxonomyContentItemId": "[js: variables('categoriesContentItemId')]",
                   "Unique": true,
                   "LeavesOnly": true
@@ -788,7 +784,6 @@
                   "Position": "0"
                 },
                 "MediaFieldSettings": {
-                  "Required": false,
                   "Multiple": false
                 }
               }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6299

I cannot repro the missing images on initial run of recipe, so will have to wait until I see the error again.

No template changes required here, everything handles things.

![blogpost](https://user-images.githubusercontent.com/13782679/83720538-22762d80-a631-11ea-8b7e-0333b761438b.PNG)
