### PR TITLE
Unused ShellSettings direct property

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellSettings.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellSettings.cs
@@ -36,12 +36,6 @@ namespace OrchardCore.Environment.Shell
             Name = settings.Name;
         }
 
-        public string Description
-        {
-            get => _configuration["Description"];
-            set => _configuration["Description"] = value;
-        }
-
         public string Name { get; set; }
 
         public string Identifier


### PR DESCRIPTION
We use shell settings direct properties for the properties coming from the settings sources as `tenants.json`, and that we need to start a tenant. For the other properties coming from the regular config sources, we use the shell settings indexer.

Unless for the `Description` that is a regular config value but for which we created a direct property

So, because we never use this `Description` direct property in the code, only the indexer, i removed it so that it is clearer that we only use shell settings direct properties for values coming from settings sources as `tenants.json`.