### PR TITLE
Fix inline add widget control not using contained content types setting

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
@@ -1,8 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.Flows.Models;
@@ -13,18 +18,21 @@ namespace OrchardCore.Flows.Controllers
     public class AdminController : Controller
     {
         private readonly IContentManager _contentManager;
+        private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
         private readonly IShapeFactory _shapeFactory;
         private readonly IUpdateModelAccessor _updateModelAccessor;
 
         public AdminController(
             IContentManager contentManager,
+            IContentDefinitionManager contentDefinitionManager,
             IContentItemDisplayManager contentItemDisplayManager,
             IShapeFactory shapeFactory,
             IUpdateModelAccessor updateModelAccessor)
         {
-            _contentItemDisplayManager = contentItemDisplayManager;
             _contentManager = contentManager;
+            _contentDefinitionManager = contentDefinitionManager;
+            _contentItemDisplayManager = contentItemDisplayManager;
             _shapeFactory = shapeFactory;
             _updateModelAccessor = updateModelAccessor;
         }
@@ -41,11 +49,14 @@ namespace OrchardCore.Flows.Controllers
             // Does this editor need the flow metadata editor?
             string cardCollectionType = null;
             int colSize = 12;
+            IEnumerable<ContentTypeDefinition> containedContentTypes = null;
+
             if (flowmetadata)
             {
                 var metadata = new FlowMetadata();
                 contentItem.Weld(metadata);
                 colSize = (int)Math.Round((double)metadata.Size / 100.0 * 12);
+                containedContentTypes = GetContainedContentTypes(parentContentType, partName);
 
                 cardCollectionType = nameof(FlowPart);
             }
@@ -64,6 +75,7 @@ namespace OrchardCore.Flows.Controllers
                 BuildEditor: true,
                 ParentContentType: parentContentType,
                 CollectionPartName: partName,
+                ContainedContentTypes: containedContentTypes,
                 //Card Specific Properties
                 TargetId: targetId,
                 Inline: true,
@@ -89,6 +101,20 @@ namespace OrchardCore.Flows.Controllers
                 EditorShape = contentCard
             };
             return View("Display", model);
+        }
+
+        private IEnumerable<ContentTypeDefinition> GetContainedContentTypes(string contentType, string partName)
+        {
+            var settings = _contentDefinitionManager.GetTypeDefinition(contentType)?.Parts.SingleOrDefault(x => x.Name == partName)?.GetSettings<FlowPartSettings>();
+
+            if (settings == null || settings.ContainedContentTypes == null || !settings.ContainedContentTypes.Any())
+            {
+                return _contentDefinitionManager.ListTypeDefinitions().Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
+            }
+
+            return settings.ContainedContentTypes
+                .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
+                .Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/ContentCard-FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/ContentCard-FlowPart.Edit.cshtml
@@ -1,11 +1,12 @@
-@using OrchardCore.ContentManagement.Metadata.Settings;
+@using OrchardCore.ContentManagement.Metadata.Models
+
 @inject OrchardCore.ContentManagement.Metadata.IContentDefinitionManager ContentDefinitionManager
 
 @{
     var contentItem = (IContent)Model.ContentItem;
     var contentTypeDisplayText = ContentDefinitionManager.GetTypeDefinition((string)Model.ContentItem.ContentType).DisplayName;
     var contentItemDisplayText = contentItem.ContentItem.DisplayText;
-    var widgetContentTypes = ContentDefinitionManager.ListTypeDefinitions().Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
+    var widgetContentTypes = (IEnumerable<ContentTypeDefinition>)Model.ContainedContentTypes;
 
     var editorId = "contentEditor_" + Model.PrefixValue;
 }
@@ -29,7 +30,8 @@
                 {
                     <div class="btn-group">
                         <button class="toggleAll btn btn-secondary btn-sm" onclick="toggleWidgets(); return false;" title="@T["Toggle all widgets"]">
-                            <i class="fa fa-angle-double-up" aria-hidden="true"></i></button>
+                            <i class="fa fa-angle-double-up" aria-hidden="true"></i>
+                        </button>
                         <button type="button" title="@T["Insert Widget"]" class="btn btn-primary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             <i class="fa fa-plus" aria-hidden="true"></i>
                         </button>


### PR DESCRIPTION
Flows editor can be configured to only display a defined collection of widgets (https://github.com/OrchardCMS/OrchardCore/pull/5970). While the add widget control at the bottom of the flow editor respects the contained content type setting, the inline one was displaying all content types with stereo type of widgets.