### PR TITLE
Reset twitter client to use HttpClientFactory

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Manifest.cs
@@ -1,8 +1,5 @@
-using System.Runtime.CompilerServices;
 using OrchardCore.Modules.Manifest;
 using OrchardCore.Twitter;
-
-[assembly: InternalsVisibleTo("OrchardCore.Tests")]
 
 [assembly: Module(
     Name = "Twitter",

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Services/TwitterClient.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Services/TwitterClient.cs
@@ -9,11 +9,12 @@ namespace OrchardCore.Twitter.Services
 {
     public class TwitterClient
     {
-        internal static HttpClient _client = new HttpClient();
+        private readonly HttpClient _client;
         private readonly ILogger _logger;
 
-        public TwitterClient(ILogger<TwitterClient> logger)
+        public TwitterClient(HttpClient client, ILogger<TwitterClient> logger)
         {
+            _client = client;
             _client.BaseAddress = new Uri("https://api.twitter.com");
             _client.DefaultRequestHeaders.Accept.Clear();
             _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Twitter/TwitterClientTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Twitter/TwitterClientTests.cs
@@ -80,10 +80,9 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Twitter
                     message = msg
                 );
 
-            var mockTwitterClient = new Mock<TwitterClient>(Mock.Of<ILogger<TwitterClient>>())
+            var mockTwitterClient = new Mock<TwitterClient>(
+                new HttpClient(mockFakeHttpMessageHandler.Object), Mock.Of<ILogger<TwitterClient>>())
             { CallBase = true };
-
-            TwitterClient._client = new HttpClient(mockFakeHttpMessageHandler.Object);
 
             mockHttpMessageHandler.Setup(c => c.GetNonce())
                 .Returns(() => "kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg");


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6373

Resets usages back to as they were before.

The usage for `HttpClientFactory` look good to me. There is no disposing of the `HttpClient` anywhere as that is managed.

I think it was the other `HttpRequestTask` workflow that was misusing it.