### PR TITLE
Remove CultureScope public culture properties

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Fluid;
@@ -18,7 +17,6 @@ using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.ContentManagement.Routing;
-using OrchardCore.DisplayManagement.Liquid;
 using OrchardCore.Environment.Cache;
 using OrchardCore.Liquid;
 using OrchardCore.Localization;

--- a/src/OrchardCore/OrchardCore.Abstractions/Localization/CultureScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Localization/CultureScope.cs
@@ -10,17 +10,11 @@ namespace OrchardCore.Localization
 
         private CultureScope(CultureInfo culture, CultureInfo uiCulture)
         {
-            Culture = culture;
-            UICulture = uiCulture;
             _originalCulture = CultureInfo.CurrentCulture;
             _originalUICulture = CultureInfo.CurrentUICulture;
 
             SetCultures(culture, uiCulture);
         }
-
-        public CultureInfo Culture { get; }
-
-        public CultureInfo UICulture { get; }
 
         public static CultureScope Create(string culture) => Create(culture, culture);
 

--- a/test/OrchardCore.Tests/Localization/CultureScopeTests.cs
+++ b/test/OrchardCore.Tests/Localization/CultureScopeTests.cs
@@ -14,11 +14,11 @@ namespace OrchardCore.Tests.Localization
             var culture = "ar-YE";
 
             // Act
-            using (var cultureScope = CultureScope.Create(culture))
+            using (CultureScope.Create(culture))
             {
                 // Assert
-                Assert.Equal(culture, cultureScope.Culture.Name);
-                Assert.Equal(culture, cultureScope.UICulture.Name);
+                Assert.Equal(culture, CultureInfo.CurrentCulture.Name);
+                Assert.Equal(culture, CultureInfo.CurrentUICulture.Name);
             }
         }
 
@@ -30,11 +30,11 @@ namespace OrchardCore.Tests.Localization
             var uiCulture = "ar-YE";
 
             // Act
-            using (var cultureScope = CultureScope.Create(culture, uiCulture))
+            using (CultureScope.Create(culture, uiCulture))
             {
                 // Assert
-                Assert.Equal(culture, cultureScope.Culture.Name);
-                Assert.Equal(uiCulture, cultureScope.UICulture.Name);
+                Assert.Equal(culture, CultureInfo.CurrentCulture.Name);
+                Assert.Equal(uiCulture, CultureInfo.CurrentUICulture.Name);
             }
         }
 
@@ -46,7 +46,7 @@ namespace OrchardCore.Tests.Localization
             var uiCulture = CultureInfo.CurrentUICulture;
 
             // Act
-            using (var cultureScope = CultureScope.Create("FR"))
+            using (CultureScope.Create("FR"))
             {
 
             }
@@ -66,11 +66,12 @@ namespace OrchardCore.Tests.Localization
             // Act & Assert
             Assert.ThrowsAsync<Exception>(() =>
             {
-                using (var cultureScope = CultureScope.Create("FR"))
+                using (CultureScope.Create("FR"))
                 {
                     throw new Exception("Something goes wrong!!");
                 }
             });
+
             Assert.Equal(culture, CultureInfo.CurrentCulture);
             Assert.Equal(uiCulture, CultureInfo.CurrentUICulture);
         }

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -43,7 +43,6 @@ namespace OrchardCore.Tests.Localization
             var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
             using (CultureScope.Create("cs"))
             {
-
                 var translation = localizer["ball"];
 
                 Assert.Equal("míč", translation);
@@ -216,13 +215,13 @@ namespace OrchardCore.Tests.Localization
         [InlineData("zh-Hans", "球", 2, new string[] { "球" })]
         public void LocalizerReturnsCorrectTranslationForPluralIfNoPluralFormsSpecified(string culture, string expected, int count, string[] translations)
         {
-            using (var cultureScope = CultureScope.Create(culture))
+            using (CultureScope.Create(culture))
             {
                 // using DefaultPluralRuleProvider to test it returns correct rule
-                TryGetRuleFromDefaultPluralRuleProvider(cultureScope.UICulture, out var rule);
+                TryGetRuleFromDefaultPluralRuleProvider(CultureInfo.CurrentUICulture, out var rule);
                 Assert.NotNull(rule);
 
-                SetupDictionary(culture, new[] { new CultureDictionaryRecord("ball", translations), }, rule);
+                SetupDictionary(culture, new[] { new CultureDictionaryRecord("ball", translations) }, rule);
                 var localizer = new PortableObjectStringLocalizer(null, _localizationManager.Object, true, _logger.Object);
                 var translation = localizer.Plural(count, "ball", "{0} balls", count);
 
@@ -340,14 +339,16 @@ namespace OrchardCore.Tests.Localization
             SetupDictionary(culture, Array.Empty<CultureDictionaryRecord>());
 
             var localizer = new PortableObjectStringLocalizer("context", _localizationManager.Object, true, _logger.Object);
-            CultureInfo.CurrentUICulture = new CultureInfo(culture);
 
-            // Act
-            var translation = localizer["Hello"];
+            using (CultureScope.Create(culture))
+            {
+                // Act
+                var translation = localizer["Hello"];
 
-            // Assert
-            _localizationManager.Verify(lm => lm.GetDictionary(It.IsAny<CultureInfo>()), Times.Exactly(expectedCalls));
-            Assert.Equal("Hello", translation);
+                // Assert
+                _localizationManager.Verify(lm => lm.GetDictionary(It.IsAny<CultureInfo>()), Times.Exactly(expectedCalls));
+                Assert.Equal("Hello", translation);
+            }
         }
 
         private void SetupDictionary(string cultureName, IEnumerable<CultureDictionaryRecord> records)


### PR DESCRIPTION
The culture scope is not intended to provide cultures but to switch the current cultures with provided values

Not so important because through these properties we retrieve the same values

**But i think it may be misleading**. E.g. in the unit tests we are checking / using these public properties in place of checking / using the current cultures that the culture scope was intended to switch.

E.g. if in the culture scope you remove the lines that update the current cultures, most of its unit tests still work.

But as said, not so important, just to show to @hishamco what i meant ;)