### PR TITLE
Add reference doc pages for missing features (Lombiq Technologies: OCORE-30)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,7 +102,8 @@ nav:
                 - Markdown: docs/reference/modules/Markdown/README.md
                 - List: docs/reference/modules/List/README.md
                 - Flow: docs/reference/modules/Flow/README.md 
-                - Bag: docs/reference/modules/Flow/BagPart.md        
+                - Bag: docs/reference/modules/Flow/BagPart.md
+                - Publish Later: docs/reference/modules/PublishLater/README.md
             - Content Fields: docs/reference/modules/ContentFields/README.md
             - Content Preview: docs/reference/modules/ContentPreview/README.md
             - Content Localization: docs/reference/modules/ContentLocalization/README.md
@@ -120,7 +121,9 @@ nav:
             - Media Azure: docs/reference/modules/Media.Azure/README.md
             - ReCaptcha: docs/reference/modules/ReCaptcha/README.md
             - Resources: docs/reference/modules/Resources/README.md
+            - ShortCodes: docs/reference/modules/ShortCodes/README.md
             - Sitemaps: docs/reference/modules/Sitemaps/README.md
+            - XML-RPC: docs/reference/modules/XmlRpc/README.md
             - Menu: docs/reference/modules/Menu/README.md
             - Navigation: docs/reference/modules/Navigation/README.md
             - Admin: docs/reference/modules/Admin/README.md
@@ -146,6 +149,7 @@ nav:
             - GraphQL: docs/reference/modules/Apis.GraphQL/README.md
             - GraphQL queries: docs/reference/core/Apis.GraphQL.Abstractions/README.md
             - Health Check: docs/reference/modules/HealthChecks/README.md
+            - HTTPS: docs/reference/modules/Https/README.md
             - Localization: docs/reference/modules/Localize/README.md
             - Logging Serilog: docs/reference/core/Logging.Serilog/readme.md
             - Mini Profiler: docs/reference/modules/MiniProfiler/README.md
@@ -153,6 +157,7 @@ nav:
             - OpenId: docs/reference/modules/OpenId/README.md
             - Razor Helpers: docs/reference/core/Razor/README.md
             - Recipes: docs/reference/modules/Recipes/README.md
+            - Response Compression: docs/reference/modules/ResponseCompression/README.md
             - Roles: docs/reference/modules/Roles/README.md
             - Scripting: docs/reference/modules/Scripting/README.md
             - Setup: docs/reference/modules/Setup/README.md

--- a/src/docs/reference/core/Data/README.md
+++ b/src/docs/reference/core/Data/README.md
@@ -1,4 +1,4 @@
-# Data (OrchardCore.Data)
+# Data (`OrchardCore.Data`)
 
 ## Running SQL queries
 

--- a/src/docs/reference/core/Logging.Serilog/readme.md
+++ b/src/docs/reference/core/Logging.Serilog/readme.md
@@ -1,12 +1,12 @@
 # OrchardCore.Logging.Serilog
 
