### PR TITLE
Move Autoroute RemovePart to content handler

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Autoroute.Models;
-using OrchardCore.Autoroute.Services;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Routing;
@@ -93,7 +92,8 @@ namespace OrchardCore.ContentManagement.Records
                 {
                     context.ContentItem.Remove<AutoroutePart>();
                     _partRemoved.Add(context.ContentItem);
-                    // When the part has been removed enlist an update for after the session has been commited.
+
+                    // When the part has been removed enlist an update for after the session has been committed.
                     var autorouteEntries = _serviceProvider.GetRequiredService<IAutorouteEntries>();
                     await autorouteEntries.UpdateEntriesAsync();
                 }
@@ -110,16 +110,16 @@ namespace OrchardCore.ContentManagement.Records
                 .Map(async contentItem =>
                 {
                     var part = contentItem.As<AutoroutePart>();
-                    var partRemoved = _partRemoved.Contains(contentItem);
-                    var contentItemRemoved = _contentItemRemoved.Contains(contentItem);
 
-                    // When the part has been removed form the type definition it will return null here but we still need to process the index.
+                    // When the part has been removed from the type definition it will return null here but we still need to process the index.
+                    var partRemoved = _partRemoved.Contains(contentItem);
                     if (!partRemoved && part == null)
                     {
                         return null;
                     }
 
                     // If the related content item was removed, a record is still added.
+                    var contentItemRemoved = _contentItemRemoved.Contains(contentItem);
                     if (!contentItem.Published && !contentItem.Latest && !contentItemRemoved)
                     {
                         return null;

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
@@ -50,7 +50,8 @@ namespace OrchardCore.ContentManagement.Records
     public class AutoroutePartIndexProvider : ContentHandlerBase, IIndexProvider, IScopedIndexProvider
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly HashSet<ContentItem> _removed = new HashSet<ContentItem>();
+        private readonly HashSet<ContentItem> _contentItemRemoved = new HashSet<ContentItem>();
+        private readonly HashSet<ContentItem> _partRemoved = new HashSet<ContentItem>();
         private IContentManager _contentManager;
         private IContentDefinitionManager _contentDefinitionManager;
 
@@ -67,11 +68,36 @@ namespace OrchardCore.ContentManagement.Records
 
                 if (part != null)
                 {
-                    _removed.Add(context.ContentItem);
+                    _contentItemRemoved.Add(context.ContentItem);
                 }
             }
 
             return Task.CompletedTask;
+        }
+
+        public override async Task UpdatedAsync(UpdateContentContext context)
+        {
+            var part = context.ContentItem.As<AutoroutePart>();
+
+            // Validate that the content definition contains an AutoroutePart.
+            // This prevents indexing parts that have been removed from the type definition, but are still present in the elements.            
+            if (part != null)
+            {
+                // Lazy initialization because of ISession cyclic dependency.
+                _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
+
+                // Search for AutoroutePart.
+                var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
+
+                if (!contentTypeDefinition.Parts.Any(ctpd => ctpd.Name == nameof(AutoroutePart)))
+                {
+                    context.ContentItem.Remove<AutoroutePart>();
+                    _partRemoved.Add(context.ContentItem);
+                    // When the part has been removed enlist an update for after the session has been commited.
+                    var autorouteEntries = _serviceProvider.GetRequiredService<IAutorouteEntries>();
+                    await autorouteEntries.UpdateEntriesAsync();
+                }
+            }
         }
 
         public string CollectionName { get; set; }
@@ -84,39 +110,24 @@ namespace OrchardCore.ContentManagement.Records
                 .Map(async contentItem =>
                 {
                     var part = contentItem.As<AutoroutePart>();
+                    var partRemoved = _partRemoved.Contains(contentItem);
+                    var contentItemRemoved = _contentItemRemoved.Contains(contentItem);
 
-                    if (part == null)
+                    // When the part has been removed form the type definition it will return null here but we still need to process the index.
+                    if (!partRemoved && part == null)
                     {
                         return null;
                     }
 
                     // If the related content item was removed, a record is still added.
-                    if (!contentItem.Published && !contentItem.Latest && !_removed.Contains(contentItem))
+                    if (!contentItem.Published && !contentItem.Latest && !contentItemRemoved)
                     {
                         return null;
                     }
 
-                    if (String.IsNullOrEmpty(part.Path))
+                    if (!partRemoved && String.IsNullOrEmpty(part.Path))
                     {
                         return null;
-                    }
-
-                    // Lazy initialization because of ISession cyclic dependency
-                    _contentDefinitionManager = _contentDefinitionManager ?? _serviceProvider.GetRequiredService<IContentDefinitionManager>();
-
-                    // Search for AutoroutePart
-                    var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentItem.ContentType);
-
-                    // Validate that the content definition contains an AutoroutePart.
-                    // This prevents indexing parts that have been removed from the type definition, but are still present in the elements.
-                    var removedFromTypeDefinition = false;
-                    if (contentTypeDefinition == null || !contentTypeDefinition.Parts.Any(ctpd => ctpd.Name == nameof(AutoroutePart)))
-                    {
-                        // When the part has been removed enlist an update for after the session has been commited.
-                        removedFromTypeDefinition = true;
-                        contentItem.Remove<AutoroutePart>();
-                        var autorouteEntries = _serviceProvider.GetRequiredService<IAutorouteEntries>();
-                        await autorouteEntries.UpdateEntriesAsync();
                     }
 
                     var results = new List<AutoroutePartIndex>
@@ -125,13 +136,13 @@ namespace OrchardCore.ContentManagement.Records
                         new AutoroutePartIndex
                         {
                             ContentItemId = contentItem.ContentItemId,
-                            Path = !part.Disabled && !removedFromTypeDefinition ? part.Path : null,
+                            Path = !partRemoved && !part.Disabled ? part.Path : null,
                             Published = contentItem.Published,
                             Latest = contentItem.Latest
                         }
                     };
 
-                    if (!part.RouteContainedItems || part.Disabled || _removed.Contains(contentItem) || removedFromTypeDefinition)
+                    if (partRemoved || !part.RouteContainedItems || part.Disabled || contentItemRemoved)
                     {
                         return results;
                     }


### PR DESCRIPTION
Follow on from here https://github.com/OrchardCMS/OrchardCore/pull/8204

Moving the removal of an autoroute part (when it is no longer defined on the content type definition) to the contenthandler base and tracking it for the index provider.

Makes the code a little trickier in the index provider bit, as now the `var part = contentItem.As<AutoroutePart>()` maybe null as it has already been removed. But tested and seems good.

Think it is the better place to remove this.

/cc @jtkech 

We should do the same for the localized content index, but it needs a little though on how to track the path = null, as that index doesn't have the same concept I suspect.