### PR TITLE
Vue use of production version (vue.min.js)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManifest.cs
@@ -343,7 +343,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("vuejs")
-                .SetUrl("~/OrchardCore.Resources/Scripts/vue.js", "~/OrchardCore.Resources/Scripts/vue.js")
+                .SetUrl("~/OrchardCore.Resources/Scripts/vue.min.js", "~/OrchardCore.Resources/Scripts/vue.js")
                 .SetCdn("https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.min.js", "https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.js")
                 .SetCdnIntegrity("sha384-OZmxTjkv7EQo5XDMPAmIkkvywVeXw59YyYh6zq8UKfkbor13jS+5p8qMTBSA1q+F", "sha384-+jvb+jCJ37FkNjPyYLI3KJzQeD8pPFXUra3B/QJFqQ3txYrUPIP1eOfxK4h3cKZP")
                 .SetVersion("2.6.11");


### PR DESCRIPTION
Fixes #6562 use Vue production version to remove warnings