### PR TITLE
Generate xml documentation (comments) for nuget packages

### DIFF
--- a/src/OrchardCore.Build/OrchardCore.Commons.props
+++ b/src/OrchardCore.Build/OrchardCore.Commons.props
@@ -9,6 +9,8 @@
     <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <DebugType>portable</DebugType>
     <NetStandardImplicitPackageVersion>2.0.0-*</NetStandardImplicitPackageVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Razor/AliasPartRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Razor/AliasPartRazorHelperExtensions.cs
@@ -12,6 +12,7 @@ public static class AliasPartRazorHelperExtensions
     /// <summary>
     /// Returns a content item id by its alias.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="alias">The alias.</param>
     /// <example>GetContentItemIdByAliasAsync("carousel")</example>
     /// <returns>A content item id or <c>null</c> if it was not found.</returns>
@@ -37,6 +38,7 @@ public static class AliasPartRazorHelperExtensions
     /// <summary>
     /// Loads a content item by its alias.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="alias">The alias to load.</param>
     /// <param name="latest">Whether a draft should be loaded if available. <c>false</c> by default.</param>
     /// <example>GetContentItemIdByAliasAsync("carousel")</example>

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Razor/AutoroutePartRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Razor/AutoroutePartRazorHelperExtensions.cs
@@ -10,6 +10,7 @@ public static class AutoroutePartRazorHelperExtensions
     /// <summary>
     /// Returns a content item id by its slug.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="slug">The slug.</param>
     /// <example>GetContentItemIdBySlugAsync("myblog/my-blog-post")</example>
     /// <returns>A content item id or <c>null</c> if it was not found.</returns>
@@ -46,6 +47,7 @@ public static class AutoroutePartRazorHelperExtensions
     /// <summary>
     /// Loads a content item by its slug.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="slug">The slug to load.</param>
     /// <param name="latest">Whether a draft should be loaded if available. <c>false</c> by default.</param>
     /// <example>GetContentItemBySlugAsync("myblog/my-blog-post")</example>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Razor/ContentRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Razor/ContentRazorHelperExtensions.cs
@@ -12,6 +12,7 @@ public static class ContentRazorHelperExtensions
     /// <summary>
     /// Returns a content item id by its handle.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="handle">The handle.</param>
     /// <example>GetContentItemIdByHandleAsync("alias:carousel")</example>
     /// <example>GetContentItemIdByHandleAsync("slug:myblog/my-blog-post")</example>
@@ -25,6 +26,7 @@ public static class ContentRazorHelperExtensions
     /// <summary>
     /// Loads a content item by its handle.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="handle">The handle to load.</param>
     /// <param name="latest">Whether a draft should be loaded if available. <c>false</c> by default.</param>
     /// <example>GetContentItemByHandleAsync("alias:carousel")</example>
@@ -40,6 +42,7 @@ public static class ContentRazorHelperExtensions
     /// <summary>
     /// Loads a content item by its id.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="contentItemId">The content item id to load.</param>
     /// <param name="latest">Whether a draft should be loaded if available. <c>false</c> by default.</param>
     /// <example>GetContentItemByIdAsync("4xxxxxxxxxxxxxxxx")</example>
@@ -53,6 +56,7 @@ public static class ContentRazorHelperExtensions
     /// <summary>
     /// Loads a list of content items by their ids.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="contentItemIds">The content item ids to load.</param>
     /// <param name="latest">Whether a draft should be loaded if available. <c>false</c> by default.</param>
     /// <returns>A list of content items with the specific ids.</returns>
@@ -65,6 +69,7 @@ public static class ContentRazorHelperExtensions
     /// <summary>
     /// Loads a content item by its version id.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="contentItemVersionId">The content item version id to load.</param>
     /// <example>GetContentItemByVersionIdAsync("4xxxxxxxxxxxxxxxx")</example>
     /// <returns>A content item with the specific version id, or <c>null</c> if it doesn't exist.</returns>
@@ -90,7 +95,9 @@ public static class ContentRazorHelperExtensions
     /// <summary>
     /// Loads content items of a specific type.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="contentType">The content type to load.</param>
