### PR TITLE
docs: fix typos

### DIFF
--- a/src/docs/guides/implement-fulltext-search/README.md
+++ b/src/docs/guides/implement-fulltext-search/README.md
@@ -52,11 +52,11 @@ namespace OrchardCore.Lucene.FrenchAnalyzer
 ```
 
 
-The third option is the culture. By default *Any culture* will be selected. Here, the option is made for being able to define that this index wether should be only indexing content items of a specific culture or any of them.
+The third option is the culture. By default *Any culture* will be selected. Here, the option is made for being able to define that this index whether should be only indexing content items of a specific culture or any of them.
 
 *Content Types* : you can pick any content types that you would like to see this index parse.
 
-*Index latest version* : this option will allow you to index only published items or also index drafts which could be usefull if you want to search for content items in a custom frontend dashboard or even in an admin backend custom module. By default if we don't check this option it will only index published content items.
+*Index latest version* : this option will allow you to index only published items or also index drafts which could be useful if you want to search for content items in a custom frontend dashboard or even in an admin backend custom module. By default if we don't check this option it will only index published content items.
 
 ## Third step : configure search settings
 

--- a/src/docs/reference/core/Shells/README.md
+++ b/src/docs/reference/core/Shells/README.md
@@ -24,7 +24,7 @@ The root of the Azure Blob Container includes a `tenants.json` file, and optiona
 
 Each shell, or tenant has a directory under the `Sites` folder, named for the tenant, with an individual `appsettings.json` file.
 
-The hierarchy is seperated into single files, and is useful if you need to manage the tenants `appsettings.json` independently from Orchard Core.
+The hierarchy is separated into single files, and is useful if you need to manage the tenants `appsettings.json` independently from Orchard Core.
 For example, you may prefer to provide different Azure Blob Storage keys, for each tenant when using the Azure Media Storage feature.
 
 The Azure Shells Configuration supports a root `appsettings.json` and `appsettings.Environment.json` file.
@@ -34,7 +34,7 @@ The Azure Shells Configuration supports a root `appsettings.json` and `appsettin
 
 ### Enable Azure Shells Configuration
 
-The Azure Shells Configuration is provided by a seperate NuGet package: `OrchardCore.Shells.Azure`
+The Azure Shells Configuration is provided by a separate NuGet package: `OrchardCore.Shells.Azure`
 
 The Azure Shells Configuration is configured via the `appsettings.json` section in the web host project.
 

--- a/src/docs/reference/modules/OpenId/README.md
+++ b/src/docs/reference/modules/OpenId/README.md
@@ -137,7 +137,7 @@ OpenID Connect Scopes require the following configuration.
 |Display Name|Display name associated with the current scope.|
 |Description|Describe how this scope is used in the system.|
 |Tenants|Build the audience based on tenants names.|
-|Additional resources|Build the audience based on the space seperated strings provided.|
+|Additional resources|Build the audience based on the space separated strings provided.|
 
 A sample of OpenID Connect Scope recipe step:
 

--- a/src/docs/reference/modules/Sitemaps/README.md
+++ b/src/docs/reference/modules/Sitemaps/README.md
@@ -35,7 +35,7 @@ Sitemap Indexes are configured by creating a Sitemap Index and selecting which S
 The Content Types Source will provide a sitemap for your content items,
 on a per Content Type basis. 
 
-You can choose to Index All Content Types, or specifiy the Content Types. 
+You can choose to Index All Content Types, or specify the Content Types. 
 
 You may also select the default Priority, and Change Frequency, either for all Content Types, 
 or individual Content Types.


### PR DESCRIPTION
Hey,

This PR will fix : 

- 2 typos in `src/docs/guides/implement-fulltext-search/README.md`
- 2 typos in `src/docs/reference/core/Shells/README.md`
- 1 typo in `src/docs/reference/modules/OpenId/README.md`
- 1 typo in `src/docs/reference/modules/Sitemaps/README.md`



Best! :robot: