### PR TITLE
Upgrade Azure.Storage.Blobs

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageManagement Include="AngleSharp" Version="0.14.0" />
-    <PackageManagement Include="Azure.Storage.Blobs" Version="12.4.2" />
+    <PackageManagement Include="Azure.Storage.Blobs" Version="12.4.4" />
     <PackageManagement Include="Castle.Core" Version="4.4.1" />
     <PackageManagement Include="Irony.Core" Version="1.0.7" />
     <PackageManagement Include="Fluid.Core" Version="1.0.0-beta-9651" />


### PR DESCRIPTION
This should fix an issue with diactrics when used with the `MediaAttached` editor.

There is a bug in the library when copying the temp files because the library uses headers for the file names to copy, but headers must only have ascii characters.

So they fixed it and the headers should now be encoded when the media file has an accent etc.

/cc @Skrypt Can you test this to see if it resolves your issue?