### PR TITLE
Add new Workflow Task for resetting a user password

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/RegisterUserTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/RegisterUserTask.Fields.Edit.cshtml
@@ -20,5 +20,5 @@
     <label asp-for="ConfirmationEmailTemplate">@T["Template for confirmation email"]</label>
     <input type="text" asp-for="ConfirmationEmailTemplate" class="form-control code" />
     <span asp-validation-for="ConfirmationEmailTemplate"></span>
-    <span class="hint">@T["The message to send. Access email confirmation url with Workflow.Properties.EmailConfirmationUrl liquid property."]</span>
+    <span class="hint">@T["The message to send in HTML. Access email confirmation url with Workflow.Properties.EmailConfirmationUrl liquid property."]</span>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/ResetUserPasswordTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/ResetUserPasswordTask.Fields.Design.cshtml
@@ -1,0 +1,9 @@
+@using OrchardCore.Workflows.Helpers;
+@using OrchardCore.Workflows.ViewModels;
+@using OrchardCore.Users.Workflows.Activities;
+
+@model ActivityViewModel<ResetUserPasswordTask>
+
+<header>
+    <h4><i class="fa fa-user"></i>@Model.Activity.GetTitleOrDefault(() => T["Reset User Password"])</h4>
+</header>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/ResetUserPasswordTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/ResetUserPasswordTask.Fields.Edit.cshtml
@@ -1,0 +1,24 @@
+@using OrchardCore.DisplayManagement.Notify
+@using OrchardCore.Users.Workflows.ViewModels;
+
+@model ResetUserPasswordTaskViewModel
+
+<div class="form-group" asp-validation-class-for="UserName">
+    <label asp-for="UserName">@T["UserName"]</label>
+    <input type="text" asp-for="UserName" class="form-control code" />
+    <span asp-validation-for="UserName"></span>
+    <span class="hint">@T["The User to reset password for. With Liquid support."]</span>
+</div>
+
+<div class="form-group" asp-validation-class-for="ResetPasswordEmailSubject">
+    <label asp-for="ResetPasswordEmailSubject">@T["Subject"]</label>
+    <input type="text" asp-for="ResetPasswordEmailSubject" class="form-control code" />
+    <span asp-validation-for="ResetPasswordEmailSubject"></span>
+</div>
+
+<div class="form-group" asp-validation-class-for="ResetPasswordEmailTemplate">
+    <label asp-for="ResetPasswordEmailTemplate">@T["Template for reset password email"]</label>
+    <input type="text" asp-for="ResetPasswordEmailTemplate" class="form-control code" />
+    <span asp-validation-for="ResetPasswordEmailTemplate"></span>
+    <span class="hint">@T["The message to send in HTML. Access reset url with Workflow.Properties.ResetPasswordUrl liquid property."]</span>
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/ResetUserPasswordTask.Fields.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/ResetUserPasswordTask.Fields.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+<h4 class="card-title"><i class="fa fa-user"></i>@T["Reset User Password"]</h4>
+<p>@T["Send user reset password link."]</p>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
@@ -3,7 +3,6 @@ using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
@@ -127,15 +126,12 @@ namespace OrchardCore.Users.Workflows.Activities
                     workflowContext.Properties["EmailConfirmationUrl"] = uri;
 
                     var subject = await _expressionEvaluator.EvaluateAsync(ConfirmationEmailSubject, workflowContext, null);
-                    var localizedSubject = new LocalizedString(nameof(RegisterUserTask), subject);
-
                     var body = await _expressionEvaluator.EvaluateAsync(ConfirmationEmailTemplate, workflowContext, _htmlEncoder);
