### PR TITLE
Media Content Security Policy

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
@@ -54,7 +54,7 @@ namespace OrchardCore.Media.Services
         private const string DefaultAssetsRequestPath = "/media";
 
         // default-src self applied to prevent possible svg xss injection.
-        // style-src applied to prevent console warnings when viewing png files.
+        // style-src applied to allow browser behaviour of wrapping raw images in a styled img element.
         private const string DefaultContentSecurityPolicy = "default-src 'self'; style-src 'unsafe-inline'";
 
         private readonly IShellConfiguration _shellConfiguration;
@@ -98,8 +98,6 @@ namespace OrchardCore.Media.Services
                 {
                     ctx.Context.Response.Headers[HeaderNames.CacheControl] = cacheControl;
                     ctx.Context.Response.Headers[HeaderNames.ContentSecurityPolicy] = contentSecurityPolicy;
-                    // Included for internet explorer compatability.
-                    ctx.Context.Response.Headers["X-Content-Security-Policy"] = contentSecurityPolicy;
                 }
             };
         }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
+using Microsoft.Net.Http.Headers;
 using OrchardCore.Environment.Shell.Configuration;
 
 namespace OrchardCore.Media.Services
@@ -49,11 +51,16 @@ namespace OrchardCore.Media.Services
         private const int DefaultMaxFileSize = 30_000_000;
 
         private const string DefaultAssetsPath = "Media";
-        private static readonly string DefaultAssetsRequestPath = "/media";
+        private const string DefaultAssetsRequestPath = "/media";
+
+        // default-src self applied to prevent possible svg xss injection.
+        // style-src applied to prevent console warnings when viewing png files.
+        private const string DefaultContentSecurityPolicy = "default-src 'self'; style-src 'unsafe-inline'";
 
         private readonly IShellConfiguration _shellConfiguration;
 
-        public MediaOptionsConfiguration(IShellConfiguration shellConfiguration)
+        public MediaOptionsConfiguration(IShellConfiguration shellConfiguration
+        )
         {
             _shellConfiguration = shellConfiguration;
         }
@@ -77,6 +84,24 @@ namespace OrchardCore.Media.Services
             options.CdnBaseUrl = section.GetValue("CdnBaseUrl", String.Empty).TrimEnd('/').ToLower();
             options.AssetsRequestPath = section.GetValue("AssetsRequestPath", DefaultAssetsRequestPath);
             options.AssetsPath = section.GetValue("AssetsPath", DefaultAssetsPath);
+
+            var contentSecurityPolicy = section.GetValue("ContentSecurityPolicy", DefaultContentSecurityPolicy);
+
+            // Use the same cache control header as ImageSharp does for resized images.
+            var cacheControl = "public, must-revalidate, max-age=" + TimeSpan.FromDays(options.MaxBrowserCacheDays).TotalSeconds.ToString();
+
+            options.StaticFileOptions = new StaticFileOptions
+            {
+                RequestPath = options.AssetsRequestPath,
+                ServeUnknownFileTypes = true,
+                OnPrepareResponse = ctx =>
+                {
+                    ctx.Context.Response.Headers[HeaderNames.CacheControl] = cacheControl;
+                    ctx.Context.Response.Headers[HeaderNames.ContentSecurityPolicy] = contentSecurityPolicy;
+                    // Included for internet explorer compatability.
+                    ctx.Context.Response.Headers["X-Content-Security-Policy"] = contentSecurityPolicy;
+                }
+            };
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -175,20 +175,11 @@ namespace OrchardCore.Media
             // ImageSharp before the static file provider.
             app.UseImageSharp();
 
-            // Use the same cache control header as ImageSharp does for resized images.
-            var cacheControl = "public, must-revalidate, max-age=" + TimeSpan.FromDays(mediaOptions.MaxBrowserCacheDays).TotalSeconds.ToString();
+            // The file provider is a circular dependency and replacable via di.
+            mediaOptions.StaticFileOptions.FileProvider = mediaFileProvider;
 
-            app.UseStaticFiles(new StaticFileOptions
-            {
-                // The tenant's prefix is already implied by the infrastructure.
-                RequestPath = mediaOptions.AssetsRequestPath,
-                FileProvider = mediaFileProvider,
-                ServeUnknownFileTypes = true,
-                OnPrepareResponse = ctx =>
-                {
-                    ctx.Context.Response.Headers[HeaderNames.CacheControl] = cacheControl;
-                }
-            });
+            // Use services.PostConfigure<MediaOptions>() to alter the media static file options event handlers.
+            app.UseStaticFiles(mediaOptions.StaticFileOptions);
 
             var adminControllerName = typeof(AdminController).ControllerName();
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -175,7 +175,7 @@ namespace OrchardCore.Media
             // ImageSharp before the static file provider.
             app.UseImageSharp();
 
