### PR TITLE
Fix CultureAspect extensibility

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Handler/LuceneIndexingContentHandler.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OrchardCore.ContentLocalization;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentPreview;
@@ -82,7 +83,8 @@ namespace OrchardCore.Lucene.Handlers
 
                 foreach (var indexSettings in await luceneIndexSettingsService.GetSettingsAsync())
                 {
-                    var ignoreIndexedCulture = indexSettings.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != indexSettings.Culture;
+                    var contentItemCultureAspect = await contentManager.PopulateAspectAsync(context.ContentItem, new CultureAspect(){ Culture = null });
+                    var ignoreIndexedCulture = indexSettings.Culture == "any" ? false : contentItemCultureAspect.Culture?.Name != indexSettings.Culture;
 
                     if (indexSettings.IndexedContentTypes.Contains(context.ContentItem.ContentType) && !ignoreIndexedCulture)
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentLocalization.Abstractions\OrchardCore.ContentLocalization.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Display\OrchardCore.ContentManagement.Display.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement\OrchardCore.ContentManagement.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexingService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentLocalization;
 using OrchardCore.Entities;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Indexing;
@@ -186,7 +187,8 @@ namespace OrchardCore.Lucene
                                     continue;
                                 }
 
-                                var ignoreIndexedCulture = settings.Culture == "any" ? false : context.ContentItem.Content?.LocalizationPart?.Culture != settings.Culture;
+                                var contentItemCultureAspect = await contentManager.PopulateAspectAsync(context.ContentItem, new CultureAspect(){ Culture = null });
+                                var ignoreIndexedCulture = settings.Culture == "any" ? false : contentItemCultureAspect.Culture?.Name != settings.Culture;
 
                                 // Ignore if the content item content type or culture is not indexed in this index
                                 if (!settings.IndexedContentTypes.Contains(context.ContentItem.ContentType) || ignoreIndexedCulture)

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardHelperExtensions.cs
@@ -15,12 +15,11 @@ namespace OrchardCore.ContentLocalization
         /// </summary>
         /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
         /// <param name="contentItem">The <see cref="ContentItem"/> in which to get its culture.</param>
-        /// <param name="defaultCulture">The <see cref="String"/> the default culture it should fallback to.</param>
         /// <returns></returns>
-        public async static Task<CultureInfo> GetContentCultureAsync(this IOrchardHelper orchardHelper, ContentItem contentItem, string defaultCulture = null)
+        public async static Task<CultureInfo> GetContentCultureAsync(this IOrchardHelper orchardHelper, ContentItem contentItem)
         {
             var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
-            var cultureAspect = await contentManager.PopulateAspectAsync(contentItem, new CultureAspect(){ Culture = defaultCulture != null ? CultureInfo.GetCultureInfo(defaultCulture) : null });
+            var cultureAspect = await contentManager.PopulateAspectAsync(contentItem, new CultureAspect());
 
             return cultureAspect.Culture;
         }

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardHelperExtensions.cs
@@ -15,12 +15,12 @@ namespace OrchardCore.ContentLocalization
         /// </summary>
         /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
         /// <param name="contentItem">The <see cref="ContentItem"/> in which to get its culture.</param>
-        /// <param name="defaultCulture">The <see cref="CultureInfo"/> the default culture it should fallback to.</param>
+        /// <param name="defaultCulture">The <see cref="String"/> the default culture it should fallback to.</param>
         /// <returns></returns>
-        public async static Task<CultureInfo> GetContentCultureAsync(this IOrchardHelper orchardHelper, ContentItem contentItem, CultureInfo defaultCulture = CultureInfo.CurrentUICulture)
+        public async static Task<CultureInfo> GetContentCultureAsync(this IOrchardHelper orchardHelper, ContentItem contentItem, string defaultCulture = null)
         {
             var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
-            var cultureAspect = await contentManager.PopulateAspectAsync(contentItem, new CultureAspect(){ Culture = defaultCulture });
+            var cultureAspect = await contentManager.PopulateAspectAsync(contentItem, new CultureAspect(){ Culture = defaultCulture != null ? CultureInfo.GetCultureInfo(defaultCulture) : null });
 
             return cultureAspect.Culture;
         }

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardHelperExtensions.cs
@@ -15,11 +15,12 @@ namespace OrchardCore.ContentLocalization
         /// </summary>
         /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
         /// <param name="contentItem">The <see cref="ContentItem"/> in which to get its culture.</param>
+        /// <param name="defaultCulture">The <see cref="CultureInfo"/> the default culture it should fallback to.</param>
         /// <returns></returns>
-        public async static Task<CultureInfo> GetContentCultureAsync(this IOrchardHelper orchardHelper, ContentItem contentItem)
+        public async static Task<CultureInfo> GetContentCultureAsync(this IOrchardHelper orchardHelper, ContentItem contentItem, CultureInfo defaultCulture = CultureInfo.CurrentUICulture)
         {
             var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
-            var cultureAspect = await contentManager.PopulateAspectAsync(contentItem, new CultureAspect());
+            var cultureAspect = await contentManager.PopulateAspectAsync(contentItem, new CultureAspect(){ Culture = defaultCulture });
 
             return cultureAspect.Culture;
         }


### PR DESCRIPTION
Here is the solution I came up with @hishamco 
Without changing the default assignment of the CultureAspect class Culture to CultureInfo.CurrentUICulture.
Feels like we should keep this since using a null culture can always be more problematic than anything.
But here in the Lucene Index we want to actually have the culture set to null if the content item has no LocalizationPart or other ContentPart that would set it's culture.

If we would store the CultureInfo.CurrentUICulture here it would be misleading if the website changes from one system to an other where the CurrentUICulture would be set from the actual OS culture. Null culture here means that it is the same culture than the default one which can vary. Also, it allows to store these values in the appropriate index all the time.

I have not changed the GetContentCultureAsync method because it is fine to be used mainly on UI things where we can't use a null culture.