### PR TITLE
Fix notification locale when the site is restart

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
@@ -118,6 +118,7 @@ namespace OrchardCore.Localization.Drivers
                     // We always release the tenant for the default culture and also supported cultures to take effect
                     await _shellHost.ReleaseShellContextAsync(_shellSettings);
 
+                    // We create a transient scope with the newly selected culture to create a notification that will use it instead of the previous culture
                     using (CultureScope.Create(section.DefaultCulture))
                     {
                         _notifier.Warning(H["The site has been restarted for the settings to take effect."]);

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
@@ -118,7 +118,10 @@ namespace OrchardCore.Localization.Drivers
                     // We always release the tenant for the default culture and also supported cultures to take effect
                     await _shellHost.ReleaseShellContextAsync(_shellSettings);
 
-                    _notifier.Warning(H["The site has been restarted for the settings to take effect."]);
+                    using (CultureScope.Create(section.DefaultCulture))
+                    {
+                        _notifier.Warning(H["The site has been restarted for the settings to take effect."]);
+                    }
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
@@ -77,7 +77,9 @@ namespace OrchardCore.Settings.Controllers
                 var culture = site.Properties
                     .GetValue("LocalizationSettings")
                     .Value<string>("DefaultCulture");
-                using(CultureScope.Create(culture))
+
+                // We create a transient scope with the newly selected culture to create a notification that will use it instead of the previous culture
+                using (CultureScope.Create(culture))
                 {
                     _notifier.Success(H["Site settings updated successfully."]);
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc.Localization;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Localization;
 using OrchardCore.Settings.ViewModels;
 
 namespace OrchardCore.Settings.Controllers
@@ -73,7 +74,13 @@ namespace OrchardCore.Settings.Controllers
             {
                 await _siteService.UpdateSiteSettingsAsync(site);
 
-                _notifier.Success(H["Site settings updated successfully."]);
+                var culture = site.Properties
+                    .GetValue("LocalizationSettings")
+                    .Value<string>("DefaultCulture");
+                using(CultureScope.Create(culture))
+                {
+                    _notifier.Success(H["Site settings updated successfully."]);
+                }
 
                 return RedirectToAction(nameof(Index), new { groupId });
             }


### PR DESCRIPTION
Fixes #4915

This fixes an old localization bug, especially when the default culture is set, some of the notification are localized with the culture before the new culture is taking a place

As I remembered Seb noted that in a very old Orchard Core Standup and said "This is weird as usual" ;)