### PR TITLE
Cors module - add missing ResourceManagement reference

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Cors/OrchardCore.Cors.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Cors/OrchardCore.Cors.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Users.Core\OrchardCore.Users.Core.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #8288

Add a missing reference to OrchardCore.ResourceManagement.