### PR TITLE
Don't join when getting users for migration

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Migrations.cs
@@ -109,7 +109,7 @@ namespace OrchardCore.Users
         // New users will be created with a generated Id.
         public async Task<int> UpdateFrom5Async()
         {
-            var users = await _session.Query<User, UserIndex>().ListAsync();
+            var users = await _session.Query<User>().ListAsync();
             foreach(var user in users)
             {
                 user.UserId = user.UserName;


### PR DESCRIPTION
Remove unnecessary join on the index when retrieving the users for the userid migration