### PR TITLE
Workflows: jQuery package version

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/package-lock.json
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-Tyctjh56U7eX2b9udu3wG853ASYP0uagChJcQJXLUXEU6C/JiW5qt5dl8ao01VRj1i5pgXPAf8f1mq4+FDLRQg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.2.tgz",
+      "integrity": "sha512-+MFOdKF5Zr41t3y2wfzJvK1PrUK0KtPLAFwYownp/0nCoMIANDDu5aFSpWfb8S0ZajCSNeaBnMrBGxksXK5yeg==",
       "requires": {
         "@types/sizzle": "*"
       }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/package.json
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/package.json
@@ -5,6 +5,6 @@
     "bootstrap": "4.5.2",
     "@types/bootstrap": "4.5.0",
     "jsplumb": "2.14.6",
-    "@types/jquery": "3.5.1"
+    "@types/jquery": "3.5.2"
   }
 }


### PR DESCRIPTION
https://www.npmjs.com/package/@types/jquery/v/3.5.2

Do not upgrade to https://www.npmjs.com/package/@types/bootstrap/v/5.0.0 yet, stay on 4.5.0.
It will need a dependency on the new @popperjs/core package, I guess.