### PR TITLE
Tenant link should open in new window

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
@@ -159,7 +159,7 @@
                             }
                             <a asp-action="Reload" asp-route-id="@entry.Name" class="btn btn-secondary btn-sm" itemprop="UnsafeUrl">@T["Reload"]</a>
                         </div>
-                        <a href="@GetEncodedUrl(entry, originalPathBase)">@entry.Name</a>
+                        <a href="@GetEncodedUrl(entry, originalPathBase)" target="_blank">@entry.Name</a>
                         <code class="hint">@GetDisplayUrl(entry, originalPathBase)</code>
                         @if (!string.IsNullOrEmpty(entry.Description))
                         {


### PR DESCRIPTION
Quick one which I missed in #7475  - tenant link should open in a new window to be consistent