### PR TITLE
Custom query schema fix

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/GraphQL/SqlQueryFieldTypeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/GraphQL/SqlQueryFieldTypeProvider.cs
@@ -56,14 +56,21 @@ namespace OrchardCore.Queries.Sql.GraphQL.Queries
                         continue;
                     }
                     var type = querySchema["type"].ToString();
+                    FieldType fieldType;
+
                     if (type.StartsWith("ContentItem/", StringComparison.OrdinalIgnoreCase))
                     {
                         var contentType = type.Remove(0, 12);
-                        schema.Query.AddField(BuildContentTypeFieldType(schema, contentType, query));
+                        fieldType = BuildContentTypeFieldType(schema, contentType, query);
                     }
                     else
                     {
-                        schema.Query.AddField(BuildSchemaBasedFieldType(schema, query, querySchema));
+                        fieldType = BuildSchemaBasedFieldType(query, querySchema);
+                    }
+
+                    if (fieldType != null)
+                    {
+                        schema.Query.AddField(fieldType);
                     }
                 }
                 catch (Exception e)
@@ -73,46 +80,51 @@ namespace OrchardCore.Queries.Sql.GraphQL.Queries
             }
         }
 
-        private FieldType BuildSchemaBasedFieldType(ISchema schema, SqlQuery query, JToken querySchema)
+        private FieldType BuildSchemaBasedFieldType(SqlQuery query, JToken querySchema)
         {
+            var properties = querySchema["properties"];
+            if (properties == null)
+            {
+                return null;
+            }
+
             var typetype = new ObjectGraphType<JObject>
             {
                 Name = query.Name
             };
 
-            var properties = querySchema["Properties"];
-            if (properties != null)
+            foreach (JProperty child in properties.Children())
             {
-                foreach (var child in properties.Children())
-                {
-                    var name = ((JProperty)child).Name;
-                    var nameLower = name.Replace('.', '_');
-                    var type = child["type"].ToString();
+                var name = child.Name;
+                var nameLower = name.Replace('.', '_');
+                var type = child.Value["type"].ToString();
+                var description = child.Value["description"]?.ToString();
 
-                    if (type == "String")
-                    {
-                        var field = typetype.Field(
-                            typeof(StringGraphType),
-                            nameLower,
-                            resolve: context =>
-                            {
-                                var source = context.Source;
-                                return source[context.FieldDefinition.Metadata["Name"].ToString()].ToObject<string>();
-                            });
-                        field.Metadata.Add("Name", name);
-                    }
-                    if (type == "Integer")
-                    {
-                        var field = typetype.Field(
-                            typeof(IntGraphType),
-                            nameLower,
-                            resolve: context =>
-                            {
-                                var source = context.Source;
-                                return source[context.FieldDefinition.Metadata["Name"].ToString()].ToObject<int>();
-                            });
-                        field.Metadata.Add("Name", name);
-                    }
+                if (type == "string")
+                {
+                    var field = typetype.Field(
+                        typeof(StringGraphType),
+                        nameLower,
+                        description: description,
+                        resolve: context =>
+                        {
+                            var source = context.Source;
+                            return source[context.FieldDefinition.Metadata["Name"].ToString()].ToObject<string>();
+                        });
+                    field.Metadata.Add("Name", name);
+                }
+                else if (type == "integer")
+                {
+                    var field = typetype.Field(
+                        typeof(IntGraphType),
+                        nameLower,
+                        description: description,
+                        resolve: context =>
+                        {
+                            var source = context.Source;
+                            return source[context.FieldDefinition.Metadata["Name"].ToString()].ToObject<int>();
+                        });
+                    field.Metadata.Add("Name", name);
                 }
             }
 
@@ -146,7 +158,11 @@ namespace OrchardCore.Queries.Sql.GraphQL.Queries
 
         private FieldType BuildContentTypeFieldType(ISchema schema, string contentType, SqlQuery query)
         {
-            var typetype = schema.Query.Fields.OfType<ContentItemsFieldType>().First(x => x.Name == contentType);
+            var typetype = schema.Query.Fields.OfType<ContentItemsFieldType>().FirstOrDefault(x => x.Name == contentType);
+            if (typetype == null)
+            {
+                return null;
+            }
 
             var fieldType = new FieldType
             {

--- a/src/docs/reference/modules/Queries/README.md
+++ b/src/docs/reference/modules/Queries/README.md
@@ -68,9 +68,10 @@ Verbs: **POST** and **GET**
 
 ## GraphQL
 
-When exposing queries (Lucene or SQL) through GraphQL you need to define schema of a query return type. There are two options, to return a `ContentItem` or to return a custom object.
+When exposing queries (Lucene or SQL) through GraphQL you need to define schema of a query return type.  
+There are two options: To return a `ContentItem` or to return a custom object.
 
-If you want to expose `ContentItems`, e.g. of type `BlogPost` you need to check `Return Content Items` checkbox and define `Schema` like this:
+If you want to expose `ContentItems`, e.g. of type `BlogPost`, you need to check `Return Content Items` checkbox and define `Schema` like this:
 
 ```json
 {
@@ -79,7 +80,7 @@ If you want to expose `ContentItems`, e.g. of type `BlogPost` you need to check 
 
 ```
 
-However if you want to expose custom object, e.g. only DisplayText, you need to uncheck `Return Content Items` checkbox and change `Schema` to look like this:
+However if you want to expose a custom object, e.g. only DisplayText, you need to uncheck `Return Content Items` checkbox and change `Schema` to look like this:
 
 ```json
 {
@@ -95,14 +96,14 @@ However if you want to expose custom object, e.g. only DisplayText, you need to 
 
 Where properties can either be of `string` or `integer` type.
 
-For Lucene queries with custom object schema you are limited to elements stored in Lucene index.
+For Lucene queries with custom object schema, you are limited to elements stored in Lucene index.
 
-For SQL queries you can expose any column where property name is column alias from query.
+For SQL queries, you can expose any column where property name is a column alias from the query.
 
 
 ## SQL Queries (`OrchardCore.Queries.Sql`)
 
-This feature provide a new type of query targeting the SQL database.
+This feature provides a new type of query targeting the SQL database.
 
 ### Queries recipe step
 
@@ -119,7 +120,8 @@ Here is an example for creating a SQL query from a Queries recipe step:
 
 ## Liquid templates
 
-You can access queries from liquid views and templates by using the `Queries` property. Queries are accessed by name, for example `Queries.RecentBlogPosts`.
+You can access queries from liquid views and templates by using the `Queries` property.  
+Queries are accessed by name, for example `Queries.RecentBlogPosts`.
 
 ### query
 

--- a/src/docs/reference/modules/Queries/README.md
+++ b/src/docs/reference/modules/Queries/README.md
@@ -68,15 +68,19 @@ Verbs: **POST** and **GET**
 
 ## GraphQL
 
-When exposing queries (Lucene or SQL) through GraphQL you need to define schema of a query return type. There are two options, to return `ContentItem` or to return custom object.
+When exposing queries (Lucene or SQL) through GraphQL you need to define schema of a query return type. There are two options, to return a `ContentItem` or to return a custom object.
+
 If you want to expose `ContentItems`, e.g. of type `BlogPost` you need to check `Return Content Items` checkbox and define `Schema` like this:
+
 ```json
 {
     "type": "ContentItem/BlogPost"
 }
 
 ```
+
 However if you want to expose custom object, e.g. only DisplayText, you need to uncheck `Return Content Items` checkbox and change `Schema` to look like this:
+
 ```json
 {
     "type": "object",
@@ -88,9 +92,13 @@ However if you want to expose custom object, e.g. only DisplayText, you need to 
     }
 }
 ```
+
 Where properties can either be of `string` or `integer` type.
+
 For Lucene queries with custom object schema you are limited to elements stored in Lucene index.
+
 For SQL queries you can expose any column where property name is column alias from query.
+
 
 ## SQL Queries (`OrchardCore.Queries.Sql`)
 

--- a/src/docs/reference/modules/Queries/README.md
+++ b/src/docs/reference/modules/Queries/README.md
@@ -71,7 +71,7 @@ Verbs: **POST** and **GET**
 When exposing queries (Lucene or SQL) through GraphQL, you need to define schema of a query return type.  
 There are two options: To return a `ContentItem` or to return a custom object.
 
-If you want to expose `ContentItems`, e.g. of type `BlogPost`, you need to check `Return Content Items` checkbox and define `Schema` like this:
+If you want to expose `ContentItems` (e.g. of type `BlogPost`), you need to check `Return Content Items` checkbox and define `Schema` like this:
 
 ```json
 {
@@ -80,7 +80,7 @@ If you want to expose `ContentItems`, e.g. of type `BlogPost`, you need to check
 
 ```
 
-However, if you want to expose a custom object (e.g. only DisplayText) you need to uncheck `Return Content Items` checkbox and change `Schema` to look like this:
+However, if you want to expose a custom object (e.g. only DisplayText), you need to uncheck `Return Content Items` checkbox and change `Schema` to look like this:
 
 ```json
 {

--- a/src/docs/reference/modules/Queries/README.md
+++ b/src/docs/reference/modules/Queries/README.md
@@ -68,7 +68,7 @@ Verbs: **POST** and **GET**
 
 ## GraphQL
 
-When exposing queries (Lucene or SQL) through GraphQL you need to define schema of a query return type.  
+When exposing queries (Lucene or SQL) through GraphQL, you need to define schema of a query return type.  
 There are two options: To return a `ContentItem` or to return a custom object.
 
 If you want to expose `ContentItems`, e.g. of type `BlogPost`, you need to check `Return Content Items` checkbox and define `Schema` like this:
@@ -80,7 +80,7 @@ If you want to expose `ContentItems`, e.g. of type `BlogPost`, you need to check
 
 ```
 
-However if you want to expose a custom object, e.g. only DisplayText, you need to uncheck `Return Content Items` checkbox and change `Schema` to look like this:
+However, if you want to expose a custom object (e.g. only DisplayText) you need to uncheck `Return Content Items` checkbox and change `Schema` to look like this:
 
 ```json
 {

--- a/src/docs/reference/modules/Queries/README.md
+++ b/src/docs/reference/modules/Queries/README.md
@@ -66,6 +66,32 @@ Verbs: **POST** and **GET**
 | `name` | `myQuery` | The name of the query to execute. |
 | `parameters` | `{ size: 3}` | A Json object representing the parameters of the query. |
 
+## GraphQL
+
+When exposing queries (Lucene or SQL) through GraphQL you need to define schema of a query return type. There are two options, to return `ContentItem` or to return custom object.
+If you want to expose `ContentItems`, e.g. of type `BlogPost` you need to check `Return Content Items` checkbox and define `Schema` like this:
+```json
+{
+    "type": "ContentItem/BlogPost"
+}
+
+```
+However if you want to expose custom object, e.g. only DisplayText, you need to uncheck `Return Content Items` checkbox and change `Schema` to look like this:
+```json
+{
+    "type": "object",
+    "properties": {  
+        "Content.ContentItem.DisplayText" : {
+            "type" : "string",
+            "description" : "This is BlogPost display text."
+        }
+    }
+}
+```
+Where properties can either be of `string` or `integer` type.
+For Lucene queries with custom object schema you are limited to elements stored in Lucene index.
+For SQL queries you can expose any column where property name is column alias from query.
+
 ## SQL Queries (`OrchardCore.Queries.Sql`)
 
 This feature provide a new type of query targeting the SQL database.


### PR DESCRIPTION
added documentation about custom schema in queries, fixed getting type property of individual fields, added support for description

PR for [7598](https://github.com/OrchardCMS/OrchardCore/issues/7598)

I wanted it to have same behavior for lucene and sql so I added null checks inside build methods in sql provider. Looking back I think it should be changed to throw logged errors when properties (of a schema) is nonexistent or there is no such content type.