### PR TITLE
Fixes manifest circular dependency

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
@@ -21,7 +21,6 @@ using OrchardCore.ContentLocalization.Sitemaps;
 using OrchardCore.ContentLocalization.ViewModels;
 using OrchardCore.Contents.Services;
 using OrchardCore.Contents.ViewModels;
-using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Indexing;
 using OrchardCore.Liquid;
@@ -42,6 +41,7 @@ namespace OrchardCore.ContentLocalization
         static Startup()
         {
             TemplateContext.GlobalMemberAccessStrategy.Register<LocalizationPartViewModel>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<CultureInfo>();
         }
 
         public Startup(IOptions<AdminOptions> adminOptions)
@@ -60,6 +60,9 @@ namespace OrchardCore.ContentLocalization
 
             services.AddScoped<IContentsAdminListFilter, LocalizationPartContentsAdminListFilter>();
             services.AddScoped<IDisplayDriver<ContentOptionsViewModel>, LocalizationContentsAdminListDisplayDriver>();
+
+            services.AddLiquidFilter<ContentLocalizationFilter>("localization_set");
+            services.AddLiquidFilter<SwitchCultureUrlFilter>("switch_culture_url");
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -119,21 +122,6 @@ namespace OrchardCore.ContentLocalization
             services.AddScoped<ISitemapContentItemValidationProvider, SitemapLocalizedContentItemValidationProvider>();
             services.AddScoped<ISitemapContentItemExtendedMetadataProvider, SitemapUrlHrefLangExtendedMetadataProvider>();
             services.Replace(ServiceDescriptor.Scoped<IContentItemsQueryProvider, LocalizedContentItemsQueryProvider>());
