### PR TITLE
Generate display-for link using url in PreviewPart

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Handlers/PreviewPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Handlers/PreviewPartHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Fluid;
-using Microsoft.AspNetCore.Routing;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
@@ -43,37 +42,18 @@ namespace OrchardCore.ContentPreview.Handlers
 
             if (!String.IsNullOrEmpty(pattern))
             {
-                string previewUrl = null;
-
-                var model = new PreviewPartViewModel()
+                await context.ForAsync<PreviewAspect>(async previewAspect =>
                 {
-                    PreviewPart = part,
-                    ContentItem = part.ContentItem
-                };
-
-                previewUrl = await _liquidTemplateManager.RenderAsync(pattern, NullEncoder.Default, model,
-                    scope => scope.SetValue("ContentItem", model.ContentItem));
-
-                previewUrl = previewUrl.Replace("\r", String.Empty).Replace("\n", String.Empty);
-
-                await context.ForAsync<PreviewAspect>(previewAspect =>
-                 {
-                     previewAspect.PreviewUrl = previewUrl;
-                     return Task.CompletedTask;
-                 });
-                await context.ForAsync<ContentItemMetadata>(metadata =>
-                {
-                    if (metadata.DisplayRouteValues == null)
+                    var model = new PreviewPartViewModel()
                     {
-                        metadata.DisplayRouteValues = new RouteValueDictionary {
-                            {"PreviewUrl", previewUrl}
-                        };
-                    }
-                    else
-                    {
-                        metadata.DisplayRouteValues.Add("PreviewUrl", previewUrl);
-                    }
-                    return Task.CompletedTask;
+                        PreviewPart = part,
+                        ContentItem = part.ContentItem
+                    };
+
+                    previewAspect.PreviewUrl = await _liquidTemplateManager.RenderAsync(pattern, NullEncoder.Default, model,
+                        scope => scope.SetValue("ContentItem", model.ContentItem));
+
+                    previewAspect.PreviewUrl = previewAspect.PreviewUrl.Replace("\r", String.Empty).Replace("\n", String.Empty);
                 });
             }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/PreviewAspect.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/PreviewAspect.cs
@@ -1,4 +1,4 @@
-namespace OrchardCore.ContentPreview.Models
+namespace OrchardCore.ContentManagement
 {
     public class PreviewAspect
     {

--- a/src/OrchardCore/OrchardCore.Contents.TagHelpers/ContentLinkTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.TagHelpers/ContentLinkTagHelper.cs
@@ -89,9 +89,29 @@ namespace OrchardCore.Contents.TagHelpers
                     return;
                 }
 
-                ApplyRouteValues(tagHelperContext, metadata.DisplayRouteValues);
+                if (metadata.DisplayRouteValues.ContainsKey("PreviewUrl"))
+                {
+                    var previewUrl = metadata.DisplayRouteValues["PreviewUrl"].ToString();
+                    if (!previewUrl.StartsWith('~'))
+                    {
+                        if (previewUrl.StartsWith('/'))
+                        {
+                            previewUrl = '~' + previewUrl;
+                        }
+                        else
+                        {
+                            previewUrl = "~/" + previewUrl;
+                        }
+                    }
 
-                output.Attributes.SetAttribute("href", urlHelper.Action(metadata.DisplayRouteValues["action"].ToString(), metadata.DisplayRouteValues));
+                    output.Attributes.SetAttribute("href", urlHelper.Content(previewUrl));
+                }
+                else
+                {
+                    ApplyRouteValues(tagHelperContext, metadata.DisplayRouteValues);
+
+                    output.Attributes.SetAttribute("href", urlHelper.Action(metadata.DisplayRouteValues["action"].ToString(), metadata.DisplayRouteValues));
+                }
             }
             else if (EditFor != null)
             {


### PR DESCRIPTION
ContentLinkTagHelper - Display-For   generates `View` based on `AdminController` in  `Content`.
However in decoupled scenario, the actual `view` is different and can be configured in `PreviewPart`.

Generating `display-for` link using url configured in PreviewPart.

Fixes: #6338