### PR TITLE
Null check connection string element on Setup Screen

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
@@ -256,9 +256,11 @@
         });
 
         toggleConnectionString = document.querySelector('#toggleConnectionString');
-        toggleConnectionString.addEventListener('click', function (e) {
-            togglePasswordVisibility(document.querySelector('#ConnectionString'), document.querySelector('#toggleConnectionString'))
-        });
+        if (toggleConnectionString) {
+            toggleConnectionString.addEventListener('click', function (e) {
+                togglePasswordVisibility(document.querySelector('#ConnectionString'), document.querySelector('#toggleConnectionString'))
+            });
+        }
 
         togglePassword = document.querySelector('#togglePassword');
         togglePassword.addEventListener('click', function (e) {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/Login.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/Login.cshtml
@@ -41,7 +41,7 @@
                     <div class="input-group">
                         <input asp-for="Password" class="form-control" tabindex="2" />
                         <div class="input-group-append">
-                            <button tabindex="-1" class="btn btn-outline-secondary" type="button" id="togglePassword"><i class="icon fa fa-eye"></i></button>
+                            <button tabindex="-1" class="btn btn-secondary" type="button" id="togglePassword"><i class="icon fa fa-eye"></i></button>
                         </div>
                     </div>
                     <span asp-validation-for="Password" class="text-danger"></span>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7188

Because when setting up a tenant and the connection string is not shown there is a null ref on the js.

Also brings to the forms, login screen and setup button color designs together
![Screenshot 2020-10-02 at 18 24 13](https://user-images.githubusercontent.com/13782679/94951910-013d2500-04dd-11eb-8be9-4225b0c1716b.png)

![Screenshot 2020-10-02 at 18 24 30](https://user-images.githubusercontent.com/13782679/94951883-f6829000-04dc-11eb-8bdb-2ea1927f0fd8.png)
