### PR TITLE
add unique filename and safe delete function

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/ExportRemoteInstanceController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/ExportRemoteInstanceController.cs
@@ -72,30 +72,25 @@ namespace OrchardCore.Deployment.Remote.Controllers
 
             using (var fileBuilder = new TemporaryFileBuilder())
             {
-                archiveFileName = PathExtensions.Combine(Path.GetTempPath(), filename);
+                archiveFileName = PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 var deploymentPlanResult = new DeploymentPlanResult(fileBuilder, new RecipeDescriptor());
                 await _deploymentManager.ExecuteDeploymentPlanAsync(deploymentPlan, deploymentPlanResult);
 
-                if (System.IO.File.Exists(archiveFileName))
-                {
-                    System.IO.File.Delete(archiveFileName);
-                }
-
                 ZipFile.CreateFromDirectory(fileBuilder.Folder, archiveFileName);
             }
 
-            HttpResponseMessage response;
-
             try
             {
+                HttpResponseMessage response;
+
                 using (var requestContent = new MultipartFormDataContent())
                 {
                     requestContent.Add(new StreamContent(
                         new FileStream(archiveFileName,
                         FileMode.Open, FileAccess.Read, FileShare.ReadWrite, 1, FileOptions.Asynchronous | FileOptions.SequentialScan)
                     ),
-                        nameof(ImportViewModel.Content), Path.GetFileName(archiveFileName));
+                        nameof(ImportViewModel.Content), filename);
                     requestContent.Add(new StringContent(remoteInstance.ClientName), nameof(ImportViewModel.ClientName));
                     requestContent.Add(new StringContent(remoteInstance.ApiKey), nameof(ImportViewModel.ApiKey));
 

--- a/src/OrchardCore/OrchardCore.Deployment.Core/Services/TemporaryFileBuilder.cs
+++ b/src/OrchardCore/OrchardCore.Deployment.Core/Services/TemporaryFileBuilder.cs
@@ -31,7 +31,6 @@ namespace OrchardCore.Deployment.Core.Services
         {
             foreach (string file in Directory.GetFiles(targetDirectory))
             {
-                File.SetAttributes(file, FileAttributes.Normal);
                 File.Delete(file);
             }
 

--- a/src/OrchardCore/OrchardCore.Deployment.Core/Services/TemporaryFileBuilder.cs
+++ b/src/OrchardCore/OrchardCore.Deployment.Core/Services/TemporaryFileBuilder.cs
@@ -22,9 +22,25 @@ namespace OrchardCore.Deployment.Core.Services
             {
                 if (Directory.Exists(Folder))
                 {
-                    Directory.Delete(Folder, true);
+                     SafeDeleteDirectory(Folder);
                 }
             }
+        }
+
+        private static void SafeDeleteDirectory(string targetDirectory)
+        {
+            foreach (string file in Directory.GetFiles(targetDirectory))
+            {
+                File.SetAttributes(file, FileAttributes.Normal);
+                File.Delete(file);
+            }
+
+            foreach (string dir in Directory.GetDirectories(targetDirectory))
+            {
+                SafeDeleteDirectory(dir);
+            }
+
+            Directory.Delete(targetDirectory, false);
         }
 
         public async Task SetFileAsync(string subpath, Stream stream)


### PR DESCRIPTION
Add a unique filename for the physical export file and add a safe delete function to prevent UnauthorizedAccessException in a windows container. 
Fixes #7025
The windows container was failing with an UnauthorizedAccessException when the TemporaryFileBuilder is disposed. The Directory.Delete(folder, recursive) call was throwing the exception. To work around, I walk the directory, set the file attributes to Normal, delete the file, then delete the empty folder. This safe delete no longer throws the exception. One side effect of this exception was the code was orphaning a zip file in the Windows/Temp folder. This filename matched the deployment plan, so once it was orphaned, it stayed broken. This also would blow up if two admins export a development plan at the same time. To fix, I save the archive file with a random filename and then export result with the correct deployment plan name for the zip. 

Aside... The export file clean up was a bit confusing at first. I finally found it happening in a ResultFilterAttribute. It would be a bit cleaner if a new TemporaryPhysicalFileResult class is created that inherits from PhysicalFileResult. Then the File.Delete() could occur in the overridden ExecuteResultAsync() method. It'd keep all of the logic for the FileResult in one place.

