### PR TITLE
Shortcodes in widget templates

### DIFF
--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Widget-Paragraph.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Widget-Paragraph.liquid
@@ -1,3 +1,3 @@
 <article class="{{ Model.Classes | join: " " }}">
-    {{ Model.ContentItem.Content.Paragraph.Content.Html | liquid | raw }}
+    {{ Model.ContentItem.Content.Paragraph.Content.Html | shortcode | raw }}
 </article>

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Widget-RawHtml.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Widget-RawHtml.liquid
@@ -1,1 +1,1 @@
-{{ Model.ContentItem.Content.RawHtml.Content.Html | liquid | raw }}
+{{ Model.ContentItem.Content.RawHtml.Content.Html | shortcode | raw }}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Widget-Paragraph.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Widget-Paragraph.liquid
@@ -1,3 +1,3 @@
 <article class="{{ Model.Classes | join: " " }}">
-    {{ Model.ContentItem.Content.Paragraph.Content.Html | liquid | raw }}
+    {{ Model.ContentItem.Content.Paragraph.Content.Html | shortcode | raw }}
 </article>

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Widget-RawHtml.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Widget-RawHtml.liquid
@@ -1,1 +1,1 @@
-{{ Model.ContentItem.Content.RawHtml.Content.Html | liquid | raw }}
+{{ Model.ContentItem.Content.RawHtml.Content.Html | shortcode | raw }}


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6435

I found the liquid filter I wrote for shortcodes, it was just in a different project.

Here - and this is up for debate :)

I have removed the liquid filter for these default templates, on the basis that we decided liquid was not a candidate for sanitizing.

So this would be a little breaking for anyone using these templates (but only if they have liquid in them).

Also the templates, as they rendered in a more decoupled approach, don't have access to the settings to know if sanitization is on or not (easily and simply)

So I don't want to add that, because these templates are supposed to be super simple, and overridable by users for customization.

Anyone have any better options?
