### PR TITLE
Set Liquid page view context if no ambient one

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -285,7 +285,7 @@ namespace OrchardCore.DisplayManagement.Liquid
 
             var tempDataProvider = services.GetService<ITempDataProvider>();
 
-            return new ViewContext(
+            var viewContext = new ViewContext(
                 actionContext,
                 viewResult.View,
                 new ViewDataDictionary(
@@ -296,6 +296,13 @@ namespace OrchardCore.DisplayManagement.Liquid
                     tempDataProvider),
                 TextWriter.Null,
                 new HtmlHelperOptions());
+
+            if (viewContext.View is RazorView razorView)
+            {
+                razorView.RazorPage.ViewContext = viewContext;
+            }
+
+            return viewContext;
         }
     }
 


### PR DESCRIPTION
Fixes #7414, replace #7413 

When we render a view without any ambient view context, e.g. in a background task, through GraphQL, and in the related issue when Lucene indexing request the body aspect of the liquid part, we build a view context on the fly.

In this case, the template context is well contextualized but not the a `LiquidPage` (derived from `RazorPage`), its `ViewContext` and then its `HttpContext Context` properties are null, so it fails if a liquid tag / filter use them.

In a similar context, for razor it doesn't fail as we use `view.RenderAsync(viewContext)` where we pass the view context we created on the fly. So in this case, for liquid the fix is just to init the `RazorPage.ViewContext` with the one we created.

Note: The `HttpContext Context` property of an mvc `RazorPage` is resolved from its `ViewContext`
