### PR TITLE
Add Docker compose for SQL Server local development

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# https://docs.docker.com/compose/reference/envvars/#compose_project_name
+# Explicit add prefix to an external volume with this value or use -P with docker run
+COMPOSE_PROJECT_NAME=orchard-core

--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,5 @@ src/Templates/**/content/**/[Oo]bj/
 # BenchmarkDotNet artifacts
 BenchmarkDotNet.Artifacts
 
+# Ignore .secret file which is useful for storing a password, e.g. SA password for SQL Server container.
+*.secret

--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ See [Docker documentation](https://docs.docker.com/engine/reference/commandline/
 ### SQL Server for Linux on Docker container
 
 - You can use SQL Server for Linux with Docker Linux container.
-- To lanuch a SQL Server instance, 
+- To launch a SQL Server instance, 
     - Create `sa_password.secret` file at root level of the project
     - Put your SA password in the file and make sure it uses LF line feed.
     - Run `docker compose up`
-    - Connect to the database server with `localhost, 1433`, SQL Server Authentication as `SA` and  your SA password.
+    - Connect to the database server with `localhost, 1433`, SQL Server Authentication as `SA` and your SA password.
     - Create a new empty database and use it for setting up OrchardCore website.
     - To remove the server instance and its volumes, run `docker-compose down --volumes`
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Here is a more detailed [roadmap](https://github.com/OrchardCMS/OrchardCore/wiki
 Docker images and parameters can be found at <https://hub.docker.com/u/orchardproject/>  
 See [Docker documentation](https://docs.docker.com/engine/reference/commandline/run/#publish-or-expose-port--p---expose) to expose different port.
 
+### SQL Server for Linux on Docker container
+
+- You can use SQL Server for Linux with Docker Linux container.
+- To lanuch a SQL Server instance, 
+    - Create `sa_password.secret` file at root level of the project
+    - Put your SA password in the file and make sure it uses LF line feed.
+    - Run `docker compose up`
+    - Connect to the database server with `localhost, 1433`, SQL Server Authentication as `SA` and  your SA password.
+    - Create a new empty database and use it for setting up OrchardCore website.
+    - To remove the server instance and its volumes, run `docker-compose down --volumes`
+
 ### Documentation
 
 The documentation can be accessed here: <https://docs.orchardcore.net/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "3.8"
+services:
+  db:
+    image: microsoft/mssql-server-linux:latest
+    container_name: orchard-core-db-server
+    ports:
+      - 1433:1433
+    volumes:
+      # Map external volumes to container volumes
+      - mssql_data:/var/opt/mssql/data
+      - mssql_log:/var/opt/mssql/log
+      - mssql_backup:/var/opt/mssql/backup
+    # https://docs.docker.com/compose/compose-file/#environment
+    environment:
+      # SQL Server environment variables
+      # https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-configure-environment-variables?view=sql-server-ver15#environment-variables
+      - ACCEPT_EULA=Y
+      - MSSQL_PID=Developer
+      - MSSQL_SA_PASSWORD_FILE=/run/secrets/sa_password
+      - MSSQL_DATA_DIR=/var/opt/mssql/data
+      - MSSQL_LOG_DIR=/var/opt/mssql/log
+      - MSSQL_BACKUP_DIR=/var/opt/mssql/backup
+    # Usage of secret file for 'db' service
+    secrets:
+      - sa_password
+
+# Create external volumes to not lose data after remove a container.
+# https://docs.docker.com/compose/compose-file/#external
+volumes:
+  mssql_data:
+  mssql_log:
+  mssql_backup:
+
+# Define a secret file at top level.
+# Create your sa_password.secret file with LF line feed in the root folder of the project.
+# FYI, external secrets are not available to containers created by docker-compose. (external: true and created by "docker secret create" command) 
+# https://docs.docker.com/compose/compose-file/#secrets 
+secrets:
+  sa_password:
+    file: ./sa_password.secret
+


### PR DESCRIPTION
- This PR is for simplify a local development by adding Docker compose file for creating local SQL Server instance.
- Just follow steps in README, "SQL Server for Linux on Docker container" section.
- Then you can use a database in SQL Server instance to setup your OrchardCore website.