### PR TITLE
Bump OpenIddict to 3.0.0-beta4.20502.55

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -30,8 +30,8 @@
     <PackageManagement Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="4.9.3" />
     <PackageManagement Include="NodaTime" Version="3.0.0" />
-    <PackageManagement Include="OpenIddict.AspNetCore" Version="[3.0.0-beta3.20403.69]" />
-    <PackageManagement Include="OpenIddict.Core" Version="[3.0.0-beta3.20403.69]" />
+    <PackageManagement Include="OpenIddict.AspNetCore" Version="[3.0.0-beta4.20502.55]" />
+    <PackageManagement Include="OpenIddict.Core" Version="[3.0.0-beta4.20502.55]" />
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-rc2-108003" />
     <PackageManagement Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageManagement Include="Shortcodes" Version="1.0.0-beta-175913881" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
@@ -118,11 +118,11 @@ namespace OrchardCore.OpenId.Configuration
             options.EnableTokenEndpointPassthrough = true;
             options.EnableUserinfoEndpointPassthrough = true;
 
-            // Note: caching is enabled for both the authorization and logout endpoints to allow sending
+            // Note: caching is enabled for both authorization and logout requests to allow sending
             // large POST authorization and logout requests, but can be programmatically disabled, as the
             // authorization and logout views support flowing the entire payload and not just the request_id.
-            options.EnableAuthorizationEndpointCaching = true;
-            options.EnableLogoutEndpointCaching = true;
+            options.EnableAuthorizationRequestCaching = true;
+            options.EnableLogoutRequestCaching = true;
 
             // Note: error pass-through is enabled to allow the actions of the MVC authorization controller
             // to handle the errors returned by the interactive endpoints without relying on the generic

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Tasks/OpenIdBackgroundTask.cs
@@ -39,34 +39,21 @@ namespace OrchardCore.OpenId.Tasks
                 _logger.LogError(exception, "An error occurred while pruning X.509 certificates from the shell storage.");
             }
 
-            // Note: this background task is also responsible of automatically removing orphaned tokens/authorizations
+            // Note: this background task is responsible of automatically removing orphaned tokens/authorizations
             // (i.e tokens that are no longer valid and ad-hoc authorizations that have no valid tokens associated).
-            // Since ad-hoc authorizations and their associated tokens are removed as part of the same operation
-            // when they no longer have any token attached, it's more efficient to remove the authorizations first.
+            // Import: since tokens associated to ad-hoc authorizations are not removed as part of the same operation,
+            // the tokens MUST be deleted before removing the ad-hoc authorizations that no longer have any token.
 
             // Note: the authorization/token managers MUST be resolved from the scoped provider
             // as they depend on scoped stores that should be disposed as soon as possible.
 
-            try
-            {
-                await serviceProvider.GetRequiredService<IOpenIdAuthorizationManager>().PruneAsync(cancellationToken);
-            }
-            catch (OpenIddictExceptions.ConcurrencyException exception)
-            {
-                _logger.LogDebug(exception, "A concurrency error occurred while pruning authorizations from the database.");
-            }
-            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
-            {
-                _logger.LogDebug("The authorizations pruning task was aborted.");
-            }
-            catch (Exception exception)
-            {
-                _logger.LogError(exception, "An error occurred while pruning authorizations from the database.");
-            }
+            // Note: this task uses a hardcoded minimum token/authorization lifespan of 14 days,
+            // which matches the default value used by the OpenIddict Quartz.NET integration.
+            var threshold = DateTimeOffset.UtcNow - TimeSpan.FromDays(14);
 
             try
             {
-                await serviceProvider.GetRequiredService<IOpenIdTokenManager>().PruneAsync(cancellationToken);
+                await serviceProvider.GetRequiredService<IOpenIdTokenManager>().PruneAsync(threshold, cancellationToken);
             }
             catch (OpenIddictExceptions.ConcurrencyException exception)
             {
@@ -79,6 +66,23 @@ namespace OrchardCore.OpenId.Tasks
             catch (Exception exception)
             {
                 _logger.LogError(exception, "An error occurred while pruning tokens from the database.");
+            }
+
+            try
+            {
+                await serviceProvider.GetRequiredService<IOpenIdAuthorizationManager>().PruneAsync(threshold, cancellationToken);
+            }
+            catch (OpenIddictExceptions.ConcurrencyException exception)
+            {
+                _logger.LogDebug(exception, "A concurrency error occurred while pruning authorizations from the database.");
+            }
+            catch (OperationCanceledException exception) when (exception.CancellationToken == cancellationToken)
+            {
+                _logger.LogDebug("The authorizations pruning task was aborted.");
+            }
+            catch (Exception exception)
+            {
+                _logger.LogError(exception, "An error occurred while pruning authorizations from the database.");
             }
         }
     }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Indexes/OpenIdAuthorizationIndex.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Indexes/OpenIdAuthorizationIndex.cs
