### PR TITLE
Added feature to slugify media folders and files to make them SEO-friendly

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -22,6 +22,7 @@ namespace OrchardCore.Media.Controllers
         
         private readonly HashSet<string> _allowedFileExtensions;
         private readonly IMediaFileStore _mediaFileStore;
+        private readonly IMediaNameNormalizerService _mediaNameNormalizerService;
         private readonly IAuthorizationService _authorizationService;
         private readonly IContentTypeProvider _contentTypeProvider;
         private readonly ILogger _logger;
@@ -29,6 +30,7 @@ namespace OrchardCore.Media.Controllers
 
         public AdminController(
             IMediaFileStore mediaFileStore,
+            IMediaNameNormalizerService mediaNameNormalizerService,
             IAuthorizationService authorizationService,
             IContentTypeProvider contentTypeProvider,
             IOptions<MediaOptions> options,
@@ -37,6 +39,7 @@ namespace OrchardCore.Media.Controllers
             )
         {
             _mediaFileStore = mediaFileStore;
+            _mediaNameNormalizerService = mediaNameNormalizerService;
             _authorizationService = authorizationService;
             _contentTypeProvider = contentTypeProvider;
             _allowedFileExtensions = options.Value.AllowedFileExtensions;
@@ -179,10 +182,12 @@ namespace OrchardCore.Media.Controllers
                     continue;
                 }
 
+                var fileName = _mediaNameNormalizerService.NormalizeFileName(file.FileName);
+
                 Stream stream = null;
                 try
                 {
-                    var mediaFilePath = _mediaFileStore.Combine(path, file.FileName);
+                    var mediaFilePath = _mediaFileStore.Combine(path, fileName);
                     stream = file.OpenReadStream();
                     mediaFilePath = await _mediaFileStore.CreateFileFromStreamAsync(mediaFilePath, stream);
 
@@ -196,7 +201,7 @@ namespace OrchardCore.Media.Controllers
 
                     result.Add(new
                     {
-                        name = file.FileName,
+                        name = fileName,
                         size = file.Length,
                         folder = path,
                         error = ex.Message
@@ -378,6 +383,8 @@ namespace OrchardCore.Media.Controllers
             {
                 path = "";
             }
+
+            name = _mediaNameNormalizerService.NormalizeFolderName(name);
 
             if (_invalidFolderNameCharacters.Any(invalidChar => name.Contains(invalidChar)))
             {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -25,3 +25,14 @@ using OrchardCore.Modules.Manifest;
     },
     Category = "Content Management"
 )]
+
+[assembly: Feature(
+    Id = "OrchardCore.Media.Slugify",
+    Name = "Media Slugify",
+    Description = "The media slugify module slugifies all folders and files to make them SEO-friendly.",
+    Dependencies = new[]
+    {
+        "OrchardCore.Media"
+    },
+    Category = "Content Management"
+)]

--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -29,7 +29,7 @@ using OrchardCore.Modules.Manifest;
 [assembly: Feature(
     Id = "OrchardCore.Media.Slugify",
     Name = "Media Slugify",
-    Description = "The media slugify module slugifies all folders and files to make them SEO-friendly.",
+    Description = "The media slugify module slugifies new folders and files to make them SEO-friendly.",
     Dependencies = new[]
     {
         "OrchardCore.Media"

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/DefaultMediaNameNormalizerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/DefaultMediaNameNormalizerService.cs
@@ -1,0 +1,9 @@
+namespace OrchardCore.Media.Services
+{
+    public class DefaultMediaNameNormalizerService : IMediaNameNormalizerService
+    {
+        public string NormalizeFolderName(string folderName) => folderName;
+
+        public string NormalizeFileName(string fileName) => fileName;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/NullMediaNameNormalizerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/NullMediaNameNormalizerService.cs
@@ -1,6 +1,6 @@
 namespace OrchardCore.Media.Services
 {
-    public class DefaultMediaNameNormalizerService : IMediaNameNormalizerService
+    public class NullMediaNameNormalizerService : IMediaNameNormalizerService
     {
         public string NormalizeFolderName(string folderName) => folderName;
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/SlugifyMediaNameNormalizerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/SlugifyMediaNameNormalizerService.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using OrchardCore.Liquid;
+
+namespace OrchardCore.Media.Services
+{
+    public class SlugifyMediaNameNormalizerService : IMediaNameNormalizerService
+    {
+        private readonly ISlugService _slugService;
+
+        public SlugifyMediaNameNormalizerService(ISlugService slugService)
+        {
+            _slugService = slugService;
+        }
+
+        public string NormalizeFolderName(string folderName)
+        {
+            return _slugService.Slugify(folderName);
+        }
+
+        public string NormalizeFileName(string fileName)
+        {
+            return _slugService.Slugify(Path.GetFileNameWithoutExtension(fileName)) + Path.GetExtension(fileName);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -159,7 +159,7 @@ namespace OrchardCore.Media
             services.AddRecipeExecutionStep<MediaProfileStep>();
 
             // Media Name Normalizer
-            services.AddScoped<IMediaNameNormalizerService, DefaultMediaNameNormalizerService>();
+            services.AddScoped<IMediaNameNormalizerService, NullMediaNameNormalizerService>();
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -157,6 +157,9 @@ namespace OrchardCore.Media
             services.AddScoped<MediaProfilesManager>();
             services.AddScoped<IMediaProfileService, MediaProfileService>();
             services.AddRecipeExecutionStep<MediaProfileStep>();
+
+            // Media Name Normalizer
+            services.AddScoped<IMediaNameNormalizerService, DefaultMediaNameNormalizerService>();
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -326,6 +329,16 @@ namespace OrchardCore.Media
         {
             services.AddScoped<IPermissionProvider, MediaCachePermissions>();
             services.AddScoped<INavigationProvider, MediaCacheAdminMenu>();
+        }
+    }
+
+    [Feature("OrchardCore.Media.Slugify")]
+    public class MediaSlugifyStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            // Media Name Normalizer
+            services.AddScoped<IMediaNameNormalizerService, SlugifyMediaNameNormalizerService>();
         }
     }
 

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/IMediaNameNormalizerService.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/IMediaNameNormalizerService.cs
@@ -1,0 +1,8 @@
+namespace OrchardCore.Media
+{
+    public interface IMediaNameNormalizerService
+    {
+        public string NormalizeFolderName(string folderName);
+        public string NormalizeFileName(string fileName);
+    }
+}


### PR DESCRIPTION
This is a follow up on https://github.com/OrchardCMS/OrchardCore/pull/7662.

The idea is to have a feature that would slugify folders and files to make them SEO-friendly.

Here's how it works (first without the feature enabled):

![mediaslugify](https://user-images.githubusercontent.com/3008547/99875025-a2e31780-2bec-11eb-943f-47a979f91095.gif)

I made seperate methods for folders and files, as I can imagine someone might implement a custom `IMediaNameNormalizerService` to change filenames (e.g. add copyright notice) but not folders.

I was looking for a place to add this to the documentation as well, but it doesn't seem to fit anywhere. https://docs.orchardcore.net/en/dev/docs/reference/modules/Media/ is all about code, not the media library.

I'd like some feedback on this PR.

/cc @deanmarcussen @Skrypt 
