### PR TITLE
Upgrade YesSql

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -42,12 +42,12 @@
     <PackageManagement Include="xunit.analyzers" Version="0.10.0" />
     <PackageManagement Include="xunit" Version="2.4.1" />
     <PackageManagement Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageManagement Include="YesSql.Abstractions" Version="2.0.0-beta-1637" />
-    <PackageManagement Include="YesSql.Core" Version="2.0.0-beta-1637" />
-    <PackageManagement Include="YesSql.Provider.MySql" Version="1.0.0-beta-1637" />
-    <PackageManagement Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1637" />
-    <PackageManagement Include="YesSql.Provider.SqLite" Version="1.0.0-beta-1637" />
-    <PackageManagement Include="YesSql.Provider.SqlServer" Version="1.0.0-beta-1637" />
+    <PackageManagement Include="YesSql.Abstractions" Version="2.0.0-beta-1674" />
+    <PackageManagement Include="YesSql.Core" Version="2.0.0-beta-1674" />
+    <PackageManagement Include="YesSql.Provider.MySql" Version="1.0.0-beta-1674" />
+    <PackageManagement Include="YesSql.Provider.PostgreSql" Version="1.0.0-beta-1674" />
+    <PackageManagement Include="YesSql.Provider.SqLite" Version="1.0.0-beta-1674" />
+    <PackageManagement Include="YesSql.Provider.SqlServer" Version="1.0.0-beta-1674" />
     <PackageManagement Include="Microsoft.SourceLink.GitHub" Version="1.0.0" /> 
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
@@ -1,6 +1,11 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Alias.Models;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Data;
 using YesSql.Indexes;
 
 namespace OrchardCore.Alias.Indexes
@@ -13,15 +18,55 @@ namespace OrchardCore.Alias.Indexes
         public bool Published { get; set; }
     }
 
