### PR TITLE
Demo videos in docs

### DIFF
--- a/src/docs/reference/core/Placement/README.md
+++ b/src/docs/reference/core/Placement/README.md
@@ -291,3 +291,7 @@ We also specify that the `Content` column will take 9 columns, of the default 12
 !!! note
     By default the columns will break responsively at the `md` breakpoint, and a modifier will be parsed to `col-md-9`.
     If you want to change the breakpoint, you could also specifiy `Content_lg-9`, which is parsed to `col-lg-9`.
+
+## Video
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/h0lZMQkUApo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/docs/reference/modules/CustomSettings/README.md
+++ b/src/docs/reference/modules/CustomSettings/README.md
@@ -59,3 +59,7 @@ public class MyController : Controller
     }
 }
 ```
+
+## Video
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/RuDsBx4wdT0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/docs/reference/modules/List/README.md
+++ b/src/docs/reference/modules/List/README.md
@@ -83,3 +83,7 @@ The `list_count` filter counts published list content items for given `ContentIt
 ### list_items
 
 The `list_items` filter loads published list content items for given `ContentItem` object or explicit `ContentItem` id given as string.
+
+## Video
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/a3yyR27vdQQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/docs/reference/modules/PublishLater/README.md
+++ b/src/docs/reference/modules/PublishLater/README.md
@@ -1,3 +1,7 @@
 # Publish Later (`OrchardCore.PublishLater`)
 
 Adds the ability to schedule content items to be published at a given future date and time. Attach the Publish Later Part to any content type where you want the feature to be available.
+
+## Video
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/E7UH8R14EUA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/docs/reference/modules/Sitemaps/README.md
+++ b/src/docs/reference/modules/Sitemaps/README.md
@@ -123,6 +123,10 @@ The cache is automatically cleared when content items are published.
 
 To clear the cache manually use the _Configuration -> SEO -> Sitemaps Cache_ feature.
 
+## Video
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/fG_rFD0wffw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ## CREDITS
 
 ### IDeliverable.Seo

--- a/src/docs/reference/modules/Taxonomies/README.md
+++ b/src/docs/reference/modules/Taxonomies/README.md
@@ -361,3 +361,13 @@ You can access the `TagNames` property directly with the following accessor:
 
 !!! note
     If the display text property of the term is updated any content items will need to be republished to reflect this change.
+
+## Videos
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/DpaN02c2sDI" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/nyPgQMwizbU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/G9lkGRD9G_E" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/NVjRz5ru7N4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
Add links to videos made during the meetings to demo features in associated doc pages.

Example in Lists doc:
![image](https://user-images.githubusercontent.com/703248/86517061-265ec080-be26-11ea-821e-872d4ab2fba7.png)
