### PR TITLE
Fix regression with Taxonomy ContentPart.TermAdmin

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/ContentPart.TermAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/ContentPart.TermAdmin.cshtml
@@ -1,0 +1,15 @@
+@using OrchardCore.Mvc.Utilities
+
+@{
+    string name = Model.Metadata.Name;
+}
+
+@if (Model.Content != null)
+{
+    // We don't render anything from custom parts in the terms list
+    // This can be customized per part by creating custom templates
+
+    @*<div class="contentpart contentpart-@name.HtmlClassify()">
+        @await DisplayAsync(Model.Content)
+    </div>*@    
+}

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyPart.Edit.cshtml
@@ -30,15 +30,17 @@
 @if (canAddTerm && Model.TermContentType != null)
 {
     var termContentType = ContentDefinitionManager.GetTypeDefinition(Model.TermContentType);
-
-    <a class="btn btn-primary btn-sm"
-        asp-route-action="Create"
-        asp-route-controller="Admin"
-        asp-route-id="@Model.TaxonomyPart.TermContentType"
-        asp-route-taxonomyContentItemId="@Model.TaxonomyPart.ContentItem.ContentItemId"
-        asp-route-area="OrchardCore.Taxonomies">
-        @T["Add {0}", termContentType.DisplayName]
-    </a>
+    @if (termContentType != null)
+    {
+        <a class="btn btn-primary btn-sm"
+            asp-route-action="Create"
+            asp-route-controller="Admin"
+            asp-route-id="@Model.TaxonomyPart.TermContentType"
+            asp-route-taxonomyContentItemId="@Model.TaxonomyPart.ContentItem.ContentItemId"
+            asp-route-area="OrchardCore.Taxonomies">
+            @T["Add {0}", termContentType.DisplayName]
+        </a>
+    }
 }
 
 <p>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6894

Fixes https://github.com/OrchardCMS/OrchardCore/issues/6893

Reintroduces a shape I thought was unused, when I refactored Taxonomies

Originally introduced here https://github.com/OrchardCMS/OrchardCore/pull/3091/files 

The null check improves the situation when content types are deleted, but there is more to do there, deeper in the content manager - we have another issue tracking that.