### PR TITLE
Better content type null checking in index providers.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/BooleanFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/BooleanFieldIndexProvider.cs
@@ -40,11 +40,26 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Text fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for BooleanField
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(BooleanField)))
                         .ToArray();
+
+                    // This type doesn't have any BooleanField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<BooleanFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/ContentPickerFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/ContentPickerFieldIndexProvider.cs
@@ -40,11 +40,26 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Text fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for ContentPickerField
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(ContentPickerField)))
                         .ToArray();
+
+                    // This type doesn't have any ContentPickerField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<ContentPickerFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/DateFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/DateFieldIndexProvider.cs
@@ -40,11 +40,26 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Text fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for DateField
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(DateField)))
                         .ToArray();
+
+                    // This type doesn't have any DateField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<DateFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/DateTimeFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/DateTimeFieldIndexProvider.cs
@@ -40,11 +40,26 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Text fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for DateTimeField
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(DateTimeField)))
                         .ToArray();
+
+                    // This type doesn't have any DateTimeField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<DateTimeFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/HtmlFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/HtmlFieldIndexProvider.cs
@@ -37,19 +37,29 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                         return null;
                     }
 
-                    if (!contentItem.Latest && !contentItem.Published)
-                    {
-                        return null;
-                    }
-
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Text fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for Html fields
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(HtmlField)))
                         .ToArray();
+
+                    // This type doesn't have any HtmlField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<HtmlFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/LinkFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/LinkFieldIndexProvider.cs
@@ -53,11 +53,26 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Text fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for LinkField
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(LinkField)))
                         .ToArray();
+
+                    // This type doesn't have any LinkField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<LinkFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/NumericFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/NumericFieldIndexProvider.cs
@@ -40,11 +40,26 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Text fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for NumericField
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(NumericField)))
                         .ToArray();
+
+                    // This type doesn't have any NumericField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<NumericFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/TextFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/TextFieldIndexProvider.cs
@@ -41,19 +41,29 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                         return null;
                     }
 
-                    if (!contentItem.Latest && !contentItem.Published)
-                    {
-                        return null;
-                    }
-
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Text fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for TextField
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(TextField)))
                         .ToArray();
+
+                   // This type doesn't have any TextField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<TextFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/TimeFieldIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/TimeFieldIndexProvider.cs
@@ -37,19 +37,29 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                         return null;
                     }
 
-                    if (!contentItem.Latest && !contentItem.Published)
-                    {
-                        return null;
-                    }
-
                     // Lazy initialization because of ISession cyclic dependency
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-                    // Search for Time fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    // Search for TimeField
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(TimeField)))
                         .ToArray();
+
+                    // This type doesn't have any TimeField, ignore it
+                    if (fieldDefinitions.Length == 0)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
 
                     var results = new List<TimeFieldIndex>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -52,8 +52,16 @@ namespace OrchardCore.Taxonomies.Indexing
                     _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
                     // Search for Taxonomy fields
-                    var fieldDefinitions = _contentDefinitionManager
-                        .GetTypeDefinition(contentItem.ContentType)
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // This can occur when content items become orphaned, particularly layer widgets when a layer is removed, before its widgets have been unpublished.
+                    if (contentTypeDefinition == null)
+                    {
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        return null;
+                    }
+                    
+                    var fieldDefinitions = contentTypeDefinition
                         .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(TaxonomyField)))
                         .ToArray();
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7350

I've updated the `TaxonomyIndex` and the SQL `ContentFields` Index providers to better null check.

@Skrypt will ask for you to have a look at the content fields here.

Most of them where indexing all items, including historic, but two of them were only indexing latest and published items.

So I have refreshed them to behave consistently, as it looks like the design was to index everything, much like we do for the `ContentItemIndex`

Also updated to include the `ignoredTypes` Hash Set which was not being used.