### PR TITLE
Fixes menu item views

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItemLink-LinkMenuItem.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItemLink-LinkMenuItem.cshtml
@@ -4,7 +4,19 @@
     var linkMenuItemPart = contentItem.As<LinkMenuItemPart>();
 
     TagBuilder tag = Tag(Model, "a");
-    tag.Attributes["href"] = linkMenuItemPart.Url;
+
+    var url = linkMenuItemPart.Url;
+    if (url.StartsWith('/'))
+    {
+        url = '~' + url;
+    }
+
+    if (url.StartsWith("~/", StringComparison.Ordinal))
+    {
+        url = Url.Content(linkMenuItemPart.Url);
+    }
+
+    tag.Attributes["href"] = url;
     tag.InnerHtml.Append(linkMenuItemPart.Name);
 }
 @tag

--- a/src/OrchardCore.Themes/TheTheme/Views/MenuItemLink-LinkMenuItem.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/MenuItemLink-LinkMenuItem.cshtml
@@ -5,7 +5,19 @@
     int level = (int)Model.Level;
 
     TagBuilder tag = Tag(Model, "a");
-    tag.Attributes["href"] = linkMenuItemPart.Url;
+
+    var url = linkMenuItemPart.Url;
+    if (url.StartsWith('/'))
+    {
+        url = '~' + url;
+    }
+
+    if (url.StartsWith("~/", StringComparison.Ordinal))
+    {
+        url = Url.Content(linkMenuItemPart.Url);
+    }
+
+    tag.Attributes["href"] = url;
     tag.InnerHtml.Append(linkMenuItemPart.Name);
 
     if (Model.Level == 0 && Model.HasItems)


### PR DESCRIPTION
E.g. Use the blog recipe

Select the default theme

The menu is not working with these kind of links `https://localhost:4303/~/about` and `https://localhost:4303/~/`