### PR TITLE
Initialize setup supported cultures only if there is a meta package

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Startup.cs
@@ -19,7 +19,7 @@ namespace OrchardCore.Setup
         private readonly string _defaultCulture = CultureInfo.InstalledUICulture.Name;
 
         private string[] _supportedCultures = new string[] {
-            "ar", "cs", "da", "de", "el", "en", "es", "fa", "fi", "fr", "he", "hr", "hu", "id", "it", "ja", "ko", "lt", "mk", "nl", "pl", "pt", "ru", "sk", "sl", "sr-cyrl-rs", "sr-latn-rs", "sv", "tr", "uk", "vi", "zh-CN", "zh-TW"
+            "ar", "cs", "de", "el", "en", "es", "fa", "fr", "it", "ja", "pl", "ru", "sv", "tr", "vi", "zh-CN", "zh-TW"
         };
 
         public Startup(IShellConfiguration shellConfiguration)


### PR DESCRIPTION
Fixes #6358

Related to https://github.com/OrchardCMS/OrchardCore.Translations/pull/38#issuecomment-639102495 