### PR TITLE
Update LuceneQuerySource.cs

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneQuerySource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneQuerySource.cs
@@ -97,7 +97,12 @@ namespace OrchardCore.Lucene
                     var results = new List<JObject>();
                     foreach (var document in docs.TopDocs.ScoreDocs.Select(hit => searcher.Doc(hit.Doc)))
                     {
-                        results.Add(new JObject(document.Select(x => new JProperty(x.Name, x.GetStringValue()))));
+                        // need to group by field name and output jproperty(s), depending on count of values,
+                        // with either 1) a singular value or 2) ienumerable list of values
+                        var jprops = document.GroupBy( f => f.Name, f => f.GetStringValue() )
+                                             .Select( g => g.Count() == 1 ? new JProperty( g.Key, g.First() ) : new JProperty( g.Key, g ) );
+
+                        results.Add( new JObject( jprops ) );
                     }
 
                     luceneQueryResults.Items = results;


### PR DESCRIPTION
Fix issue #7665. Lucene document API now handles case where Lucene document contains duplicate fields names, representing a field that has multiple values. # #