### PR TITLE
Fix sizing of html/markdowneditor settings to be consistent 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/HtmlFieldSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/HtmlFieldSettingsDriver.cs
@@ -18,7 +18,7 @@ namespace OrchardCore.ContentFields.Settings
                 model.SanitizeHtml = settings.SanitizeHtml;
                 model.Hint = settings.Hint;
             })
-            .Location("Content");
+            .Location("Content:20");
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentPartFieldDefinition partFieldDefinition, UpdatePartFieldEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldSettings.Edit.cshtml
@@ -1,14 +1,14 @@
 @model OrchardCore.ContentFields.ViewModels.HtmlSettingsViewModel
 
 <div class="form-group">
-    <div class="row col-sm-6">
+    <div class="w-md-50">
         <label asp-for="Hint">@T["Hint"]</label>
         <textarea asp-for="Hint" rows="2" class="form-control"></textarea>
-        <span class="hint">@T["The hint text to display for this field on the editor."]</span>
     </div>
+    <span class="hint">@T["The hint text to display for this field on the editor."]</span>
 </div>
 
-<div class="form-group col-md-6">
+<div class="form-group">
     <div class="custom-control custom-checkbox">
         <input type="checkbox" class="custom-control-input" asp-for="SanitizeHtml" checked="@Model.SanitizeHtml" />
         <label class="custom-control-label" asp-for="SanitizeHtml">@T["Sanitize Html"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldTrumbowygEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldTrumbowygEditorSettings.Edit.cshtml
@@ -1,6 +1,6 @@
 @model OrchardCore.ContentFields.ViewModels.TrumbowygSettingsViewModel
 <div id="@Html.IdFor(m => m)" class="field-editor field-editor-trumbowyg">
-    <div class="form-group col-md-6">
+    <div class="form-group">
         <div class="custom-control custom-checkbox">
             <input type="checkbox" class="custom-control-input" asp-for="InsertMediaWithUrl" checked="@Model.InsertMediaWithUrl" />
             <label class="custom-control-label" asp-for="InsertMediaWithUrl">@T["Insert Media with url"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditField.cshtml
@@ -21,19 +21,19 @@
 <form asp-action="EditField" asp-route-returnUrl="@ViewData["returnUrl"]">
     @Html.ValidationSummary()
     <div class="form-group">
-        <div class="row col-medium">
+        <div class="w-md-50">
             <label asp-for="DisplayName">@T["Display Name"]</label>
             <input asp-for="DisplayName" autofocus class="form-control" />
-            <span class="hint">@T["Name of the field as it will be displayed in screens."]</span>
         </div>
+        <span class="hint">@T["Name of the field as it will be displayed in screens."]</span>
     </div>
 
     <div class="form-group">
-        <div class="row col-small">
+        <div class="w-md-25">
             <label asp-for="Name">@T["Technical Name"]</label>
             <input asp-for="Name" class="form-control" readonly />
-            <span class="hint">@T["Technical name of the field."]</span>
         </div>
+        <span class="hint">@T["Technical name of the field."]</span>
     </div>
 
     @if (Model.Shape.Content != null)
@@ -46,7 +46,7 @@
         {
             <div class="form-group">
                 <label asp-for="Editor">@T["What type of editor should be used?"]</label>
-                <select asp-for="Editor" class="form-control col-sm-6" id="field-editor-select">
+                <select asp-for="Editor" class="form-control w-md-50" id="field-editor-select">
                     @foreach (var editorShape in editorShapes)
                     {
                         dynamic shape = await Factory.CreateAsync(editorShape);
@@ -65,7 +65,7 @@
         {
             <div class="form-group">
                 <label asp-for="DisplayMode">@T["What type of display mode should be used?"]</label>
-                <select asp-for="DisplayMode" class="form-control col-sm-6" id="field-display-select">
+                <select asp-for="DisplayMode" class="form-control w-md-50" id="field-display-select">
                     @foreach (var displayShape in displayShapes)
                     {
                         dynamic shape = await Factory.CreateAsync(displayShape);

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditTypePart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditTypePart.cshtml
@@ -25,19 +25,19 @@
     @if (typePart.PartDefinition.IsReusable())
     {
         <div class="form-group">
-            <div class="row col-sm-6">
+            <div class="w-md-50">
                 <label asp-for="DisplayName">@T["Display Name"]</label>
                 <input asp-for="DisplayName" class="form-control" />
-                <span class="hint">@T["Name of the part as it will be displayed in screens."]</span>
             </div>
+            <span class="hint">@T["Name of the part as it will be displayed in screens."]</span>
         </div>
 
         <div class="form-group">
-            <div class="row col-sm-6">
+            <div class="w-md-50">
                 <label asp-for="Description">@T["Description"]</label>
                 <input asp-for="Description" class="form-control" />
-                <span class="hint">@T["The description of the part as it will be displayed in screens."]</span>
             </div>
+            <span class="hint">@T["The description of the part as it will be displayed in screens."]</span>
         </div>
     }
 
@@ -49,18 +49,16 @@
 
         @if (editorShapes.Any())
         {
-            <div class="row">
-                <div class="form-group col-sm-6">
-                    <label asp-for="Editor">@T["What type of editor should be used?"]</label>
-                    <select asp-for="Editor" class="form-control" id="type-part-editor-select">
-                        @foreach (var editorShape in editorShapes)
-                        {
-                            dynamic shape = await Factory.CreateAsync(editorShape);
-                            shape.Editor = Model.Editor;
-                            @await DisplayAsync(shape)
-                        }
-                    </select>
-                </div>
+            <div class="form-group">
+                <label asp-for="Editor">@T["What type of editor should be used?"]</label>
+                <select asp-for="Editor" class="form-control w-md-50" id="type-part-editor-select">
+                    @foreach (var editorShape in editorShapes)
+                    {
+                        dynamic shape = await Factory.CreateAsync(editorShape);
+                        shape.Editor = Model.Editor;
+                        @await DisplayAsync(shape)
+                    }
+                </select>
             </div>
         }
 
@@ -72,7 +70,7 @@
         {
             <div class="form-group">
                 <label asp-for="DisplayMode">@T["What type of display mode should be used?"]</label>
-                <select asp-for="DisplayMode" class="form-control col-sm-6" id="type-part-display-select">
+                <select asp-for="DisplayMode" class="form-control w-md-50" id="type-part-display-select">
                     @foreach (var displayShape in displayShapes)
                     {
                         dynamic shape = await Factory.CreateAsync(displayShape);

--- a/src/OrchardCore.Modules/OrchardCore.Html/Settings/HtmlBodyPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Settings/HtmlBodyPartSettingsDisplayDriver.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Html.Settings
 
                 model.SanitizeHtml = settings.SanitizeHtml;
             })
-            .Location("Editor");
+            .Location("Content:20");
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartSettings.Edit.cshtml
@@ -1,6 +1,6 @@
 @model HtmlBodyPartSettingsViewModel
 
-<div class="form-group col-md-6">
+<div class="form-group">
     <div class="custom-control custom-checkbox">
         <input type="checkbox" class="custom-control-input" asp-for="SanitizeHtml" checked="@Model.SanitizeHtml" />
         <label class="custom-control-label" asp-for="SanitizeHtml">@T["Sanitize Html"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartTrumbowygSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartTrumbowygSettings.Edit.cshtml
@@ -1,6 +1,6 @@
 @model OrchardCore.Html.ViewModels.TrumbowygSettingsViewModel
 <div id="@Html.IdFor(m => m)" class="type-part-editor type-part-editor-trumbowyg">
-    <div class="form-group col-md-6">
+    <div class="form-group">
         <div class="custom-control custom-checkbox">
             <input type="checkbox" class="custom-control-input" asp-for="InsertMediaWithUrl" checked="@Model.InsertMediaWithUrl" />
             <label class="custom-control-label" asp-for="InsertMediaWithUrl">@T["Insert Media with url"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Settings/ContentPartFieldIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Settings/ContentPartFieldIndexSettingsDisplayDriver.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Lucene.Settings
             return Initialize<ContentIndexSettingsViewModel>("ContentIndexSettings_Edit", model =>
             {
                 model.ContentIndexSettings = contentPartFieldDefinition.GetSettings<ContentIndexSettings>();
-            }).Location("Content");
+            }).Location("Content:10");
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentPartFieldDefinition contentPartFieldDefinition, UpdatePartFieldEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Settings/ContentTypePartIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Settings/ContentTypePartIndexSettingsDisplayDriver.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Lucene.Settings
             return Initialize<ContentIndexSettingsViewModel>("ContentIndexSettings_Edit", model =>
             {
                 model.ContentIndexSettings = contentTypePartDefinition.GetSettings<ContentIndexSettings>();
-            }).Location("Content");
+            }).Location("Content:10");
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Settings/MarkdownBodyPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Settings/MarkdownBodyPartSettingsDisplayDriver.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.Markdown.Settings
 
                     model.SanitizeHtml = settings.SanitizeHtml;
                 })
-                .Location("Editor");
+                .Location("Content:20");
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition contentTypePartDefinition, UpdateTypePartEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Settings/MarkdownFieldSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Settings/MarkdownFieldSettingsDriver.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Markdown.Settings
 
                 model.SanitizeHtml = settings.SanitizeHtml;
                 model.Hint = settings.Hint;
-            }).Location("Content");
+            }).Location("Content:20");
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentPartFieldDefinition partFieldDefinition, UpdatePartFieldEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPartSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPartSettings.Edit.cshtml
@@ -1,6 +1,6 @@
 @model MarkdownBodyPartSettingsViewModel
 
