### PR TITLE
Admin section in appsettings

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -50,6 +50,9 @@
     // Uncomment to configure markdown
     //"OrchardCore_Markdown": {
     //  "Extensions": "nohtml+advanced"
-    //}
+    //},
+    "OrchardCore_Admin": {
+      "AdminUrlPrefix": "Admin"
+    }
   }
 }


### PR DESCRIPTION
Add Admin section in appsettings.json so that people understand that they can change it easily.

Plus, adding it at the bottom as an benefit: You can uncomment any other settings section without needing to remove the comma the end.