### PR TITLE
Added Material Icon themes

### DIFF
--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
@@ -9,7 +9,7 @@
 
     <!-- Bootstrap CSS -->
     <style asp-name="admin" asp-src="~/TheAdmin/Styles/TheAdmin.min.css" debug-src="~/TheAdmin/Styles/TheAdmin.css" depends-on="jQuery-ui"></style>
-    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined|Material+Icons+Two+Tone|Material+Icons+Round|Material+Icons+Sharp" rel="stylesheet">
 
     <script asp-name="font-awesome" at="Foot" version="5"></script>
     <script asp-name="font-awesome-v4-shims" at="Foot" version="5"></script>


### PR DESCRIPTION
Fixes #6831  to support following

```html
<i class="material-icons">donut_small</i>
<i class="material-icons-outlined">donut_small</i>
<i class="material-icons-two-tone">donut_small</i>
<i class="material-icons-round">donut_small</i>
<i class="material-icons-sharp">donut_small</i>
```