### PR TITLE
Fixes indexing items created in a migration recipe

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -218,7 +218,7 @@ namespace OrchardCore.Environment.Shell.Scope
         /// Executes a delegate using this shell scope in an isolated async flow,
         /// while managing the shell state and invoking tenant events.
         /// </summary>
-        public async Task UsingAsync(Func<ShellScope, Task> execute)
+        public async Task UsingAsync(Func<ShellScope, Task> execute, bool activateShell = true)
         {
             if (Current == this)
             {
@@ -229,7 +229,11 @@ namespace OrchardCore.Environment.Shell.Scope
             using (this)
             {
                 StartAsyncFlow();
-                await ActivateShellInternalAsync();
+
+                if (activateShell)
+                {
+                    await ActivateShellInternalAsync();
+                }
 
                 await execute(this);
 
@@ -281,7 +285,7 @@ namespace OrchardCore.Environment.Shell.Scope
                 // The tenant gets activated here.
                 if (!ShellContext.IsActivated)
                 {
-                    await new ShellScope(ShellContext).UsingServiceScopeAsync(async scope =>
+                    await new ShellScope(ShellContext).UsingAsync(async scope =>
                     {
                         var tenantEvents = scope.ServiceProvider.GetServices<IModularTenantEvents>();
                         foreach (var tenantEvent in tenantEvents)
@@ -293,7 +297,7 @@ namespace OrchardCore.Environment.Shell.Scope
                         {
                             await tenantEvent.ActivatedAsync();
                         }
-                    });
+                    }, activateShell: false);
 
                     ShellContext.IsActivated = true;
                 }


### PR DESCRIPTION
Fixes #7557 

When activating a given shell in a given shell scope, migration recipes aside other regular migrations are executed in a "light" child scope that should not activate the related shell because it is being activated by the parent scope.

So, this "light" scope doesn't activate the shell, can't terminate the shell, **but also doesn't run any deferred task**, that's why, in the related issue, contents created in a migration recipe are not indexed by lucene.

So here, **we now activate the shell through a regular child shell scope**, but by passing a new `activateShell` parameter (true by default) set to false. So this child scope doesn't activate the shell to prevent an infinite loop, can't terminate the shell as a child scope is never the last one, **but it will execute deferred tasks**.

Migration recipes have other singularities, but before starting a bigger change that may not be worth, let see if there will be other reported issues. So for now this PR only fixes #7557 


