### PR TITLE
Implement the new localized display names/descriptions store APIs introduced in OpenIddict 3.0 beta3

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <add key="OpenIddict" value="https://www.myget.org/F/openiddict/api/v3/index.json" />
     <!-- This feed should not be used when shipping on NuGet. It should just be used in the dev branch while dependencies are not available on NuGet.org -->
     <!--<add key="OrchardCore" value="https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json" />-->
   </packageSources>

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="OpenIddict" value="https://www.myget.org/F/openiddict/api/v3/index.json" />
     <!-- This feed should not be used when shipping on NuGet. It should just be used in the dev branch while dependencies are not available on NuGet.org -->
     <!--<add key="OrchardCore" value="https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json" />-->
   </packageSources>

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -30,8 +30,8 @@
     <PackageManagement Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="4.9.2" />
     <PackageManagement Include="NodaTime" Version="3.0.0" />
-    <PackageManagement Include="OpenIddict.AspNetCore" Version="[3.0.0-beta3.20402.59]" />
-    <PackageManagement Include="OpenIddict.Core" Version="[3.0.0-beta3.20402.59]" />
+    <PackageManagement Include="OpenIddict.AspNetCore" Version="[3.0.0-beta3.20403.69]" />
+    <PackageManagement Include="OpenIddict.Core" Version="[3.0.0-beta3.20403.69]" />
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-rc2-108003" />
     <PackageManagement Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageManagement Include="Shortcodes" Version="1.0.0-beta-141475106" />

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -30,8 +30,8 @@
     <PackageManagement Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="4.9.2" />
     <PackageManagement Include="NodaTime" Version="3.0.0" />
-    <PackageManagement Include="OpenIddict.AspNetCore" Version="[3.0.0-beta2.20358.71]" />
-    <PackageManagement Include="OpenIddict.Core" Version="[3.0.0-beta2.20358.71]" />
+    <PackageManagement Include="OpenIddict.AspNetCore" Version="[3.0.0-beta3.20402.59]" />
+    <PackageManagement Include="OpenIddict.Core" Version="[3.0.0-beta3.20402.59]" />
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-rc2-108003" />
     <PackageManagement Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageManagement Include="Shortcodes" Version="1.0.0-beta-141475106" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -155,7 +155,7 @@ namespace OrchardCore.OpenId.Controllers
                 default:
                     return View(new AuthorizeViewModel
                     {
-                        ApplicationName = await _applicationManager.GetDisplayNameAsync(application),
+                        ApplicationName = await _applicationManager.GetLocalizedDisplayNameAsync(application),
                         RequestId = request.RequestId,
                         Scope = request.Scope
                     });

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdApplicationManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdApplicationManager.cs
@@ -7,6 +7,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
@@ -22,10 +23,11 @@ namespace OrchardCore.OpenId.Services.Managers
     {
         public OpenIdApplicationManager(
             IOpenIddictApplicationCache<TApplication> cache,
-            IOpenIddictApplicationStoreResolver resolver,
+            IStringLocalizer<OpenIddictResources> localizer,
             ILogger<OpenIdApplicationManager<TApplication>> logger,
-            IOptionsMonitor<OpenIddictCoreOptions> options)
-            : base(cache, resolver, logger, options)
+            IOptionsMonitor<OpenIddictCoreOptions> options,
+            IOpenIddictApplicationStoreResolver resolver)
+            : base(cache, localizer, logger, options, resolver)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdAuthorizationManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdAuthorizationManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
@@ -15,10 +16,11 @@ namespace OrchardCore.OpenId.Services.Managers
     {
         public OpenIdAuthorizationManager(
             IOpenIddictAuthorizationCache<TAuthorization> cache,
-            IOpenIddictAuthorizationStoreResolver resolver,
+            IStringLocalizer<OpenIddictResources> localizer,
             ILogger<OpenIddictAuthorizationManager<TAuthorization>> logger,
-            IOptionsMonitor<OpenIddictCoreOptions> options)
-            : base(cache, resolver, logger, options)
+            IOptionsMonitor<OpenIddictCoreOptions> options,
+            IOpenIddictAuthorizationStoreResolver resolver)
+            : base(cache, localizer, logger, options, resolver)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdScopeManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdScopeManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
@@ -14,10 +15,11 @@ namespace OrchardCore.OpenId.Services.Managers
     {
         public OpenIdScopeManager(
             IOpenIddictScopeCache<TScope> cache,
-            IOpenIddictScopeStoreResolver resolver,
+            IStringLocalizer<OpenIddictResources> localizer,
             ILogger<OpenIddictScopeManager<TScope>> logger,
-            IOptionsMonitor<OpenIddictCoreOptions> options)
-            : base(cache, resolver, logger, options)
+            IOptionsMonitor<OpenIddictCoreOptions> options,
+            IOpenIddictScopeStoreResolver resolver)
+            : base(cache, localizer, logger, options, resolver)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdTokenManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdTokenManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
@@ -14,10 +15,11 @@ namespace OrchardCore.OpenId.Services.Managers
     {
         public OpenIdTokenManager(
             IOpenIddictTokenCache<TToken> cache,
-            IOpenIddictTokenStoreResolver resolver,
+            IStringLocalizer<OpenIddictResources> localizer,
             ILogger<OpenIddictTokenManager<TToken>> logger,
-            IOptionsMonitor<OpenIddictCoreOptions> options)
-            : base(cache, resolver, logger, options)
+            IOptionsMonitor<OpenIddictCoreOptions> options,
+            IOpenIddictTokenStoreResolver resolver)
+            : base(cache, localizer, logger, options, resolver)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdApplication.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdApplication.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using Newtonsoft.Json.Linq;
 
 namespace OrchardCore.OpenId.YesSql.Models
