### PR TITLE
Improved layout of LinkField settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkFieldSettings.Edit.cshtml
@@ -1,23 +1,21 @@
 @model OrchardCore.ContentFields.Settings.LinkFieldSettings
 @using OrchardCore.ContentFields.Settings
 
-<div class="row">
-    <div class="form-group col-md-6">
-        <div class="custom-control custom-checkbox">
-            <input type="checkbox" class="custom-control-input" asp-for="Required" checked="@Model.Required" />
-            <label class="custom-control-label" asp-for="Required">@T["Required"]</label>
-            <span class="hint">— @T["Whether the url is required."]</span>
-        </div>
+<div class="form-group">
+    <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" asp-for="Required" checked="@Model.Required" />
+        <label class="custom-control-label" asp-for="Required">@T["Required"]</label>
+        <span class="hint">— @T["Whether the url is required."]</span>
     </div>
-    <div class="form-group col-md-6">
-        <label asp-for="LinkTextMode">@T["Text"]</label>
-        <select asp-for="LinkTextMode" class="form-control">
-            <option value="@LinkTextMode.Optional" selected="@(Model.LinkTextMode == LinkTextMode.Optional)">@T["Text is optional"]</option>
-            <option value="@LinkTextMode.Required" selected="@(Model.LinkTextMode == LinkTextMode.Required)">@T["Text is required"]</option>
-            <option value="@LinkTextMode.Static" selected="@(Model.LinkTextMode == LinkTextMode.Static)">@T["Use the default value"]</option>
-            <option value="@LinkTextMode.Url" selected="@(Model.LinkTextMode == LinkTextMode.Url)">@T["Use the url of the link"]</option>
-        </select>
-    </div>
+</div>
+<div class="form-group">
+    <label asp-for="LinkTextMode">@T["Text"]</label>
+    <select asp-for="LinkTextMode" class="form-control w-md-50">
+        <option value="@LinkTextMode.Optional" selected="@(Model.LinkTextMode == LinkTextMode.Optional)">@T["Text is optional"]</option>
+        <option value="@LinkTextMode.Required" selected="@(Model.LinkTextMode == LinkTextMode.Required)">@T["Text is required"]</option>
+        <option value="@LinkTextMode.Static" selected="@(Model.LinkTextMode == LinkTextMode.Static)">@T["Use the default value"]</option>
+        <option value="@LinkTextMode.Url" selected="@(Model.LinkTextMode == LinkTextMode.Url)">@T["Use the url of the link"]</option>
+    </select>
 </div>
 <div class="row">
     <div class="form-group col-md-6">


### PR DESCRIPTION
It's strange to have an input-element next to a checkbox. Moved it down to improve layout.

Before:

![image](https://user-images.githubusercontent.com/3008547/97800568-8f204300-1c36-11eb-92c4-b92d86300c1f.png)

After:

![image](https://user-images.githubusercontent.com/3008547/97800572-9a736e80-1c36-11eb-98d2-999f0ce66956.png)
