### PR TITLE
Update RazorPage.cs

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -107,7 +107,7 @@ namespace OrchardCore.DisplayManagement.Razor
             {
                 if (_themeLayout == null)
                 {
-                    _themeLayout = Context.Features.Get<RazorViewFeature>()?.ThemeLayout;
+                    _themeLayout = Context?.Features.Get<RazorViewFeature>()?.ThemeLayout;
                 }
 
                 return _themeLayout;


### PR DESCRIPTION
### Why?
Saving a liquid page with a custom layout throws null ref runtime error.

1. Create a new liquid page
2. Provide and save: `{% layout 'ThreeJSLayout' %}`
3. On save 'Object reference null' runtime exception thrown.

### Observations:

1. Page gets saved successfully.
2. Layout template name does exist and renders after save.
3. Adding Context?. 'seems' to fix it - please review/check.
1. If you don't set the layout (in step 2), error doesn't occur as Context seems to be not null in those usual scenarios.

Fixes #7414
