### PR TITLE
Prevent rendering same script multiple times by naming it

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SummaryAdmin.cshtml
@@ -43,7 +43,7 @@
                         <button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             @T["Actions"]
                         </button>
-                        <div id="actionsMenu" class="dropdown-menu dropdown-menu-right">
+                        <div class="actions-menu dropdown-menu dropdown-menu-right">
                             @await DisplayAsync(Model.ActionsMenu)
                         </div>
                     </div>
@@ -61,7 +61,7 @@
 <script asp-name="removeEmptyActionsMenu" at="Foot" type="text/javascript">
     $(function(){
         
-        $("#actionsMenu.dropdown-menu").each(function(i, e){
+        $(".actions-menu.dropdown-menu").each(function(i, e){
             var count = $(e).children().length;
             if(count == 0){
                 $(this).parent().hide();

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SummaryAdmin.cshtml
@@ -58,7 +58,7 @@
     <div class="col primary">@await DisplayAsync(Model.Content)</div>
 }
 
-<script at="Foot" type="text/javascript">
+<script asp-name="removeEmptyActionsMenu" at="Foot" type="text/javascript">
     $(function(){
         
         $("#actionsMenu.dropdown-menu").each(function(i, e){


### PR DESCRIPTION
There is a script in `Content.SummaryAdmin.cshtml` that is rendered for each content item. In the 'Manage Content' page this results in the same script being rendered multiple times.

You can verify this behaviour by going to /Admin/Contents/ContentItems and view the source:

```
<script type="text/javascript">
    $(function(){
        
        $("#actionsMenu.dropdown-menu").each(function(i, e){
            var count = $(e).children().length;
            if(count == 0){
                $(this).parent().hide();
            }
        });
    });
</script>
<script type="text/javascript">
    $(function(){
        
        $("#actionsMenu.dropdown-menu").each(function(i, e){
            var count = $(e).children().length;
            if(count == 0){
                $(this).parent().hide();
            }
        });
    });
</script>
<script type="text/javascript">
    $(function(){
        
        $("#actionsMenu.dropdown-menu").each(function(i, e){
            var count = $(e).children().length;
            if(count == 0){
                $(this).parent().hide();
            }
        });
    });
</script>
...
```

Solved by adding a name to the script.

