### PR TITLE
Better responsive behaviour for DateField

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField-Localized.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField-Localized.Edit.cshtml
@@ -7,11 +7,16 @@
 }
 
 <div class="form-group">
-    <div class="row col-md-6 col-lg-4">
-        <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>
-        <input asp-for="Value" type="text" class="form-control content-preview-select datepicker" required="@settings.Required" />
-        <span class="hint">@settings.Hint</span>
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>
+            <input asp-for="Value" type="text" class="form-control content-preview-select datepicker" required="@settings.Required" />
+        </div>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>
 
 <script at="Foot">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.Edit.cshtml
@@ -5,9 +5,14 @@
 }
 
 <div class="form-group">
-    <div class="row col-md-6 col-lg-4">
-        <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>
-        <input asp-for="Value" type="date" class="form-control content-preview-select" required="@settings.Required" />
-        <span class="hint">@settings.Hint</span>
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>
+            <input asp-for="Value" type="date" class="form-control content-preview-select" required="@settings.Required" />
+        </div>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateTimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateTimeField.Edit.cshtml
@@ -5,9 +5,14 @@
 }
 
 <div class="form-group">
-    <div class="row col-sm-12 col-md-6 col-lg-3">
-        <label asp-for="LocalDateTime">@Model.PartFieldDefinition.DisplayName()</label>
-        <input asp-for="LocalDateTime" type="datetime-local" class="form-control content-preview-select" required="@settings.Required" />
-        <span class="hint">@settings.Hint</span>
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="LocalDateTime">@Model.PartFieldDefinition.DisplayName()</label>
+            <input asp-for="LocalDateTime" type="datetime-local" class="form-control content-preview-select" required="@settings.Required" />
+        </div>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
@@ -5,9 +5,14 @@
 }
 
 <div class="form-group">
-    <div class="row col-md-4 col-lg-2">
-        <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>
-        <input asp-for="Value" type="time" class="form-control content-preview-select" required="@settings.Required" />
-        <span class="hint">@settings.Hint</span>
+    <div class="row">
+        <div class="col-md-6 col-lg-4">
+            <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>
+            <input asp-for="Value" type="time" class="form-control content-preview-select" required="@settings.Required" />
+        </div>
     </div>
+    @if (!String.IsNullOrEmpty(settings.Hint))
+    {
+        <span class="hint">@settings.Hint</span>
+    }
 </div>


### PR DESCRIPTION
Since row has margin-right and margin-left -15px and col has padding-right and padding-left 15px an element should not contain both classes. Columns should always be child elements of a row.

The hint was moved outside of the column so it can be full width.