### PR TITLE
Taxonomy Field validation error message improvement

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldDriver.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
+using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Taxonomies.Fields;
@@ -82,7 +83,7 @@ namespace OrchardCore.Taxonomies.Drivers
                 {
                     updater.ModelState.AddModelError(
                         nameof(EditTaxonomyFieldViewModel.TermEntries),
-                        S["A value is required for '{0}'", context.PartFieldDefinition.Name]);
+                        S["A value is required for '{0}'", context.PartFieldDefinition.DisplayName()]);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldTagsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldTagsDriver.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
+using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Taxonomies.Fields;
@@ -75,7 +76,7 @@ namespace OrchardCore.Taxonomies.Drivers
                 {
                     updater.ModelState.AddModelError(
                         nameof(EditTaxonomyFieldViewModel.TermEntries),
-                        S["A value is required for '{0}'", context.PartFieldDefinition.Name]);
+                        S["A value is required for '{0}'", context.PartFieldDefinition.DisplayName()]);
                 }
 
                 // Update display text for tags.


### PR DESCRIPTION
Fixes #7227.

When taxonomy field is set as required field , validation error shows technical name of part field definition
It's better to show display name .