### PR TITLE
Add 'isInRole' layer rule & make 'is_in_role' liquid filter case insensitive

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/DefaultLayersMethodProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/DefaultLayersMethodProvider.cs
@@ -12,6 +12,7 @@ namespace OrchardCore.Layers.Services
         private readonly GlobalMethod _isHomepage;
         private readonly GlobalMethod _isAnonymous;
         private readonly GlobalMethod _isAuthenticated;
+        private readonly GlobalMethod _isInRole;
         private readonly GlobalMethod _url;
         private readonly GlobalMethod _culture;
 
@@ -47,6 +48,16 @@ namespace OrchardCore.Layers.Services
                 {
                     var httpContext = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
                     return httpContext.User?.Identity.IsAuthenticated == true;
+                })
+            };
+
+            _isInRole = new GlobalMethod
+            {
+                Name = "isInRole",
+                Method = serviceProvider => (Func<string, bool>) (role =>
+                {
+                    var httpContext = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
+                    return httpContext.User?.IsInRole(role) == true;
                 })
             };
 
@@ -88,7 +99,7 @@ namespace OrchardCore.Layers.Services
                 })
             };
 
-            _allMethods = new[] { _isAnonymous, _isAuthenticated, _isHomepage, _url, _culture };
+            _allMethods = new[] { _isAnonymous, _isAuthenticated, _isInRole, _isHomepage, _url, _culture };
         }
 
         public IEnumerable<GlobalMethod> GetMethods()

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/DefaultLayersMethodProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/DefaultLayersMethodProvider.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OrchardCore.Scripting;
 
 namespace OrchardCore.Layers.Services
@@ -57,7 +60,9 @@ namespace OrchardCore.Layers.Services
                 Method = serviceProvider => (Func<string, bool>) (role =>
                 {
                     var httpContext = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext;
-                    return httpContext.User?.IsInRole(role) == true;
+                    var optionsAccessor = serviceProvider.GetRequiredService<IOptions<IdentityOptions>>();
+                    var roleClaimType = optionsAccessor.Value.ClaimsIdentity.RoleClaimType;
+                    return httpContext.User?.Claims.Any(claim => claim.Type == roleClaimType && claim.Value.Equals(role, StringComparison.OrdinalIgnoreCase)) == true; // IsInRole() & HasClaim() are case sensitive
                 })
             };
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Liquid/IsInRoleFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Liquid/IsInRoleFilter.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Fluid;
@@ -25,7 +27,7 @@ namespace OrchardCore.Users.Liquid
 
             if (input.ToObjectValue() is ClaimsPrincipal principal)
             {
-                ret = principal.HasClaim(_roleClaimType, claimName);
+                ret = principal.Claims.Any(claim => claim.Type == _roleClaimType && claim.Value.Equals(claimName, StringComparison.OrdinalIgnoreCase)) == true;
             }
 
             return new ValueTask<FluidValue>(ret ? BooleanValue.True : BooleanValue.False);

--- a/src/docs/reference/modules/Layers/README.md
+++ b/src/docs/reference/modules/Layers/README.md
@@ -20,7 +20,7 @@ Here are some available functions:
 | `isHomepage(): Boolean` | Returns true if the current request Url is the current homepage |
 | `isAnonymous(): Boolean` | Returns true if there is no authenticated user on the current request |
 | `isAuthenticated(): Boolean` | Returns true if there is an authenticated user on the current request |
-| `isInRole(role: string): Boolean` | Returns true if the user is in the provided role |
+| `isInRole(role: String): Boolean` | Returns true if the user is in the provided role |
 | `url(url: String): Boolean` | Returns true if the current url matches the provided url. Add a `*` to the end of the url parameter to match any url that start with  |
 | `culture(name: String): Boolean` | Returns true if the current culture name or the current culture's parent name matches the `name` argument |
 

--- a/src/docs/reference/modules/Layers/README.md
+++ b/src/docs/reference/modules/Layers/README.md
@@ -20,6 +20,7 @@ Here are some available functions:
 | `isHomepage(): Boolean` | Returns true if the current request Url is the current homepage |
 | `isAnonymous(): Boolean` | Returns true if there is no authenticated user on the current request |
 | `isAuthenticated(): Boolean` | Returns true if there is an authenticated user on the current request |
+| `isInRole(role: string): Boolean` | Returns true if the user is in the provided role |
 | `url(url: String): Boolean` | Returns true if the current url matches the provided url. Add a `*` to the end of the url parameter to match any url that start with  |
 | `culture(name: String): Boolean` | Returns true if the current culture name or the current culture's parent name matches the `name` argument |
 


### PR DESCRIPTION
This PR adds an 'isInRole' layer rule. I also updated the documentation.

I noticed `IsInRole(role)` is case SENSITIVE. So `isInRole('editor')` does not match role `Editor`. I don't know if it should stay this way, or be made case insensitive?

This fixes https://github.com/OrchardCMS/OrchardCore/issues/5494

/cc @agriffard 