### PR TITLE
Include stereotype on build editor for placement

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
@@ -116,6 +116,7 @@ namespace OrchardCore.ContentManagement.Display
 
             dynamic itemShape = await CreateContentShapeAsync(actualShapeType);
             itemShape.ContentItem = contentItem;
+            itemShape.Stereotype = stereotype;
 
             // adding an alternate for [Stereotype]_Edit__[ContentType] e.g. Content-Menu.Edit
             ((IShape)itemShape).Metadata.Alternates.Add(actualShapeType + "__" + contentItem.ContentType);
@@ -150,6 +151,7 @@ namespace OrchardCore.ContentManagement.Display
 
             dynamic itemShape = await CreateContentShapeAsync(actualShapeType);
             itemShape.ContentItem = contentItem;
+            itemShape.Stereotype = stereotype;
 
             // adding an alternate for [Stereotype]_Edit__[ContentType] e.g. Content-Menu.Edit
             ((IShape)itemShape).Metadata.Alternates.Add(actualShapeType + "__" + contentItem.ContentType);


### PR DESCRIPTION
The `contentType` placement rule allows placing via `stereotype` as well as by `contentType` (it checks `contentType` first, then stereotype`.

That works fine on front end placement, but when I tried to use it for editor placement the stereotype value wasn't passed to the placement context, so this adds it the the properties.