### PR TITLE
Update Autoroutes indexes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Migrations.cs
@@ -1,4 +1,3 @@
-using OrchardCore.Autoroute.Drivers;
 using OrchardCore.Autoroute.Models;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
@@ -32,15 +31,7 @@ namespace OrchardCore.Autoroute
                 .Column<bool>("Latest")
             );
 
-            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
-                .CreateIndex("IDX_AutoroutePartIndex_ContentItemIds", "ContentItemId", "ContainedContentItemId")
-            );
-
-            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
-                .CreateIndex("IDX_AutoroutePartIndex_State", "Published", "Latest")
-            );
-
-            // Return 4 to shortcut the second migration on new content definition schemas.
+            // Return 4 to shortcut other migrations on new content definition schemas.
             return 4;
         }
 
@@ -50,16 +41,13 @@ namespace OrchardCore.Autoroute
         {
             _contentDefinitionManager.MigratePartSettings<AutoroutePart, AutoroutePartSettings>();
 
-            return 2;
+            // Return 3 to shortcut the next migration that does nothing.
+            return 3;
         }
 
         // This code can be removed in a later version.
         public int UpdateFrom2()
         {
-            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
-                .CreateIndex("IDX_AutoroutePartIndex_Published", "Published")
-            );
-
             return 3;
         }
 
@@ -76,22 +64,6 @@ namespace OrchardCore.Autoroute
 
             SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
                 .AddColumn<bool>("Latest", c => c.WithDefault(false))
-            );
-
-            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
-                .DropIndex("IDX_AutoroutePartIndex_ContentItemId")
-            );
-
-            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
-                .CreateIndex("IDX_AutoroutePartIndex_ContentItemIds", "ContentItemId", "ContainedContentItemId")
-            );
-
-            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
-                .DropIndex("IDX_AutoroutePartIndex_Published")
-            );
-
-            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
-                .CreateIndex("IDX_AutoroutePartIndex_State", "Published", "Latest")
             );
 
             return 4;

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Migrations.cs
@@ -31,8 +31,12 @@ namespace OrchardCore.Autoroute
                 .Column<bool>("Latest")
             );
 
-            // Return 4 to shortcut other migrations on new content definition schemas.
-            return 4;
+            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
+                .CreateIndex("IDX_AutoroutePartIndex_DocumentId", "DocumentId")
+            );
+
+            // Return 5 to shortcut other migrations on new content definition schemas.
+            return 5;
         }
 
         // Migrate PartSettings. This only needs to run on old content definition schemas.
@@ -41,8 +45,7 @@ namespace OrchardCore.Autoroute
         {
             _contentDefinitionManager.MigratePartSettings<AutoroutePart, AutoroutePartSettings>();
 
-            // Return 3 to shortcut the next migration that does nothing.
-            return 3;
+            return 2;
         }
 
         // This code can be removed in a later version.
@@ -67,6 +70,16 @@ namespace OrchardCore.Autoroute
             );
 
             return 4;
+        }
+
+        // This code can be removed in a later version.
+        public int UpdateFrom4()
+        {
+            SchemaBuilder.AlterIndexTable<AutoroutePartIndex>(table => table
+                .CreateIndex("IDX_AutoroutePartIndex_DocumentId", "DocumentId")
+            );
+
+            return 5;
         }
     }
 }


### PR DESCRIPTION
Related to the last comments of #7757 about `LocalizedContentItemIndex`, but here applied to `AutoroutePartIndex`

> So, when we do a QueryIndex(...) as the produced select is on all columns, unclustered indexes are never used and seem to be useless, unless we define an index including all columns

> Then, when we do a query on Document with an inner join on LocalizedContentItemIndex, so on DocumentId, an unclustered index may be used if it includes DocumentId

But `AutoroutePartIndex` is only queried through `QueryIndex()`, so here we can remove by code the existing indexes, so that there are not created on new sites, and without having to create a new one including `DocumentId`.