### PR TITLE
Fix double encoding of non-HTML strings in feed

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
@@ -46,7 +46,7 @@ namespace OrchardCore.Contents.Feeds.Builders
                         guid.Add(url);
                     });
 
-                    feedItem.Element.SetElementValue("title", WebUtility.HtmlEncode(contentItem.DisplayText));
+                    feedItem.Element.SetElementValue("title", contentItem.DisplayText);
                     feedItem.Element.Add(link);
 
                     feedItem.Element.Add(new XElement("description", new XCData(bodyAspect.Body?.ToString() ?? String.Empty)));
@@ -74,7 +74,7 @@ namespace OrchardCore.Contents.Feeds.Builders
                         context.Builder.AddProperty(context, feedItem, "link", url);
                     });
 
-                    context.Builder.AddProperty(context, feedItem, "title", WebUtility.HtmlEncode(contentItem.DisplayText));
+                    context.Builder.AddProperty(context, feedItem, "title", contentItem.DisplayText);
                     context.Builder.AddProperty(context, feedItem, new XElement("description", new XCData(bodyAspect.Body?.ToString() ?? String.Empty)));
 
                     if (contentItem.PublishedUtc != null)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Feeds/CommonFeedItemBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Mvc;

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.AspNetCore.Mvc;

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Feeds/ListFeedQuery.cs
@@ -63,7 +63,7 @@ namespace OrchardCore.Lists.Feeds
             if (context.Format == "rss")
             {
                 var link = new XElement("link");
-                context.Response.Element.SetElementValue("title", WebUtility.HtmlEncode(contentItem.DisplayText));
+                context.Response.Element.SetElementValue("title", contentItem.DisplayText);
                 context.Response.Element.Add(link);
 
                 context.Response.Element.Add(new XElement("description", new XCData(bodyAspect.Body?.ToString() ?? String.Empty)));

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/Feeds/RssFeedTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/Feeds/RssFeedTests.cs
@@ -84,7 +84,7 @@ namespace OrchardCore.Tests.Modules.Contents.Feeds
             // Assert
             var title = feedContext.Response.Items[0].Element.Element("title").ToString();
 
-            Assert.NotEqual("<title>It&amp;#39;s a great title &amp;amp; so much &amp;gt; than anybody&amp;#39;s!</title>", title);
+            // Test to ensure that double encoding of title does not occur and complies with XML requirements
             Assert.Equal("<title>It's a great title &amp; so much &gt; than anybody's!</title>", title);
         }
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/Feeds/RssFeedTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/Feeds/RssFeedTests.cs
@@ -55,7 +55,7 @@ namespace OrchardCore.Tests.Modules.Contents.Feeds
         [Theory]
         [InlineData("rss")]
         [InlineData("non rss")]
-        public async Task AvoidDoubleEncodeStrings(string format)
+        public async Task ShouldOnlyHtmlEntityEscapeFeedTitle(string format)
         {
             // Arrange
             var contentManagerMock = new Mock<IContentManager>();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Contents/Feeds/RssFeedTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Contents/Feeds/RssFeedTests.cs
@@ -52,6 +52,42 @@ namespace OrchardCore.Tests.Modules.Contents.Feeds
             Assert.Equal("<description><![CDATA[<p>The news description goes here ...</p>]]></description>", description);
         }
 
+        [Theory]
+        [InlineData("rss")]
+        [InlineData("non rss")]
+        public async Task AvoidDoubleEncodeStrings(string format)
+        {
+            // Arrange
+            var contentManagerMock = new Mock<IContentManager>();
+            var commonFeedItemBuilder = new CommonFeedItemBuilder(contentManagerMock.Object);
+            var feedContext = CreateFeedContext(format);
+
+            contentManagerMock.SetReturnsDefault(Task.FromResult(new ContentItemMetadata
+            {
+                DisplayRouteValues = new RouteValueDictionary()
+            }));
+
+            contentManagerMock.SetReturnsDefault(Task.FromResult(new BodyAspect
+            {
+                Body = new HtmlString("<p>The news description goes here ...</p>")
+            }));
+
+            feedContext.Builder.AddItem(feedContext, new ContentItem
+            {
+                DisplayText = "It's a great title & so much > than anybody's!",
+                PublishedUtc = DateTime.UtcNow
+            });
+
+            // Act
+            await commonFeedItemBuilder.PopulateAsync(feedContext);
+
+            // Assert
+            var title = feedContext.Response.Items[0].Element.Element("title").ToString();
+
+            Assert.NotEqual("<title>It&amp;#39;s a great title &amp;amp; so much &amp;gt; than anybody&amp;#39;s!</title>", title);
+            Assert.Equal("<title>It's a great title &amp; so much &gt; than anybody's!</title>", title);
+        }
+
         private static FeedContext CreateFeedContext(string format)
         {
             var feedContextMock = new Mock<FeedContext>(Mock.Of<IUpdateModel>(), format);


### PR DESCRIPTION
Fixes #7323 

WebUtility.HtmlEncode is not required as this results in double encoding. Adds a test as well. Interestingly .Net built-in encoding for XDocument doesn't encode all pre-defined entity references for XML only the strickly illegal onces: https://www.w3schools.com/xml/xml_syntax.asp