### PR TITLE
Make import integration tests behave with dotnet test

### DIFF
--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostValidateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostValidateDeploymentPlanTests.cs
@@ -1,4 +1,4 @@
-using System.Net.Http;
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
@@ -40,10 +40,12 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 secondContentItem[nameof(AutoroutePart)][nameof(AutoroutePart.Path)] = "blog/post-1";
                 data.Add(secondContentItem);
 
-                var response = await context.PostRecipeAsync(recipe, false);
-
                 // Test
-                Assert.Throws<HttpRequestException>(() => response.EnsureSuccessStatusCode());
+                await Assert.ThrowsAnyAsync<Exception>(async () =>
+                {
+                    var response = await context.PostRecipeAsync(recipe, false);
+                    response.EnsureSuccessStatusCode();
+                });
 
                 // Confirm creation of both content items was cancelled.
                 using (var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName))


### PR DESCRIPTION
Fixes an issue where the test ran correctly under VS, but not under `dotnet test`

Note: We will still see an error log in the test run, as the controller logs an error