### PR TITLE
Add shortcode name validation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -36,8 +36,6 @@ namespace OrchardCore.Shortcodes.Controllers
         private readonly IHtmlLocalizer H;
         private readonly dynamic New;
 
-        private const string NameValidationRegex = "^[a-zA-Z$_][a-zA-Z0-9$_]*$";
-
         public AdminController(
             IAuthorizationService authorizationService,
             ShortcodeTemplatesManager shortcodeTemplatesManager,

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -234,6 +234,11 @@ namespace OrchardCore.Shortcodes.Controllers
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name contains invalid characters."]);
                 }
+                else if (!String.Equals(model.Name, sourceName, StringComparison.OrdinalIgnoreCase)
+                    && shortcodeTemplatesDocument.ShortcodeTemplates.ContainsKey(model.Name))
+                {
+                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["A template with the same name already exists."]);
+                }
 
                 if (String.IsNullOrEmpty(model.Content))
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -20,6 +20,7 @@ using OrchardCore.Settings;
 using OrchardCore.Shortcodes.Models;
 using OrchardCore.Shortcodes.Services;
 using OrchardCore.Shortcodes.ViewModels;
+using Parlot;
 
 namespace OrchardCore.Shortcodes.Controllers
 {
@@ -131,7 +132,7 @@ namespace OrchardCore.Shortcodes.Controllers
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name is mandatory."]);
                 }
-                else if (!Regex.IsMatch(model.Name, NameValidationRegex))
+                else if (!IsValidShortcodeName(model.Name))
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name contains invalid characters."]);
                 }
@@ -232,7 +233,7 @@ namespace OrchardCore.Shortcodes.Controllers
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name is mandatory."]);
                 }
-                else if (!Regex.IsMatch(model.Name, NameValidationRegex))
+                else if (!IsValidShortcodeName(model.Name))
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name contains invalid characters."]);
                 }
@@ -333,6 +334,14 @@ namespace OrchardCore.Shortcodes.Controllers
             }
 
             return RedirectToAction("Index");
+        }
+
+        private static bool IsValidShortcodeName(string name)
+        {
+            var scanner = new Scanner(name);
+            var result = new TokenResult();
+            scanner.ReadIdentifier(result);
+            return result.Success && name.Length == result.Length;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -265,7 +265,11 @@ namespace OrchardCore.Shortcodes.Controllers
 
                 await _shortcodeTemplatesManager.UpdateShortcodeTemplateAsync(model.Name, template);
 
-                if (submit != "SaveAndContinue")
+                if (submit == "SaveAndContinue")
+                {
+                    return RedirectToAction(nameof(Edit), new { name = model.Name });
+                }
+                else
                 {
                     return RedirectToAction(nameof(Index));
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -13,7 +14,6 @@ using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.Liquid;
 using OrchardCore.Modules;
-using OrchardCore.Mvc.Utilities;
 using OrchardCore.Navigation;
 using OrchardCore.Routing;
 using OrchardCore.Settings;
@@ -34,6 +34,8 @@ namespace OrchardCore.Shortcodes.Controllers
         private readonly IStringLocalizer S;
         private readonly IHtmlLocalizer H;
         private readonly dynamic New;
+
+        private const string NameValidationRegex = "[a-zA-Z$_][a-zA-Z0-9$_]*";
 
         public AdminController(
             IAuthorizationService authorizationService,
@@ -69,7 +71,7 @@ namespace OrchardCore.Shortcodes.Controllers
 
             var shortcodeTemplates = shortcodeTemplatesDocument.ShortcodeTemplates.ToList();
 
-            if (!string.IsNullOrWhiteSpace(options.Search))
+            if (!String.IsNullOrWhiteSpace(options.Search))
             {
                 shortcodeTemplates = shortcodeTemplates.Where(x => x.Key.Contains(options.Search, StringComparison.OrdinalIgnoreCase)).ToList();
             }
@@ -129,7 +131,7 @@ namespace OrchardCore.Shortcodes.Controllers
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name is mandatory."]);
                 }
-                else if (!String.Equals(model.Name, model.Name.ToSafeName(), StringComparison.OrdinalIgnoreCase))
+                else if (!Regex.IsMatch(model.Name, NameValidationRegex))
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name contains invalid characters."]);
                 }
@@ -149,7 +151,7 @@ namespace OrchardCore.Shortcodes.Controllers
                 }
                 else if (!_liquidTemplateManager.Validate(model.Content, out var errors))
                 {
-                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template doesn't contain a valid Liquid expression. Details: {0}", String.Join(" ", errors)]);
                 }
             }
 