-        }
-    }
-
-    [RequireFeatures("OrchardCore.Liquid")]
-    public class LiquidStartup : StartupBase
-    {
-        static LiquidStartup()
-        {
-            TemplateContext.GlobalMemberAccessStrategy.Register<CultureInfo>();
-        }
-
-        public override void ConfigureServices(IServiceCollection services)
-        {
-            services.AddLiquidFilter<ContentLocalizationFilter>("localization_set");
-            services.AddLiquidFilter<SwitchCultureUrlFilter>("switch_culture_url");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemFilter.cs
@@ -23,7 +23,6 @@ namespace OrchardCore.Contents.Liquid
             if (input.Type == FluidValues.Array)
             {
                 // List of content item ids
-
                 var contentItemIds = input.Enumerate().Select(x => x.ToStringValue()).ToArray();
 
                 return FluidValue.Create(await contentManager.GetAsync(contentItemIds));

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayTextFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayTextFilter.cs
@@ -2,8 +2,9 @@ using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
 using OrchardCore.ContentManagement;
+using OrchardCore.Liquid;
 
-namespace OrchardCore.Liquid.Filters
+namespace OrchardCore.Contents.Liquid
 {
     public class DisplayTextFilter : ILiquidFilter
     {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
@@ -8,8 +8,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Routing;
+using OrchardCore.Liquid;
 
-namespace OrchardCore.Liquid.Filters
+namespace OrchardCore.Contents.Liquid
 {
     public class DisplayUrlFilter : ILiquidFilter
     {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilter.cs
@@ -9,7 +9,6 @@ using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Records;
-using OrchardCore.Contents.Services;
 using OrchardCore.Contents.ViewModels;
 using OrchardCore.DisplayManagement.ModelBinding;
 using YesSql;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -224,6 +224,8 @@ namespace OrchardCore.Contents
 
             services.AddLiquidFilter<BuildDisplayFilter>("shape_build_display");
             services.AddLiquidFilter<ContentItemFilter>("content_item_id");
+            services.AddLiquidFilter<DisplayTextFilter>("display_text");
+            services.AddLiquidFilter<DisplayUrlFilter>("display_url");
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using Fluid;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
@@ -10,6 +11,7 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Handlers;
+using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentManagement.Routing;
 using OrchardCore.Contents.AdminNodes;
 using OrchardCore.Contents.Controllers;
@@ -33,6 +35,7 @@ using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Entities;
 using OrchardCore.Feeds;
 using OrchardCore.Indexing;
@@ -53,6 +56,17 @@ namespace OrchardCore.Contents
     public class Startup : StartupBase
     {
         private readonly AdminOptions _adminOptions;
+
+        static Startup()
+        {
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentItem>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentElement>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ShapeViewModel<ContentItem>>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentTypePartDefinition>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentPartFieldDefinition>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentFieldDefinition>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentPartDefinition>();
+        }
 
         public Startup(IOptions<AdminOptions> adminOptions)
         {
@@ -120,6 +134,14 @@ namespace OrchardCore.Contents
 
             services.AddScoped<IDisplayManager<ContentOptionsViewModel>, DisplayManager<ContentOptionsViewModel>>();
             services.AddScoped<IDisplayDriver<ContentOptionsViewModel>, ContentOptionsDisplayDriver>();
+
+            // Liquid
+            services.AddScoped<ILiquidTemplateEventHandler, ContentLiquidTemplateEventHandler>();
+
+            services.AddLiquidFilter<BuildDisplayFilter>("shape_build_display");
+            services.AddLiquidFilter<ContentItemFilter>("content_item_id");
+            services.AddLiquidFilter<DisplayTextFilter>("display_text");
+            services.AddLiquidFilter<DisplayUrlFilter>("display_url");
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -212,20 +234,6 @@ namespace OrchardCore.Contents
                 pattern: _adminOptions.AdminUrlPrefix + "/Contents/ContentItems/{contentItemId}/Unpublish",
                 defaults: new { controller = adminControllerName, action = nameof(AdminController.Unpublish) }
             );
-        }
-    }
-
-    [RequireFeatures("OrchardCore.Liquid")]
-    public class LiquidStartup : StartupBase
-    {
-        public override void ConfigureServices(IServiceCollection services)
-        {
-            services.AddScoped<ILiquidTemplateEventHandler, ContentLiquidTemplateEventHandler>();
-
-            services.AddLiquidFilter<BuildDisplayFilter>("shape_build_display");
-            services.AddLiquidFilter<ContentItemFilter>("content_item_id");
-            services.AddLiquidFilter<DisplayTextFilter>("display_text");
-            services.AddLiquidFilter<DisplayUrlFilter>("display_url");
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Manifest.cs
@@ -6,6 +6,5 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "The liquid module enables content items to have liquid syntax.",
-    Dependencies = new[] { "OrchardCore.Contents", "OrchardCore.Shortcodes" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/OrchardCore.Liquid.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/OrchardCore.Liquid.csproj
@@ -10,14 +10,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Abstractions\OrchardCore.ContentManagement.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement\OrchardCore.ContentManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentTypes.Abstractions\OrchardCore.ContentTypes.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data\OrchardCore.Data.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement.Liquid\OrchardCore.DisplayManagement.Liquid.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Indexing.Abstractions\OrchardCore.Indexing.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Shortcodes.Abstractions\OrchardCore.Shortcodes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
@@ -4,10 +4,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
-using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement.Descriptors;
-using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Indexing;
 using OrchardCore.Liquid.Drivers;
 using OrchardCore.Liquid.Filters;
@@ -50,17 +48,6 @@ namespace OrchardCore.Liquid
     [RequireFeatures("OrchardCore.Contents")]
     public class ContentsStartup : StartupBase
     {
-        static ContentsStartup()
-        {
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentItem>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentElement>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ShapeViewModel<ContentItem>>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentTypePartDefinition>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentPartFieldDefinition>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentFieldDefinition>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentPartDefinition>();
-        }
-
         public override void ConfigureServices(IServiceCollection services)
         {
             // Liquid Part

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
@@ -23,14 +23,6 @@ namespace OrchardCore.Liquid
     {
         static Startup()
         {
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentItem>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentElement>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ShapeViewModel<ContentItem>>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentTypePartDefinition>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentPartFieldDefinition>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentFieldDefinition>();
-            TemplateContext.GlobalMemberAccessStrategy.Register<ContentPartDefinition>();
-
             // When accessing a property of a JObject instance
             TemplateContext.GlobalMemberAccessStrategy.Register<JObject, object>((obj, name) => obj[name]);
 
@@ -47,21 +39,28 @@ namespace OrchardCore.Liquid
 
             services.AddLiquidFilter<TimeZoneFilter>("local");
             services.AddLiquidFilter<SlugifyFilter>("slugify");
-            services.AddLiquidFilter<ContainerFilter>("container");
-            services.AddLiquidFilter<DisplayTextFilter>("display_text");
-            services.AddLiquidFilter<DisplayUrlFilter>("display_url");
             services.AddLiquidFilter<ContentUrlFilter>("href");
             services.AddLiquidFilter<AbsoluteUrlFilter>("absolute_url");
             services.AddLiquidFilter<LiquidFilter>("liquid");
             services.AddLiquidFilter<JsonFilter>("json");
             services.AddLiquidFilter<JsonParseFilter>("jsonparse");
-            services.AddLiquidFilter<ShortcodeFilter>("shortcode");
         }
     }
 
     [RequireFeatures("OrchardCore.Contents")]
-    public class LiquidPartStartup : StartupBase
+    public class ContentsStartup : StartupBase
     {
+        static ContentsStartup()
+        {
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentItem>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentElement>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ShapeViewModel<ContentItem>>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentTypePartDefinition>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentPartFieldDefinition>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentFieldDefinition>();
+            TemplateContext.GlobalMemberAccessStrategy.Register<ContentPartDefinition>();
+        }
+
         public override void ConfigureServices(IServiceCollection services)
         {
             // Liquid Part
@@ -72,6 +71,15 @@ namespace OrchardCore.Liquid
 
             services.AddScoped<IDataMigration, Migrations>();
             services.AddScoped<IContentPartIndexHandler, LiquidPartIndexHandler>();
+        }
+    }
+
+    [RequireFeatures("OrchardCore.Shortcodes")]
+    public class ShortcodesStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddLiquidFilter<ShortcodeFilter>("shortcode");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
@@ -46,7 +46,7 @@ namespace OrchardCore.Liquid
     }
 
     [RequireFeatures("OrchardCore.Contents")]
-    public class ContentsStartup : StartupBase
+    public class LiquidPartStartup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Liquid/ContainerFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Liquid/ContainerFilter.cs
@@ -3,8 +3,10 @@ using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
 using OrchardCore.ContentManagement;
+using OrchardCore.Liquid;
+using OrchardCore.Lists.Models;
 
-namespace OrchardCore.Liquid.Filters
+namespace OrchardCore.Lists.Liquid
 {
     public class ContainerFilter : ILiquidFilter
     {
@@ -24,7 +26,7 @@ namespace OrchardCore.Liquid.Filters
                 throw new ArgumentException("A Content Item was expected");
             }
 
-            string containerId = contentItem.Content?.ContainedPart?.ListContentItemId;
+            var containerId = contentItem.As<ContainedPart>()?.ListContentItemId;
 
             if (containerId != null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
@@ -124,6 +124,7 @@ namespace OrchardCore.Lists
         {
             services.AddLiquidFilter<ListCountFilter>("list_count");
             services.AddLiquidFilter<ListItemsFilter>("list_items");
+            services.AddLiquidFilter<ContainerFilter>("container");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
@@ -74,6 +74,11 @@ namespace OrchardCore.Lists
             services.AddContentPart<ListPart>()
                 .UseDisplayDriver<ListPartFeedDisplayDriver>()
                 .AddHandler<ListPartFeedHandler>();
+
+            // Liquid
+            services.AddLiquidFilter<ListCountFilter>("list_count");
+            services.AddLiquidFilter<ListItemsFilter>("list_items");
+            services.AddLiquidFilter<ContainerFilter>("container");
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -114,17 +119,6 @@ namespace OrchardCore.Lists
             services.AddScoped<IContentLocalizationPartHandler, ListPartLocalizationHandler>();
             services.AddContentPart<LocalizationPart>()
                 .AddHandler<LocalizationContainedPartHandler>();
-        }
-    }
-
-    [RequireFeatures("OrchardCore.Liquid")]
-    public class LiquidStartup : StartupBase
-    {
-        public override void ConfigureServices(IServiceCollection services)
-        {
-            services.AddLiquidFilter<ListCountFilter>("list_count");
-            services.AddLiquidFilter<ListItemsFilter>("list_items");
-            services.AddLiquidFilter<ContainerFilter>("container");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Manifest.cs
@@ -14,7 +14,6 @@ using OrchardCore.Modules.Manifest;
     Dependencies = new[]
     {
         "OrchardCore.Indexing",
-        "OrchardCore.Liquid",
         "OrchardCore.ContentTypes"
     },
     Category = "Content Management"

--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -11,11 +11,7 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.Media",
     Name = "Media",
     Description = "The media module adds media management support.",
-    Dependencies = new[]
-    {
-        "OrchardCore.ContentTypes",
-        "OrchardCore.Shortcodes"
-    },
+    Dependencies = new[] { "OrchardCore.ContentTypes" },
     Category = "Content Management"
 )]
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -22,7 +22,6 @@ using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Environment.Shell;
 using OrchardCore.FileStorage;
 using OrchardCore.FileStorage.FileSystem;
-using OrchardCore.Shortcodes;
 using OrchardCore.Liquid;
 using OrchardCore.Media.Controllers;
 using OrchardCore.Media.Core;
@@ -34,9 +33,9 @@ using OrchardCore.Media.Filters;
 using OrchardCore.Media.Handlers;
 using OrchardCore.Media.Processing;
 using OrchardCore.Media.Recipes;
-using OrchardCore.Media.Shortcodes;
 using OrchardCore.Media.Services;
 using OrchardCore.Media.Settings;
+using OrchardCore.Media.Shortcodes;
 using OrchardCore.Media.TagHelpers;
 using OrchardCore.Media.ViewModels;
 using OrchardCore.Modules;
@@ -157,8 +156,6 @@ namespace OrchardCore.Media
 
             services.AddTagHelpers<ImageTagHelper>();
             services.AddTagHelpers<ImageResizeTagHelper>();
-
-            services.AddScoped<IShortcodeProvider, ImageShortcodeProvider>();
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -318,6 +315,15 @@ namespace OrchardCore.Media
             services.AddTransient<IDeploymentSource, MediaDeploymentSource>();
             services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<MediaDeploymentStep>());
             services.AddScoped<IDisplayDriver<DeploymentStep>, MediaDeploymentStepDriver>();
+        }
+    }
+
+    [RequireFeatures("OrchardCore.Shortcodes")]
+    public class ShortcodesStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<IShortcodeProvider, ImageShortcodeProvider>();
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Startup.cs
@@ -49,6 +49,9 @@ namespace OrchardCore.Queries
             services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<AllQueriesDeploymentStep>());
             services.AddScoped<IDisplayDriver<DeploymentStep>, AllQueriesDeploymentStepDriver>();
             services.AddSingleton<IGlobalMethodProvider, QueryGlobalMethodProvider>();
+
+            services.AddScoped<ILiquidTemplateEventHandler, QueriesLiquidTemplateEventHandler>();
+            services.AddLiquidFilter<QueryFilter>("query");
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -89,17 +92,6 @@ namespace OrchardCore.Queries
                 pattern: _adminOptions.AdminUrlPrefix + "/Queries/Sql/Query",
                 defaults: new { controller = typeof(Sql.Controllers.AdminController).ControllerName(), action = nameof(Sql.Controllers.AdminController.Query) }
             );
-        }
-    }
-
-    [RequireFeatures("OrchardCore.Liquid")]
-    public class LiquidStartup : StartupBase
-    {
-        public override void ConfigureServices(IServiceCollection services)
-        {
-            services.AddScoped<ILiquidTemplateEventHandler, QueriesLiquidTemplateEventHandler>();
-
-            services.AddLiquidFilter<QueryFilter>("query");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Manifest.cs
@@ -14,7 +14,6 @@ using OrchardCore.Modules.Manifest;
     Dependencies = new[]
     {
         "OrchardCore.Contents",
-        "OrchardCore.Liquid"
     },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Manifest.cs
@@ -19,5 +19,6 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.Taxonomies.ContentsAdminList",
     Name = "Taxonomies Contents List Filters",
     Description = "Provides taxonomy filters in the contents list.",
+    Dependencies = new[] { "OrchardCore.Taxonomies" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Startup.cs
@@ -10,8 +10,8 @@ using OrchardCore.Apis;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Handlers;
-using OrchardCore.Contents.ViewModels;
 using OrchardCore.Contents.Services;
+using OrchardCore.Contents.ViewModels;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data;
 using OrchardCore.Data.Migration;
@@ -89,6 +89,10 @@ namespace OrchardCore.Taxonomies
             services.AddContentPart<TermPart>();
             services.AddScoped<IContentHandler, TermPartContentHandler>();
             services.AddScoped<IContentDisplayDriver, TermPartContentDriver>();
+
+            // Liquid
+            services.AddLiquidFilter<TaxonomyTermsFilter>("taxonomy_terms");
+            services.AddLiquidFilter<InheritedTermsFilter>("inherited_terms");
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -144,16 +148,6 @@ namespace OrchardCore.Taxonomies
                 return new SiteSettingsPropertyDeploymentStepDriver<TaxonomyContentsAdminListSettings>(S["Taxonomy Filters settings"], S["Exports the Taxonomy filters settings."]);
             });
             services.AddSingleton<IDeploymentStepFactory>(new SiteSettingsPropertyDeploymentStepFactory<TaxonomyContentsAdminListSettings>());
-        }
-    }
-
-    [RequireFeatures("OrchardCore.Liquid")]
-    public class LiquidStartup : StartupBase
-    {
-        public override void ConfigureServices(IServiceCollection services)
-        {
-            services.AddLiquidFilter<TaxonomyTermsFilter>("taxonomy_terms");
-            services.AddLiquidFilter<InheritedTermsFilter>("inherited_terms");
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Manifest.cs
@@ -19,6 +19,6 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.AdminTemplates",
     Name = "Admin Templates",
     Description = "The Admin Templates module provides a way to write custom admin shape templates.",
-    Dependencies = new[] { "OrchardCore.Templates", "OrchardCore.Liquid" },
+    Dependencies = new[] { "OrchardCore.Templates" },
     Category = "Development"
 )]

--- a/src/OrchardCore.Themes/TheAdmin/Recipes/empty.recipe.json
+++ b/src/OrchardCore.Themes/TheAdmin/Recipes/empty.recipe.json
@@ -51,7 +51,6 @@
         "OrchardCore.Layers",
         "OrchardCore.Lucene",
         "OrchardCore.Lists",
-        "OrchardCore.Liquid",
         "OrchardCore.Markdown",
         "OrchardCore.Media",
         "OrchardCore.Menu",

--- a/src/OrchardCore.Themes/TheAdmin/Recipes/headless.recipe.json
+++ b/src/OrchardCore.Themes/TheAdmin/Recipes/headless.recipe.json
@@ -48,7 +48,6 @@
         "OrchardCore.Layers",
         "OrchardCore.Lucene",
         "OrchardCore.Lists",
-        "OrchardCore.Liquid",
         "OrchardCore.Markdown",
         "OrchardCore.Media",
         "OrchardCore.Menu",

--- a/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
@@ -50,7 +50,6 @@
         "OrchardCore.Flows",
         "OrchardCore.Layers",
         "OrchardCore.Lists",
-        "OrchardCore.Liquid",
         "OrchardCore.Markdown",
         "OrchardCore.Media",
         "OrchardCore.Menu",

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -61,7 +61,6 @@
         "OrchardCore.Layers",
         "OrchardCore.Lucene",
         "OrchardCore.Lists",
-        "OrchardCore.Liquid",
         "OrchardCore.Markdown",
         "OrchardCore.Media",
         "OrchardCore.Menu",

--- a/src/OrchardCore.Themes/TheComingSoonTheme/Recipes/comingsoon.recipe.json
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/Recipes/comingsoon.recipe.json
@@ -47,7 +47,6 @@
         "OrchardCore.HomeRoute",
         "OrchardCore.Html",
 
-        "OrchardCore.Liquid",
         "OrchardCore.Localization",
 
         "OrchardCore.Media",
@@ -56,7 +55,6 @@
         "OrchardCore.Recipes",
         "OrchardCore.Resources",
         "OrchardCore.Roles",
-
 
         "OrchardCore.Scripting",
         "OrchardCore.Settings",

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/PageTitleShapes.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/PageTitleShapes.cs
@@ -2,7 +2,6 @@ using System;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Title;
@@ -32,7 +31,7 @@ namespace OrchardCore.DisplayManagement.Shapes
         }
 
         [Shape]
-        public async Task<IHtmlContent> PageTitle(IHtmlHelper Html)
+        public async Task<IHtmlContent> PageTitle()
         {
             var siteSettings = await ShellScope.Services.GetRequiredService<ISiteService>().GetSiteSettingsAsync();
 

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/Recipes/pages.recipe.json
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/Recipes/pages.recipe.json
@@ -51,7 +51,6 @@
         "OrchardCore.Layers",
         "OrchardCore.Lucene",
         "OrchardCore.Lists",
-        "OrchardCore.Liquid",
         "OrchardCore.Markdown",
         "OrchardCore.Media",
         "OrchardCore.Queries",


### PR DESCRIPTION
Fixes #6691 

- **I kept the dependency `Contents => Liquid`** because e.g. the `FullTextAspectSettingsDisplayDriver` injects `ILiquidTemplateManager`. So features having a direct / transitive dependency on `Contents` don't need a direct dependency on `Liquid`, this was already the case for most of them, and they don't need a custom startup with a `[RequireFeatures("Liquid")]` on a feature they depend on, so i did some cleanups.

    I also removed `OC.Liquid` from the recipes as they also contains the `OC.Contents` feature. Note: Because of transitive dependencies we could remove many other features, but maybe clearer to still show in recipes a more complete list.

- Then i moved some liquid filters as the `container` one from `OC.Liquid` to `OC.Lists`

- **I fixed the circular dependency by removing `Liquid => Contents`**, i moved the member access strategies related to content management in the static ctor of the `Contents` startup. I also removed the dependency `Liquid => Shortcodes` by using instead `[RequireFeatures("Shortcodes")]` to register the `shortcode` liquid filter.
