### PR TITLE
NumericField Range: keep slider in sync with input values

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
@@ -23,7 +23,7 @@
                         <div class="input-group-text">@min</div>
                     </div>
                 }
-                <input asp-for="Value" class="form-control content-preview-select" placeholder="@settings.Placeholder" required="@settings.Required" />
+                <input asp-for="Value" class="form-control content-preview-select" placeholder="@settings.Placeholder" required="@settings.Required" onchange="numericFieldRangeSync('@(id)-range', value);" />
                 @if (settings.Maximum.HasValue)
                 {
                     <div class="input-group-append">
@@ -47,6 +47,15 @@
         {
             <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)');</text>
         }
+        $('#' + id).val(value);
+    }
+
+    function numericFieldRangeSync(id, value) {
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
+            <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)');</text>
+        }
+        value = (Number(value) || 0);
         $('#' + id).val(value);
     }
 


### PR DESCRIPTION
The 'Range' NumericField should keep the slider in sync with input values, just like the 'Slider' NumericField.

Before:

![RangeSyncBefore](https://user-images.githubusercontent.com/3008547/97558845-f5118e00-19dc-11eb-987c-da214ecdb3f6.gif)

After:

![RangeSyncAfter](https://user-images.githubusercontent.com/3008547/97558857-f8a51500-19dc-11eb-8697-76a1797be8d0.gif)

Non-numeric input values are defaulted to 0. A range can handle values outside min/max boundaries.