### PR TITLE
Admin UI : remove layout stray div

### DIFF
--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
@@ -63,7 +63,6 @@
             </div>
         </div>
 
-
         <div id="ta-left-sidebar" class="d-flex flex-column justify-content-between align-items-stretch">
             @await RenderSectionAsync("Navigation", required: false)
             <div class="footer">
@@ -71,7 +70,7 @@
             </div>
         </div>
 
-        <div class="ta-content flex-fill">
+        <div class="ta-content">
             @await RenderSectionAsync("Header", required: false)
             @await RenderSectionAsync("Messages", required: false)
             @await RenderSectionAsync("Breadcrumbs", required: false)
@@ -81,13 +80,11 @@
             }
             @await RenderBodyAsync()
         </div>
-        </div>
 
         @await RenderSectionAsync("Footer", required: false)
 
-        <div id="confirmRemoveModalMetadata" data-title="@T["Delete"]" data-message="@T["Are you sure you want to remove this element?"]" data-ok-text="@T["Ok"]" data-cancel-text="@T["Cancel"]" data-ok-class="btn-danger" data-cancel-class="btn-secondary"></div>
-
-        <resources type="Footer" />
     </div>
+    <div id="confirmRemoveModalMetadata" data-title="@T["Delete"]" data-message="@T["Are you sure you want to remove this element?"]" data-ok-text="@T["Ok"]" data-cancel-text="@T["Cancel"]" data-ok-class="btn-danger" data-cancel-class="btn-secondary"></div>
+    <resources type="Footer" />
 </body>
 </html>


### PR DESCRIPTION
Remove stray div and move bottom scripts and model from the first "ta-wrapper" div.
Remove flex-fill as not necessary anymore.

In fact the "ta-wrapper" does nothing at all now. And it never did. It's just a wrapper ...