### PR TITLE
Specify background color when resize mode is pad or boxpad

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
@@ -131,7 +131,8 @@ namespace OrchardCore.Media.Controllers
                     Height = isCustomHeight ? model.CustomHeight : model.SelectedHeight,
                     Mode = model.SelectedMode,
                     Format = model.SelectedFormat,
-                    Quality = model.Quality
+                    Quality = model.Quality,
+                    BackgroundColor = model.BackgroundColor
                 };
 
                 await _mediaProfilesManager.UpdateMediaProfileAsync(model.Name, mediaProfile);
@@ -181,7 +182,8 @@ namespace OrchardCore.Media.Controllers
                 CustomHeight = isCustomHeight ? mediaProfile.Height : 0,
                 SelectedMode = mediaProfile.Mode,
                 SelectedFormat = mediaProfile.Format,
-                Quality = mediaProfile.Quality
+                Quality = mediaProfile.Quality,
+                BackgroundColor = mediaProfile.BackgroundColor
             };
 
             BuildViewModel(model);
@@ -224,7 +226,8 @@ namespace OrchardCore.Media.Controllers
                     Height = isCustomHeight ? model.CustomHeight : model.SelectedHeight,
                     Mode = model.SelectedMode,
                     Format = model.SelectedFormat,
-                    Quality = model.Quality
+                    Quality = model.Quality,
+                    BackgroundColor = model.BackgroundColor
                 };
 
                 await _mediaProfilesManager.RemoveMediaProfileAsync(sourceName);

--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
@@ -80,21 +81,25 @@ namespace OrchardCore.Media.Filters
                 var quality = arguments["quality"];
                 var format = arguments["format"];
                 var anchor = arguments["anchor"];
+                var bgcolor = arguments["bgcolor"];
 
-                ApplyQueryStringParams(queryStringParams, width, height, mode, quality, format, anchor);
+                ApplyQueryStringParams(queryStringParams, width, height, mode, quality, format, anchor, bgcolor);
             }
             else
             {
                 queryStringParams = new Dictionary<string, string>();
 
-                var width = arguments["width"].Or(arguments.At(0));
-                var height = arguments["height"].Or(arguments.At(1));
-                var mode = arguments["mode"].Or(arguments.At(2));
-                var quality = arguments["quality"].Or(arguments.At(3));
-                var format = arguments["format"].Or(arguments.At(4));
-                var anchor = arguments["anchor"].Or(arguments.At(5));
+                var useNamed = arguments.Names.Any(); // Never mix named and indexed arguments as this leads to unpredictable results
 
-                ApplyQueryStringParams(queryStringParams, width, height, mode, quality, format, anchor);
+                var width = useNamed ? arguments["width"] : arguments.At(0);
+                var height = useNamed ? arguments["height"] : arguments.At(1);
+                var mode = useNamed ? arguments["mode"] : arguments.At(2);
+                var quality = useNamed ? arguments["quality"] : arguments.At(3);
+                var format = useNamed ? arguments["format"] : arguments.At(4);
+                var anchor = useNamed ? arguments["anchor"] : arguments.At(5);
+                var bgcolor = useNamed ? arguments["bgcolor"] : arguments.At(6);
+
+                ApplyQueryStringParams(queryStringParams, width, height, mode, quality, format, anchor, bgcolor);
             }
 
             var resizedUrl = QueryHelpers.AddQueryString(url, queryStringParams);
@@ -110,7 +115,7 @@ namespace OrchardCore.Media.Filters
             return new StringValue(resizedUrl);
         }
 
