### PR TITLE
Upgrade Fluid.Core

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -12,7 +12,7 @@
     <PackageManagement Include="Azure.Storage.Blobs" Version="12.4.4" />
     <PackageManagement Include="Castle.Core" Version="4.4.1" />
     <PackageManagement Include="Irony.Core" Version="1.0.7" />
-    <PackageManagement Include="Fluid.Core" Version="1.0.0-beta-9651" />
+    <PackageManagement Include="Fluid.Core" Version="1.0.0-beta-9672" />
     <PackageManagement Include="GraphQL" Version="2.4.0" />
     <PackageManagement Include="Jint" Version="3.0.0-beta-1632" />
     <PackageManagement Include="HtmlSanitizer" Version="5.0.319" />


### PR DESCRIPTION
Fixes #4912

Tested with version 1.0.0-beta-9672:
`{{ 5 | divide_by: 2 }}` returns 2
`{{ 5 | divide_by: 2.0 }}` returns 2.5