### PR TITLE
Add cache-dependency tag helper

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/Startup.cs
@@ -28,6 +28,7 @@ namespace OrchardCore.DynamicCache
             services.AddSingleton<IDynamicCache, DefaultDynamicCache>();
             services.AddSingleton<DynamicCacheTagHelperService>();
             services.AddTagHelpers<DynamicCacheTagHelper>();
+            services.AddTagHelpers<CacheDependencyTagHelper>();
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/TagHelpers/CacheDependencyTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/TagHelpers/CacheDependencyTagHelper.cs
@@ -1,0 +1,50 @@
+using System;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using OrchardCore.Environment.Cache;
+
+namespace OrchardCore.DynamicCache.TagHelpers
+{
+    [HtmlTargetElement("cache-dependency", Attributes = DependencyAttributeName)]
+    public class CacheDependencyTagHelper : TagHelper
+    {
+        private const string DependencyAttributeName = "dependency";
+
+        /// <summary>
+        /// Gets or sets a <see cref="string" /> with the dependency to invalidate the cache with.
+        /// </summary>
+        [HtmlAttributeName(DependencyAttributeName)]
+        public string Dependency { get; set; }
+
+        private readonly ICacheScopeManager _cacheScopeManager;
+
+        public CacheDependencyTagHelper(
+            ICacheScopeManager cacheScopeManager)
+
+        {
+            _cacheScopeManager = cacheScopeManager;
+        }
+
+
+        /// <inheritdoc />
+        public override void Process(TagHelperContext context, TagHelperOutput output)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            if (!String.IsNullOrEmpty(Dependency))
+            {
+                _cacheScopeManager.AddDependencies(Dependency);
+            }
+
+            // Clear the contents of the "cache-dependency" element since we don't want to render it.
+            output.SuppressOutput();
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6517

Corresponding tag helper to work with dynamic cache entries to add dependencies after the cache block has started
i.e.

```
<cache cache-id="foo">
   var query = myquery;
   foreach(var item in query)
  {
      <cache-dependency dependency="contentitemid:@item.ContentItemId"/>
  }
<cache>
```

Works fine, but did discover an issue with the dynamic cache tag helper, where by default it conflicts with the ASP.NET Core Tag Helper, and both are activated, meaning the inner content is built by the ASP.NET Core tag helper, stored in it's memory cache, and then passed of to the dynamic cache tag helper, which then stores it, in it's cache.

This is because they are both targeting the `cache` element, but it means the `cache-dependency` doesn't have a scope available in the scope manager, as it is being rendered by the ASP.NET Core one.

Removing the ASP.Net Core one fixes the issue
`@removeTagHelper Microsoft.AspNetCore.Mvc.TagHelpers.CacheTagHelper, Microsoft.AspNetCore.Mvc.TagHelpers`

@jtkech wondered if you had any ideas on targeting the dynamic cache tag helper better, to block to ASP.NET one out of the box, or if we just update the docs?