### PR TITLE
#6585 Fixing Linux setup by making sure a directory created before creating a file

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
@@ -65,6 +65,12 @@ namespace OrchardCore.ContentManagement
         {
             lock (this)
             {
+                var directoryPath = Path.GetDirectoryName(Filename);
+                if (!Directory.Exists(directoryPath))
+                {
+                    Directory.CreateDirectory(directoryPath);
+                }
+
                 using (var file = File.CreateText(Filename))
                 {
                     var serializer = new JsonSerializer();

--- a/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/FileContentDefinitionStore.cs
@@ -66,7 +66,7 @@ namespace OrchardCore.ContentManagement
             lock (this)
             {
                 var directoryPath = Path.GetDirectoryName(Filename);
-                if (!Directory.Exists(directoryPath))
+                if (!String.IsNullOrEmpty(directoryPath) && !Directory.Exists(directoryPath))
                 {
                     Directory.CreateDirectory(directoryPath);
                 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13991195/87610157-68ef8b00-c6b9-11ea-91c9-326269bb2553.png)
Setup fails on Installation from Docker-Linux container. The directory needs to be created before file creation. On the image above Setup failed because there wasn't "Default" folder.