### PR TITLE
IQueryResults for Razor views

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Razor/ContentQueryOrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Razor/ContentQueryOrchardRazorHelperExtensions.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrchardCore;
 using OrchardCore.ContentManagement;
+using OrchardCore.Queries;
 
 public static class ContentQueryOrchardRazorHelperExtensions
 {
@@ -16,28 +17,66 @@ public static class ContentQueryOrchardRazorHelperExtensions
         var results = await orchardHelper.QueryAsync(queryName, parameters);
         var contentItems = new List<ContentItem>();
 
-        foreach (var result in results)
+        if (results != null)
         {
-            if (!(result is ContentItem contentItem))
+            foreach (var result in results)
             {
-                contentItem = null;
-
-                if (result is JObject jObject)
+                if (!(result is ContentItem contentItem))
                 {
-                    contentItem = jObject.ToObject<ContentItem>();
+                    contentItem = null;
+
+                    if (result is JObject jObject)
+                    {
+                        contentItem = jObject.ToObject<ContentItem>();
+                    }
                 }
-            }
 
-            // If input is a 'JObject' but which not represents a 'ContentItem',
-            // a 'ContentItem' is still created but with some null properties.
-            if (contentItem?.ContentItemId == null)
-            {
-                continue;
-            }
+                // If input is a 'JObject' but which not represents a 'ContentItem',
+                // a 'ContentItem' is still created but with some null properties.
+                if (contentItem?.ContentItemId == null)
+                {
+                    continue;
+                }
 
-            contentItems.Add(contentItem);
+                contentItems.Add(contentItem);
+            }
         }
 
         return contentItems;
+    }
+
+    public static async Task<IQueryResults> ContentQueryResultsAsync(this IOrchardHelper orchardHelper, string queryName, Dictionary<string, object> parameters)
+    {
+        var contentItems = new List<ContentItem>();
+        var queryResult = await orchardHelper.QueryResultsAsync(queryName, parameters);
+
+        if (queryResult.Items != null)
+        {
+            foreach (var item in queryResult.Items)
+            {
+                if (!(item is ContentItem contentItem))
+                {
+                    contentItem = null;
+
+                    if (item is JObject jObject)
+                    {
+                        contentItem = jObject.ToObject<ContentItem>();
+                    }
+                }
+
+                // If input is a 'JObject' but which not represents a 'ContentItem',
+                // a 'ContentItem' is still created but with some null properties.
+                if (contentItem?.ContentItemId == null)
+                {
+                    continue;
+                }
+
+                contentItems.Add(contentItem);
+            }
+
+            queryResult.Items = contentItems;
+        }
+
+        return queryResult;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Razor/QueryOrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Razor/QueryOrchardRazorHelperExtensions.cs
@@ -26,4 +26,19 @@ public static class QueryOrchardRazorHelperExtensions
         var result = await queryManager.ExecuteQueryAsync(query, parameters);
         return result.Items;
     }
+
+    public static async Task<IQueryResults> QueryResultsAsync(this IOrchardHelper orchardHelper, string queryName, IDictionary<string, object> parameters)
+    {
+        var queryManager = orchardHelper.HttpContext.RequestServices.GetService<IQueryManager>();
+
+        var query = await queryManager.GetQueryAsync(queryName);
+
+        if (query == null)
+        {
+            return null;
+        }
+
+        var result = await queryManager.ExecuteQueryAsync(query, parameters);
+        return result;
+    }
 }


### PR DESCRIPTION
Allows to use IQueryResults with Queries made in Razor views.
This allows to be able to return a Total Count of the records from a "named Lucene Query" and use it on a PagerShape for example.