### PR TITLE
Add the ability to export any site settings (Lombiq Technologies: OCORE-31)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Items/SiteSettingsDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Items/SiteSettingsDeploymentStep.Fields.Edit.cshtml
@@ -8,8 +8,8 @@
     var siteSettings = await SiteService.GetSiteSettingsAsync();
 
     var propertyNames =
-        typeof(ISite).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(property => property.Name)
-        .Union(((IDictionary<string, JToken>)siteSettings.Properties).Keys.Where(key => key != "name"));
+        typeof(ISite).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(property => property.Name).OrderBy(name => name)
+        .Union(((IDictionary<string, JToken>)siteSettings.Properties).Keys.Where(key => key != "name").OrderBy(key => key));
 }
 <h5>@T["Site Settings"]</h5>
 

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Items/SiteSettingsDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Items/SiteSettingsDeploymentStep.Fields.Edit.cshtml
@@ -1,22 +1,29 @@
 @model SiteSettingsDeploymentStepViewModel
 @using System.Reflection
+@using Newtonsoft.Json.Linq
+@inject ISiteService SiteService
+
 @{
     var settings = Model.Settings;
+    var siteSettings = await SiteService.GetSiteSettingsAsync();
+
+    var propertyNames =
+        typeof(ISite).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(property => property.Name)
+        .Union(((IDictionary<string, JToken>)siteSettings.Properties).Keys.Where(key => key != "name"));
 }
 <h5>@T["Site Settings"]</h5>
 
 <div class="form-group">
     <span class="hint">@T["The site settings to add as part of the plan."]</span>
     <ul class="list-group w-md-50">
-        @foreach (var setting in typeof(ISite).GetProperties(BindingFlags.Public | BindingFlags.Instance))
+        @foreach (var setting in propertyNames)
         {
-            var name = setting.Name;
-            var checkd = settings?.Contains(name);
+            var checkd = settings?.Contains(setting);
 
             <li class="list-group-item">
                 <div class="custom-control custom-checkbox">
-                    <input type="checkbox" class="custom-control-input" id="@(Html.IdFor(m => m.Settings) + "-" + @name)" name="@Html.NameFor(m => m.Settings)" value="@name" checked="@checkd">
-                    <label class="custom-control-label" for="@(Html.IdFor(m => m.Settings) + "-" + @name)">@name</label>
+                    <input type="checkbox" class="custom-control-input" id="@(Html.IdFor(m => m.Settings) + "-" + setting)" name="@Html.NameFor(m => m.Settings)" value="@setting" checked="@checkd">
+                    <label class="custom-control-label" for="@(Html.IdFor(m => m.Settings) + "-" + setting)">@setting</label>
                 </div>
             </li>
         }


### PR DESCRIPTION
Currently, only those site settings can be exported as a deployment step that are properties on `ISite`. This PR adds the ability to export any other site settings (i.e. `ISite.Properties`) optionally too:

![image](https://user-images.githubusercontent.com/1976647/84552501-444a7100-ad11-11ea-8baa-c3b984a16c28.png)

While the UI could be more descriptive overall, this quick change builds on what's already there. While you won't get as granular control on what's deployed than with `ISite` options I think it's good enough. `ISite` properties come first, ordered alphabetically, then come the other settings.

Note that this is just simply taking the storage format, nothing more involved happens so probably not suitable for everything.

Touches on https://github.com/OrchardCMS/OrchardCore/issues/5325 and https://github.com/OrchardCMS/OrchardCore/issues/5558.