### PR TITLE
Fixes #6677 duplicate startup

### DIFF
--- a/src/OrchardCore/OrchardCore/Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/ShellContainerFactory.cs
@@ -62,8 +62,8 @@ namespace OrchardCore.Environment.Shell.Builders
 
             foreach (var dependency in blueprint.Dependencies.Where(t => typeof(IStartup).IsAssignableFrom(t.Key)))
             {
-                moduleServiceCollection.AddSingleton(typeof(IStartup), dependency.Key);
-                tenantServiceCollection.AddSingleton(typeof(IStartup), dependency.Key);
+                moduleServiceCollection.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IStartup), dependency.Key));
+                tenantServiceCollection.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IStartup), dependency.Key));
             }
 
             // To not trigger features loading before it is normally done by 'ShellHost',


### PR DESCRIPTION
Fixes #6677, last remaining part of this issue

When we register an `IStartup` class through `OrchardCoreBuilder.RegisterStartup()`, if the class is defined in the application, this startup is resolved twice, one through the DI and one through reflexion (because the app is a module) and then re-added to the tenant container.