### PR TITLE
Use String instead of string in BlobFileStore to get new dev build

### DIFF
--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -75,7 +75,7 @@ namespace OrchardCore.FileStorage.AzureBlob
 
         public async Task<IFileStoreEntry> GetDirectoryInfoAsync(string path)
         {
-            if (path == string.Empty)
+            if (path == String.Empty)
             {
                 return new BlobDirectory(path, _clock.UtcNow);
             }


### PR DESCRIPTION
The most recent build with a user id fix failed to push correctly to cloudsmith (timeout).

Merging this to get a new build through