### PR TITLE
Update ServiceCollectionExtensions namespace

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/ServiceCollectionExtensions.cs
@@ -1,5 +1,5 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using OrchardCore.ContentLocalization;
 using OrchardCore.ContentLocalization.Drivers;
 using OrchardCore.ContentLocalization.Handlers;
 using OrchardCore.ContentLocalization.Models;
@@ -9,7 +9,7 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.Data.Migration;
 using YesSql.Indexes;
 
-namespace OrchardCore.ContentLocalization
+namespace Microsoft.Extensions.DependencyInjection
 {
     public static class ServiceCollectionExtensions
     {

--- a/src/OrchardCore/OrchardCore/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/ServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Extensions.Features;
 
-namespace OrchardCore.Environment.Extensions
+namespace Microsoft.Extensions.DependencyInjection
 {
-    public static class ServiceCollectionExtensions
+    public static partial class ServiceCollectionExtensions
     {
         public static IServiceCollection AddExtensionManagerHost(this IServiceCollection services)
         {

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 using OrchardCore;
-using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Configuration;
@@ -33,7 +32,7 @@ using SameSiteMode = Microsoft.AspNetCore.Http.SameSiteMode;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    public static class ServiceCollectionExtensions
+    public static partial class ServiceCollectionExtensions
     {
         /// <summary>
         /// Adds OrchardCore services to the host service collection.


### PR DESCRIPTION
For fast discovery the extensions for `IServiceCollection` should be in `Microsoft.Extensions.DependencyInjection` namespace, I found there 're many namespaces need to be modified, @jtkech if sounds is good to rename I will continue to rename the other once