### PR TITLE
Default admin settings

### DIFF
--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/Models/AdminSettings.cs
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/Models/AdminSettings.cs
@@ -2,7 +2,7 @@ namespace OrchardCore.Admin.Models
 {
     public class AdminSettings
     {
-        public bool DisplayDarkMode { get; set; }
+        public bool DisplayDarkMode { get; set; } = true;
 
         public bool DisplayMenuFilter { get; set; }
 

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/Models/AdminSettings.cs
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/Models/AdminSettings.cs
@@ -4,9 +4,9 @@ namespace OrchardCore.Admin.Models
     {
         public bool DisplayDarkMode { get; set; } = true;
 
-        public bool DisplayMenuFilter { get; set; } = true;
+        public bool DisplayMenuFilter { get; set; }
 
-        public bool DisplayNewMenu { get; set; } = true;
+        public bool DisplayNewMenu { get; set; }
 
         public bool DisplayTitlesInTopbar { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/Models/AdminSettings.cs
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/Models/AdminSettings.cs
@@ -2,7 +2,7 @@ namespace OrchardCore.Admin.Models
 {
     public class AdminSettings
     {
-        public bool DisplayDarkMode { get; set; } = true;
+        public bool DisplayDarkMode { get; set; }
 
         public bool DisplayMenuFilter { get; set; }
 


### PR DESCRIPTION
Do not enable `DisplayDarkMode`, `DisplayMenuFilter `and `DisplayNewMenu `admin settings by default.