### PR TITLE
Flow / Bag Null References when using deleted content type definitions

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
@@ -112,9 +112,17 @@ namespace OrchardCore.Flows.Controllers
                 return _contentDefinitionManager.ListTypeDefinitions().Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
             }
 
-            return settings.ContainedContentTypes
-                .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
-                .Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
+            var ctds = new List<ContentTypeDefinition>();
+            foreach(var containedContentType in settings.ContainedContentTypes)
+            {
+                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(containedContentType);
+                if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Stereotype == "Widget")
+                {
+                    ctds.Add(contentTypeDefinition);
+                }
+            }
+
+            return ctds;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
@@ -112,17 +112,9 @@ namespace OrchardCore.Flows.Controllers
                 return _contentDefinitionManager.ListTypeDefinitions().Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
             }
 
-            var ctds = new List<ContentTypeDefinition>();
-            foreach(var containedContentType in settings.ContainedContentTypes)
-            {
-                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(containedContentType);
-                if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Stereotype == "Widget")
-                {
-                    ctds.Add(contentTypeDefinition);
-                }
-            }
-
-            return ctds;
+            return settings.ContainedContentTypes
+                .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
+                .Where(t => t != null && t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
@@ -91,7 +91,17 @@ namespace OrchardCore.Flows.Drivers
         private IEnumerable<ContentTypeDefinition> GetContainedContentTypes(ContentTypePartDefinition typePartDefinition)
         {
             var settings = typePartDefinition.GetSettings<BagPartSettings>();
-            return settings.ContainedContentTypes.Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType));
+            var ctds = new List<ContentTypeDefinition>();
+            foreach(var containedContentType in settings.ContainedContentTypes)
+            {
+                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(containedContentType);
+                if (contentTypeDefinition != null)
+                {
+                    ctds.Add(contentTypeDefinition);
+                }
+            }
+
+            return ctds;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
@@ -91,17 +91,10 @@ namespace OrchardCore.Flows.Drivers
         private IEnumerable<ContentTypeDefinition> GetContainedContentTypes(ContentTypePartDefinition typePartDefinition)
         {
             var settings = typePartDefinition.GetSettings<BagPartSettings>();
-            var ctds = new List<ContentTypeDefinition>();
-            foreach(var containedContentType in settings.ContainedContentTypes)
-            {
-                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(containedContentType);
-                if (contentTypeDefinition != null)
-                {
-                    ctds.Add(contentTypeDefinition);
-                }
-            }
 
-            return ctds;
+            return settings.ContainedContentTypes
+                .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
+                .Where(contentType => contentType != null);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -99,9 +99,17 @@ namespace OrchardCore.Flows.Drivers
                 return _contentDefinitionManager.ListTypeDefinitions().Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
             }
 
-            return settings.ContainedContentTypes
-                .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
-                .Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
+            var ctds = new List<ContentTypeDefinition>();
+            foreach(var containedContentType in settings.ContainedContentTypes)
+            {
+                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(containedContentType);
+                if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Stereotype == "Widget")
+                {
+                    ctds.Add(contentTypeDefinition);
+                }
+            }
+
+            return ctds;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -99,17 +99,9 @@ namespace OrchardCore.Flows.Drivers
                 return _contentDefinitionManager.ListTypeDefinitions().Where(t => t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
             }
 
-            var ctds = new List<ContentTypeDefinition>();
-            foreach(var containedContentType in settings.ContainedContentTypes)
-            {
-                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(containedContentType);
-                if (contentTypeDefinition != null && contentTypeDefinition.GetSettings<ContentTypeSettings>().Stereotype == "Widget")
-                {
-                    ctds.Add(contentTypeDefinition);
-                }
-            }
-
-            return ctds;
+            return settings.ContainedContentTypes
+                .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
+                .Where(t => t != null && t.GetSettings<ContentTypeSettings>().Stereotype == "Widget");
         }
     }
 }


### PR DESCRIPTION
Related to https://github.com/OrchardCMS/OrchardCore/issues/6751

and the many other issues when deleting content type definitions.

This fixes null reference exceptions thrown by bag parts and /or flow parts when the list of contained content types includes a type which has been deleted.

Does not fix throwing null references, if the content type is currently in use inside the bag, that's another pr.

However this is a common place error, when refactoring content type definitions.

The contained content types list on the settings is self healing already.