@@ -6,14 +7,12 @@ namespace OrchardCore.OpenId.YesSql.Models
     public class OpenIdApplication
     {
         /// <summary>
-        /// Gets or sets the unique identifier
-        /// associated with the current application.
+        /// Gets or sets the unique identifier associated with the current application.
         /// </summary>
         public string ApplicationId { get; set; }
 
         /// <summary>
-        /// Gets or sets the client identifier
-        /// associated with the current application.
+        /// Gets or sets the client identifier associated with the current application.
         /// </summary>
         public string ClientId { get; set; }
 
@@ -25,20 +24,23 @@ namespace OrchardCore.OpenId.YesSql.Models
         public string ClientSecret { get; set; }
 
         /// <summary>
-        /// Gets or sets the consent type
-        /// associated with the current application.
+        /// Gets or sets the consent type associated with the current application.
         /// </summary>
         public string ConsentType { get; set; }
 
         /// <summary>
-        /// Gets or sets the display name
-        /// associated with the current application.
+        /// Gets or sets the display name associated with the current application.
         /// </summary>
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Gets or sets the physical identifier
-        /// associated with the current application.
+        /// Gets or sets the localized display names associated with the application.
+        /// </summary>
+        public ImmutableDictionary<CultureInfo, string> DisplayNames { get; set; }
+            = ImmutableDictionary.Create<CultureInfo, string>();
+
+        /// <summary>
+        /// Gets or sets the physical identifier associated with the current application.
         /// </summary>
         public int Id { get; set; }
 
@@ -55,10 +57,9 @@ namespace OrchardCore.OpenId.YesSql.Models
             = ImmutableArray.Create<string>();
 
         /// <summary>
-        /// Gets or sets the additional properties
-        /// associated with the current application.
+        /// Gets or sets the additional properties associated with the current application.
         /// </summary>
-        public virtual JObject Properties { get; set; }
+        public JObject Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the callback URLs associated with the current application.
@@ -79,8 +80,7 @@ namespace OrchardCore.OpenId.YesSql.Models
             = ImmutableArray.Create<string>();
 
         /// <summary>
-        /// Gets or sets the application type
-        /// associated with the current application.
+        /// Gets or sets the application type associated with the current application.
         /// </summary>
         public string Type { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdAuthorization.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdAuthorization.cs
@@ -6,8 +6,7 @@ namespace OrchardCore.OpenId.YesSql.Models
     public class OpenIdAuthorization
     {
         /// <summary>
-        /// Gets or sets the unique identifier
-        /// associated with the current application.
+        /// Gets or sets the unique identifier associated with the current application.
         /// </summary>
         public string AuthorizationId { get; set; }
 
@@ -18,16 +17,14 @@ namespace OrchardCore.OpenId.YesSql.Models
         public string ApplicationId { get; set; }
 
         /// <summary>
-        /// Gets or sets the physical identifier
-        /// associated with the current authorization.
+        /// Gets or sets the physical identifier associated with the current authorization.
         /// </summary>
         public int Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the additional properties
-        /// associated with the current authorization.
+        /// Gets or sets the additional properties associated with the current authorization.
         /// </summary>
-        public virtual JObject Properties { get; set; }
+        public JObject Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the scopes associated with the current authorization.

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdScope.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdScope.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Globalization;
 using Newtonsoft.Json.Linq;
 
 namespace OrchardCore.OpenId.YesSql.Models
@@ -6,45 +7,51 @@ namespace OrchardCore.OpenId.YesSql.Models
     public class OpenIdScope
     {
         /// <summary>
-        /// Gets or sets the unique identifier
-        /// associated with the current scope.
+        /// Gets or sets the unique identifier associated with the current scope.
         /// </summary>
         public string ScopeId { get; set; }
 
         /// <summary>
-        /// Gets or sets the public description
-        /// associated with the current scope.
+        /// Gets or sets the public description associated with the current scope.
         /// </summary>
         public string Description { get; set; }
 
         /// <summary>
-        /// Gets or sets the display name
-        /// associated with the current scope.
+        /// Gets or sets the localized descriptions associated with the scope.
+        /// </summary>
+        public ImmutableDictionary<CultureInfo, string> Descriptions { get; set; }
+            = ImmutableDictionary.Create<CultureInfo, string>();
+
+        /// <summary>
+        /// Gets or sets the display name associated with the current scope.
         /// </summary>
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Gets or sets the physical identifier
-        /// associated with the current scope.
+        /// Gets or sets the localized display names associated with the scope.
+        /// </summary>
+        public ImmutableDictionary<CultureInfo, string> DisplayNames { get; set; }
+            = ImmutableDictionary.Create<CultureInfo, string>();
+
+        /// <summary>
+        /// Gets or sets the physical identifier associated with the current scope.
         /// </summary>
         public int Id { get; set; }
 
         /// <summary>
-        /// Gets or sets the unique name
-        /// associated with the current scope.
+        /// Gets or sets the unique name associated with the current scope.
         /// </summary>
         public string Name { get; set; }
 
         /// <summary>
-        /// Gets or sets the additional properties
-        /// associated with the current scope.
+        /// Gets or sets the additional properties associated with the current scope.
         /// </summary>
-        public virtual JObject Properties { get; set; }
+        public JObject Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the resources associated with the current scope.
         /// </summary>
-        public virtual ImmutableArray<string> Resources { get; set; }
+        public ImmutableArray<string> Resources { get; set; }
             = ImmutableArray.Create<string>();
     }
 }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdToken.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdToken.cs
@@ -9,37 +9,32 @@ namespace OrchardCore.OpenId.YesSql.Models
     public class OpenIdToken
     {
         /// <summary>
-        /// Gets or sets the unique identifier
-        /// associated with the current token.
+        /// Gets or sets the unique identifier associated with the current token.
         /// </summary>
         public string TokenId { get; set; }
 
-        /// Gets or sets the identifier of the application
-        /// associated with the current token.
+        /// <summary>
+        /// Gets or sets the identifier of the application associated with the current token.
         /// </summary>
         public string ApplicationId { get; set; }
 
         /// <summary>
-        /// Gets or sets the identifier of the authorization
-        /// associated with the current token.
+        /// Gets or sets the identifier of the authorization associated with the current token.
         /// </summary>
         public string AuthorizationId { get; set; }
 
         /// <summary>
-        /// Gets or sets the date on which the token
-        /// will start to be considered valid.
+        /// Gets or sets the date on which the token will start to be considered valid.
         /// </summary>
         public DateTimeOffset? CreationDate { get; set; }
 
         /// <summary>
-        /// Gets or sets the date on which the token
-        /// will no longer be considered valid.
+        /// Gets or sets the date on which the token will no longer be considered valid.
         /// </summary>
         public DateTimeOffset? ExpirationDate { get; set; }
 
         /// <summary>
-        /// Gets or sets the physical identifier
-        /// associated with the current token.
+        /// Gets or sets the physical identifier associated with the current token.
         /// </summary>
         public int Id { get; set; }
 
@@ -51,10 +46,9 @@ namespace OrchardCore.OpenId.YesSql.Models
         public string Payload { get; set; }
 
         /// <summary>
-        /// Gets or sets the additional properties
-        /// associated with the current token.
+        /// Gets or sets the additional properties associated with the current token.
         /// </summary>
-        public virtual JObject Properties { get; set; }
+        public JObject Properties { get; set; }
 
         /// <summary>
         /// Gets or sets the reference identifier associated

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Resolvers/OpenIdApplicationStoreResolver.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Resolvers/OpenIdApplicationStoreResolver.cs
@@ -8,9 +8,7 @@ using OrchardCore.OpenId.YesSql.Stores;
 
 namespace OrchardCore.OpenId.YesSql.Resolvers
 {
-    /// <summary>
-    /// Exposes a method allowing to resolve an application store.
-    /// </summary>
+    /// <inheritdoc/>
     public class OpenIdApplicationStoreResolver : IOpenIddictApplicationStoreResolver
     {
         private readonly TypeResolutionCache _cache;
@@ -22,12 +20,7 @@ namespace OrchardCore.OpenId.YesSql.Resolvers
             _provider = provider;
         }
 
-        /// <summary>
-        /// Returns an application store compatible with the specified application type or throws an
-        /// <see cref="InvalidOperationException"/> if no store can be built using the specified type.
-        /// </summary>
-        /// <typeparam name="TApplication">The type of the Application entity.</typeparam>
-        /// <returns>An <see cref="IOpenIddictApplicationStore{TApplication}"/>.</returns>
+        /// <inheritdoc/>
         public IOpenIddictApplicationStore<TApplication> Get<TApplication>() where TApplication : class
         {
             var store = _provider.GetService<IOpenIddictApplicationStore<TApplication>>();

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Resolvers/OpenIdAuthorizationStoreResolver.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Resolvers/OpenIdAuthorizationStoreResolver.cs
@@ -8,9 +8,7 @@ using OrchardCore.OpenId.YesSql.Stores;
 
 namespace OrchardCore.OpenId.YesSql.Resolvers
 {
-    /// <summary>
-    /// Exposes a method allowing to resolve an authorization store.
-    /// </summary>
+    /// <inheritdoc/>
     public class OpenIdAuthorizationStoreResolver : IOpenIddictAuthorizationStoreResolver
     {
         private readonly TypeResolutionCache _cache;
@@ -22,12 +20,7 @@ namespace OrchardCore.OpenId.YesSql.Resolvers
             _provider = provider;
         }
 
-        /// <summary>
-        /// Returns an authorization store compatible with the specified authorization type or throws an
-        /// <see cref="InvalidOperationException"/> if no store can be built using the specified type.
-        /// </summary>
-        /// <typeparam name="TAuthorization">The type of the Authorization entity.</typeparam>
-        /// <returns>An <see cref="IOpenIddictAuthorizationStore{TAuthorization}"/>.</returns>
+        /// <inheritdoc/>
         public IOpenIddictAuthorizationStore<TAuthorization> Get<TAuthorization>() where TAuthorization : class
         {
             var store = _provider.GetService<IOpenIddictAuthorizationStore<TAuthorization>>();

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Resolvers/OpenIdScopeStoreResolver.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Resolvers/OpenIdScopeStoreResolver.cs
@@ -8,9 +8,7 @@ using OrchardCore.OpenId.YesSql.Stores;
 
 namespace OrchardCore.OpenId.YesSql.Resolvers
 {
-    /// <summary>
-    /// Exposes a method allowing to resolve a scope store.
-    /// </summary>
+    /// <inheritdoc/>
     public class OpenIdScopeStoreResolver : IOpenIddictScopeStoreResolver
     {
         private readonly TypeResolutionCache _cache;
@@ -22,12 +20,7 @@ namespace OrchardCore.OpenId.YesSql.Resolvers
             _provider = provider;
         }
 
-        /// <summary>
-        /// Returns a scope store compatible with the specified scope type or throws an
-        /// <see cref="InvalidOperationException"/> if no store can be built using the specified type.
-        /// </summary>
-        /// <typeparam name="TScope">The type of the Scope entity.</typeparam>
-        /// <returns>An <see cref="IOpenIddictScopeStore{TScope}"/>.</returns>
+        /// <inheritdoc/>
         public IOpenIddictScopeStore<TScope> Get<TScope>() where TScope : class
         {
             var store = _provider.GetService<IOpenIddictScopeStore<TScope>>();

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Resolvers/OpenIdTokenStoreResolver.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Resolvers/OpenIdTokenStoreResolver.cs
@@ -8,9 +8,7 @@ using OrchardCore.OpenId.YesSql.Stores;
 
 namespace OrchardCore.OpenId.YesSql.Resolvers
 {
-    /// <summary>
-    /// Exposes a method allowing to resolve a token store.
-    /// </summary>
+    /// <inheritdoc/>
     public class OpenIdTokenStoreResolver : IOpenIddictTokenStoreResolver
     {
         private readonly TypeResolutionCache _cache;
@@ -22,12 +20,7 @@ namespace OrchardCore.OpenId.YesSql.Resolvers
             _provider = provider;
         }
 
-        /// <summary>
-        /// Returns a token store compatible with the specified token type or throws an
-        /// <see cref="InvalidOperationException"/> if no store can be built using the specified type.
-        /// </summary>
-        /// <typeparam name="TToken">The type of the Token entity.</typeparam>
-        /// <returns>An <see cref="IOpenIddictTokenStore{TToken}"/>.</returns>
+        /// <inheritdoc/>
         public IOpenIddictTokenStore<TToken> Get<TToken>() where TToken : class
         {
             var store = _provider.GetService<IOpenIddictTokenStore<TToken>>();

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdApplicationStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdApplicationStore.cs
@@ -318,6 +318,23 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(application.DisplayName);
         }
 
+        /// <inheritdoc/>
+        public virtual ValueTask<ImmutableDictionary<CultureInfo, string>> GetDisplayNamesAsync(
+            TApplication application, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            if (application.DisplayNames == null)
+            {
+                return new ValueTask<ImmutableDictionary<CultureInfo, string>>(ImmutableDictionary.Create<CultureInfo, string>());
+            }
+
+            return new ValueTask<ImmutableDictionary<CultureInfo, string>>(application.DisplayNames);
+        }
+
         /// <summary>
         /// Retrieves the unique identifier associated with an application.
         /// </summary>
@@ -616,6 +633,19 @@ namespace OrchardCore.OpenId.YesSql.Stores
             }
 
             application.DisplayName = name;
+
+            return default;
+        }
+
+        /// <inheritdoc/>
+        public virtual ValueTask SetDisplayNamesAsync(TApplication application, ImmutableDictionary<CultureInfo, string> names, CancellationToken cancellationToken)
+        {
+            if (application == null)
+            {
+                throw new ArgumentNullException(nameof(application));
+            }
+
+            application.DisplayNames = names;
 
             return default;
         }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdApplicationStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdApplicationStore.cs
@@ -27,14 +27,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             _session = session;
         }
 
-        /// <summary>
-        /// Determines the number of applications that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of applications in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -42,27 +35,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TApplication>().CountAsync();
         }
 
-        /// <summary>
-        /// Determines the number of applications that match the specified query.
-        /// </summary>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of applications that match the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<long> CountAsync<TResult>(Func<IQueryable<TApplication>, IQueryable<TResult>> query, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Creates a new application.
-        /// </summary>
-        /// <param name="application">The application to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask CreateAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -76,14 +53,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             await _session.CommitAsync();
         }
 
-        /// <summary>
-        /// Removes an existing application.
-        /// </summary>
-        /// <param name="application">The application to delete.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask DeleteAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -97,15 +67,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             await _session.CommitAsync();
         }
 
-        /// <summary>
-        /// Retrieves an application using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client application corresponding to the identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TApplication> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -118,15 +80,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TApplication, OpenIdApplicationIndex>(index => index.ApplicationId == identifier).FirstOrDefaultAsync();
         }
 
-        /// <summary>
-        /// Retrieves an application using its client identifier.
-        /// </summary>
-        /// <param name="identifier">The client identifier associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client application corresponding to the identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TApplication> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -139,15 +93,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TApplication, OpenIdApplicationIndex>(index => index.ClientId == identifier).FirstOrDefaultAsync();
         }
 
-        /// <summary>
-        /// Retrieves an application using its physical identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client application corresponding to the identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -160,15 +106,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.GetAsync<TApplication>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves all the applications associated with the specified post_logout_redirect_uri.
-        /// </summary>
-        /// <param name="address">The post_logout_redirect_uri associated with the applications.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the client applications corresponding to the specified post_logout_redirect_uri.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TApplication> FindByPostLogoutRedirectUriAsync(string address, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(address))
@@ -182,15 +120,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.LogoutRedirectUri == address).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves all the applications associated with the specified redirect_uri.
-        /// </summary>
-        /// <param name="address">The redirect_uri associated with the applications.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation, whose result
-        /// returns the client applications corresponding to the specified redirect_uri.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TApplication> FindByRedirectUriAsync(string address, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(address))
@@ -204,32 +134,13 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.RedirectUri == address).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Executes the specified query and returns the first element.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the first element returned when executing the query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<TResult> GetAsync<TState, TResult>(
             Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Retrieves the client identifier associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client identifier associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetClientIdAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -240,17 +151,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(application.ClientId);
         }
 
