### PR TITLE
Inner recipe overwrite parent variables

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -19,6 +19,7 @@ namespace OrchardCore.Recipes.Controllers
 {
     public class AdminController : Controller
     {
+        private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
         private readonly IExtensionManager _extensionManager;
         private readonly IAuthorizationService _authorizationService;
@@ -29,6 +30,7 @@ namespace OrchardCore.Recipes.Controllers
         private readonly IHtmlLocalizer H;
 
         public AdminController(
+            IShellHost shellHost,
             ShellSettings shellSettings,
             ISiteService siteService,
             IExtensionManager extensionManager,
@@ -38,6 +40,7 @@ namespace OrchardCore.Recipes.Controllers
             IRecipeExecutor recipeExecutor,
             INotifier notifier)
         {
+            _shellHost = shellHost;
             _shellSettings = shellSettings;
             _siteService = siteService;
             _recipeExecutor = recipeExecutor;
@@ -116,6 +119,8 @@ namespace OrchardCore.Recipes.Controllers
                 // Don't lock the tenant if the recipe fails.
                 _shellSettings.State = TenantState.Running;
             }
+
+            await _shellHost.ReleaseShellContextAsync(_shellSettings);
 
             _notifier.Success(H["The recipe '{0}' has been run successfully", recipe.Name]);
             return RedirectToAction("Index");

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
@@ -3,16 +3,21 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.FileProviders;
 using OrchardCore.Deployment;
+using OrchardCore.Environment.Shell;
 using OrchardCore.Recipes.Models;
 
 namespace OrchardCore.Recipes.Services
 {
     public class RecipeDeploymentTargetHandler : IDeploymentTargetHandler
     {
+        private readonly IShellHost _shellHost;
+        private readonly ShellSettings _shellSettings;
         private readonly IRecipeExecutor _recipeExecutor;
 
-        public RecipeDeploymentTargetHandler(IRecipeExecutor recipeExecutor)
+        public RecipeDeploymentTargetHandler(IShellHost shellHost, ShellSettings shellSettings, IRecipeExecutor recipeExecutor)
         {
+            _shellHost = shellHost;
+            _shellSettings = shellSettings;
             _recipeExecutor = recipeExecutor;
         }
 
@@ -27,6 +32,8 @@ namespace OrchardCore.Recipes.Services
             };
 
             await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, new object(), CancellationToken.None);
+
+            await _shellHost.ReleaseShellContextAsync(_shellSettings);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IScriptingManager.cs
@@ -29,6 +29,6 @@ namespace OrchardCore.Scripting
         /// The list of available method providers for this <see cref="IScriptingManager"/>
         /// instance.
         /// </summary>
-        IList<IGlobalMethodProvider> GlobalMethodProviders { get; }
+        IReadOnlyList<IGlobalMethodProvider> GlobalMethodProviders { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Scripting/DefaultScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Scripting/DefaultScriptingManager.cs
@@ -14,10 +14,10 @@ namespace OrchardCore.Scripting
             IEnumerable<IGlobalMethodProvider> globalMethodProviders)
         {
             _engines = engines;
-            GlobalMethodProviders = new List<IGlobalMethodProvider>(globalMethodProviders);
+            GlobalMethodProviders = new List<IGlobalMethodProvider>(globalMethodProviders).AsReadOnly();
         }
 
-        public IList<IGlobalMethodProvider> GlobalMethodProviders { get; }
+        public IReadOnlyList<IGlobalMethodProvider> GlobalMethodProviders { get; }
 
         public object Evaluate(string directive,
             IFileProvider fileProvider,

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/Events/IRecipeEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/Events/IRecipeEventHandler.cs
@@ -3,6 +3,11 @@ using OrchardCore.Recipes.Models;
 
 namespace OrchardCore.Recipes.Events
 {
+    /// <summary>
+    /// Note: The recipe executor creates for each step a scope that may be based on a new shell if the features have changed,
+    /// so an 'IRecipeEventHandler', that is also used in each step scope, can't be a tenant level service, otherwise it may
+    /// be used in a shell container it doesn't belong, so it should be an application level transient or singleton service.
+    /// </summary>
     public interface IRecipeEventHandler
     {
         Task RecipeExecutingAsync(string executionId, RecipeDescriptor descriptor);

--- a/src/OrchardCore/OrchardCore.Recipes.Core/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/ServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Recipes
         {
             services.AddScoped<IRecipeHarvester, ApplicationRecipeHarvester>();
             services.AddScoped<IRecipeHarvester, RecipeHarvester>();
-            services.AddSingleton<IRecipeExecutor, RecipeExecutor>();
+            services.AddTransient<IRecipeExecutor, RecipeExecutor>();
             services.AddScoped<IRecipeMigrator, RecipeMigrator>();
             services.AddScoped<IRecipeReader, RecipeReader>();
 

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -26,10 +26,6 @@ namespace OrchardCore.Recipes.Services
 
         private readonly Dictionary<string, List<IGlobalMethodProvider>> _methodProviders = new Dictionary<string, List<IGlobalMethodProvider>>();
 
-        // Note: A new scope is created on each step that may be based on a new shell if the features have been updated, so
-        // the 'IRecipeEventHandler', that are also used in step scopes, can't be tenant level services, otherwise they may
-        // be used in a shell container they don't belong, they should be application level transient / singleton services.
-
         public RecipeExecutor(
             IShellHost shellHost,
             ShellSettings shellSettings,

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -166,23 +166,23 @@ namespace OrchardCore.Recipes.Services
                 // Substitutes the script elements by their actual values
                 EvaluateJsonTree(scriptingManager, recipeStep, recipeStep.Step);
 
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation("Executing recipe step '{RecipeName}'.", recipeStep.Name);
+                }
+
+                await _recipeEventHandlers.InvokeAsync((handler, recipeStep) => handler.RecipeStepExecutingAsync(recipeStep), recipeStep, _logger);
+
                 foreach (var recipeStepHandler in recipeStepHandlers)
                 {
-                    if (_logger.IsEnabled(LogLevel.Information))
-                    {
-                        _logger.LogInformation("Executing recipe step '{RecipeName}'.", recipeStep.Name);
-                    }
-
-                    await _recipeEventHandlers.InvokeAsync((handler, recipeStep) => handler.RecipeStepExecutingAsync(recipeStep), recipeStep, _logger);
-
                     await recipeStepHandler.ExecuteAsync(recipeStep);
+                }
 
-                    await _recipeEventHandlers.InvokeAsync((handler, recipeStep) => handler.RecipeStepExecutedAsync(recipeStep), recipeStep, _logger);
+                await _recipeEventHandlers.InvokeAsync((handler, recipeStep) => handler.RecipeStepExecutedAsync(recipeStep), recipeStep, _logger);
 
-                    if (_logger.IsEnabled(LogLevel.Information))
-                    {
-                        _logger.LogInformation("Finished executing recipe step '{RecipeName}'.", recipeStep.Name);
-                    }
+                if (_logger.IsEnabled(LogLevel.Information))
+                {
+                    _logger.LogInformation("Finished executing recipe step '{RecipeName}'.", recipeStep.Name);
                 }
             });
         }

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -173,10 +173,7 @@ namespace OrchardCore.Recipes.Services
 
                 await _recipeEventHandlers.InvokeAsync((handler, recipeStep) => handler.RecipeStepExecutingAsync(recipeStep), recipeStep, _logger);
 
-                foreach (var recipeStepHandler in recipeStepHandlers)
-                {
-                    await recipeStepHandler.ExecuteAsync(recipeStep);
-                }
+                await recipeStepHandlers.InvokeAsync((handler, recipeStep) => handler.ExecuteAsync(recipeStep), recipeStep, _logger);
 
                 await _recipeEventHandlers.InvokeAsync((handler, recipeStep) => handler.RecipeStepExecutedAsync(recipeStep), recipeStep, _logger);
 

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -26,6 +26,10 @@ namespace OrchardCore.Recipes.Services
 
         private readonly Dictionary<string, List<IGlobalMethodProvider>> _methodProviders = new Dictionary<string, List<IGlobalMethodProvider>>();
 
+        // Note: A new scope is created on each step that may be based on a new shell if the features have been updated, so
+        // the 'IRecipeEventHandler', that are also used in step scopes, can't be tenant level services, otherwise they would
+        // be used in a shell container they don't belong, they should be application level transient / singleton services.
+
         public RecipeExecutor(
             IShellHost shellHost,
             ShellSettings shellSettings,

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.Recipes.Services
         private readonly Dictionary<string, List<IGlobalMethodProvider>> _methodProviders = new Dictionary<string, List<IGlobalMethodProvider>>();
 
         // Note: A new scope is created on each step that may be based on a new shell if the features have been updated, so
-        // the 'IRecipeEventHandler', that are also used in step scopes, can't be tenant level services, otherwise they would
+        // the 'IRecipeEventHandler', that are also used in step scopes, can't be tenant level services, otherwise they may
         // be used in a shell container they don't belong, they should be application level transient / singleton services.
 
         public RecipeExecutor(

--- a/src/OrchardCore/OrchardCore.Recipes.Core/VariablesMethodProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/VariablesMethodProvider.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
+using OrchardCore.Environment.Shell.Scope;
 using OrchardCore.Scripting;
 
 namespace OrchardCore.Recipes
@@ -31,7 +33,7 @@ namespace OrchardCore.Recipes
             };
         }
 
-        public IScriptingManager ScriptingManager { get; set; }
+        public IScriptingManager ScriptingManager => ShellScope.Services.GetRequiredService<IScriptingManager>();
 
         public IEnumerable<GlobalMethod> GetMethods()
         {

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostValidateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostValidateDeploymentPlanTests.cs
@@ -46,17 +46,15 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 Assert.Throws<HttpRequestException>(() => response.EnsureSuccessStatusCode());
 
                 // Confirm creation of both content items was cancelled.
-                using (var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName))
+                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                await shellScope.UsingAsync(async scope =>
                 {
-                    await shellScope.UsingAsync(async scope =>
-                    {
-                        var session = scope.ServiceProvider.GetRequiredService<ISession>();
-                        var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
-                            x.ContentType == "BlogPost").ListAsync();
+                    var session = scope.ServiceProvider.GetRequiredService<ISession>();
+                    var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
+                        x.ContentType == "BlogPost").ListAsync();
 
-                        Assert.Single(blogPosts);
-                    });
-                }
+                    Assert.Single(blogPosts);
+                });
             }
         }
     }


