### PR TITLE
Added Azure Deploy Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Nightly (dev):
 [![Build status](https://img.shields.io/appveyor/ci/alexbocharov/orchardcore/dev.svg?label=appveyor&style=flat-square)](https://ci.appveyor.com/project/alexbocharov/orchardcore/branch/dev)
 [![Cloudsmith](https://api-prd.cloudsmith.io/badges/version/orchardcore/preview/nuget/OrchardCore.Application.Cms.Targets/latest/x/?render=true&badge_token=gAAAAABey9hKFD_C-ZIpLvayS3HDsIjIorQluDs53KjIdlxoDz6Ntt1TzvMNJp7a_UWvQbsfN5nS7_0IbxCyqHZsjhmZP6cBkKforo-NqwrH5-E6QCrJ3D8%3D)](https://cloudsmith.io/~orchardcore/repos/preview/packages/detail/nuget/OrchardCore.Application.Cms.Targets/latest/)
 
+## Deploy
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsalem84%2FOrchardCore%2Fbtn-deploy-azure%2Fazuredeploy.json)
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fsalem84%2FOrchardCore%2Fbtn-deploy-azure%2Fazuredeploy.json)
+
 ## Status
 
 ### RC 2

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -34,26 +34,30 @@
         },
         "sqlServerName": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "The name of the sql server. It has to be unique."
+                "description": "(Only if SqlServer is selected) The name of the Sql Server instance"
             }
         },
         "databaseName": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "The name of the sql databaseName. It has to be unique."
+                "description": "(Only if SqlServer is selected) The name of the Sql Server database"
             }
         },
         "sqlAdministratorLogin": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
-                "description": "The admin user of the SQL Server"
+                "description": "(Only if SqlServer is selected) The admin user of the SQL Server"
             }
         },
         "sqlAdministratorLoginPassword": {
             "type": "securestring",
+            "defaultValue": "",
             "metadata": {
-                "description": "The password of the admin user of the SQL Server"
+                "description": "(Only if SqlServer is selected) The password of the admin user of the SQL Server"
             }
         }
     },

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -32,28 +32,28 @@
                 "description": "Type of database to use"
             }
         },
-        "sqlServerName": {
+        "sqlServerInstanceName": {
             "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "(Only if SqlServer is selected) The name of the Sql Server instance"
             }
         },
-        "databaseName": {
+        "sqlServerDatabaseName": {
             "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "(Only if SqlServer is selected) The name of the Sql Server database"
             }
         },
