### PR TITLE
Fix inline stylesheet rendering

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -581,6 +581,11 @@ namespace OrchardCore.ResourceManagement
 
             foreach (var context in styleSheets)
             {
+                if (context.Settings.Location == ResourceLocation.Inline)
+                {
+                    continue;
+                }
+
                 if (!first)
                 {
                     builder.AppendHtml(System.Environment.NewLine);

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -299,7 +299,10 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 {
                     _resourceManager.RegisterHeadScript(builder);
                 }
-                else
+                else if (At == ResourceLocation.Inline)
+                {
+                    output.Content.SetHtmlContent(builder);
+                } else 
                 {
                     _resourceManager.RegisterFootScript(builder);
                 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -223,11 +223,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     setting.UseCulture(Culture);
                 }
 
-                if (At == ResourceLocation.Inline)
-                {
-                    _resourceManager.RenderLocalStyle(setting, output.Content);
-                }
-                else if (At != ResourceLocation.Unspecified)
+                if (At != ResourceLocation.Unspecified)
                 {
                     setting.AtLocation(At);
                 }
@@ -235,6 +231,11 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 {
                     setting.AtLocation(ResourceLocation.Head);
                 }
+
+                if (At == ResourceLocation.Inline)
+                {
+                    _resourceManager.RenderLocalStyle(setting, output.Content);
+                }                
             }
             else if (String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Src))
             {
@@ -257,7 +258,14 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     builder.Attributes.Add("type", "text/css");
                 }
 
-                _resourceManager.RegisterStyle(builder);
+                if (At == ResourceLocation.Inline)
+                {
+                    output.Content.SetHtmlContent(builder);
+                }
+                else
+                {
+                    _resourceManager.RegisterStyle(builder);
+                }
             }
         }
     }


### PR DESCRIPTION
There was a couple of issues with rendering stylesheets inline from https://github.com/OrchardCMS/OrchardCore/pull/8211

- Didn't work properly through liquid
- Rendered some inline style sheets twice (depending on how they were placed)
- Consistency for `At` supplied for unamed inline styles/scripts