### PR TITLE
Add missing ReCaptcha TagHelper registration (Lombiq Technologies: OCORE-37)

### DIFF
--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 using OrchardCore.ReCaptcha.ActionFilters.Detection;
 using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.ReCaptcha.Services;
+using OrchardCore.ReCaptcha.TagHelpers;
 using Polly;
 
 namespace OrchardCore.ReCaptcha.Core
@@ -18,6 +19,7 @@ namespace OrchardCore.ReCaptcha.Core
             services.AddTransient<IDetectRobots, IpAddressRobotDetector>();
             services.AddTransient<IConfigureOptions<ReCaptchaSettings>, ReCaptchaSettingsConfiguration>();
             services.AddTransient<ReCaptchaService>();
+            services.AddTagHelpers<ReCaptchaTagHelper>();
 
             if (configure != null)
             {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/2768. Now the TagHelper works both in Razor and in Liquid (e.g. `{% helper "captcha", mode: "AlwaysShow" %}`)