### PR TITLE
Added alternate to alias part

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Alias.Models;
@@ -29,8 +31,8 @@ namespace OrchardCore.Alias.Drivers
 
         public override IDisplayResult Display(AliasPart part, BuildPartDisplayContext context)
         {
-            var contentType = part.ContentItem.ContentType;
-            var alias = part.Alias;
+            var contentType = EncodeAlternateElement(part.ContentItem.ContentType);
+            var alias = FormatName(part.Alias);
             context.Shape.Metadata.Alternates.Add($"Content__{contentType}__{alias}");
             return base.Display(part, context);
         }
@@ -60,5 +62,44 @@ namespace OrchardCore.Alias.Drivers
             model.Settings = settings;
         }
 
+        private string EncodeAlternateElement(string alternateElement)
+        {
+            return alternateElement.Replace("-", "__").Replace('.', '_');
+        }
+
+        private static string FormatName(string name)
+        {
+            if (String.IsNullOrEmpty(name))
+            {
+                return null;
+            }
+
+            name = name.Trim();
+            var nextIsUpper = true;
+            var result = new StringBuilder(name.Length);
+            for (var i = 0; i < name.Length; i++)
+            {
+                var c = name[i];
+
+                if (c == '-' || char.IsWhiteSpace(c))
+                {
+                    nextIsUpper = true;
+                    continue;
+                }
+
+                if (nextIsUpper)
+                {
+                    result.Append(c.ToString().ToUpper());
+                }
+                else
+                {
+                    result.Append(c);
+                }
+
+                nextIsUpper = false;
+            }
+
+            return result.ToString();
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
@@ -29,7 +29,9 @@ namespace OrchardCore.Alias.Drivers
 
         public override IDisplayResult Display(AliasPart part, BuildPartDisplayContext context)
         {
-            context.Shape.Metadata.Alternates.Add($"Content__{part.ContentItem.ContentType}__{part.Alias}");
+            var contentType = part.ContentItem.ContentType;
+            var alias = part.Alias;
+            context.Shape.Metadata.Alternates.Add($"Content__{contentType}__{alias}");
             return base.Display(part, context);
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
@@ -27,6 +27,12 @@ namespace OrchardCore.Alias.Drivers
             S = localizer;
         }
 
+        public override IDisplayResult Display(AliasPart part, BuildPartDisplayContext context)
+        {
+            context.Shape.Metadata.Alternates.Add($"Content__{part.ContentItem.ContentType}__{part.Alias}");
+            return base.Display(part, context);
+        }
+
         public override IDisplayResult Edit(AliasPart aliasPart, BuildPartEditorContext context)
         {
             return Initialize<AliasPartViewModel>(GetEditorShapeType(context), m => BuildViewModel(m, aliasPart, context.TypePartDefinition.GetSettings<AliasPartSettings>()));


### PR DESCRIPTION
Fixes #2866. When an alias part is displayed, an alternate is added in the format "Content__[ContentType]__[Alias]". For example, a `Page` content item with an alias of `home-page` will get an alternate of `Content_Page_home-page`.