### PR TITLE
Fixes Concurrency and MARS issues

### DIFF
--- a/src/OrchardCore/OrchardCore.Data.Abstractions/Documents/Document.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/Documents/Document.cs
@@ -6,5 +6,10 @@ namespace OrchardCore.Data.Documents
         /// The <see cref="IDocument.Identifier"/>.
         /// </summary>
         public string Identifier { get; set; }
+
+        /// <summary>
+        /// Only defined to prevent a version missmatch https://github.com/sebastienros/yessql/pull/287
+        /// </summary>
+        public int Version { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/Documents/Document.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/Documents/Document.cs
@@ -8,7 +8,7 @@ namespace OrchardCore.Data.Documents
         public string Identifier { get; set; }
 
         /// <summary>
-        /// Only defined to prevent a version missmatch https://github.com/sebastienros/yessql/pull/287
+        /// Only defined to prevent a version missmatch, see https://github.com/sebastienros/yessql/pull/287
         /// </summary>
         public int Version { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.Data/Documents/DocumentStore.cs
+++ b/src/OrchardCore/OrchardCore.Data/Documents/DocumentStore.cs
@@ -59,6 +59,7 @@ namespace OrchardCore.Data.Documents
             T document = null;
 
             // Querying a document on a session that is already committed may throw a 'MARS' exception.
+            // Note: This issue may happen using 'Sql Server', but doesn't happen with 'Sqlite' at all.
             if (_committed)
             {
                 // So we create a scope on the current context, but just to resolve a new session.

--- a/src/OrchardCore/OrchardCore.Data/Documents/DocumentStore.cs
+++ b/src/OrchardCore/OrchardCore.Data/Documents/DocumentStore.cs
@@ -63,10 +63,10 @@ namespace OrchardCore.Data.Documents
             if (_committed)
             {
                 // So we create a scope on the current context, but just to resolve a new session.
-                await new ShellScope(ShellScope.Context).UsingServiceScopeAsync(async scope =>
+                await new ShellScope(ShellScope.Context).UsingServiceScopeAsync(scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
-                    document = await session.Query<T>().FirstOrDefaultAsync();
+                    return session.Query<T>().FirstOrDefaultAsync();
                 });
             }
             else

--- a/src/OrchardCore/OrchardCore.Data/Documents/DocumentStore.cs
+++ b/src/OrchardCore/OrchardCore.Data/Documents/DocumentStore.cs
@@ -63,7 +63,7 @@ namespace OrchardCore.Data.Documents
             if (_committed)
             {
                 // So we create a scope on the current context, but just to resolve a new session.
-                await ShellScope.Context.CreateScope().UsingServiceScopeAsync(async scope =>
+                await new ShellScope(ShellScope.Context).UsingServiceScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     document = await session.Query<T>().FirstOrDefaultAsync();


### PR DESCRIPTION
Fixes #7449 

When updating a shared document, if its `CheckConsistency` option is true (as it is by default), after the session is committed successfully, we query again the document for consistency checking.

On YesSql side, this query calls `YesSql.Store.ProduceAsync()` that may throw a MARS exception.

    InvalidOperationException: The connection does not support MultipleActiveResultSets.
    Microsoft.Data.SqlClient.SqlCommand+<>c.<ExecuteDbDataReaderAsync>b__164_0(Task<SqlDataReader> result)
    ...
    Dapper.SqlMapper.QueryAsync<T>(IDbConnection cnn, Type effectiveType, ...) in SqlMapper.Async.cs
    YesSql.Store.ProduceAsync<T>(WorkerQueryKey key, Func<object[], Task<T>> work, object[] args)
    YesSql.Services.DefaultQuery+Query<T>.FirstOrDefaultImpl()

So here, if the session is already committed, we create a new light scope on the existing current context (which is fast), and just to resolve a new session, then we use it to get back the document for consistency checking.

In #7449 the original issue of @giannik will be fixed through sebastienros/yessql#287

But i have an idea how to temporarily fix it in OC in the meantime, if it works i will update this PR so that it will also fixes #7545. **Update**: Okay, defining a `Version` property in our `Document` base class prevents a version missmatch