### PR TITLE
Lucene Indexation with LocalizationPart issue

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OrchardCore.ContentLocalization;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentPreview;
@@ -82,7 +83,8 @@ namespace OrchardCore.Lucene.Handlers
 
                 foreach (var indexSettings in await luceneIndexSettingsService.GetSettingsAsync())
                 {
-                    bool ignoreIndexedCulture = indexSettings.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != indexSettings.Culture;
+                    var cultureAspect = await contentManager.PopulateAspectAsync(context.ContentItem, new CultureAspect());
+                    bool ignoreIndexedCulture = indexSettings.Culture == "any" ? false : cultureAspect?.Culture.Name != indexSettings.Culture;
                     if (indexSettings.IndexedContentTypes.Contains(context.ContentItem.ContentType) && !ignoreIndexedCulture)
                     {
                         if (!indexSettings.IndexLatest && !publishedLoaded)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
@@ -82,7 +82,8 @@ namespace OrchardCore.Lucene.Handlers
 
                 foreach (var indexSettings in await luceneIndexSettingsService.GetSettingsAsync())
                 {
-                    if (indexSettings.IndexedContentTypes.Contains(context.ContentItem.ContentType))
+                    bool ignoreIndexedCulture = indexSettings.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != indexSettings.Culture;
+                    if (indexSettings.IndexedContentTypes.Contains(context.ContentItem.ContentType) && !ignoreIndexedCulture)
                     {
                         if (!indexSettings.IndexLatest && !publishedLoaded)
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OrchardCore.ContentLocalization;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentPreview;
@@ -83,9 +82,8 @@ namespace OrchardCore.Lucene.Handlers
 
                 foreach (var indexSettings in await luceneIndexSettingsService.GetSettingsAsync())
                 {
-                    var cultureAspect = await contentManager.PopulateAspectAsync(context.ContentItem, new CultureAspect());
-                    bool ignoreIndexedCulture = indexSettings.Culture == "any" ? false : cultureAspect?.Culture.Name != indexSettings.Culture;
-                    
+                    var ignoreIndexedCulture = indexSettings.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != indexSettings.Culture;
+
                     if (indexSettings.IndexedContentTypes.Contains(context.ContentItem.ContentType) && !ignoreIndexedCulture)
                     {
                         if (!indexSettings.IndexLatest && !publishedLoaded)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
@@ -85,6 +85,7 @@ namespace OrchardCore.Lucene.Handlers
                 {
                     var cultureAspect = await contentManager.PopulateAspectAsync(context.ContentItem, new CultureAspect());
                     bool ignoreIndexedCulture = indexSettings.Culture == "any" ? false : cultureAspect?.Culture.Name != indexSettings.Culture;
+                    
                     if (indexSettings.IndexedContentTypes.Contains(context.ContentItem.ContentType) && !ignoreIndexedCulture)
                     {
                         if (!indexSettings.IndexLatest && !publishedLoaded)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentLocalization.Abstractions\OrchardCore.ContentLocalization.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Display\OrchardCore.ContentManagement.Display.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement\OrchardCore.ContentManagement.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentLocalization.Abstractions\OrchardCore.ContentLocalization.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Display\OrchardCore.ContentManagement.Display.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement\OrchardCore.ContentManagement.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using OrchardCore.ContentLocalization;
 using OrchardCore.ContentManagement;
 using OrchardCore.Entities;
 using OrchardCore.Environment.Shell;
@@ -187,8 +186,7 @@ namespace OrchardCore.Lucene
                                     continue;
                                 }
 
-                                var cultureAspect = await contentManager.PopulateAspectAsync(context.ContentItem, new CultureAspect());
-                                bool ignoreIndexedCulture = settings.Culture == "any" ? false : cultureAspect?.Culture.Name != settings.Culture;
+                                var ignoreIndexedCulture = settings.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != settings.Culture;
 
                                 // Ignore if the content item content type or culture is not indexed in this index
                                 if (!settings.IndexedContentTypes.Contains(context.ContentItem.ContentType) || ignoreIndexedCulture)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OrchardCore.ContentLocalization;
 using OrchardCore.ContentManagement;
 using OrchardCore.Entities;
 using OrchardCore.Environment.Shell;
@@ -186,7 +187,8 @@ namespace OrchardCore.Lucene
                                     continue;
                                 }
 
-                                bool ignoreIndexedCulture = settings.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != settings.Culture;
+                                var cultureAspect = await contentManager.PopulateAspectAsync(context.ContentItem, new CultureAspect());
+                                bool ignoreIndexedCulture = settings.Culture == "any" ? false : cultureAspect?.Culture.Name != settings.Culture;
 
                                 // Ignore if the content item content type or culture is not indexed in this index
                                 if (!settings.IndexedContentTypes.Contains(context.ContentItem.ContentType) || ignoreIndexedCulture)


### PR DESCRIPTION
Fix issue with indexing a ContentType with a LocalizationPart in LuceneIndexingContentHandler which indexes directly when we publish or save a content item.

We are doing it properly in the LuceneIndexingService when it runs from a background task. So, if you had the Lucene background task enabled it was probably cleaning up those records. Also, if you we're running periodical rebuild / reset of indexes it would have cleaned up too.

Closes #7278