### PR TITLE
Support Inline location for styles and scripts

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/IResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/IResourceManager.cs
@@ -121,5 +121,10 @@ namespace OrchardCore.ResourceManagement
         /// Renders the registered local script tags.
         /// </summary>
         void RenderLocalScript(RequireSettings settings, IHtmlContentBuilder builder);
+
+        /// <summary>
+        /// Renders the registered local style tags.
+        /// </summary>
+        void RenderLocalStyle(RequireSettings settings, IHtmlContentBuilder builder);
     }
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceLocation.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceLocation.cs
@@ -5,5 +5,6 @@ namespace OrchardCore.ResourceManagement
         Unspecified,
         Foot,
         Head,
+        Inline
     }
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -131,7 +131,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.SetAttribute(attribute.Name, attribute.Value.ToString());
                 }
 
-                if (At == ResourceLocation.Unspecified)
+                if (At == ResourceLocation.Unspecified || At == ResourceLocation.Inline)
                 {
                     _resourceManager.RenderLocalScript(setting, output.Content);
                 }
@@ -183,19 +183,25 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.SetDependencies(DependsOn.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
                 }
 
-                if (At == ResourceLocation.Unspecified)
-                {
-                    _resourceManager.RenderLocalScript(setting, output.Content);
-                }
-                else
+                // Allow Inline to work with both named scripts, and named inline scripts.
+                if (At != ResourceLocation.Unspecified)
                 {
                     var childContent = await output.GetChildContentAsync();
+                    // Named inline declaration.
                     if (!childContent.IsEmptyOrWhiteSpace)
                     {
                         // Inline content definition
                         _resourceManager.InlineManifest.DefineScript(Name)
                             .SetInnerContent(childContent.GetContent());
                     }
+                    if (At == ResourceLocation.Inline)
+                    {
+                        _resourceManager.RenderLocalScript(setting, output.Content);
+                    }
+                }
+                else
+                {
+                    _resourceManager.RenderLocalScript(setting, output.Content);
                 }
             }
             else if (!String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
@@ -265,6 +271,11 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     foreach (var attribute in output.Attributes)
                     {
                         setting.SetAttribute(attribute.Name, attribute.Value.ToString());
+                    }
+
+                    if (At == ResourceLocation.Inline)
+                    {
+                        _resourceManager.RenderLocalScript(setting, output.Content);
                     }
                 }
             }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -186,14 +186,15 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 // Allow Inline to work with both named scripts, and named inline scripts.
                 if (At != ResourceLocation.Unspecified)
                 {
-                    var childContent = await output.GetChildContentAsync();
                     // Named inline declaration.
+                    var childContent = await output.GetChildContentAsync();
                     if (!childContent.IsEmptyOrWhiteSpace)
                     {
                         // Inline content definition
                         _resourceManager.InlineManifest.DefineScript(Name)
                             .SetInnerContent(childContent.GetContent());
                     }
+
                     if (At == ResourceLocation.Inline)
                     {
                         _resourceManager.RenderLocalScript(setting, output.Content);

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -51,13 +51,8 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
             if (String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
             {
-                // Include custom script
+                // Include custom style
                 var setting = _resourceManager.RegisterUrl("stylesheet", Src, DebugSrc);
-                
-                foreach (var attribute in output.Attributes)
-                {
-                    setting.SetAttribute(attribute.Name, attribute.Value.ToString());
-                }
 
                 if (At != ResourceLocation.Unspecified)
                 {
@@ -66,6 +61,11 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 else
                 {
                     setting.AtLocation(ResourceLocation.Head);
+                }
+
+                foreach (var attribute in output.Attributes)
+                {
+                    setting.SetAttribute(attribute.Name, attribute.Value.ToString());
                 }
 
                 if (!String.IsNullOrEmpty(Condition))
@@ -87,6 +87,17 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 {
                     setting.UseCulture(Culture);
                 }
+
+                if (!String.IsNullOrEmpty(DependsOn))
+                {
+                    setting.SetDependencies(DependsOn.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
+                }
+
+                if (At == ResourceLocation.Inline)
+                {
+                    _resourceManager.RenderLocalStyle(setting, output.Content);
+                }
+
             }
             else if (!String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Src))
             {
@@ -138,7 +149,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.UseVersion(Version);
                 }
 
-                // This allows additions to the pre registered scripts dependencies.
+                // This allows additions to the pre registered style dependencies.
                 if (!String.IsNullOrEmpty(DependsOn))
                 {
                     setting.SetDependencies(DependsOn.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
@@ -147,9 +158,14 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 var childContent = await output.GetChildContentAsync();
                 if (!childContent.IsEmptyOrWhiteSpace)
                 {
-                    // Inline content definition
+                    // Inline named style definition
                     _resourceManager.InlineManifest.DefineStyle(Name)
                         .SetInnerContent(childContent.GetContent());
+                }
+
+                if (At == ResourceLocation.Inline)
+                {
+                    _resourceManager.RenderLocalStyle(setting, output.Content);
                 }
             }
             else if (!String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
@@ -184,18 +200,8 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     definition.SetDependencies(DependsOn.Split(',', StringSplitOptions.RemoveEmptyEntries));
                 }
 
-                // Also include the style
-
+                // Also include the style.
                 var setting = _resourceManager.RegisterResource("stylesheet", Name);
-
-                if (At != ResourceLocation.Unspecified)
-                {
-                    setting.AtLocation(At);
-                }
-                else
-                {
-                    setting.AtLocation(ResourceLocation.Head);
-                }
 
                 if (UseCdn != null)
                 {
@@ -215,6 +221,19 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 if (!String.IsNullOrEmpty(Culture))
                 {
                     setting.UseCulture(Culture);
+                }
+
+                if (At == ResourceLocation.Inline)
+                {
+                    _resourceManager.RenderLocalStyle(setting, output.Content);
+                }
+                else if (At != ResourceLocation.Unspecified)
+                {
+                    setting.AtLocation(At);
+                }
+                else
+                {
+                    setting.AtLocation(ResourceLocation.Head);
                 }
             }
             else if (String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Src))

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -54,6 +54,11 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 // Include custom style
                 var setting = _resourceManager.RegisterUrl("stylesheet", Src, DebugSrc);
 
+                foreach (var attribute in output.Attributes)
+                {
+                    setting.SetAttribute(attribute.Name, attribute.Value.ToString());
+                }
+
                 if (At != ResourceLocation.Unspecified)
                 {
                     setting.AtLocation(At);
@@ -61,11 +66,6 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 else
                 {
                     setting.AtLocation(ResourceLocation.Head);
-                }
-
-                foreach (var attribute in output.Attributes)
-                {
-                    setting.SetAttribute(attribute.Name, attribute.Value.ToString());
                 }
 
                 if (!String.IsNullOrEmpty(Condition))

--- a/src/docs/reference/modules/Resources/README.md
+++ b/src/docs/reference/modules/Resources/README.md
@@ -263,7 +263,7 @@ You can append a version hash that will be calculated, and calculation cached, a
 
 ##### Specify location
 
-Specify a location the script should load using `at`, for example `Foot` to rendered wherever the `FootScript` helper is located or `Head` to render with the `HeadScript` [See Foot Resources](#foot-resources). If the location is not specified, the script will be inserted wherever it is placed (inline).
+Specify a location the script should load using `at`, for example `Foot` to rendered wherever the `FootScript` helper is located or `Head` to render with the `HeadScript` [See Foot Resources](#foot-resources). If the location is not specified, or specified as `Inline`, the script will be inserted wherever it is placed (inline).
 
 === "Liquid"
 
@@ -277,7 +277,7 @@ Specify a location the script should load using `at`, for example `Foot` to rend
     <script asp-name="bootstrap" at="Foot"></script>
     ```
 
-Link and styles tag helpers always inject into the header section of the HTML document regardless of the `at` value.
+Link and styles tag helpers always inject into the header section of the HTML document, unless the `at` location is set to `Inline`.
 
 #### Inline definition
 
@@ -336,7 +336,7 @@ When rendering the scripts the resource manager will order the output based on t
 3. `bar`
 
 !!! note
-    You do not have to define a name for your script or style unless you want to reference it as a dependency.
+    You do not have to define a name for your script or style unless you want to reference it as a dependency, or declare it as `Inline`.
 
 #### Custom scripts
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6593

Adds support for `at="Inline"` for both styles and scripts.

We partially had support for this in scripts (to fix an older issue), but have extended it to support `at="Inline"` which allows it work with `depends-on` and naming. So full support, rather than partial.

Think you added the partial support here https://github.com/OrchardCMS/OrchardCore/pull/2973 @jtkech 

By adding `Inline` as an option, this is non breaking, as to do it without, i.e. use `Unspecified` would break existing `style` tags.

Obviously `Inline` is only useful as an option if using the tag helpers. It would do nothing if registered directly.