### PR TITLE
NumericField (Range): get continuous updates while dragging the slider

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
@@ -29,7 +29,7 @@
                     </div>
                 }
             </div>
-            <input id="@(id)-range" class="form-control-range" type="range" min="@min" max="@max" step="@step" onchange="$('#@(id)').val(value);" />
+            <input id="@(id)-range" class="form-control-range" type="range" min="@min" max="@max" step="@step" oninput="$('#@(id)').val(value);" onchange="$('#@(id)').val(value);" />
         </div>
     </div>
     @if (!String.IsNullOrEmpty(settings.Hint))


### PR DESCRIPTION
onchange is triggered when the user releases the mouse. To get continuous updates, you should use the oninput event, which will capture live updates in Firefox, Safari and Chrome, both from the mouse and the keyboard.

However, oninput is not supported in IE10, so it's best to combine the two event handlers.

Before:

![RangeBefore](https://user-images.githubusercontent.com/3008547/97275925-d96c8300-1836-11eb-920f-fc3e8893a1a6.gif)

After:

![RangeAfter](https://user-images.githubusercontent.com/3008547/97275937-dd98a080-1836-11eb-9eb3-450864d01f86.gif)