### PR TITLE
Fields: Display name

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.cshtml
@@ -10,7 +10,7 @@
 }
 
 <div class="field field-type-contentpickerfield field-name-@name">
-    <span class="name">@Model.PartFieldDefinition.DisplayName():</span>
+    <span class="name">@Model.PartFieldDefinition.DisplayName()</span>
     @if (contentItems.Any())
     {
         foreach (var contentItem in contentItems)

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.cshtml
@@ -12,7 +12,7 @@
 }
 
 <div class="field field-type-localizationsetpickerfield field-name-@name">
-    <span class="name">@Model.PartFieldDefinition.DisplayName():</span>
+    <span class="name">@Model.PartFieldDefinition.DisplayName()</span>
     @if (contentItems.Any())
     {
         foreach (var contentItem in contentItems)

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField.cshtml
@@ -9,7 +9,7 @@
 @if (Model.Values.Any())
 {
 <div class="field field-type-multitextfield field-name-@name">
-    <span class="name">@Model.PartFieldDefinition.DisplayName()@T[":"]</span>
+    <span class="name">@Model.PartFieldDefinition.DisplayName()</span>
     @foreach (var value in Model.Values)
     {
         <span class="value">@value</span>if (value != Model.Values.Last()){@T[", "]}

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField-UserNames.Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField-UserNames.Display.cshtml
@@ -6,7 +6,7 @@
 }
 
 <div class="field field-type-userpickerfield field-name-@name">
-    <span class="name">@Model.PartFieldDefinition.DisplayName():</span>
+    <span class="name">@Model.PartFieldDefinition.DisplayName()</span>
     @if (Model.UserNames.Any())
     {
         foreach (var userName in Model.UserNames)

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField.cshtml
@@ -7,7 +7,7 @@
 }
 
 <div class="field field-type-userpickerfield field-name-@name">
-    <span class="name">@Model.PartFieldDefinition.DisplayName():</span>
+    <span class="name">@Model.PartFieldDefinition.DisplayName()</span>
     @if (users.Any())
     {
         foreach (var user in users)

--- a/src/docs/reference/modules/ContentFields/README.md
+++ b/src/docs/reference/modules/ContentFields/README.md
@@ -214,7 +214,7 @@ When adding the field to a content type, use the settings to specify whether to
     }
 
     <div class="field field-type-userpickerfield field-name-@name">
-        <span class="name">@Model.PartFieldDefinition.DisplayName():</span>
+        <span class="name">@Model.PartFieldDefinition.DisplayName()</span>
         @if (users.Any())
         {
             foreach (var user in users)


### PR DESCRIPTION
Same behaviour for all the fields: No `:` after the display name as it depends of the culture direction.