### PR DESCRIPTION
Fixes #6717 and refactoring

- Fixes the related issue by holding in a dictionary additional method providers per recipe executionId. @deanmarcussen i made the recipe executor transient, not to fix the issue but to be thread safe even if we use here a simple dictionary.

- Here the singularity is that the recipe executor creates a new scope on each step that may be based on a new shell / container, e.g. after updating the features, so resolving a service in a given step scope, even it is a tenant singleton, may return another instance (including the recipe executor itself if you try it).

    That's why we need to resolve the script manager in each step scope, and we need that the recipe executor only injects e.g. app level transients / singletons as the shell host, that's okay for the shell settings that stays the same as a recipe is not intended to reload it, only externally after its execution e.g. at the end of a setup.

- But **i'm not sure that the injection and the usage of the `IRecipeEventHandler` are good**, they would need to be app level transients / singletons. Maybe at least tenant level transients / singletons, and then okay for the event at the beginning but they would need to be part of the setup features. But at the end of a recipe, maybe better to be resolved in a new scope that may be based on a new shell, as we do at the end of a setup for the `ISetupEventHandler`.

    They also have step events called for each step, here maybe better to resolve them in each step scope. Notice that here they were called each time we call a scoped `IRecipeStepHandler`, fixed here by calling them outside the related loop. **So i'm tempted to remove them, we have no concrete implementations and i think there are not used or very rarely**.

- In the recipes admin controller, we now release the tenant after a recipe execution, e.g if they have changed some site settings that needs to release the tenant so that it will be rebuilt. If features have changed it is automatically done through the shell descriptor manager, at the end of a setup it is done somewhere when updating shell settings.

Need more thinkings about the need / usage of `IRecipeEventHandler` (not `IRecipeStepHandler`), but @deanmarcussen as it is already done, when you will have time can you try it to check if it fixes the usage of your inner recipe.


**Update**: That said there is still an unit test that is failing, will see tomorrow