### PR TITLE
NumericField Slider: fixed localization & layout improvements

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -8,6 +8,8 @@
     decimal min = settings.Minimum.HasValue ? settings.Minimum.Value : 0;
     decimal max = settings.Maximum.HasValue ? settings.Maximum.Value : 10000;
     string id = Html.IdFor(m => m.Value);
+    string javascriptDecimalSeparator = CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
+    string serverDecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
 }
 
 <script asp-name="bootstrap-slider" at="Foot" version="11"></script>
@@ -18,31 +20,58 @@
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@name</label>
             <div class="input-group mb-2">
-                @*<div class="input-group-prepend">
-                    <div class="input-group-text">@min</div>
-                </div>*@
-                <input asp-for="Value" type="number" class="form-control content-preview-select" />
-                @*<div class="input-group-append">
-                    <div class="input-group-text">@max</div>
-                </div>*@
-            </div>
-            <div class="input-group mb-2 ml-2">            
-                @if (settings.Minimum.HasValue) {<span class="mr-3">@min</span>}
-                <input id="@(id)-slider" type="text" data-slider-min="@min" data-slider-max="@max" data-slider-step="@step" data-slider-value="@Model.Value" />            
-                @if (settings.Maximum.HasValue) {<span class="ml-1">@max</span>}
+                @if (settings.Minimum.HasValue)
+                {
+                    <div class="input-group-prepend">
+                        <div class="input-group-text">@min</div>
+                    </div>
+                }
+                <input asp-for="Value" class="form-control content-preview-select" placeholder="@settings.Placeholder" required="@settings.Required" />
+                @if (settings.Maximum.HasValue)
+                {
+                    <div class="input-group-append">
+                        <div class="input-group-text">@max</div>
+                    </div>
+                }
             </div>
         </div>
+    </div>
+    <div class="input-group mb-2">            
+        @if (settings.Minimum.HasValue)
+        {
+            <span class="ml-1 mr-3">@min</span>
+        }
+        <input id="@(id)-slider" type="text" data-slider-min="@min" data-slider-max="@max" data-slider-step="@step" data-slider-value="@Model.Value" />            
+        @if (settings.Maximum.HasValue)
+        {
+            <span class="ml-3 mr-1">@max</span>
+        }
     </div>
     @if (!String.IsNullOrEmpty(settings.Hint))
     {
         <span class="hint">@settings.Hint</span>
     }
 </div>
+
 <script at="Foot">
-    $('#@(id)-slider').bootstrapSlider({ tooltip: 'always' }).on('change', function (ev) {
-        $('#@(id)').val(ev.value.newValue);
+
+    $('#@(id)-slider').bootstrapSlider({ tooltip: 'show' }).on('change', function (ev) {
+        let value = ev.value.newValue.toString();
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
+            <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)');</text>
+        }
+        $('#@(id)').val(value);
     });
+
     $('#@(id)').change(function () {
-        $('#@(id)-slider').bootstrapSlider('setValue', this.value);
+        let value = this.value;
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
+            <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)');</text>
+        }
+        value = (Number(value) || 0);
+        $('#@(id)-slider').bootstrapSlider('setValue', value);
     });
+
 </script>


### PR DESCRIPTION
The 'Slider' NumericField did not use localized values when scale > 0. Fixed this by using the same technique as in the 'Spinner' NumericField.

Because it used `type="number"` localization seemed okay, but you could not save a content item.

Before:

![SliderBefore](https://user-images.githubusercontent.com/3008547/97547419-15861c00-19ce-11eb-9972-7451ea095695.gif)

After:

![SliderAfter](https://user-images.githubusercontent.com/3008547/97547440-1ae36680-19ce-11eb-966d-a63d23e96adf.gif)

I also changed the layout to match the other fields (like min/max).

The slider itself is not responsive, it has hardcoded values in its stylesheet. I moved it out of the column so it can be bigger than the input-element (like the hint).

I changed the tooltip to 'show' instead of 'always' so it's only visible when hovering over the slider, as it could overlap the input-element.

When entering non-numeric values, there are no more javascript-exceptions.