-        /// <summary>
-        /// Retrieves the client secret associated with an application.
-        /// Note: depending on the manager used to create the application,
-        /// the client secret may be hashed for security reasons.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client secret associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetClientSecretAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -261,15 +162,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(application.ClientSecret);
         }
 
-        /// <summary>
-        /// Retrieves the client type associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the client type of the application (by default, "public").
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetClientTypeAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -280,15 +173,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(application.Type);
         }
 
-        /// <summary>
-        /// Retrieves the consent type associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the consent type of the application (by default, "explicit").
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetConsentTypeAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -299,15 +184,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(application.ConsentType);
         }
 
-        /// <summary>
-        /// Retrieves the display name associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the display name associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetDisplayNameAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -335,15 +212,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableDictionary<CultureInfo, string>>(application.DisplayNames);
         }
 
-        /// <summary>
-        /// Retrieves the unique identifier associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the unique identifier associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetIdAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -354,15 +223,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(application.ApplicationId);
         }
 
-        /// <summary>
-        /// Retrieves the permissions associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the permissions associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetPermissionsAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -373,15 +234,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableArray<string>>(application.Permissions);
         }
 
-        /// <summary>
-        /// Retrieves the physical identifier associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the physical identifier associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetPhysicalIdAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -392,15 +245,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(application.Id.ToString(CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves the logout callback addresses associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the post_logout_redirect_uri associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -411,15 +256,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableArray<string>>(application.PostLogoutRedirectUris);
         }
 