-        "sqlAdministratorLogin": {
+        "sqlServerAdministratorLogin": {
             "type": "string",
             "defaultValue": "",
             "metadata": {
                 "description": "(Only if SqlServer is selected) The admin user of the SQL Server"
             }
         },
-        "sqlAdministratorLoginPassword": {
+        "sqlServerAdministratorLoginPassword": {
             "type": "securestring",
             "defaultValue": "",
             "metadata": {
@@ -70,7 +70,7 @@
     "resources": [
         {
             "condition": "[equals(parameters('databaseType'),'SqlServer')]",
-            "name": "[parameters('sqlServerName')]",
+            "name": "[parameters('sqlServerInstanceName')]",
             "type": "Microsoft.Sql/servers",
             "apiVersion": "2014-04-01",
             "location": "[resourceGroup().location]",
@@ -78,13 +78,13 @@
                 "displayName": "SqlServer"
             },
             "properties": {
-                "administratorLogin": "[parameters('sqlAdministratorLogin')]",
-                "administratorLoginPassword": "[parameters('sqlAdministratorLoginPassword')]",
+                "administratorLogin": "[parameters('sqlServerAdministratorLogin')]",
+                "administratorLoginPassword": "[parameters('sqlServerAdministratorLoginPassword')]",
                 "version": "12.0"
             },
             "resources": [
                 {
-                    "name": "[parameters('databaseName')]",
+                    "name": "[parameters('sqlServerDatabaseName')]",
                     "type": "databases",
                     "apiVersion": "2015-01-01",
                     "location": "[resourceGroup().location]",
@@ -97,7 +97,7 @@
                         "requestedServiceObjectiveName": "[variables('databaseServiceObjectiveName')]"
                     },
                     "dependsOn": [
-                        "[parameters('sqlServerName')]"
+                        "[parameters('sqlServerInstanceName')]"
                     ],
                     "resources": [
                         {
@@ -109,7 +109,7 @@
                                 "status": "Enabled"
                             },
                             "dependsOn": [
-                                "[parameters('databaseName')]"
+                                "[parameters('sqlServerDatabaseName')]"
                             ]
                         }
                     ]
@@ -124,7 +124,7 @@
                         "startIpAddress": "0.0.0.0"
                     },
                     "dependsOn": [
-                        "[parameters('sqlServerName')]"
+                        "[parameters('sqlServerInstanceName')]"
                     ]
                 }
             ]
@@ -176,7 +176,7 @@
         "connectionString" : {
             "condition": "[equals(parameters('databaseType'),'SqlServer')]",
             "type": "string",
-            "value": "[concat('Server=tcp:',reference(parameters('sqlserverName')).fullyQualifiedDomainName,',1433;Initial Catalog=',parameters('databaseName'),';Persist Security Info=False;User ID=',parameters('sqlAdministratorLogin'),';Password=',parameters('sqlAdministratorLoginPassword'),';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;')]"
+            "value": "[concat('Server=tcp:',reference(parameters('sqlServerInstanceName')).fullyQualifiedDomainName,',1433;Initial Catalog=',parameters('sqlServerDatabaseName'),';Persist Security Info=False;User ID=',parameters('sqlServerAdministratorLogin'),';Password=',parameters('sqlServerAdministratorLoginPassword'),';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;')]"
         }
     }
 }

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,178 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "webAppName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of web app and app service plan "
+            }
+        },
+        "sku": {
+            "type": "string",
+            "defaultValue": "S1",
+            "metadata": {
+                "description": "The SKU of App Service Plan "
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "databaseType": {
+            "type": "string",
+            "allowedValues": [
+                "SqlServer",
+                "Sqlite"
+            ],
+            "metadata": {
+                "description": "Type of database to use"
+            }
+        },
+        "sqlServerName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the sql server. It has to be unique."
+            }
+        },
+        "databaseName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the sql databaseName. It has to be unique."
+            }
+        },
+        "sqlAdministratorLogin": {
+            "type": "string",
+            "metadata": {
+                "description": "The admin user of the SQL Server"
+            }
+        },
+        "sqlAdministratorLoginPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The password of the admin user of the SQL Server"
+            }
+        }
+    },
+    "variables": {
+        "appServicePlanName": "[concat('asp-', parameters('webAppName'))]",
+        "databaseEdition": "Standard",
+        "databaseCollation": "SQL_Latin1_General_CP1_CI_AS",
+        "databaseServiceObjectiveName": "Standard"
+    },
+    "resources": [
+        {
+            "condition": "[equals(parameters('databaseType'),'SqlServer')]",
+            "name": "[parameters('sqlServerName')]",
+            "type": "Microsoft.Sql/servers",
+            "apiVersion": "2014-04-01",
+            "location": "[resourceGroup().location]",
+            "tags": {
+                "displayName": "SqlServer"
+            },
+            "properties": {
+                "administratorLogin": "[parameters('sqlAdministratorLogin')]",
+                "administratorLoginPassword": "[parameters('sqlAdministratorLoginPassword')]",
+                "version": "12.0"
+            },
+            "resources": [
+                {
+                    "name": "[parameters('databaseName')]",
+                    "type": "databases",
+                    "apiVersion": "2015-01-01",
+                    "location": "[resourceGroup().location]",
+                    "tags": {
+                        "displayName": "Database"
+                    },
+                    "properties": {
+                        "edition": "[variables('databaseEdition')]",
+                        "collation": "[variables('databaseCollation')]",
+                        "requestedServiceObjectiveName": "[variables('databaseServiceObjectiveName')]"
+                    },
+                    "dependsOn": [
+                        "[parameters('sqlServerName')]"
+                    ],
+                    "resources": [
+                        {
+                            "comments": "Transparent Data Encryption",
+                            "name": "current",
+                            "type": "transparentDataEncryption",
+                            "apiVersion": "2014-04-01-preview",
+                            "properties": {
+                                "status": "Enabled"
+                            },
+                            "dependsOn": [
+                                "[parameters('databaseName')]"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "AllowAllMicrosoftAzureIps",
+                    "type": "firewallrules",
+                    "apiVersion": "2014-04-01",
+                    "location": "[resourceGroup().location]",
+                    "properties": {
+                        "endIpAddress": "0.0.0.0",
+                        "startIpAddress": "0.0.0.0"
+                    },
+                    "dependsOn": [
+                        "[parameters('sqlServerName')]"
+                    ]
+                }
+            ]
+        },
+
+        {
+            "type": "Microsoft.Web/serverfarms",
+            "apiVersion": "2019-08-01",
+            "name": "[variables('appServicePlanName')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "[parameters('sku')]"
+            },
+            "kind": "linux",
+            "properties": {
+                "reserved": true
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2019-08-01",
+            "name": "[parameters('webAppName')]",
+            "location": "[parameters('location')]",
+            "kind": "app,linux,container",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
+            ],
+            "properties": {
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
+                "siteConfig": {
+                    "netFrameworkVersion": "v4.0",
+                    "linuxFxVersion": "DOCKER|orchardproject/orchardcore-cms-linux",
+
+                    "appSettings": [
+                        {
+                            "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+                            "value": "true"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "websiteUrl": {
+            "type": "string",
+            "value": "[reference(resourceId('Microsoft.Web/sites', parameters('webAppName'))).defaultHostName]"
+        },
+        "connectionString" : {
+            "condition": "[equals(parameters('databaseType'),'SqlServer')]",
+            "type": "string",
+            "value": "[concat('Server=tcp:',reference(parameters('sqlserverName')).fullyQualifiedDomainName,',1433;Initial Catalog=',parameters('databaseName'),';Persist Security Info=False;User ID=',parameters('sqlAdministratorLogin'),';Password=',parameters('sqlAdministratorLoginPassword'),';MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;')]"
+        }
+    }
+}


### PR DESCRIPTION
In regard to #7068, I have create an ARM template with following fields:

![image](https://user-images.githubusercontent.com/219757/95792040-f0fa2680-0ce2-11eb-9e18-1594c2b0347e.png)

In details
* Web app name: name of Azure App Service
* SKU: pricing tiers of App Service Plan
* Location: the same as location of ResourceGroup
* Database type: it's a select box, now choices ar Sqlite or Sql Server
* Sql Server section: unfortunately, at least I know, it's not possible to hide this section based on Database type condition; there are all details to create a Sql Server instance and database to use during setup. Sql Server is deployed only if Database Type = SqlServer (condition in ARM template)

Behind the scenes Azure App service use a Linux container instance with orchardproject/orchardcore-cms-linux image

In Readme I have added Deploy To Azure and Visualize button.

_As described on Microsoft Docs the absolute path to azuredeploy.json file must be linked to buttons, so they must be changed before merge!_