### PR TITLE
FileDocumentStoreAttribute providing a FileName

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Records/ContentDefinitionRecord.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Records/ContentDefinitionRecord.cs
@@ -3,6 +3,7 @@ using OrchardCore.Data.Documents;
 
 namespace OrchardCore.ContentManagement.Metadata.Records
 {
+    [FileDocumentStore(FileName = "ContentDefinition")]
     public class ContentDefinitionRecord : Document
     {
         public ContentDefinitionRecord()

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/Documents/FileDocumentStoreAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/Documents/FileDocumentStoreAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace OrchardCore.Data.Documents
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class FileDocumentStoreAttribute : Attribute
+    {
+        public string FileName { get; set; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Data/Documents/FileDocumentStore.cs
+++ b/src/OrchardCore/OrchardCore.Data/Documents/FileDocumentStore.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
@@ -87,10 +88,10 @@ namespace OrchardCore.Data.Documents
         {
             var typeName = typeof(T).Name;
 
-            // Backward compatibility.
-            if (typeName == "ContentDefinitionRecord")
+            var attribute = typeof(T).GetCustomAttribute<FileDocumentStoreAttribute>();
+            if (attribute != null)
             {
-                typeName = "ContentDefinition";
+                typeName = attribute.FileName ?? typeName;
             }
 
             var filename = _tenantPath + typeName + ".json";


### PR DESCRIPTION
By default the file name is equal to the name of the related document type

E.g. `ContentDefinitionRecord` => `ContentDefinitionRecord.json`

So, for compatibility, this attribute allows to keep the current `ContentDefinition.json` without having to manage this specific case in `FileDocumentStore` with an hard coded string