### PR TITLE
Add option to allow Lucene query syntax in search

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Drivers/LuceneSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Drivers/LuceneSettingsDisplayDriver.cs
@@ -44,12 +44,13 @@ namespace OrchardCore.Lucene.Drivers
                     model.SearchIndex = section.SearchIndex;
                     model.SearchFields = String.Join(", ", section.DefaultSearchFields ?? new string[0]);
                     model.SearchIndexes = (await _luceneIndexSettingsService.GetSettingsAsync()).Select(x => x.IndexName);
+                    model.AllowLuceneQueriesInSearch = section.AllowLuceneQueriesInSearch;
                 }).Location("Content:2").OnGroup(GroupId);
         }
 
         public override async Task<IDisplayResult> UpdateAsync(LuceneSettings section, BuildEditorContext context)
         {
-           var user = _httpContextAccessor.HttpContext?.User;
+            var user = _httpContextAccessor.HttpContext?.User;
 
             if (!await _authorizationService.AuthorizeAsync(user, Permissions.ManageIndexes))
             {
@@ -64,6 +65,7 @@ namespace OrchardCore.Lucene.Drivers
 
                 section.SearchIndex = model.SearchIndex;
                 section.DefaultSearchFields = model.SearchFields?.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                section.AllowLuceneQueriesInSearch = model.AllowLuceneQueriesInSearch;
             }
 
             return await EditAsync(section, context);

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Model/LuceneSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Model/LuceneSettings.cs
@@ -14,5 +14,7 @@ namespace OrchardCore.Lucene.Model
         public string SearchIndex { get; set; }
 
         public string[] DefaultSearchFields { get; set; } = FullTextField;
+
+        public bool AllowLuceneQueriesInSearch { get; set; } = false;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/ViewModels/LuceneSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/ViewModels/LuceneSettingsViewModel.cs
@@ -8,5 +8,6 @@ namespace OrchardCore.Lucene.ViewModels
         public string SearchIndex { get; set; }
         public IEnumerable<string> SearchIndexes { get; set; }
         public string SearchFields { get; set; }
+        public bool AllowLuceneQueriesInSearch { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/LuceneSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/LuceneSettings.Edit.cshtml
@@ -25,3 +25,11 @@ else
     <span asp-validation-for="SearchFields"></span>
     <span class="hint">@T["A comma separated list of fields to use for search pages. The default value is <code>Content.ContentItem.FullText</code>."]</span>
 </div>
+
+<div class="form-group" asp-validation-class-for="AllowLuceneQueriesInSearch">
+    <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" asp-for="AllowLuceneQueriesInSearch" />
+        <label class="custom-control-label" asp-for="AllowLuceneQueriesInSearch">@T["Allow Lucene queries in search forms"]</label>
+        <span class="hint">— @T["Whether search queries should be allowed to use <a href=\"https://lucene.apache.org/core/2_9_4/queryparsersyntax.html\">Lucene query parser syntax</a>."]</span>
+    </div>
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Search/Search.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Search/Search.cshtml
@@ -4,3 +4,6 @@
 @await DisplayAsync(Model.SearchForm)
 @await DisplayAsync(Model.SearchResults)
 @await DisplayAsync(Model.Pager)
+@if (!ViewData.ModelState.IsValid) {
+  <span class="alert alert-danger" asp-validation-for="Terms"></span>
+}

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/_ViewImports.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/_ViewImports.cshtml
@@ -3,9 +3,7 @@
 
 *@
 
-
 @inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
-
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, OrchardCore.DisplayManagement
 @addTagHelper *, OrchardCore.ResourceManagement

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/_ViewImports.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/_ViewImports.cshtml
@@ -3,6 +3,7 @@
 
 *@
 
+
 @inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Shared/Search.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Shared/Search.liquid
@@ -9,6 +9,12 @@
 
 {{ Model.SearchForm | shape_render }}
 
+{% unless Model.SearchResults %}
+  {% if Model.Terms %}
+    {% helper "span", validation_for: "Terms", class: "alert alert-danger" %}
+  {% endif %}
+{% endunless %}
+
 {{ Model.SearchResults | shape_render }}
 
 {{ Model.Pager | shape_render }}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Shared/Search.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Shared/Search.liquid
@@ -17,6 +17,12 @@
 
 {{ Model.SearchForm | shape_render }}
 
+{% unless Model.SearchResults %}
+  {% if Model.Terms %}
+    {% helper "span", validation_for: "Terms", class: "alert alert-danger" %}
+  {% endif %}
+{% endunless %}
+
 {{ Model.SearchResults | shape_render }}
 
 {{ Model.Pager | shape_render }}


### PR DESCRIPTION
Closes #6829.

This PR adds a setting to allow Lucene query syntax in search forms. The setting defaults to false.

I'm not sure what the behavior should be when a user enters invalid Lucene syntax. Right now, the error is caught and no results are returned to the user.