### PR TITLE
Update Cms Module template name

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Orchard Project",
   "classifications": [ "Web", "Orchard Core", "CMS" ],
-  "name": "Orchard Core Module",
+  "name": "Orchard Core Cms Module",
   "identity": "OrchardCore.Templates.Cms.Module",
   "shortName": "ocmodulecms",
   "sourceName": "OrchardCore.Templates.Cms.Module",


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6405

Done through github as these files are gitignored locally. 

But tested locally

```
/Users/deanmarcussen/Projects/OrchardCore/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module
    Templates:
      Orchard Core Cms Module (ocmodulecms) C#
    Uninstall Command:
      dotnet new -u /Users/deanmarcussen/Projects/OrchardCore/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module
```