### PR TITLE
Limit content item recursions to 20

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/BuildDisplayFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/BuildDisplayFilter.cs
@@ -14,6 +14,8 @@ namespace OrchardCore.Contents.Liquid
 {
     public class BuildDisplayFilter : ILiquidFilter
     {
+        private const int MaxContentItemRecursions = 20;
+
         public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
         {
             static async ValueTask<FluidValue> Awaited(Task<IShape> task)
@@ -49,8 +51,8 @@ namespace OrchardCore.Contents.Liquid
 
             var buildDisplayRecursionHelper = serviceProvider.GetRequiredService<IContentItemRecursionHelper<BuildDisplayFilter>>();
 
-            // When {{ Model.ContentItem | shape_build_display | shape_render }} is called prevent recursion.
-            if (buildDisplayRecursionHelper.IsRecursive(contentItem))
+            // When {{ Model.ContentItem | shape_build_display | shape_render }} is called prevent unlimited recursions.
+            if (buildDisplayRecursionHelper.IsRecursive(contentItem, MaxContentItemRecursions))
             {
                 return new ValueTask<FluidValue>(NilValue.Instance);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/BuildDisplayFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/BuildDisplayFilter.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.Contents.Liquid
 {
     public class BuildDisplayFilter : ILiquidFilter
     {
-        private const int MaxContentItemRecursions = 20;
+        private const int DefaultMaxContentItemRecursions = 20;
 
         public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, TemplateContext ctx)
         {
@@ -52,7 +52,10 @@ namespace OrchardCore.Contents.Liquid
             var buildDisplayRecursionHelper = serviceProvider.GetRequiredService<IContentItemRecursionHelper<BuildDisplayFilter>>();
 
             // When {{ Model.ContentItem | shape_build_display | shape_render }} is called prevent unlimited recursions.
-            if (buildDisplayRecursionHelper.IsRecursive(contentItem, MaxContentItemRecursions))
+            // max_recursions is an optional argument to override the default limit of 20.
+            var maxRecursions = arguments["max_recursions"];
+            var recursionLimit = maxRecursions.Type == FluidValues.Number ? Convert.ToInt32(maxRecursions.ToNumberValue()) : DefaultMaxContentItemRecursions;
+            if (buildDisplayRecursionHelper.IsRecursive(contentItem, recursionLimit))
             {
                 return new ValueTask<FluidValue>(NilValue.Instance);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemRecursionHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemRecursionHelper.cs
@@ -27,6 +27,11 @@ namespace OrchardCore.Contents.Liquid
             if (_recursions.ContainsKey(contentItem))
             {
                 var counter = _recursions[contentItem];
+                if (maxRecursions < 1)
+                {
+                    maxRecursions = 1;
+                }
+                
                 if (counter == maxRecursions)
                 {
                     return true;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemRecursionHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemRecursionHelper.cs
@@ -19,38 +19,24 @@ namespace OrchardCore.Contents.Liquid
     /// <inheritdocs />
     public class ContentItemRecursionHelper<T> : IContentItemRecursionHelper<T> where T : ILiquidFilter
     {
-        private HashSet<string> _contentItemIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        private Dictionary<string, int> _recursions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<ContentItem, int> _recursions = new Dictionary<ContentItem, int>();
 
         /// <inheritdocs />
         public bool IsRecursive(ContentItem contentItem, int maxRecursions = 1)
         {
-            if (_contentItemIds.Contains(contentItem.ContentItemId))
+            if (_recursions.ContainsKey(contentItem))
             {
-                if (maxRecursions > 1)
+                var counter = _recursions[contentItem];
+                if (counter == maxRecursions)
                 {
-                    if (_recursions.TryGetValue(contentItem.ContentItemId, out var counter))
-                    {
-                        if (counter == maxRecursions)
-                        {
-                            return true;
-                        }
-
-                        _recursions[contentItem.ContentItemId] = counter + 1;
-                        return false;
-                    }
-                    else
-                    {
-                        _recursions[contentItem.ContentItemId] = 1;
-                        return false;
-                    }
+                    return true;
                 }
 
-                return true;
+                _recursions[contentItem] = counter + 1;
+                return false;
             }
 
-            _contentItemIds.Add(contentItem.ContentItemId);
-
+            _recursions[contentItem] = 1;
             return false;
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemRecursionHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemRecursionHelper.cs
@@ -13,19 +13,39 @@ namespace OrchardCore.Contents.Liquid
         /// <summary>
         /// Returns <see langword="True"/> when the <see cref="ContentItem"/> has already been evaluated during this request by the particular filter./>
         /// </summary>
-        bool IsRecursive(ContentItem contentItem);
+        bool IsRecursive(ContentItem contentItem, int maxRecursions = 1);
     }
 
     /// <inheritdocs />
     public class ContentItemRecursionHelper<T> : IContentItemRecursionHelper<T> where T : ILiquidFilter
     {
         private HashSet<string> _contentItemIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        private Dictionary<string, int> _recursions = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
         /// <inheritdocs />
-        public bool IsRecursive(ContentItem contentItem)
+        public bool IsRecursive(ContentItem contentItem, int maxRecursions = 1)
         {
             if (_contentItemIds.Contains(contentItem.ContentItemId))
             {
+                if (maxRecursions > 1)
+                {
+                    if (_recursions.TryGetValue(contentItem.ContentItemId, out var counter))
+                    {
+                        if (counter == maxRecursions)
+                        {
+                            return true;
+                        }
+
+                        _recursions[contentItem.ContentItemId] = counter + 1;
+                        return false;
+                    }
+                    else
+                    {
+                        _recursions[contentItem.ContentItemId] = 1;
+                        return false;
+                    }
+                }
+
                 return true;
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemRecursionHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentItemRecursionHelper.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.Contents.Liquid
                     maxRecursions = 1;
                 }
                 
-                if (counter == maxRecursions)
+                if (counter > maxRecursions)
                 {
                     return true;
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -140,8 +140,7 @@ namespace OrchardCore.Contents
             services.AddLiquidFilter<DisplayUrlFilter>("display_url");
             services.AddLiquidFilter<FullTextFilter>("full_text");
 
-            services.AddScoped<IContentItemRecursionHelper<FullTextFilter>, ContentItemRecursionHelper<FullTextFilter>>();
-            services.AddScoped<IContentItemRecursionHelper<BuildDisplayFilter>, ContentItemRecursionHelper<BuildDisplayFilter>>();
+            services.AddScoped(typeof(IContentItemRecursionHelper<>), typeof(ContentItemRecursionHelper<>));
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7451

@jtkech I ended up using both a dictionary and hashset, because comparing by ref wasn't possible, because when it is recursing like this it's creating new shapes everytime, so new objects getting spawned.

I picked 20 as the number, as @jeffolmstead has already experienced the issue you spotted, trying to build multiple display types, on the same content item.

The other option is to remove recursion checking here on this filter completely.

But a bit of bad code, i.e. `{{ Model.ContentItem | shape_build_display | shape_render }}` does stackoverflow the system.