### PR TITLE
Update Mvc Module template name

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/.template.config.src/template.json
@@ -2,7 +2,7 @@
   "$schema": "http://json.schemastore.org/template",
   "author": "Orchard Project",
   "classifications": [ "Web", "Orchard Core", "Mvc" ],
-  "name": "Orchard Core Module",
+  "name": "Orchard Core Mvc Module",
   "identity": "OrchardCore.Templates.Mvc.Module",
   "shortName": "ocmodulemvc",
   "sourceName": "OrchardCore.Templates.Mvc.Module",


### PR DESCRIPTION
Fixes #6405

Done through github as these files are gitignored locally.

But tested locally

```
/Users/deanmarcussen/Projects/OrchardCore/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module
    Templates:
      Orchard Core Mvc Module (ocmodulemvc) C#
    Uninstall Command:
      dotnet new -u /Users/deanmarcussen/Projects/OrchardCore/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module
```