### PR TITLE
Update UseCDN  default value

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/SiteSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/SiteSettings.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Settings
         public string SiteSalt { get; set; }
         public string PageTitleFormat { get; set; }
         public string SuperUser { get; set; }
-        public bool UseCdn { get; set; } = true;
+        public bool UseCdn { get; set; } = false;
         public string CdnBaseUrl { get; set; }
         public RouteValueDictionary HomeRoute { get; set; } = new RouteValueDictionary();
         public bool AppendVersion { get; set; } = true;


### PR DESCRIPTION
I think it should be set to false, because in some cases (such as internal networks), the CDN server is not always available.
For example, I am from China. My network problem directly caused me to be unable to access some key js file resources, which also caused me to be unable to click the login button. Even if the login is successful, I cannot expand the settings menu.