### PR TITLE
Don't encode ShapeStringify

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -108,7 +108,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
                 using (var writer = new StringWriter())
                 {
                     task.Result.WriteTo(writer, NullHtmlEncoder.Default);
-                    value = new StringValue(writer.ToString());
+                    value = new StringValue(writer.ToString(), false);
                 }
 
                 return new ValueTask<FluidValue>(value);


### PR DESCRIPTION
Fixes #7497 

`shape_stringify` should return a string, that's why i did #7463, but should not be marked to be encoded again as it is the representation of a shape, so normally already encoded

E.g. `shape_render` return an `HtmlContentValue` holding a `ViewBuffer` whose `WriteTo()` doesn't encode again

**I think there are other filters that wrongly return a string marked to be encoded**, i'm thinking about those that generate urls, maybe currently it works because the browser is aware of this and html decodes them before url encoding them.

**Update**:

So the filters that would need to return a string no to be html encoded aqain, are those that return a string that is intended to be already encoded, or intended to be encoded differently, e.g. url encoded for an url in an `href`.

**Seems okay for filters that generate urls as the strings are first url encoded by the filters**, so most of the time html encoding an url encoded string does nothing, maybe not in all cases but again seems that the browser is aware of this.

 Notice that for urls sometimes we want to also display them as texts, so here we would need strings that are not url encoded but only html encoded, but we would need 2 sets of filters, one for links and one for display values ;)

**But there are other candidates, that would need to not mark their `StringValue` to be encoded again, as the `sanitize_html` and `markdownify` filters and so on, so that we don't need to add on them a `| raw` filter.**