### PR TITLE
Bring back database integration testing

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -18,6 +18,21 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     name: Build & Test
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: admin
+          POSTGRES_DB: app
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ORCHARD_TEST_POSTGRESQL_CONNECTION_STRING: "User ID=postgres;Password=admin;Host=postgres;Port=5432;Database=app;"
     steps:
     - uses: actions/checkout@v2
     - name: Setup .NET Core 3.1 on ${{ matrix.os }}

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     name: Build & Test
     services:
       postgres:

--- a/test/OrchardCore.Tests/Apis/Recipes/AgencyRecipeTests.cs
+++ b/test/OrchardCore.Tests/Apis/Recipes/AgencyRecipeTests.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using OrchardCore.Tests.Apis.Context;
+using OrchardCore.Tests.Apis.Context.Attributes;
+using Xunit;
+
+namespace OrchardCore.Tests.Apis.Recipes
+{
+    public class AgencyRecipeTests
+    {
+        [Theory]
+        [SqliteData]
+        [SqlServerData]
+        [MySqlData]
+        [PostgreSqlData]
+        public async Task ShouldCreateAgency(string databaseProvider, string connectionString)
+        {
+            using var context = new AgencyContext()
+                .WithDatabaseProvider(databaseProvider)
+                .WithConnectionString(connectionString);
+
+            // Act
+            await context.InitializeAsync();
+
+            var result = await context.Client.GetAsync("/");
+            Assert.True(result.IsSuccessStatusCode);
+        }
+    }
+}


### PR DESCRIPTION
An experiment to see if we can't have a bit of database testing that runs all the time, instead of manually - when nuget containers aren't broken ;) 

The experiment is to see how much time it will actually take on the CI hours and if it works!