### PR TITLE
Replace or create an existing admin menu tree when deploying

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Deployment/AdminMenuDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Deployment/AdminMenuDeploymentSource.cs
@@ -9,9 +9,9 @@ namespace OrchardCore.AdminMenu.Deployment
     {
         private readonly IAdminMenuService _adminMenuService;
 
-        public AdminMenuDeploymentSource(IAdminMenuService adminMenuervice)
+        public AdminMenuDeploymentSource(IAdminMenuService adminMenuService)
         {
-            _adminMenuService = adminMenuervice;
+            _adminMenuService = adminMenuService;
         }
 
         public async Task ProcessDeploymentStepAsync(DeploymentStep step, DeploymentPlanResult result)

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Recipes/AdminMenuStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Recipes/AdminMenuStep.cs
@@ -33,8 +33,8 @@ namespace OrchardCore.AdminMenu.Recipes
             foreach (JObject token in model.Data)
             {
                 var adminMenu = token.ToObject<Models.AdminMenu>(serializer);
-                
-                // When the id is not supplied create a new tree, otherwise replace or create the existing tree.
+
+                // When the id is not supplied create a new menu, otherwise replace the existing menu, or create a new menu.
                 if (String.IsNullOrEmpty(adminMenu.Id))
                 {
                     adminMenu.Id = Guid.NewGuid().ToString("n");

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Recipes/AdminMenuStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Recipes/AdminMenuStep.cs
@@ -12,11 +12,11 @@ namespace OrchardCore.AdminMenu.Recipes
     /// </summary>
     public class AdminMenuStep : IRecipeStepHandler
     {
-        private readonly IAdminMenuService _AdminMenuService;
+        private readonly IAdminMenuService _adminMenuService;
 
-        public AdminMenuStep(IAdminMenuService AdminMenuervice)
+        public AdminMenuStep(IAdminMenuService adminMenuService)
         {
-            _AdminMenuService = AdminMenuervice;
+            _adminMenuService = adminMenuService;
         }
 
         public async Task ExecuteAsync(RecipeExecutionContext context)
@@ -33,8 +33,14 @@ namespace OrchardCore.AdminMenu.Recipes
             foreach (JObject token in model.Data)
             {
                 var adminMenu = token.ToObject<Models.AdminMenu>(serializer);
-                adminMenu.Id = Guid.NewGuid().ToString("n");// we always add it as a new tree.
-                await _AdminMenuService.SaveAsync(adminMenu);
+                
+                // When the id is not supplied create a new tree, otherwise replace or create the existing tree.
+                if (String.IsNullOrEmpty(adminMenu.Id))
+                {
+                    adminMenu.Id = Guid.NewGuid().ToString("n");
+                }
+
+                await _adminMenuService.SaveAsync(adminMenu);
             }
 
             return;

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Recipes/AdminMenuStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Recipes/AdminMenuStep.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.AdminMenu.Recipes
             {
                 var adminMenu = token.ToObject<Models.AdminMenu>(serializer);
 
-                // When the id is not supplied create a new menu, otherwise replace the existing menu, or create a new menu.
+                // When the id is not supplied generate an id, otherwise replace the menu if it exists, or create a new menu.
                 if (String.IsNullOrEmpty(adminMenu.Id))
                 {
                     adminMenu.Id = Guid.NewGuid().ToString("n");


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6996

Changes the behaviour, and that behaviour had a comment on it (so @Skrypt if you happen to remember why it was done that way)

Have made it replace an existing tree, or create if it doesn't exist. (service already handles that)

Merging an existing tree with a new one would make no sense as there is not enough unique ids to merge the arrays