### PR TITLE
Add logoutpath to cookie

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -157,6 +157,7 @@ namespace OrchardCore.Users
                 // tenant prefix but may also start by a path related e.g to a virtual folder.
 
                 options.LoginPath = "/" + userOptions.Value.LoginPath;
+                options.LogoutPath = "/" + userOptions.Value.LogoffPath;
                 options.AccessDeniedPath = "/Error/403";
             });
 


### PR DESCRIPTION
Add logoff path to the cookie settings. So in my theme log-off and login buttons which use these path's, work when external login provider like azure AD is not enabled yet.