### PR TITLE
Fix setup user name validation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Startup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,6 +37,12 @@ namespace OrchardCore.Setup
             services.Replace(ServiceDescriptor.Singleton<ILocalizationFileLocationProvider, ModularPoFileLocationProvider>());
 
             services.AddSetup();
+
+            services.Configure<IdentityOptions>(options =>
+            {
+                options.User.AllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._+";
+                options.User.RequireUniqueEmail = true;
+            });
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Views/Setup/Index.cshtml
@@ -198,7 +198,7 @@
             <div class="form-group col-md-6" asp-validation-class-for="UserName">
                 <label asp-for="UserName">@T["User name"]</label>
                 <input asp-for="UserName" class="form-control" required />
-                <span asp-validation-for="UserName" class="text-danger">@T["The user name is required."]</span>
+                <span asp-validation-for="UserName" class="text-danger"></span>
             </div>
             <div class="form-group col-md-6" asp-validation-class-for="Email">
                 <label for="Email">@T["Email"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/SetupTenantTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Workflows/Activities/SetupTenantTask.cs
@@ -1,8 +1,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.Email;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Models;
 using OrchardCore.Environment.Shell.Scope;
@@ -19,12 +22,27 @@ namespace OrchardCore.Tenants.Workflows.Activities
     {
         private readonly IClock _clock;
         private readonly IUpdateModelAccessor _updateModelAccessor;
-        public SetupTenantTask(IShellSettingsManager shellSettingsManager, IShellHost shellHost, ISetupService setupService, IClock clock, IWorkflowExpressionEvaluator expressionEvaluator, IWorkflowScriptEvaluator scriptEvaluator, IUpdateModelAccessor updateModelAccessor, IStringLocalizer<SetupTenantTask> localizer)
+        private readonly IEmailAddressValidator _emailAddressValidator;
+        private readonly IdentityOptions _identityOptions;
+
+        public SetupTenantTask(
+            IClock clock,
+            IUpdateModelAccessor updateModelAccessor,
+            IEmailAddressValidator emailAddressValidator,
+            IOptions<IdentityOptions> identityOptions,
+            IShellSettingsManager shellSettingsManager,
+            IShellHost shellHost,
+            ISetupService setupService,
+            IWorkflowExpressionEvaluator expressionEvaluator,
+            IWorkflowScriptEvaluator scriptEvaluator,
+            IStringLocalizer<SetupTenantTask> localizer)
             : base(shellSettingsManager, shellHost, expressionEvaluator, scriptEvaluator, localizer)
         {
             SetupService = setupService;
             _clock = clock;
             _updateModelAccessor = updateModelAccessor;
+            _emailAddressValidator = emailAddressValidator;
+            _identityOptions = identityOptions.Value;
         }
 
         protected ISetupService SetupService { get; }
@@ -120,6 +138,17 @@ namespace OrchardCore.Tenants.Workflows.Activities
             var siteName = (await ExpressionEvaluator.EvaluateAsync(SiteName, workflowContext, null))?.Trim();
             var adminUsername = (await ExpressionEvaluator.EvaluateAsync(AdminUsername, workflowContext, null))?.Trim();
             var adminEmail = (await ExpressionEvaluator.EvaluateAsync(AdminEmail, workflowContext, null))?.Trim();
+
+            if (string.IsNullOrEmpty(adminUsername) || adminUsername.Any(c => !_identityOptions.User.AllowedUserNameCharacters.Contains(c)))
+            {
+                return Outcomes("Failed");
+            }
+
+            if (string.IsNullOrEmpty(adminEmail) || !_emailAddressValidator.Validate(adminEmail))
+            {
+                return Outcomes("Failed");
+            }
+
             var adminPassword = (await ExpressionEvaluator.EvaluateAsync(AdminPassword, workflowContext, null))?.Trim();
 
             var databaseProvider = (await ExpressionEvaluator.EvaluateAsync(DatabaseProvider, workflowContext, null))?.Trim();

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -235,6 +235,9 @@ namespace OrchardCore.Setup.Services
 
             if (context.Errors.Any())
             {
+                // So that the new registered shell is reverted back to the 'Uninitialized' state.
+                context.ShellSettings = shellSettings;
+
                 return executionId;
             }
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/8189

Fixes https://github.com/OrchardCMS/OrchardCore/issues/1665

Fixes the user name validation for setup/api/tenants

Tidies up some of the email validation, and now using the same localization strings as are in the view. So less work for translators.