-        /// <summary>
-        /// Retrieves the additional properties associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the additional properties associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -436,15 +273,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 JsonSerializer.Deserialize<ImmutableDictionary<string, JsonElement>>(application.Properties.ToString()));
         }
 
-        /// <summary>
-        /// Retrieves the callback addresses associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the redirect_uri associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetRedirectUrisAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -455,15 +284,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableArray<string>>(application.RedirectUris);
         }
 
-        /// <summary>
-        /// Retrieves the requirements associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the requirements associated with the application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetRequirementsAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -474,27 +295,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableArray<string>>(application.Requirements);
         }
 
-        /// <summary>
-        /// Instantiates a new application.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the instantiated application, that can be persisted in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<TApplication> InstantiateAsync(CancellationToken cancellationToken)
             => new ValueTask<TApplication>(new TApplication { ApplicationId = Guid.NewGuid().ToString("n") });
 
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TApplication> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             var query = _session.Query<TApplication>();
@@ -512,32 +317,13 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return query.ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TResult> ListAsync<TState, TResult>(
             Func<IQueryable<TApplication>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Sets the client identifier associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="identifier">The client identifier associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetClientIdAsync(TApplication application,
             string identifier, CancellationToken cancellationToken)
         {
@@ -551,17 +337,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the client secret associated with an application.
-        /// Note: depending on the manager used to create the application,
-        /// the client secret may be hashed for security reasons.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="secret">The client secret associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetClientSecretAsync(TApplication application, string secret, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -574,15 +350,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the client type associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="type">The client type associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetClientTypeAsync(TApplication application, string type, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -595,15 +363,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the consent type associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="type">The consent type associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetConsentTypeAsync(TApplication application, string type, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -616,15 +376,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the display name associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="name">The display name associated with the application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetDisplayNameAsync(TApplication application, string name, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -650,15 +402,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the permissions associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="permissions">The permissions associated with the application </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetPermissionsAsync(TApplication application, ImmutableArray<string> permissions, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -671,15 +415,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the logout callback addresses associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="addresses">The logout callback addresses associated with the application </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetPostLogoutRedirectUrisAsync(TApplication application,
             ImmutableArray<string> addresses, CancellationToken cancellationToken)
         {
@@ -693,15 +429,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the additional properties associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="properties">The additional properties associated with the application </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetPropertiesAsync(TApplication application, ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -725,15 +453,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the callback addresses associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="addresses">The callback addresses associated with the application </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetRedirectUrisAsync(TApplication application,
             ImmutableArray<string> addresses, CancellationToken cancellationToken)
         {
@@ -747,13 +467,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the requirements associated with an application.
-        /// </summary>
-        /// <param name="application">The application.</param>
-        /// <param name="requirements">The requirements associated with the application </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetRequirementsAsync(TApplication application,
             ImmutableArray<string> requirements, CancellationToken cancellationToken)
         {
@@ -767,14 +481,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Updates an existing application.
-        /// </summary>
-        /// <param name="application">The application to update.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask UpdateAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -799,6 +506,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             }
         }
 
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetRolesAsync(TApplication application, CancellationToken cancellationToken)
         {
             if (application == null)
@@ -809,6 +517,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableArray<string>>(application.Roles);
         }
 
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TApplication> ListInRoleAsync(string role, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(role))
@@ -819,6 +528,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return _session.Query<TApplication, OpenIdAppByRoleNameIndex>(index => index.RoleName == role).ToAsyncEnumerable();
         }
 
+        /// <inheritdoc/>
         public virtual ValueTask SetRolesAsync(TApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
         {
             if (application == null)

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdAuthorizationStore.cs
@@ -29,14 +29,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             _session = session;
         }
 
-        /// <summary>
-        /// Determines the number of authorizations that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of authorizations in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -44,27 +37,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TAuthorization>().CountAsync();
         }
 
-        /// <summary>
-        /// Determines the number of authorizations that match the specified query.
-        /// </summary>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of authorizations that match the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<long> CountAsync<TResult>(Func<IQueryable<TAuthorization>, IQueryable<TResult>> query, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Creates a new authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask CreateAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -78,14 +55,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             await _session.CommitAsync();
         }
 
-        /// <summary>
-        /// Removes an existing authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization to delete.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask DeleteAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -99,17 +69,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             await _session.CommitAsync();
         }
 
