### PR TITLE
Format CommonPart DateTime

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/CommonPart-Date.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/CommonPart-Date.Edit.cshtml
@@ -4,7 +4,7 @@
 <div class="form-group" asp-validation-class-for="LocalDateTime">
     <div class="row col-md-6 col-lg-3">
         <label asp-for="LocalDateTime">@T["Created"]</label>
-        <input asp-for="LocalDateTime" class="form-control" type="datetime-local" />
+        <input asp-for="LocalDateTime" asp-format="{0:yyyy-MM-ddTHH:mm}" class="form-control" type="datetime-local" />
         <span asp-validation-for="LocalDateTime"></span>
     </div>
     <span class="hint">@T["The date when the content item was created or first published."]</span>


### PR DESCRIPTION
Fixes #6655

Use `asp-format="{0:yyyy-MM-ddTHH:mm}"` with `<input type="datetime-local" />` to edit the CommonPart CreatedDate with only hours and seconds.