### PR TITLE
#6567 AliasPartContentAliasProvider should work without prefix

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentAliasProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentAliasProvider.cs
@@ -21,12 +21,10 @@ namespace OrchardCore.Alias.Services
             if (alias.StartsWith("alias:", System.StringComparison.OrdinalIgnoreCase))
             {
                 alias = alias.Substring(6);
-
-                var aliasPartIndex = await _session.Query<ContentItem, AliasPartIndex>(x => x.Alias == alias.ToLowerInvariant()).FirstOrDefaultAsync();
-                return aliasPartIndex?.ContentItemId;
             }
 
-            return null;
+            var aliasPartIndex = await _session.Query<ContentItem, AliasPartIndex>(x => x.Alias == alias.ToLowerInvariant()).FirstOrDefaultAsync();
+            return aliasPartIndex?.ContentItemId;
         }
     }
 }


### PR DESCRIPTION
AliasPartContentAliasProvider should work for alias parameter regardless of whether it is prefixed with "alias:".

Moved contentItemId retrieval outside of statement.