### PR TITLE
fix jsonparse liquid filter to supports arrays

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/JsonParseFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/JsonParseFilter.cs
@@ -9,7 +9,11 @@ namespace OrchardCore.Liquid.Filters
     {
         public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new ValueTask<FluidValue>(new ObjectValue(JToken.Parse(input.ToStringValue())));
+            var parsedValue = JToken.Parse(input.ToStringValue());
+            if(parsedValue.Type == JTokenType.Array){
+                 return new ValueTask<FluidValue>(FluidValue.Create(parsedValue));
+            }
+            return new ValueTask<FluidValue>(new ObjectValue(parsedValue));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/JsonParseFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/JsonParseFilter.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Liquid.Filters
     {
         public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext context)
         {
-            return new ValueTask<FluidValue>(new ObjectValue(JObject.Parse(input.ToStringValue())));
+            return new ValueTask<FluidValue>(new ObjectValue(JToken.Parse(input.ToStringValue())));
         }
     }
 }


### PR DESCRIPTION
fix #6497

I had to check the JToken type to support iterating over the array using a for loop.