+    /// <param name="maxContentItems">The maximum content items to return.</param>
     public static Task<IEnumerable<ContentItem>> GetRecentContentItemsByContentTypeAsync(this IOrchardHelper orchardHelper, string contentType, int maxContentItems = 10)
     {
         return orchardHelper.QueryContentItemsAsync(query => query.Where(x => x.ContentType == contentType && x.Published == true).OrderByDescending(x => x.CreatedUtc).Take(maxContentItems));

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/TagHelpers/DynamicCacheTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/TagHelpers/DynamicCacheTagHelper.cs
@@ -79,7 +79,7 @@ namespace OrchardCore.DynamicCache.TagHelpers
         public bool Enabled { get; set; } = true;
 
         /// <summary>
-        /// Prefix used by <see cref="CacheTagHelper"/> instances when creating entries in <see cref="IDynamicCacheService"/>.
+        /// Prefix used by <see cref="DynamicCacheTagHelper"/> instances when creating entries in <see cref="IDynamicCacheService"/>.
         /// </summary>
         public static readonly string CacheKeyPrefix = nameof(DynamicCacheTagHelper);
 

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubOptions.cs
@@ -6,12 +6,12 @@ using Microsoft.AspNetCore.Http;
 namespace OrchardCore.GitHub.Configuration
 {
     /// <summary>
-    /// Configuration options for <see cref="MicrosoftAccountHandler"/>.
+    /// Configuration options for <see cref="GitHubHandler"/>.
     /// </summary>
     public class GitHubOptions : OAuthOptions
     {
         /// <summary>
-        /// Initializes a new <see cref="MicrosoftAccountOptions"/>.
+        /// Initializes a new <see cref="GitHubOptions"/>.
         /// </summary>
         public GitHubOptions()
         {

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Razor/LiquidRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Razor/LiquidRazorHelperExtensions.cs
@@ -19,10 +19,10 @@ public static class LiquidRazorHelperExtensions
 
     /// <summary>
     /// Parses a liquid string to HTML.
+    /// </summary>
     /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="liquid">The liquid to parse.</param>
     /// <param name="model">A model to bind against.</param>
-    /// </summary>
     public static async Task<IHtmlContent> LiquidToHtmlAsync(this IOrchardHelper orchardHelper, string liquid, object model)
     {
         var serviceProvider = orchardHelper.HttpContext.RequestServices;

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Razor/LiquidRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Razor/LiquidRazorHelperExtensions.cs
@@ -10,8 +10,8 @@ public static class LiquidRazorHelperExtensions
     /// <summary>
     /// Parses a liquid string to HTML.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="liquid"></param>
-    /// <returns></returns>
     public static Task<IHtmlContent> LiquidToHtmlAsync(this IOrchardHelper orchardHelper, string liquid)
     {
         return orchardHelper.LiquidToHtmlAsync(liquid, null);
@@ -19,10 +19,10 @@ public static class LiquidRazorHelperExtensions
 
     /// <summary>
     /// Parses a liquid string to HTML.
-    /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="liquid">The liquid to parse.</param>
     /// <param name="model">A model to bind against.</param>
-    /// <summary>
+    /// </summary>
     public static async Task<IHtmlContent> LiquidToHtmlAsync(this IOrchardHelper orchardHelper, string liquid, object model)
     {
         var serviceProvider = orchardHelper.HttpContext.RequestServices;

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Helpers/ListOrchardHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Helpers/ListOrchardHelperExtensions.cs
@@ -14,6 +14,7 @@ public static class ListOrchardHelperExtensions
     /// <summary>
     /// Returns list count.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="listContentItemId">The list content item id.</param>
     /// <param name="itemPredicate">The optional predicate applied to each item. By defult published items only.</param>
     /// <returns>A number of list items satisfying given predicate.</returns>
@@ -27,6 +28,7 @@ public static class ListOrchardHelperExtensions
     /// <summary>
     /// Returns list items.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="listContentItemId">The list content item id.</param>
     /// <param name="itemPredicate">The optional predicate applied to each item. By defult published items only.</param>
     /// <returns>An enumerable of list items satisfying given predicate.</returns>

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
@@ -17,7 +17,10 @@ using OrchardCore.Localization.ViewModels;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Localization.Drivers
-{
+{    
+    /// <summary>
+    /// Represents a <see cref="SectionDisplayDriver{TModel,TSection}"/> for the localization settings section in the admin site.
+    /// </summary>
     public class LocalizationSettingsDisplayDriver : SectionDisplayDriver<ISite, LocalizationSettings>
     {
         public const string GroupId = "localization";

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
@@ -18,9 +18,6 @@ using OrchardCore.Settings;
 
 namespace OrchardCore.Localization.Drivers
 {
-    /// <summary>
-    /// Represents a <see cref="DisplayDriver"/> for the localization settings section in the admin site.
-    /// </summary>
     public class LocalizationSettingsDisplayDriver : SectionDisplayDriver<ISite, LocalizationSettings>
     {
         public const string GroupId = "localization";
@@ -32,14 +29,6 @@ namespace OrchardCore.Localization.Drivers
         private readonly IHtmlLocalizer H;
         private readonly IStringLocalizer S;
 
-        /// <summary>
-        /// Creates a new instance of <see cref="LocalizationSettingsDisplayDriver"/>.
-        /// </summary>
-        /// <param name="notifier">The <see cref="INotifier"/>.</param>
-        /// <param name="shellHost">The <see cref="IShellHost"/>.</param>
-        /// <param name="shellSettings">The <see cref="ShellSettings"/>.</param>
-        /// <param name="h">The <see cref="IHtmlLocalizer"/>.</param>
-        /// <param name="s">The <see cref="IStringLocalizer"/>.</param>
         public LocalizationSettingsDisplayDriver(
             INotifier notifier,
             IShellHost shellHost,

--- a/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/ModularPoFileLocationProvider.cs
@@ -29,8 +29,8 @@ namespace OrchardCore.Localization
         /// </summary>
         /// <param name="extensionsManager">The <see cref="IExtensionManager"/>.</param>
         /// <param name="hostingEnvironment">The <see cref="IHostEnvironment"/>.</param>
-        /// <param name="shellOptions">The <see cref="IOptions"/> for the <see cref="ShellOptions"/>.</param>
-        /// <param name="localizationOptions">The <see cref="IOptions"/> for the <see cref="LocalizationOptions"/>.</param>
+        /// <param name="shellOptions">The <see cref="ShellOptions"/>.</param>
+        /// <param name="localizationOptions">The <see cref="LocalizationOptions"/>.</param>
         /// <param name="shellSettings">The <see cref="ShellSettings"/>.</param>
         public ModularPoFileLocationProvider(
             IExtensionManager extensionsManager,

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Razor/MarkdownHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Razor/MarkdownHelperExtensions.cs
@@ -16,7 +16,7 @@ public static class ContentRazorHelperExtensions
     /// </summary>
     /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="markdown">The markdown to convert.</param>
-    /// <param name="sanitize">Whether to sanitze the markdown. Defaults to True.</param>
+    /// <param name="sanitize">Whether to sanitze the markdown. Defaults to <see langword="true"/>.</param>
     public static async Task<IHtmlContent> MarkdownToHtmlAsync(this IOrchardHelper orchardHelper, string markdown, bool sanitize = true)
     {
         var shortcodeService = orchardHelper.HttpContext.RequestServices.GetRequiredService<IShortcodeService>();

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Razor/MarkdownHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Razor/MarkdownHelperExtensions.cs
@@ -14,7 +14,9 @@ public static class ContentRazorHelperExtensions
     /// <summary>
     /// Converts Markdown string to HTML.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="markdown">The markdown to convert.</param>
+    /// <param name="sanitize">Whether to sanitze the markdown. Defaults to True.</param>
     public static async Task<IHtmlContent> MarkdownToHtmlAsync(this IOrchardHelper orchardHelper, string markdown, bool sanitize = true)
     {
         var shortcodeService = orchardHelper.HttpContext.RequestServices.GetRequiredService<IShortcodeService>();

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Razor/OrchardRazorHelperExtensions.cs
@@ -9,6 +9,7 @@ public static class OrchardRazorHelperExtensions
     /// <summary>
     /// Applies short codes to html.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/></param>
     /// <param name="html">The html to apply short codes.</param>
     public static async Task<IHtmlContent> HtmlToShortcodesAsync(this IOrchardHelper orchardHelper, string html)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldDriverHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldDriverHelper.cs
@@ -14,6 +14,7 @@ namespace OrchardCore.Taxonomies.Drivers
         /// <summary>
         /// Populates a list of <see cref="TermEntry"/> with the hierarchy of terms.
         /// The list is ordered so that roots appear right before their child terms.
+        /// </summary>
         public static void PopulateTermEntries(List<TermEntry> termEntries, TaxonomyField field, IEnumerable<ContentItem> contentItems, int level)
         {
             foreach (var contentItem in contentItems)

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Helper/TaxonomyOrchardHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Helper/TaxonomyOrchardHelperExtensions.cs
@@ -13,6 +13,7 @@ public static class TaxonomyOrchardHelperExtensions
     /// <summary>
     /// Returns a term from its content item id and taxonomy.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="taxonomyContentItemId">The taxonomy content item id.</param>
     /// <param name="termContentItemId">The term content item id.</param>
     /// <returns>A content item id <c>null</c> if it was not found.</returns>
@@ -32,6 +33,7 @@ public static class TaxonomyOrchardHelperExtensions
     /// <summary>
     /// Returns the list of terms including their parents.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="taxonomyContentItemId">The taxonomy content item id.</param>
     /// <param name="termContentItemId">The term content item id.</param>
     /// <returns>A list content items.</returns>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -74,7 +74,7 @@ namespace OrchardCore.Themes.Controllers
                 var tags = extensionDescriptor.Manifest.Tags.ToArray();
                 var isHidden = tags.Any(x => string.Equals(x, "hidden", StringComparison.OrdinalIgnoreCase));
 
-                // is the theme allowed for this tenant ?
+                // Is the theme allowed for this tenant?
                 // allowed = _shellSettings.Themes.Length == 0 || _shellSettings.Themes.Contains(extensionDescriptor.Id);
 
                 return !isHidden;

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -74,7 +74,7 @@ namespace OrchardCore.Themes.Controllers
                 var tags = extensionDescriptor.Manifest.Tags.ToArray();
                 var isHidden = tags.Any(x => string.Equals(x, "hidden", StringComparison.OrdinalIgnoreCase));
 
-                /// is the theme allowed for this tenant ?
+                // is the theme allowed for this tenant ?
                 // allowed = _shellSettings.Themes.Length == 0 || _shellSettings.Themes.Contains(extensionDescriptor.Id);
 
                 return !isHidden;

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/ITypeFeatureProvider.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/ITypeFeatureProvider.cs
@@ -4,7 +4,7 @@ using OrchardCore.Environment.Extensions.Features;
 namespace OrchardCore.Environment.Extensions
 {
     /// <summary>
-    /// An implementation of this service is able to provide the <see cref="Feature"/> that
+    /// An implementation of this service is able to provide the <see cref="IFeatureInfo"/> that
     /// any services was harvested from.
     /// </summary>
     public interface ITypeFeatureProvider

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/FileProviders/EmbeddedDirectoryInfo.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/FileProviders/EmbeddedDirectoryInfo.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Modules.FileProviders
         /// <summary>
         /// Initializes an instance of <see cref="EmbeddedDirectoryInfo"/>
         /// </summary>
-        /// <param name="info">The directory</param>
+        /// <param name="name">The directory</param>
         public EmbeddedDirectoryInfo(string name)
         {
             Name = name;

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/IShellHost.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/IShellHost.cs
@@ -42,7 +42,7 @@ namespace OrchardCore.Environment.Shell
         /// Releases a shell so that a new one will be built for subsequent requests.
         /// Note: Can be used to free up resources after a given time of inactivity.
         /// </summary>
-        /// <param name="settings">The <see cref="ShellSettings"/> to reload</param>
+        /// <param name="settings">The <see cref="ShellSettings"/> to reload.</param>
         /// <param name="eventSource">
         /// Whether the related <see cref="ShellEvent"/> is invoked.
         /// </param>

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/IShellHost.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/IShellHost.cs
@@ -32,6 +32,7 @@ namespace OrchardCore.Environment.Shell
         /// Reloads the settings and releases the shell so that a new one will be
         /// built for subsequent requests, while existing requests get flushed.
         /// </summary>
+        /// <param name="settings">The <see cref="ShellSettings"/> to reload</param>
         /// <param name="eventSource">
         /// Whether the related <see cref="ShellEvent"/> is invoked.
         /// </param>
@@ -41,6 +42,7 @@ namespace OrchardCore.Environment.Shell
         /// Releases a shell so that a new one will be built for subsequent requests.
         /// Note: Can be used to free up resources after a given time of inactivity.
         /// </summary>
+        /// <param name="settings">The <see cref="ShellSettings"/> to reload</param>
         /// <param name="eventSource">
         /// Whether the related <see cref="ShellEvent"/> is invoked.
         /// </param>

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/IShellHost.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/IShellHost.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.Environment.Shell
         /// Reloads the settings and releases the shell so that a new one will be
         /// built for subsequent requests, while existing requests get flushed.
         /// </summary>
-        /// <param name="settings">The <see cref="ShellSettings"/> to reload</param>
+        /// <param name="settings">The <see cref="ShellSettings"/> to reload.</param>
         /// <param name="eventSource">
         /// Whether the related <see cref="ShellEvent"/> is invoked.
         /// </param>

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellHostReloadException.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellHostReloadException.cs
@@ -3,7 +3,7 @@ using System;
 namespace OrchardCore.Environment.Shell
 {
     /// <summary>
-    /// The <see cref="Exception"/> that is thrown if <see cref="IShellHost.ReloadShellContextAsync(ShellSettings)"/> fails.
+    /// The <see cref="Exception"/> that is thrown if <see cref="IShellHost.ReloadShellContextAsync(ShellSettings, bool)"/> fails.
     /// </summary>
     public class ShellHostReloadException : Exception
     {

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/AdminAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/AdminAttribute.cs
@@ -5,11 +5,11 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace OrchardCore.Admin
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     /// <summary>
     /// When applied to an action or a controller or a page model, intercepts any request to check whether it applies to the admin site.
     /// If so it marks the request as such and ensures the user has the right to access it.
     /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public class AdminAttribute : Attribute, IAsyncResourceFilter
     {
         public AdminAttribute()

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
@@ -8,7 +8,8 @@ namespace OrchardCore.Apis
         /// <summary>
         /// Registers a type describing input arguments
         /// </summary>
-        /// <typeparam name="TInputType"></typeparam>
+        /// <typeparam name="TObject"></typeparam>
+        /// <typeparam name="TObjectType"></typeparam>
         /// <param name="services"></param>
         public static void AddInputObjectGraphType<TObject, TObjectType>(this IServiceCollection services)
             where TObject : class

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/Extensions/HttpRequestExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/Extensions/HttpRequestExtensions.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.Apis.GraphQL.Client
         /// <param name="value">
         /// The value.
         /// </param>
-        /// <param name="formatter">
+        /// <param name="settings">
         /// The formatter.
         /// </param>
         /// <typeparam name="T">
@@ -94,7 +94,7 @@ namespace OrchardCore.Apis.GraphQL.Client
         /// <param name="value">
         /// The value.
         /// </param>
-        /// <param name="formatter">
+        /// <param name="settings">
         /// The formatter.
         /// </param>
         /// <typeparam name="T">
@@ -128,7 +128,7 @@ namespace OrchardCore.Apis.GraphQL.Client
         /// <param name="value">
         /// The value.
         /// </param>
-        /// <param name="formatter">
+        /// <param name="settings">
         /// The formatter.
         /// </param>
         /// <typeparam name="T">

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/IContentLocalizationManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/IContentLocalizationManager.cs
@@ -11,11 +11,13 @@ namespace OrchardCore.ContentLocalization
         /// </summary>
         /// <returns>List of all items matching a localizationSet</returns>
         Task<IEnumerable<ContentItem>> GetItemsForSetAsync(string localizationSet);
+
         /// <summary>
         /// Get the content item that matches the localizationSet / culture combination
         /// </summary>
         /// <returns>ContentItem or null if not found</returns>
         Task<ContentItem> GetContentItemAsync(string localizationSet, string culture);
+
         /// <summary>
         /// Localizes the content item to the target culture.
         /// This method will clone the ContentItem of the default locale
@@ -24,14 +26,16 @@ namespace OrchardCore.ContentLocalization
         /// <returns>The localized content item</returns>
         Task<ContentItem> LocalizeAsync(ContentItem content, string targetCulture);
 
+        /// <summary>
         /// Deduplicate the list of contentItems to only keep a single contentItem per LocalizationSet.
         /// Each ContentItem is chosen with the following rules:
         /// - ContentItemId of the current culture for the set
         /// - OR ContentItemId of the default culture for the set
         /// - OR First ContentItemId found in the set
-        /// </summary
+        /// </summary>
         /// <returns>Cleaned list of ContentItem</returns>
         Task<IDictionary<string, ContentItem>> DeduplicateContentItemsAsync(IEnumerable<ContentItem> contentItems);
+        
         /// <summary>
         /// Gets a list of ContentItemId for the LocalizationSet based on some rules
         /// Order of elements is kept.

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs
@@ -17,8 +17,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Gets a content element by its name.
         /// </summary>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
+        /// <param name="name">The name of the content element.</param>
         /// <typeparam name="TElement">The expected type of the content element.</typeparam>
-        /// <typeparam name="name">The name of the content element.</typeparam>
         /// <returns>The content element instance or <code>null</code> if it doesn't exist.</returns>
         public static TElement Get<TElement>(this ContentElement contentElement, string name) where TElement : ContentElement
         {
@@ -28,6 +29,7 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Gets whether a content element has a specific element attached.
         /// </summary>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
         /// <typeparam name="TElement">The expected type of the content element.</typeparam>
         public static bool Has<TElement>(this ContentElement contentElement) where TElement : ContentElement
         {
@@ -37,8 +39,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Gets a content element by its name.
         /// </summary>
-        /// <typeparam name="contentElementType">The expected type of the content element.</typeparam>
-        /// <typeparam name="name">The name of the content element.</typeparam>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
+        /// <param name="contentElementType">The expected type of the content element.</param>
+        /// <param name="name">The name of the content element.</param>
         /// <returns>The content element instance or <code>null</code> if it doesn't exist.</returns>
         public static ContentElement Get(this ContentElement contentElement, Type contentElementType, string name)
         {
@@ -66,8 +69,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Gets a content element by its name or create a new one.
         /// </summary>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
+        /// <param name="name">The name of the content element.</param>
         /// <typeparam name="TElement">The expected type of the content element.</typeparam>
-        /// <typeparam name="name">The name of the content element.</typeparam>
         /// <returns>The content element instance or a new one if it doesn't exist.</returns>
         public static TElement GetOrCreate<TElement>(this ContentElement contentElement, string name) where TElement : ContentElement, new()
         {
@@ -88,8 +92,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Adds a content element by name.
         /// </summary>
-        /// <typeparam name="name">The name of the content element.</typeparam>
-        /// <typeparam name="element">The element to add to the <see cref="ContentItem"/>.</typeparam>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
+        /// <param name="name">The name of the content element.</param>
+        /// <param name="element">The element to add to the <see cref="ContentItem"/>.</param>
         /// <returns>The current <see cref="ContentItem"/> instance.</returns>
         public static ContentElement Weld(this ContentElement contentElement, string name, ContentElement element)
         {
@@ -109,7 +114,7 @@ namespace OrchardCore.ContentManagement
         /// Welds a new part to the content item. If a part of the same type is already welded nothing is done.
         /// This part can be not defined in Content Definitions.
         /// </summary>
-        /// <typeparam name="TPart">The type of the part to be welded.</typeparam>
+        /// <typeparam name="TElement">The type of the part to be welded.</typeparam>
         public static ContentElement Weld<TElement>(this ContentElement contentElement, object settings = null) where TElement : ContentElement, new()
         {
             var elementName = typeof(TElement).Name;
@@ -139,8 +144,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Updates the content element with the specified name.
         /// </summary>
-        /// <typeparam name="name">The name of the element to update.</typeparam>
-        /// <typeparam name="element">The content element instance to update.</typeparam>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
+        /// <param name="name">The name of the element to update.</param>
+        /// <param name="element">The content element instance to update.</param>
         /// <returns>The current <see cref="ContentItem"/> instance.</returns>
         public static ContentElement Apply(this ContentElement contentElement, string name, ContentElement element)
         {
@@ -173,7 +179,8 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Updates the whole content.
         /// </summary>
-        /// <typeparam name="element">The content element instance to update.</typeparam>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
+        /// <param name="element">The content element instance to update.</param>
         /// <returns>The current <see cref="ContentItem"/> instance.</returns>
         public static ContentElement Apply(this ContentElement contentElement, ContentElement element)
         {
@@ -193,8 +200,10 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Modifies a new or existing content element by name.
         /// </summary>
-        /// <typeparam name="name">The name of the content element to update.</typeparam>
-        /// <typeparam name="action">An action to apply on the content element.</typeparam>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
+        /// <param name="name">The name of the content element to update.</param>
+        /// <param name="action">An action to apply on the content element.</param>
+        /// <typeparam name="TElement">The type of the part to be altered.</typeparam>
         /// <returns>The current <see cref="ContentElement"/> instance.</returns>
         public static ContentElement Alter<TElement>(this ContentElement contentElement, string name, Action<TElement> action) where TElement : ContentElement, new()
         {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
@@ -9,6 +9,8 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Gets a content part by its type.
         /// </summary>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <typeparam name="TPart">The type of the content part.</typeparam>
         /// <returns>The content part or <code>null</code> if it doesn't exist.</returns>
         public static TPart As<TPart>(this ContentItem contentItem) where TPart : ContentPart
         {
@@ -18,6 +20,7 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Gets a content part by its type or create a new one.
         /// </summary>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
         /// <typeparam name="TPart">The type of the content part.</typeparam>
         /// <returns>The content part instance or a new one if it doesn't exist.</returns>
         public static TPart GetOrCreate<TPart>(this ContentItem contentItem) where TPart : ContentPart, new()
@@ -28,7 +31,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Adds a content part by its type.
         /// </summary>
-        /// <typeparam name="part">The part to add to the <see cref="ContentItem"/>.</typeparam>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <param name="part">The content part to weld.</param>
+        /// <typeparam name="TPart">The type of the content part.</typeparam>
         /// <returns>The current <see cref="ContentItem"/> instance.</returns>
         public static ContentItem Weld<TPart>(this ContentItem contentItem, TPart part) where TPart : ContentPart
         {
@@ -39,7 +44,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Updates the content part with the specified type.
         /// </summary>
-        /// <typeparam name="TPart">The type of the part to update.</typeparam>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <param name="part">The content part to update.</param>
+        /// <typeparam name="TPart">The type of the content part.</typeparam>
         /// <returns>The current <see cref="ContentItem"/> instance.</returns>
         public static ContentItem Apply<TPart>(this ContentItem contentItem, TPart part) where TPart : ContentPart
         {
@@ -50,8 +57,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Modifies a new or existing content part by name.
         /// </summary>
-        /// <typeparam name="name">The name of the content part to update.</typeparam>
-        /// <typeparam name="action">An action to apply on the content part.</typeparam>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <param name="action">An action to apply on the content part.</param>
+        /// <typeparam name="TPart">The type of the content part.</typeparam>
         /// <returns>The current <see cref="ContentPart"/> instance.</returns>
         public static ContentItem Alter<TPart>(this ContentItem contentItem, Action<TPart> action) where TPart : ContentPart, new()
         {
@@ -65,8 +73,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Modifies a new or existing content part by name.
         /// </summary>
-        /// <typeparam name="name">The name of the content part to update.</typeparam>
-        /// <typeparam name="action">An action to apply on the content part.</typeparam>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <param name="action">An action to apply on the content part.</param>
+        /// <typeparam name="TPart">The type of the content part.</typeparam>
         /// <returns>The current <see cref="ContentItem"/> instance.</returns>
         public static async Task<ContentItem> AlterAsync<TPart>(this ContentItem contentItem, Func<TPart, Task> action) where TPart : ContentPart, new()
         {
@@ -80,7 +89,9 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Merges properties to the contents of a content item.
         /// </summary>
-        /// <typeparam name="properties">The object to merge.</typeparam>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <param name="properties">The object to merge.</param>
+        /// <param name="jsonMergeSettings">The <see cref="JsonMergeSettings"/> to use.</param>
         /// <returns>The current <see cref="ContentItem"/> instance.</returns>
         public static ContentItem Merge(this ContentItem contentItem, object properties, JsonMergeSettings jsonMergeSettings = null)
         {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentDefinitionManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentDefinitionManager.cs
@@ -33,7 +33,6 @@ namespace OrchardCore.ContentManagement.Metadata
         /// <summary>
         /// Returns an unique identifier that is updated when content definitions have changed.
         /// </summary>
-        /// <returns>
         Task<string> GetIdentifierAsync();
     }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs
@@ -135,6 +135,7 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Creates (persists) a new Published content item
         /// </summary>
+        /// <param name="contentManager">The <see cref="IContentManager"/> instance.</param>
         /// <param name="contentItem">The content instance filled with all necessary data</param>
 
         public static Task CreateAsync(this IContentManager contentManager, ContentItem contentItem)
@@ -190,6 +191,7 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Gets either the published container content item with the specified id, or if the json path supplied gets the contained content item. 
         /// </summary>
+        /// <param name="contentManager">The <see cref="IContentManager"/> instance.</param>
         /// <param name="id">The content item id to load</param>
         /// <param name="jsonPath">The json path of the contained content item</param>
         public static Task<ContentItem> GetAsync(this IContentManager contentManager, string id, string jsonPath)
@@ -200,6 +202,7 @@ namespace OrchardCore.ContentManagement
         /// <summary>
         /// Gets either the container content item with the specified id and version, or if the json path supplied gets the contained content item.
         /// </summary>
+        /// <param name="contentManager">The <see cref="IContentManager"/> instance.</param>
         /// <param name="id">The id content item id to load</param>
         /// <param name="options">The version option</param>
         /// <param name="jsonPath">The json path of the contained content item</param>

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ITypeActivatorFactory.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ITypeActivatorFactory.cs
@@ -3,8 +3,7 @@ using System;
 namespace OrchardCore.ContentManagement
 {
     /// <summary>
-    /// Represents a service that can provide an <see cref="ITypeActivator{TInstance}"/> instance for a
-    /// <see cref="TInstance"/> name.
+    /// Represents a service that can provide an <see cref="ITypeActivator{TInstance}"/> instance.
     /// </summary>
     public interface ITypeActivatorFactory<TInstance>
     {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Models/ContentTypeDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Models/ContentTypeDefinition.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.ContentManagement.Metadata.Models
 
         /// <summary>
         /// Returns the <see cref="DisplayName"/> value of the type if defined,
-        /// or the <see cref="Name"/> otherwise.
+        /// or the <see cref="ContentDefinition.Name"/> otherwise.
         /// </summary>
         /// <returns></returns>
         public override string ToString()

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/Razor/OrchardRazorHelperExtensions.cs
@@ -24,6 +24,7 @@ public static class OrchardRazorHelperExtensions
     /// <summary>
     /// Renders an object in the browser's console.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="content">The object to render.</param>
     /// <returns>The encoded script rendering the object to the console.</returns>
     public static IHtmlContent ConsoleLog(this IOrchardHelper orchardHelper, object content)

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Abstractions/ModelBinding/ModelStateDictionaryExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Abstractions/ModelBinding/ModelStateDictionaryExtensions.cs
@@ -25,8 +25,7 @@ namespace OrchardCore.Mvc.ModelBinding
         /// </summary>
         /// <param name="modelState">The model state.</param>
         /// <param name="prefix">The prefix of the key.</param>
-        /// <param name="key">The key.</param>
-        /// <param name="errorMessage">The error message.</param>
+        /// <param name="validationResults">The <see cref="ValidationResult"/>.</param>
         public static void BindValidationResults(this ModelStateDictionary modelState, string prefix, IEnumerable<ValidationResult> validationResults)
         {
             foreach (var item in validationResults)

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
@@ -79,7 +79,7 @@ namespace OrchardCore.DisplayManagement.Liquid
         }
 
         /// <summary>
-        /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see cref="char[]"/>.
+        /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see langref="char[]"/>.
         /// </summary>
         private class CharrArrayHtmlContent : IHtmlContent
         {
@@ -109,7 +109,7 @@ namespace OrchardCore.DisplayManagement.Liquid
         }
 
         /// <summary>
-        /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see cref="char[]"/>.
+        /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see langref="char[]"/>.
         /// </summary>
         private class CharrArrayFragmentHtmlContent : IHtmlContent
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
@@ -79,7 +79,7 @@ namespace OrchardCore.DisplayManagement.Liquid
         }
 
         /// <summary>
-        /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see langref="char[]"/>.
+        /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see langword="char[]"/>.
         /// </summary>
         private class CharrArrayHtmlContent : IHtmlContent
         {
@@ -109,7 +109,7 @@ namespace OrchardCore.DisplayManagement.Liquid
         }
 
         /// <summary>
-        /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see langref="char[]"/>.
+        /// An <see cref="IHtmlContent"/> implementation that wraps an HTML encoded <see langword="char[]"/>.
         /// </summary>
         private class CharrArrayFragmentHtmlContent : IHtmlContent
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/Interfaces.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/Interfaces.cs
@@ -45,7 +45,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
         /// Builds a contextualized <see cref="IPlacementInfoResolver"/>
         /// </summary>
         /// <param name="context">The <see cref="IBuildShapeContext"/> for which we need a placement resolver</param>
-        /// <returns>An instance of <see cref="IPlacementInfoResolver"/> for the current context or <see cref="null"/> if this provider is not concerned.</returns>
+        /// <returns>An instance of <see cref="IPlacementInfoResolver"/> for the current context or <see langref="null"/> if this provider is not concerned.</returns>
         Task<IPlacementInfoResolver> BuildPlacementInfoResolverAsync(IBuildShapeContext context);
     }
 
@@ -58,7 +58,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
         /// Resolves <see cref="PlacementInfo"/> for the provided <see cref="ShapePlacementContext"/>
         /// </summary>
         /// <param name="placementContext">The <see cref="ShapePlacementContext"/></param>
-        /// <returns>An <see cref="PlacementInfo"/> or <see cref="null"/> if not concerned.</returns>
+        /// <returns>An <see cref="PlacementInfo"/> or <see langref="null"/> if not concerned.</returns>
         PlacementInfo ResolvePlacement(ShapePlacementContext placementContext);
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/Interfaces.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/Interfaces.cs
@@ -45,7 +45,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
         /// Builds a contextualized <see cref="IPlacementInfoResolver"/>
         /// </summary>
         /// <param name="context">The <see cref="IBuildShapeContext"/> for which we need a placement resolver</param>
-        /// <returns>An instance of <see cref="IPlacementInfoResolver"/> for the current context or <see langref="null"/> if this provider is not concerned.</returns>
+        /// <returns>An instance of <see cref="IPlacementInfoResolver"/> for the current context or <see langword="null"/> if this provider is not concerned.</returns>
         Task<IPlacementInfoResolver> BuildPlacementInfoResolverAsync(IBuildShapeContext context);
     }
 
@@ -58,7 +58,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
         /// Resolves <see cref="PlacementInfo"/> for the provided <see cref="ShapePlacementContext"/>
         /// </summary>
         /// <param name="placementContext">The <see cref="ShapePlacementContext"/></param>
-        /// <returns>An <see cref="PlacementInfo"/> or <see langref="null"/> if not concerned.</returns>
+        /// <returns>An <see cref="PlacementInfo"/> or <see langword="null"/> if not concerned.</returns>
         PlacementInfo ResolvePlacement(ShapePlacementContext placementContext);
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateFileProviderAccessor.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateFileProviderAccessor.cs
@@ -4,14 +4,14 @@ using Microsoft.Extensions.Options;
 namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
 {
     /// <summary>
-    /// Default implementation of <see cref="ITemplateFileProviderAccessor"/>.
+    /// Default implementation of <see cref="IShapeTemplateFileProviderAccessor"/>.
     /// </summary>
     public class ShapeTemplateFileProviderAccessor : IShapeTemplateFileProviderAccessor
     {
         /// <summary>
         /// Initializes a new instance of <see cref="ShapeTemplateFileProviderAccessor"/>.
         /// </summary>
-        /// <param name="optionsAccessor">Accessor to <see cref="FluidViewOptions"/>.</param>
+        /// <param name="optionsAccessor">Accessor to <see cref="ShapeTemplateOptions"/>.</param>
         public ShapeTemplateFileProviderAccessor(IOptions<ShapeTemplateOptions> optionsAccessor)
         {
             var fileProviders = optionsAccessor.Value.FileProviders;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateOptionsSetup.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTemplateStrategy/ShapeTemplateOptionsSetup.cs
@@ -7,7 +7,7 @@ using OrchardCore.Mvc;
 namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
 {
     /// <summary>
-    /// Sets up default options for <see cref="ShapeTemplateViewOptions"/>.
+    /// Sets up default options for <see cref="ShapeTemplateOptions"/>.
     /// </summary>
     public class ShapeTemplateOptionsSetup : IConfigureOptions<ShapeTemplateOptions>
     {
@@ -15,9 +15,10 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy
         private readonly IApplicationContext _applicationContext;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="ShapeTemplateViewOptions"/>.
+        /// Initializes a new instance of <see cref="ShapeTemplateOptions"/>.
         /// </summary>
         /// <param name="hostingEnvironment"><see cref="IHostEnvironment"/> for the application.</param>
+        /// <param name="applicationContext"><see cref="IApplicationContext"/> for the application.</param>
         public ShapeTemplateOptionsSetup(IHostEnvironment hostingEnvironment, IApplicationContext applicationContext)
         {
             _hostingEnvironment = hostingEnvironment ?? throw new ArgumentNullException(nameof(hostingEnvironment));

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Entities/SectionDisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Entities/SectionDisplayDriver.cs
@@ -12,6 +12,7 @@ namespace OrchardCore.DisplayManagement.Entities
     /// shape instance for a specific section of the object. A section represents a property of an entity instance
     /// where the name of the property is the type of the section.
     /// </summary>
+    /// <typeparam name="TModel">The type of model this driver handles.</typeparam>
     /// <typeparam name="TSection">The type of the section this driver handles.</typeparam>
     public abstract class SectionDisplayDriver<TModel, TSection> : DisplayDriver<TModel>
         where TSection : new()

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriverBase.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriverBase.cs
@@ -108,7 +108,7 @@ namespace OrchardCore.DisplayManagement.Handlers
         }
 
         /// <summary>
-        /// If the shape needs to be rendered, it is created automatically from its type name and initialized with a <see param name="model" />
+        /// If the shape needs to be rendered, it is created automatically from its type name and initialized.
         /// </summary>
         public ShapeResult Shape(string shapeType, IShape shape)
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/FindPlacementDelegate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/FindPlacementDelegate.cs
@@ -13,6 +13,6 @@ namespace OrchardCore.DisplayManagement.Handlers
     /// </param>
     /// <param name="displayType">The display type the content item owning the shape is rendered with.</param>
     /// <param name="context">The <see cref="IBuildShapeContext"/> in which the shape is placed.</param>
-    /// <returns>The <see cref="PlacementInfo"/> to use or <see cref="null"/> if this function is not concerned.</returns>
+    /// <returns>The <see cref="PlacementInfo"/> to use or <see langword="null"/> if this function is not concerned.</returns>
     public delegate PlacementInfo FindPlacementDelegate(string shapeType, string differentiator, string displayType, IBuildShapeContext context);
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/IShapeFactory.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/IShapeFactory.cs
@@ -31,6 +31,7 @@ namespace OrchardCore.DisplayManagement
         /// <summary>
         /// Creates a new shape by copying the properties of the specific model.
         /// </summary>
+        /// <param name="factory">The <see cref="IShapeFactory"/>.</param>
         /// <param name="shapeType">The type of shape to create.</param>
         /// <param name="model">The model to copy.</param>
         /// <returns></returns>
@@ -66,9 +67,10 @@ namespace OrchardCore.DisplayManagement
         }
 
         /// <summary>
-        /// Creates a dynamic proxy instance for the <see cref="TModel"/> type and initializes it.
+        /// Creates a dynamic proxy instance for the type and initializes it.
         /// </summary>
         /// <typeparam name="TModel">The type to instantiate.</typeparam>
+        /// <param name="factory">The <see cref="IShapeFactory"/>.</param>
         /// <param name="shapeType">The shape type to create.</param>
         /// <param name="initializeAsync">The initialization method.</param>
         /// <returns></returns>
@@ -96,9 +98,10 @@ namespace OrchardCore.DisplayManagement
         }
 
         /// <summary>
-        /// Creates a dynamic proxy instance for the <see cref="TModel"/> type and initializes it.
+        /// Creates a dynamic proxy instance for the type and initializes it.
         /// </summary>
         /// <typeparam name="TModel">The type to instantiate.</typeparam>
+        /// <param name="factory">The <see cref="IShapeFactory"/>.</param>
         /// <param name="shapeType">The shape type to create.</param>
         /// <param name="initialize">The initialization method.</param>
         /// <returns></returns>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifierExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifierExtensions.cs
@@ -7,7 +7,8 @@ namespace OrchardCore.DisplayManagement.Notify
         /// <summary>
         /// Adds a new UI notification of type Information
         /// </summary>
-        /// <seealso cref="INotifier.Add()"/>
+        /// <seealso cref="INotifier.Add"/>
+        /// <param name="notifier">The <see cref="INotifier"/></param>
         /// <param name="message">A localized message to display</param>
         public static void Information(this INotifier notifier, LocalizedHtmlString message)
         {
@@ -17,7 +18,8 @@ namespace OrchardCore.DisplayManagement.Notify
         /// <summary>
         /// Adds a new UI notification of type Warning
         /// </summary>
-        /// <seealso cref="INotifier.Add()"/>
+        /// <seealso cref="INotifier.Add"/>
+        /// <param name="notifier">The <see cref="INotifier"/></param>
         /// <param name="message">A localized message to display</param>
         public static void Warning(this INotifier notifier, LocalizedHtmlString message)
         {
@@ -27,7 +29,8 @@ namespace OrchardCore.DisplayManagement.Notify
         /// <summary>
         /// Adds a new UI notification of type Error
         /// </summary>
-        /// <seealso cref="INotifier.Add()"/>
+        /// <seealso cref="INotifier.Add"/>
+        /// <param name="notifier">The <see cref="INotifier"/></param>
         /// <param name="message">A localized message to display</param>
         public static void Error(this INotifier notifier, LocalizedHtmlString message)
         {
@@ -37,7 +40,8 @@ namespace OrchardCore.DisplayManagement.Notify
         /// <summary>
         /// Adds a new UI notification of type Success
         /// </summary>
-        /// <seealso cref="INotifier.Add()"/>
+        /// <seealso cref="INotifier.Add"/>
+        /// <param name="notifier">The <see cref="INotifier"/></param>
         /// <param name="message">A localized message to display</param>
         public static void Success(this INotifier notifier, LocalizedHtmlString message)
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -243,7 +243,7 @@ namespace OrchardCore.DisplayManagement.Razor
             return Shape.GetTagBuilder(shape, tag);
         }
 
-        // <summary>
+        /// <summary>
         /// In a Razor layout page, renders the portion of a content page that is not within a named zone.
         /// </summary>
         /// <returns>The HTML content to render.</returns>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeMetadata.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeMetadata.cs
@@ -88,7 +88,7 @@ namespace OrchardCore.DisplayManagement.Shapes
         }
 
         /// <summary>
-        /// Returns the <see cref="ShapeMetadataCacheContext"/> instance if the shape is cached.
+        /// Returns the <see cref="CacheContext"/> instance if the shape is cached.
         /// </summary>
         public CacheContext Cache()
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Title/IPageTitleBuilder.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Title/IPageTitleBuilder.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.DisplayManagement.Title
         /// Adds a segment to the title.
         /// </summary>
         /// <param name="segment">A segments to add at the specific location in the title.</param>
+        /// <param name="position">The position, defaults to 0.</param>
         void AddSegment(IHtmlContent segment, string position = "0");
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpSettings.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/SmtpSettings.cs
@@ -33,9 +33,11 @@ namespace OrchardCore.Email
         /// </summary>
         public string Host { get; set; }
 
-        [Range(0, 65535)]
 
-        ///Gets or sets the SMTP port number. Defaults to <c>25</c>.
+        /// <summary>
+        /// Gets or sets the SMTP port number. Defaults to <c>25</c>.
+        /// </summary>
+        [Range(0, 65535)]
         public int Port { get; set; } = 25;
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.FileStorage.Abstractions/IFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.Abstractions/IFileStore.cs
@@ -120,6 +120,7 @@ namespace OrchardCore.FileStorage
         /// <summary>
         /// Combines multiple path parts using the path delimiter semantics of the abstract virtual file store.
         /// </summary>
+        /// <param name="fileStore">The <see cref="IFileStore"/>.</param>
         /// <param name="paths">The path parts to combine.</param>
         /// <returns>The full combined path.</returns>
         public static string Combine(this IFileStore fileStore, params string[] paths)

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/ContentFieldIndexHandler.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/ContentFieldIndexHandler.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Indexing
 {
     /// <summary>
     /// An implementation of <see cref="ContentFieldIndexHandler&lt;TField&gt;"/> is able to take part in the rendering of
-    /// a <see cref="TField"/> instance.
+    /// a <see typeparamref="TField"/> instance.
     /// </summary>
     public abstract class ContentFieldIndexHandler<TField> : IContentFieldIndexHandler where TField : ContentField
     {

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/ContentPartIndexHandler.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/ContentPartIndexHandler.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Indexing
 {
     /// <summary>
     /// An implementation of <see cref="ContentPartIndexHandler&lt;TPart&gt;"/> is able to take part in the rendering of
-    /// a <see cref="TPart"/> instance.
+    /// a <see typeparamref="TPart"/> instance.
     /// </summary>
     public abstract class ContentPartIndexHandler<TPart> : IContentPartIndexHandler where TPart : ContentPart
     {

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Documents/IDocumentEntityManagerOfT.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Documents/IDocumentEntityManagerOfT.cs
@@ -3,7 +3,7 @@ using OrchardCore.Data.Documents;
 namespace OrchardCore.Documents
 {
     /// <summary>
-    /// An <see cref="IDocumentEntityManager<TDocumentEntity>"/> using a given type of <see cref="IDocumentStore"/>.
+    /// An <see cref="IDocumentEntityManager{TDocumentEntity}"/> using a given type of <see cref="IDocumentStore"/>.
     /// </summary>
     public interface IDocumentEntityManager<TDocumentStore, TDocumentEntity> : IDocumentEntityManager<TDocumentEntity>
         where TDocumentStore : IDocumentStore where TDocumentEntity : class, IDocumentEntity, new()

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Documents/IDocumentManagerOfT.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Documents/IDocumentManagerOfT.cs
@@ -3,7 +3,7 @@ using OrchardCore.Data.Documents;
 namespace OrchardCore.Documents
 {
     /// <summary>
-    /// An <see cref="IDocumentManager<TDocument>"/> using a given type of <see cref="IDocumentStore"/>.
+    /// An <see cref="IDocumentManager{TDocument}"/> using a given type of <see cref="IDocumentStore"/>.
     /// </summary>
     public interface IDocumentManager<TDocumentStore, TDocument> : IDocumentManager<TDocument>
         where TDocumentStore : IDocumentStore where TDocument : class, IDocument, new()

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Documents/IVolatileDocumentEntityManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Documents/IVolatileDocumentEntityManager.cs
@@ -1,7 +1,7 @@
 namespace OrchardCore.Documents
 {
     /// <summary>
-    /// An <see cref="IDocumentEntityManager<TDocumentEntity>"/> using a shared cache but without any persistent storage.
+    /// An <see cref="IDocumentEntityManager{TDocumentEntity}"/> using a shared cache but without any persistent storage.
     /// </summary>
     public interface IVolatileDocumentEntityManager<TDocumentEntity> : IDocumentEntityManager<TDocumentEntity> where TDocumentEntity : class, IDocumentEntity, new()
     {

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Documents/IVolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Documents/IVolatileDocumentManager.cs
@@ -3,7 +3,7 @@ using OrchardCore.Data.Documents;
 namespace OrchardCore.Documents
 {
     /// <summary>
-    /// An <see cref="IDocumentManager<TDocument>"/> using a shared cache but without any persistent storage.
+    /// An <see cref="IDocumentManager{TDocument}"/> using a shared cache but without any persistent storage.
     /// </summary>
     public interface IVolatileDocumentManager<TDocument> : IDocumentManager<TDocument> where TDocument : class, IDocument, new()
     {

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Entities/EntityExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Entities/EntityExtensions.cs
@@ -8,6 +8,7 @@ namespace OrchardCore.Entities
         /// <summary>
         /// Extracts the specified type of property.
         /// </summary>
+        /// <param name="entity">The <see cref="IEntity"/>.</param>
         /// <typeparam name="T">The type of the property to extract.</typeparam>
         /// <returns>A new instance of the requested type if the property was not found.</returns>
         public static T As<T>(this IEntity entity) where T : new()
@@ -20,6 +21,7 @@ namespace OrchardCore.Entities
         /// Extracts the specified named property.
         /// </summary>
         /// <typeparam name="T">The type of the property to extract.</typeparam>
+        /// <param name="entity">The <see cref="IEntity"/>.</param>
         /// <param name="name">The name of the property to extract.</param>
         /// <returns>A new instance of the requested type if the property was not found.</returns>
         public static T As<T>(this IEntity entity, string name) where T : new()
@@ -38,6 +40,7 @@ namespace OrchardCore.Entities
         /// Indicates if the specified type of property is attached to the <see cref="IEntity"/> instance.
         /// </summary>
         /// <typeparam name="T">The type of the property to check.</typeparam>
+        /// <param name="entity">The <see cref="IEntity"/>.</param>
         /// <returns>True if the property was found, otherwise false.</returns>
         public static bool Has<T>(this IEntity entity)
         {
@@ -48,6 +51,7 @@ namespace OrchardCore.Entities
         /// <summary>
         /// Indicates if the specified property is attached to the <see cref="IEntity"/> instance.
         /// </summary>
+        /// <param name="entity">The <see cref="IEntity"/>.</param>
         /// <param name="name">The name of the property to check.</param>
         /// <returns>True if the property was found, otherwise false.</returns>
         public static bool Has(this IEntity entity, string name)
@@ -69,8 +73,9 @@ namespace OrchardCore.Entities
         /// <summary>
         /// Modifies or create an aspect.
         /// </summary>
-        /// <typeparam name="name">The name of the aspect.</typeparam>
-        /// <typeparam name="action">An action to apply on the aspect.</typeparam>
+        /// <param name="entity">The <see cref="IEntity"/>.</param>
+        /// <param name="name">The name of the aspect.</param>
+        /// <param name="action">An action to apply on the aspect.</param>
         /// <returns>The current <see cref="IEntity"/> instance.</returns>
         public static IEntity Alter<TAspect>(this IEntity entity, string name, Action<TAspect> action) where TAspect : new()
         {

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IScriptingManager.cs
@@ -21,6 +21,7 @@ namespace OrchardCore.Scripting
         /// </summary>
         /// <param name="directive">The directive to execute. A directive is made of a </param>
         /// <param name="fileProvider">An optional <see cref="IFileProvider"/> instance.</param>
+        /// <param name="basePath">The base path.</param>
         /// <param name="scopedMethodProviders">A list of method providers scoped to the script evaluation.</param>
         /// <returns>The result of the script if any.</returns>
         object Evaluate(string directive, IFileProvider fileProvider, string basePath, IEnumerable<IGlobalMethodProvider> scopedMethodProviders);

--- a/src/OrchardCore/OrchardCore.Infrastructure/Cache/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Cache/OrchardCoreBuilderExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddSingleton<IDistributedCache, MemoryDistributedCache>();
             });
 
-            /// Adds services to keep in sync any document type between a document store and a multi level cache.
+            // Adds services to keep in sync any document type between a document store and a multi level cache.
             return builder.AddDocumentManagement();
         }
     }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentEntityManagerOfT.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentEntityManagerOfT.cs
@@ -3,7 +3,7 @@ using OrchardCore.Data.Documents;
 namespace OrchardCore.Documents
 {
     /// <summary>
-    /// A <see cref="DocumentEntityManager<TDocumentEntity>"/> using a given type of <see cref="IDocumentStore"/>.
+    /// A <see cref="DocumentEntityManager{TDocumentEntity}"/> using a given type of <see cref="IDocumentStore"/>.
     /// </summary>
     public class DocumentEntityManager<TDocumentStore, TDocumentEntity> : DocumentEntityManager<TDocumentEntity>, IDocumentEntityManager<TDocumentStore, TDocumentEntity>
         where TDocumentStore: IDocumentStore where TDocumentEntity : class, IDocumentEntity, new()

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManagerOfT.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManagerOfT.cs
@@ -6,7 +6,7 @@ using OrchardCore.Documents.Options;
 namespace OrchardCore.Documents
 {
     /// <summary>
-    /// A <see cref="DocumentManager<TDocument>"/> using a given type of <see cref="IDocumentStore"/>.
+    /// A <see cref="DocumentManager{TDocument}"/> using a given type of <see cref="IDocumentStore"/>.
     /// </summary>
     public class DocumentManager<TDocumentStore, TDocument> : DocumentManager<TDocument>, IDocumentManager<TDocumentStore, TDocument>
         where TDocumentStore: IDocumentStore where TDocument : class, IDocument, new()

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentEntityManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentEntityManager.cs
@@ -1,7 +1,7 @@
 namespace OrchardCore.Documents
 {
     /// <summary>
-    /// A <see cref="DocumentEntityManager<TDocumentEntity>"/> using a multi level cache but without any persistent storage.
+    /// A <see cref="DocumentEntityManager{TDocumentEntity}"/> using a multi level cache but without any persistent storage.
     /// </summary>
     public class VolatileDocumentEntityManager<TDocumentEntity> : DocumentEntityManager<TDocumentEntity>, IVolatileDocumentEntityManager<TDocumentEntity> where TDocumentEntity : class, IDocumentEntity, new()
     {

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
@@ -6,7 +6,7 @@ using OrchardCore.Documents.Options;
 namespace OrchardCore.Documents
 {
     /// <summary>
-    /// A <see cref="DocumentManager<TDocument>"/> using a multi level cache but without any persistent storage.
+    /// A <see cref="DocumentManager{TDocument}"/> using a multi level cache but without any persistent storage.
     /// </summary>
     public class VolatileDocumentManager<TDocument> : DocumentManager<TDocument>, IVolatileDocumentManager<TDocument> where TDocument : class, IDocument, new()
     {

--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerRazorExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/HtmlSanitizerRazorExtensions.cs
@@ -8,6 +8,7 @@ public static class HtmlSanitizerRazorExtensions
     /// <summary>
     /// Sanitizes a string of html.
     /// </summary>
+    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
     /// <param name="html">The html to sanitize.</param>
     public static IHtmlContent SanitizeHtml(this IOrchardHelper orchardHelper, string html)
     {

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/ILocalizationManager.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/ILocalizationManager.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Localization
         /// <summary>
         /// Retrieves a dictionary for a specified culture.
         /// </summary>
-        /// <param name="culture">The <see cref="CulureInfo"/>.</param>
+        /// <param name="culture">The <see cref="CultureInfo"/>.</param>
         /// <returns>A <see cref="CultureDictionary"/> for the specified culture.</returns>
         CultureDictionary GetDictionary(CultureInfo culture);
     }

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/PluralFormNotFoundException.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/PluralFormNotFoundException.cs
@@ -28,8 +28,7 @@ namespace OrchardCore.Localization
         /// Creates new instance of <see cref="PluralFormNotFoundException"/> with a message.
         /// </summary>
         /// <param name="message">The exception message.</param>
-        /// <param name="key">The localized string that doesn't have plural form.</param>
-        /// <param name="pluralForm">The <see cref="PluralForm"/> that causes the exception.</param>
+        /// <param name="form">The <see cref="PluralForm"/> that causes the exception.</param>
         public PluralFormNotFoundException(string message, PluralForm form) : base(message)
         {
             Form = form;

--- a/src/OrchardCore/OrchardCore.Localization.Core/ContentRootPoFileLocationProvider.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/ContentRootPoFileLocationProvider.cs
@@ -18,8 +18,8 @@ namespace OrchardCore.Localization.PortableObject
         /// <summary>
         /// Creates a new instance of <see cref="ContentRootPoFileLocationProvider"/>.
         /// </summary>
-        /// <param name="hostingEnvironment"><see cref="IHostEnvironment"/>.</param>
-        /// <param name="localizationOptions">The IOptions<LocalizationOptions>.</param>
+        /// <param name="hostingEnvironment">The <see cref="IHostEnvironment"/>.</param>
+        /// <param name="localizationOptions">The <see cref="LocalizationOptions"/>.</param>
         public ContentRootPoFileLocationProvider(IHostEnvironment hostingEnvironment, IOptions<LocalizationOptions> localizationOptions)
         {
             _fileProvider = hostingEnvironment.ContentRootFileProvider;

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/PageConventionCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/PageConventionCollectionExtensions.cs
@@ -24,6 +24,7 @@ namespace Microsoft.AspNetCore.Mvc.ApplicationModels
         /// set of path based routes. Links generated for these pages will use the specified folder route.
         /// Note: Applied to all pages whose razor view file path contains an '/Admin/' segment
         /// or whose route model properties contains an 'Admin' key.
+        /// </summary>
         public static PageConventionCollection AddAdminAreaFolderRoute(this PageConventionCollection conventions,
             string areaName, string folderPath, string folderRoute)
         {

--- a/src/OrchardCore/OrchardCore.Mvc.Core/ShellFeatureApplicationPart.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/ShellFeatureApplicationPart.cs
@@ -26,7 +26,6 @@ namespace OrchardCore.Mvc
         /// <summary>
         /// Initalizes a new <see cref="AssemblyPart"/> instance.
         /// </summary>
-        /// <param name="assembly"></param>
         public ShellFeatureApplicationPart()
         {
         }

--- a/src/OrchardCore/OrchardCore.Navigation.Core/NavigationHelper.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/NavigationHelper.cs
@@ -17,6 +17,7 @@ namespace OrchardCore.Navigation
         /// <param name="parentShape">The menu parent shape.</param>
         /// <param name="menu">The menu shape.</param>
         /// <param name="menuItems">The current level to populate.</param>
+        /// <param name="viewContext">The current <see cref="ViewContext"/>.</param>
         public static async Task PopulateMenuAsync(dynamic shapeFactory, dynamic parentShape, dynamic menu, IEnumerable<MenuItem> menuItems, ViewContext viewContext)
         {
             await PopulateMenuLevelAsync(shapeFactory, parentShape, menu, menuItems, viewContext);
@@ -30,6 +31,7 @@ namespace OrchardCore.Navigation
         /// <param name="parentShape">The menu parent shape.</param>
         /// <param name="menu">The menu shape.</param>
         /// <param name="menuItems">The current level to populate.</param>
+        /// <param name="viewContext">The current <see cref="ViewContext"/>.</param>
         public static async Task PopulateMenuLevelAsync(dynamic shapeFactory, dynamic parentShape, dynamic menu, IEnumerable<MenuItem> menuItems, ViewContext viewContext)
         {
             foreach (MenuItem menuItem in menuItems)
@@ -52,6 +54,7 @@ namespace OrchardCore.Navigation
         /// <param name="parentShape">The parent shape.</param>
         /// <param name="menu">The menu shape.</param>
         /// <param name="menuItem">The menu item to build the shape for.</param>
+        /// <param name="viewContext">The current <see cref="ViewContext"/>.</param>
         /// <returns>The menu item shape.</returns>
         private static async Task<dynamic> BuildMenuItemShapeAsync(dynamic shapeFactory, dynamic parentShape, dynamic menu, MenuItem menuItem, ViewContext viewContext)
         {
@@ -118,6 +121,7 @@ namespace OrchardCore.Navigation
         /// Ensures only one menuitem (and its ancestors) are marked as selected for the menu.
         /// </summary>
         /// <param name="parentShape">The menu shape.</param>
+        /// <param name="viewContext">The current <see cref="ViewContext"/>.</param>
         private static void ApplySelection(dynamic parentShape, ViewContext viewContext)
         {
             var selectedItem = GetHighestPrioritySelectedMenuItem(parentShape);
@@ -139,7 +143,7 @@ namespace OrchardCore.Navigation
         /// Traverses the menu and returns the selected item with the highest priority
         /// </summary>
         /// <param name="parentShape">The menu shape.</param>
-        /// /// <returns>The selected menu item shape</returns>
+        /// <returns>The selected menu item shape</returns>
         private static dynamic GetHighestPrioritySelectedMenuItem(dynamic parentShape)
         {
             dynamic result = null;

--- a/src/OrchardCore/OrchardCore.Navigation.Core/Pager.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/Pager.cs
@@ -10,8 +10,8 @@ namespace OrchardCore.Navigation
         /// <summary>
         /// Constructs a new pager.
         /// </summary>
-        /// <param name="site">The site settings.</param>
         /// <param name="pagerParameters">The pager parameters.</param>
+        /// <param name="defaultPageSize">The default page size.</param>
         public Pager(PagerParameters pagerParameters, int defaultPageSize)
             : this(pagerParameters.Page, pagerParameters.PageSize, defaultPageSize)
         {
@@ -20,9 +20,9 @@ namespace OrchardCore.Navigation
         /// <summary>
         /// Constructs a new pager.
         /// </summary>
-        /// <param name="site">The site settings.</param>
         /// <param name="page">The page parameter.</param>
         /// <param name="pageSize">The page size parameter.</param>
+        /// <param name="defaultPageSize">The default page size.</param>
         public Pager(int? page, int? pageSize, int defaultPageSize)
         {
             Page = (int)(page != null ? (page > 0 ? page : PageDefault) : PageDefault);

--- a/src/OrchardCore/OrchardCore.Navigation.Core/SafePager.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/SafePager.cs
@@ -5,8 +5,8 @@ namespace OrchardCore.Navigation
         /// <summary>
         /// Constructs a new pager.
         /// </summary>
-        /// <param name="site">The site settings.</param>
         /// <param name="pagerParameters">The pager parameters.</param>
+        /// <param name="pageSize">The page size parameter.</param>
         public PagerSlim(PagerSlimParameters pagerParameters, int pageSize)
             : this(pagerParameters.Before, pagerParameters.After, pageSize)
         {

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdScopeManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdScopeManager.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.OpenId.Services.Managers
         /// <summary>
         /// Retrieves the physical identifier associated with an authorization.
         /// </summary>
-        /// <param name="authorization">The authorization.</param>
+        /// <param name="scope">The scope.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to abort the operation.</param>
         /// <returns>
         /// A <see cref="ValueTask{TResult}"/> that can be used to monitor the asynchronous operation,

--- a/src/OrchardCore/OrchardCore.Queries.Abstractions/IQueryManager.cs
+++ b/src/OrchardCore/OrchardCore.Queries.Abstractions/IQueryManager.cs
@@ -39,6 +39,7 @@ namespace OrchardCore.Queries
         /// Executes a query.
         /// </summary>
         /// <param name="query">The query to execute.</param>
+        /// <param name="parameters">The parameters for the query.</param>
         /// <returns>The result of the query.</returns>
         Task<IQueryResults> ExecuteQueryAsync(Query query, IDictionary<string, object> parameters);
 

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/DefaultUserClaimsPrincipalFactory.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/DefaultUserClaimsPrincipalFactory.cs
@@ -8,7 +8,7 @@ using OrchardCore.Security;
 namespace OrchardCore.Users.Services
 {
     /// <summary>
-    /// Custom implementation of  <see cref="IUserClaimsPrincipalFactory"/> adding email claims.
+    /// Custom implementation of <see cref="IUserClaimsPrincipalFactory{TUser}"/> adding email claims.
     /// </summary>
     public class DefaultUserClaimsPrincipalFactory : UserClaimsPrincipalFactory<IUser, IRole>
     {

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -209,7 +209,7 @@ namespace OrchardCore.Users.Services
         /// <summary>
         /// Gets the user, if any, associated with the normalized value of the specified identifier, which can refer both to username or email
         /// </summary>
-        /// <param name="userIdentification">The username or email address to refer to</param>
+        /// <param name="userIdentifier">The username or email address to refer to</param>
         private async Task<IUser> FindByUsernameOrEmailAsync(string userIdentifier)
             => await _userManager.FindByNameAsync(userIdentifier) ??
                await _userManager.FindByEmailAsync(userIdentifier);

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowManager.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowManager.cs
@@ -22,10 +22,11 @@ namespace OrchardCore.Workflows.Services
         /// Creates a new <see cref="ActivityContext"/>.
         /// </summary>
         /// <param name="activityRecord"></param>
+        /// <param name="properties"></param>
         Task<ActivityContext> CreateActivityExecutionContextAsync(ActivityRecord activityRecord, JObject properties);
 
         /// <summary>
-        /// Triggers a specific <see cref="IEvent"/>.
+        /// Triggers a specific <see cref="OrchardCore.Workflows.Activities.IEvent"/>.
         /// </summary>
         /// <param name="name">The type of the event to trigger, e.g. ContentPublishedEvent.</param>
         /// <param name="input">An object containing context for the event.</param>
@@ -42,9 +43,9 @@ namespace OrchardCore.Workflows.Services
         /// Starts a new workflow using the specified workflow definition.
         /// </summary>
         /// <param name="workflowType">The workflow definition to start.</param>
+        /// <param name="startActivity">If a workflow definition contains multiple start activities, you can specify which one to use. If none specified, the first one will be used.</param>
         /// <param name="input">Optionally specify any inputs to be used by the workflow.</param>
         /// <param name="correlationId">Optionally specify an application-specific value to associate the workflow instance with. For example, a content item ID.</param>
-        /// <param name="startActivityName">If a workflow definition contains multiple start activities, you can specify which one to use. If none specified, the first one will be used.</param>
         /// <returns>Returns the created workflow context. Can be used for further inspection of the workflow state.</returns>
         Task<WorkflowExecutionContext> StartWorkflowAsync(WorkflowType workflowType, ActivityRecord startActivity = null, IDictionary<string, object> input = null, string correlationId = null);
 

--- a/src/OrchardCore/OrchardCore/Modules/ModularTenantRouterMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularTenantRouterMiddleware.cs
@@ -16,7 +16,7 @@ using OrchardCore.Environment.Shell.Scope;
 namespace OrchardCore.Modules
 {
     /// <summary>
-    /// Handles a request by forwarding it to the tenant specific instance.
+    /// Handles a request by forwarding it to the tenant specific pipeline.
     /// It also initializes the middlewares for the requested tenant on the first request.
     /// </summary>
     public class ModularTenantRouterMiddleware

--- a/src/OrchardCore/OrchardCore/Modules/ModularTenantRouterMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularTenantRouterMiddleware.cs
@@ -16,7 +16,7 @@ using OrchardCore.Environment.Shell.Scope;
 namespace OrchardCore.Modules
 {
     /// <summary>
-    /// Handles a request by forwarding it to the tenant specific <see cref="IRouter"/> instance.
+    /// Handles a request by forwarding it to the tenant specific instance.
     /// It also initializes the middlewares for the requested tenant on the first request.
     /// </summary>
     public class ModularTenantRouterMiddleware

--- a/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
@@ -156,6 +156,7 @@ namespace OrchardCore.Environment.Shell
         /// Reloads the settings and releases the shell so that a new one will be
         /// built for subsequent requests, while existing requests get flushed.
         /// </summary>
+        /// <param name="settings">The <see cref="ShellSettings"/> to reload.</param>
         /// <param name="eventSource">
         /// Whether the related <see cref="ShellEvent"/> is invoked.
         /// </param>
@@ -227,6 +228,7 @@ namespace OrchardCore.Environment.Shell
         /// Releases a shell so that a new one will be built for subsequent requests.
         /// Note: Can be used to free up resources after a given time of inactivity.
         /// </summary>
+        /// <param name="settings">The <see cref="ShellSettings"/> to reload.</param>
         /// <param name="eventSource">
         /// Whether the related <see cref="ShellEvent"/> is invoked.
         /// </param>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6081

I turned these on for one of my nuget packages this morning and it all worked there.

So I (foolishly) turned in on for Orchard Core, and then had to fix all the malformed comments.

The `<NoWarn>$(NoWarn);CS1591</NoWarn>` removes the warning that some public members do not have comments.

However it now generates an xml documentation file that should be packaged by nuget.