### PR TITLE
Convert anchors to strings using InvariantCulture

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
@@ -151,7 +152,7 @@ namespace OrchardCore.Media.Filters
                 }
                 if (anchor != null)
                 {
-                    queryStringParams["rxy"] = anchor.X.ToString() + ',' + anchor.Y.ToString();
+                    queryStringParams["rxy"] = anchor.X.ToString(CultureInfo.InvariantCulture) + ',' + anchor.Y.ToString(CultureInfo.InvariantCulture);
                 }
             }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Microsoft.AspNetCore.WebUtilities;
 using OrchardCore.Media.Fields;
 
@@ -67,7 +68,7 @@ namespace OrchardCore.Media.Processing
 
             if (anchor != null)
             {
-                queryStringParams["rxy"] = anchor.X.ToString() + ',' + anchor.Y.ToString();
+                queryStringParams["rxy"] = anchor.X.ToString(CultureInfo.InvariantCulture) + ',' + anchor.Y.ToString(CultureInfo.InvariantCulture);
             }
 
             return QueryHelpers.AddQueryString(path, queryStringParams);


### PR DESCRIPTION
When converting anchors to strings the InvariantCulture should be used.

On my machine (Belgium) I was getting
`?width=100&height=150&rmode=crop&rxy=0,37297297,0,10037175`
but it should be
`?width=100&height=150&rmode=crop&rxy=0.37297297,0.10037175`.
