### PR TITLE
Add missing taghelper references

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/OrchardCore.Shortcodes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/OrchardCore.Shortcodes.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Shortcodes.Abstractions\OrchardCore.Shortcodes.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Settings.Core\OrchardCore.Settings.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Setup.Abstractions\OrchardCore.Setup.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6943

@Piedone have done this pr, as the shortcodes one is affecting my prod sites.

I don't think it's something we should do by default on all razor projects (because I think it buries the issue), but that's just my opinion, so if you want to do that, make a pr.

I wonder if its not a job for your analyzers, if they could pick that up, it would be pretty cool?