-        private static void ApplyQueryStringParams(IDictionary<string, string> queryStringParams, FluidValue width, FluidValue height, FluidValue mode, FluidValue quality, FluidValue format, FluidValue anchorValue)
+        private static void ApplyQueryStringParams(IDictionary<string, string> queryStringParams, FluidValue width, FluidValue height, FluidValue mode, FluidValue quality, FluidValue format, FluidValue anchorValue, FluidValue bgcolor)
         {
             if (!width.IsNil())
             {
@@ -154,6 +159,11 @@ namespace OrchardCore.Media.Filters
                 {
                     queryStringParams["rxy"] = anchor.X.ToString(CultureInfo.InvariantCulture) + ',' + anchor.Y.ToString(CultureInfo.InvariantCulture);
                 }
+            }
+
+            if (!bgcolor.IsNil())
+            {
+                queryStringParams["bgcolor"] = bgcolor.ToStringValue();
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Models/MediaProfilesDocument.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Models/MediaProfilesDocument.cs
@@ -20,5 +20,6 @@ namespace OrchardCore.Media.Models
         public ResizeMode Mode { get; set; }
         public Format Format { get; set; }
         public int Quality { get; set; }
+        public string BackgroundColor { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.Media.Processing
 
     internal class ImageSharpUrlFormatter
     {
-        public static string GetImageResizeUrl(string path, IDictionary<string, string> queryStringParams = null, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined, Anchor anchor = null)
+        public static string GetImageResizeUrl(string path, IDictionary<string, string> queryStringParams = null, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined, Anchor anchor = null, string bgcolor = null)
         {
             if (string.IsNullOrEmpty(path) || (!width.HasValue && !height.HasValue && queryStringParams == null))
             {
@@ -69,6 +69,11 @@ namespace OrchardCore.Media.Processing
             if (anchor != null)
             {
                 queryStringParams["rxy"] = anchor.X.ToString(CultureInfo.InvariantCulture) + ',' + anchor.Y.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (!String.IsNullOrEmpty(bgcolor))
+            {
+                queryStringParams["bgcolor"] = bgcolor;
             }
 
             return QueryHelpers.AddQueryString(path, queryStringParams);

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaImageSharpConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaImageSharpConfiguration.cs
@@ -73,7 +73,6 @@ namespace OrchardCore.Media.Processing
                 context.Commands.Remove(ResizeWebProcessor.Compand);
                 context.Commands.Remove(ResizeWebProcessor.Sampler);
                 context.Commands.Remove(ResizeWebProcessor.Anchor);
-                context.Commands.Remove(BackgroundColorWebProcessor.Color);
 
                 // When only a version command is applied pass on this request.
                 if (context.Commands.Count == 1 && context.Commands.ContainsKey(ImageVersionProcessor.VersionCommand))
@@ -94,6 +93,7 @@ namespace OrchardCore.Media.Processing
             // The following commands are not supported without a tokenized query string.
             context.Commands.Remove(ResizeWebProcessor.Xy);
             context.Commands.Remove(ImageVersionProcessor.VersionCommand);
+            context.Commands.Remove(BackgroundColorWebProcessor.Color);
 
             // Width and height must be part of the supported sizes array when tokenization is disabled.
             if (context.Commands.TryGetValue(ResizeWebProcessor.Width, out var widthString))

--- a/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
@@ -13,7 +13,7 @@ public static class OrchardRazorHelperExtensions
     /// <summary>
     /// Returns the relative URL of the specified asset path with optional resizing parameters.
     /// </summary>
-    public static string AssetUrl(this IOrchardHelper orchardHelper, string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, bool appendVersion = false, int? quality = null, Format format = Format.Undefined, Anchor anchor = null)
+    public static string AssetUrl(this IOrchardHelper orchardHelper, string assetPath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, bool appendVersion = false, int? quality = null, Format format = Format.Undefined, Anchor anchor = null, string bgcolor = null)
     {
         var mediaFileStore = orchardHelper.HttpContext.RequestServices.GetService<IMediaFileStore>();
 
@@ -31,13 +31,13 @@ public static class OrchardRazorHelperExtensions
             resolvedAssetPath = fileVersionProvider.AddFileVersionToPath(orchardHelper.HttpContext.Request.PathBase, resolvedAssetPath);
         }
 
-        return orchardHelper.ImageResizeUrl(resolvedAssetPath, width, height, resizeMode, quality, format, anchor);
+        return orchardHelper.ImageResizeUrl(resolvedAssetPath, width, height, resizeMode, quality, format, anchor, bgcolor);
     }
 
     /// <summary>
     /// Returns the relative URL of the specified asset path for a media profile with optional resizing parameters.
     /// </summary>
-    public static async Task<string> AssetProfileUrlAsync(this IOrchardHelper orchardHelper, string assetPath, string imageProfile, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, bool appendVersion = false, int? quality = null, Format format = Format.Undefined, Anchor anchor = null)
+    public static async Task<string> AssetProfileUrlAsync(this IOrchardHelper orchardHelper, string assetPath, string imageProfile, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, bool appendVersion = false, int? quality = null, Format format = Format.Undefined, Anchor anchor = null, string bgcolor = null)
     {
         var mediaFileStore = orchardHelper.HttpContext.RequestServices.GetService<IMediaFileStore>();
 
@@ -55,15 +55,15 @@ public static class OrchardRazorHelperExtensions
             resolvedAssetPath = fileVersionProvider.AddFileVersionToPath(orchardHelper.HttpContext.Request.PathBase, resolvedAssetPath);
         }
 
-        return await orchardHelper.ImageProfileResizeUrlAsync(resolvedAssetPath, imageProfile, width, height, resizeMode, quality, format, anchor);
+        return await orchardHelper.ImageProfileResizeUrlAsync(resolvedAssetPath, imageProfile, width, height, resizeMode, quality, format, anchor, bgcolor);
     }
 
     /// <summary>
     /// Returns a URL with custom resizing parameters for an existing image path.
     /// </summary>
-    public static string ImageResizeUrl(this IOrchardHelper orchardHelper, string imagePath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined, Anchor anchor = null)
+    public static string ImageResizeUrl(this IOrchardHelper orchardHelper, string imagePath, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined, Anchor anchor = null, string bgcolor = null)
     {
-        var resizedUrl = ImageSharpUrlFormatter.GetImageResizeUrl(imagePath, null, width, height, resizeMode, quality, format, anchor);
+        var resizedUrl = ImageSharpUrlFormatter.GetImageResizeUrl(imagePath, null, width, height, resizeMode, quality, format, anchor, bgcolor);
 
         return orchardHelper.TokenizeUrl(resizedUrl);
     }
@@ -71,12 +71,12 @@ public static class OrchardRazorHelperExtensions
     /// <summary>
     /// Returns a URL with custom resizing parameters for a media profile for an existing image path.
     /// </summary>
-    public static async Task<string> ImageProfileResizeUrlAsync(this IOrchardHelper orchardHelper, string imagePath, string imageProfile, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined, Anchor anchor = null)
+    public static async Task<string> ImageProfileResizeUrlAsync(this IOrchardHelper orchardHelper, string imagePath, string imageProfile, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined, Anchor anchor = null, string bgcolor = null)
     {
         var mediaProfileService = orchardHelper.HttpContext.RequestServices.GetRequiredService<IMediaProfileService>();
         var queryStringParams = await mediaProfileService.GetMediaProfileCommands(imageProfile);
 
-        var resizedUrl = ImageSharpUrlFormatter.GetImageResizeUrl(imagePath, queryStringParams, width, height, resizeMode, quality, format, anchor);
+        var resizedUrl = ImageSharpUrlFormatter.GetImageResizeUrl(imagePath, queryStringParams, width, height, resizeMode, quality, format, anchor, bgcolor);
 
         return orchardHelper.TokenizeUrl(resizedUrl);
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaProfileService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaProfileService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using OrchardCore.Media.Processing;
@@ -43,6 +44,11 @@ namespace OrchardCore.Media.Services
                 if (mediaProfile.Format != Format.Undefined)
                 {
                     commands["format"] = mediaProfile.Format.ToString().ToLower();
+                }
+
+                if (!String.IsNullOrEmpty(mediaProfile.BackgroundColor))
+                {
+                    commands["bgcolor"] = mediaProfile.BackgroundColor;
                 }
 
                 return commands;

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
@@ -53,7 +53,7 @@ namespace OrchardCore.Media.TagHelpers
         public Anchor ImageAnchor { get; set; }
 
         [HtmlAttributeName(ImageBackgroundColorAttributeName)]
-        public string  ImageBackgroundColor { get; set; }
+        public string ImageBackgroundColor { get; set; }
 
         [HtmlAttributeName("src")]
         public string Src { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
@@ -24,6 +24,7 @@ namespace OrchardCore.Media.TagHelpers
         private const string ImageFormatAttributeName = ImageSizeAttributePrefix + "format";
         private const string ImageProfileAttributeName = ImageSizeAttributePrefix + "profile";
         private const string ImageAnchorAttributeName = ImageSizeAttributePrefix + "anchor";
+        private const string ImageBackgroundColorAttributeName = ImageSizeAttributePrefix + "bgcolor";
 
         private readonly IMediaProfileService _mediaProfileService;
         private readonly MediaOptions _mediaOptions;
@@ -50,6 +51,9 @@ namespace OrchardCore.Media.TagHelpers
 
         [HtmlAttributeName(ImageAnchorAttributeName)]
         public Anchor ImageAnchor { get; set; }
+
+        [HtmlAttributeName(ImageBackgroundColorAttributeName)]
+        public string  ImageBackgroundColor { get; set; }
 
         [HtmlAttributeName("src")]
         public string Src { get; set; }
@@ -85,7 +89,7 @@ namespace OrchardCore.Media.TagHelpers
                 queryStringParams = await _mediaProfileService.GetMediaProfileCommands(ImageProfile);
             }
 
-            var resizedSrc = ImageSharpUrlFormatter.GetImageResizeUrl(imgSrc, queryStringParams, ImageWidth, ImageHeight, ResizeMode, ImageQuality, ImageFormat, ImageAnchor);
+            var resizedSrc = ImageSharpUrlFormatter.GetImageResizeUrl(imgSrc, queryStringParams, ImageWidth, ImageHeight, ResizeMode, ImageQuality, ImageFormat, ImageAnchor, ImageBackgroundColor);
 
             if (_mediaOptions.UseTokenizedQueryString)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Media/ViewModels/MediaProfileViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/ViewModels/MediaProfileViewModel.cs
@@ -17,6 +17,7 @@ namespace OrchardCore.Media.ViewModels
         public ResizeMode SelectedMode { get; set; }
         public Format SelectedFormat { get; set; }
         public int Quality { get; set; } = 100;
+        public string BackgroundColor { get; set; }
 
         [BindNever]
         public List<SelectListItem> AvailableWidths { get; set; } = new List<SelectListItem>();

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Create.cshtml
@@ -63,6 +63,17 @@
         </div>
     </div>
 
+    <div class="form-group" asp-validation-class-for="BackgroundColor" style="@(Model.SelectedMode == ResizeMode.Pad || Model.SelectedMode == ResizeMode.BoxPad ? "" : "display: none;")">
+        <div class="w-100 w-md-50">
+            <label asp-for="BackgroundColor">@T["Background Color"]</label>
+            <input type="text" asp-for="BackgroundColor" class="form-control" />
+            <span asp-validation-for="BackgroundColor"></span>
+        </div>
+        <div class="w-100">
+            <span class="hint">@T["Select the background color for the processed image. An empty value means a bgcolor command will not be applied. Examples of valid values: 'white', 'ffff00', 'ffff0080', '128,64,32' and '128,64,32,80'."]</span>
+        </div>
+    </div>
+
     <div class="form-group" asp-validation-class-for="SelectedFormat">
         <div class="w-100 w-md-50">
                 <label asp-for="SelectedFormat">@T["Format"]</label>
@@ -100,11 +111,17 @@
     </div>
 </form>
 
-
 <script at="Foot">
     $(function () {
+        $('#@Html.IdFor(x => x.SelectedMode)').on('change', function() {
+            if ((this.value === '@((int)ResizeMode.Pad)') || (this.value === '@((int)ResizeMode.BoxPad)')) {
+                $('#@Html.IdFor(x => x.BackgroundColor)').closest('.form-group').show();
+            } else {
+                $('#@Html.IdFor(x => x.BackgroundColor)').closest('.form-group').hide();
+                $('#@Html.IdFor(x => x.BackgroundColor)').val('');
+            }
+        });
         $('#@Html.IdFor(x => x.SelectedWidth)').on('change', function() {
-            console.log(this.value)
             if (this.value === "-1") {
                 $('#@Html.IdFor(x => x.CustomWidth)').show();
             } else {
@@ -113,7 +130,6 @@
             }
         });
         $('#@Html.IdFor(x => x.SelectedHeight)').on('change', function() {
-            console.log(this.value)
             if (this.value === "-1") {
                 $('#@Html.IdFor(x => x.CustomHeight)').show();
             } else {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Edit.cshtml
@@ -22,7 +22,7 @@
             <textarea asp-for="Hint" rows="2" class="form-control"></textarea>
             <span asp-validation-for="Hint"></span>
         </div>
-         <div class="w-100">
+        <div class="w-100">
             <span class="hint">@T["The hint for the media profile."]</span>
         </div>
     </div>
@@ -32,7 +32,7 @@
             <label asp-for="SelectedWidth">@T["Width"]</label>
             <select asp-for="SelectedWidth" asp-items="@Model.AvailableWidths" class="form-control content-preview-select" asp-validation-class-for="SelectedWidth"></select>
             <span asp-validation-for="SelectedWidth"></span>
-            <input type="number" asp-for="CustomWidth" class="form-control mt-3" style="@(Model.CustomWidth != 0 ? "" : "display: none;")"/>
+            <input type="number" asp-for="CustomWidth" class="form-control mt-3" style="@(Model.CustomWidth != 0 ? "" : "display: none;")" />
             <span asp-validation-for="CustomWidth"></span>
         </div>
         <div class="w-100">
@@ -45,7 +45,7 @@
             <label asp-for="SelectedHeight">@T["Height"]</label>
             <select asp-for="SelectedHeight" asp-items="@Model.AvailableHeights" class="form-control content-preview-select" asp-validation-class-for="SelectedHeight"></select>
             <span asp-validation-for="SelectedHeight"></span>
-            <input type="number" asp-for="CustomHeight" class="form-control mt-3" style="@(Model.CustomHeight != 0 ? "" : "display: none;")"/>
+            <input type="number" asp-for="CustomHeight" class="form-control mt-3" style="@(Model.CustomHeight != 0 ? "" : "display: none;")" />
             <span asp-validation-for="CustomHeight"></span>
         </div>
         <div class="w-100">
@@ -64,11 +64,22 @@
         </div>
     </div>
 
+    <div class="form-group" asp-validation-class-for="BackgroundColor" style="@(Model.SelectedMode == ResizeMode.Pad || Model.SelectedMode == ResizeMode.BoxPad ? "" : "display: none;")">
+        <div class="w-100 w-md-50">
+            <label asp-for="BackgroundColor">@T["Background Color"]</label>
+            <input type="text" asp-for="BackgroundColor" class="form-control" />
+            <span asp-validation-for="BackgroundColor"></span>
+        </div>
+        <div class="w-100">
+            <span class="hint">@T["Select the background color for the processed image. An empty value means a bgcolor command will not be applied. Examples of valid values: 'white', 'ffff00', 'ffff0080', '128,64,32' and '128,64,32,16'."]</span>
+        </div>
+    </div>
+
     <div class="form-group" asp-validation-class-for="SelectedFormat">
         <div class="w-100 w-md-50">
-                <label asp-for="SelectedFormat">@T["Format"]</label>
-                <select asp-for="SelectedFormat" asp-items="Model.AvailableFormats" class="form-control content-preview-select" asp-validation-class-for="SelectedFormat"></select>
-                <span asp-validation-for="SelectedFormat"></span>
+            <label asp-for="SelectedFormat">@T["Format"]</label>
+            <select asp-for="SelectedFormat" asp-items="Model.AvailableFormats" class="form-control content-preview-select" asp-validation-class-for="SelectedFormat"></select>
+            <span asp-validation-for="SelectedFormat"></span>
         </div>
         <div class="w-100">
             <span class="hint">@T["Select the format for the processed image. A default value means a format command will not be applied."]</span>
@@ -103,6 +114,14 @@
 
 <script at="Foot">
     $(function () {
+        $('#@Html.IdFor(x => x.SelectedMode)').on('change', function() {
+            if ((this.value === '@((int)ResizeMode.Pad)') || (this.value === '@((int)ResizeMode.BoxPad)')) {
+                $('#@Html.IdFor(x => x.BackgroundColor)').closest('.form-group').show();
+            } else {
+                $('#@Html.IdFor(x => x.BackgroundColor)').closest('.form-group').hide();
+                $('#@Html.IdFor(x => x.BackgroundColor)').val('');
+            }
+        });
         $('#@Html.IdFor(x => x.SelectedWidth)').on('change', function() {
             if (this.value === "-1") {
                 $('#@Html.IdFor(x => x.CustomWidth)').show();
@@ -112,7 +131,6 @@
             }
         });
         $('#@Html.IdFor(x => x.SelectedHeight)').on('change', function() {
-            console.log(this.value)
             if (this.value === "-1") {
                 $('#@Html.IdFor(x => x.CustomHeight)').show();
             } else {

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -60,6 +60,9 @@ Convert the input URL to create a resized image with the specified size argument
 Refer [Query string tokens](#query-string-tokens) to understand the valid values for a width or height command,
 and how the query string will differ from the examples provided.
 
+!!! note
+    You cannot mix named and indexed arguments. If any of the arguments is named, all arguments must be named.
+
 #### `width` (or first argument)
 
 The width of the new image. One of the allowed values.
@@ -198,7 +201,7 @@ To obtain the correct URL for a resized asset use `AssetUrl` with the optional w
 
 To obtain the correct URL for a resized asset use `AssetUrl` with the optional width, height, resizeMode and bgcolor, e.g.:
 
-`@Orchard.AssetUrl(Model.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Pad, bgcolor: 'white')`
+`@Orchard.AssetUrl(Model.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Pad, bgcolor: "white")`
 
 To append a version hash for an asset use `AssetUrl` with the append version parameter, e.g.:
 

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -144,6 +144,20 @@ The anchor of the new image.
 
 `<img src="~/media/animals/kittens.jpg?width=100&height=240&rmode=crop&rxy=0.5,0.5" />`
 
+### `bgcolor` (or seventh argument)
+
+The background color of the new image when `mode` is `pad` or `boxpad`. Examples of valid values: `white`, `ffff00`, `ffff0080`, `128,64,32` and `128,64,32,16`.
+
+#### bgcolor Input
+
+```
+{{ 'animals/kittens.jpg' | asset_url | resize_url: width:100, height:240, mode:'pad', bgcolor: 'white' }}
+```
+
+#### bgcolor Output
+
+`<img src="~/media/animals/kittens.jpg?width=100&height=240&rmode=pad&bgcolor=white" />`
+
 ### `profile` (named argument)
 
 A [Media Profile](#media-profiles) can be specified as a named argument to provide preset formatting commands.
@@ -182,6 +196,10 @@ To obtain the correct URL for a resized asset use `AssetUrl` with the optional w
 
 `@Orchard.AssetUrl(Model.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Crop, quality: 50, format: Format.Jpg)`
 
+To obtain the correct URL for a resized asset use `AssetUrl` with the optional width, height, resizeMode and bgcolor, e.g.:
+
+`@Orchard.AssetUrl(Model.Paths[0], width: 100 , height: 240, resizeMode: ResizeMode.Pad, bgcolor: 'white')`
+
 To append a version hash for an asset use `AssetUrl` with the append version parameter, e.g.:
 
 `@Orchard.AssetUrl(Model.Paths[0], appendVersion: true)`
@@ -209,6 +227,10 @@ To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to `_ViewI
 Alternatively the Asset Url can be resolved independently and the `src` attribute used:
 
 `<img src="@Orchard.AssetUrl(Model.Paths[0])" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" img-quality="50" img-format="Jpg" />`
+
+When resize mode is `pad` or `boxpad`, the background color can be set using `img-bgcolor`, e.g.:
+
+`<img asset-src="Model.Paths[0]" alt="..." img-width="100" img-height="240" img-resize-mode="Pad" img-bgcolor="white" />`
 
 To use a [Media Profile](#media-profiles) set the `asset-src` property and the `img-profile` attribute.
 

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -137,7 +137,7 @@ The anchor of the new image.
 
 ```
 {% assign anchor = Model.ContentItem.Content.Blog.Image.Anchors.first %}
-{{ 'animals/kittens.jpg' | asset_url | resize_url: width:100, height:240, mode:'crop', anchor: anchor }}
+{{ 'animals/kittens.jpg' | asset_url | resize_url: width:100, height:240, mode:'crop', anchor:anchor }}
 ```
 
 #### anchor Output
@@ -151,7 +151,7 @@ The background color of the new image when `mode` is `pad` or `boxpad`. Examples
 #### bgcolor Input
 
 ```
-{{ 'animals/kittens.jpg' | asset_url | resize_url: width:100, height:240, mode:'pad', bgcolor: 'white' }}
+{{ 'animals/kittens.jpg' | asset_url | resize_url: width:100, height:240, mode:'pad', bgcolor:'white' }}
 ```
 
 #### bgcolor Output


### PR DESCRIPTION
Added the option to specify a background color when resize mode is `pad` or `boxpad`.

- Added `Background Color` field to the media profile. This field is only visible when `pad` or `boxpad` is selected.
- Added an optional argument to the Razor helpers `AssetUrl`, `AssetProfileUrlAsync`, `ImageResizeUrl` and  `ImageProfileResizeUrlAsync`.
- Added an optional argument `bgcolor` to the Liquid filter.
- Added an optional attribute `img-bgcolor` to the taghelper.
- Updated the docs accordingly.
