### PR TITLE
Small update to the docs for layers

### DIFF
--- a/src/docs/reference/modules/Layers/README.md
+++ b/src/docs/reference/modules/Layers/README.md
@@ -4,12 +4,12 @@ The layers can be managed from the `Design > Widgets` page in the admin.
 
 A layer has a name, a description and a rule in which you specify a condition to render the widgets that will be associated to this layer.
 
-When you add a widget into a zone, you can select the associated Layer for which the widget will be displayed if the corresponding display rule is valid.
+When you add a widget into a zone, you must also select a Layer to associate the widget with. The widget is displayed if the layer's corresponding display rule evaluates to true.
 
 You can select the checkbox next to each layer in order to highlight the associated Widgets on the left.
 
-In the rule, you can use a javascript function that will return a boolean.  
-Ex: The `Always` rule has the rule set to `true`.
+In the rule, you can use a javascript function that will return a boolean, or you could just use a boolean.  
+Ex: The `Always` layer has the rule set to `true`, so widgets on this layer will always be shown.
 
 ## Rules
 


### PR DESCRIPTION
Update the docs for layers to make the Always layer rule clearer.

The Always layer was referred to as the Always rule.

I made this change after I got confused by this part of the docs. While using the blank template with no pre defined layers I tried to make my own layer called 'All pages' where I typed 'always' as the rule, only to be told there was no rule called always. @sebastienros explained my mistake to me in the forum.