### PR TITLE
Hide Content Type filter when using Admin Menus Content Type feature

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -188,14 +188,18 @@ namespace OrchardCore.Contents.Controllers
 
             //if ContentTypeOptions is not initialized by query string or by the code above, initialize it
             if (model.Options.ContentTypeOptions == null)
+            {
                 model.Options.ContentTypeOptions = new List<SelectListItem>();
+            }
 
             // With the model populated we filter the query, allowing the filters to alter the model.
             var query = await _contentsAdminListQueryService.QueryAsync(model.Options, _updateModelAccessor.ModelUpdater);
 
             var maxPagedCount = siteSettings.MaxPagedCount;
             if (maxPagedCount > 0 && pager.PageSize > maxPagedCount)
+            {
                 pager.PageSize = maxPagedCount;
+            }
 
             // We prepare the pager
             var routeData = new RouteData();

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -157,7 +157,7 @@ namespace OrchardCore.Contents.Controllers
             };
 
             // When using the AdminMenus ContentTypes Feature and specifying a Content Type hide the 'Content Type' filter.
-            if (string.IsNullOrEmpty(contentTypeId) && model.Options.ContentTypeOptions == null)
+            if (String.IsNullOrEmpty(contentTypeId) && model.Options.ContentTypeOptions == null)
             {
                 var listableTypes = new List<ContentTypeDefinition>();
                 foreach (var ctd in _contentDefinitionManager.ListTypeDefinitions())

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -156,7 +156,7 @@ namespace OrchardCore.Contents.Controllers
                 new SelectListItem() { Text = S["Delete"], Value = nameof(ContentsBulkAction.Remove) }
             };
 
-            //doesn't fill model.Options.ContentTypeOptions to hide "Content Type" filter on the right side of the interface, because user viewing a list of a specific contenttype items
+            // When using the AdminMenus ContentTypes Feature and specifying a Content Type hide the 'Content Type' filter.
             if (string.IsNullOrEmpty(contentTypeId) && model.Options.ContentTypeOptions == null)
             {
                 var listableTypes = new List<ContentTypeDefinition>();

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList-Filters.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList-Filters.cshtml
@@ -4,8 +4,10 @@
 }
 <div class="form-group mb-n1 filter">
     <div class="btn-group mt-1">
-        <select asp-for="SelectedContentType" asp-items="Model.ContentTypeOptions" class="selectpicker contenttypes-selectpicker show-tick mr-2" data-header="@T["Filter by content type"]" data-live-search="true" data-selected-text-format="static" data-width="fit" title="@T["Content Type"]" data-style="btn-sm">
-        </select>
+        @if(Model.ContentTypeOptions.Any()){
+            <select asp-for="SelectedContentType" asp-items="Model.ContentTypeOptions" class="selectpicker contenttypes-selectpicker show-tick mr-2" data-header="@T["Filter by content type"]" data-live-search="true" data-selected-text-format="static" data-width="fit" title="@T["Content Type"]" data-style="btn-sm">
+            </select>
+        }
         <select asp-for="ContentsStatus" asp-items="@Model.ContentStatuses" class="selectpicker contentstatuses-selectpicker show-tick mr-2" data-header="@T["Filter by status"]" data-selected-text-format="static" data-width="fit" data-dropdown-align-right="true" title="@T["Show"]" data-style="btn-sm"></select>
         <select asp-for="OrderBy" asp-items="@Model.ContentSorts" class="selectpicker contentsorts-selectpicker show-tick" data-header="@T["Sort by"]" data-width="fit" data-selected-text-format="static" data-dropdown-align-right="true" title="@T["Sort"]" data-style="btn-sm"></select>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList-Filters.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList-Filters.cshtml
@@ -4,7 +4,8 @@
 }
 <div class="form-group mb-n1 filter">
     <div class="btn-group mt-1">
-        @if(Model.ContentTypeOptions.Any()){
+        @if(Model.ContentTypeOptions.Any())
+        {
             <select asp-for="SelectedContentType" asp-items="Model.ContentTypeOptions" class="selectpicker contenttypes-selectpicker show-tick mr-2" data-header="@T["Filter by content type"]" data-live-search="true" data-selected-text-format="static" data-width="fit" title="@T["Content Type"]" data-style="btn-sm">
             </select>
         }


### PR DESCRIPTION
Fixes #7094 

When contentTypeId have a value means the user want to list the items of a specific content type and the ContentType filter is not necessary. I have left the possiblity to set up ContentTypeOptions from the query string.