### PR TITLE
Allow media width and height values without a token

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaImageSharpConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaImageSharpConfiguration.cs
@@ -57,41 +57,16 @@ namespace OrchardCore.Media.Processing
                             context.Commands[command.Key] = command.Value;
                         }
 
-                        // Do not check supported sizes here, as with tokenization any size is allowed.
+                        // Do not evaluate supported sizes here, as with tokenization any size is allowed.
                     }
                     else
                     {
-                        // When tokenization is enabled, but a token is not present, clear the commands to no-op the image processing pipeline.
-                        context.Commands.Clear();
-                        return Task.CompletedTask;
+                        ValidateTokenlessCommands(context, mediaOptions);
                     }
                 }
                 else
                 {
-                    // The following commands are not supported without a tokenized query string.
-                    context.Commands.Remove(ResizeWebProcessor.Xy);
-                    context.Commands.Remove(ImageVersionProcessor.VersionCommand);
-
-                    // Width and height must be part of the supported sizes array when tokenization is disabled.
-                    if (context.Commands.TryGetValue(ResizeWebProcessor.Width, out var widthString))
-                    {
-                        var width = context.Parser.ParseValue<int>(widthString, context.Culture);
-
-                        if (Array.BinarySearch<int>(mediaOptions.SupportedSizes, width) < 0)
-                        {
-                            context.Commands.Remove(ResizeWebProcessor.Width);
-                        }
-                    }
-
-                    if (context.Commands.TryGetValue(ResizeWebProcessor.Height, out var heightString))
-                    {
-                        var height = context.Parser.ParseValue<int>(heightString, context.Culture);
-
-                        if (Array.BinarySearch<int>(mediaOptions.SupportedSizes, height) < 0)
-                        {
-                            context.Commands.Remove(ResizeWebProcessor.Height);
-                        }
-                    }
+                    ValidateTokenlessCommands(context, mediaOptions);
                 }
 
                 // The following commands are not supported by default.
@@ -112,6 +87,34 @@ namespace OrchardCore.Media.Processing
 
                 return Task.CompletedTask;
             };
+        }
+
+        private static void ValidateTokenlessCommands(ImageCommandContext context, MediaOptions mediaOptions)
+        {
+            // The following commands are not supported without a tokenized query string.
+            context.Commands.Remove(ResizeWebProcessor.Xy);
+            context.Commands.Remove(ImageVersionProcessor.VersionCommand);
+
+            // Width and height must be part of the supported sizes array when tokenization is disabled.
+            if (context.Commands.TryGetValue(ResizeWebProcessor.Width, out var widthString))
+            {
+                var width = context.Parser.ParseValue<int>(widthString, context.Culture);
+
+                if (Array.BinarySearch<int>(mediaOptions.SupportedSizes, width) < 0)
+                {
+                    context.Commands.Remove(ResizeWebProcessor.Width);
+                }
+            }
+
+            if (context.Commands.TryGetValue(ResizeWebProcessor.Height, out var heightString))
+            {
+                var height = context.Parser.ParseValue<int>(heightString, context.Culture);
+
+                if (Array.BinarySearch<int>(mediaOptions.SupportedSizes, height) < 0)
+                {
+                    context.Commands.Remove(ResizeWebProcessor.Height);
+                }
+            }
         }
     }
 }

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -58,7 +58,7 @@ Convert the input URL to create a resized image with the specified size argument
 #### Arguments
 
 Refer [Query string tokens](#query-string-tokens) to understand the valid values for a width or height command,
-and how the query string will defer from the examples provided.
+and how the query string will differ from the examples provided.
 
 #### `width` (or first argument)
 
@@ -403,9 +403,9 @@ The `MediaText[]` is kept in sync with the `Paths[]` array and the index for a g
 
 Image anchors are an optional setting, off by default, on the `MediaField`.
 
-When enabled they allow a media field to provide an anchor x or y value for use when cropping, or padding the image.
+When enabled they allow a media field to provide an anchor point, or x and y value for use when cropping, or padding the image.
 
-The anchor value provided can be used to specify the center of a crop or pad.
+The anchor value provided can be used to specify the center point of a crop or pad.
 
 When the setting is enabled the template must read and provide the value to the resizing helpers or filters.
 
@@ -450,9 +450,11 @@ those commands. e.g.
     Tokens are only available from the [Preview Feed](../../../getting-started/preview-package-source)
     Prior to this the width or height values are limited to `16`, `32`, `50`, `100`, `160`, `240`, `480`, `600`, `1024`, `2048`.
 
-## Video
+## Videos
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/BQHUlvPFRR4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/K0_i4vj00yM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## CREDITS
 


### PR DESCRIPTION
Discussed on gitter.

Allows values for width and height to be provided via the query string even when tokens are enabled.

i.e. `foo.jpg?width=1024&height=600` <-- but only if they match the supported sizes array values.