### PR TITLE
Content type badges

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
@@ -29,13 +29,6 @@
 
     <input type="hidden" asp-for="Name" />
 
-    @if (Model.Editor.Shortcuts != null)
-    {
-        <div class="form-group">
-            @await DisplayAsync(Model.Editor.Shortcuts)
-        </div>
-    }
-
     @await DisplayAsync(Model.Editor)
 
     <div class="form-group">
@@ -53,6 +46,14 @@
                                 <a asp-route-action="RemoveFieldFrom" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@field.Name" class="btn btn-danger btn-sm" role="button" itemprop="UnsafeUrl RemoveUrl">@T["Remove"]</a>
                             </div>
                             @field.DisplayName() <span class="hint dashed">@field.FieldDefinition.Name.CamelFriendly()</span>
+                            @if (!string.IsNullOrEmpty(field.DisplayMode()))
+                            {
+                                <span class="badge ta-badge font-weight-normal" data-toggle="tooltip" title="@T["Display mode"]"><i class="fa fa-eye text-info"></i> @field.DisplayMode()</span>
+                            }
+                                @if (!string.IsNullOrEmpty(field.Editor()))
+                            {
+                                <span class="badge ta-badge font-weight-normal" data-toggle="tooltip" title="@T["Editor"]"><i class="fa fa-edit text-info"></i> @field.Editor()</span>
+                            }
                         </div>
                         <input type="hidden" asp-for="OrderedFieldNames" value="@field.Name" />
                     </li>
@@ -100,6 +101,13 @@
         <a asp-route-action="AddPartsTo" asp-route-id="@Model.TypeDefinition.Name" class="btn btn-info btn-sm" role="button">@T["Add Parts"]</a>
         <a asp-route-action="AddReusablePartTo" asp-route-id="@Model.TypeDefinition.Name" class="btn btn-info btn-sm" role="button">@T["Add Named Part"]</a>
     </div>
+    
+    @if (Model.Editor.Shortcuts != null)
+    {
+        <div class="form-group">
+            @await DisplayAsync(Model.Editor.Shortcuts)
+        </div>
+    }
 
     <div class="form-group">
         <button class="btn btn-primary save" type="submit" name="submit.Save" value="Save">@T["Save"]</button>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditPart.cshtml
@@ -22,13 +22,6 @@
         <span class="hint">@T["Technical name of the part."]</span>
     </div>
 
-    @if (Model.Editor.Shortcuts != null)
-    {
-        <div class="form-group">
-            @await DisplayAsync(Model.Editor.Shortcuts)
-        </div>
-    }
-
     @await DisplayAsync(Model.Editor)
 
     <div class="form-group">
@@ -56,6 +49,13 @@
     <div class="form-group">
         <a asp-route-action="AddFieldTo" asp-route-id="@Model.PartDefinition.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-info btn-sm" role="button">@T["Add Field"]</a>
     </div>
+    
+    @if (Model.Editor.Shortcuts != null)
+    {
+        <div class="form-group">
+            @await DisplayAsync(Model.Editor.Shortcuts)
+        </div>
+    }
 
     <div class="form-group">
         <button class="btn btn-primary save" type="submit" name="submit.Save" value="Save">@T["Save"]</button>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
@@ -1,49 +1,81 @@
 @model ContentTypeSettingsViewModel
 
-<div class="form-group">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="Creatable">
-        <label class="custom-control-label" asp-for="Creatable">@T["Creatable"]</label>
-        <span class="hint dashed">@T["Determines if an instance of this content type can be created through the UI."]</span>
-    </div>
-</div>
+<p>
+    <button class="btn btn-primary btn-sm dropdown-toggle" type="button" data-toggle="collapse" data-target="#options" aria-expanded="false" aria-controls="options">
+        @T["Options"]
+    </button>
+    @if (Model.Creatable)
+    {
+        <span class="badge ta-badge font-weight-normal"><i class="fa fa-plus text-info"></i> @T["Creatable"]</span>
+    }
+    @if (Model.Listable)
+    {
+        <span class="badge ta-badge font-weight-normal"><i class="fa fa-list text-info"></i> @T["Listable"]</span>
+    }
+    @if (Model.Draftable)
+    {
+        <span class="badge ta-badge font-weight-normal"><i class="fa fa-edit text-info"></i> @T["Draftable"]</span>
+    }
+    @if (Model.Versionable)
+    {
+        <span class="badge ta-badge font-weight-normal"><i class="fa fa-sort-numeric-down text-info"></i> @T["Versionable"]</span>
+    }
+    @if (Model.Securable)
+    {
+        <span class="badge ta-badge font-weight-normal"><i class="fa fa-lock text-info"></i> @T["Securable"]</span>
+    }
+    @if (!string.IsNullOrEmpty(Model.Stereotype))
+    {
+        <span class="badge ta-badge font-weight-normal"><i class="fa fa-cog text-info"></i> @Model.Stereotype</span>
+    }
+</p>
 
