### PR TITLE
Prevents building a shell from an outdated descriptor

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Extensions/ShellFeaturesManagerExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Extensions/ShellFeaturesManagerExtensions.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Environment.Shell
         public static async Task<IEnumerable<IFeatureInfo>> EnableFeaturesAsync(this IShellFeaturesManager shellFeaturesManager,
             IEnumerable<IFeatureInfo> features, bool force)
         {
-            var (featuresToDisable, featuresToEnable) = await shellFeaturesManager.UpdateFeaturesAsync(new IFeatureInfo[0], features, force);
+            var (_, featuresToEnable) = await shellFeaturesManager.UpdateFeaturesAsync(new IFeatureInfo[0], features, force);
             return featuresToEnable;
         }
 
@@ -28,7 +28,7 @@ namespace OrchardCore.Environment.Shell
         public static async Task<IEnumerable<IFeatureInfo>> DisableFeaturesAsync(this IShellFeaturesManager shellFeaturesManager,
             IEnumerable<IFeatureInfo> features, bool force)
         {
-            var (featuresToDisable, featuresToEnable) = await shellFeaturesManager.UpdateFeaturesAsync(features, new IFeatureInfo[0], force);
+            var (featuresToDisable, _) = await shellFeaturesManager.UpdateFeaturesAsync(features, new IFeatureInfo[0], force);
             return featuresToDisable;
         }
     }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
@@ -105,6 +105,11 @@ namespace OrchardCore.Environment.Shell.Data.Descriptors
 
             _session.Save(shellDescriptorRecord);
 
+            // In the 'ChangedAsync()' event the shell will be released so that, on request, a new one will be built.
+            // So, we commit the session earlier to prevent a new shell from being built with an outdated descriptor.
+
+            await _session.CommitAsync();
+
             await _shellDescriptorManagerEventHandlers.InvokeAsync((handler, shellDescriptorRecord, _shellSettings) =>
                 handler.ChangedAsync(shellDescriptorRecord, _shellSettings), shellDescriptorRecord, _shellSettings, _logger);
         }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
@@ -106,7 +106,7 @@ namespace OrchardCore.Environment.Shell.Data.Descriptors
             _session.Save(shellDescriptorRecord);
 
             // In the 'ChangedAsync()' event the shell will be released so that, on request, a new one will be built.
-            // So, we commit the session earlier to prevent a new shell from being built with an outdated descriptor.
+            // So, we commit the session earlier to prevent a new shell from being built from an outdated descriptor.
 
             await _session.CommitAsync();
 


### PR DESCRIPTION
Found and fixed while working on tenants syncing, i did a separate PR so that it is easier to track