### PR TITLE
Add shortcode resolver to HTMLField

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Fields/ContentFieldsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Fields/ContentFieldsProvider.cs
@@ -45,16 +45,6 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
                 }
             },
             {
-                nameof(HtmlField),
-                new FieldTypeDescriptor
-                {
-                    Description = "Html field",
-                    FieldType = typeof(StringGraphType),
-                    UnderlyingType = typeof(HtmlField),
-                    FieldAccessor = field => field.Content.Html
-                }
-            },
-            {
                 nameof(NumericField),
                 new FieldTypeDescriptor
                 {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Startup.cs
@@ -17,6 +17,7 @@ namespace OrchardCore.ContentFields.GraphQL
             services.AddScoped<IContentFieldProvider, ContentFieldsProvider>();
 
             services.AddObjectGraphType<LinkField, LinkFieldQueryObjectType>();
+            services.AddObjectGraphType<HtmlField, HtmlFieldQueryObjectType>();
             services.AddObjectGraphType<ContentPickerField, ContentPickerFieldQueryObjectType>();
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/HtmlFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/HtmlFieldQueryObjectType.cs
@@ -36,7 +36,6 @@ namespace OrchardCore.ContentFields.GraphQL
             var shortcodeService = serviceProvider.GetRequiredService<IShortcodeService>();
             var contentDefinitionManager = serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
-
             var jObject = ctx.Source.Content as JObject;
             // The JObject.Path is consistent here even when contained in a bag part.
             var jsonPath = jObject.Path;
@@ -65,7 +64,7 @@ namespace OrchardCore.ContentFields.GraphQL
                 html = await liquidTemplateManager.RenderAsync(html, htmlEncoder, model,
                     scope => scope.SetValue("ContentItem", ctx.Source.ContentItem));
             }
-            // TODO: sanitize html missing?? even in htmlbodyqueryobjecttype
+
             return await shortcodeService.ProcessAsync(html,
                 new Context
                 {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/HtmlFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/HtmlFieldQueryObjectType.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using GraphQL.Types;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+using Newtonsoft.Json.Linq;
+using OrchardCore.Apis.GraphQL;
+using OrchardCore.ContentFields.Fields;
+using OrchardCore.ContentFields.Settings;
+using OrchardCore.ContentFields.ViewModels;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.Liquid;
+using OrchardCore.Shortcodes.Services;
+using Shortcodes;
+
+namespace OrchardCore.ContentFields.GraphQL
+{
+    public class HtmlFieldQueryObjectType : ObjectGraphType<HtmlField>
+    {
+        public HtmlFieldQueryObjectType(IStringLocalizer<HtmlFieldQueryObjectType> S)
+        {
+            Name = "HtmlBodyPart";
+            Description = S["Content stored as HTML."];
+
+            Field<StringGraphType>()
+                .Name("html")
+                .Description(S["the HTML content"])
+                .ResolveLockedAsync(RenderHtml);
+        }
+
+        private static async Task<object> RenderHtml(ResolveFieldContext<HtmlField> ctx)
+        {
+            var serviceProvider = ctx.ResolveServiceProvider();
+            var shortcodeService = serviceProvider.GetRequiredService<IShortcodeService>();
+            var contentDefinitionManager = serviceProvider.GetRequiredService<IContentDefinitionManager>();
+
+
+            var jObject = ctx.Source.Content as JObject;
+            // The JObject.Path is consistent here even when contained in a bag part.
+            var jsonPath = jObject.Path;
+            var paths = jsonPath.Split('.');
+            var partName = paths[0];
+            var fieldName = paths[1];
+            var contentTypeDefinition = contentDefinitionManager.GetTypeDefinition(ctx.Source.ContentItem.ContentType);
+            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName));
+            var contentPartFieldDefintion = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName));
+            var settings = contentPartFieldDefintion.GetSettings<HtmlFieldSettings>();
+
+            var html = ctx.Source.Html;
+
+            if (!settings.SanitizeHtml)
+            {
+                var model = new EditHtmlFieldViewModel()
+                {
+                    Html = ctx.Source.Html,
+                    Field = ctx.Source,
+                    Part = ctx.Source.ContentItem.Get<ContentPart>(partName),
+                    PartFieldDefinition = contentPartFieldDefintion
+                };
+                var liquidTemplateManager = serviceProvider.GetRequiredService<ILiquidTemplateManager>();
+                var htmlEncoder = serviceProvider.GetService<HtmlEncoder>();
+
+                html = await liquidTemplateManager.RenderAsync(html, htmlEncoder, model,
+                    scope => scope.SetValue("ContentItem", ctx.Source.ContentItem));
+            }
+            // TODO: sanitize html missing?? even in htmlbodyqueryobjecttype
+            return await shortcodeService.ProcessAsync(html,
+                new Context
+                {
+                    ["ContentItem"] = ctx.Source.ContentItem,
+                    ["PartFieldDefinition"] = contentPartFieldDefintion
+                });
+        }
+    }
+}


### PR DESCRIPTION
Added shortcode resolver to htmlfield, based on htmbody part + inspiration from markdown field.

But @deanmarcussen  I have noticed that htmlbodypart has no branch to process "SanitizeHtml" prop, but markdownpart/field does. Should htmlbodypart/htmlfield also include processing of sanitizehtml? 

Related to #8241