### PR TITLE
Admin menus for Twitter are reversed

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenu.cs
@@ -6,12 +6,12 @@ using OrchardCore.Navigation;
 
 namespace OrchardCore.Twitter
 {
-    [Feature(TwitterConstants.Features.Twitter)]
-    public class AdminMenu : INavigationProvider
+    [Feature(TwitterConstants.Features.Signin)]
+    public class AdminMenuSignin : INavigationProvider
     {
         private readonly IStringLocalizer S;
 
-        public AdminMenu(IStringLocalizer<AdminMenu> localizer)
+        public AdminMenuSignin(IStringLocalizer<AdminMenuSignin> localizer)
         {
             S = localizer;
         }
@@ -33,12 +33,12 @@ namespace OrchardCore.Twitter
         }
     }
 
-    [Feature(TwitterConstants.Features.Signin)]
-    public class AdminMenuSignin : INavigationProvider
+    [Feature(TwitterConstants.Features.Twitter)]
+    public class AdminMenu : INavigationProvider
     {
         private readonly IStringLocalizer S;
 
-        public AdminMenuSignin(IStringLocalizer<AdminMenuSignin> localizer)
+        public AdminMenu(IStringLocalizer<AdminMenu> localizer)
         {
             S = localizer;
         }


### PR DESCRIPTION
When activating the Twitter Integration feature, the new menu "Security/Authentication/Twitter" is added and links to OrchardCore.Twitter.Signin. Conversely, activating "Sign in with Twitter" adds the "Configuration/Settings/Twitter" menu, which links to OrchardCore.Twitter. This is backwards. This patch just reverses the activation of the admin menus for the two Twitter features.