### PR TITLE
Fix container part getting welded to widgets inside list

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/ViewModels/EditContainedPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/ViewModels/EditContainedPartViewModel.cs
@@ -3,6 +3,7 @@ namespace OrchardCore.Lists.ViewModels
     public class EditContainedPartViewModel
     {
         public string ContainerId { get; set; }
+        public string ContentType { get; set; }
         public bool EnableOrdering { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPart.ContainerId.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPart.ContainerId.cshtml
@@ -1,2 +1,4 @@
+@model OrchardCore.Lists.ViewModels.EditContainedPartViewModel
 <input type="hidden" name="ListPart.ContainerId" value="@Model.ContainerId" />
+<input type="hidden" name="ListPart.ContentType" value="@Model.ContentType.ToString()" />
 <input type="hidden" name="ListPart.EnableOrdering" value="@Model.EnableOrdering.ToString()" />

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPart.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPart.DetailAdmin.cshtml
@@ -26,7 +26,7 @@ else
                     <a class="btn btn-sm btn-primary" edit-for="@Model.ListPart.ContentItem" asp-route-returnUrl="@FullRequestPath">
                         @T["Edit {0}", @Model.ListPart.ContentItem.DisplayText]
                     </a>                
-                    <a class="btn btn-sm btn-success" asp-action="Create" asp-controller="Admin" asp-route-id="@contentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
+                    <a class="btn btn-sm btn-success" asp-action="Create" asp-controller="Admin" asp-route-id="@contentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.ContentType="@contentTypeDefinition.Name" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
                         @T["Create {0}", contentTypeDefinition.DisplayName]
                     </a>
                 </div>
@@ -47,7 +47,7 @@ else
                     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
                         @foreach (var containedContentTypeDefinition in Model.ContainedContentTypeDefinitions)
                         {
-                            <a class="dropdown-item" asp-action="Create" asp-controller="Admin" asp-route-id="@containedContentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
+                            <a class="dropdown-item" asp-action="Create" asp-controller="Admin" asp-route-id="@containedContentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.ListPart.ContentItem.ContentItemId" asp-route-ListPart.ContentType="@containedContentTypeDefinition.Name" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
                                 @containedContentTypeDefinition.DisplayName
                             </a>
                         }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7265

Uses the `ContentType` of the primary list content item to validate whether the `ContainedPart` should be welded onto the content item.