### PR TITLE
Keep value of NumericField in sync when slider was clicked instead of…

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -34,8 +34,8 @@
     </div>
 </div>
 <script at="Foot">
-    $('#@(id)-slider').bootstrapSlider({ tooltip: 'always' }).on('slide', function (ev) {
-        $('#@(id)').val(ev.value);
+    $('#@(id)-slider').bootstrapSlider({ tooltip: 'always' }).on('change', function (ev) {
+        $('#@(id)').val(ev.value.newValue);
     });
     $('#@(id)').change(function () {
         $('#@(id)-slider').bootstrapSlider('setValue', this.value);


### PR DESCRIPTION
… dragged

The slider can also be changed by clicking anywhere in the slider bar, without dragging the slider itself. This would not update the value in the NumericField, as shown here:

> ![image](https://user-images.githubusercontent.com/3008547/97112101-bfba2700-16e2-11eb-8e17-c72715e84599.png)

This issue was fixed, values are now always in sync:

> ![image](https://user-images.githubusercontent.com/3008547/97112193-348d6100-16e3-11eb-932f-40ec92c8ffe3.png)
