### PR TITLE
Remove duplicate registration for user picker field index

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
@@ -193,7 +193,6 @@ namespace OrchardCore.ContentFields
             services.AddScoped<IScopedIndexProvider, TimeFieldIndexProvider>();
             services.AddScoped<IScopedIndexProvider, LinkFieldIndexProvider>();
             services.AddScoped<IScopedIndexProvider, HtmlFieldIndexProvider>();
-            services.AddScoped<IScopedIndexProvider, UserPickerFieldIndexProvider>();
             services.AddScoped<IScopedIndexProvider, MultiTextFieldIndexProvider>();
         }
     }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/8394

It was registered twice @Skrypt 

There's another startup which depends on Users