### PR TITLE
Fixes #6629 PreserveCompilationReferences

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/OrchardCore.Mvc.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/OrchardCore.Mvc.Core.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" ExcludeAssets="build" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" ExcludeAssets="build;buildtransitive" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #6629 

Because the related msbuild script, that forces `PreserveCompilationReferences` to true, is not only in the `build` folder but also in the `buildtransitive` folder of the runtime compilation package.