@@ -1,3 +1,4 @@
+using System;
 using OrchardCore.OpenId.YesSql.Models;
 using YesSql.Indexes;
 
@@ -7,6 +8,7 @@ namespace OrchardCore.OpenId.YesSql.Indexes
     {
         public string AuthorizationId { get; set; }
         public string ApplicationId { get; set; }
+        public DateTimeOffset? CreationDate { get; set; }
         public string Status { get; set; }
         public string Subject { get; set; }
         public string Type { get; set; }
@@ -21,6 +23,7 @@ namespace OrchardCore.OpenId.YesSql.Indexes
                 {
                     ApplicationId = authorization.ApplicationId,
                     AuthorizationId = authorization.AuthorizationId,
+                    CreationDate = authorization.CreationDate,
                     Status = authorization.Status,
                     Subject = authorization.Subject,
                     Type = authorization.Type

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Indexes/OpenIdTokenIndex.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Indexes/OpenIdTokenIndex.cs
@@ -9,6 +9,7 @@ namespace OrchardCore.OpenId.YesSql.Indexes
         public string TokenId { get; set; }
         public string ApplicationId { get; set; }
         public string AuthorizationId { get; set; }
+        public DateTimeOffset? CreationDate { get; set; }
         public DateTimeOffset? ExpirationDate { get; set; }
         public string ReferenceId { get; set; }
         public string Status { get; set; }
@@ -26,6 +27,7 @@ namespace OrchardCore.OpenId.YesSql.Indexes
                     TokenId = token.TokenId,
                     ApplicationId = token.ApplicationId,
                     AuthorizationId = token.AuthorizationId,
+                    CreationDate = token.CreationDate,
                     ExpirationDate = token.ExpirationDate,
                     ReferenceId = token.ReferenceId,
                     Status = token.Status,

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Migrations/OpenIdMigrations.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Migrations/OpenIdMigrations.cs
@@ -85,5 +85,16 @@ namespace OrchardCore.OpenId.YesSql.Migrations
 
             return 3;
         }
+
+        public int UpdateFrom3()
+        {
+            SchemaBuilder.AlterTable(nameof(OpenIdAuthorizationIndex), table => table
+                .AddColumn<DateTimeOffset>(nameof(OpenIdAuthorizationIndex.CreationDate)));
+
+            SchemaBuilder.AlterTable(nameof(OpenIdTokenIndex), table => table
+                .AddColumn<DateTimeOffset>(nameof(OpenIdTokenIndex.CreationDate)));
+
+            return 4;
+        }
     }
 }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdAuthorization.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdAuthorization.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using Newtonsoft.Json.Linq;
 
@@ -15,6 +16,11 @@ namespace OrchardCore.OpenId.YesSql.Models
         /// associated with the current authorization.
         /// </summary>
         public string ApplicationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation date of the current authorization.
+        /// </summary>
+        public DateTimeOffset? CreationDate { get; set; }
 
         /// <summary>
         /// Gets or sets the physical identifier associated with the current authorization.


### PR DESCRIPTION
OpenIddict 3.0 beta4 was released earlier today: https://kevinchalet.com/2020/10/02/introducing-quartz-net-support-and-new-languages-in-openiddict-3-0-beta4/