-            // The file provider is a circular dependency and replacable via di.
+            // The file provider is a circular dependency and replaceable via di.
             mediaOptions.StaticFileOptions.FileProvider = mediaFileProvider;
 
             // Use services.PostConfigure<MediaOptions>() to alter the media static file options event handlers.

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/MediaOptions.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/MediaOptions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 
 namespace OrchardCore.Media
@@ -47,5 +48,10 @@ namespace OrchardCore.Media
         /// The path used to store media assets. The path can be relative to the tenant's App_Data folder, or absolute.
         /// </summary>
         public string AssetsPath { get; set; }
+
+        /// <summary>
+        /// The static file options used to serve non resized media.
+        /// </summary>
+        public StaticFileOptions StaticFileOptions { get; set; }
     }
 }

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -250,13 +250,13 @@ The following configuration values are used by default and can be customized:
     }
 ```
 
-To configure the `StaticFileOptions` in more detail, including event handlers, for the Media Library `StaticFileMiddleware` apply 
+To configure the `StaticFileOptions` in more detail, including event handlers, for the Media Library `StaticFileMiddleware` apply:
 
 ```
 services.PostConfigure<MediaOptions>(o => ...);
 ```
 
-To configure the `ImageSharpMiddleware` in more detail, including event handlers, apply :
+To configure the `ImageSharpMiddleware` in more detail, including event handlers, apply:
 
 ```
 services.PostConfigure<ImageSharpMiddlewareOptions>(o => ...);
@@ -265,7 +265,7 @@ services.PostConfigure<ImageSharpMiddlewareOptions>(o => ...);
 !!! note
     The Media Library `StaticFileOptions` configuration is seperated from the configuration for static files contained in module `wwwroot` folders.
 
-To configure `wwwroot` static file options apply :
+To configure `wwwroot` static file options apply:
 
 ```
 services.Configure<StaticFileOptions>(o => ...);

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -243,8 +243,32 @@ The following configuration values are used by default and can be customized:
             ".mpg",
             ".ogv", // Ogg
             ".3gp", // 3GPP
-        ]
+        ],
+
+      // The Content Security Policy to apply to assets served from the media library.
+      "ContentSecurityPolicy" : "default-src 'self'; style-src 'unsafe-inline'"
     }
+```
+
+To configure the `StaticFileOptions` in more detail, including event handlers, for the Media Library `StaticFileMiddleware` apply 
+
+```
+services.PostConfigure<MediaOptions>(o => ...);
+```
+
+To configure the `ImageSharpMiddleware` in more detail, including event handlers, apply :
+
+```
+services.PostConfigure<ImageSharpMiddlewareOptions>(o => ...);
+```
+
+!!! note
+    The Media Library `StaticFileOptions` configuration is seperated from the configuration for static files contained in module `wwwroot` folders.
+
+To configure `wwwroot` static file options apply :
+
+```
+services.Configure<StaticFileOptions>(o => ...);
 ```
 
 ## CREDITS

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -263,7 +263,7 @@ services.PostConfigure<ImageSharpMiddlewareOptions>(o => ...);
 ```
 
 !!! note
-    The Media Library `StaticFileOptions` configuration is seperated from the configuration for static files contained in module `wwwroot` folders.
+    The Media Library `StaticFileOptions` configuration is separated from the configuration for static files contained in module `wwwroot` folders.
 
 To configure `wwwroot` static file options apply:
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6897

Complementary to https://github.com/OrchardCMS/OrchardCore/pull/6900

Applies a CSP to content served from the media library, if not resized (because ImageSharp does not server any .svg files, so has no issue with this.)

So this works :

![Screenshot 2020-08-15 at 10 22 43](https://user-images.githubusercontent.com/13782679/90309589-d291cd80-dee1-11ea-8041-a87b9fb970d1.png)

And you can see in the browser console that it's blocked the script execution.

Tested on Safari and Firefox as well.

But it doesn't work for IE, because IE does not support much of the `Content-Security-Policy` header refer : https://stackoverflow.com/questions/42937146/content-security-policy-does-not-work-in-internet-explorer-11

tested in ie, and the result is
![badie](https://user-images.githubusercontent.com/13782679/90309625-1553a580-dee2-11ea-9769-65a0d07770d6.PNG)

Things to note about this issue.

- it's only related to direct serving of svg files. 
- we still want to protect against that, as it would be easy, and common for an editor, to make a link to the image file for download, or full screen viewing.

My thoughts
- we should apply this, and probably also remove the `.svg` extension by default as @hisham has done.
- document it where and why (can you update your pr to include in the docs the default file extensions @hishamco ), and how to enable svg, and the caveats, i.e. not protected in IE.

What I've also done on this pr, is made the `Media.StaticFileOptions` slightly more configurable with `services.PostConfigure` to allow more fine grained controlled, if any wants to adapt the event handlers and/or use them to block certain types of requests, or whatever they feel they need to.

Good article you linked to by the way @rmgc77, shame it didn't mention IE.

IE doesn't support the `Content-Disposition` header either, so that's no help either.

Other things tested to make sure it wouldn't break anything :

`.js` and `.css` files are still servable, and work fine, if users are placing them in the media library.