### PR TITLE
Use recipe.DisplayName in Tenants pages

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
@@ -49,7 +49,7 @@
                 @foreach (var recipe in Model.Recipes)
                 {
                     <option value="@recipe.Name" selected="@(Model.RecipeName == recipe.Name)">
-                        @recipe.Name
+                        @recipe.DisplayName
                     </option>
                 }
             </select>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Edit.cshtml
@@ -49,7 +49,7 @@
                     @foreach (var recipe in Model.Recipes)
                     {
                         <option value="@recipe.Name" selected="@(Model.RecipeName == recipe.Name)">
-                            @recipe.Name
+                            @recipe.DisplayName
                         </option>
                     }
                 </select>


### PR DESCRIPTION
Use recipe DisplayName in the tenants create and edit page instead of the name.