### PR TITLE
ImageSharp.Web RTM

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,7 @@
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <!-- This feed should not be used when shipping on NuGet. It should just be used in the dev branch while dependencies are not available on NuGet.org -->
     <!--<add key="OrchardCore" value="https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json" />-->
+    <add key="MyGetIS" value="https://www.myget.org/F/sixlabors/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,7 +5,6 @@
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <!-- This feed should not be used when shipping on NuGet. It should just be used in the dev branch while dependencies are not available on NuGet.org -->
     <!--<add key="OrchardCore" value="https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json" />-->
-    <add key="MyGetIS" value="https://www.myget.org/F/sixlabors/api/v3/index.json" />
   </packageSources>
   <disabledPackageSources />
 </configuration>

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -35,7 +35,7 @@
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-rc2-108003" />
     <PackageManagement Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageManagement Include="Shortcodes" Version="1.0.0-beta-175913881" />
-    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.0-rc.3.16" />
+    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.0-rc.3.17" />
     <PackageManagement Include="xunit.analyzers" Version="0.10.0" />
     <PackageManagement Include="xunit" Version="2.4.1" />
     <PackageManagement Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -35,7 +35,7 @@
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-rc2-108003" />
     <PackageManagement Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageManagement Include="Shortcodes" Version="1.0.0-beta-175913881" />
-    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.0-rc0003" />
+    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.0-rc.3.16" />
     <PackageManagement Include="xunit.analyzers" Version="0.10.0" />
     <PackageManagement Include="xunit" Version="2.4.1" />
     <PackageManagement Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -35,7 +35,7 @@
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-rc2-108003" />
     <PackageManagement Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageManagement Include="Shortcodes" Version="1.0.0-beta-175913881" />
-    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.0-rc.3.17" />
+    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.0" />
     <PackageManagement Include="xunit.analyzers" Version="0.10.0" />
     <PackageManagement Include="xunit" Version="2.4.1" />
     <PackageManagement Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
@@ -55,6 +55,8 @@ namespace OrchardCore.Media.Filters
             var width = arguments["width"].Or(arguments.At(0));
             var height = arguments["height"].Or(arguments.At(1));
             var mode = arguments["mode"].Or(arguments.At(2));
+            var quality = arguments["quality"].Or(arguments.At(3));
+            var format = arguments["format"].Or(arguments.At(4));
 
             if (!width.IsNil())
             {
@@ -69,6 +71,16 @@ namespace OrchardCore.Media.Filters
             if (!mode.IsNil())
             {
                 queryStringParams.Add("rmode", mode.ToStringValue());
+            }
+
+            if (!quality.IsNil())
+            {
+                queryStringParams.Add("quality", quality.ToStringValue());
+            }
+
+            if (!format.IsNil())
+            {
+                queryStringParams.Add("format", format.ToStringValue());
             }
 
             return new ValueTask<FluidValue>(new StringValue(QueryHelpers.AddQueryString(url, queryStringParams)));

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -13,9 +13,20 @@ namespace OrchardCore.Media.Processing
         Stretch
     }
 