-<div class="form-group col-md-6">
+<div class="form-group">
     <div class="custom-control custom-checkbox">
         <input type="checkbox" class="custom-control-input" asp-for="SanitizeHtml" checked="@Model.SanitizeHtml" />
         <label class="custom-control-label" asp-for="SanitizeHtml">@T["Sanitize Html"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownFieldSettings.Edit.cshtml
@@ -1,14 +1,14 @@
 @model MarkdownFieldSettingsViewModel
 
 <div class="form-group">
-    <div class="row col-sm-6">
+    <div class="w-md-50">
         <label asp-for="Hint">@T["Hint"]</label>
         <textarea asp-for="Hint" rows="2" class="form-control"></textarea>
         <span class="hint">@T["The hint text to display for this field on the editor."]</span>
     </div>
 </div>
 
-<div class="form-group col-md-6">
+<div class="form-group">
     <div class="custom-control custom-checkbox">
         <input type="checkbox" class="custom-control-input" asp-for="SanitizeHtml" checked="@Model.SanitizeHtml" />
         <label class="custom-control-label" asp-for="SanitizeHtml">@T["Sanitize Html"]</label>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6615

Closes https://github.com/OrchardCMS/OrchardCore/pull/6618

Related also to https://github.com/OrchardCMS/OrchardCore/pull/7175 

Bringing them all together for some consistency.

They all look like this now, without uneven padding, and shapes are consistently ordered.

![Screenshot 2020-10-02 at 19 03 49](https://user-images.githubusercontent.com/13782679/94955133-081a6680-04e2-11eb-8091-17d8a77025de.png)