-        /// <summary>
-        /// Retrieves the authorizations corresponding to the specified
-        /// subject and associated with the application identifier.
-        /// </summary>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="client">The client associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorizations corresponding to the subject/client.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TAuthorization> FindAsync(
             string subject, string client, CancellationToken cancellationToken)
         {
@@ -129,17 +89,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.ApplicationId == client && index.Subject == subject).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the authorizations matching the specified parameters.
-        /// </summary>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="client">The client associated with the authorization.</param>
-        /// <param name="status">The status associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorizations corresponding to the subject/client.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TAuthorization> FindAsync(
             string subject, string client, string status, CancellationToken cancellationToken)
         {
@@ -164,18 +114,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.ApplicationId == client && index.Subject == subject && index.Status == status).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the authorizations matching the specified parameters.
-        /// </summary>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="client">The client associated with the authorization.</param>
-        /// <param name="status">The status associated with the authorization.</param>
-        /// <param name="type">The type associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorizations corresponding to the subject/client.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TAuthorization> FindAsync(
             string subject, string client,
             string status, string type, CancellationToken cancellationToken)
@@ -207,19 +146,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                          index.Status == status && index.Type == type).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the authorizations matching the specified parameters.
-        /// </summary>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="client">The client associated with the authorization.</param>
-        /// <param name="status">The authorization status.</param>
-        /// <param name="type">The authorization type.</param>
-        /// <param name="scopes">The minimal scopes associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorizations corresponding to the criteria.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async IAsyncEnumerable<TAuthorization> FindAsync(
             string subject, string client, string status, string type,
             ImmutableArray<string> scopes, [EnumeratorCancellation] CancellationToken cancellationToken)
@@ -233,15 +160,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             }
         }
 
-        /// <summary>
-        /// Retrieves the list of authorizations corresponding to the specified application identifier.
-        /// </summary>
-        /// <param name="identifier">The application identifier associated with the authorizations.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorizations corresponding to the specified application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TAuthorization> FindByApplicationIdAsync(
             string identifier, CancellationToken cancellationToken)
         {
@@ -256,15 +175,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.ApplicationId == identifier).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves an authorization using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorization corresponding to the identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TAuthorization> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -278,15 +189,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.AuthorizationId == identifier).FirstOrDefaultAsync();
         }
 
-        /// <summary>
-        /// Retrieves an authorization using its physical identifier.
-        /// </summary>
-        /// <param name="identifier">The physical identifier associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorization corresponding to the identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -299,15 +202,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.GetAsync<TAuthorization>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves all the authorizations corresponding to the specified subject.
-        /// </summary>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorizations corresponding to the specified subject.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TAuthorization> FindBySubjectAsync(
             string subject, CancellationToken cancellationToken)
         {
@@ -322,15 +217,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.Subject == subject).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the optional application identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the application identifier associated with the authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetApplicationIdAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -341,32 +228,13 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(authorization.ApplicationId);
         }
 
-        /// <summary>
-        /// Executes the specified query and returns the first element.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the first element returned when executing the query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<TResult> GetAsync<TState, TResult>(
             Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Retrieves the unique identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the unique identifier associated with the authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetIdAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -377,15 +245,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(authorization.AuthorizationId);
         }
 
-        /// <summary>
-        /// Retrieves the physical identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the physical identifier associated with the authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetPhysicalIdAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -396,15 +256,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(authorization.Id.ToString(CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves the additional properties associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the additional properties associated with the authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -421,15 +273,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 JsonSerializer.Deserialize<ImmutableDictionary<string, JsonElement>>(authorization.Properties.ToString()));
         }
 
-        /// <summary>
-        /// Retrieves the scopes associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the scopes associated with the specified authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetScopesAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -440,15 +284,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableArray<string>>(authorization.Scopes);
         }
 
-        /// <summary>
-        /// Retrieves the status associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the status associated with the specified authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetStatusAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -459,15 +295,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(authorization.Status);
         }
 
-        /// <summary>
-        /// Retrieves the subject associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the subject associated with the specified authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetSubjectAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -478,15 +306,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(authorization.Subject);
         }
 
-        /// <summary>
-        /// Retrieves the type associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the type associated with the specified authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetTypeAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -497,27 +317,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(authorization.Type);
         }
 
