### PR TITLE
Restrict Content Type Admin Menus to only create the specified Content Type

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
@@ -41,7 +41,7 @@ namespace OrchardCore.Contents
                 .AddClass("content").Id("content")
                 .Add(S["Content Items"], S["Content Items"].PrefixPosition(), contentItems => contentItems
                     .Permission(Permissions.EditOwnContent)
-                    .Action(nameof(AdminController.List), typeof(AdminController).ControllerName(), new { area = "OrchardCore.Contents" })
+                    .Action(nameof(AdminController.List), typeof(AdminController).ControllerName(), new { area = "OrchardCore.Contents", contentTypeId = "" })
                     .LocalNav())
                 );
             var contentTypes = contentTypeDefinitions.Where(ctd => ctd.GetSettings<ContentTypeSettings>().Creatable).OrderBy(ctd => ctd.DisplayName);

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -93,7 +93,7 @@ namespace OrchardCore.Contents.Controllers
             }
 
             // Populate the creatable types.
-             if (!string.IsNullOrEmpty(model.Options.SelectedContentType))
+            if (!string.IsNullOrEmpty(model.Options.SelectedContentType))
             {
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.Options.SelectedContentType);
                 if (contentTypeDefinition == null)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -93,7 +93,7 @@ namespace OrchardCore.Contents.Controllers
             }
 
             // Populate the creatable types.
-            if (!string.IsNullOrEmpty(model.Options.SelectedContentType))
+             if (!string.IsNullOrEmpty(model.Options.SelectedContentType))
             {
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.Options.SelectedContentType);
                 if (contentTypeDefinition == null)
@@ -102,7 +102,7 @@ namespace OrchardCore.Contents.Controllers
                 }
 
                 // Allows non creatable types to be created by another admin page.
-                if (model.Options.CanCreateSelectedContentType)
+                if (contentTypeDefinition.GetSettings<ContentTypeSettings>().Creatable || model.Options.CanCreateSelectedContentType)
                 {
                     model.Options.CreatableTypes = new List<SelectListItem>
                     {
@@ -110,8 +110,7 @@ namespace OrchardCore.Contents.Controllers
                     };
                 }
             }
-
-            if (model.Options.CreatableTypes == null)
+            else
             {
                 var contentTypes = _contentDefinitionManager
                     .ListTypeDefinitions()

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -87,14 +87,13 @@ namespace OrchardCore.Contents.Controllers
             var pager = new Pager(pagerParameters, siteSettings.PageSize);
 
             // This is used by the AdminMenus so needs to be passed into the options.
-            if (!string.IsNullOrEmpty(contentTypeId))
+            if (!String.IsNullOrEmpty(contentTypeId))
             {
                 model.Options.SelectedContentType = contentTypeId;
             }
 
             // Populate the creatable types.
-            model.Options.CreatableTypes = new List<SelectListItem>();
-            if (!string.IsNullOrEmpty(model.Options.SelectedContentType))
+            if (!String.IsNullOrEmpty(model.Options.SelectedContentType))
             {
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.Options.SelectedContentType);
                 if (contentTypeDefinition == null)
@@ -102,30 +101,34 @@ namespace OrchardCore.Contents.Controllers
                     return NotFound();
                 }
 
+                var creatableList = new List<SelectListItem>();
+
                 // Allows non creatable types to be created by another admin page.
                 if (contentTypeDefinition.GetSettings<ContentTypeSettings>().Creatable || model.Options.CanCreateSelectedContentType)
                 {
-                    model.Options.CreatableTypes.Add(
-                        new SelectListItem(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName).Value, contentTypeDefinition.Name)
-                    );
+                    creatableList.Add(new SelectListItem(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName).Value, contentTypeDefinition.Name));
                 }
+
+                model.Options.CreatableTypes = creatableList;
             }
-            else
+
+            if (model.Options.CreatableTypes == null)
             {
                 var contentTypes = _contentDefinitionManager
                     .ListTypeDefinitions()
                     .Where(ctd => ctd.GetSettings<ContentTypeSettings>().Creatable)
                     .OrderBy(ctd => ctd.DisplayName);
 
+                var creatableList = new List<SelectListItem>();
                 if (contentTypes.Any())
                 {
                     foreach (var contentTypeDefinition in contentTypes)
                     {
-                        model.Options.CreatableTypes.Add(
-                            new SelectListItem(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName).Value, contentTypeDefinition.Name)
-                            );
+                        creatableList.Add(new SelectListItem(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName).Value, contentTypeDefinition.Name));
                     }
                 }
+
+                model.Options.CreatableTypes = creatableList;
             }
 
             // We populate the remaining SelectLists.

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -93,6 +93,7 @@ namespace OrchardCore.Contents.Controllers
             }
 
             // Populate the creatable types.
+            model.Options.CreatableTypes = new List<SelectListItem>();
             if (!string.IsNullOrEmpty(model.Options.SelectedContentType))
             {
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.Options.SelectedContentType);
@@ -104,10 +105,9 @@ namespace OrchardCore.Contents.Controllers
                 // Allows non creatable types to be created by another admin page.
                 if (contentTypeDefinition.GetSettings<ContentTypeSettings>().Creatable || model.Options.CanCreateSelectedContentType)
                 {
-                    model.Options.CreatableTypes = new List<SelectListItem>
-                    {
+                    model.Options.CreatableTypes.Add(
                         new SelectListItem(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName).Value, contentTypeDefinition.Name)
-                    };
+                    );
                 }
             }
             else
@@ -117,16 +117,15 @@ namespace OrchardCore.Contents.Controllers
                     .Where(ctd => ctd.GetSettings<ContentTypeSettings>().Creatable)
                     .OrderBy(ctd => ctd.DisplayName);
 
-                var creatableList = new List<SelectListItem>();
                 if (contentTypes.Any())
                 {
                     foreach (var contentTypeDefinition in contentTypes)
                     {
-                        creatableList.Add(new SelectListItem(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName).Value, contentTypeDefinition.Name));
+                        model.Options.CreatableTypes.Add(
+                            new SelectListItem(new LocalizedString(contentTypeDefinition.DisplayName, contentTypeDefinition.DisplayName).Value, contentTypeDefinition.Name)
+                            );
                     }
                 }
-
-                model.Options.CreatableTypes = creatableList;
             }
 
             // We populate the remaining SelectLists.

--- a/src/OrchardCore.Modules/OrchardCore.Menu/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/AdminMenu.cs
@@ -24,6 +24,7 @@ namespace OrchardCore.Menu
 
             var rvd = new RouteValueDictionary
             {
+                { "contentTypeId", "Menu" },
                 { "Area", "OrchardCore.Contents" },
                 { "Options.SelectedContentType", "Menu" },
                 { "Options.CanCreateSelectedContentType", true }


### PR DESCRIPTION
Fixes #7013 

restored the new button specific for each contentitems when user filter by contenttype or the user access to contentitem list interface by link for a single contenttype in the AdminMenu.

fixed behavior of the Admin Menu's links Menus and Content Items: if they are not defined inside a recipe, they have a dynamic behavior and it cause issue if user define link for specific contenttype inside the AdminMenu.

In the `BlogTheme`, the "Content Items" link of the Admin menu is defined in the recipe and doesn't have the dynamic behavior.