### PR TITLE
Match hint styling of PredefinedList with other fields

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-PredefinedList.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-PredefinedList.Edit.cshtml
@@ -40,6 +40,6 @@
 
     @if (!String.IsNullOrEmpty(settings.Hint))
     {
-        <span class="hint">— @settings.Hint</span>
+        <span class="hint">@settings.Hint</span>
     }
 </div>


### PR DESCRIPTION
The hyphen is never used when the hint is shown below the editor