### PR TITLE
Bump OpenIddict to 3.0.0-beta5.20503.76 and fix a bug in OpenIdApplicationManager

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -30,8 +30,8 @@
     <PackageManagement Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="4.9.3" />
     <PackageManagement Include="NodaTime" Version="3.0.0" />
-    <PackageManagement Include="OpenIddict.AspNetCore" Version="[3.0.0-beta4.20502.55]" />
-    <PackageManagement Include="OpenIddict.Core" Version="[3.0.0-beta4.20502.55]" />
+    <PackageManagement Include="OpenIddict.AspNetCore" Version="[3.0.0-beta5.20503.76]" />
+    <PackageManagement Include="OpenIddict.Core" Version="[3.0.0-beta5.20503.76]" />
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.0.0-rc2-108003" />
     <PackageManagement Include="Serilog.AspNetCore" Version="3.4.0" />
     <PackageManagement Include="Shortcodes" Version="1.0.0-beta-175913881" />

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdApplicationManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdApplicationManager.cs
@@ -155,7 +155,7 @@ namespace OrchardCore.OpenId.Services.Managers
             else
             {
                 var properties = await Store.GetPropertiesAsync(application, cancellationToken);
-                properties = properties.Add(OpenIdConstants.Properties.Roles, JsonSerializer.Deserialize<JsonElement>(
+                properties = properties.SetItem(OpenIdConstants.Properties.Roles, JsonSerializer.Deserialize<JsonElement>(
                     JsonSerializer.Serialize(roles, new JsonSerializerOptions
                     {
                         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
@@ -189,7 +189,7 @@ namespace OrchardCore.OpenId.Services.Managers
                 else
                 {
                     var properties = await Store.GetPropertiesAsync(application, cancellationToken);
-                    properties = properties.Add(OpenIdConstants.Properties.Roles, JsonSerializer.Deserialize<JsonElement>(
+                    properties = properties.SetItem(OpenIdConstants.Properties.Roles, JsonSerializer.Deserialize<JsonElement>(
                         JsonSerializer.Serialize(model.Roles, new JsonSerializerOptions
                         {
                             Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping


### PR DESCRIPTION
While writing my blog post about OrchardCore's OpenID module, I discovered a bug that impacted scenarios where the EF 6/EF Core/MongoDB stores are used (instead of the default YesSql stores). I released a new version and this PR targets it (and fixes a related bug in `OpenIdApplicationManager`).