### PR TITLE
Add and implement IsJson() string extension method

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/HtmlFieldTrumbowygEditorSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/HtmlFieldTrumbowygEditorSettingsDriver.cs
@@ -1,11 +1,12 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
-using Newtonsoft.Json.Linq;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentFields.ViewModels;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Mvc.Utilities;
 
 namespace OrchardCore.ContentFields.Settings
 {
@@ -39,20 +40,17 @@ namespace OrchardCore.ContentFields.Settings
 
                 await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-                settings.InsertMediaWithUrl = model.InsertMediaWithUrl;
-
-                try
+                if (!model.Options.IsJson())
                 {
+                    context.Updater.ModelState.AddModelError(Prefix + '.' + nameof(TrumbowygSettingsViewModel.Options), S["The options are written in an incorrect format."]);
+                }
+                else
+                {
+                    settings.InsertMediaWithUrl = model.InsertMediaWithUrl;
                     settings.Options = model.Options;
-                    JObject.Parse(settings.Options);
-                }
-                catch
-                {
-                    context.Updater.ModelState.AddModelError(Prefix, S["The options are written in an incorrect format."]);
-                    return Edit(partFieldDefinition);
-                }
 
-                context.Builder.WithSettings(settings);
+                    context.Builder.WithSettings(settings);
+                }
             }
 
             return Edit(partFieldDefinition);

--- a/src/OrchardCore.Modules/OrchardCore.Html/Settings/HtmlBodyPartTrumbowygEditorSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Settings/HtmlBodyPartTrumbowygEditorSettingsDriver.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
-using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Html.Models;
 using OrchardCore.Html.ViewModels;
+using OrchardCore.Mvc.Utilities;
 
 namespace OrchardCore.Html.Settings
 {
@@ -51,20 +51,16 @@ namespace OrchardCore.Html.Settings
 
                 await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-                settings.InsertMediaWithUrl = model.InsertMediaWithUrl;
-
-                try
+                if (!model.Options.IsJson())
                 {
+                    context.Updater.ModelState.AddModelError(Prefix + "." + nameof(TrumbowygSettingsViewModel.Options), S["The options are written in an incorrect format."]);
+                }
+                else
+                {
+                    settings.InsertMediaWithUrl = model.InsertMediaWithUrl;
                     settings.Options = model.Options;
-                    JObject.Parse(settings.Options);
+                    context.Builder.WithSettings(settings);
                 }
-                catch
-                {
-                    context.Updater.ModelState.AddModelError(Prefix, S["The options are written in an incorrect format."]);
-                    return Edit(contentTypePartDefinition, context.Updater);
-                }
-
-                context.Builder.WithSettings(settings);
             }
 
             return Edit(contentTypePartDefinition, context.Updater);

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Localization;
+using Newtonsoft.Json.Linq;
 
 namespace OrchardCore.Mvc.Utilities
 {
@@ -472,6 +473,22 @@ namespace OrchardCore.Mvc.Utilities
             }
 
             return result.ToString();
+        }
+
+        /// <summary>
+        /// Tests if a string is valid json.
+        /// </summary>
+        public static bool IsJson(this string json)
+        {
+            try
+            {
+                JToken.Parse(json);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
We have a few pr's in the works that are using JSON in their editor templates, and want to / need to validate that the text supplied in the editor is valid json. (refer https://github.com/OrchardCMS/OrchardCore/pull/6536 and https://github.com/OrchardCMS/OrchardCore/pull/6595)

This adds a string extension method .IsJson()` to the `OrchardCore.Mvc.Utilities` classes to do this, and implements it for the `Trumbowyg` editors 