### PR TITLE
Flex summary admin

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SummaryAdmin.cshtml
@@ -6,43 +6,55 @@
 }
 
 <div class="row">
-    <div class="col-lg-6 col-sm-12 title">
-        @if (Model.Selectors != null)
-        {
-            <div class="selectors d-inline cursor-pointer">
-                @await DisplayAsync(Model.Selectors)
+    <div class="col-lg col-12 title d-flex">
+        <div class="selectors-container d-flex">
+            @if (Model.Selectors != null)
+            {
+                <div class="selectors cursor-pointer">
+                    @await DisplayAsync(Model.Selectors)
+                </div>
+            }
+            <div class="custom-control custom-checkbox">
+                <input type="checkbox" class="custom-control-input" value="@contentItem.Id" name="itemIds" id="itemIds-@contentItem.Id">
+                <label class="custom-control-label" for="itemIds-@contentItem.Id"></label>
             </div>
-        }
-        <div class="custom-control custom-checkbox d-inline">
-            <input type="checkbox" class="custom-control-input" value="@contentItem.Id" name="itemIds" id="itemIds-@contentItem.Id">
-            <label class="custom-control-label" for="itemIds-@contentItem.Id"></label>
         </div>
-        @if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem))
-        {
-            <a admin-for="@contentItem" asp-route-returnUrl="@FullRequestPath" />
-        }
-        else
-        {
-            @contentItem
-        }
-        - <small class="badge ta-badge font-weight-normal"><i class="far fa-file-alt text-secondary"></i> <a href="@(FullRequestPath)&Options.SelectedContentType=@contentItem.ContentType" data-toggle="tooltip" title="@T["Content type"]">@contentItem.ContentType</a></small>
-        @if (Model.Header != null)
-        {
-            <div class="header">@await DisplayAsync(Model.Header)</div>
-        }
-        @if (Model.Tags != null)
-        {
-            <div class="d-inline">
-                @await DisplayAsync(Model.Tags)
+        <div class="summary d-flex flex-column flex-md-row">
+            <div class="contentitem mr-2">
+                @if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem))
+                {
+                    <a admin-for="@contentItem" asp-route-returnUrl="@FullRequestPath"/>
+                }
+                else
+                {
+                    @contentItem
+                }
             </div>
-        }
-        @if (Model.Meta != null)
-        {
-            <div class="d-inline">@await DisplayAsync(Model.Meta)</div>
-        }
+            <div class="contenttype">
+                <span class="badge ta-badge font-weight-normal align-text-top"><i class="far fa-file-alt text-secondary"></i> <a href="@(FullRequestPath)&Options.SelectedContentType=@contentItem.ContentType" data-toggle="tooltip" title="@T["Content type"]">@contentItem.ContentType</a></span>
+            </div>
+            @if (Model.Header != null)
+            {
+                <div class="header">
+                    @await DisplayAsync(Model.Header)
+                </div>
+            }
+            @if (Model.Tags != null)
+            {
+                <div class="tags">
+                    @await DisplayAsync(Model.Tags)
+                </div>
+            }
+            @if (Model.Meta != null)
+            {
+                <div class="metadata">
+                    @await DisplayAsync(Model.Meta)
+                </div>
+            }
+        </div>
     </div>
-    <div class="col-lg-6 col-sm-12">
-        <div class="float-right">
+    <div class="col-lg-auto col-12 d-flex justify-content-end">
+        <div class="actions">
             @if (Model.Actions != null)
             {
                 @await DisplayAsync(Model.Actions)
@@ -64,5 +76,9 @@
 
 @if (Model.Content != null)
 {
-    <div class="col primary">@await DisplayAsync(Model.Content)</div>
+    <div class="row">
+        <div class="col primary">
+            @await DisplayAsync(Model.Content)
+        </div>
+    </div>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsMeta_SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsMeta_SummaryAdmin.cshtml
@@ -7,10 +7,13 @@
 
 @if (contentItem.ModifiedUtc.HasValue)
 {
-    <small class="badge ta-badge font-weight-normal" data-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: contentItem.ModifiedUtc, Format: "g"))">
+    <span class="badge ta-badge font-weight-normal align-text-top" data-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: contentItem.ModifiedUtc, Format: "g"))">
         <i class="fa fa-calendar text-secondary"></i> <time datetime="@modifiedUtc">@await DisplayAsync(await New.Timespan(Utc: contentItem.ModifiedUtc))</time>
