### PR TITLE
Content list search does not submit on Safari, iOS or PadOS browsers

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList.cshtml
@@ -3,8 +3,8 @@
 <script asp-name="bootstrap-select" depends-on="admin" at="Foot"></script>
 
 <!-- Hidden submit button do not remove -->
-<input type="submit" name="submit.Filter" id="submitFilter" class="d-none" />
-<input type="submit" name="submit.BulkAction" class="d-none" />
+<input type="submit" name="submit.Filter" id="submitFilter" class="sr-only" />
+<input type="submit" name="submit.BulkAction" class="sr-only" />
 @Html.HiddenFor(o => o.Options.BulkAction)
 
 <div class="card mb-3 position-sticky action-bar">

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListSearch.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListSearch.cshtml
@@ -12,5 +12,5 @@
     </div>
     <label asp-for="DisplayText" class="sr-only">@T["Search"]</label>
     <i class="fa fa-search form-control-feedback"></i>
-    <input asp-for="DisplayText" class="form-control" placeholder="@T["Search"]" inputmode="search" autocomplete="off" type="search" autofocus />
+    <input asp-for="DisplayText" class="form-control" placeholder="@T["Search"]" inputmode="search" type="search" autofocus />
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListSearch.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListSearch.cshtml
@@ -10,6 +10,7 @@
             <a class="dropdown-item" href="?Options.ContentsStatus=Owner">@T["Owned by me"]</a>
         </div>
     </div>
+    <label asp-for="DisplayText" class="sr-only">@T["Search"]</label>
     <i class="fa fa-search form-control-feedback"></i>
-    <input asp-for="DisplayText" class="form-control" placeholder="@T["Search"]" type="search" autofocus />
+    <input asp-for="DisplayText" class="form-control" placeholder="@T["Search"]" inputmode="search" autocomplete="off" type="search" autofocus />
 </div>


### PR DESCRIPTION
Fixes #8505 

Safari, iOS or PadOS browsers requires a submit input that does not have `display: none` applied. There are two submit inputs in the forms already with `display: none` applied via a `d-none` class. Solution is to use the `sr-only` which hides the submit buttons without using `display: none`. This might be better for accessibility too but not sure since there is two submit buttons. I think submit.Filter input is used by the text field technically so could probably get away with just applying the `sr-only` class to it - I will await feedback.

As part of this also made two extra enhancements:
 
1. added a label with `sr-only` to the search field for accessibility.
2. added the search input mode for better keyboard experience on devices.