### PR TITLE
Resolve differentiators for UpdateEdit as well as BuildEditor

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentFieldDisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentFieldDisplayDriver.cs
@@ -202,7 +202,13 @@ namespace OrchardCore.ContentManagement.Display.ContentDisplay
 
             var updateFieldEditorContext = new UpdateFieldEditorContext(contentPart, typePartDefinition, partFieldDefinition, context);
 
+            _typePartDefinition = typePartDefinition;
+            _partFieldDefinition = partFieldDefinition;
+
             var result = await UpdateAsync(field, context.Updater, updateFieldEditorContext);
+
+            _typePartDefinition = null;
+            _partFieldDefinition = null;
 
             if (result == null)
             {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentPartDisplayDriverTPart.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentPartDisplayDriverTPart.cs
@@ -235,9 +235,13 @@ namespace OrchardCore.ContentManagement.Display.ContentDisplay
             {
                 var updateEditorContext = new UpdatePartEditorContext(typePartDefinition, context);
 
+                _typePartDefinition = typePartDefinition;
+
                 var result = await UpdateAsync(part, context.Updater, updateEditorContext);
 
                 part.ContentItem.Apply(typePartDefinition.Name, part);
+
+                _typePartDefinition = null;
 
                 return result;
             }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7663

@Skrypt you were right! 

@jtkech you are aware of the `_typePartDefinition` temporary part variables for the `Factory` I suspect?

They're set on `BuildEditorAsync`, and then reset after, but weren't set on `UpdateEditorAsync` so the placement didn't resolve the differentiator values.

But need to check with you that there is no other side effects from setting and resetting these here? 