-    public class AliasPartIndexProvider : IndexProvider<ContentItem>
+    public class AliasPartIndexProvider : IndexProvider<ContentItem>, IScopedIndexProvider
     {
+        private readonly IServiceProvider _serviceProvider;
+        private IContentDefinitionManager _contentDefinitionManager;
+        private HashSet<string> _ignoredTypes;
+
+        public AliasPartIndexProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
         public override void Describe(DescribeContext<ContentItem> context)
         {
             context.For<AliasPartIndex>()
-                .When(contentItem => contentItem.Has<AliasPart>())
                 .Map(contentItem =>
                 {
-                    var alias = contentItem.As<AliasPart>()?.Alias;
+                    var aliasPart = contentItem.As<AliasPart>();
+
+                    if (aliasPart == null)
+                    {
+                        return null;
+                    }
+
+                    // Can we safely ignore this content item?
+                    if (_ignoredTypes != null && _ignoredTypes.Contains(contentItem.ContentType))
+                    {
+                        contentItem.Remove<AliasPart>();
+                        return null;
+                    }
+
+                    // Lazy initialization because of ISession cyclic dependency
+                    _contentDefinitionManager ??= _serviceProvider.GetRequiredService<IContentDefinitionManager>();
+
+                    // Search for AliasPart
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // Validate that the content definition contains an AliasPart.
+                    // This prevents indexing parts that have been removed from the type definition, but are still present in the elements.
+                    if (contentTypeDefinition == null || !contentTypeDefinition.Parts.Any(ctpd => ctpd.Name == nameof(AliasPart)))
+                    {
+                        _ignoredTypes ??= new HashSet<string>();
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        contentItem.Remove<AliasPart>();
+
+                        return null;
+                    }
+
+                    var alias = aliasPart.Alias;
+
                     if (!String.IsNullOrEmpty(alias) && (contentItem.Published || contentItem.Latest))
                     {
                         return new AliasPartIndex

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Indexes/AliasPartIndex.cs
@@ -18,6 +18,7 @@ namespace OrchardCore.Alias.Indexes
         public override void Describe(DescribeContext<ContentItem> context)
         {
             context.For<AliasPartIndex>()
+                .When(contentItem => contentItem.Has<AliasPart>())
                 .Map(contentItem =>
                 {
                     var alias = contentItem.As<AliasPart>()?.Alias;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Startup.cs
@@ -12,17 +12,16 @@ using OrchardCore.Alias.ViewModels;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
+using OrchardCore.Data;
 using OrchardCore.Data.Migration;
 using OrchardCore.Indexing;
 using OrchardCore.Liquid;
 using OrchardCore.Modules;
-using YesSql.Indexes;
 
 namespace OrchardCore.Alias
 {
     public class Startup : StartupBase
     {
-
         static Startup()
         {
             TemplateContext.GlobalMemberAccessStrategy.Register<AliasPartViewModel>();
@@ -30,7 +29,7 @@ namespace OrchardCore.Alias
 
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<IIndexProvider, AliasPartIndexProvider>();
+            services.AddScoped<IScopedIndexProvider, AliasPartIndexProvider>();
             services.AddScoped<IDataMigration, Migrations>();
             services.AddScoped<IContentHandleProvider, AliasPartContentHandleProvider>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
@@ -77,6 +77,7 @@ namespace OrchardCore.ContentManagement.Records
         public void Describe(DescribeContext<ContentItem> context)
         {
             context.For<AutoroutePartIndex>()
+                .When(contentItem => contentItem.Has<AutoroutePart>())
                 .Map(async contentItem =>
                 {
                     var part = contentItem.As<AutoroutePart>();

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Autoroute.Models;
+using OrchardCore.Autoroute.Services;
 using OrchardCore.ContentManagement.Handlers;
+using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Routing;
 using OrchardCore.Data;
 using YesSql.Indexes;
@@ -49,6 +52,7 @@ namespace OrchardCore.ContentManagement.Records
         private readonly IServiceProvider _serviceProvider;
         private readonly HashSet<ContentItem> _removed = new HashSet<ContentItem>();
         private IContentManager _contentManager;
+        private IContentDefinitionManager _contentDefinitionManager;
 
         public AutoroutePartIndexProvider(IServiceProvider serviceProvider)
         {
@@ -77,7 +81,6 @@ namespace OrchardCore.ContentManagement.Records
         public void Describe(DescribeContext<ContentItem> context)
         {
             context.For<AutoroutePartIndex>()
-                .When(contentItem => contentItem.Has<AutoroutePart>())
                 .Map(async contentItem =>
                 {
                     var part = contentItem.As<AutoroutePart>();
@@ -98,19 +101,37 @@ namespace OrchardCore.ContentManagement.Records
                         return null;
                     }
 
+                    // Lazy initialization because of ISession cyclic dependency
+                    _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
+
+                    // Search for AutoroutePart
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // Validate that the content definition contains an AutoroutePart.
+                    // This prevents indexing parts that have been removed from the type definition, but are still present in the elements.
+                    var removedFromTypeDefinition = false;
+                    if (contentTypeDefinition == null || !contentTypeDefinition.Parts.Any(ctpd => ctpd.Name == nameof(AutoroutePart)))
+                    {
+                        // When the part has been removed enlist an update for after the session has been commited.
+                        removedFromTypeDefinition = true;
+                        contentItem.Remove<AutoroutePart>();
+                        var autorouteEntries = _serviceProvider.GetRequiredService<IAutorouteEntries>();
+                        await autorouteEntries.UpdateEntriesAsync();
+                    }
+
                     var results = new List<AutoroutePartIndex>
                     {
-                        // If the part is disabled, a record is still added but with a null path.
+                        // If the part is disabled, or removed, a record is still added but with a null path.
                         new AutoroutePartIndex
                         {
                             ContentItemId = contentItem.ContentItemId,
-                            Path = !part.Disabled ? part.Path : null,
+                            Path = !part.Disabled && !removedFromTypeDefinition ? part.Path : null,
                             Published = contentItem.Published,
                             Latest = contentItem.Latest
                         }
                     };
 
-                    if (!part.RouteContainedItems || part.Disabled || _removed.Contains(contentItem))
+                    if (!part.RouteContainedItems || part.Disabled || _removed.Contains(contentItem) || removedFromTypeDefinition)
                     {
                         return results;
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Indexes/LayerMetadataIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Indexes/LayerMetadataIndex.cs
@@ -14,6 +14,7 @@ namespace OrchardCore.Layers.Indexes
         public override void Describe(DescribeContext<ContentItem> context)
         {
             context.For<LayerMetadataIndex>()
+                .When(contentItem => contentItem.Has<LayerMetadata>())
                 .Map(contentItem =>
                 {
                     var layerMetadata = contentItem.As<LayerMetadata>();

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ContainedPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ContainedPartIndex.cs
@@ -15,6 +15,7 @@ namespace OrchardCore.Lists.Indexes
         public override void Describe(DescribeContext<ContentItem> context)
         {
             context.For<ContainedPartIndex>()
+                .When(contentItem => contentItem.Has<ContainedPart>())
                 .Map(contentItem =>
                 {
                     var containedPart = contentItem.As<ContainedPart>();

--- a/src/OrchardCore.Modules/OrchardCore.PublishLater/Indexes/PublishLaterPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.PublishLater/Indexes/PublishLaterPartIndex.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Data;
 using OrchardCore.PublishLater.Models;
 using YesSql.Indexes;
 
@@ -10,12 +15,20 @@ namespace OrchardCore.PublishLater.Indexes
         public DateTime? ScheduledPublishUtc { get; set; }
     }
 
-    public class PublishLaterPartIndexProvider : IndexProvider<ContentItem>
+    public class PublishLaterPartIndexProvider : IndexProvider<ContentItem>, IScopedIndexProvider
     {
+        private readonly IServiceProvider _serviceProvider;
+        private IContentDefinitionManager _contentDefinitionManager;
+        private HashSet<string> _ignoredTypes;
+
+        public PublishLaterPartIndexProvider(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
         public override void Describe(DescribeContext<ContentItem> context)
         {
             context.For<PublishLaterPartIndex>()
-                .When(contentItem => contentItem.Has<PublishLaterPart>())
                 .Map(contentItem =>
                 {
                     var publishLaterPart = contentItem.As<PublishLaterPart>();
@@ -29,6 +42,32 @@ namespace OrchardCore.PublishLater.Indexes
                     {
                         return null;
                     }
+
+                    // Can we safely ignore this content item?
+                    if (_ignoredTypes != null && _ignoredTypes.Contains(contentItem.ContentType))
+                    {
+                        contentItem.Remove<PublishLaterPart>();
+                        return null;
+                    }
+
+                    // Lazy initialization because of ISession cyclic dependency
+                    _contentDefinitionManager ??= _serviceProvider.GetRequiredService<IContentDefinitionManager>();
+
+                    // Search for AliasPart
+                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
+
+                    // Validate that the content definition contains an PublishLaterPart.
+                    // This prevents indexing parts that have been removed from the type definition, but are still present in the elements.
+                    if (contentTypeDefinition == null || !contentTypeDefinition.Parts.Any(ctpd => ctpd.Name == nameof(PublishLaterPart)))
+                    {
+                        _ignoredTypes ??= new HashSet<string>();
+                        _ignoredTypes.Add(contentItem.ContentType);
+                        contentItem.Remove<PublishLaterPart>();
+
+                        return null;
+                    }
+
+                    // wouldn't it be better to do valid types?
 
                     return new PublishLaterPartIndex
                     {

--- a/src/OrchardCore.Modules/OrchardCore.PublishLater/Indexes/PublishLaterPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.PublishLater/Indexes/PublishLaterPartIndex.cs
@@ -15,6 +15,7 @@ namespace OrchardCore.PublishLater.Indexes
         public override void Describe(DescribeContext<ContentItem> context)
         {
             context.For<PublishLaterPartIndex>()
+                .When(contentItem => contentItem.Has<PublishLaterPart>())
                 .Map(contentItem =>
                 {
                     var publishLaterPart = contentItem.As<PublishLaterPart>();

--- a/src/OrchardCore.Modules/OrchardCore.PublishLater/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.PublishLater/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.BackgroundTasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.Data;
 using OrchardCore.Data.Migration;
 using OrchardCore.Modules;
 using OrchardCore.PublishLater.Drivers;
@@ -11,7 +12,6 @@ using OrchardCore.PublishLater.Indexes;
 using OrchardCore.PublishLater.Models;
 using OrchardCore.PublishLater.Services;
 using OrchardCore.PublishLater.ViewModels;
-using YesSql.Indexes;
 
 namespace OrchardCore.PublishLater
 {
@@ -29,7 +29,7 @@ namespace OrchardCore.PublishLater
                 .UseDisplayDriver<PublishLaterPartDisplayDriver>()
                 .AddHandler<PublishLaterPartHandler>();
             services.AddScoped<IDataMigration, Migrations>();
-            services.AddSingleton<IIndexProvider, PublishLaterPartIndexProvider>();
+            services.AddScoped<IScopedIndexProvider, PublishLaterPartIndexProvider>();
 
             services.AddSingleton<IBackgroundTask, ScheduledPublishingBackgroundTask>();
         }

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/Records/LocalizedContentItemIndex.cs
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/Records/LocalizedContentItemIndex.cs
@@ -48,6 +48,7 @@ namespace OrchardCore.ContentLocalization.Records
         public void Describe(DescribeContext<ContentItem> context)
         {
             context.For<LocalizedContentItemIndex>()
+                .When(contentItem => contentItem.Has<LocalizationPart>())
                 .Map(contentItem =>
                 {
                     var part = contentItem.As<LocalizationPart>();

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/Records/LocalizedContentItemIndex.cs
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/Records/LocalizedContentItemIndex.cs
@@ -48,7 +48,6 @@ namespace OrchardCore.ContentLocalization.Records
         public void Describe(DescribeContext<ContentItem> context)
         {
             context.For<LocalizedContentItemIndex>()
-                .When(contentItem => contentItem.Has<LocalizationPart>())
                 .Map(contentItem =>
                 {
                     var part = contentItem.As<LocalizationPart>();

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs
@@ -67,6 +67,18 @@ namespace OrchardCore.ContentManagement
         }
 
         /// <summary>
+        /// Removes a content element by its name.
+        /// </summary>
+        /// <param name="contentElement">The <see cref="ContentElement"/>.</param>
+        /// <param name="name">The name of the content element.</param>
+        /// <returns><see langword="True"/> is successfully found and removed; otherwise. <see langword="False"/> This method returns false if the name is not found.</returns>
+        public static bool Remove(this ContentElement contentElement, string name)
+        {
+            contentElement.Elements.Remove(name);
+            return contentElement.Data.Remove(name);
+        }
+
+        /// <summary>
         /// Gets a content element by its name or create a new one.
         /// </summary>
         /// <param name="contentElement">The <see cref="ContentElement"/>.</param>

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
@@ -29,6 +29,16 @@ namespace OrchardCore.ContentManagement
         }
 
         /// <summary>
+        /// Removes a content part by its type.
+        /// </summary>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <typeparam name="TPart">The type of the content part.</typeparam>
+        public static void Remove<TPart>(this ContentItem contentItem) where TPart : ContentPart, new()
+        {
+            contentItem.Remove(typeof(TPart).Name);
+        }
+
+        /// <summary>
         /// Adds a content part by its type.
         /// </summary>
         /// <param name="contentItem">The <see cref="ContentItem"/>.</param>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7949
Fixes https://github.com/OrchardCMS/OrchardCore/issues/5586

Tested with SQL Server, all seems fine, and faster 👍 

@sebastienros I implemented `When` for the `ContentParts`. 

I don't think it's appropriate for the `IScopedIndexProvider` such as `TaxonomyFieldIndex` and other field indexes.

Here its relying on the type definition to determine if it should be in the index (and therefore deleted)
https://github.com/OrchardCMS/OrchardCore/blob/8280e2ba8caaadfbf6f72e4ee998d8cda9bb441e/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs#L64-L66

So if you use the same logic for `When` and remove a field from the definition, when saving an old document, the field would not get deleted from the index, because `When` would say that it isn't relevant (when actually it is, on that first Save)

Unless I'm missing something?

Passed all databases https://github.com/OrchardCMS/OrchardCore/actions/runs/454447735