### PR TITLE
Add CloneContent Permission as Content Type dynamic permission

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyContentsAdminListDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyContentsAdminListDisplayDriver.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Localization;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
-using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Contents.ViewModels;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Handlers;
@@ -14,7 +13,6 @@ using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Entities;
 using OrchardCore.Settings;
-using OrchardCore.Taxonomies.Fields;
 using OrchardCore.Taxonomies.Models;
 using OrchardCore.Taxonomies.Settings;
 using OrchardCore.Taxonomies.ViewModels;
@@ -27,18 +25,15 @@ namespace OrchardCore.Taxonomies.Drivers
 
         private readonly ISiteService _siteService;
         private readonly IContentManager _contentManager;
-        private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly IStringLocalizer S;
 
         public TaxonomyContentsAdminListDisplayDriver(
             ISiteService siteService,
             IContentManager contentManager,
-            IContentDefinitionManager contentDefinitionManager,
             IStringLocalizer<TaxonomyContentsAdminListDisplayDriver> stringLocalizer)
         {
             _siteService = siteService;
             _contentManager = contentManager;
-            _contentDefinitionManager = contentDefinitionManager;
             S = stringLocalizer;
         }
 
@@ -51,18 +46,8 @@ namespace OrchardCore.Taxonomies.Drivers
                 return null;
             }
 
-            var taxonomyContentItemIds = settings.TaxonomyContentItemIds;
-            if (!string.IsNullOrWhiteSpace(model.SelectedContentType))
-            {
-                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.SelectedContentType);
-                var fieldDefinitions = contentTypeDefinition
-                    .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(TaxonomyField)));
-                var fieldTaxonomyContentItemIds = fieldDefinitions.Select(x => x.GetSettings<TaxonomyFieldSettings>().TaxonomyContentItemId);
-                taxonomyContentItemIds = taxonomyContentItemIds.Intersect(fieldTaxonomyContentItemIds).ToArray();
-            }
-
             var results = new List<IDisplayResult>();
-            var taxonomies = await _contentManager.GetAsync(taxonomyContentItemIds);
+            var taxonomies = await _contentManager.GetAsync(settings.TaxonomyContentItemIds);
 
             var position = 5;
             foreach (var taxonomy in taxonomies)

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyContentsAdminListDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyContentsAdminListDisplayDriver.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Localization;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Contents.ViewModels;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Handlers;
@@ -13,6 +14,7 @@ using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Entities;
 using OrchardCore.Settings;
+using OrchardCore.Taxonomies.Fields;
 using OrchardCore.Taxonomies.Models;
 using OrchardCore.Taxonomies.Settings;
 using OrchardCore.Taxonomies.ViewModels;
@@ -25,15 +27,18 @@ namespace OrchardCore.Taxonomies.Drivers
 
         private readonly ISiteService _siteService;
         private readonly IContentManager _contentManager;
+        private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly IStringLocalizer S;
 
         public TaxonomyContentsAdminListDisplayDriver(
             ISiteService siteService,
             IContentManager contentManager,
+            IContentDefinitionManager contentDefinitionManager,
             IStringLocalizer<TaxonomyContentsAdminListDisplayDriver> stringLocalizer)
         {
             _siteService = siteService;
             _contentManager = contentManager;
+            _contentDefinitionManager = contentDefinitionManager;
             S = stringLocalizer;
         }
 
@@ -46,8 +51,18 @@ namespace OrchardCore.Taxonomies.Drivers
                 return null;
             }
 
+            var taxonomyContentItemIds = settings.TaxonomyContentItemIds;
+            if (!string.IsNullOrWhiteSpace(model.SelectedContentType))
+            {
+                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(model.SelectedContentType);
+                var fieldDefinitions = contentTypeDefinition
+                    .Parts.SelectMany(x => x.PartDefinition.Fields.Where(f => f.FieldDefinition.Name == nameof(TaxonomyField)));
+                var fieldTaxonomyContentItemIds = fieldDefinitions.Select(x => x.GetSettings<TaxonomyFieldSettings>().TaxonomyContentItemId);
+                taxonomyContentItemIds = taxonomyContentItemIds.Intersect(fieldTaxonomyContentItemIds).ToArray();
+            }
+
             var results = new List<IDisplayResult>();
-            var taxonomies = await _contentManager.GetAsync(settings.TaxonomyContentItemIds);
+            var taxonomies = await _contentManager.GetAsync(taxonomyContentItemIds);
 
             var position = 5;
             foreach (var taxonomy in taxonomies)

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -23,7 +23,10 @@ namespace OrchardCore.Contents.Security
         private static readonly Permission ViewOwnContent = new Permission("ViewOwn_{0}", "View own {0}", new[] { ViewContent, CommonPermissions.ViewOwnContent });
         private static readonly Permission PreviewContent = new Permission("Preview_{0}", "Preview {0} by others", new[] { EditContent, CommonPermissions.PreviewContent });
         private static readonly Permission PreviewOwnContent = new Permission("PreviewOwn_{0}", "Preview own {0}", new[] { PreviewContent, CommonPermissions.PreviewOwnContent });
+        private static readonly Permission CloneContent = new Permission("Clone_{0}", "Clone {0} by others", new[] { EditContent, CommonPermissions.CloneContent });
+        private static readonly Permission CloneOwnContent = new Permission("CloneOwn_{0}", "Clone own {0}", new[] { CloneContent, CommonPermissions.CloneOwnContent });
         private static readonly Permission ListContent = new Permission("ListContent_{0}", "List {0} content item(s) owned by all users", new[] { CommonPermissions.ListContent });
+
 
         public static readonly Dictionary<string, Permission> PermissionTemplates = new Dictionary<string, Permission>
         {
@@ -37,6 +40,8 @@ namespace OrchardCore.Contents.Security
             { CommonPermissions.ViewOwnContent.Name, ViewOwnContent },
             { CommonPermissions.PreviewContent.Name, PreviewContent },
             { CommonPermissions.PreviewOwnContent.Name, PreviewOwnContent },
+            { CommonPermissions.CloneContent.Name, CloneContent },
+            { CommonPermissions.CloneOwnContent.Name, CloneOwnContent },
             { CommonPermissions.ListContent.Name, ListContent }
         };
 

--- a/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/ContentTypePermissionsHelper.cs
@@ -27,7 +27,6 @@ namespace OrchardCore.Contents.Security
         private static readonly Permission CloneOwnContent = new Permission("CloneOwn_{0}", "Clone own {0}", new[] { CloneContent, CommonPermissions.CloneOwnContent });
         private static readonly Permission ListContent = new Permission("ListContent_{0}", "List {0} content item(s) owned by all users", new[] { CommonPermissions.ListContent });
 
-
         public static readonly Dictionary<string, Permission> PermissionTemplates = new Dictionary<string, Permission>
         {
             { CommonPermissions.PublishContent.Name, PublishContent },


### PR DESCRIPTION
Adds the ability to set CloneContent permission on each Content Type.
Closes [#7441](https://github.com/OrchardCMS/OrchardCore/issues/7441)
![image](https://user-images.githubusercontent.com/16968103/97674330-52ced480-1ac8-11eb-9626-5ca66475f360.png)
