### PR TITLE
Fix regression - tags shape missing in blog template

### DIFF
--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Content-BlogPost.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Content-BlogPost.liquid
@@ -29,4 +29,4 @@
 {{ Model.Content.ContentsMetadata | shape_render }}
 {{ Model.Content.MarkdownBodyPart | shape_render }}
 {{ Model.Content.BlogPost-Category | shape_render }}
-{{ Model.Content.BlogPost-Tags-TaxonomyField_Display__Tags | shape_render }}
+{{ Model.Content.BlogPost-Tags | shape_render }}


### PR DESCRIPTION
Fixes a regression from https://github.com/OrchardCMS/OrchardCore/pull/6406 where we changed how the name of a shape was maintained.

@jtkech that change to handling shape names with display types, and putting the differentiator on the shape metadata has been really useful this past week. Cheers :)