-<div class="form-group">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="Listable">
-        <label class="custom-control-label" asp-for="Listable">@T["Listable"]</label>
-        <span class="hint dashed">@T["Determines if an instance of this content type can be listed through the UI."]</span>
+<div class="collapse" id="options">
+    <div class="form-group">
+        <div class="custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" asp-for="Creatable">
+            <label class="custom-control-label" asp-for="Creatable">@T["Creatable"]</label>
+            <span class="hint dashed">@T["Determines if an instance of this content type can be created through the UI."]</span>
+        </div>
     </div>
-</div>
 
-<div class="form-group">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="Draftable">
-        <label class="custom-control-label" asp-for="Draftable">@T["Draftable"]</label>
-        <span class="hint dashed">@T["Determines if this content type supports draft versions."]</span>
+    <div class="form-group">
+        <div class="custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" asp-for="Listable">
+            <label class="custom-control-label" asp-for="Listable">@T["Listable"]</label>
+            <span class="hint dashed">@T["Determines if an instance of this content type can be listed through the UI."]</span>
+        </div>
     </div>
-</div>
 
-<div class="form-group">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="Versionable">
-        <label class="custom-control-label" asp-for="Versionable">@T["Versionable"]</label>
-        <span class="hint dashed">@T["Determines if this content type supports versioning."]</span>
+    <div class="form-group">
+        <div class="custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" asp-for="Draftable">
+            <label class="custom-control-label" asp-for="Draftable">@T["Draftable"]</label>
+            <span class="hint dashed">@T["Determines if this content type supports draft versions."]</span>
+        </div>
     </div>
-</div>
 
-<div class="form-group">
-    <div class="custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="Securable">
-        <label class="custom-control-label" asp-for="Securable">@T["Securable"]</label>
-        <span class="hint dashed">@T["Determines if this content type can have custom permissions."]</span>
+    <div class="form-group">
+        <div class="custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" asp-for="Versionable">
+            <label class="custom-control-label" asp-for="Versionable">@T["Versionable"]</label>
+            <span class="hint dashed">@T["Determines if this content type supports versioning."]</span>
+        </div>
     </div>
-</div>
 
-<div class="form-group">
-    <div class="w-md-75 w-xl-50">
-        <label asp-for="Stereotype">@T["Stereotype"]</label>
-        <input asp-for="Stereotype" type="text" class="form-control">
+    <div class="form-group">
+        <div class="custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" asp-for="Securable">
+            <label class="custom-control-label" asp-for="Securable">@T["Securable"]</label>
+            <span class="hint dashed">@T["Determines if this content type can have custom permissions."]</span>
+        </div>
     </div>
-    <span class="hint">@T["(Optional) The stereotype of the content type. e.g., Widget, MenuItem, ..."]</span>
+
+    <div class="form-group">
+        <div class="w-md-75 w-xl-50">
+            <label asp-for="Stereotype">@T["Stereotype"]</label>
+            <input asp-for="Stereotype" type="text" class="form-control">
+        </div>
+        <span class="hint">@T["(Optional) The stereotype of the content type. e.g., Widget, MenuItem, ..."]</span>
+    </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/FullTextAspectSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/FullTextAspectSettings.Edit.cshtml
@@ -10,33 +10,40 @@
 
 <script asp-src="~/OrchardCore.Liquid/codemirror/liquid.js" at="Foot"></script>
 
-<h3 class="mb-n1">@T["Full-text"]</h3>
-<span class="hint">@T["The full-text content is used in search queries to find content items from free-text searches."]</span>
+<p>
+    <button class="btn btn-primary btn-sm dropdown-toggle" type="button" data-toggle="collapse" data-target="#indexingOptions" aria-expanded="false" aria-controls="indexingOptions">
+        @T["Indexing"]
+    </button>
+</p>
+<div class="collapse" id="indexingOptions">
+    <h3 class="mb-n1">@T["Full-text"]</h3>
+    <span class="hint">@T["The full-text content is used in search queries to find content items from free-text searches."]</span>
 
-<div class="border rounded mt-2 pt-3 pl-3 pr-3 mb-3">
-    <div class="form-group custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="IncludeDisplayText" checked="@Model.IncludeDisplayText" />
-        <label class="custom-control-label" asp-for="IncludeDisplayText">@T["Include display text"]</label>
-        <span class="hint dashed">@T["Check to include the display text in the full-text content."]</span>
-    </div>
+    <div class="border rounded mt-2 pt-3 pl-3 pr-3 mb-3">
+        <div class="form-group custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" asp-for="IncludeDisplayText" checked="@Model.IncludeDisplayText" />
+            <label class="custom-control-label" asp-for="IncludeDisplayText">@T["Include display text"]</label>
+            <span class="hint dashed">@T["Check to include the display text in the full-text content."]</span>
+        </div>
 
