### PR TITLE
Add cache debugging for dynamic cache tag helper

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/CachedShapeWrapperShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/CachedShapeWrapperShapes.cs
@@ -17,6 +17,7 @@ namespace OrchardCore.DynamicCache
             var metadata = Shape.Metadata;
             var cache = metadata.Cache();
 
+            contentBuilder.AppendLine();
             contentBuilder.AppendHtmlLine($"<!-- CACHED SHAPE: {cache.CacheId} ({Guid.NewGuid()})");
             contentBuilder.AppendHtmlLine($"          VARY BY: {String.Join(", ", cache.Contexts)}");
             contentBuilder.AppendHtmlLine($"     DEPENDENCIES: {String.Join(", ", cache.Tags)}");

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/TagHelpers/DynamicCacheTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/TagHelpers/DynamicCacheTagHelper.cs
@@ -226,6 +226,7 @@ namespace OrchardCore.DynamicCache.TagHelpers
                                     // Write the start of a cache debug block.
                                     if (_cacheOptions.DebugMode)
                                     {
+                                        // No need to optimize this code as it will be used for debugging purpose.
                                         writer.WriteLine();
                                         writer.WriteLine($"<!-- CACHE BLOCK: {cacheContext.CacheId} ({Guid.NewGuid()})");
                                         writer.WriteLine($"         VARY BY: {String.Join(", ", cacheContext.Contexts)}");

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/TagHelpers/DynamicCacheTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/TagHelpers/DynamicCacheTagHelper.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.TagHelpers.Cache;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Environment.Cache;
 
@@ -87,18 +88,21 @@ namespace OrchardCore.DynamicCache.TagHelpers
         private readonly IDynamicCacheService _dynamicCacheService;
         private readonly ICacheScopeManager _cacheScopeManager;
         private readonly DynamicCacheTagHelperService _dynamicCacheTagHelperService;
+        private readonly CacheOptions _cacheOptions;
 
         public DynamicCacheTagHelper(
             IDynamicCacheService dynamicCacheService,
             ICacheScopeManager cacheScopeManager,
             HtmlEncoder htmlEncoder,
-            DynamicCacheTagHelperService dynamicCacheTagHelperService)
+            DynamicCacheTagHelperService dynamicCacheTagHelperService,
+            IOptions<CacheOptions> cacheOptions)
 
         {
             _dynamicCacheService = dynamicCacheService;
             _cacheScopeManager = cacheScopeManager;
             HtmlEncoder = htmlEncoder;
             _dynamicCacheTagHelperService = dynamicCacheTagHelperService;
+            _cacheOptions = cacheOptions.Value;
         }
 
         /// <summary>
@@ -219,7 +223,29 @@ namespace OrchardCore.DynamicCache.TagHelpers
                             {
                                 using (var writer = new StringWriter(sb.Builder))
                                 {
+                                    // Write the start of a cache debug block.
+                                    if (_cacheOptions.DebugMode)
+                                    {
+                                        writer.WriteLine();
+                                        writer.WriteLine($"<!-- CACHE BLOCK: {cacheContext.CacheId} ({Guid.NewGuid()})");
+                                        writer.WriteLine($"         VARY BY: {String.Join(", ", cacheContext.Contexts)}");
+                                        writer.WriteLine($"    DEPENDENCIES: {String.Join(", ", cacheContext.Tags)}");
+                                        writer.WriteLine($"      EXPIRES ON: {cacheContext.ExpiresOn}");
+                                        writer.WriteLine($"   EXPIRES AFTER: {cacheContext.ExpiresAfter}");
+                                        writer.WriteLine($" EXPIRES SLIDING: {cacheContext.ExpiresSliding}");
+                                        writer.WriteLine("-->");
+                                    }
+
+                                    // Always write the content regardless of debug mode.
                                     processedContent.WriteTo(writer, HtmlEncoder);
+
+                                    // Write the end of a cache debug block.
+                                    if (_cacheOptions.DebugMode)
+                                    {
+                                        writer.WriteLine();
+                                        writer.WriteLine($"<!-- END CACHE BLOCK: {cacheContext.CacheId} -->");
+                                    }
+
                                     await writer.FlushAsync();
                                 }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Cache/CacheStatement.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Cache/CacheStatement.cs
@@ -95,9 +95,10 @@ namespace OrchardCore.DynamicCache.Liquid
             if (cacheOptions.DebugMode)
             {
                 var debugContent = new StringWriter();
-                debugContent.WriteLine($"<!-- CACHE BLOCK: {cacheContext.CacheId} ({Guid.NewGuid()})\r\n");
-                debugContent.WriteLine($"         VARY BY: {String.Join(", ", cacheContext.Contexts)}\r\n");
-                debugContent.WriteLine($"    DEPENDENCIES: {String.Join(", ", cacheContext.Tags)}\r\n");
+                debugContent.WriteLine();
+                debugContent.WriteLine($"<!-- CACHE BLOCK: {cacheContext.CacheId} ({Guid.NewGuid()})");
+                debugContent.WriteLine($"         VARY BY: {String.Join(", ", cacheContext.Contexts)}");
+                debugContent.WriteLine($"    DEPENDENCIES: {String.Join(", ", cacheContext.Tags)}");
                 debugContent.WriteLine($"      EXPIRES ON: {cacheContext.ExpiresOn}");
                 debugContent.WriteLine($"   EXPIRES AFTER: {cacheContext.ExpiresAfter}");
                 debugContent.WriteLine($" EXPIRES SLIDING: {cacheContext.ExpiresSliding}");

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Cache/CacheStatement.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Cache/CacheStatement.cs
@@ -94,6 +94,7 @@ namespace OrchardCore.DynamicCache.Liquid
 
             if (cacheOptions.DebugMode)
             {
+                // No need to optimize this code as it will be used for debugging purpose.
                 var debugContent = new StringWriter();
                 debugContent.WriteLine();
                 debugContent.WriteLine($"<!-- CACHE BLOCK: {cacheContext.CacheId} ({Guid.NewGuid()})");


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6573

Also tweaks the liquid and cache shape wrapper to render on seperate lines from the start and end of the cache block

i.e.
```
<!-- CACHE BLOCK: test (1cc63a96-5195-4acd-8176-37ce3b19ce16)
         VARY BY:
    DEPENDENCIES:
      EXPIRES ON:
   EXPIRES AFTER:
 EXPIRES SLIDING: 00:00:30
-->
<p>cached content</p>
<!-- END CACHE BLOCK: test -->
```