### PR TITLE
Shell Activation Atomicity

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Locking/ILocalLock.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Locking/ILocalLock.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.Locking
+{
+    public interface ILocalLock : ILock
+    {
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContextExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContextExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Environment.Shell.Builders;
+using OrchardCore.Environment.Shell.Models;
+using OrchardCore.Locking;
+using OrchardCore.Locking.Distributed;
+
+namespace OrchardCore.Environment.Shell.Builders
+{
+    public static class ShellContextExtensions
+    {
+        /// <summary>
+        /// Tries to acquire a lock on this shell, a distributed lock if it is not initializing, otherwise a local lock.
+        /// </summary>
+        public static Task<(ILocker locker, bool locked)> TryAcquireActivateShellLockAsync(this ShellContext shellContext)
+        {
+            var lockService = shellContext.Settings.State == TenantState.Initializing
+                ? (ILock)shellContext.ServiceProvider.GetRequiredService<ILocalLock>()
+                : shellContext.ServiceProvider.GetRequiredService<IDistributedLock>();
+
+            return lockService.TryAcquireLockAsync(
+                "ACTIVATE_SHELL_LOCK",
+                TimeSpan.FromMilliseconds(10_000),
+                TimeSpan.FromMilliseconds(10_000));
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -8,6 +8,8 @@ using Microsoft.Extensions.Logging;
 using OrchardCore.Environment.Cache;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Models;
+using OrchardCore.Locking;
+using OrchardCore.Locking.Distributed;
 using OrchardCore.Modules;
 
 namespace OrchardCore.Environment.Shell.Scope
@@ -18,7 +20,6 @@ namespace OrchardCore.Environment.Shell.Scope
     public class ShellScope : IServiceScope
     {
         private static readonly AsyncLocal<ShellScope> _current = new AsyncLocal<ShellScope>();
-        private static readonly Dictionary<string, SemaphoreSlim> _semaphores = new Dictionary<string, SemaphoreSlim>();
 
         private readonly IServiceScope _serviceScope;
         private readonly Dictionary<object, object> _items = new Dictionary<object, object>();
@@ -270,41 +271,33 @@ namespace OrchardCore.Environment.Shell.Scope
                 return;
             }
 
-            SemaphoreSlim semaphore;
-            lock (_semaphores)
+            // Try to acquire a lock before using a new scope, so that a next process gets the last committed data.
+            (var locker, var locked) = await ShellContext.TryAcquireActivateShellLockAsync();
+            if (!locked)
             {
-                if (!_semaphores.TryGetValue(ShellContext.Settings.Name, out semaphore))
-                {
-                    _semaphores[ShellContext.Settings.Name] = semaphore = new SemaphoreSlim(1);
-                }
+                return;
             }
 
-            await semaphore.WaitAsync();
-            try
+            await using var acquiredLock = locker;
+
+            // The tenant gets activated here.
+            if (!ShellContext.IsActivated)
             {
-                // The tenant gets activated here.
-                if (!ShellContext.IsActivated)
+                await new ShellScope(ShellContext).UsingAsync(async scope =>
                 {
-                    await new ShellScope(ShellContext).UsingAsync(async scope =>
+                    var tenantEvents = scope.ServiceProvider.GetServices<IModularTenantEvents>();
+                    foreach (var tenantEvent in tenantEvents)
                     {
-                        var tenantEvents = scope.ServiceProvider.GetServices<IModularTenantEvents>();
-                        foreach (var tenantEvent in tenantEvents)
-                        {
-                            await tenantEvent.ActivatingAsync();
-                        }
+                        await tenantEvent.ActivatingAsync();
+                    }
 
-                        foreach (var tenantEvent in tenantEvents.Reverse())
-                        {
-                            await tenantEvent.ActivatedAsync();
-                        }
-                    }, activateShell: false);
+                    foreach (var tenantEvent in tenantEvents.Reverse())
+                    {
+                        await tenantEvent.ActivatedAsync();
+                    }
+                }, activateShell: false);
 
-                    ShellContext.IsActivated = true;
-                }
-            }
-            finally
-            {
-                semaphore.Release();
+                ShellContext.IsActivated = true;
             }
         }
 

--- a/src/OrchardCore/OrchardCore/Locking/LocalLock.cs
+++ b/src/OrchardCore/OrchardCore/Locking/LocalLock.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Locking
     /// <summary>
     /// This component is a tenant singleton which allows to acquire named locks for a given tenant.
     /// </summary>
-    public class LocalLock : IDistributedLock, IDisposable
+    public class LocalLock : IDistributedLock, ILocalLock, IDisposable
     {
         private readonly ILogger _logger;
 

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.ConfigureServices(s =>
             {
                 s.AddSingleton<LocalLock>();
-                s.AddSingleton<ILock>(sp => sp.GetRequiredService<LocalLock>());
+                s.AddSingleton<ILocalLock>(sp => sp.GetRequiredService<LocalLock>());
                 s.AddSingleton<IDistributedLock>(sp => sp.GetRequiredService<LocalLock>());
             });
         }


### PR DESCRIPTION
Fixes #7941 related to multiple instances starting and then executing migration steps concurrently.

- Here, the solution is to use a distributed lock when activating the shell, knowing that the default implementation uses local semaphores, **so, as long as we don't enable a distributed lock (e.g. `RedisLock`), it works as before**.

- **If the shell is initializing** (during a setup), we force the usage of the default using local semaphores, **so as before**.

Todo: Make locking times configurable