-                    var localizedBody = new LocalizedHtmlString(nameof(RegisterUserTask), body);
                     var message = new MailMessage()
                     {
                         To = email,
-                        Subject = localizedSubject.ResourceNotFound ? subject : localizedSubject.Value,
-                        Body = localizedBody.IsResourceNotFound ? body : localizedBody.Value,
+                        Subject = subject,
+                        Body = body,
                         IsBodyHtml = true
                     };
                     var smtpService = _httpContextAccessor.HttpContext.RequestServices.GetService<ISmtpService>();

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/ResetUserPasswordTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/ResetUserPasswordTask.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Entities;
+using OrchardCore.Settings;
+using OrchardCore.Users.Models;
+using OrchardCore.Users.Services;
+using OrchardCore.Workflows.Abstractions.Models;
+using OrchardCore.Workflows.Activities;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Services;
+using Microsoft.AspNetCore.Routing;
+using OrchardCore.Email;
+using OrchardCore.DisplayManagement.ModelBinding;
+using Microsoft.Extensions.DependencyInjection;
+using System.Text.Encodings.Web;
+
+namespace OrchardCore.Users.Workflows.Activities
+{
+    public class ResetUserPasswordTask : TaskActivity
+    {
+        private readonly UserManager<IUser> _userManager;
+        private readonly IUserService _userService;
+        private readonly ISiteService _siteService;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
+        private readonly LinkGenerator _linkGenerator;
+        private readonly IUpdateModelAccessor _updateModelAccessor;
+        private readonly IStringLocalizer S;
+        private readonly HtmlEncoder _htmlEncoder;
+
+        public ResetUserPasswordTask(
+            UserManager<IUser> userManager,
+            IUserService userService,
+            ISiteService siteService,
+            IHttpContextAccessor httpContextAccessor,
+            IWorkflowExpressionEvaluator expressionvaluator,
+            LinkGenerator linkGenerator,
+            IUpdateModelAccessor updateModelAccessor,
+            IStringLocalizer<AssignUserRoleTask> localizer,
+            HtmlEncoder htmlEncoder)
+        {
+            _userManager = userManager;
+            _userService = userService;
+            _siteService = siteService;
+            _httpContextAccessor = httpContextAccessor;
+            _expressionEvaluator = expressionvaluator;
+            _linkGenerator = linkGenerator;
+            _updateModelAccessor = updateModelAccessor;
+            S = localizer;
+            _htmlEncoder = htmlEncoder;
+        }
+
+        // The technical name of the activity. Activities on a workflow definition reference this name.
+        public override string Name => nameof(ResetUserPasswordTask);
+
+        public override LocalizedString DisplayText => S["Reset User Password Task"];
+
+        // The category to which this activity belongs. The activity picker groups activities by this category.
+        public override LocalizedString Category => S["User"];
+
+        public WorkflowExpression<string> UserName
+        {
+            get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+
+        public WorkflowExpression<string> ResetPasswordEmailSubject
+        {
+            get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+
+        // The message to display.
+        public WorkflowExpression<string> ResetPasswordEmailTemplate
+        {
+            get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+
+        // Returns the possible outcomes of this activity.
+        public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            return Outcomes(S["Done"], S["Invalid"]);
+        }
+
+        // This is the heart of the activity and actually performs the work to be done.
+        public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            var userName = await _expressionEvaluator.EvaluateAsync(UserName, workflowContext, null);
+
+            var user = await _userService.GetForgotPasswordUserAsync(userName) as User;
+            if (user == null || ((await _siteService.GetSiteSettingsAsync()).As<RegistrationSettings>().UsersMustValidateEmail && !await _userManager.IsEmailConfirmedAsync(user)))
+            {
+                var updater = _updateModelAccessor.ModelUpdater;
+                if (updater != null)
+                {
+                    updater.ModelState.TryAddModelError("", S["No email service is available"]);
+                }
+                return Outcomes("Invalid");
+            }
+            else
+            {
+                user.ResetToken = Convert.ToBase64String(Encoding.UTF8.GetBytes(user.ResetToken));
+                var resetPasswordUrl = _linkGenerator.GetUriByAction(_httpContextAccessor.HttpContext,
+                    "ResetPassword", "ResetPassword", new { area = "OrchardCore.Users", code = user.ResetToken });
+
+                workflowContext.Properties["ResetPasswordUrl"] = resetPasswordUrl;
+
+                var subject = await _expressionEvaluator.EvaluateAsync(ResetPasswordEmailSubject, workflowContext, null);
+                var body = await _expressionEvaluator.EvaluateAsync(ResetPasswordEmailTemplate, workflowContext, _htmlEncoder);
+                var message = new MailMessage()
+                {
+                    To = user.Email,
+                    Subject = subject,
+                    Body = body,
+                    IsBodyHtml = true
+                };
+                var smtpService = _httpContextAccessor.HttpContext.RequestServices.GetService<ISmtpService>();
+
+                if (smtpService == null)
+                {
+                    var updater = _updateModelAccessor.ModelUpdater;
+                    if (updater != null)
+                    {
+                        updater.ModelState.TryAddModelError("", S["No email service is available"]);
+                    }
+                    return Outcomes("Invalid");
+                }
+                else
+                {
+                    var result = await smtpService.SendAsync(message);
+                    if (!result.Succeeded)
+                    {
+                        var updater = _updateModelAccessor.ModelUpdater;
+                        if (updater != null)
+                        {
+                            foreach (var item in result.Errors)
+                            {
+                                updater.ModelState.TryAddModelError(item.Name, item.Value);
+                            }
+                        }
+                        return Outcomes("Invalid");
+                    }
+                }
+
+                return Outcomes("Done");
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Drivers/ResetUserPasswordTaskDisplay.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Drivers/ResetUserPasswordTaskDisplay.cs
@@ -1,0 +1,24 @@
+using OrchardCore.Users.Workflows.Activities;
+using OrchardCore.Users.Workflows.ViewModels;
+using OrchardCore.Workflows.Display;
+using OrchardCore.Workflows.Models;
+
+namespace OrchardCore.Users.Workflows.Drivers
+{
+    public class ResetUserPasswordTaskDisplay : ActivityDisplayDriver<ResetUserPasswordTask, ResetUserPasswordTaskViewModel>
+    {
+        protected override void EditActivity(ResetUserPasswordTask activity, ResetUserPasswordTaskViewModel model)
+        {
+            model.UserName = model.UserName = activity.UserName.Expression;
+            model.ResetPasswordEmailSubject = activity.ResetPasswordEmailSubject.Expression;
+            model.ResetPasswordEmailTemplate = activity.ResetPasswordEmailTemplate.Expression;
+        }
+
+        protected override void UpdateActivity(ResetUserPasswordTaskViewModel model, ResetUserPasswordTask activity)
+        {
+            activity.UserName = new WorkflowExpression<string>(model.UserName);
+            activity.ResetPasswordEmailSubject = new WorkflowExpression<string>(model.ResetPasswordEmailSubject);
+            activity.ResetPasswordEmailTemplate = new WorkflowExpression<string>(model.ResetPasswordEmailTemplate);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Startup.cs
@@ -22,4 +22,13 @@ namespace OrchardCore.Users.Workflows
             services.AddActivity<AssignUserRoleTask, AssignUserRoleTaskDisplay>();
         }
     }
+
+    [RequireFeatures("OrchardCore.Workflows", "OrchardCore.Users.ResetPassword")]
+    public class ResetPasswordStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddActivity<ResetUserPasswordTask, ResetUserPasswordTaskDisplay>();
+        }
+    }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/ViewModels/ResetUserPasswordTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/ViewModels/ResetUserPasswordTaskViewModel.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OrchardCore.Users.Workflows.ViewModels
+{
+    public class ResetUserPasswordTaskViewModel
+    {
+        [Required]
+        public string UserName { get; set; }
+
+        public string ResetPasswordEmailSubject { get; set; }
+
+        [Required]
+        public string ResetPasswordEmailTemplate { get; set; }
+    }
+}


### PR DESCRIPTION
A new workflow task that will send the user a "Reset Password" url, needed in order to setup their account. Current behavior in OC admin users page is to create users with null password by default.