### PR TITLE
Add ActionsMenu zone to Widget.SummaryAdmin

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.SummaryAdmin.cshtml
@@ -31,9 +31,20 @@
         <div class="col-xl-6 col-sm-12 related">
             <div class="float-right">
                 @await DisplayAsync(Model.Actions)
+                @if (Model.ActionsMenu != null)
+                {
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            @T["Actions"]
+                        </button>
+                        <div class="dropdown-menu dropdown-menu-right">
+                            @await DisplayAsync(Model.ActionsMenu)
+                        </div>
+                    </div>
+                }
             </div>
         </div>
-    }
+    }    
 </div>
 
 @if (Model.Content != null)


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6904

because the actions moved to new zone, so that you can inject options into the `ActionsMenu` zone