### PR TITLE
Add authentication checks to some ISite drivers

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Drivers/ContentCulturePickerSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Drivers/ContentCulturePickerSettingsDriver.cs
@@ -1,4 +1,6 @@
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using OrchardCore.ContentLocalization.Models;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
@@ -10,9 +12,26 @@ namespace OrchardCore.ContentLocalization.Drivers
     public class ContentCulturePickerSettingsDriver : SectionDisplayDriver<ISite, ContentCulturePickerSettings>
     {
         public const string GroupId = "ContentCulturePicker";
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IAuthorizationService _authorizationService;
 
-        public override IDisplayResult Edit(ContentCulturePickerSettings section)
+        public ContentCulturePickerSettingsDriver(
+            IHttpContextAccessor httpContextAccessor,
+            IAuthorizationService authorizationService)
         {
+            _httpContextAccessor = httpContextAccessor;
+            _authorizationService = authorizationService;
+        }
+
+        public override async Task<IDisplayResult> EditAsync(ContentCulturePickerSettings section, BuildEditorContext context)
+        {
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageContentCulturePicker))
+            {
+                return null;
+            }
+
             return Initialize<ContentCulturePickerSettings>("ContentCulturePickerSettings_Edit", model =>
             {
                 model.SetCookie = section.SetCookie;
@@ -22,10 +41,18 @@ namespace OrchardCore.ContentLocalization.Drivers
 
         public override async Task<IDisplayResult> UpdateAsync(ContentCulturePickerSettings section, BuildEditorContext context)
         {
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageContentCulturePicker))
+            {
+                return null;
+            }
+
             if (context.GroupId == GroupId)
             {
                 await context.Updater.TryUpdateModelAsync(section, Prefix);
             }
+
             return await EditAsync(section, context);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/AdminMenu.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
+using OrchardCore.Lucene.Drivers;
 using OrchardCore.Navigation;
 
 namespace OrchardCore.Lucene
@@ -35,7 +36,7 @@ namespace OrchardCore.Lucene
                             .LocalNav()))
                     .Add(S["Settings"], settings => settings
                         .Add(S["Search"],S["Search"].PrefixPosition(), entry => entry
-                            .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "search" })
+                            .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = LuceneSettingsDisplayDriver.GroupId})
                             .Permission(Permissions.ManageIndexes)
                             .LocalNav()
                         )));

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.Lucene
                 o.Analyzers.Add(new LuceneAnalyzer(LuceneSettings.StandardAnalyzer,
                     new StandardAnalyzer(LuceneSettings.DefaultVersion))));
 
-            services.AddScoped<IDisplayDriver<ISite>, LuceneSiteSettingsDisplayDriver>();
+            services.AddScoped<IDisplayDriver<ISite>, LuceneSettingsDisplayDriver>();
             services.AddScoped<IDisplayDriver<Query>, LuceneQueryDisplayDriver>();
 
             services.AddScoped<IContentHandler, LuceneIndexingContentHandler>();

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaSectionDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaSectionDisplayDriver.cs
@@ -1,4 +1,6 @@
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -14,15 +16,30 @@ namespace OrchardCore.ReCaptcha.Drivers
         public const string GroupId = "recaptcha";
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IAuthorizationService _authorizationService;
 
-        public ReCaptchaSettingsDisplayDriver(IShellHost shellHost, ShellSettings shellSettings)
+        public ReCaptchaSettingsDisplayDriver(
+            IShellHost shellHost,
+            ShellSettings shellSettings,
+            IHttpContextAccessor httpContextAccessor,
+            IAuthorizationService authorizationService)
         {
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            _httpContextAccessor = httpContextAccessor;
+            _authorizationService = authorizationService;
         }
 
-        public override IDisplayResult Edit(ReCaptchaSettings section, BuildEditorContext context)
+        public override async Task<IDisplayResult> EditAsync(ReCaptchaSettings section, BuildEditorContext context)
         {
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageReCaptchaSettings))
+            {
+                return null;
+            }
+
             return Initialize<ReCaptchaSettingsViewModel>("ReCaptchaSettings_Edit", model =>
                 {
                     model.SiteKey = section.SiteKey;
@@ -34,6 +51,13 @@ namespace OrchardCore.ReCaptcha.Drivers
 
         public override async Task<IDisplayResult> UpdateAsync(ReCaptchaSettings section, BuildEditorContext context)
         {
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageReCaptchaSettings))
+            {
+                return null;
+            }
+
             if (context.GroupId == GroupId)
             {
                 var model = new ReCaptchaSettingsViewModel();

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
@@ -1,4 +1,6 @@
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -12,9 +14,25 @@ namespace OrchardCore.Users.Drivers
     public class RegistrationSettingsDisplayDriver : SectionDisplayDriver<ISite, RegistrationSettings>
     {
         public const string GroupId = "RegistrationSettings";
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IAuthorizationService _authorizationService;
 
-        public override IDisplayResult Edit(RegistrationSettings section)
+        public RegistrationSettingsDisplayDriver(
+            IHttpContextAccessor httpContextAccessor,
+            IAuthorizationService authorizationService)
         {
+            _httpContextAccessor = httpContextAccessor;
+            _authorizationService = authorizationService;
+        }
+        public override async Task<IDisplayResult> EditAsync(RegistrationSettings section, BuildEditorContext context)
+        {
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageUsers))
+            {
+                return null;
+            }
+
             return Initialize<RegistrationSettings>("RegistrationSettings_Edit", model =>
             {
                 model.UsersCanRegister = section.UsersCanRegister;
@@ -30,11 +48,19 @@ namespace OrchardCore.Users.Drivers
 
         public override async Task<IDisplayResult> UpdateAsync(RegistrationSettings section, BuildEditorContext context)
         {
+            var user = _httpContextAccessor.HttpContext?.User;
+
+            if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageUsers))
+            {
+                return null;
+            }
+
             if (context.GroupId == GroupId)
             {
                 await context.Updater.TryUpdateModelAsync(section, Prefix);
             }
-            return Edit(section);
+
+            return await EditAsync(section, context);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6555

Note: This only applies to `ISite` drivers, there's a couple of other types of section display drivers (`User` etc), but they do not use the `GroupId` technique for display, or authentication. In their cases auth is managed just by the controller.