### PR TITLE
Don't fail when creating a scope on a dependent shell that has been disposed.

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContext.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContext.cs
@@ -48,7 +48,10 @@ namespace OrchardCore.Environment.Shell.Builders
 
         public ShellScope CreateScope()
         {
-            if (_placeHolder)
+            // We can't create a scope with a null 'ServiceProvider' meaning that the shell has been disposed. Normally, the
+            // 'ShellHost' removes the shell from its collection as soon as it is released so that a new one will be created.
+            // But this may happen when a shell releases itself its dependent shells and disposes those that are not in use.
+            if (_placeHolder || ServiceProvider == null)
             {
                 return null;
             }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContext.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using OrchardCore.Environment.Shell.Builders.Models;
+using OrchardCore.Environment.Shell.Models;
 using OrchardCore.Environment.Shell.Scope;
 
 namespace OrchardCore.Environment.Shell.Builders
@@ -51,7 +52,7 @@ namespace OrchardCore.Environment.Shell.Builders
             // We can't create a scope with a null 'ServiceProvider' meaning that the shell has been disposed. Normally, the
             // 'ShellHost' removes the shell from its collection as soon as it is released so that a new one will be created.
             // But this may happen when a shell releases its dependent shells and disposes those that are not in use.
-            if (_placeHolder || ServiceProvider == null)
+            if (_placeHolder || (ServiceProvider == null && Settings.State != TenantState.Disabled))
             {
                 return null;
             }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContext.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContext.cs
@@ -50,7 +50,7 @@ namespace OrchardCore.Environment.Shell.Builders
         {
             // We can't create a scope with a null 'ServiceProvider' meaning that the shell has been disposed. Normally, the
             // 'ShellHost' removes the shell from its collection as soon as it is released so that a new one will be created.
-            // But this may happen when a shell releases itself its dependent shells and disposes those that are not in use.
+            // But this may happen when a shell releases its dependent shells and disposes those that are not in use.
             if (_placeHolder || ServiceProvider == null)
             {
                 return null;


### PR DESCRIPTION
Fixes #6605 

    // We can't create a scope with a null 'ServiceProvider' meaning that the shell has been disposed. Normally, the
    // 'ShellHost' removes the shell from its collection as soon as it is released so that a new one will be created.
    // But this may happen when a shell releases itself its dependent shells and disposes those that are not in use.
    if (_placeHolder || ServiceProvider == null)
    {
        return null;
    }

As i remember at some point we were checking the `ServiceProvider` before creating a scope, but we removed this check and added a `throw new ArgumentNullException()` in the `ShellScope` constructor.