### PR TITLE
Default value for AllowMediaText Setting

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Settings/MediaFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Settings/MediaFieldSettings.cs
@@ -9,6 +9,8 @@ namespace OrchardCore.Media.Settings
 
         [DefaultValue(true)]
         public bool Multiple { get; set; } = true;
+        
+        [DefaultValue(true)]
         public bool AllowMediaText { get; set; } = true;
         public bool AllowAnchors { get; set; }
     }


### PR DESCRIPTION
It is incorrectly merged by Newtonsoft when used via `WithSettings`