### PR TITLE
Fixes #8442 Taxonomy content list filter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -19,6 +19,8 @@ namespace OrchardCore.Taxonomies.Indexing
         public string ContentPart { get; set; }
         public string ContentField { get; set; }
         public string TermContentItemId { get; set; }
+        public bool Published { get; set; }
+        public bool Latest { get; set; }
     }
 
     public class TaxonomyIndexProvider : IndexProvider<ContentItem>, IScopedIndexProvider
@@ -37,7 +39,7 @@ namespace OrchardCore.Taxonomies.Indexing
             context.For<TaxonomyIndex>()
                 .Map(contentItem =>
                 {
-                    if (!contentItem.IsPublished())
+                    if (!contentItem.Published && !contentItem.Latest)
                     {
                         return null;
                     }
@@ -103,6 +105,8 @@ namespace OrchardCore.Taxonomies.Indexing
                                 ContentPart = fieldDefinition.PartDefinition.Name,
                                 ContentField = fieldDefinition.Name,
                                 TermContentItemId = termContentItemId,
+                                Published = contentItem.Published,
+                                Latest = contentItem.Latest
                             });
                         }
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Migrations.cs
@@ -49,6 +49,8 @@ namespace OrchardCore.Taxonomies
                 .Column<string>("ContentPart", column => column.WithLength(ContentItemIndex.MaxContentPartSize))
                 .Column<string>("ContentField", column => column.WithLength(ContentItemIndex.MaxContentFieldSize))
                 .Column<string>("TermContentItemId", column => column.WithLength(26))
+                .Column<bool>("Published", c => c.WithDefault(true))
+                .Column<bool>("Latest", c => c.WithDefault(false))
             );
 
             SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
@@ -56,7 +58,9 @@ namespace OrchardCore.Taxonomies
                 "DocumentId",
                 "TaxonomyContentItemId",
                 "ContentItemId",
-                "TermContentItemId")
+                "TermContentItemId",
+                "Published",
+                "Latest")
             );
 
             SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
@@ -64,11 +68,13 @@ namespace OrchardCore.Taxonomies
                 "DocumentId",
                 "ContentType",
                 "ContentPart",
-                "ContentField")
+                "ContentField",
+                "Published",
+                "Latest")
             );
 
             // Shortcut other migration steps on new content definition schemas.
-            return 4;
+            return 5;
         }
 
         // Migrate FieldSettings. This only needs to run on old content definition schemas.
@@ -99,13 +105,24 @@ namespace OrchardCore.Taxonomies
         // This code can be removed in a later version.
         public int UpdateFrom3()
         {
+            // This step has been updated to also add these new columns.
+            SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
+                .AddColumn<bool>("Published", c => c.WithDefault(true))
+            );
 
+            SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
+                .AddColumn<bool>("Latest", c => c.WithDefault(false))
+            );
+
+            // So that the new indexes can be fully created.
             SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
                 .CreateIndex("IDX_TaxonomyIndex_DocumentId",
                 "DocumentId",
                 "TaxonomyContentItemId",
                 "ContentItemId",
-                "TermContentItemId")
+                "TermContentItemId",
+                "Published",
+                "Latest")
             );
 
             SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
@@ -113,10 +130,37 @@ namespace OrchardCore.Taxonomies
                 "DocumentId",
                 "ContentType",
                 "ContentPart",
-                "ContentField")
+                "ContentField",
+                "Published",
+                "Latest")
             );
 
-            return 4;
+            // We then shortcut the next migration step.
+            return 5;
+        }
+
+        // This code can be removed in a later version.
+        public int UpdateFrom4()
+        {
+            // This step run only if the previous one was executed before
+            // it was updated, so here we also add the following columns.
+            SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
+                .AddColumn<bool>("Published", c => c.WithDefault(true))
+            );
+
+            SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
+                .AddColumn<bool>("Latest", c => c.WithDefault(false))
+            );
+
+            // But we create a separate index for these new columns.
+            SchemaBuilder.AlterIndexTable<TaxonomyIndex>(table => table
+                .CreateIndex("IDX_TaxonomyIndex_DocumentId_Published",
+                "DocumentId",
+                "Published",
+                "Latest")
+            );
+
+            return 5;
         }
     }
 


### PR DESCRIPTION
Fixes #8442 

I also added the `Published` and `Latest` as you asked @deanmarcussen, no luck as we just merged #8245 ;)

So what i did is that on a new installation the 2 new indexes are fully created, also on the migration step 3 that we added in #8245 and that i updated to also include these 2 new columns and then to fully create the 2 new indexes.

But in case this step 3 was already executed by some people before it was updated, i added a new step 4 (now skipped by step 3) to also include these 2 new columns but to only create a separate index including them, better than nothing.

I think i will merge it soon to prevent too many people from executing the migation step 3 without the fully created indexes.