-        /// <summary>
-        /// Instantiates a new authorization.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the instantiated authorization, that can be persisted in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<TAuthorization> InstantiateAsync(CancellationToken cancellationToken)
             => new ValueTask<TAuthorization>(new TAuthorization { AuthorizationId = Guid.NewGuid().ToString("n") });
 
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TAuthorization> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             var query = _session.Query<TAuthorization>();
@@ -535,30 +339,13 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return query.ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TResult> ListAsync<TState, TResult>(
             Func<IQueryable<TAuthorization>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Removes the ad-hoc authorizations that are marked as invalid or have no valid token attached.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask PruneAsync(CancellationToken cancellationToken)
         {
             // Note: YesSql doesn't support set-based deletes, which prevents removing entities
@@ -605,15 +392,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             }
         }
 
-        /// <summary>
-        /// Sets the application identifier associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="identifier">The unique identifier associated with the client application.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetApplicationIdAsync(TAuthorization authorization,
             string identifier, CancellationToken cancellationToken)
         {
@@ -634,15 +413,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the additional properties associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="properties">The additional properties associated with the authorization </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetPropertiesAsync(TAuthorization authorization, ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken)
         {
             if (authorization == null)
@@ -666,15 +437,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the scopes associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="scopes">The scopes associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetScopesAsync(TAuthorization authorization,
             ImmutableArray<string> scopes, CancellationToken cancellationToken)
         {
@@ -688,15 +451,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the status associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="status">The status associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetStatusAsync(TAuthorization authorization,
             string status, CancellationToken cancellationToken)
         {
@@ -710,15 +465,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the subject associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="subject">The subject associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetSubjectAsync(TAuthorization authorization,
             string subject, CancellationToken cancellationToken)
         {
@@ -732,15 +479,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the type associated with an authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization.</param>
-        /// <param name="type">The type associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetTypeAsync(TAuthorization authorization,
             string type, CancellationToken cancellationToken)
         {
@@ -754,14 +493,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Updates an existing authorization.
-        /// </summary>
-        /// <param name="authorization">The authorization to update.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask UpdateAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
             if (authorization == null)

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdScopeStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdScopeStore.cs
@@ -28,14 +28,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             _session = session;
         }
 
-        /// <summary>
-        /// Determines the number of scopes that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of scopes in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -43,27 +36,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TScope>().CountAsync();
         }
 
-        /// <summary>
-        /// Determines the number of scopes that match the specified query.
-        /// </summary>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of scopes that match the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<long> CountAsync<TResult>(Func<IQueryable<TScope>, IQueryable<TResult>> query, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Creates a new scope.
-        /// </summary>
-        /// <param name="scope">The scope to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask CreateAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -77,14 +54,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             await _session.CommitAsync();
         }
 
-        /// <summary>
-        /// Removes an existing scope.
-        /// </summary>
-        /// <param name="scope">The scope to delete.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask DeleteAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -98,15 +68,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             await _session.CommitAsync();
         }
 
-        /// <summary>
-        /// Retrieves an authorization using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorization corresponding to the identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TScope> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -119,15 +81,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TScope, OpenIdScopeIndex>(index => index.ScopeId == identifier).FirstOrDefaultAsync();
         }
 
-        /// <summary>
-        /// Retrieves a scope using its name.
-        /// </summary>
-        /// <param name="name">The name associated with the scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the scope corresponding to the specified name.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TScope> FindByNameAsync(string name, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(name))
@@ -140,15 +94,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TScope, OpenIdScopeIndex>(index => index.Name == name).FirstOrDefaultAsync();
         }
 
-        /// <summary>
-        /// Retrieves a list of scopes using their name.
-        /// </summary>
-        /// <param name="names">The names associated with the scopes.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the scopes corresponding to the specified names.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TScope> FindByNamesAsync(
             ImmutableArray<string> names, CancellationToken cancellationToken)
         {
@@ -162,15 +108,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return _session.Query<TScope, OpenIdScopeIndex>(index => index.Name.IsIn(names)).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves a scope using its physical identifier.
-        /// </summary>
-        /// <param name="identifier">The physical identifier associated with the scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the scope corresponding to the identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -183,15 +121,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.GetAsync<TScope>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves all the scopes that contain the specified resource.
-        /// </summary>
-        /// <param name="resource">The resource associated with the scopes.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the scopes associated with the specified resource.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TScope> FindByResourceAsync(string resource, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(resource))
@@ -205,32 +135,13 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.Resource == resource).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Executes the specified query and returns the first element.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the first element returned when executing the query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<TResult> GetAsync<TState, TResult>(
             Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Retrieves the description associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the description associated with the specified scope.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetDescriptionAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -258,15 +169,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableDictionary<CultureInfo, string>>(scope.Descriptions);
         }
 
-        /// <summary>
-        /// Retrieves the display name associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the display name associated with the scope.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetDisplayNameAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -294,15 +197,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableDictionary<CultureInfo, string>>(scope.DisplayNames);
         }
 
-        /// <summary>
-        /// Retrieves the unique identifier associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the unique identifier associated with the scope.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetIdAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -313,15 +208,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(scope.ScopeId);
         }
 
-        /// <summary>
-        /// Retrieves the name associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the name associated with the specified scope.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetNameAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -332,15 +219,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(scope.Name);
         }
 
-        /// <summary>
-        /// Retrieves the physical identifier associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the physical identifier associated with the scope.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetPhysicalIdAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -351,15 +230,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(scope.Id.ToString(CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves the additional properties associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the additional properties associated with the scope.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -376,15 +247,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 JsonSerializer.Deserialize<ImmutableDictionary<string, JsonElement>>(scope.Properties.ToString()));
         }
 
-        /// <summary>
-        /// Retrieves the resources associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the resources associated with the scope.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetResourcesAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -395,27 +258,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<ImmutableArray<string>>(scope.Resources);
         }
 
