### PR TITLE
Queries documentation - Small fix to make description match code sample

### DIFF
--- a/src/docs/reference/modules/Queries/README.md
+++ b/src/docs/reference/modules/Queries/README.md
@@ -115,10 +115,10 @@ The `QueryAsync` and `ContentQueryAsync` Orchard Helper extension methods (in th
 
 You can use the `DisplayAsync` extension method (also in `OrchardCore.ContentManagement`) to display the content items returned from `ContentQueryAsync`.
 
-For example, to run a query called `LatestBlogPosts`, and display the results:
+For example, to run a query called `RecentBlogPosts`, and display the results:
 
 ```liquid
-@foreach (var contentItem in await Orchard.ContentQueryAsync("LatestBlogPosts"))
+@foreach (var contentItem in await Orchard.ContentQueryAsync("RecentBlogPosts"))
 {
     @await Orchard.DisplayAsync(contentItem)
 }

--- a/src/docs/reference/modules/Queries/README.md
+++ b/src/docs/reference/modules/Queries/README.md
@@ -118,7 +118,7 @@ You can use the `DisplayAsync` extension method (also in `OrchardCore.ContentMan
 For example, to run a query called `LatestBlogPosts`, and display the results:
 
 ```liquid
-@foreach (var contentItem in await Orchard.ContentQueryAsync("AllContent"))
+@foreach (var contentItem in await Orchard.ContentQueryAsync("LatestBlogPosts"))
 {
     @await Orchard.DisplayAsync(contentItem)
 }


### PR DESCRIPTION
The description talks about a query called LatestBlogPosts, but the code sample was running a query called AllContent. These should match and I thought LatestBlogPosts was a nicer sounding query, so I kept that one.

Update: Now using actual query from blog recipe called `RecentBlogPosts`.