### PR TITLE
Better responsive behaviour for all editors of NumericField

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
@@ -11,24 +11,29 @@
 }
 
 <div class="form-group">
-    <div class="row col-sm-3">
-        <label asp-for="Value">@name</label>
-        <div class="input-group mb-2">
-            @if (settings.Minimum.HasValue)
-            {
-                <div class="input-group-prepend">
-                    <div class="input-group-text">@min</div>
-                </div>
-            }
-            <input asp-for="Value" class="form-control content-preview-select" />
-            @if (settings.Maximum.HasValue)
-            {
-                <div class="input-group-append">
-                    <div class="input-group-text">@max</div>
-                </div>
-            }
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="Value">@name</label>
+            <div class="input-group mb-2">
+                @if (settings.Minimum.HasValue)
+                {
+                    <div class="input-group-prepend">
+                        <div class="input-group-text">@min</div>
+                    </div>
+                }
+                <input asp-for="Value" class="form-control content-preview-select" />
+                @if (settings.Maximum.HasValue)
+                {
+                    <div class="input-group-append">
+                        <div class="input-group-text">@max</div>
+                    </div>
+                }
+            </div>
             <input id="@(id)-range" class="form-control-range" type="range" min="@min" max="@max" step="@step" onchange="$('#@(id)').val(value);" />
         </div>
-        <span class="hint">@settings.Hint</span>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Select.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Select.Edit.cshtml
@@ -9,18 +9,23 @@
 }
 
 <div class="form-group">
-    <div class="row col-sm-3">
-        <label asp-for="Value">@name</label>
-        <select asp-for="Value" class="form-control content-preview-select">
-            @if (!settings.Required)
-            {
-                <option value="">@T["None"]</option>
-            }
-            @for (decimal d = from; d <= to; d += step)
-            {
-                <option value="@d">@d</option>
-            }
-        </select>
-        <span class="hint">@settings.Hint</span>
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="Value">@name</label>
+            <select asp-for="Value" class="form-control content-preview-select">
+                @if (!settings.Required)
+                {
+                    <option value="">@T["None"]</option>
+                }
+                @for (decimal d = from; d <= to; d += step)
+                {
+                    <option value="@d">@d</option>
+                }
+            </select>
+        </div>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -14,24 +14,29 @@
 <style asp-name="bootstrap-slider" version="11"></style>
 
 <div class="form-group">
-    <div class="row col-small">
-        <label asp-for="Value">@name</label>
-        <div class="input-group mb-2">
-            @*<div class="input-group-prepend">
-                <div class="input-group-text">@min</div>
-            </div>*@
-            <input asp-for="Value" type="number" class="form-control content-preview-select" />
-            @*<div class="input-group-append">
-                <div class="input-group-text">@max</div>
-            </div>*@
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="Value">@name</label>
+            <div class="input-group mb-2">
+                @*<div class="input-group-prepend">
+                    <div class="input-group-text">@min</div>
+                </div>*@
+                <input asp-for="Value" type="number" class="form-control content-preview-select" />
+                @*<div class="input-group-append">
+                    <div class="input-group-text">@max</div>
+                </div>*@
+            </div>
+            <div class="input-group mb-2 ml-2">            
+                @if (settings.Minimum.HasValue) {<span class="mr-3">@min</span>}
+                <input id="@(id)-slider" type="text" data-slider-min="@min" data-slider-max="@max" data-slider-step="@step" data-slider-value="@Model.Value" />            
+                @if (settings.Maximum.HasValue) {<span class="ml-1">@max</span>}
+            </div>
         </div>
-        <div class="input-group mb-2 ml-2">            
-            @if (settings.Minimum.HasValue) {<span class="mr-3">@min</span>}
-            <input id="@(id)-slider" type="text" data-slider-min="@min" data-slider-max="@max" data-slider-step="@step" data-slider-value="@Model.Value" />            
-            @if (settings.Maximum.HasValue) {<span class="ml-1">@max</span>}
-        </div>
-        <span class="hint">@settings.Hint</span>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>
 <script at="Foot">
     $('#@(id)-slider').bootstrapSlider({ tooltip: 'always' }).on('slide', function (ev) {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
@@ -12,25 +12,30 @@
 }
 
 <div class="form-group">
-    <div class="row col-small">
-        <label asp-for="Value">@name</label>
-        <div class="input-group mb-2">
-            @if (settings.Minimum.HasValue)
-            {
-            <div class="input-group-prepend">
-                <div class="input-group-text">@min</div>
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="Value">@name</label>
+            <div class="input-group mb-2">
+                @if (settings.Minimum.HasValue)
+                {
+                <div class="input-group-prepend">
+                    <div class="input-group-text">@min</div>
+                </div>
+                }
+                <input asp-for="Value" typeof="text" class="form-control content-preview-select" type="number" required="@settings.Required" />
+                @if (settings.Maximum.HasValue)
+                {
+                <div class="input-group-append">
+                    <div class="input-group-text">@max</div>
+                </div>
+                }
             </div>
-            }
-            <input asp-for="Value" typeof="text" class="form-control content-preview-select" type="number" required="@settings.Required" />
-            @if (settings.Maximum.HasValue)
-            {
-            <div class="input-group-append">
-                <div class="input-group-text">@max</div>
-            </div>
-            }
         </div>
-        <span class="hint">@settings.Hint</span>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>
 <script at="Foot">
     $(function () {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.Edit.cshtml
@@ -8,23 +8,28 @@
 }
 
 <div class="form-group">
-    <div class="row col-sm-3">
-        <label asp-for="Value">@name</label>
-        <div class="input-group mb-2">
-            @if (settings.Minimum.HasValue)
-            {
-                <div class="input-group-prepend">
-                    <div class="input-group-text">@min</div>
-                </div>
-            }
-            <input asp-for="Value" class="form-control content-preview-select" placeholder="@settings.Placeholder" required="@settings.Required" />
-            @if (settings.Maximum.HasValue)
-            {
-                <div class="input-group-append">
-                    <div class="input-group-text">@max</div>
-                </div>
-            }
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="Value">@name</label>
+            <div class="input-group">
+                @if (settings.Minimum.HasValue)
+                {
+                    <div class="input-group-prepend">
+                        <div class="input-group-text">@min</div>
+                    </div>
+                }
+                <input asp-for="Value" class="form-control content-preview-select" placeholder="@settings.Placeholder" required="@settings.Required" />
+                @if (settings.Maximum.HasValue)
+                {
+                    <div class="input-group-append">
+                        <div class="input-group-text">@max</div>
+                    </div>
+                }
+            </div>
         </div>
-        <span class="hint">@settings.Hint</span>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>


### PR DESCRIPTION
Since row has `margin-right` and `margin-left -15px` and col has `padding-right` and `padding-left 15px` an element should not contain both classes. Columns should always be child elements of a row.

`col-sm-3` was changed to `col-md-6 col-lg-4` to make it usable on small screens.

The hint was moved outside of the column so it can be full width. 
