### PR TITLE
Prevent creating folders with trailing space & check for invalid characters

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -380,7 +380,7 @@ namespace OrchardCore.Media.Controllers
             var invalidFolderNameCharacters = new char[] { '\\', '/' };
             if (invalidFolderNameCharacters.Any(invalidChar => name.Contains(invalidChar)))
             {
-                return StatusCode(StatusCodes.Status403Forbidden, S["Cannot create folder because the folder name contains invalid characters"]);
+                return StatusCode(StatusCodes.Status400BadRequest, S["Cannot create folder because the folder name contains invalid characters"]);
             }
 
             var newPath = _mediaFileStore.Combine(path, name);

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -377,7 +377,9 @@ namespace OrchardCore.Media.Controllers
                 path = "";
             }
 
-            var newPath = _mediaFileStore.Combine(path, name.Trim());
+            name = name.Replace('\\', '-').Replace('/', '-'); // Don't create nested folders
+
+            var newPath = _mediaFileStore.Combine(path, name);
 
             if (!await authorizationService.AuthorizeAsync(User, Permissions.ManageMedia)
                 || !await authorizationService.AuthorizeAsync(User, Permissions.ManageAttachedMediaFieldsFolder, (object)newPath))

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -377,7 +377,11 @@ namespace OrchardCore.Media.Controllers
                 path = "";
             }
 
-            name = name.Replace('\\', '-').Replace('/', '-'); // Don't create nested folders
+            var invalidFolderNameCharacters = new char[] { '\\', '/' };
+            if (invalidFolderNameCharacters.Any(invalidChar => name.Contains(invalidChar)))
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, S["Cannot create folder because the folder name contains invalid characters"]);
+            }
 
             var newPath = _mediaFileStore.Combine(path, name);
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -377,7 +377,7 @@ namespace OrchardCore.Media.Controllers
                 path = "";
             }
 
-            var newPath = _mediaFileStore.Combine(path, name);
+            var newPath = _mediaFileStore.Combine(path, name.Trim());
 
             if (!await authorizationService.AuthorizeAsync(User, Permissions.ManageMedia)
                 || !await authorizationService.AuthorizeAsync(User, Permissions.ManageAttachedMediaFieldsFolder, (object)newPath))

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -18,6 +18,8 @@ namespace OrchardCore.Media.Controllers
 {
     public class AdminController : Controller
     {
+        private static readonly char[] _invalidFolderNameCharacters = new char[] { '\\', '/' };
+        
         private readonly HashSet<string> _allowedFileExtensions;
         private readonly IMediaFileStore _mediaFileStore;
         private readonly IAuthorizationService _authorizationService;
@@ -377,8 +379,7 @@ namespace OrchardCore.Media.Controllers
                 path = "";
             }
 
-            var invalidFolderNameCharacters = new char[] { '\\', '/' };
-            if (invalidFolderNameCharacters.Any(invalidChar => name.Contains(invalidChar)))
+            if (_invalidFolderNameCharacters.Any(invalidChar => name.Contains(invalidChar)))
             {
                 return StatusCode(StatusCodes.Status400BadRequest, S["Cannot create folder because the folder name contains invalid characters"]);
             }

--- a/src/OrchardCore/OrchardCore.FileStorage.Abstractions/IFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.Abstractions/IFileStore.cs
@@ -155,7 +155,7 @@ namespace OrchardCore.FileStorage
             if (path == null)
                 return null;
 
-            return path.Replace('\\', '/').Trim('/');
+            return path.Replace('\\', '/').Trim('/', ' ');
         }
     }
 }


### PR DESCRIPTION
Folders should not have leading or trailing whitespace characters.

Creation succeeds but it's impossible to upload anything to these folders. They also can't be removed easily (at least not on Windows).