@@ -230,7 +232,7 @@ namespace OrchardCore.Shortcodes.Controllers
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name is mandatory."]);
                 }
-                else if (!String.Equals(model.Name, model.Name.ToSafeName(), StringComparison.OrdinalIgnoreCase))
+                else if (!Regex.IsMatch(model.Name, NameValidationRegex))
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name contains invalid characters."]);
                 }
@@ -246,7 +248,7 @@ namespace OrchardCore.Shortcodes.Controllers
                 }
                 else if (!_liquidTemplateManager.Validate(model.Content, out var errors))
                 {
-                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template doesn't contain a valid Liquid expression. Details: {0}", String.Join(" ", errors)]);
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.Shortcodes.Controllers
         private readonly IHtmlLocalizer H;
         private readonly dynamic New;
 
-        private const string NameValidationRegex = "[a-zA-Z$_][a-zA-Z0-9$_]*";
+        private const string NameValidationRegex = "^[a-zA-Z$_][a-zA-Z0-9$_]*$";
 
         public AdminController(
             IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -13,6 +13,7 @@ using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.Liquid;
 using OrchardCore.Modules;
+using OrchardCore.Mvc.Utilities;
 using OrchardCore.Navigation;
 using OrchardCore.Routing;
 using OrchardCore.Settings;
@@ -128,13 +129,9 @@ namespace OrchardCore.Shortcodes.Controllers
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name is mandatory."]);
                 }
-                else if (String.IsNullOrEmpty(model.Content))
+                else if (!String.Equals(model.Name, model.Name.ToSafeName(), StringComparison.OrdinalIgnoreCase))
                 {
-                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template content is mandatory."]);
-                }
-                else if (!_liquidTemplateManager.Validate(model.Content, out var errors))
-                {
-                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
+                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name contains invalid characters."]);
                 }
                 else
                 {
@@ -144,6 +141,15 @@ namespace OrchardCore.Shortcodes.Controllers
                     {
                         ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["A template with the same name already exists."]);
                     }
+                }
+
+                if (String.IsNullOrEmpty(model.Content))
+                {
+                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template content is mandatory."]);
+                }
+                else if (!_liquidTemplateManager.Validate(model.Content, out var errors))
+                {
+                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template doesn't contain a valid Liquid expression. Details: {0}", string.Join(" ", errors)]);
                 }
             }
 
@@ -224,7 +230,12 @@ namespace OrchardCore.Shortcodes.Controllers
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name is mandatory."]);
                 }
-                else if (String.IsNullOrEmpty(model.Content))
+                else if (!String.Equals(model.Name, model.Name.ToSafeName(), StringComparison.OrdinalIgnoreCase))
+                {
+                    ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Name), S["The name contains invalid characters."]);
+                }
+
+                if (String.IsNullOrEmpty(model.Content))
                 {
                     ModelState.AddModelError(nameof(ShortcodeTemplateViewModel.Content), S["The template content is mandatory."]);
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Create.cshtml
@@ -105,6 +105,7 @@
             <div class="form-group" asp-validation-class-for="Content">
                 <label asp-for="Content">@T["Content"]</label>
                 <textarea asp-for="Content" rows="10" class="form-control"></textarea>
+                <span asp-validation-for="Content"></span>
                 <span class="hint">@T["The Shortcode Liquid template."]</span>
             </div>
         </div>

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Edit.cshtml
@@ -114,6 +114,7 @@
             <div class="form-group" asp-validation-class-for="Content">
                 <label asp-for="Content">@T["Content"]</label>
                 <textarea asp-for="Content" rows="10" class="form-control"></textarea>
+                <span asp-validation-for="Content"></span>
                 <span class="hint">@T["The Liquid template."]</span>
             </div>
         </div>    


### PR DESCRIPTION
Fixes #8399 by validating that a shortcode name is correct.

Also:
- Changed the order and grouping of validation so that name and content are both validated at the same time. Before it would only validate the template content if the name was valid.
- Added inline validation message for template content to create and edit view
- Prevent rename from deleting existing short codes (if you try to rename to an existing shortcode name)
- Always redirect on successful edit