### PR TITLE
Prevent disabling or removing administrator role

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -194,7 +194,7 @@ namespace OrchardCore.Users.Drivers
                     foreach (var role in rolesToRemove)
                     {
                         // Make sure we always have at least one administrator account
-                        if(usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName && role == "Administrator")
+                        if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName && role == "Administrator")
                         {
                             _notifier.Warning(H["Cannot remove administrator role from unique administrator."]);
                             continue;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -83,6 +83,7 @@ namespace OrchardCore.Users.Drivers
         public override async Task<IDisplayResult> UpdateAsync(User user, UpdateEditorContext context)
         {
             var model = new EditUserViewModel();
+            var httpContext = _httpContextAccessor.HttpContext;
 
             if (!await context.Updater.TryUpdateModelAsync(model, Prefix))
             {
@@ -95,7 +96,7 @@ namespace OrchardCore.Users.Drivers
             var usersOfAdminRole = await _userManager.GetUsersInRoleAsync("Administrator");
             if (!model.IsEnabled && user.IsEnabled)
             {
-                if (user.UserName != _httpContextAccessor.HttpContext.User.Identity.Name)
+                if (user.UserName != httpContext.User.Identity.Name)
                 {
                     if(usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
                     {
@@ -140,7 +141,7 @@ namespace OrchardCore.Users.Drivers
                 }
             }
 
-            if (model.UserName != user.UserName && user.UserName == _httpContextAccessor.HttpContext.User.Identity.Name)
+            if (model.UserName != user.UserName && user.UserName == httpContext.User.Identity.Name)
             {
                 context.Updater.ModelState.AddModelError(string.Empty, S["Cannot modify user name of the currently logged in user."]);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -98,7 +98,7 @@ namespace OrchardCore.Users.Drivers
             {
                 if (user.UserName != httpContext.User.Identity.Name)
                 {
-                    if(usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
+                    if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
                     {
                         _notifier.Warning(H["Cannot disable unique administrator."]);
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -29,6 +29,7 @@ namespace OrchardCore.Users.Drivers
         private readonly ILogger _logger;
         private readonly IStringLocalizer S;
         private readonly IHtmlLocalizer H;
+        private static readonly string _administratorRole = "Administrator";
 
         public UserDisplayDriver(
             UserManager<IUser> userManager,
@@ -48,7 +49,6 @@ namespace OrchardCore.Users.Drivers
             _notifier = notifier;
             _logger = logger;
             Handlers = handlers;
-
             H = htmlLocalizer;
             S = stringLocalizer;
         }
@@ -93,7 +93,7 @@ namespace OrchardCore.Users.Drivers
             model.UserName = model.UserName?.Trim();
             model.Email = model.Email?.Trim();
 
-            var usersOfAdminRole = await _userManager.GetUsersInRoleAsync("Administrator");
+            var usersOfAdminRole = await _userManager.GetUsersInRoleAsync(_administratorRole);
             if (!model.IsEnabled && user.IsEnabled)
             {
                 if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
@@ -192,7 +192,7 @@ namespace OrchardCore.Users.Drivers
                     foreach (var role in rolesToRemove)
                     {
                         // Make sure we always have at least one administrator account
-                        if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName && role == "Administrator")
+                        if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName && role == _administratorRole)
                         {
                             _notifier.Warning(H["Cannot remove administrator role from the only administrator."]);
                             continue;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -194,7 +194,7 @@ namespace OrchardCore.Users.Drivers
                         // Make sure we always have at least one administrator account
                         if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName && role == "Administrator")
                         {
-                            _notifier.Warning(H["Cannot remove administrator role from unique administrator."]);
+                            _notifier.Warning(H["Cannot remove administrator role from the only administrator."]);
                             continue;
                         }
                         else

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -98,7 +98,7 @@ namespace OrchardCore.Users.Drivers
             {
                 if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
                 {
-                    _notifier.Warning(H["Cannot disable the super administrator."]);
+                    _notifier.Warning(H["Cannot disable the only administrator."]);
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Modules;
 using OrchardCore.Security.Services;
@@ -21,22 +24,32 @@ namespace OrchardCore.Users.Drivers
         private readonly UserManager<IUser> _userManager;
         private readonly IRoleService _roleService;
         private readonly IUserRoleStore<IUser> _userRoleStore;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly INotifier _notifier;
         private readonly ILogger _logger;
         private readonly IStringLocalizer S;
+        private readonly IHtmlLocalizer H;
 
         public UserDisplayDriver(
             UserManager<IUser> userManager,
             IRoleService roleService,
             IUserRoleStore<IUser> userRoleStore,
+            IHttpContextAccessor httpContextAccessor,
+            INotifier notifier,
             ILogger<UserDisplayDriver> logger,
             IEnumerable<IUserEventHandler> handlers,
+            IHtmlLocalizer<UserDisplayDriver> htmlLocalizer,
             IStringLocalizer<UserDisplayDriver> stringLocalizer)
         {
             _userManager = userManager;
             _roleService = roleService;
             _userRoleStore = userRoleStore;
+            _httpContextAccessor = httpContextAccessor;
+            _notifier = notifier;
             _logger = logger;
             Handlers = handlers;
+
+            H = htmlLocalizer;
             S = stringLocalizer;
         }
 
@@ -79,11 +92,27 @@ namespace OrchardCore.Users.Drivers
             model.UserName = model.UserName?.Trim();
             model.Email = model.Email?.Trim();
 
+            var usersOfAdminRole = await _userManager.GetUsersInRoleAsync("Administrator");
             if (!model.IsEnabled && user.IsEnabled)
             {
-                user.IsEnabled = model.IsEnabled;
-                var userContext = new UserContext(user);
-                await Handlers.InvokeAsync((handler, context) => handler.DisabledAsync(userContext), userContext, _logger);
+                if (user.UserName != _httpContextAccessor.HttpContext.User.Identity.Name)
+                {
+                    if(usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
+                    {
+                        _notifier.Warning(H["Cannot disable unique administrator."]);
+
+                    }
+                    else
+                    {
+                        user.IsEnabled = model.IsEnabled;
+                        var userContext = new UserContext(user);
+                        await Handlers.InvokeAsync((handler, context) => handler.DisabledAsync(userContext), userContext, _logger);
+                    }
+                }
+                else
+                {
+                    _notifier.Warning(H["Cannot disable current user."]);
+                }
             }
             else if (model.IsEnabled && !user.IsEnabled)
             {
@@ -112,6 +141,11 @@ namespace OrchardCore.Users.Drivers
                 }
             }
 
+            if (model.UserName != user.UserName && user.UserName == _httpContextAccessor.HttpContext.User.Identity.Name)
+            {
+                context.Updater.ModelState.AddModelError(string.Empty, S["Cannot modify user name of the currently logged in user."]);
+            }
+
             var userWithSameEmail = await _userManager.FindByEmailAsync(model.Email);
             if (userWithSameEmail != null)
             {
@@ -121,6 +155,8 @@ namespace OrchardCore.Users.Drivers
                     context.Updater.ModelState.AddModelError(string.Empty, S["The email is already used."]);
                 }
             }
+
+            
 
             if (context.Updater.ModelState.IsValid)
             {
@@ -157,7 +193,16 @@ namespace OrchardCore.Users.Drivers
 
                     foreach (var role in rolesToRemove)
                     {
-                        await _userRoleStore.RemoveFromRoleAsync(user, _userManager.NormalizeName(role), default(CancellationToken));
+                        // Make sure we always have at least one administrator account
+                        if(usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName && role == "Administrator")
+                        {
+                            _notifier.Warning(H["Cannot remove administrator role from unique administrator."]);
+                            continue;
+                        }
+                        else
+                        {
+                            await _userRoleStore.RemoveFromRoleAsync(user, _userManager.NormalizeName(role), default(CancellationToken));
+                        }
                     }
 
                     // Add new roles

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -100,7 +100,7 @@ namespace OrchardCore.Users.Drivers
                 {
                     if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
                     {
-                        _notifier.Warning(H["Cannot disable unique administrator."]);
+                        _notifier.Warning(H["Cannot disable the super administrator."]);
                     }
                     else
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -96,22 +96,22 @@ namespace OrchardCore.Users.Drivers
             var usersOfAdminRole = await _userManager.GetUsersInRoleAsync("Administrator");
             if (!model.IsEnabled && user.IsEnabled)
             {
-                if (user.UserName != httpContext.User.Identity.Name)
+                if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
                 {
-                    if (usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
-                    {
-                        _notifier.Warning(H["Cannot disable the super administrator."]);
-                    }
-                    else
+                    _notifier.Warning(H["Cannot disable the super administrator."]);
+                }
+                else
+                {
+                    if (user.UserName != httpContext.User.Identity.Name)
                     {
                         user.IsEnabled = model.IsEnabled;
                         var userContext = new UserContext(user);
                         await Handlers.InvokeAsync((handler, context) => handler.DisabledAsync(userContext), userContext, _logger);
                     }
-                }
-                else
-                {
-                    _notifier.Warning(H["Cannot disable current user."]);
+                    else
+                    {
+                        _notifier.Warning(H["Cannot disable current user."]);
+                    }
                 }
             }
             else if (model.IsEnabled && !user.IsEnabled)
@@ -155,8 +155,6 @@ namespace OrchardCore.Users.Drivers
                     context.Updater.ModelState.AddModelError(string.Empty, S["The email is already used."]);
                 }
             }
-
-            
 
             if (context.Updater.ModelState.IsValid)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -100,7 +100,6 @@ namespace OrchardCore.Users.Drivers
                     if(usersOfAdminRole.Count == 1 && usersOfAdminRole.First().UserName == user.UserName)
                     {
                         _notifier.Warning(H["Cannot disable unique administrator."]);
-
                     }
                     else
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserFields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserFields.Edit.cshtml
@@ -44,14 +44,7 @@
     @for (var i = 0; i < Model.Roles.Length; i++)
     {
         <div class="custom-control custom-checkbox">
-            @if (Model.UserName == User.Identity.Name)
-            {
-                <input asp-for="Roles[i].IsSelected" type="checkbox" class="custom-control-input" disabled>
-            }
-            else
-            {
-                <input asp-for="Roles[i].IsSelected" type="checkbox" class="custom-control-input">
-            }
+            <input asp-for="Roles[i].IsSelected" type="checkbox" class="custom-control-input">
             <input type="hidden" asp-for="Roles[i].Role" />
             <label class="custom-control-label cursor-pointer" asp-for="Roles[i].IsSelected">@Model.Roles[i].Role</label>
         </div>
@@ -60,14 +53,7 @@
 
 <div class="form-group">
     <div class="custom-control custom-switch">
-        @if (Model.UserName == User.Identity.Name)
-        {
-            <input asp-for="IsEnabled" type="checkbox" class="custom-control-input" checked="@Model.IsEnabled" disabled />
-        }
-        else
-        {
-            <input asp-for="IsEnabled" type="checkbox" class="custom-control-input" checked="@Model.IsEnabled" />
-        }
+        <input asp-for="IsEnabled" type="checkbox" class="custom-control-input" checked="@Model.IsEnabled" />
         <label asp-for="IsEnabled" class="custom-control-label cursor-pointer">@T["Is enabled?"]</label>
         <span class="hint">— @T["Uncheck to disable this user account."]</span>
     </div>


### PR DESCRIPTION
Add validations to prevent disabling or removing administrator role on the last user account marked as so.

Closes #7125 