+    public enum Format
+    {
+        Undefined,
+        Bmp,
+        Gif,
+        Jpg,
+        Png,
+        Tga
+
+    }
+
     internal class ImageSharpUrlFormatter
     {
-        public static string GetImageResizeUrl(string path, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
+        public static string GetImageResizeUrl(string path, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined)
         {
             if (string.IsNullOrEmpty(path) || (!width.HasValue && !height.HasValue))
             {
@@ -38,6 +49,16 @@ namespace OrchardCore.Media.Processing
             if (resizeMode != ResizeMode.Undefined)
             {
                 query["rmode"] = resizeMode.ToString().ToLower();
+            }
+
+            if (quality.HasValue)
+            {
+                query["quality"] = quality.ToString();
+            }
+
+            if (format != Format.Undefined)
+            {
+                query["format"] = format.ToString().ToLower();
             }
 
             return $"{pathParts[0]}?{query.ToString()}";

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -21,7 +21,6 @@ namespace OrchardCore.Media.Processing
         Jpg,
         Png,
         Tga
-
     }
 
     internal class ImageSharpUrlFormatter

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageVersionProcessor.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageVersionProcessor.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp.Web;
+using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.Processors;
 
 namespace OrchardCore.Media.Processing
@@ -14,7 +16,7 @@ namespace OrchardCore.Media.Processing
 
         public IEnumerable<string> Commands => VersionCommands;
 
-        public FormattedImage Process(FormattedImage image, ILogger logger, IDictionary<string, string> commands)
+        public FormattedImage Process(FormattedImage image, ILogger logger, IDictionary<string, string> commands, CommandParser parser, CultureInfo culture)
             => image;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaImageSharpConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaImageSharpConfiguration.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.Middleware;
@@ -20,10 +22,10 @@ namespace OrchardCore.Media.Processing
         public void Configure(ImageSharpMiddlewareOptions options)
         {
             options.Configuration = Configuration.Default;
-            options.MaxBrowserCacheDays = _mediaOptions.MaxBrowserCacheDays;
-            options.MaxCacheDays = _mediaOptions.MaxCacheDays;
+            options.BrowserMaxAge = TimeSpan.FromDays(_mediaOptions.MaxBrowserCacheDays);
+            options.CacheMaxAge = TimeSpan.FromDays(_mediaOptions.MaxCacheDays);
             options.CachedNameLength = 12;
-            options.OnParseCommands = validation =>
+            options.OnParseCommandsAsync = validation =>
             {
                 // Force some parameters to prevent disk filling.
                 // For more advanced resize parameters the usage of profiles will be necessary.
@@ -43,9 +45,9 @@ namespace OrchardCore.Media.Processing
                         validation.Commands[ResizeWebProcessor.Mode] = "max";
                     }
                 }
+
+                return Task.CompletedTask;
             };
-            options.OnProcessed = _ => { };
-            options.OnPrepareResponse = _ => { };
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
@@ -34,8 +34,8 @@ public static class OrchardRazorHelperExtensions
     /// <summary>
     /// Returns a URL with custom resizing parameters for an existing image path.
     /// </summary>
-    public static string ImageResizeUrl(this IOrchardHelper orchardHelper, string imagePath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined)
+    public static string ImageResizeUrl(this IOrchardHelper orchardHelper, string imagePath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined)
     {
-        return ImageSharpUrlFormatter.GetImageResizeUrl(imagePath, width, height, resizeMode);
+        return ImageSharpUrlFormatter.GetImageResizeUrl(imagePath, width, height, resizeMode, quality, format);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
@@ -9,7 +9,7 @@ public static class OrchardRazorHelperExtensions
     /// <summary>
     /// Returns the relative URL of the specifier asset path with optional resizing parameters.
     /// </summary>
-    public static string AssetUrl(this IOrchardHelper orchardHelper, string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, bool appendVersion = false)
+    public static string AssetUrl(this IOrchardHelper orchardHelper, string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, bool appendVersion = false, int? quality = null, Format format = Format.Undefined)
     {
         var mediaFileStore = orchardHelper.HttpContext.RequestServices.GetService<IMediaFileStore>();
 
@@ -20,7 +20,7 @@ public static class OrchardRazorHelperExtensions
 
         var resolvedAssetPath = mediaFileStore.MapPathToPublicUrl(assetPath);
 
-        var resizedUrl = orchardHelper.ImageResizeUrl(resolvedAssetPath, width, height, resizeMode);
+        var resizedUrl = orchardHelper.ImageResizeUrl(resolvedAssetPath, width, height, resizeMode, quality, format);
 
         if (appendVersion)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Shortcodes/ImageShortcodeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Shortcodes/ImageShortcodeProvider.cs
@@ -80,6 +80,8 @@ namespace OrchardCore.Media.Shortcodes
                 var width = arguments.Named("width");
                 var height = arguments.Named("height");
                 var mode = arguments.Named("mode");
+                var quality = arguments.Named("quality");
+                var format = arguments.Named("format");
                 className = arguments.Named("class");
                 altText = arguments.Named("alt");
 
@@ -96,6 +98,16 @@ namespace OrchardCore.Media.Shortcodes
                 if (mode != null)
                 {
                     queryStringParams.Add("rmode", mode);
+                }
+
+                if (quality != null)
+                {
+                    queryStringParams.Add("quality", quality);
+                }
+
+                if (format != null)
+                {
+                    queryStringParams.Add("format", format);
                 }
 
                 if (className != null)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -133,7 +133,6 @@ namespace OrchardCore.Media
             services.AddTransient<IConfigureOptions<ImageSharpMiddlewareOptions>, MediaImageSharpConfiguration>();
 
             services.AddImageSharp()
-                .SetMemoryAllocator<ArrayPoolMemoryAllocator>()
                 .RemoveProvider<PhysicalFileSystemProvider>()
                 .AddProvider<MediaResizingFileProvider>()
                 .AddProcessor<ImageVersionProcessor>();

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -8,10 +8,8 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.Net.Http.Headers;
 using OrchardCore.Admin;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
@@ -46,13 +44,8 @@ using OrchardCore.Navigation;
 using OrchardCore.Recipes;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Shortcodes;
-using Shortcodes;
-using SixLabors.ImageSharp.Memory;
-using SixLabors.ImageSharp.Web.Caching;
-using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.DependencyInjection;
 using SixLabors.ImageSharp.Web.Middleware;
-using SixLabors.ImageSharp.Web.Processors;
 using SixLabors.ImageSharp.Web.Providers;
 
 namespace OrchardCore.Media

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -133,6 +133,7 @@ namespace OrchardCore.Media
             services.AddTransient<IConfigureOptions<ImageSharpMiddlewareOptions>, MediaImageSharpConfiguration>();
 
             services.AddImageSharp()
+                .SetMemoryAllocator<ArrayPoolMemoryAllocator>()
                 .RemoveProvider<PhysicalFileSystemProvider>()
                 .AddProvider<MediaResizingFileProvider>()
                 .AddProcessor<ImageVersionProcessor>();

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -53,6 +53,7 @@ using SixLabors.ImageSharp.Web.Commands;
 using SixLabors.ImageSharp.Web.DependencyInjection;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Processors;
+using SixLabors.ImageSharp.Web.Providers;
 
 namespace OrchardCore.Media
 {
@@ -131,16 +132,10 @@ namespace OrchardCore.Media
             // Add ImageSharp Configuration first, to override ImageSharp defaults.
             services.AddTransient<IConfigureOptions<ImageSharpMiddlewareOptions>, MediaImageSharpConfiguration>();
 
-            services.AddImageSharpCore()
-                .SetRequestParser<QueryCollectionRequestParser>()
-                .SetMemoryAllocator<ArrayPoolMemoryAllocator>()
-                .SetCache<PhysicalFileSystemCache>()
-                .SetCacheHash<CacheHash>()
+            services.AddImageSharp()
+                .RemoveProvider<PhysicalFileSystemProvider>()
                 .AddProvider<MediaResizingFileProvider>()
-                .AddProcessor<ResizeWebProcessor>()
-                .AddProcessor<FormatWebProcessor>()
-                .AddProcessor<ImageVersionProcessor>()
-                .AddProcessor<BackgroundColorWebProcessor>();
+                .AddProcessor<ImageVersionProcessor>();
 
             // Media Field
             services.AddContentField<MediaField>()

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
@@ -14,6 +14,8 @@ namespace OrchardCore.Media.TagHelpers
         private const string ImageSizeWidthAttributeName = ImageSizeAttributePrefix + "width";
         private const string ImageSizeHeightAttributeName = ImageSizeAttributePrefix + "height";
         private const string ImageSizeModeAttributeName = ImageSizeAttributePrefix + "resize-mode";
+        private const string ImageQualityAttributeName = ImageSizeAttributePrefix + "quality";
+        private const string ImageFormatAttributeName = ImageSizeAttributePrefix + "format";
 
         [HtmlAttributeName(ImageSizeWidthAttributeName)]
         public int? ImageWidth { get; set; }
@@ -21,8 +23,14 @@ namespace OrchardCore.Media.TagHelpers
         [HtmlAttributeName(ImageSizeHeightAttributeName)]
         public int? ImageHeight { get; set; }
 
+        [HtmlAttributeName(ImageQualityAttributeName)]
+        public int? ImageQuality { get; set; }
+
         [HtmlAttributeName(ImageSizeModeAttributeName)]
         public ResizeMode ResizeMode { get; set; }
+
+        [HtmlAttributeName(ImageFormatAttributeName)]
+        public Format ImageFormat { get; set; }
 
         [HtmlAttributeName("src")]
         public string Src { get; set; }
@@ -41,7 +49,7 @@ namespace OrchardCore.Media.TagHelpers
                 return;
             }
 
-            var resizedSrc = ImageSharpUrlFormatter.GetImageResizeUrl(imgSrc, ImageWidth, ImageHeight, ResizeMode);
+            var resizedSrc = ImageSharpUrlFormatter.GetImageResizeUrl(imgSrc, ImageWidth, ImageHeight, ResizeMode, ImageQuality, ImageFormat);
             output.Attributes.SetAttribute("src", resizedSrc);
         }
     }

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -99,13 +99,36 @@ Stretches the resized image to fit the bounds of its container.
 
 Resizes the image using the same functionality as `max` then removes any image area falling outside the bounds of its container.
 
-### mode Input
+#### mode Input
 
 `{{ 'animals/kittens.jpg' | asset_url | resize_url: width:100, height:240, mode:'crop' }}`
 
-### mode Output
+#### mode Output
 
 `<img src="~/media/animals/kittens.jpg?width=100&height=240&rmode=crop" />`
+
+#### `quality` (or fourth argument)
+
+The quality used when compressing the image.
+
+!!! note
+    The quality argument is only supported for `JPG` images, but can be combined with the `format` argument to convert to `JPG`
+
+#### `format` (or fifth argument)
+
+The image format to use when processing the ouput of an image.
+
+Supported formats include `bmp`, `gif`, `jpg`, `png`, `tga`.
+
+Can be combined with the `quality` argument to convert an image to a `JPG` and reduce the quality.
+
+#### quality/format Input
+
+`{{ 'animals/kittens.jpg' | asset_url | resize_url: width:100, height:240, mode:'crop', quality: 50, format:'jpg' }}`
+
+#### quality/format Output
+
+`<img src="~/media/animals/kittens.jpg?width=100&height=240&rmode=crop&quality=50&format=jpg" />`
 
 ### `append_version`
 
@@ -129,6 +152,10 @@ To obtain the correct URL for a resized asset use `AssetUrl` with the optional w
 
 `@Orchard.AssetUrl(Model.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Crop)`
 
+To obtain the correct URL for a resized asset use `AssetUrl` with the optional width, height, resizeMode, quality and format parameters, e.g.:
+
+`@Orchard.AssetUrl(Model.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Crop, quality: 50, format: Format.Jpg)`
+
 To append a version hash for an asset use `AssetUrl` with the append version parameter, e.g.:
 
 `@Orchard.AssetUrl(Model.Paths[0], appendVersion: true)`
@@ -139,15 +166,15 @@ or with resizing options as well, noting that the version hash is based on the s
 
 ### Razor image resizing tag helpers
 
-To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to `_ViewImports.cshtml`.
+To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to `_ViewImports.cshtml`, and take a direct reference to the `OrchardCore.Media` nuget package.
 
-`asset-src` is used to obtain the correct URL for the asset and set the `src` attribute. Width, height and resize mode can be set using `img-width`, `img-height` and `img-resize-mode` respectively. e.g.:
+`asset-src` is used to obtain the correct URL for the asset and set the `src` attribute. Width, height, resize mode, quality and format can be set using `img-width`, `img-height`, `img-resize-mode`, `img-quality`, and `img-format` respectively. e.g.:
 
-`<img asset-src="Model.Paths[0]" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" />`
+`<img asset-src="Model.Paths[0]" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" img-quality="50" img-format="Jpg" />`
 
 Alternatively the Asset Url can be resolved independently and the `src` attribute used:
 
-`<img src="@Orchard.AssetUrl(Model.Paths[0])" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" />`
+`<img src="@Orchard.AssetUrl(Model.Paths[0])" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" img-quality="50" img-format="Jpg" />`
 
 ### Razor append version
 
@@ -164,6 +191,9 @@ Or when using the MVC tag helpers and the image is resolved from static assets, 
 `<img src="/favicon.ico" asp-append-version="true"/>`
 
 > The Razor Helper is accessible on the `Orchard` property if the view is using Orchard Core's Razor base class, or by injecting `OrchardCore.IOrchardHelper` in all other cases.
+
+!!! note
+    When using tag helpers in Razor you must take a direct reference to the `OrchardCore.Media` nuget package in each theme or module that uses the tag helpers. This is not required when using Liquid.
 
 ## Deployment Step Editor
 

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -193,7 +193,7 @@ Or when using the MVC tag helpers and the image is resolved from static assets, 
 > The Razor Helper is accessible on the `Orchard` property if the view is using Orchard Core's Razor base class, or by injecting `OrchardCore.IOrchardHelper` in all other cases.
 
 !!! note
-    When using tag helpers in Razor you must take a direct reference to the `OrchardCore.Media` nuget package in each theme or module that uses the tag helpers. This is not required when using Liquid.
+    When using tag helpers in Razor, you must take a direct reference to the `OrchardCore.Media` nuget package in each theme or module that uses the tag helpers. This is not required when using Liquid.
 
 ## Deployment Step Editor
 


### PR DESCRIPTION
`ImageSharp.Web` is currently going through many improvements to the image processing pipeline and a release to RTM

New features included:
- Format support to the Tag Helpers / Liquid Filters
The slight weirdness with adding this is the file extension on the url will remain .png, but the image will be returned with the correct mime/type, so I like it.
- Quality support to jpg encoding and Tag Helpers / Liquid Filters
The Quality support allows you to specify a quality % to jpg encoding.
Note: only jpg encoding is supported, but the Format support allows you to convert an image from say png, to jpg, and then reduce the quality.

- CurrentCulture / InvariantCulture for query string parameters.
Supported through custom ImageSharp configuration, but not integrated into OrchardCore.
Basing this decision primarily on the idea that most of our resizing / processing query string building, is done through templates, which are culture invariant.
Open to opinions on this choice.

@JimBobSquarePants LRUCache performing awesome :)

/cc @dodyg I know you've been asking about compression ratios.

