### PR TITLE
Add IShapePlacementProvider and ShapeTablePlacementProvider

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/DefaultContentDefinitionDisplayManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/DefaultContentDefinitionDisplayManager.cs
@@ -9,7 +9,6 @@ using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Layout;
 using OrchardCore.DisplayManagement.ModelBinding;
-using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Modules;
 
 namespace OrchardCore.ContentTypes.Editors
@@ -20,7 +19,6 @@ namespace OrchardCore.ContentTypes.Editors
         private readonly IShapeTableManager _shapeTableManager;
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly IShapeFactory _shapeFactory;
-        private readonly IThemeManager _themeManager;
         private readonly ILayoutAccessor _layoutAccessor;
         private readonly ILogger _logger;
 
@@ -29,16 +27,15 @@ namespace OrchardCore.ContentTypes.Editors
             IShapeTableManager shapeTableManager,
             IContentDefinitionManager contentDefinitionManager,
             IShapeFactory shapeFactory,
-            IThemeManager themeManager,
+            IEnumerable<IShapePlacementProvider> placementProviders,
             ILogger<DefaultContentDefinitionDisplayManager> logger,
             ILayoutAccessor layoutAccessor
-            ) : base(shapeTableManager, shapeFactory, themeManager)
+            ) : base(shapeFactory, placementProviders)
         {
             _handlers = handlers;
             _shapeTableManager = shapeTableManager;
             _contentDefinitionManager = contentDefinitionManager;
             _shapeFactory = shapeFactory;
-            _themeManager = themeManager;
             _layoutAccessor = layoutAccessor;
             _logger = logger;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/ActivityDisplayManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/ActivityDisplayManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -8,7 +9,6 @@ using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Layout;
 using OrchardCore.DisplayManagement.ModelBinding;
-using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Helpers;
 using OrchardCore.Workflows.Options;
@@ -18,10 +18,16 @@ namespace OrchardCore.Workflows.Services
     public class ActivityDisplayManager : IActivityDisplayManager
     {
         private readonly DisplayManager<IActivity> _displayManager;
-        public ActivityDisplayManager(IOptions<WorkflowOptions> workflowOptions, IServiceProvider serviceProvider, IShapeTableManager shapeTableManager, IShapeFactory shapeFactory, IThemeManager themeManager, ILogger<DisplayManager<IActivity>> displayManagerLogger, ILayoutAccessor layoutAccessor)
+        public ActivityDisplayManager(
+            IOptions<WorkflowOptions> workflowOptions,
+            IServiceProvider serviceProvider,
+            IShapeFactory shapeFactory,
+            IEnumerable<IShapePlacementProvider> placementProviders,
+            ILogger<DisplayManager<IActivity>> displayManagerLogger,
+            ILayoutAccessor layoutAccessor)
         {
             var drivers = workflowOptions.Value.ActivityDisplayDriverTypes.Select(x => serviceProvider.CreateInstance<IDisplayDriver<IActivity>>(x));
-            _displayManager = new DisplayManager<IActivity>(drivers, shapeTableManager, shapeFactory, themeManager, displayManagerLogger, layoutAccessor);
+            _displayManager = new DisplayManager<IActivity>(drivers, shapeFactory, placementProviders, displayManagerLogger, layoutAccessor);
         }
 
         public Task<IShape> BuildDisplayAsync(IActivity model, IUpdateModel updater, string displayType = "", string groupId = "")

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplayManager.cs
@@ -13,7 +13,6 @@ using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Layout;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Shapes;
-using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Modules;
 
 namespace OrchardCore.ContentManagement.Display
@@ -31,7 +30,6 @@ namespace OrchardCore.ContentManagement.Display
         private readonly IShapeTableManager _shapeTableManager;
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly IShapeFactory _shapeFactory;
-        private readonly IThemeManager _themeManager;
         private readonly ILayoutAccessor _layoutAccessor;
         private readonly ILogger _logger;
 
@@ -41,17 +39,16 @@ namespace OrchardCore.ContentManagement.Display
             IShapeTableManager shapeTableManager,
             IContentDefinitionManager contentDefinitionManager,
             IShapeFactory shapeFactory,
-            IThemeManager themeManager,
+            IEnumerable<IShapePlacementProvider> placementProviders,
             ILogger<ContentItemDisplayManager> logger,
             ILayoutAccessor layoutAccessor
-            ) : base(shapeTableManager, shapeFactory, themeManager)
+            ) : base(shapeFactory, placementProviders)
         {
             _handlers = handlers;
             _contentHandlers = contentHandlers;
             _shapeTableManager = shapeTableManager;
             _contentDefinitionManager = contentDefinitionManager;
             _shapeFactory = shapeFactory;
-            _themeManager = themeManager;
             _layoutAccessor = layoutAccessor;
             _logger = logger;
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
@@ -1,45 +1,44 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Handlers;
-using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.DisplayManagement.Zones;
 
 namespace OrchardCore.DisplayManagement
 {
     public abstract class BaseDisplayManager
     {
-        private readonly IShapeTableManager _shapeTableManager;
         private readonly IShapeFactory _shapeFactory;
-        private readonly IThemeManager _themeManager;
+        private readonly IEnumerable<IShapePlacementProvider> _placementProviders;
 
         public BaseDisplayManager(
-            IShapeTableManager shapeTableManager,
             IShapeFactory shapeFactory,
-            IThemeManager themeManager
+            IEnumerable<IShapePlacementProvider> placementProviders
             )
         {
-            _shapeTableManager = shapeTableManager;
             _shapeFactory = shapeFactory;
-            _themeManager = themeManager;
+            _placementProviders = placementProviders;
         }
 
         protected async Task BindPlacementAsync(IBuildShapeContext context)
         {
-            var theme = await _themeManager.GetThemeAsync();
+            var resolvers = new List<IPlacementInfoResolver>();
 
-            // If there is no active theme, do nothing
-            if (theme == null)
+            foreach(var provider in _placementProviders)
             {
-                return;
+                var resolver = await provider.BuildPlacementInfoResolverAsync(context);
+
+                if (resolver != null)
+                {
+                    resolvers.Add(resolver);
+                }
             }
 
-            var shapeTable = _shapeTableManager.GetShapeTable(theme.Id);
-
-            context.FindPlacement = (shapeType, differentiator, displayType, displayContext) => FindPlacementImpl(shapeTable, shapeType, differentiator, displayType, context);
+            context.FindPlacement = (shapeType, differentiator, displayType) => FindPlacementImpl(resolvers, shapeType, differentiator, displayType, context);
         }
 
-        private static PlacementInfo FindPlacementImpl(ShapeTable shapeTable, string shapeType, string differentiator, string displayType, IBuildShapeContext context)
+        private static PlacementInfo FindPlacementImpl(IList<IPlacementInfoResolver> placementResolvers, string shapeType, string differentiator, string displayType, IBuildShapeContext context)
         {
             var delimiterIndex = shapeType.IndexOf("__", StringComparison.Ordinal);
 
@@ -48,20 +47,20 @@ namespace OrchardCore.DisplayManagement
                 shapeType = shapeType.Substring(0, delimiterIndex);
             }
 
-            if (shapeTable.Descriptors.TryGetValue(shapeType, out var descriptor))
-            {
-                var placementContext = new ShapePlacementContext(
-                    shapeType,
-                    displayType,
-                    differentiator,
-                    context.Shape
-                );
+            var placementContext = new ShapePlacementContext(
+                shapeType,
+                displayType,
+                differentiator,
+                context.Shape
+            );
 
-                var placement = descriptor.Placement(placementContext);
-                if (placement != null)
+            for(int i = placementResolvers.Count - 1; i >= 0; i--)
+            {
+                var info = placementResolvers[i].ResolvePlacement(placementContext);
+
+                if (info != null)
                 {
-                    placement.Source = placementContext.Source;
-                    return placement;
+                    return info;
                 }
             }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
@@ -63,7 +63,11 @@ namespace OrchardCore.DisplayManagement
 
         private static PlacementInfo CombinePlacements(PlacementInfo first, PlacementInfo second)
         {
-            if (first != null && second != null)
+            if (first == null)
+            {
+                return second;
+            }
+            else if (second != null)
             {
                 CombineAlternates(first.Alternates, second.Alternates);
                 CombineAlternates(first.Wrappers, second.Wrappers);
@@ -81,22 +85,18 @@ namespace OrchardCore.DisplayManagement
                 }
                 first.Source += "," + second.Source;
             }
-            else if (second != null)
-            {
-                return second;
-            }
             return first;
         }
 
         private static AlternatesCollection CombineAlternates(AlternatesCollection first, AlternatesCollection second)
         {
-            if (first != null && second != null)
+            if (first == null)
             {
-                first.AddRange(second);
+                return second;
             }
             else if (second != null)
             {
-                return second;
+                first.AddRange(second);
             }
             return first;
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
@@ -79,7 +79,7 @@ namespace OrchardCore.DisplayManagement
                 {
                     first.DefaultPosition = second.DefaultPosition;
                 }
-                first.Source = second.Source + "," + second.Source;
+                first.Source += "," + second.Source;
             }
             else if (second != null)
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/BaseDisplayManager.cs
@@ -37,7 +37,7 @@ namespace OrchardCore.DisplayManagement
                 }
             }
 
-            context.FindPlacement = (shapeType, differentiator, displayType) => FindPlacementImpl(resolvers, shapeType, differentiator, displayType, context);
+            context.FindPlacement = (shapeType, differentiator, displayType, displayContext) => FindPlacementImpl(resolvers, shapeType, differentiator, displayType, context);
         }
 
         private static PlacementInfo FindPlacementImpl(IList<IPlacementInfoResolver> placementResolvers, string shapeType, string differentiator, string displayType, IBuildShapeContext context)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/Interfaces.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/Interfaces.cs
