### PR TITLE
Order deployment plans by name

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
@@ -85,6 +85,7 @@ namespace OrchardCore.Deployment.Controllers
             var count = await deploymentPlans.CountAsync();
 
             var results = await deploymentPlans
+                .OrderBy(p => p.Name)
                 .Skip(pager.GetStartIndex())
                 .Take(pager.PageSize)
                 .ListAsync();


### PR DESCRIPTION
The deployment plans shown on ```/Admin/DeploymentPlan/Index``` are shown in the order they were created so I've made it order them by name.