### PR TITLE
Obsolete IContentAliasManager

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentHandleManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentHandleManager.cs
@@ -3,14 +3,11 @@ using System.Threading.Tasks;
 
 namespace OrchardCore.ContentManagement
 {
-    public interface IContentHandleManager
+    public interface IContentHandleManager 
     {
-        Task<string> GetContentItemIdAsync(string alias);
+        Task<string> GetContentItemIdAsync(string handle);
     }
 
-    /// <summary>
-    /// This interface has been renamed to IContentHandleManager
-    /// and will be removed in a future release.
-    /// </summary>
-    public interface IContentAliasManager : IContentHandleManager {}
+    [Obsolete("This interface has been renamed to IContentHandlerManager")]
+    public interface IContentAliasManager {}
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentHandleManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentHandleManager.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace OrchardCore.ContentManagement
 {
-    public interface IContentHandleManager 
+    public interface IContentHandleManager
     {
         Task<string> GetContentItemIdAsync(string handle);
     }

--- a/src/OrchardCore/OrchardCore.ContentManagement/ContentHandleManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ContentHandleManager.cs
@@ -14,11 +14,11 @@ namespace OrchardCore.ContentManagement
             _contentHandleProviders = contentHandleProviders.OrderBy(x => x.Order);
         }
 
-        public async Task<string> GetContentItemIdAsync(string alias)
+        public async Task<string> GetContentItemIdAsync(string handle)
         {
             foreach (var provider in _contentHandleProviders)
             {
-                var result = await provider.GetContentItemIdAsync(alias);
+                var result = await provider.GetContentItemIdAsync(handle);
 
                 if (!String.IsNullOrEmpty(result))
                 {

--- a/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
@@ -28,8 +28,6 @@ namespace OrchardCore.ContentManagement
 
             services.AddSingleton<IContentItemIdGenerator, DefaultContentItemIdGenerator>();
             services.AddScoped<IContentHandleManager, ContentHandleManager>();
-            // This code can be removed in a future release.
-            services.AddScoped<IContentAliasManager>(sp => (IContentAliasManager)sp.GetRequiredService<IContentHandleManager>());
 
             services.AddOptions<ContentOptions>();
             services.AddScoped<IContentPartHandlerResolver, ContentPartHandlerResolver>();


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7215

@rjpowers10 we renamed this interface, and the backwards compatibility code didn't work.

I've just obsoleted it instead as making it totally backwards compatible just made for weird code.

So inject `IContentHandleManager`  