-    <div class="form-group custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="IncludeBodyAspect" checked="@Model.IncludeBodyAspect" />
-        <label class="custom-control-label" asp-for="IncludeBodyAspect">@T["Include body parts"]</label>
-        <span class="hint dashed">@T["Check to include the body parts content in the full-text content."]</span>
-    </div>
+        <div class="form-group custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" asp-for="IncludeBodyAspect" checked="@Model.IncludeBodyAspect" />
+            <label class="custom-control-label" asp-for="IncludeBodyAspect">@T["Include body parts"]</label>
+            <span class="hint dashed">@T["Check to include the body parts content in the full-text content."]</span>
+        </div>
 
-    <div class="form-group custom-control custom-checkbox">
-        <input type="checkbox" class="custom-control-input" asp-for="IncludeFullTextTemplate" data-toggle="collapse" data-target="#fulltext-template" checked="@Model.IncludeFullTextTemplate" />
-        <label class="custom-control-label" asp-for="IncludeFullTextTemplate">@T["Use custom full-text"]</label>
-        <span class="hint dashed">@T["Check to define a custom Liquid template generating some text to include in the full-text content."]</span>
-    </div>
+        <div class="form-group custom-control custom-checkbox">
+            <input type="checkbox" class="custom-control-input" asp-for="IncludeFullTextTemplate" data-toggle="collapse" data-target="#fulltext-template" checked="@Model.IncludeFullTextTemplate" />
+            <label class="custom-control-label" asp-for="IncludeFullTextTemplate">@T["Use custom full-text"]</label>
+            <span class="hint dashed">@T["Check to define a custom Liquid template generating some text to include in the full-text content."]</span>
+        </div>
 
-    <div id="fulltext-template" class="collapse">
-        <div class="form-group row">
-            <div class="col">
-                <textarea asp-for="FullTextTemplate" type="text" class="form-control"></textarea>
-                <span class="hint">@T["Tip: Include custom fields like <code>{{{{ Model.Content.Article.Summary.Text }}}}</code>."]</span>
+        <div id="fulltext-template" class="collapse">
+            <div class="form-group row">
+                <div class="col">
+                    <textarea asp-for="FullTextTemplate" type="text" class="form-control"></textarea>
+                    <span class="hint">@T["Tip: Include custom fields like <code>{{{{ Model.Content.Article.Summary.Text }}}}</code>."]</span>
+                </div>
             </div>
         </div>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Views/PlacementSettings.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Views/PlacementSettings.cshtml
@@ -1,7 +1,7 @@
 @model OrchardCore.Placements.ViewModels.ContentSettingsViewModel
 
 <div class="btn-group">
-    <button class="btn btn-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button class="btn btn-info btn-sm dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         @T["Edit placements"]
     </button>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/TemplateSettings.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/TemplateSettings.cshtml
@@ -1,7 +1,7 @@
 @model OrchardCore.Templates.ViewModels.ContentSettingsViewModel
 
 <div class="btn-group">
-    <button class="btn btn-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button class="btn btn-info btn-sm dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         @T["Edit templates"]
     </button>
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Edit.cshtml
@@ -23,7 +23,7 @@
         </div>
         <div class="btn-group float-right">
             <a class="btn btn-secondary btn-sm" asp-action="EditProperties" asp-route-id="@Model.WorkflowType.Id" asp-route-returnUrl="@FullRequestPath">@T["Properties"]</a>
-            <a class="btn btn-secondary btn-sm" asp-action="Index" asp-controller="Workflow" asp-route-workflowtypeid="@Model.WorkflowType.Id" asp-route-returnUrl="@FullRequestPath">@T["Instances"] <span class="badge badge-light">@Model.WorkflowCount</span></a>
+            <a class="btn btn-secondary btn-sm" asp-action="Index" asp-controller="Workflow" asp-route-workflowtypeid="@Model.WorkflowType.Id" asp-route-returnUrl="@FullRequestPath">@T["Instances"] <span class="badge ta-badge">@Model.WorkflowCount</span></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Use badges in Content Type: Display mode, Editor.
Collapsable Options (Creatable, ...), Indexing (Full-text).
Move Shortcuts at bottom.

![image](https://user-images.githubusercontent.com/703248/102487064-439ce980-406a-11eb-99e7-7e7b9490de41.png)
