### PR TITLE
FormPart: Add wrapper for content type

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
@@ -13,10 +13,14 @@ namespace OrchardCore.Forms.Drivers
         public override Task<IDisplayResult> DisplayAsync(ContentItem model, BuildDisplayContext context)
         {
             var formItemShape = context.Shape;
-            // If the content item contains FormPart add Form Wrapper.
+            // If the content item contains FormPart add Form Wrapper only in Display type Detail
             var formPart = model.As<FormPart>();
-            if (formPart != null)
+            if (formPart != null && context.DisplayType == "Detail")
             {
+                //Add wrapper for content type
+                formItemShape.Metadata.Wrappers.Add($"Form_Wrapper__{model.ContentType}");
+
+                // Add wrapper for <form> tag
                 formItemShape.Metadata.Wrappers.Add("Form_Wrapper");
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
@@ -17,11 +17,8 @@ namespace OrchardCore.Forms.Drivers
             var formPart = model.As<FormPart>();
             if (formPart != null && context.DisplayType == "Detail")
             {
-                // Add wrapper for content type
+                // Add wrapper for content type if template is not available it will fall back to Form_Wrapper
                 formItemShape.Metadata.Wrappers.Add($"Form_Wrapper__{model.ContentType}");
-
-                // Add wrapper for <form> tag
-                formItemShape.Metadata.Wrappers.Add("Form_Wrapper");
             }
 
             // We don't need to return a shape result

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
@@ -1,7 +1,6 @@
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
-using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Forms.Models;

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Forms.Drivers
             var formPart = model.As<FormPart>();
             if (formPart != null && context.DisplayType == "Detail")
             {
-                //Add wrapper for content type
+                // Add wrapper for content type
                 formItemShape.Metadata.Wrappers.Add($"Form_Wrapper__{model.ContentType}");
 
                 // Add wrapper for <form> tag

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Views/Form.Wrapper.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Views/Form.Wrapper.cshtml
@@ -8,7 +8,7 @@
     var formContentTypeClassName = "form-" + ((string)Model.ContentItem.ContentType).HtmlClassify();
 }
 
-<form id="form_@Model.ContentItem.ContentItemId" action="@formPart.Action" method="@formPart.Method"  enctype="@encType" class="form-content @formContentTypeClassName">
+<form action="@formPart.Action" method="@formPart.Method"  enctype="@encType" class="form-content @formContentTypeClassName">
     @if(formPart.EnableAntiForgeryToken)
     {
         @Html.AntiForgeryToken()

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Views/Form.Wrapper.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Views/Form.Wrapper.cshtml
@@ -1,9 +1,6 @@
 @using OrchardCore.ContentManagement
 @using OrchardCore.Forms.Models;
 @using OrchardCore.Mvc.Utilities;
-@using Newtonsoft.Json.Linq;
-
-@inject OrchardCore.ContentManagement.Display.IContentItemDisplayManager ContentItemDisplayManager
 
 @{
     var formPart = ((ContentItem)Model.ContentItem).As<FormPart>();
@@ -11,7 +8,7 @@
     var formContentTypeClassName = "form-" + ((string)Model.ContentItem.ContentType).HtmlClassify();
 }
 
-<form action="@formPart.Action" method="@formPart.Method"  enctype="@encType" class="form-content @formContentTypeClassName">
+<form id="form_@Model.ContentItem.ContentItemId" action="@formPart.Action" method="@formPart.Method"  enctype="@encType" class="form-content @formContentTypeClassName">
     @if(formPart.EnableAntiForgeryToken)
     {
         @Html.AntiForgeryToken()


### PR DESCRIPTION
Fixes #7180  Add wrapper for content type

**(Updated)** For example, following wrapper template `Form-SignupLead.Wrapper.cshtml` for content type `SignupLead` enables form submitted to workflow via ajax - fetch api.

```cshtml
@using OrchardCore.Mvc.Utilities;


@{
    dynamic formPart = Model.ContentItem.Content.FormPart; 
}

<form action="@formPart.Action" 
      method="@formPart.Method"  enctype="@formPart.encType" 
      class="form-content form-@((Model.ContentItem.ContentType as string).HtmlClassify())"
      onsubmit="ajaxSubmit(event)">
    @if(formPart.EnableAntiForgeryToken.Value as bool? ?? false)
    {
        @Html.AntiForgeryToken()
    }

    @await DisplayAsync(Model.Metadata.ChildContent)

    <input type="hidden" name="customHidden1" value="value1" />
    <input type="hidden" name="customHidden1" value="value1" />

    <script at="Foot">
        function ajaxSubmit(e){

                e.preventDefault();

                const formJson = [].reduce.call(e.target.elements, function(data, element) {
                    data[element.name] = element.value;
                    return data;
                }, {});
                
                var url = e.target.getAttribute('action');  
                fetch(url, {
                    method: e.target.getAttribute('method'),
                    headers: {
                        'Content-Type': 'application/json'  
                    },
                    body: JSON.stringify(formJson) 
                }).then( function(resp){
                    // process response
                });
                
            }
    </script>
</form>
```