### PR TITLE
Prevents distributed cache network contention

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
@@ -145,7 +145,7 @@ namespace OrchardCore.Documents
             string id;
             if (_isDistributed)
             {
-                // cache the id locally for one second to prevent network contention.
+                // Cache the id locally for one second to prevent network contention.
                 id = await _memoryCache.GetOrCreateAsync(_options.CacheIdKey, entry =>
                 {
                     entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(1);
@@ -154,7 +154,7 @@ namespace OrchardCore.Documents
             }
             else
             {
-                // Othewise, always get the id from the in memory distributed cache.
+                // Otherwise, always get the id from the in memory distributed cache.
                 id = await _distributedCache.GetStringAsync(_options.CacheIdKey);
             }
 


### PR DESCRIPTION
I did some benchmarks while using the redis distributed cache. I saw that the max RPS is lower.

Even if most of the time we only get identifiers from the cache, there are many cache accesses. If you have N1 requests per second and you use N2 documents per request, you will try to do N1 * N2 cache **id** accesses per second.

To fix it, and only if we really use a distributed cache (not an in memory one), here we also cache locally the document identifiers themselves, but only for one second.

Now the rps is quite the same as without using a distributed cache.