### PR TITLE
Remove the EF Core section from the OpenID module documentation

### DIFF
--- a/src/docs/reference/modules/OpenId/README.md
+++ b/src/docs/reference/modules/OpenId/README.md
@@ -5,7 +5,6 @@
 `OrchardCore.OpenId` provides the following features:
 
 - Core Components
-- Entity Framework Core Stores
 - Authorization Server
 - Management Interface
 - Token Validation
@@ -14,10 +13,6 @@
 ## Core Components
 
 Registers the core components used by the OpenID module.
-
-## Entity Framework Core Stores
-
-Provides an Entity Framework Core 2.x adapter for the OpenID module.
 
 ## Management Interface
 


### PR DESCRIPTION
The OpenID EF Core stores were removed some time ago, but for some reasons, the documentation wasn't updated to reflect that.