### PR TITLE
Fixes autoroute trailing slash

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.Autoroute.Services
         {
             await EnsureInitializedAsync();
 
-            if (_contentItemIds.TryGetValue(path, out var entry))
+            if (_contentItemIds.TryGetValue(path.TrimEnd('/'), out var entry))
             {
                 return (true, entry);
             }


### PR DESCRIPTION
`PathBase` traps, it fails if you init it with a value without leading `/` but can have a trailing `/`.