### PR TITLE
Fix Do not display setup recipes in admin

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -63,7 +63,7 @@ namespace OrchardCore.Recipes.Controllers
             var recipes = recipeCollections.SelectMany(x => x);
 
             // Do not display the setup recipes and the ones whith the hidden tag
-            recipes = recipes.Where(r => r.IsSetupRecipe = false && !r.Tags.Contains("hidden", StringComparer.InvariantCultureIgnoreCase));
+            recipes = recipes.Where(r => r.IsSetupRecipe == false && !r.Tags.Contains("hidden", StringComparer.InvariantCultureIgnoreCase));
 
             var features = _extensionManager.GetFeatures();
 


### PR DESCRIPTION
Typo in this line means assignment is used rather than equality.

( r.IsSetupRecipe = false)

Always equates to false.

So after this recipe list is always empty,