### PR TITLE
Remove properties that cannot be exported from site settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/Deployment/SiteSettingsDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Deployment/SiteSettingsDeploymentSource.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Deployment;
@@ -94,8 +95,7 @@ namespace OrchardCore.Settings.Deployment
                         break;
 
                     default:
-                        data.Add(new JProperty(settingName, site.Properties[settingName]));
-                        break;
+                        throw new InvalidOperationException($"Unsupported setting '{settingName}'");
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Items/SiteSettingsDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Items/SiteSettingsDeploymentStep.Fields.Edit.cshtml
@@ -3,6 +3,7 @@
 @using Newtonsoft.Json
 @{
     var settings = Model.Settings;
+    var ignoredPropeties = new HashSet<string> { "Identifier", "Properties" };
 }
 <h5>@T["Site Settings"]</h5>
 
@@ -12,6 +13,11 @@
         @foreach (var setting in typeof(SiteSettings).GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
             if (setting.GetCustomAttributes(false).OfType<JsonIgnoreAttribute>().Any())
+            {
+                continue;
+            }
+
+            if (ignoredPropeties.Contains(setting.Name))
             {
                 continue;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Items/SiteSettingsDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Items/SiteSettingsDeploymentStep.Fields.Edit.cshtml
@@ -3,7 +3,7 @@
 @using Newtonsoft.Json
 @{
     var settings = Model.Settings;
-    var ignoredPropeties = new HashSet<string> { "Identifier", "Properties" };
+    var ignoredProperties = new HashSet<string> { "Identifier", "Properties" };
 }
 <h5>@T["Site Settings"]</h5>
 
@@ -17,7 +17,7 @@
                 continue;
             }
 
-            if (ignoredPropeties.Contains(setting.Name))
+            if (ignoredProperties.Contains(setting.Name))
             {
                 continue;
             }


### PR DESCRIPTION
Removes the `Properties` and `Identifier` value from the site settings export screen.

All properties should be exported through a seperate step.

If we're missing any steps the registration is simple for the step (no views or anything, we have a shared helper for them now).


/cc @Skrypt 