### PR TITLE
Fixes Resource Dependencies accumulation and thread safety

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -170,18 +170,6 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
-        public ResourceDefinition SetDependencies(List<string> dependencies)
-        {
-            if (Dependencies == null)
-            {
-                Dependencies = new List<string>();
-            }
-
-            Dependencies.AddRange(dependencies);
-
-            return this;
-        }
-
         public ResourceDefinition SetInnerContent(string innerContent)
         {
             InnerContent = innerContent;

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -385,13 +385,6 @@ namespace OrchardCore.ResourceManagement
                     throw new InvalidOperationException($"Could not find a resource of type '{settings.Type}' named '{settings.Name}' with version '{settings.Version ?? "any"}'.");
                 }
 
-                // Register any additional dependencies for the resource here,
-                // rather than in Combine as they are additive, and should not be Combined.
-                if (settings.Dependencies != null)
-                {
-                    resource.SetDependencies(settings.Dependencies);
-                }
-
                 ExpandDependencies(resource, settings, allResources);
             }
 
@@ -421,6 +414,21 @@ namespace OrchardCore.ResourceManagement
                 return;
             }
 
+            // Use any additional dependencies from the settings without mutating the resource that is held in a singleton collection.
+            List<string> dependencies = null;
+            if (resource.Dependencies != null)
+            {
+                dependencies = new List<string>(resource.Dependencies);
+                if (settings.Dependencies != null)
+                {
+                    dependencies = dependencies.Concat(settings.Dependencies).ToList();
+                }
+            }
+            else if (settings.Dependencies != null)
+            {
+                dependencies = new List<string>(settings.Dependencies);
+            }
+
             // Settings is given so they can cascade down into dependencies. For example, if Foo depends on Bar, and Foo's required
             // location is Head, so too should Bar's location.
             // forge the effective require settings for this resource
@@ -430,14 +438,14 @@ namespace OrchardCore.ResourceManagement
                 ? ((RequireSettings)allResources[resource]).Combine(settings)
                 : new RequireSettings(_options) { Type = resource.Type, Name = resource.Name }.Combine(settings);
 
-            if (resource.Dependencies != null)
+            if (dependencies != null)
             {
                 // share search instance
                 var tempSettings = new RequireSettings();
 
-                for (var i = 0; i < resource.Dependencies.Count; i++)
+                for (var i = 0; i < dependencies.Count; i++)
                 {
-                    var d = resource.Dependencies[i];
+                    var d = dependencies[i];
                     var idx = d.IndexOf(':');
                     var name = d;
                     string version = null;

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -421,7 +421,7 @@ namespace OrchardCore.ResourceManagement
                 dependencies = new List<string>(resource.Dependencies);
                 if (settings.Dependencies != null)
                 {
-                    dependencies = dependencies.Concat(settings.Dependencies).ToList();
+                    dependencies.AddRange(settings.Dependencies);
                 }
             }
             else if (settings.Dependencies != null)


### PR DESCRIPTION
Fixes #7712 
Fixes #7939 

On each request, for a given resource definition we may add the dependencies from the require settings if any, but the resource definition is held in a singleton collection, so its dependencies are growing up, and it is not thread safe.

Here we still use any additional dependencies from the require settings, but without mutating the resource definition to prevent its dependencies from growing up, and we no longer mutate a singleton dictionary through a scoped service.