### PR TITLE
Fix code issues popping up in Rider IDE

### DIFF
--- a/OrchardCore.sln.DotSettings
+++ b/OrchardCore.sln.DotSettings
@@ -1,0 +1,11 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EActionNotResolved/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EAreaNotResolved/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EControllerNotResolved/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EInvalidModelType/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EMasterpageNotResolved/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EPartialViewNotResolved/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002ETemplateNotResolved/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EViewComponentNotResolved/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EViewComponentViewNotResolved/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EViewNotResolved/@EntryIndexedValue">WARNING</s:String></wpf:ResourceDictionary>

--- a/OrchardCore.sln.DotSettings
+++ b/OrchardCore.sln.DotSettings
@@ -8,4 +8,5 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002ETemplateNotResolved/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EViewComponentNotResolved/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EViewComponentViewNotResolved/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EViewNotResolved/@EntryIndexedValue">WARNING</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Mvc_002EViewNotResolved/@EntryIndexedValue">WARNING</s:String>
+</wpf:ResourceDictionary>

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.Edit.cshtml
@@ -1,2 +1,2 @@
 @*Alternate this shape using in Module - like ContentCard-FlowPart.Edit.cshtml *@
-@**TODO: Provide default Shape here*@
+@*TODO: Provide default Shape here*@

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLContentOptions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLContentOptions.cs
@@ -52,10 +52,10 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
             return this;
         }
 
-        public GraphQLContentOptions IgnoreField<IGraphType>(string fieldName) where IGraphType : IObjectGraphType
+        public GraphQLContentOptions IgnoreField<TGraphType>(string fieldName) where TGraphType : IObjectGraphType
         {
             HiddenFields = HiddenFields.Union(new[] {
-                new GraphQLField<IGraphType>(fieldName),
+                new GraphQLField<TGraphType>(fieldName),
             });
 
             return this;

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLField.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLField.cs
@@ -3,9 +3,9 @@ using GraphQL.Types;
 
 namespace OrchardCore.ContentManagement.GraphQL.Options
 {
-    public class GraphQLField<IGraphType> : GraphQLField where IGraphType : IObjectGraphType
+    public class GraphQLField<TGraphType> : GraphQLField where TGraphType : IObjectGraphType
     {
-        public GraphQLField(string fieldName) : base(typeof(IGraphType), fieldName)
+        public GraphQLField(string fieldName) : base(typeof(TGraphType), fieldName)
         {
         }
     }

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/Documents/IDocumentStore.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/Documents/IDocumentStore.cs
@@ -11,14 +11,14 @@ namespace OrchardCore.Data.Documents
     {
         /// <summary>
         /// Loads a single document (or create a new one) for updating and that should not be cached.
-        /// For a full isolation, it needs to be used in pair with <see cref="GetOrCreateImmutableAsync"/>.
+        /// For a full isolation, it needs to be used in pair with <see cref="GetOrCreateImmutableAsync{T}"/>.
         /// </summary>
         Task<T> GetOrCreateMutableAsync<T>(Func<Task<T>> factoryAsync = null) where T : class, new();
 
         /// <summary>
         /// Gets a single document (or create a new one) for caching and that should not be updated,
         /// and a bool indicating if it can be cached, not if it has been already loaded for update.
-        /// For a full isolation, it needs to be used in pair with <see cref="GetOrCreateMutableAsync"/>.
+        /// For a full isolation, it needs to be used in pair with <see cref="GetOrCreateMutableAsync{T}"/>.
         /// </summary>
         Task<(bool, T)> GetOrCreateImmutableAsync<T>(Func<Task<T>> factoryAsync = null) where T : class, new();
 

--- a/test/OrchardCore.Tests/DisplayManagement/ZoneonDemandTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ZoneonDemandTests.cs
@@ -75,8 +75,11 @@ namespace OrchardCore.Tests.DisplayManagement
             Composite zoneComposite1 = zoneOnDemand, zoneComposite2 = zoneOnDemand;
             object zoneObject1 = zoneOnDemand, zoneObject2 = zoneOnDemand;
 
+#pragma warning disable 252,253
+            // Intended reference comparison
             Assert.True(zoneShape1 == zoneShape2);
             Assert.True(zoneComposite1 == zoneComposite2);
+#pragma warning restore 252,253
             Assert.True(zoneObject1 == zoneObject2);
         }
 


### PR DESCRIPTION
Opening the project in Rider with the default inspection settings shows 161 errors.
![errors](https://user-images.githubusercontent.com/1174592/99569351-ccbff280-29d0-11eb-9945-4301121f4964.png)

Most of the errors come from the MVC inspections - unknown controller, action, view and so on, which makes totally sense due to the dynamic nature of OrchardCore. After changing the MVC inspection severity from `Error` to `Warning` 7 errors remain.

![error-details](https://user-images.githubusercontent.com/1174592/99570271-fa596b80-29d1-11eb-8348-cacdd79266ed.png)
 
This pull request fixes these errors and adds `OrchardCore.sln.DotSettings` to change the MVC inspection severity. 