### PR TITLE
Fixes ShapeResult Copy()

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Demo/Views/Shared/Header.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Views/Shared/Header.cshtml
@@ -5,7 +5,7 @@
             <div class="row">
                 <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
                     <div class="post-heading">
-                        <h1>@T[(string)Model.Title]</h1>
+                        <h1>@Model.Title</h1>
                         <h2>Header coming from the module shared views</h2>
                     </div>
                 </div>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriverBase.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriverBase.cs
@@ -48,7 +48,7 @@ namespace OrchardCore.DisplayManagement.Handlers
         /// </summary>
         public ShapeResult Copy<TModel>(string shapeType, TModel model) where TModel : class
         {
-            return Dynamic(shapeType, ctx => ctx.ShapeFactory.CreateAsync(shapeType, model));
+            return Factory(shapeType, ctx => ctx.ShapeFactory.CreateAsync(shapeType, model));
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.DisplayManagement.Title;
-using OrchardCore.DisplayManagement.Zones;
 using OrchardCore.Settings;
 
 namespace OrchardCore.DisplayManagement.Razor


### PR DESCRIPTION
Currently we have

    public ShapeResult Copy<TModel>(string shapeType, TModel model) where TModel : class
    {
        return Dynamic(shapeType, ctx => ctx.ShapeFactory.CreateAsync(shapeType, model));
    }

Which always fails here

    public ShapeResult Dynamic(string shapeType, Func<dynamic, Task> initializeAsync)
    {
        return Factory(shapeType,
            async ctx =>
            {
                dynamic shape = await ctx.ShapeFactory.CreateAsync(shapeType);
                await initializeAsync(shape); <= ALWAYS FAILS HERE
                return shape;
            });
    }

Because `ctx => ctx.ShapeFactory.CreateAsync(shapeType, model))` is more like a shapeBuilder delegate than an `initializeAsync` delegate, so, fixed by using instead

    public ShapeResult Copy<TModel>(string shapeType, TModel model) where TModel : class
    {
        return Factory(shapeType, ctx => ctx.ShapeFactory.CreateAsync(shapeType, model));
    }

    // The Factory signature being
    public ShapeResult Factory(string shapeType, Func<IBuildShapeContext, ValueTask<IShape>> shapeBuilder)
