### PR TITLE
Fixes #6621 The user has been disabled, but can still authenticated b…

### DIFF
--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -51,7 +51,11 @@ namespace OrchardCore.Users.Services
                 reportError(string.Empty, S["The specified username/password couple is invalid."]);
                 return null;
             }
-
+            if (user is User userModel && !userModel.IsEnabled)
+            {
+                reportError(string.Empty, S["Your account is disabled. Please contact an administrator."]);
+                return null;
+            }
             var result = await _signInManager.CheckPasswordSignInAsync(user, password, lockoutOnFailure: true);
             if (result.IsNotAllowed)
             {


### PR DESCRIPTION
OpenId uses `IUserService.AuthenticateAsync` to determine whether the user is effectively authorized, but `IUserService.AuthenticateAsync` did not check whether the user was disabled.

https://github.com/OrchardCMS/OrchardCore/issues/6621