### PR TITLE
Replace ShellSettings Identifier by VersionId

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellSettings.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellSettings.cs
@@ -38,10 +38,10 @@ namespace OrchardCore.Environment.Shell
 
         public string Name { get; set; }
 
-        public string Identifier
+        public string VersionId
         {
-            get => _settings["Identifier"];
-            set => _settings["Identifier"] = value;
+            get => _settings["VersionId"];
+            set => _settings["VersionId"] = value;
         }
 
         public string RequestUrlHost

--- a/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
@@ -141,7 +141,7 @@ namespace OrchardCore.Environment.Shell
 
         public async Task UpdateShellSettingsAsync(ShellSettings settings)
         {
-            settings.Identifier = IdGenerator.GenerateId();
+            settings.VersionId = IdGenerator.GenerateId();
             await _shellSettingsManager.SaveSettingsAsync(settings);
             await ReloadShellContextAsync(settings);
         }
@@ -212,12 +212,12 @@ namespace OrchardCore.Environment.Shell
                     return;
                 }
 
-                var currentIdentifier = settings.Identifier;
+                var currentVersionId = settings.VersionId;
 
                 settings = await _shellSettingsManager.LoadSettingsAsync(settings.Name);
 
                 // Consistency: We may have been the last to add the shell but not with the last settings.
-                if (settings.Identifier == currentIdentifier)
+                if (settings.VersionId == currentVersionId)
                 {
                     return;
                 }


### PR DESCRIPTION
The ShellSettings Identifier is used for consistency checking and we may introduce a real ID property later, so as suggested by @kevinchalet https://github.com/OrchardCMS/OrchardCore/issues/1610#issuecomment-733021441, see below, here we use a `VersionId` property instead.

> @jtkech hum, then maybe Version, Timestamp or ConcurrencyCheck would have been better names? If we decide to introduce a real ID property later, having both Id and Identifier will be very confusing.