### PR TITLE
NumericField Spinner: replaced jQuery UI with Bootstrap components & …

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
@@ -5,10 +5,13 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<NumericFieldSettings>();
     string name = Model.PartFieldDefinition.DisplayName();
+    int scale = settings.Scale;
     string step = Math.Pow(10, 0 - settings.Scale).ToString(CultureInfo.InvariantCulture);
     decimal min = settings.Minimum.HasValue ? settings.Minimum.Value : 0;
     decimal max = settings.Maximum.HasValue ? settings.Maximum.Value : 10000;
     string id = Html.IdFor(m => m.Value);
+    string javascriptDecimalSeparator = CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
+    string serverDecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
 }
 
 <div class="form-group">
@@ -18,16 +21,20 @@
             <div class="input-group mb-2">
                 @if (settings.Minimum.HasValue)
                 {
-                <div class="input-group-prepend">
-                    <div class="input-group-text">@min</div>
-                </div>
+                    <div class="input-group-prepend">
+                        <div class="input-group-text">@min</div>
+                    </div>
                 }
-                <input asp-for="Value" typeof="text" class="form-control content-preview-select" type="number" required="@settings.Required" />
+                <input asp-for="Value" typeof="text" class="form-control content-preview-select" placeholder="@settings.Placeholder" required="@settings.Required" />
+                <div class="input-group-append">
+                    <button class="btn btn-outline-secondary" type="button" onclick="numericFieldSpinner('@(id)', @(scale), -@(step), @(min), @(max))"><i class="fa fa-minus" aria-hidden="true"></i></button>
+                    <button class="btn btn-outline-secondary" type="button" onclick="numericFieldSpinner('@(id)', @(scale), +@(step), @(min), @(max))"><i class="fa fa-plus" aria-hidden="true"></i></button>
+                </div>
                 @if (settings.Maximum.HasValue)
                 {
-                <div class="input-group-append">
-                    <div class="input-group-text">@max</div>
-                </div>
+                    <div class="input-group-append">
+                        <div class="input-group-text">@max</div>
+                    </div>
                 }
             </div>
         </div>
@@ -37,12 +44,24 @@
         <span class="hint">@settings.Hint</span>
     }
 </div>
-<script at="Foot">
-    $(function () {
-        $('#@(id)').spinner({
-            min: @min,
-            max: @max,
-            step: @step
-        });
-    });
+
+<script asp-name="numericFieldSpinner" at="Foot">
+
+    function numericFieldSpinner(id, scale, step, min, max) {
+        let value = $('#' + id).val();
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
+            <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)');</text>
+        }
+        value = (Number(value) || 0) + step;
+        value = Math.min(value, max); // Never go above max
+        value = Math.max(value, min); // or below min
+        value = Number(value.toFixed(scale)).toString(); // Drop insignificant trailing zeros
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
+            <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)');</text>
+        }
+        $('#' + id).val(value);
+    }
+
 </script>


### PR DESCRIPTION
…added support for scale > 0 with localization

The old implementation, based on jQuery UI, had some issues. It was not responsive, it added unnecessary style classes and it did not support configured min/max values. Furthermore, it did not support scale > 0 at all.

I created a content type with some numeric fields. The hint shows how they are configured.

The old spinner in action:

![SpinnerBefore](https://user-images.githubusercontent.com/3008547/97477863-7707a580-1950-11eb-9644-ab6d3e45e468.gif)

I removed the jQuery UI dependency and replaced it with Bootstrap components. Styling and responsive behaviour is now in line with other fields. Values are also kept within the min/max range.

The new spinner in action:

![SpinnerAfter](https://user-images.githubusercontent.com/3008547/97478199-e7aec200-1950-11eb-94eb-5fe9e8f57373.gif)

Support for scale > 0 was also added. For this I had to check the decimal separator that is used on the server and optionally convert commas to points and vice versa. Look at the sourcecode how I implemented this. If there is a better way, I'd like to know.

