### PR TITLE
Fixes Workflow after upgrading YesSql

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -93,10 +93,10 @@ namespace OrchardCore.Workflows.Controllers
             switch (model.Options.Filter)
             {
                 case WorkflowFilter.Finished:
-                    query = query.Where(x => x.WorkflowStatus == WorkflowStatus.Finished);
+                    query = query.Where(x => x.WorkflowStatus == (int)WorkflowStatus.Finished);
                     break;
                 case WorkflowFilter.Faulted:
-                    query = query.Where(x => x.WorkflowStatus == WorkflowStatus.Faulted);
+                    query = query.Where(x => x.WorkflowStatus == (int)WorkflowStatus.Faulted);
                     break;
                 case WorkflowFilter.All:
                 default:

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Indexes/WorkflowIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Indexes/WorkflowIndexProvider.cs
@@ -7,10 +7,10 @@ namespace OrchardCore.Workflows.Indexes
 {
     public class WorkflowIndex : MapIndex
     {
-        public string DocumentId { get; set; }
+        public int DocumentId { get; set; }
         public string WorkflowTypeId { get; set; }
         public string WorkflowId { get; set; }
-        public WorkflowStatus WorkflowStatus { get; set; }
+        public int WorkflowStatus { get; set; }
         public DateTime CreatedUtc { get; set; }
     }
 
@@ -35,7 +35,7 @@ namespace OrchardCore.Workflows.Indexes
                         WorkflowTypeId = workflow.WorkflowTypeId,
                         WorkflowId = workflow.WorkflowId,
                         CreatedUtc = workflow.CreatedUtc,
-                        WorkflowStatus = workflow.Status
+                        WorkflowStatus = (int)workflow.Status
                     }
                 );
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Indexes/WorkflowTypeIndexProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Indexes/WorkflowTypeIndexProvider.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Workflows.Indexes
 {
     public class WorkflowTypeIndex : MapIndex
     {
-        public string DocumentId { get; set; }
+        public int DocumentId { get; set; }
         public string WorkflowTypeId { get; set; }
         public string Name { get; set; }
         public bool IsEnabled { get; set; }


### PR DESCRIPTION
Related issue #8223 

After the YesSql upgrade, running a Worflow fails on YesSql side

    ...
    System.InvalidOperationException: This operation is only valid on generic types.
       at System.RuntimeType.GetGenericTypeDefinition()
       at YesSql.Sql.Schema.SchemaUtils.ToDbType(Type type)
       at YesSql.Commands.IndexCommand.GetProperties(DynamicParameters parameters, Object item, String suffix)
       at YesSql.Commands.CreateIndexCommand.AddToBatch(ISqlDialect dialect, List`1 queries, DynamicParameters ...)
       at YesSql.Session.BatchCommands()
       at YesSql.Session.FlushAsync()
    ...

I fails in https://github.com/sebastienros/yessql/blob/b2b8dd3c140f8335368bdbb426b2665ac50f478d/src/YesSql.Core/Sql/Schema/SchemaUtils.cs#L41-L42 when doing

            // Nullable<T> ?
            if (type.GetGenericTypeDefinition() == typeof(Nullable<>))

When the type, here a `WorkflowStatus`, is an **enum type** that is not included in the `DbTypes`.

Fixed by replacing in `WorkflowIndex` the `WorkflowStatus` enum type by an int

    public class WorkflowIndex : MapIndex
    {
        ...
        public WorkflowStatus WorkflowStatus { get; set; } => public int WorkflowStatus { get; set; }
        ...
    }

I will merge it as Workflows are broken, waiting maybe for a fix on YesSql side if better to include **enum type** and / or using a try / catch when doing `GetGenericTypeDefinition()` that is only valid on generic types as `Nullable<>`