### PR TITLE
Refactor media tokens

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Filters/MediaFilters.cs
@@ -109,7 +109,7 @@ namespace OrchardCore.Media.Filters
             if (mediaOptions.UseTokenizedQueryString)
             {
                 var mediaTokenService = serviceProvider.GetRequiredService<IMediaTokenService>();
-                resizedUrl = mediaTokenService.TokenizePath(resizedUrl);
+                resizedUrl = mediaTokenService.AddTokenToPath(resizedUrl);
             }
 
             return new StringValue(resizedUrl);

--- a/src/OrchardCore.Modules/OrchardCore.Media/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Migrations.cs
@@ -1,24 +1,17 @@
-using System.Security.Cryptography;
-using System.Threading.Tasks;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Data.Migration;
-using OrchardCore.Entities;
 using OrchardCore.Media.Fields;
-using OrchardCore.Media.Processing;
 using OrchardCore.Media.Settings;
-using OrchardCore.Settings;
 
 namespace OrchardCore.Media
 {
     public class Migrations : DataMigration
     {
         private readonly IContentDefinitionManager _contentDefinitionManager;
-        private readonly ISiteService _siteService;
 
-        public Migrations(IContentDefinitionManager contentDefinitionManager, ISiteService siteService)
+        public Migrations(IContentDefinitionManager contentDefinitionManager)
         {
             _contentDefinitionManager = contentDefinitionManager;
-            _siteService = siteService;
         }
 
         // This migration does not need to run on new installations, but because there is no
@@ -27,26 +20,7 @@ namespace OrchardCore.Media
         {
             _contentDefinitionManager.MigrateFieldSettings<MediaField, MediaFieldSettings>();
 
-            // Return 2 to shortcut migrations on new installations.
-            return 2;
-        }
-
-        // This migration sets a hash key for the media token service.
-        // On new installations this is performed by the MediaTokenSettingsUpdater
-        public async Task<int> UpdateFrom1Async()
-        {
-            var siteSettings = await _siteService.LoadSiteSettingsAsync();
-            var mediaTokenSettings = siteSettings.As<MediaTokenSettings>();
-
-            var rng = RandomNumberGenerator.Create();
-
-            mediaTokenSettings.HashKey = new byte[64];
-            rng.GetBytes(mediaTokenSettings.HashKey);
-            siteSettings.Put(mediaTokenSettings);
-
-            await _siteService.UpdateSiteSettingsAsync(siteSettings);
-
-            return 2;
+            return 1;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Migrations.cs
@@ -27,9 +27,12 @@ namespace OrchardCore.Media
         {
             _contentDefinitionManager.MigrateFieldSettings<MediaField, MediaFieldSettings>();
 
-            return 1;
+            // Return 2 to shortcut migrations on new installations.
+            return 2;
         }
 
+        // This migration sets a hash key for the media token service.
+        // On new installations this is performed by the MediaTokenSettingsUpdater
         public async Task<int> UpdateFrom1Async()
         {
             var siteSettings = await _siteService.LoadSiteSettingsAsync();

--- a/src/OrchardCore.Modules/OrchardCore.Media/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Migrations.cs
@@ -1,17 +1,24 @@
+using System.Security.Cryptography;
+using System.Threading.Tasks;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Data.Migration;
+using OrchardCore.Entities;
 using OrchardCore.Media.Fields;
+using OrchardCore.Media.Processing;
 using OrchardCore.Media.Settings;
+using OrchardCore.Settings;
 
 namespace OrchardCore.Media
 {
     public class Migrations : DataMigration
     {
         private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly ISiteService _siteService;
 
-        public Migrations(IContentDefinitionManager contentDefinitionManager)
+        public Migrations(IContentDefinitionManager contentDefinitionManager, ISiteService siteService)
         {
             _contentDefinitionManager = contentDefinitionManager;
+            _siteService = siteService;
         }
 
         // This migration does not need to run on new installations, but because there is no
@@ -21,6 +28,22 @@ namespace OrchardCore.Media
             _contentDefinitionManager.MigrateFieldSettings<MediaField, MediaFieldSettings>();
 
             return 1;
+        }
+
+        public async Task<int> UpdateFrom1Async()
+        {
+            var siteSettings = await _siteService.LoadSiteSettingsAsync();
+            var mediaTokenSettings = siteSettings.As<MediaTokenSettings>();
+
+            var rng = RandomNumberGenerator.Create();
+
+            mediaTokenSettings.HashKey = new byte[64];
+            rng.GetBytes(mediaTokenSettings.HashKey);
+            siteSettings.Put(mediaTokenSettings);
+
+            await _siteService.UpdateSiteSettingsAsync(siteSettings);
+
+            return 2;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenOptions.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace OrchardCore.Media.Processing
 {
-    public class MediaTokenSettings
+    public class MediaTokenOptions
     {
         public byte[] HashKey { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenOptionsConfiguration.cs
@@ -1,0 +1,39 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Options;
+using OrchardCore.Entities;
+using OrchardCore.Settings;
+
+namespace OrchardCore.Media.Processing
+{
+    public class MediaTokenOptionsConfiguration : IConfigureOptions<MediaTokenOptions>
+    {
+        private readonly ISiteService _siteService;
+
+        public MediaTokenOptionsConfiguration(ISiteService siteService)
+        {
+            _siteService = siteService;
+        }
+
+        public void Configure(MediaTokenOptions options)
+        {
+            var mediaTokenSettings = _siteService.GetSiteSettingsAsync()
+                .GetAwaiter().GetResult()
+                .As<MediaTokenSettings>();
+
+            if (mediaTokenSettings.HashKey == null)
+            {
+                var siteSettings = _siteService.LoadSiteSettingsAsync().GetAwaiter().GetResult();
+
+                var rng = RandomNumberGenerator.Create();
+
+                mediaTokenSettings.HashKey = new byte[64];
+                rng.GetBytes(mediaTokenSettings.HashKey);
+                siteSettings.Put(mediaTokenSettings);
+
+                _siteService.UpdateSiteSettingsAsync(siteSettings).GetAwaiter().GetResult();
+            }
+
+            options.HashKey = mediaTokenSettings.HashKey;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenOptionsConfiguration.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using Microsoft.Extensions.Options;
 using OrchardCore.Entities;
 using OrchardCore.Settings;
@@ -16,24 +15,10 @@ namespace OrchardCore.Media.Processing
 
         public void Configure(MediaTokenOptions options)
         {
-            var mediaTokenSettings = _siteService.GetSiteSettingsAsync()
+            options.HashKey = _siteService.GetSiteSettingsAsync()
                 .GetAwaiter().GetResult()
-                .As<MediaTokenSettings>();
-
-            if (mediaTokenSettings.HashKey == null)
-            {
-                var siteSettings = _siteService.LoadSiteSettingsAsync().GetAwaiter().GetResult();
-
-                var rng = RandomNumberGenerator.Create();
-
-                mediaTokenSettings.HashKey = new byte[64];
-                rng.GetBytes(mediaTokenSettings.HashKey);
-                siteSettings.Put(mediaTokenSettings);
-
-                _siteService.UpdateSiteSettingsAsync(siteSettings).GetAwaiter().GetResult();
-            }
-
-            options.HashKey = mediaTokenSettings.HashKey;
+                .As<MediaTokenSettings>()
+                .HashKey;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
@@ -1,34 +1,31 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Web;
-using Microsoft.AspNetCore.DataProtection;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Primitives;
-using Newtonsoft.Json;
-using OrchardCore.Modules;
+using OrchardCore.Entities;
+using OrchardCore.Settings;
 using SixLabors.ImageSharp.Web.Processors;
 
 namespace OrchardCore.Media.Processing
 {
     public class MediaTokenService : IMediaTokenService
     {
-        private readonly IDataProtector _dataProtector;
-        private readonly IMemoryCache _memoryCache;
-        private readonly HashSet<string> _knownCommands = new HashSet<string>();
-
         private const string TokenCacheKeyPrefix = "MediaToken:";
-        private const string CommandCacheKeyPrefix = "MediaCommands:";
+        private readonly IMemoryCache _memoryCache;
+        private readonly ISiteService _siteService;
+
+        private readonly HashSet<string> _knownCommands = new HashSet<string>();
+        private readonly byte[] _hashKey;
 
         public MediaTokenService(
-            IDataProtectionProvider dataProtectionProvider,
             IMemoryCache memoryCache,
+            ISiteService siteService,
             IEnumerable<IImageWebProcessor> processors)
         {
-            _dataProtector = dataProtectionProvider.CreateProtector("MediaProcessingTokenService");
             _memoryCache = memoryCache;
+            _siteService = siteService;
             foreach (IImageWebProcessor processor in processors)
             {
                 foreach (string command in processor.Commands)
@@ -36,9 +33,13 @@ namespace OrchardCore.Media.Processing
                     _knownCommands.Add(command);
                 }
             }
+
+            var siteSettings = _siteService.GetSiteSettingsAsync().GetAwaiter().GetResult();
+            var mediaTokenSettings = siteSettings.As<MediaTokenSettings>();
+            _hashKey = mediaTokenSettings.HashKey;
         }
 
-        public string TokenizePath(string path)
+        public string AddTokenToPath(string path)
         {
             var pathParts = path.Split('?');
 
@@ -51,7 +52,7 @@ namespace OrchardCore.Media.Processing
             }
 
             var processingCommands = new Dictionary<string, string>();
-            var otherCommands = new Dictionary<string, string>();
+            Dictionary<string, string> otherCommands = null;
 
             foreach (var command in parsed)
             {
@@ -61,54 +62,62 @@ namespace OrchardCore.Media.Processing
                 }
                 else
                 {
+                    otherCommands ??= new Dictionary<string, string>();
                     otherCommands[command.Key] = command.Value.ToString();
                 }
             }
 
             // Using the command values as a key retrieve from cache
-            var key = String.Concat(processingCommands.Values);
+            var commandValues = String.Concat(processingCommands.Values);
 
-            var queryStringTokenKey = TokenCacheKeyPrefix + key;
+            var queryStringTokenKey = TokenCacheKeyPrefix + commandValues;
 
-            var queryStringToken = _memoryCache.GetOrCreate(queryStringTokenKey, entry =>
+            var queryStringToken = GetHash(commandValues, queryStringTokenKey);
+
+            processingCommands["token"] = queryStringToken;
+
+            // If any non-resizing paramters have been added to the path include these on the query string output.
+            if (otherCommands != null)
             {
-                entry.SlidingExpiration = TimeSpan.FromHours(5);
+                foreach(var command in otherCommands)
+                {
+                    processingCommands.Add(command.Key, command.Value);
+                }
+            }
 
-                var json = JsonConvert.SerializeObject(processingCommands);
-
-                return _dataProtector.Protect(json);
-            });
-
-            otherCommands["token"] = queryStringToken;
-
-            var commandCacheKey = CommandCacheKeyPrefix + key;
-
-            var query = _memoryCache.GetOrCreate(commandCacheKey, entry =>
-            {
-                entry.SlidingExpiration = TimeSpan.FromHours(24);
-                return processingCommands;
-            });
-
-            return QueryHelpers.AddQueryString(pathParts[0], otherCommands);
+            return QueryHelpers.AddQueryString(pathParts[0], processingCommands);
         }
 
-        public IDictionary<string, string> GetTokenizedCommands(string token)
+        public bool TryValidateToken(IDictionary<string, string> commands, string token)
         {
-            return _memoryCache.GetOrCreate(token, entry =>
+            var commandValues = String.Concat(commands.Values);
+
+            var queryStringTokenKey = TokenCacheKeyPrefix + commandValues;
+
+            // Store a hash of the valid query string commands.
+            var queryStringToken = GetHash(commandValues, queryStringTokenKey);
+
+            if (String.Equals(queryStringToken, token, StringComparison.OrdinalIgnoreCase))
             {
-                entry.SlidingExpiration = TimeSpan.FromHours(24);
-                try
-                {
-                    var json = _dataProtector.Unprotect(token);
+                return true;
+            }
 
-                    return JsonConvert.DeserializeObject<IDictionary<string, string>>(json);
-                }
-                catch
-                {
-                }
+            return false;
 
-                return null;
-            });
         }
+
+        private string GetHash(string commandValues, string queryStringTokenKey)
+            =>  _memoryCache.GetOrCreate(queryStringTokenKey, entry =>
+                {
+                    entry.SlidingExpiration = TimeSpan.FromHours(12);
+
+                    using var hmac = new HMACSHA256(_hashKey);
+
+                    var bytes = Encoding.UTF8.GetBytes(commandValues);
+
+                    var hash = hmac.ComputeHash(bytes);
+
+                    return Convert.ToBase64String(hash);
+                });
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
@@ -121,7 +121,6 @@ namespace OrchardCore.Media.Processing
                    return Convert.ToBase64String(hash);
                });
 
-
         private void GetHashKey()
         {
             if (_hashKey == null)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
@@ -109,7 +109,7 @@ namespace OrchardCore.Media.Processing
         private string GetHash(string commandValues, string queryStringTokenKey)
             =>  _memoryCache.GetOrCreate(queryStringTokenKey, entry =>
                 {
-                    entry.SlidingExpiration = TimeSpan.FromHours(12);
+                    entry.SlidingExpiration = TimeSpan.FromHours(5);
 
                     using var hmac = new HMACSHA256(_hashKey);
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
@@ -98,7 +98,6 @@ namespace OrchardCore.Media.Processing
             }
 
             return false;
-
         }
 
         private string GetHash(string commandValues, string queryStringTokenKey)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenSettings.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace OrchardCore.Media.Processing
+{
+    public class MediaTokenSettings
+    {
+        public byte[] HashKey { get; set; } = Array.Empty<byte>();
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenSettingsUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenSettingsUpdater.cs
@@ -1,0 +1,53 @@
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using OrchardCore.Entities;
+using OrchardCore.Environment.Extensions.Features;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Settings;
+
+namespace OrchardCore.Media.Processing
+{
+    /// <summary>
+    /// Generates a random key for media token hashing.
+    /// To regenerate the key disabled and enable the feature.
+    /// </summary>
+    public class MediaTokenSettingsUpdater : IFeatureEventHandler
+    {
+        private readonly ISiteService _siteService;
+
+        public MediaTokenSettingsUpdater(ISiteService siteService)
+        {
+            _siteService = siteService;
+        }
+
+        Task IFeatureEventHandler.InstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+        Task IFeatureEventHandler.InstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+        Task IFeatureEventHandler.EnablingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+        Task IFeatureEventHandler.EnabledAsync(IFeatureInfo feature) => SetMediaTokenSettingsAsync();
+
+        Task IFeatureEventHandler.DisablingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+        Task IFeatureEventHandler.DisabledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+        Task IFeatureEventHandler.UninstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+        Task IFeatureEventHandler.UninstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+        private async Task SetMediaTokenSettingsAsync()
+        {
+            var siteSettings = await _siteService.LoadSiteSettingsAsync();
+            var mediaTokenSettings = siteSettings.As<MediaTokenSettings>();
+
+            var rng = RandomNumberGenerator.Create();
+
+            mediaTokenSettings.HashKey = new byte[64];
+            rng.GetBytes(mediaTokenSettings.HashKey);
+            siteSettings.Put(mediaTokenSettings);
+
+            await _siteService.UpdateSiteSettingsAsync(siteSettings);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenSettingsUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenSettingsUpdater.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Media.Processing
 
         Task IFeatureEventHandler.EnablingAsync(IFeatureInfo feature) => Task.CompletedTask;
 
-        Task IFeatureEventHandler.EnabledAsync(IFeatureInfo feature) => SetMediaTokenSettingsAsync();
+        Task IFeatureEventHandler.EnabledAsync(IFeatureInfo feature) => SetMediaTokenSettingsAsync(feature);
 
         Task IFeatureEventHandler.DisablingAsync(IFeatureInfo feature) => Task.CompletedTask;
 
@@ -36,8 +36,13 @@ namespace OrchardCore.Media.Processing
 
         Task IFeatureEventHandler.UninstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
 
-        private async Task SetMediaTokenSettingsAsync()
+        private async Task SetMediaTokenSettingsAsync(IFeatureInfo feature)
         {
+            if (feature.Extension.Id != GetType().Assembly.GetName().Name)
+            {
+                return;
+            }
+
             var siteSettings = await _siteService.LoadSiteSettingsAsync();
             var mediaTokenSettings = siteSettings.As<MediaTokenSettings>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Razor/OrchardRazorHelperExtensions.cs
@@ -88,7 +88,7 @@ public static class OrchardRazorHelperExtensions
         {
             var mediaTokenService = orchardHelper.HttpContext.RequestServices.GetService<IMediaTokenService>();
 
-            url = mediaTokenService.TokenizePath(url);
+            url = mediaTokenService.AddTokenToPath(url);
         }
 
         return url;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -44,7 +44,6 @@ using OrchardCore.Navigation;
 using OrchardCore.Recipes;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Shortcodes;
-using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Web.DependencyInjection;
 using SixLabors.ImageSharp.Web.Middleware;
 using SixLabors.ImageSharp.Web.Providers;
@@ -133,9 +132,11 @@ namespace OrchardCore.Media
                 .AddProcessor<ImageVersionProcessor>()
                 .AddProcessor<TokenCommandProcessor>();
 
-            services.AddScoped<IFeatureEventHandler, MediaTokenSettingsUpdater>();
+            services.AddScoped<MediaTokenSettingsUpdater>();
             services.AddScoped<IMediaTokenService, MediaTokenService>();
             services.AddTransient<IConfigureOptions<MediaTokenOptions>, MediaTokenOptionsConfiguration>();
+            services.AddScoped<IFeatureEventHandler>(sp => sp.GetRequiredService<MediaTokenSettingsUpdater>());
+            services.AddScoped<IModularTenantEvents>(sp => sp.GetRequiredService<MediaTokenSettingsUpdater>());
 
             // Media Field
             services.AddContentField<MediaField>()

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -134,7 +134,8 @@ namespace OrchardCore.Media
                 .AddProcessor<TokenCommandProcessor>();
 
             services.AddScoped<IFeatureEventHandler, MediaTokenSettingsUpdater>();
-            services.AddSingleton<IMediaTokenService, MediaTokenService>();
+            services.AddScoped<IMediaTokenService, MediaTokenService>();
+            services.AddTransient<IConfigureOptions<MediaTokenOptions>, MediaTokenOptionsConfiguration>();
 
             // Media Field
             services.AddContentField<MediaField>()

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -133,6 +133,7 @@ namespace OrchardCore.Media
                 .AddProcessor<ImageVersionProcessor>()
                 .AddProcessor<TokenCommandProcessor>();
 
+            services.AddScoped<IFeatureEventHandler, MediaTokenSettingsUpdater>();
             services.AddSingleton<IMediaTokenService, MediaTokenService>();
 
             // Media Field
@@ -291,7 +292,7 @@ namespace OrchardCore.Media
                 pattern: _adminOptions.AdminUrlPrefix + "/Media/Options",
                 defaults: new { controller = adminControllerName, action = nameof(AdminController.Options) }
             );
-                
+
             var mediaProfilesControllerName = typeof(MediaProfilesController).ControllerName();
 
             routes.MapAreaControllerRoute(

--- a/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/TagHelpers/ImageResizeTagHelper.cs
@@ -93,7 +93,7 @@ namespace OrchardCore.Media.TagHelpers
 
             if (_mediaOptions.UseTokenizedQueryString)
             {
-                resizedSrc = _mediaTokenService.TokenizePath(resizedSrc);
+                resizedSrc = _mediaTokenService.AddTokenToPath(resizedSrc);
             }
 
             output.Attributes.SetAttribute("src", resizedSrc);

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/IMediaTokenService.cs
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/IMediaTokenService.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 namespace OrchardCore.Media
 {
     /// <summary>
-    /// The media token service encrypts and decrypts a query string with image processing commands.
+    /// The media token service adds a digital signature to a query string.
+    /// This allows the media processor to validate that commands were issued by this host.
     /// </summary>
     public interface IMediaTokenService
     {
-        string TokenizePath(string path);
-        IDictionary<string, string> GetTokenizedCommands(string token);
+        string AddTokenToPath(string path);
+        bool TryValidateToken(IDictionary<string, string> commands, string token);
     }
 }

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -58,7 +58,7 @@ Convert the input URL to create a resized image with the specified size argument
 #### Arguments
 
 Refer [Query string tokens](#query-string-tokens) to understand the valid values for a width or height command,
-and how the query string will differ from the examples provided.
+and when a query string must utilize a token.
 
 !!! note
     You cannot mix named and indexed arguments. If any of the arguments is named, all arguments must be named.
@@ -456,7 +456,7 @@ The `Anchors[]` is kept in sync with the `Paths[]` array and the index for a giv
 
 ## Query string tokens
 
-When resizing images, the query string command values are, by default, encrypted, and the encrypted values are cached.
+When resizing images, the query string command values are, by default, signed with an HMAC signature that is unique to the tenant.
 
 This prevents prevent malicious clients from creating too many variations of the same image. 
 
@@ -465,11 +465,11 @@ If the `UseTokenizedQueryString` is set to `false` the following features will b
 - Cache busting, or query string versioning.
 - Anchors.
 - The width or height must match a value from the `SupportedSizes` configuration.
+- Background color.
 
-When the query string is tokenized it will no longer contain the plain text commands shown in the examples above, but will be an encrypted version of 
-those commands. e.g.
+When the query string is signed with a token any width, height value may be used.
 
-`<img src="/media/kitten.jpg?token=CfDJ8ML-t4y_bo9InuZxvH6ig5IiGTc0BWLzVfnTMJg-2Cc08xmElsv_O2ZcMCKfcicXKDiF1pS-Z1xcMIWn-c5GH5W0UNd9ZN1xVOaom5gZatm5dLwjRG7aYAevqWXLrsNdbqV_CyOekgKsQJo89-qadoXVNaQh-PAXWuoBwitnkQOjzUyUxGXZFjK5akYuEcQRt0KbT24gj0WUETKU9Cd-6Go">`
+`<img src="/media/kittens.jpg?width=101&height=241&token=0J3hyv6jIPEsSdlvTCrf30fIdygkpmrF6mphqgYQyas%3D">`
 
 !!! note
     Tokens are only available from the [Preview Feed](../../../getting-started/preview-package-source)

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Media;
@@ -77,7 +78,8 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media
             services.AddSingleton<IImageWebProcessor, TokenCommandProcessor>();
             services.AddSingleton<IImageWebProcessor, TokenCommandProcessor>();
             services.AddSingleton<IImageWebProcessor, ResizeWebProcessor>();
-            services.AddSingleton<IMediaTokenService, MediaTokenService>();
+            services.AddScoped<IMediaTokenService, MediaTokenService>();
+            services.AddTransient<IConfigureOptions<MediaTokenOptions>, MediaTokenOptionsConfiguration>();
 
             var serviceProvider = services.BuildServiceProvider();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Newtonsoft.Json.Linq;
+using OrchardCore.Media;
+using OrchardCore.Media.Processing;
+using OrchardCore.Settings;
+using SixLabors.ImageSharp.Web.Processors;
+using Xunit;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Media
+{
+    public class MediaTokenTests
+    {
+        private readonly MediaTokenSettings _mediaTokenSettings;
+        public MediaTokenTests()
+        {
+            var rng = RandomNumberGenerator.Create();
+            _mediaTokenSettings = new MediaTokenSettings();
+            _mediaTokenSettings.HashKey = new byte[64];
+            rng.GetBytes(_mediaTokenSettings.HashKey);
+        }
+
+        [Fact]
+        public void ShouldAddToken()
+        {
+            var serviceProvider = CreateServiceProvider();
+            var mediaTokenService = serviceProvider.GetRequiredService<IMediaTokenService>();
+            var path = "/media/blog.jpg?width=100&height=100";
+
+            var tokenizedPath = mediaTokenService.AddTokenToPath(path);
+
+            Assert.True(tokenizedPath.Contains("token", StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Theory]
+        [InlineData("/media/blog.jpg?v=version")]
+        [InlineData("/media/blog.jpg")]
+        public void ShouldNotAddTokens(string path)
+        {
+            var serviceProvider = CreateServiceProvider();
+            var mediaTokenService = serviceProvider.GetRequiredService<IMediaTokenService>();
+
+            var tokenizedPath = mediaTokenService.AddTokenToPath(path);
+            Assert.Equal(path, tokenizedPath);
+        }
+
+        [Fact]
+        public void ShouldGenerateConsistentToken()
+        {
+            var sp1 = CreateServiceProvider();
+            var sp2 = CreateServiceProvider();
+            var mts1 = sp1.GetRequiredService<IMediaTokenService>();
+            var mts2 = sp2.GetRequiredService<IMediaTokenService>();
+            var path = "/media/blog.jpg?width=100&height=100";
+
+            var tokenizedPath1 = mts1.AddTokenToPath(path);
+            var tokenizedPath2 = mts2.AddTokenToPath(path);
+            Assert.Equal(tokenizedPath1, tokenizedPath2);
+        }
+
+        private IServiceProvider CreateServiceProvider()
+        {
+            var services = new ServiceCollection();
+
+            var mockSiteService = Mock.Of<ISiteService>(ss =>
+                ss.GetSiteSettingsAsync() == Task.FromResult(
+                    Mock.Of<ISite>(s => s.Properties == JObject.FromObject(new { MediaTokenSettings = _mediaTokenSettings }))
+                )
+            );
+
+            services.AddMemoryCache();
+
+            services.AddSingleton<ISiteService>(mockSiteService);
+            services.AddSingleton<IImageWebProcessor, TokenCommandProcessor>();
+            services.AddSingleton<IImageWebProcessor, TokenCommandProcessor>();
+            services.AddSingleton<IImageWebProcessor, ResizeWebProcessor>();
+            services.AddSingleton<IMediaTokenService, MediaTokenService>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            return serviceProvider;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7935

Replaces using Data Protection to encrypt tokens, as the encrypted token changed every server restart (because of course encryption should never produce the same value twice, for a given input - dup!).

This caused the browser and/or CDN to refresh all the images every time the server is restarted/deployed.

The is-cache wasn't affected by this, just the browser/cdn caches.

Uses instead an HMAC, with a unique randomly generated tenant key.

It becomes obfuscation, rather than encryption.

I've used a migration to set the key on existing installations, and a feature handler to set the key on new installations, OR when the media module is disabled, and re-enabled. 
Consider it a shortcut to exposing a settings driver for it, as it didn't feel like it should be super exposed.