### PR TITLE
Remove incorrect permission check on "Design" admin menu

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Themes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/AdminMenu.cs
@@ -24,7 +24,6 @@ namespace OrchardCore.Themes
             builder
                 .Add(S["Design"], NavigationConstants.AdminMenuDesignPosition, design => design
                     .AddClass("themes").Id("themes")
-                    .Permission(Permissions.ApplyTheme)
                     .Add(S["Themes"], "Themes", installed => installed
                         .Action("Index", "Admin", new { area = "OrchardCore.Themes" })
                         .Permission(Permissions.ApplyTheme)


### PR DESCRIPTION
When a role only has `ManageTemplates` or `ManageLayers`, the "Design" admin menu doesn't display due to an incorrect check for `ApplyTheme`.