-        /// <summary>
-        /// Instantiates a new scope.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the instantiated scope, that can be persisted in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<TScope> InstantiateAsync(CancellationToken cancellationToken)
             => new ValueTask<TScope>(new TScope { ScopeId = Guid.NewGuid().ToString("n") });
 
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TScope> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             var query = _session.Query<TScope>();
@@ -433,32 +280,13 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return query.ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TResult> ListAsync<TState, TResult>(
             Func<IQueryable<TScope>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Sets the description associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="description">The description associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetDescriptionAsync(TScope scope, string description, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -485,15 +313,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the display name associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="name">The display name associated with the scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetDisplayNameAsync(TScope scope, string name, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -506,6 +326,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
+        /// <inheritdoc/>
         public virtual ValueTask SetDisplayNamesAsync(TScope scope,
             ImmutableDictionary<CultureInfo, string> names, CancellationToken cancellationToken)
         {
@@ -519,15 +340,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the name associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="name">The name associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetNameAsync(TScope scope, string name, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -540,15 +353,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the additional properties associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="properties">The additional properties associated with the scope </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetPropertiesAsync(TScope scope, ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -572,15 +377,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the resources associated with a scope.
-        /// </summary>
-        /// <param name="scope">The scope.</param>
-        /// <param name="resources">The resources associated with the scope.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetResourcesAsync(TScope scope, ImmutableArray<string> resources, CancellationToken cancellationToken)
         {
             if (scope == null)
@@ -593,14 +390,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Updates an existing scope.
-        /// </summary>
-        /// <param name="scope">The scope to update.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask UpdateAsync(TScope scope, CancellationToken cancellationToken)
         {
             if (scope == null)

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdScopeStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdScopeStore.cs
@@ -241,6 +241,23 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(scope.Description);
         }
 
+        /// <inheritdoc/>
+        public virtual ValueTask<ImmutableDictionary<CultureInfo, string>> GetDescriptionsAsync(
+            TScope scope, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            if (scope.Descriptions == null)
+            {
+                return new ValueTask<ImmutableDictionary<CultureInfo, string>>(ImmutableDictionary.Create<CultureInfo, string>());
+            }
+
+            return new ValueTask<ImmutableDictionary<CultureInfo, string>>(scope.Descriptions);
+        }
+
         /// <summary>
         /// Retrieves the display name associated with a scope.
         /// </summary>
@@ -258,6 +275,23 @@ namespace OrchardCore.OpenId.YesSql.Stores
             }
 
             return new ValueTask<string>(scope.DisplayName);
+        }
+
+        /// <inheritdoc/>
+        public virtual ValueTask<ImmutableDictionary<CultureInfo, string>> GetDisplayNamesAsync(
+            TScope scope, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            if (scope.DisplayNames == null)
+            {
+                return new ValueTask<ImmutableDictionary<CultureInfo, string>>(ImmutableDictionary.Create<CultureInfo, string>());
+            }
+
+            return new ValueTask<ImmutableDictionary<CultureInfo, string>>(scope.DisplayNames);
         }
 
         /// <summary>
@@ -437,6 +471,20 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
+        /// <inheritdoc/>
+        public virtual ValueTask SetDescriptionsAsync(TScope scope,
+            ImmutableDictionary<CultureInfo, string> descriptions, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            scope.Descriptions = descriptions;
+
+            return default;
+        }
+
         /// <summary>
         /// Sets the display name associated with a scope.
         /// </summary>
@@ -454,6 +502,19 @@ namespace OrchardCore.OpenId.YesSql.Stores
             }
 
             scope.DisplayName = name;
+
+            return default;
+        }
+
+        public virtual ValueTask SetDisplayNamesAsync(TScope scope,
+            ImmutableDictionary<CultureInfo, string> names, CancellationToken cancellationToken)
+        {
+            if (scope == null)
+            {
+                throw new ArgumentNullException(nameof(scope));
+            }
+
+            scope.DisplayNames = names;
 
             return default;
         }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
@@ -27,14 +27,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             _session = session;
         }
 
-        /// <summary>
-        /// Determines the number of tokens that exist in the database.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of applications in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<long> CountAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -42,27 +35,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TToken>().CountAsync();
         }
 
-        /// <summary>
-        /// Determines the number of tokens that match the specified query.
-        /// </summary>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the number of tokens that match the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<long> CountAsync<TResult>(Func<IQueryable<TToken>, IQueryable<TResult>> query, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Creates a new token.
-        /// </summary>
-        /// <param name="token">The token to create.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask CreateAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -76,12 +53,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             await _session.CommitAsync();
         }
 
-        /// <summary>
-        /// Removes a token.
-        /// </summary>
-        /// <param name="token">The token to delete.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.</returns>
+        /// <inheritdoc/>
         public virtual async ValueTask DeleteAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -95,17 +67,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             await _session.CommitAsync();
         }
 
-        /// <summary>
-        /// Retrieves the tokens corresponding to the specified
-        /// subject and associated with the application identifier.
-        /// </summary>
-        /// <param name="subject">The subject associated with the token.</param>
-        /// <param name="client">The client associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the subject/client.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindAsync(
             string subject, string client, CancellationToken cancellationToken)
         {
@@ -125,17 +87,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.ApplicationId == client && index.Subject == subject).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the tokens matching the specified parameters.
-        /// </summary>
-        /// <param name="subject">The subject associated with the token.</param>
-        /// <param name="client">The client associated with the token.</param>
-        /// <param name="status">The token status.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the criteria.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindAsync(
             string subject, string client, string status, CancellationToken cancellationToken)
         {
@@ -160,18 +112,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 index => index.ApplicationId == client && index.Subject == subject && index.Status == status).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the tokens matching the specified parameters.
-        /// </summary>
-        /// <param name="subject">The subject associated with the token.</param>
-        /// <param name="client">The client associated with the token.</param>
-        /// <param name="status">The token status.</param>
-        /// <param name="type">The token type.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the criteria.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindAsync(
             string subject, string client, string status, string type, CancellationToken cancellationToken)
         {
@@ -202,15 +143,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                          index.Status == status && index.Type == type).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified application identifier.
-        /// </summary>
-        /// <param name="identifier">The application identifier associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified application.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -223,15 +156,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return _session.Query<TToken, OpenIdTokenIndex>(index => index.ApplicationId == identifier).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified authorization identifier.
-        /// </summary>
-        /// <param name="identifier">The authorization identifier associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified authorization.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -244,16 +169,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return _session.Query<TToken, OpenIdTokenIndex>(index => index.AuthorizationId == identifier).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified reference identifier.
-        /// Note: the reference identifier may be hashed or encrypted for security reasons.
-        /// </summary>
-        /// <param name="identifier">The reference identifier associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified reference identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TToken> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -266,15 +182,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TToken, OpenIdTokenIndex>(index => index.ReferenceId == identifier).FirstOrDefaultAsync();
         }
 
-        /// <summary>
-        /// Retrieves a token using its unique identifier.
-        /// </summary>
-        /// <param name="identifier">The unique identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the token corresponding to the unique identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TToken> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -287,15 +195,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.Query<TToken, OpenIdTokenIndex>(index => index.TokenId == identifier).FirstOrDefaultAsync();
         }
 
