### PR TITLE
Preserve Features migrations ordering

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/ExportContentToDeploymentTarget/ExportContentToDeploymentTargetMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/ExportContentToDeploymentTarget/ExportContentToDeploymentTargetMigrations.cs
@@ -3,11 +3,13 @@ using System.Threading.Tasks;
 using OrchardCore.Data.Migration;
 using OrchardCore.Deployment;
 using OrchardCore.Entities;
+using OrchardCore.Modules;
 using OrchardCore.Recipes.Services;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Contents.Deployment.ExportContentToDeploymentTarget
 {
+    [Feature("OrchardCore.Contents.Deployment.ExportContentToDeploymentTarget")]
     public class ExportContentToDeploymentTargetMigrations : DataMigration
     {
         private readonly IRecipeMigrator _recipeMigrator;

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Widgets/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Widgets/Migrations.cs
@@ -3,10 +3,12 @@ using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.Data.Migration;
 using OrchardCore.Facebook.Widgets.Models;
+using OrchardCore.Modules;
 using OrchardCore.Recipes.Services;
 
 namespace OrchardCore.Facebook.Widgets
 {
+    [Feature(FacebookConstants.Features.Widgets)]
     public class WidgetMigrations : DataMigration
     {
         private readonly IRecipeMigrator _recipeMigrator;


### PR DESCRIPTION
Fixes #7853 

Feature dependencies define the order in which services are registered, also the order of migrations types that are enlisted through `ITypeFeatureProvider`. Yes, migrations are not resolved through the DI but by type, the order is still preserved for any migrations defined by the main feature of any module, but not for another "sub" feature of this module if its specific migrations class is not decorated by the [Feature("TheSubFeatureId")] attribute.
