### PR TITLE
Improve configuration method provider

### DIFF
--- a/src/OrchardCore/OrchardCore.Recipes.Core/ConfigurationMethodProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/ConfigurationMethodProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Scripting;
 
@@ -14,7 +15,7 @@ namespace OrchardCore.Recipes
             _globalMethod = new GlobalMethod
             {
                 Name = "configuration",
-                Method = serviceprovider => (Func<string, object>)(name => configuration[name])
+                Method = serviceprovider => (Func<string, object, object>)((key, defaultValue) => configuration.GetValue<object>(key, defaultValue))
             };
         }
 

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -66,7 +66,7 @@ namespace OrchardCore.Recipes.Services
 
                             var variables = await JObject.LoadAsync(reader);
 
-                            methodProviders.Add(new VariablesMethodProvider(variables));
+                            methodProviders.Add(new VariablesMethodProvider(variables, methodProviders));
                         }
 
                         if (reader.Path == "steps" && reader.TokenType == JsonToken.StartArray)

--- a/src/OrchardCore/OrchardCore.Recipes.Core/VariablesMethodProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/VariablesMethodProvider.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Recipes
     {
         private readonly GlobalMethod _globalMethod;
 
-        public VariablesMethodProvider(JObject variables)
+        public VariablesMethodProvider(JObject variables, List<IGlobalMethodProvider> scopedMethodProviders)
         {
             _globalMethod = new GlobalMethod
             {
@@ -24,7 +24,7 @@ namespace OrchardCore.Recipes
                     while (value.StartsWith('[') && value.EndsWith(']'))
                     {
                         value = value.Trim('[', ']');
-                        value = (ScriptingManager.Evaluate(value, null, null, null) ?? "").ToString();
+                        value = (ScriptingManager.Evaluate(value, null, null, scopedMethodProviders) ?? "").ToString();
                         variables[name] = new JValue(value);
                     }
 

--- a/src/docs/reference/modules/Scripting/README.md
+++ b/src/docs/reference/modules/Scripting/README.md
@@ -75,9 +75,6 @@ Here is a list of javascript methods provided by Orchard Modules.
 | `base64(String): String` | Decodes the specified string from Base64 encoding. Use https://www.base64-image.de/ to convert your files to base64. |
 | `html(String): String` | Decodes the specified string from HTML encoding. |
 | `gzip(String): String` | Decodes the specified string from gzip/base64 encoding. Use http://www.txtwizard.net/compression to gzip your strings. |
-| `variables()` | Declare variables at the root of a recipe. Ex: `"variables": { "blogContentItemId": "[js:uuid()]" }`  Retrieve a variable value like this: `"ContentItemId": "[js: variables('blogContentItemId')]"` |
-| `parameters()` | Retrieves the parameters specified during the setup. Ex: `"Owner": "[js: parameters('AdminUsername')]"` See the available [Setup Recipe parameters](../Setup/#recipe-parameters) |
-| `configuration()` | Retrieves the specified configuration setting by its name. |
 
 #### Content (`OrchardCore.Contents`)
 
@@ -119,6 +116,13 @@ Here is a list of javascript methods provided by Orchard Modules.
 | `queryStringAsJson(): JObject` | Returns the entire query string as a JSON object. Example: ` { "param1": [ "param1-value1", "param1-value2" ], "param2": [ "param2-value1", "param2-value2" ], ... }` |
 | `requestFormAsJson(): JObject` | Returns the entire request form as a JSON object. Example: ` { "field1": [ "field1-value1", "field1-value2" ], "field2": [ "field2-value1", "field2-value2" ], ... }` |
 
+#### Recipes (`OrchardCore.Recipes`)
+
+| Function | Description 
+| -------- | ----------- |
+| `variables()` | Declare variables at the root of a recipe. Ex: `"variables": { "blogContentItemId": "[js:uuid()]" }`  Retrieve a variable value like this: `"ContentItemId": "[js: variables('blogContentItemId')]"` |
+| `parameters()` | Retrieves the parameters specified during the setup. Ex: `"Owner": "[js: parameters('AdminUserId')]"` See the available [Setup Recipe parameters](../Setup/#recipe-parameters) |
+| `configuration(key: String, defaultValue: String)` | Retrieves the specified configuration setting by its key, optionally providing a default. Ex: `[js: configuration('OrchardCore_Admin:AdminUrlPrefix', '/Admin')]` See [IShellConfiguration](../../core/Configuration/README.md) |
 
 #### Workflows (`OrchardCore.Workflows.Http`)
 

--- a/src/docs/reference/modules/Setup/README.md
+++ b/src/docs/reference/modules/Setup/README.md
@@ -7,6 +7,7 @@ During setup, all recipes have access to the setup screen values using these par
 | Parameter | Description |
 | --- | --- |
 | `SiteName` | The name of the site. |
+| `AdminUserId` | The user id of the super user. |
 | `AdminUsername` | The username of the super user. |
 | `AdminEmail` | The email of the super user. |
 | `AdminPassword` | The password of the super user. |
@@ -14,24 +15,40 @@ During setup, all recipes have access to the setup screen values using these par
 | `DatabaseConnectionString` | The connection string. |
 | `DatabaseTablePrefix` | The database table prefix. |
 
-These parameters can be used in the recipe using a scripted value like `[js: parameters('AdminUsername')]`.
+These parameters can be used in the recipe using a scripted value like `[js: parameters('AdminUserId')]`.
 
-### Custom Parameters
+### Recipe Configuration Keys
 
-Custom parameters can also be used in the recipe, using a scripted value like `[js: configuration('CustomParameterKey')]`.
+Custom configuration keys can also be used in the recipe, using a scripted key value like `[js: configuration('CustomConfigurationKey')]`.
 
-The value will be retrieved from the `appsettings.json` tenant file.
+The key will be retrieved from the current [IShellConfiguration](../../core/Configuration/README.md). 
+
+For example to provide a key for a tenant
 
 ```json
     {
         "ConnectionString": "...",
         "DatabaseProvider": "Sqlite",
         "TablePrefix": "Test",
-        "CustomParameterKey": "Custom Parameter Value"
+        "CustomConfigurationKey": "Custom Configuration Value"
     }
 ```
 
-## Configuration
+Other configuration keys can also be used, i.e. from the hosts `appsettings.json` 
+
+`[js: configuration('OrchardCore_Admin:AdminUrlPrefix', '/Admin')]`
+
+In this example we also provide a default value, which will be used if the key is not found.
+
+```json
+    {
+        "OrchardCore_Admin" : {
+            "AdminUrlPrefix" : "/MyAdmin"
+        }
+    }
+```
+
+## Setup Configuration
 
 The following configuration values are used by default and can be customized:
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7508

Note: This is a scoped method provider only for recipes, so doesn't give global access to configuration.

Improvements to it.
- available in the `variables` section now as well.
- can access keys, as the existing was only returning strings.
- has a default value option (not required - so is non breaking)

/cc @Skrypt @jtkech 

Note: I haven't updated the blog recipe, there may still be a value in having a method provider specific. 

This is mostly just fixes to remove some limitations, and correct the docs, as they were misleading.