### PR TITLE
Fix Roles Deployment Startup

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Roles/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Startup.cs
@@ -45,11 +45,6 @@ namespace OrchardCore.Roles
             services.AddScoped<IAuthorizationHandler, RolesPermissionsHandler>();
             services.AddScoped<INavigationProvider, AdminMenu>();
             services.AddScoped<IPermissionProvider, Permissions>();
-
-            // Deployment
-            services.AddTransient<IDeploymentSource, AllRolesDeploymentSource>();
-            services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<AllRolesDeploymentStep>());
-            services.AddScoped<IDisplayDriver<DeploymentStep>, AllRolesDeploymentStepDriver>();
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -82,4 +77,15 @@ namespace OrchardCore.Roles
             );
         }
     }
+
+    [RequireFeatures("OrchardCore.Deployment")]
+    public class DeploymentStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddTransient<IDeploymentSource, AllRolesDeploymentSource>();
+            services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<AllRolesDeploymentStep>());
+            services.AddScoped<IDisplayDriver<DeploymentStep>, AllRolesDeploymentStepDriver>();
+        }
+    }    
 }


### PR DESCRIPTION
Noticed while working on something else.

Deployments should be registered in their own startup, as it's an optional feature.