### PR TITLE
Add missing ContentItem property assignments for view models (Lombiq Technologies: OCORE-34)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
@@ -48,6 +48,7 @@ namespace OrchardCore.Alias.Drivers
         {
             model.Alias = part.Alias;
             model.AliasPart = part;
+            model.ContentItem = part.ContentItem;
             model.Settings = settings;
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplay.cs
@@ -25,6 +25,7 @@ namespace OrchardCore.Title.Drivers
             {
                 model.Title = titlePart.ContentItem.DisplayText;
                 model.TitlePart = titlePart;
+                model.ContentItem = titlePart.ContentItem;
             })
             .Location("Detail", "Header:5")
             .Location("Summary", "Header:5");
@@ -36,6 +37,7 @@ namespace OrchardCore.Title.Drivers
             {
                 model.Title = titlePart.ContentItem.DisplayText;
                 model.TitlePart = titlePart;
+                model.ContentItem = titlePart.ContentItem;
                 model.Settings = context.TypePartDefinition.GetSettings<TitlePartSettings>();
             });
         }


### PR DESCRIPTION
Noticed that these were null when working with shape templates. Checked all the similar properties too, nothing else seems missing.