-`OrchardCore.Logging.Serilog` integrates [Serilog](https://serilog.net/) structured logging with OrchardCore
+`OrchardCore.Logging.Serilog` integrates [Serilog](https://serilog.net/) structured logging with OrchardCore.
 
 ## How to use
 
-add a reference to `OrchardCore.Logging.Serilog`
+Add a reference to `OrchardCore.Logging.Serilog`.
 
-### add serilog configuration in appsettings.json
+### Add serilog configuration in appsettings.json
 
 ``` json
   "Serilog": {

--- a/src/docs/reference/modules/ContentPreview/README.md
+++ b/src/docs/reference/modules/ContentPreview/README.md
@@ -1,4 +1,4 @@
-# Content Preview (OrchardCore.ContentPreview)
+# Content Preview (`OrchardCore.ContentPreview`)
 
 Content preview allows you to display the result that will be rendered on the frontend in a separate window, while you are editing a content item in the admin.
 

--- a/src/docs/reference/modules/Contents/README.md
+++ b/src/docs/reference/modules/Contents/README.md
@@ -1,4 +1,4 @@
-# Contents (OrchardCore.Contents)
+# Contents (`OrchardCore.Contents`)
 
 This module provides Content Management services.
 

--- a/src/docs/reference/modules/CustomSettings/README.md
+++ b/src/docs/reference/modules/CustomSettings/README.md
@@ -1,4 +1,4 @@
-# Custom Settings (OrchardCore.CustomSettings)
+# Custom Settings (`OrchardCore.CustomSettings`)
 
 Custom Settings allow a site administrator to create a customized set of properties that are global to the web sites.  
 These settings are edited in the standard Settings section and can be protected with specific permissions.

--- a/src/docs/reference/modules/DataProtection.Azure/README.md
+++ b/src/docs/reference/modules/DataProtection.Azure/README.md
@@ -1,4 +1,4 @@
-# Data Protection (Azure Storage) (OrchardCore.DataProtection.Azure)
+# Data Protection (Azure Storage) (`OrchardCore.DataProtection.Azure`)
 
 ## Purpose
 

--- a/src/docs/reference/modules/DynamicCache/README.md
+++ b/src/docs/reference/modules/DynamicCache/README.md
@@ -1,4 +1,4 @@
-# Dynamic Cache (OrchardCore.DynamicCache)
+# Dynamic Cache (`OrchardCore.DynamicCache`)
 
 ## Purpose
 

--- a/src/docs/reference/modules/Facebook/README.md
+++ b/src/docs/reference/modules/Facebook/README.md
@@ -1,8 +1,8 @@
-# OrchardCore.Facebook
+# Facebook (`OrchardCore.Facebook`)
 
 ## Facebook Module
 
-`OrchardCore.Facebook` provides the following features
+`OrchardCore.Facebook` provides the following features:
 
 - Core Components
 - Facebook Login

--- a/src/docs/reference/modules/GitHub/README.md
+++ b/src/docs/reference/modules/GitHub/README.md
@@ -1,4 +1,4 @@
-# GitHub (OrchardCore.GitHub)
+# GitHub (`OrchardCore.GitHub`)
 
 This module adds GitHub Authentication to OrchardCore.
 

--- a/src/docs/reference/modules/Google/README.md
+++ b/src/docs/reference/modules/Google/README.md
@@ -1,4 +1,4 @@
-# Google (OrchardCore.Google)
+# Google (`OrchardCore.Google`)
 
 This module adds Google features to OrchardCore.
 

--- a/src/docs/reference/modules/HealthChecks/README.md
+++ b/src/docs/reference/modules/HealthChecks/README.md
@@ -1,4 +1,4 @@
-# Health Check (OrchardCore.HealthChecks)
+# Health Check (`OrchardCore.HealthChecks`)
 
 This module enables the health checks feature from ASP.NET Core.
 

--- a/src/docs/reference/modules/Https/README.md
+++ b/src/docs/reference/modules/Https/README.md
@@ -1,0 +1,3 @@
+# HTTPS (`OrchardCore.Https`)
+
+The module will ensure HTTPS is used when accessing the website. You can force HTTPS on all pages, enable HSTS, and configure the HTTPS port.

--- a/src/docs/reference/modules/Lucene/README.md
+++ b/src/docs/reference/modules/Lucene/README.md
@@ -1,4 +1,4 @@
-# Lucene (OrchardCore.Lucene)
+# Lucene (`OrchardCore.Lucene`)
 
 The Lucene module allows to manage Lucene indices.
 

--- a/src/docs/reference/modules/Microsoft.Authentication/README.md
+++ b/src/docs/reference/modules/Microsoft.Authentication/README.md
@@ -1,4 +1,4 @@
-# Microsoft Authentication (OrchardCore.Microsoft.Authentication)
+# Microsoft Authentication (`OrchardCore.Microsoft.Authentication`)
 
 This module configures Orchard to support Microsoft Account and/or Microsoft Azure Active Directory accounts.
 

--- a/src/docs/reference/modules/MiniProfiler/README.md
+++ b/src/docs/reference/modules/MiniProfiler/README.md
@@ -1,4 +1,4 @@
-# Orchard Core Mini Profiler
+# Mini Profiler (`OrchardCore.MiniProfiler`)
 
 The module lets you use [Mini Profiler](https://miniprofiler.com/) to troubleshoot performance issues and generally to profile the performance of the application. Just enable the corresponding feature.
 

--- a/src/docs/reference/modules/OpenId/README.md
+++ b/src/docs/reference/modules/OpenId/README.md
@@ -1,4 +1,4 @@
-# `OrchardCore.OpenId`
+# OpenID (`OrchardCore.OpenId`)
 
 ## OpenID Connect Module
 

--- a/src/docs/reference/modules/PublishLater/README.md
+++ b/src/docs/reference/modules/PublishLater/README.md
@@ -1,0 +1,3 @@
+# Publish Later (`OrchardCore.PublishLater`)
+
+Adds the ability to schedule content items to be published at a given future date and time. Attach the Publish Later Part to any content type where you want the feature to be available.

--- a/src/docs/reference/modules/ReCaptcha/README.md
+++ b/src/docs/reference/modules/ReCaptcha/README.md
@@ -1,4 +1,4 @@
-# ReCaptcha
+# ReCaptcha (`OrchardCore.ReCaptcha`)
 
 The OrchardCore.ReCaptcha module can be used to prevent robots from abusing your OrchardCore website.
 

--- a/src/docs/reference/modules/Recipes/README.md
+++ b/src/docs/reference/modules/Recipes/README.md
@@ -1,4 +1,4 @@
-# Recipes (OrchardCore.Recipes)
+# Recipes (`OrchardCore.Recipes`)
 
 ## Recipe file
 

--- a/src/docs/reference/modules/ResponseCompression/README.md
+++ b/src/docs/reference/modules/ResponseCompression/README.md
@@ -1,0 +1,3 @@
+# Response Compression (`OrchardCore.ResponseCompression`)
+
+Compresses HTTP responses with gzip, just enable the feature.

--- a/src/docs/reference/modules/Scripting/README.md
+++ b/src/docs/reference/modules/Scripting/README.md
@@ -1,4 +1,4 @@
-# Scripting `OrchardCore.Scripting`
+# Scripting (`OrchardCore.Scripting`)
 
 ## Purpose
 

--- a/src/docs/reference/modules/ShortCodes/README.md
+++ b/src/docs/reference/modules/ShortCodes/README.md
@@ -1,0 +1,3 @@
+# ShortCodes (`OrchardCore.ShortCodes`)
+
+Adds short code capabilities. Short codes are small pieces of code wrapped into \[brackets\] that can add some behavior to your content, like embedding media files.

--- a/src/docs/reference/modules/Taxonomies/README.md
+++ b/src/docs/reference/modules/Taxonomies/README.md
@@ -1,4 +1,4 @@
-# Taxonomies (OrchardCore.Taxonomies)
+# Taxonomies (`OrchardCore.Taxonomies`)
 
 This module provides a Taxonomy content type that is used to define managed vocabularies (categories) of any type.  
 Taxonomy content items are made of terms organized as a hierarchy. Using the Taxonomy Field allows any content item

--- a/src/docs/reference/modules/Themes/README.md
+++ b/src/docs/reference/modules/Themes/README.md
@@ -1,4 +1,4 @@
-# Orchard Core Theming explained
+# Orchard Core Theming explained (`OrchardCore.Themes`)
 
 This article explains how a Content Item is rendered, and the many ways in which the HTML that is rendered can be customized.  
 It also explains the fundamental theming concepts, namely __Shapes__, __Alternates__, __Templates__, __Differentiators__, __Content Zones__ and __Display Types__.

--- a/src/docs/reference/modules/Twitter/README.md
+++ b/src/docs/reference/modules/Twitter/README.md
@@ -1,4 +1,4 @@
-# Twitter (OrchardCore.Twitter)
+# Twitter (`OrchardCore.Twitter`)
 
 This module adds Twitter for Websites features to OrchardCore.
 

--- a/src/docs/reference/modules/Users/README.md
+++ b/src/docs/reference/modules/Users/README.md
@@ -1,4 +1,4 @@
-# Users (OrchardCore.Users)
+# Users (`OrchardCore.Users`)
 
 The Users module enables authentication UI and user management.
 

--- a/src/docs/reference/modules/Workflows/README.md
+++ b/src/docs/reference/modules/Workflows/README.md
@@ -1,4 +1,4 @@
-# Workflows (OrchardCore.Workflows)
+# Workflows (`OrchardCore.Workflows`)
 
 The Workflows module provides a way for users to visually implement business rules using flowchart diagrams.
 

--- a/src/docs/reference/modules/XmlRpc/README.md
+++ b/src/docs/reference/modules/XmlRpc/README.md
@@ -1,0 +1,3 @@
+# XML-RPC (`OrchardCore.XmlRpc`)
+
+Enables creation of contents from client applications such as Open Live Writer.


### PR DESCRIPTION
Only added some rudimentary docs so people can at least see that these features exist. Don't have time for more in-depth docs right now but these features are quite simple anyway.

Also fixing inconsistencies in reference pages' titles.