-        /// <summary>
-        /// Retrieves a token using its physical identifier.
-        /// </summary>
-        /// <param name="identifier">The physical identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the token corresponding to the physical identifier.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask<TToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(identifier))
@@ -308,15 +208,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return await _session.GetAsync<TToken>(int.Parse(identifier, CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves the list of tokens corresponding to the specified subject.
-        /// </summary>
-        /// <param name="subject">The subject associated with the tokens.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the tokens corresponding to the specified subject.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindBySubjectAsync(string subject, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(subject))
@@ -329,32 +221,13 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return _session.Query<TToken, OpenIdTokenIndex>(index => index.Subject == subject).ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Executes the specified query and returns the first element.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the first element returned when executing the query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<TResult> GetAsync<TState, TResult>(
             Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Retrieves the optional application identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the application identifier associated with the token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetApplicationIdAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -365,15 +238,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.ApplicationId?.ToString(CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves the optional authorization identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the authorization identifier associated with the token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetAuthorizationIdAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -384,15 +249,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.AuthorizationId);
         }
 
-        /// <summary>
-        /// Retrieves the creation date associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the creation date associated with the specified token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<DateTimeOffset?> GetCreationDateAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -403,15 +260,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<DateTimeOffset?>(token.CreationDate);
         }
 
-        /// <summary>
-        /// Retrieves the expiration date associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the expiration date associated with the specified token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<DateTimeOffset?> GetExpirationDateAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -422,15 +271,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<DateTimeOffset?>(token.ExpirationDate);
         }
 
-        /// <summary>
-        /// Retrieves the unique identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the unique identifier associated with the token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetIdAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -441,15 +282,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.TokenId);
         }
 
-        /// <summary>
-        /// Retrieves the payload associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the payload associated with the specified token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetPayloadAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -460,15 +293,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.Payload);
         }
 
-        /// <summary>
-        /// Retrieves the physical identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the physical identifier associated with the token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetPhysicalIdAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -479,15 +304,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.Id.ToString(CultureInfo.InvariantCulture));
         }
 
-        /// <summary>
-        /// Retrieves the additional properties associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the additional properties associated with the token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -504,17 +321,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 JsonSerializer.Deserialize<ImmutableDictionary<string, JsonElement>>(token.Properties.ToString()));
         }
 
-        /// <summary>
-        /// Retrieves the reference identifier associated with a token.
-        /// Note: depending on the manager used to create the token,
-        /// the reference identifier may be hashed for security reasons.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the reference identifier associated with the specified token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetReferenceIdAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -525,15 +332,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.ReferenceId);
         }
 
-        /// <summary>
-        /// Retrieves the status associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the status associated with the specified token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetStatusAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -544,15 +343,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.Status);
         }
 
-        /// <summary>
-        /// Retrieves the subject associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the subject associated with the specified token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetSubjectAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -563,15 +354,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.Subject);
         }
 
-        /// <summary>
-        /// Retrieves the token type associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the token type associated with the specified token.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<string> GetTypeAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -582,27 +365,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return new ValueTask<string>(token.Type);
         }
 
-        /// <summary>
-        /// Instantiates a new token.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns the instantiated token, that can be persisted in the database.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask<TToken> InstantiateAsync(CancellationToken cancellationToken)
             => new ValueTask<TToken>(new TToken { TokenId = Guid.NewGuid().ToString("n") });
 
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <param name="count">The number of results to return.</param>
-        /// <param name="offset">The number of results to skip.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> ListAsync(int? count, int? offset, CancellationToken cancellationToken)
         {
             var query = _session.Query<TToken>();
@@ -620,30 +387,13 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return query.ToAsyncEnumerable();
         }
 
-        /// <summary>
-        /// Executes the specified query and returns all the corresponding elements.
-        /// </summary>
-        /// <typeparam name="TState">The state type.</typeparam>
-        /// <typeparam name="TResult">The result type.</typeparam>
-        /// <param name="query">The query to execute.</param>
-        /// <param name="state">The optional state.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation,
-        /// whose result returns all the elements returned when executing the specified query.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual IAsyncEnumerable<TResult> ListAsync<TState, TResult>(
             Func<IQueryable<TToken>, TState, IQueryable<TResult>> query,
             TState state, CancellationToken cancellationToken)
             => throw new NotSupportedException();
 
-        /// <summary>
-        /// Removes the tokens that are marked as expired or invalid.
-        /// </summary>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask PruneAsync(CancellationToken cancellationToken = default)
         {
             // Note: Entity Framework Core doesn't support set-based deletes, which prevents removing
@@ -686,15 +436,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             }
         }
 
-        /// <summary>
-        /// Sets the application identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="identifier">The unique identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetApplicationIdAsync(TToken token, string identifier, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -714,15 +456,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the authorization identifier associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="identifier">The unique identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetAuthorizationIdAsync(TToken token, string identifier, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -742,15 +476,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the creation date associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="date">The creation date.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetCreationDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -763,15 +489,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the expiration date associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="date">The expiration date.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetExpirationDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -784,15 +502,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the payload associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="payload">The payload associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetPayloadAsync(TToken token, string payload, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -805,15 +515,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the additional properties associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="properties">The additional properties associated with the token </param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetPropertiesAsync(TToken token, ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -837,17 +539,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the reference identifier associated with a token.
-        /// Note: depending on the manager used to create the token,
-        /// the reference identifier may be hashed for security reasons.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="identifier">The reference identifier associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetReferenceIdAsync(TToken token, string identifier, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -860,15 +552,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the status associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="status">The status associated with the authorization.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetStatusAsync(TToken token, string status, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -886,15 +570,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the subject associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="subject">The subject associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetSubjectAsync(TToken token, string subject, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -912,15 +588,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Sets the token type associated with a token.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="type">The token type associated with the token.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual ValueTask SetTypeAsync(TToken token, string type, CancellationToken cancellationToken)
         {
             if (token == null)
@@ -938,14 +606,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        /// <summary>
-        /// Updates an existing token.
-        /// </summary>
-        /// <param name="token">The token to update.</param>
-        /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
-        /// <returns>
-        /// A <see cref="ValueTask"/> that can be used to monitor the asynchronous operation.
-        /// </returns>
+        /// <inheritdoc/>
         public virtual async ValueTask UpdateAsync(TToken token, CancellationToken cancellationToken)
         {
             if (token == null)


### PR DESCRIPTION
OpenIddict 3.0 beta3 - that will be released next week - introduces new APIs allowing to store localized versions of user facing strings:
  - Application display names.
  - Scope display names.
  - Scope descriptions.

Note: this PR implements the OpenIddict stores methods but doesn't update the GUI to support adding multiple display names/descriptions. I'll open a separate ticket to track that for a future Orchard version.