### PR TITLE
ChallengeOrForbid in Api controllers

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ApiController.cs
@@ -38,7 +38,7 @@ namespace OrchardCore.Content.Controllers
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.AccessContentApi))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             var contentItem = await _contentManager.GetAsync(contentItemId);
@@ -50,7 +50,7 @@ namespace OrchardCore.Content.Controllers
 
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.ViewContent, contentItem))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             return Ok(contentItem);
@@ -62,7 +62,7 @@ namespace OrchardCore.Content.Controllers
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.AccessContentApi))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             var contentItem = await _contentManager.GetAsync(contentItemId);
@@ -74,7 +74,7 @@ namespace OrchardCore.Content.Controllers
 
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.DeleteContent, contentItem))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             await _contentManager.RemoveAsync(contentItem);
@@ -87,7 +87,7 @@ namespace OrchardCore.Content.Controllers
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.AccessContentApi))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             // It is really important to keep the proper method calls order with the ContentManager
@@ -99,7 +99,7 @@ namespace OrchardCore.Content.Controllers
             {
                 if (!await _authorizationService.AuthorizeAsync(User, Permissions.PublishContent))
                 {
-                    return this.ChallengeOrForbid();
+                    return this.ChallengeOrForbid("Api");
                 }
 
                 var newContentItem = await _contentManager.NewAsync(model.ContentType);
@@ -130,7 +130,7 @@ namespace OrchardCore.Content.Controllers
             {
                 if (!await _authorizationService.AuthorizeAsync(User, Permissions.EditContent, contentItem))
                 {
-                    return this.ChallengeOrForbid();
+                    return this.ChallengeOrForbid("Api");
                 }
 
                 contentItem.Merge(model, UpdateJsonMergeSettings);

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/ContentApiController.cs
@@ -36,14 +36,14 @@ namespace OrchardCore.Demo.Controllers
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.DemoAPIAccess))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             var contentItem = await _contentManager.GetAsync(id);
 
             if (!await _authorizationService.AuthorizeAsync(User, OrchardCore.Contents.CommonPermissions.ViewContent, contentItem))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             if (contentItem == null)
@@ -60,7 +60,7 @@ namespace OrchardCore.Demo.Controllers
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.DemoAPIAccess))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             await _contentManager.CreateAsync(contentItem);

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/ApiController.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.Lucene.Controllers
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.QueryLuceneApi))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             var luceneQuery = new LuceneQuery
@@ -60,7 +60,7 @@ namespace OrchardCore.Lucene.Controllers
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.QueryLuceneApi))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             var luceneQuery = new LuceneQuery

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -73,7 +73,7 @@ namespace OrchardCore.Tenants.Controllers
 
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageTenants))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             if (!String.IsNullOrEmpty(model.Name) && !Regex.IsMatch(model.Name, @"^\w+$"))
@@ -137,12 +137,12 @@ namespace OrchardCore.Tenants.Controllers
         {
             if (!IsDefaultShell())
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageTenants))
             {
-                return this.ChallengeOrForbid();
+                return this.ChallengeOrForbid("Api");
             }
 
             if (!ModelState.IsValid)

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/ControllerExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/ControllerExtensions.cs
@@ -8,19 +8,23 @@ namespace OrchardCore.Mvc.Utilities
         /// Returns the proper actionresult for unauthorized or unauthenticated users.
         /// Will return a forbid when the user is authenticated.
         /// Will return a challenge when the user is not authenticated.
-        /// If a authentication scheme is specified, will return a challenge to it.
         /// </summary>
         /// <param name="controller"></param>
-        /// <param name="authenticationScheme"></param>
         /// <returns>The proper actionresult based upon if the user is authenticated</returns>
-        public static ActionResult ChallengeOrForbid(this Controller controller, string authenticationScheme = null)
-        {
-            if (!string.IsNullOrEmpty(authenticationScheme))
-            {
-                return controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid(new string[] { authenticationScheme }) : (ActionResult)controller.Challenge(new string[] { authenticationScheme });
-            }
+        public static ActionResult ChallengeOrForbid(this Controller controller)
+            => controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid() : (ActionResult)controller.Challenge();
 
-            return controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid() : (ActionResult)controller.Challenge();
-        }
+        /// <summary>
+        /// Returns the proper actionresult for unauthorized or unauthenticated users
+        /// with the specified authenticationSchemes.
+        /// Will return a forbid when the user is authenticated.
+        /// Will return a challenge when the user is not authenticated.
+        /// If authentication schemes are specified, will return a challenge to them.
+        /// </summary>
+        /// <param name="controller"></param>
+        /// <param name="authenticationSchemes">The authentication schemes to challenge.</param>
+        /// <returns>The proper actionresult based upon if the user is authenticated</returns>
+        public static ActionResult ChallengeOrForbid(this Controller controller, params string[] authenticationSchemes)
+            => controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid(authenticationSchemes) : (ActionResult)controller.Challenge(authenticationSchemes);
     }
 }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/ControllerExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/ControllerExtensions.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Mvc.Utilities
         {
             if (!string.IsNullOrEmpty(authenticationScheme))
             {
-                return controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid() : (ActionResult)controller.Challenge(new string[] { authenticationScheme });
+                return controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid(new string[] { authenticationScheme }) : (ActionResult)controller.Challenge(new string[] { authenticationScheme });
             }
 
             return controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid() : (ActionResult)controller.Challenge();

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/ControllerExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/ControllerExtensions.cs
@@ -8,11 +8,18 @@ namespace OrchardCore.Mvc.Utilities
         /// Returns the proper actionresult for unauthorized or unauthenticated users.
         /// Will return a forbid when the user is authenticated.
         /// Will return a challenge when the user is not authenticated.
+        /// If a authentication scheme is specified, will return a challenge to it.
         /// </summary>
         /// <param name="controller"></param>
+        /// <param name="authenticationScheme"></param>
         /// <returns>The proper actionresult based upon if the user is authenticated</returns>
-        public static ActionResult ChallengeOrForbid(this Controller controller)
+        public static ActionResult ChallengeOrForbid(this Controller controller, string authenticationScheme = null)
         {
+            if (!string.IsNullOrEmpty(authenticationScheme))
+            {
+                return controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid() : (ActionResult)controller.Challenge(new string[] { authenticationScheme });
+            }
+
             return controller.User.Identity.IsAuthenticated ? (ActionResult)controller.Forbid() : (ActionResult)controller.Challenge();
         }
     }


### PR DESCRIPTION
Fixes #7039

Added an optional `authenticationScheme` to the `ChallengeOrForbid` method.

Replaced `this.ChallengeOrForbid()` by `this.ChallengeOrForbid("Api")` in Api controllers.

`api/queries` doesn't seem to have any ChallengeOrForbid.