### PR TITLE
Add empty ContentPart.Thumbnail shape

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart.Thumbnail.cshtml
@@ -1,0 +1,4 @@
+@* 
+An empty shape for any content types which require a thumbnail shape for their dynamic content parts, such as menu items.
+This can be customized per part by creating custom templates.
+*@


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/4237
Fixes https://github.com/OrchardCMS/OrchardCore/issues/6173

Added in the `Contents` module, as though currently this issue only affects menus, it might one day also affect any module, which uses the thumbnail display type.