@@ -1,4 +1,6 @@
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.DisplayManagement.Handlers;
 
 namespace OrchardCore.DisplayManagement.Descriptors
 {
@@ -32,5 +34,31 @@ namespace OrchardCore.DisplayManagement.Descriptors
 
             return services;
         }
+    }
+
+    /// <summary>
+    /// Represents a marker interface for classes that provide Shape placement informations
+    /// </summary>
+    public interface IShapePlacementProvider
+    {
+        /// <summary>
+        /// Builds a contextualized <see cref="IPlacementInfoResolver"/>
+        /// </summary>
+        /// <param name="context">The <see cref="IBuildShapeContext"/> for which we need a placement resolver</param>
+        /// <returns>An instance of <see cref="IPlacementInfoResolver"/> for the current context or <see cref="null"/> if this provider is not concerned.</returns>
+        Task<IPlacementInfoResolver> BuildPlacementInfoResolverAsync(IBuildShapeContext context);
+    }
+
+    /// <summary>
+    /// Represents a class capable of resolving <see cref="PlacementInfo"/> of Shapes
+    /// </summary>
+    public interface IPlacementInfoResolver
+    {
+        /// <summary>
+        /// Resolves <see cref="PlacementInfo"/> for the provided <see cref="ShapePlacementContext"/>
+        /// </summary>
+        /// <param name="placementContext">The <see cref="ShapePlacementContext"/></param>
+        /// <returns>An <see cref="PlacementInfo"/> or <see cref="null"/> if not concerned.</returns>
+        PlacementInfo ResolvePlacement(ShapePlacementContext placementContext);
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTablePlacementProvider.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTablePlacementProvider.cs
@@ -1,0 +1,61 @@
+using System.Threading.Tasks;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Theming;
+
+namespace OrchardCore.DisplayManagement.Descriptors
+{
+    public class ShapeTablePlacementProvider : IShapePlacementProvider
+    {
+        private readonly IShapeTableManager _shapeTableManager;
+        private readonly IThemeManager _themeManager;
+
+        public ShapeTablePlacementProvider(
+            IShapeTableManager shapeTableManager,
+            IThemeManager themeManager
+            )
+        {
+            _shapeTableManager = shapeTableManager;
+            _themeManager = themeManager;
+        }
+
+        public async Task<IPlacementInfoResolver> BuildPlacementInfoResolverAsync(IBuildShapeContext context)
+        {
+            var theme = await _themeManager.GetThemeAsync();
+
+            // If there is no active theme, do nothing
+            if (theme == null)
+            {
+                return null;
+            }
+
+            var shapeTable = _shapeTableManager.GetShapeTable(theme.Id);
+
+            return new ShapeTablePlacementResolver(shapeTable);
+        }
+
+        private class ShapeTablePlacementResolver : IPlacementInfoResolver
+        {
+            private readonly ShapeTable _shapeTable;
+
+            internal ShapeTablePlacementResolver(ShapeTable shapeTable)
+            {
+                _shapeTable = shapeTable;
+            }
+
+            public PlacementInfo ResolvePlacement(ShapePlacementContext placementContext)
+            {
+                if (_shapeTable.Descriptors.TryGetValue(placementContext.ShapeType, out var descriptor))
+                {
+                    var placement = descriptor.Placement(placementContext);
+                    if (placement != null)
+                    {
+                        placement.Source = placementContext.Source;
+                        return placement;
+                    }
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement/DisplayManager.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/DisplayManager.cs
@@ -5,7 +5,6 @@ using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Layout;
 using OrchardCore.DisplayManagement.ModelBinding;
-using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Modules;
 
 namespace OrchardCore.DisplayManagement
@@ -19,12 +18,11 @@ namespace OrchardCore.DisplayManagement
 
         public DisplayManager(
             IEnumerable<IDisplayDriver<TModel>> drivers,
-            IShapeTableManager shapeTableManager,
             IShapeFactory shapeFactory,
-            IThemeManager themeManager,
+            IEnumerable<IShapePlacementProvider> placementProviders,
             ILogger<DisplayManager<TModel>> logger,
             ILayoutAccessor layoutAccessor
-            ) : base(shapeTableManager, shapeFactory, themeManager)
+            ) : base(shapeFactory, placementProviders)
         {
             _shapeFactory = shapeFactory;
             _layoutAccessor = layoutAccessor;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/BuildShapeContext.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/BuildShapeContext.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.DisplayManagement.Handlers
         public string DefaultZone { get; set; }
         public string DefaultPosition { get; set; }
 
-        private static PlacementInfo FindDefaultPlacement(string shapeType, string differentiator, string displayType, IBuildShapeContext context)
+        private static PlacementInfo FindDefaultPlacement(string shapeType, string differentiator, string displayType)
         {
             return null;
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/BuildShapeContext.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/BuildShapeContext.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.DisplayManagement.Handlers
         public string DefaultZone { get; set; }
         public string DefaultPosition { get; set; }
 
-        private static PlacementInfo FindDefaultPlacement(string shapeType, string differentiator, string displayType)
+        private static PlacementInfo FindDefaultPlacement(string shapeType, string differentiator, string displayType, IBuildShapeContext context)
         {
             return null;
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/FindPlacementDelegate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/FindPlacementDelegate.cs
@@ -1,4 +1,4 @@
-﻿using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.DisplayManagement.Descriptors;
 
 namespace OrchardCore.DisplayManagement.Handlers
 {
@@ -13,5 +13,5 @@ namespace OrchardCore.DisplayManagement.Handlers
     /// </param>
     /// <param name="displayType">The display type the content item owning the shape is rendered with.</param>
     /// <returns>The <see cref="PlacementInfo"/> to use or <see cref="null"/> if this function is not concerned.</returns>
-    public delegate PlacementInfo FindPlacementDelegate(string shapeType, string differentiator, string displayType, IBuildShapeContext context);
+    public delegate PlacementInfo FindPlacementDelegate(string shapeType, string differentiator, string displayType);
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/FindPlacementDelegate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/FindPlacementDelegate.cs
@@ -5,13 +5,14 @@ namespace OrchardCore.DisplayManagement.Handlers
     /// <summary>
     /// A function that provides a <see cref="PlacementInfo"/> instance for a shape.
     /// </summary>
-    /// <param name="shape">The shape to render.</param>
+    /// <param name="shapeType">The shape type to render.</param>
     /// <param name="differentiator">
     /// A discriminator that differentiates this specific shape to the others of the same type.
     /// For instance multiple field shape smight be displayed in different locations even though
     /// they are of the same type.
     /// </param>
     /// <param name="displayType">The display type the content item owning the shape is rendered with.</param>
+    /// <param name="context">The <see cref="IBuildShapeContext"/> in which the shape is placed.</param>
     /// <returns>The <see cref="PlacementInfo"/> to use or <see cref="null"/> if this function is not concerned.</returns>
-    public delegate PlacementInfo FindPlacementDelegate(string shapeType, string differentiator, string displayType);
+    public delegate PlacementInfo FindPlacementDelegate(string shapeType, string differentiator, string displayType, IBuildShapeContext context);
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     services.AddScoped<IPlacementNodeFilterProvider, PathPlacementNodeFilterProvider>();
 
+                    services.AddScoped<IShapePlacementProvider, ShapeTablePlacementProvider>();
+
                     services.TryAddEnumerable(
                         ServiceDescriptor.Transient<IConfigureOptions<ShapeTemplateOptions>, ShapeTemplateOptionsSetup>());
                     services.TryAddSingleton<IShapeTemplateFileProviderAccessor, ShapeTemplateFileProviderAccessor>();
@@ -98,11 +100,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     services.AddTagHelpers<ShapeTagHelper>();
                     services.AddTagHelpers<ValidationMessageTagHelper>();
                     services.AddTagHelpers<ZoneTagHelper>();
-                })
-                .ConfigureServices(services => {
-                    // Configure default services
-                    services.AddScoped<IShapePlacementProvider, ShapeTablePlacementProvider>();
-                }, order: -10);
+                });
 
             return builder;
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Extensions.DependencyInjection
                     services.AddScoped<IShapeTableProvider, ShapePlacementParsingStrategy>();
                     services.AddScoped<IShapeTableProvider, ShapeTemplateBindingStrategy>();
 
-                    services.AddScoped<IShapePlacementProvider, ShapeTablePlacementProvider>();
                     services.AddScoped<IPlacementNodeFilterProvider, PathPlacementNodeFilterProvider>();
 
                     services.TryAddEnumerable(
@@ -99,7 +98,11 @@ namespace Microsoft.Extensions.DependencyInjection
                     services.AddTagHelpers<ShapeTagHelper>();
                     services.AddTagHelpers<ValidationMessageTagHelper>();
                     services.AddTagHelpers<ZoneTagHelper>();
-                });
+                })
+                .ConfigureServices(services => {
+                    // Configure default services
+                    services.AddScoped<IShapePlacementProvider, ShapeTablePlacementProvider>();
+                }, order: -10);
 
             return builder;
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     services.AddScoped<IShapeTableProvider, ShapePlacementParsingStrategy>();
                     services.AddScoped<IShapeTableProvider, ShapeTemplateBindingStrategy>();
 
+                    services.AddScoped<IShapePlacementProvider, ShapeTablePlacementProvider>();
                     services.AddScoped<IPlacementNodeFilterProvider, PathPlacementNodeFilterProvider>();
 
                     services.TryAddEnumerable(

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeResult.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeResult.cs
@@ -59,7 +59,7 @@ namespace OrchardCore.DisplayManagement.Views
             }
 
             // Look into specific implementations of placements (like placement.json files)
-            var placement = context.FindPlacement(_shapeType, _differentiator, displayType, context);
+            var placement = context.FindPlacement(_shapeType, _differentiator, displayType);
 
             // Look for mapped display type locations
             if (_otherLocations != null)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeResult.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeResult.cs
@@ -58,8 +58,8 @@ namespace OrchardCore.DisplayManagement.Views
                 _defaultLocation = context.DefaultZone;
             }
 
-            // Look into specific implementations of placements (like placement.json files)
-            var placement = context.FindPlacement(_shapeType, _differentiator, displayType);
+            // Look into specific implementations of placements (like placement.json files and IShapePlacementProviders)
+            var placement = context.FindPlacement(_shapeType, _differentiator, displayType, context);
 
             // Look for mapped display type locations
             if (_otherLocations != null)


### PR DESCRIPTION
The goal is to add a way to provide shape placement overrides at runtime without rebuilding ShapeTable (as discussed in #6503)

The new `IShapePlacementProvider` interface allows to asynchronously (usefull if it relies on an async placement store) build an `IPlacementInfoResolver` for each `IBuildShapeContext`.

The `IPlacementInfoResolver` implementation keeps placement rules for the current `IBuildShapeContext` to be able to quickly resolve shape placements synchronously.

This PR don't add any direct way to provide placement in admin UI, but opens a way to add this feature.

### Breaking changes

- ~~Removed `IBuildShapeContext` argument from `FindPlacementDelegate` because it's not used anywhere.~~
- Moved ShapeTable provided placement logic from `BaseDisplayManager` to newly created `ShapeTablePlacementProvider` (the first `IShapePlacementProvider` implementation).
It allowed me to remove `BaseDisplayManager` direct dependencies on  `IShapeTableManager` and `IThemeManager`