-    </small>
-    <small class="badge ta-badge font-weight-normal" data-toggle="tooltip" title="@contentItem.Owner">
-        <i class="fa fa-user text-secondary"></i> @contentItem.Author
-    </small>
+    </span>
+}
+@if (!String.IsNullOrEmpty(contentItem.Author))
+{
+    <span class="badge ta-badge font-weight-normal align-text-top" data-toggle="tooltip" title="@T["Author"]">
+        <i class="fa fa-user text-secondary mr-1"></i>@contentItem.Author
+    </span>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsTags_SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsTags_SummaryAdmin.cshtml
@@ -8,14 +8,14 @@
 }
 @if (hasPublished)
 {
-    <span class="badge ta-badge font-weight-normal" data-toggle="tooltip" title="@T["Status"]">
+    <span class="badge ta-badge font-weight-normal align-text-top" data-toggle="tooltip" title="@T["Status"]">
         <i class="fa fa-check text-success" aria-hidden="true"></i> @T["Published"]
     </span>
 }
 
 @if (hasDraft)
 {
-    <span class="badge ta-badge font-weight-normal" data-toggle="tooltip" title="@T["Status"]">
+    <span class="badge ta-badge font-weight-normal align-text-top" data-toggle="tooltip" title="@T["Status"]">
         <i class="fa fa-pencil text-primary" aria-hidden="true"></i> @T["Draft"]
     </span>
 }


### PR DESCRIPTION
Moving the summary admin display to a single row caused a few hiccups, and the changes to how the Zones were displayed has caused a few extensibility issues, as the zones are now in different places, so can no longer contain the items that were added to those Zones.

Additionally wrapping was a problem, not just on smaller screens, and with more text than our default recipes have.

In the interests of moving forward, rather than reverting back, here we move towards flexbox as a way of managing tags and selectors, and meta.

Notes
- Buttons are a seperate pr/issue. They've never stacked well. Suggest we move the `related` classes towards flexbox, and away from floats.
- Zones now stack instead of just adding to a weird difficult to predict wrap. Might be controversial. Might get changed back if not liked.
- To get a new line, the `Content` zone is now needed instead of the `Meta` zone. However it will render underneath the buttons. This was probably the biggest regresion for me, as having that on a seperate line made more sense, with the extra `Meta` some content items have.
- There is still a visual lack of alignment due to the light grey of the tags. Technically they now line up, but you can't easily see that, because the badge grey is so light. Minor.
- We lose the - between title and content type as it looks weird when things are stacked.
- Shown here as `ListPart` content to see how the selectors needed to be their own effective column.
- The two columns become auto cols so there is more room to display extra meta data without everything having to start wrapping.
- Brings back some of the zone classes that were removed, and used for targetting.

TODO
- Widgets

**What I'm not sure about is whether this further reduces the Zone extensibility by forcing stacking (and therefore items that are small enough to suit a stack) or not. So opinions from anyone using Zones please**

Before @ 1920
![Before1920](https://user-images.githubusercontent.com/13782679/103210223-01429a80-48fd-11eb-9da1-fa617db7311f.png)
After @ 1920

![After1920](https://user-images.githubusercontent.com/13782679/103210297-30f1a280-48fd-11eb-8e4f-5098adf0e03d.png)

Before @ Ipad

![BeforeiPad](https://user-images.githubusercontent.com/13782679/103210256-14ee0100-48fd-11eb-8e3d-27a5870c94e4.png)

After @ ipad

![AfterIpad](https://user-images.githubusercontent.com/13782679/103210317-3b13a100-48fd-11eb-9d14-c68183dccec0.png)

Before @ Iphone X

![BeforeIphoneX](https://user-images.githubusercontent.com/13782679/103210270-1d463c00-48fd-11eb-9fee-aea1c4382177.png)


After @ iphonex

![AfterIphoneX](https://user-images.githubusercontent.com/13782679/103210331-423aaf00-48fd-11eb-8af4-935eff6aeb2a.png)
