### PR TITLE
Remove space separator in email

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpService.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Email.Services
     {
         private const string EmailExtension = ".eml";
 
-        private static readonly char[] EmailsSeparator = new char[] { ',', ';', ' ' };
+        private static readonly char[] EmailsSeparator = new char[] { ',', ';' };
 
         private readonly SmtpSettings _options;
         private readonly ILogger _logger;

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email/EmailTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email/EmailTests.cs
@@ -58,7 +58,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Email
         }
 
         [Fact]
-        public async Task SendEmail_UsesCustomAutherAndSender()
+        public async Task SendEmail_UsesCustomAuthorAndSender()
         {
             var message = new MailMessage
             {
@@ -78,7 +78,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Email
         {
             var message = new MailMessage
             {
-                To = "info@oc.com",
+                To = "Hisham Bin Ateya <hishamco_2007@hotmail.com>",
                 Subject = "Test",
                 Body = "Test Message",
                 From = "sebastienros@gmail.com",


### PR DESCRIPTION
While working on PR #7590 I found a bug when sending an email with a display name say `Hisham Bin Ateya <hishamco_2007@hotmail.com>`, so we no longer need to use the space as email separator anymore

/cc @agriffard 