### PR TITLE
ImageSharp license update

### DIFF
--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -251,6 +251,6 @@ The following configuration values are used by default and can be customized:
 
 ### ImageSharp
 
-<https://sixlabors.com/projects/imagesharp/>  
+<https://sixlabors.com/products/imagesharpweb/>  
 Copyright 2012 James South  
-Licensed under the Apache License, Version 2.0
+Licensed under the Apache License, Version 2.0, or with a commercial support license <https://sixlabors.com/pricing>


### PR DESCRIPTION
Updated to include the optional commercial support license that is now available.