### PR TITLE
Fix WorkflowBlockingActivitiesIndex table indices name length for PostgreSQL

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextFieldIndex_DocumentId",
+                .CreateIndex("IDX_TextField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -34,7 +34,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_TextField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -44,7 +44,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextFieldIndex_DocumentId_Text",
+                .CreateIndex("IDX_TextField_DocumentId_Text",
                     "DocumentId",
                     "Text",
                     "Published",
@@ -63,7 +63,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
-                .CreateIndex("IDX_BooleanFieldIndex_DocumentId",
+                .CreateIndex("IDX_BooleanField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -72,7 +72,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
-                .CreateIndex("IDX_BooleanFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_BooleanField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -94,7 +94,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericFieldIndex_DocumentId",
+                .CreateIndex("IDX_NumericField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -103,7 +103,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_NumericField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -113,7 +113,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericFieldIndex_DocumentId_Numeric",
+                .CreateIndex("IDX_NumericField_DocumentId_Numeric",
                     "DocumentId",
                     "Numeric",
                     "Published",
@@ -132,7 +132,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId",
+                .CreateIndex("IDX_DateTimeField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -141,7 +141,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_DateTimeField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -151,7 +151,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_DateTime",
+                .CreateIndex("IDX_DateTimeField_DocumentId_DateTime",
                     "DocumentId",
                     "DateTime",
                     "Published",
@@ -170,7 +170,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateFieldIndex_DocumentId",
+                .CreateIndex("IDX_DateField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -179,7 +179,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_DateField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -189,7 +189,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateFieldIndex_DocumentId_Date",
+                .CreateIndex("IDX_DateField_DocumentId_Date",
                     "DocumentId",
                     "ContentType",
                     "Date",
@@ -209,7 +209,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId",
+                .CreateIndex("IDX_CPickerField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -218,7 +218,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_CPickerField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -228,7 +228,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_SelectedContentItemId",
+                .CreateIndex("IDX_CPickerField_DocumentId_SelectedContentItemId",
                     "DocumentId",
                     "SelectedContentItemId",
                     "Published",
@@ -247,7 +247,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeFieldIndex_DocumentId",
+                .CreateIndex("IDX_TimeField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -256,7 +256,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_TimeField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -266,7 +266,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeFieldIndex_DocumentId_Time",
+                .CreateIndex("IDX_TimeField_DocumentId_Time",
                     "DocumentId",
                     "Time",
                     "Published",
@@ -292,7 +292,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkFieldIndex_DocumentId",
+                .CreateIndex("IDX_LinkField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -301,7 +301,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_LinkField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -311,7 +311,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkFieldIndex_DocumentId_Url",
+                .CreateIndex("IDX_LinkField_DocumentId_Url",
                     "DocumentId",
                     "Url",
                     "Published",
@@ -319,7 +319,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkFieldIndex_DocumentId_Text",
+                .CreateIndex("IDX_LinkField_DocumentId_Text",
                     "DocumentId",
                     "Text",
                     "Published",
@@ -338,7 +338,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
-                .CreateIndex("IDX_HtmlFieldIndex_DocumentId",
+                .CreateIndex("IDX_HtmlField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -347,7 +347,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
-                .CreateIndex("IDX_HtmlFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_HtmlField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -369,7 +369,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId",
+                .CreateIndex("IDX_MultiTextField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -378,7 +378,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_MultiTextField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -388,7 +388,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_Value",
+                .CreateIndex("IDX_MultiTextField_DocumentId_Value",
                     "DocumentId",
                     "Value",
                     "Published",
@@ -433,7 +433,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
         public int UpdateFrom3()
         {
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextFieldIndex_DocumentId",
+                .CreateIndex("IDX_TextField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -442,7 +442,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_TextField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -453,7 +453,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 
             // Can't be created on existing databases where the 'Text' may be of 768 chars.
             //SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-            //    .CreateIndex("IDX_TextFieldIndex_DocumentId_Text",
+            //    .CreateIndex("IDX_TextField_DocumentId_Text",
             //        "DocumentId",
             //        "Text",
             //        "Published",
@@ -461,7 +461,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             //);
 
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
-                .CreateIndex("IDX_BooleanFieldIndex_DocumentId",
+                .CreateIndex("IDX_BooleanField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -470,7 +470,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
-                .CreateIndex("IDX_BooleanFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_BooleanField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -481,7 +481,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericFieldIndex_DocumentId",
+                .CreateIndex("IDX_NumericField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -490,7 +490,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_NumericField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -500,7 +500,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericFieldIndex_DocumentId_Numeric",
+                .CreateIndex("IDX_NumericField_DocumentId_Numeric",
                     "DocumentId",
                     "Numeric",
                     "Published",
@@ -508,7 +508,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId",
+                .CreateIndex("IDX_DateTimeField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -517,7 +517,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_DateTimeField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -527,7 +527,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_DateTime",
+                .CreateIndex("IDX_DateTimeField_DocumentId_DateTime",
                     "DocumentId",
                     "DateTime",
                     "Published",
@@ -535,7 +535,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateFieldIndex_DocumentId",
+                .CreateIndex("IDX_DateField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -544,7 +544,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_DateField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -554,7 +554,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateFieldIndex_DocumentId_Date",
+                .CreateIndex("IDX_DateField_DocumentId_Date",
                     "DocumentId",
                     "Date",
                     "Published",
@@ -562,7 +562,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId",
+                .CreateIndex("IDX_CPickerField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -571,7 +571,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_CPickerField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -581,7 +581,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_SelectedContentItemId",
+                .CreateIndex("IDX_CPickerField_DocumentId_SelectedContentItemId",
                     "DocumentId",
                     "SelectedContentItemId",
                     "Published",
@@ -589,7 +589,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeFieldIndex_DocumentId",
+                .CreateIndex("IDX_TimeField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -598,7 +598,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_TimeField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -608,7 +608,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeFieldIndex_DocumentId_Time",
+                .CreateIndex("IDX_TimeField_DocumentId_Time",
                     "DocumentId",
                     "Time",
                     "Published",
@@ -616,7 +616,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkFieldIndex_DocumentId",
+                .CreateIndex("IDX_LinkField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -625,7 +625,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_LinkField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -636,7 +636,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 
             // Can't be created on existing databases where the 'Url' may be of 768 chars.
             //SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-            //    .CreateIndex("IDX_LinkFieldIndex_DocumentId_Url",
+            //    .CreateIndex("IDX_LinkField_DocumentId_Url",
             //        "DocumentId",
             //        "Url",
             //        "Published",
@@ -645,7 +645,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 
             // Can't be created on existing databases where the 'Text' may be of 768 chars.
             //SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-            //    .CreateIndex("IDX_LinkFieldIndex_DocumentId_Text",
+            //    .CreateIndex("IDX_LinkField_DocumentId_Text",
             //        "DocumentId",
             //        "Text",
             //        "Published",
@@ -653,7 +653,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             //);
 
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
-                .CreateIndex("IDX_HtmlFieldIndex_DocumentId",
+                .CreateIndex("IDX_HtmlField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -662,7 +662,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
-                .CreateIndex("IDX_HtmlFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_HtmlField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -672,7 +672,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId",
+                .CreateIndex("IDX_MultiTextField_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -681,7 +681,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_ContentType",
+                .CreateIndex("IDX_MultiTextField_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -691,7 +691,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_Value",
+                .CreateIndex("IDX_MultiTextField_DocumentId_Value",
                     "DocumentId",
                     "Value",
                     "Published",

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextField_DocumentId",
+                .CreateIndex("IDX_TextFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -34,7 +34,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextField_DocumentId_ContentType",
+                .CreateIndex("IDX_TextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -44,7 +44,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextField_DocumentId_Text",
+                .CreateIndex("IDX_TextFieldIndex_DocumentId_Text",
                     "DocumentId",
                     "Text",
                     "Published",
@@ -63,7 +63,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
-                .CreateIndex("IDX_BooleanField_DocumentId",
+                .CreateIndex("IDX_BooleanFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -72,7 +72,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
-                .CreateIndex("IDX_BooleanField_DocumentId_ContentType",
+                .CreateIndex("IDX_BooleanFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -94,7 +94,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericField_DocumentId",
+                .CreateIndex("IDX_NumericFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -103,7 +103,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericField_DocumentId_ContentType",
+                .CreateIndex("IDX_NumericFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -113,7 +113,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericField_DocumentId_Numeric",
+                .CreateIndex("IDX_NumericFieldIndex_DocumentId_Numeric",
                     "DocumentId",
                     "Numeric",
                     "Published",
@@ -132,7 +132,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeField_DocumentId",
+                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -141,7 +141,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeField_DocumentId_ContentType",
+                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -151,7 +151,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeField_DocumentId_DateTime",
+                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_DateTime",
                     "DocumentId",
                     "DateTime",
                     "Published",
@@ -170,7 +170,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateField_DocumentId",
+                .CreateIndex("IDX_DateFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -179,7 +179,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateField_DocumentId_ContentType",
+                .CreateIndex("IDX_DateFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -189,7 +189,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateField_DocumentId_Date",
+                .CreateIndex("IDX_DateFieldIndex_DocumentId_Date",
                     "DocumentId",
                     "ContentType",
                     "Date",
@@ -209,7 +209,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_CPickerField_DocumentId",
+                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -218,7 +218,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_CPickerField_DocumentId_ContentType",
+                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -228,7 +228,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_CPickerField_DocumentId_SelectedContentItemId",
+                .CreateIndex("IDX_ContentPickerField_DocumentId_SelectedItemId",
                     "DocumentId",
                     "SelectedContentItemId",
                     "Published",
@@ -247,7 +247,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeField_DocumentId",
+                .CreateIndex("IDX_TimeFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -256,7 +256,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeField_DocumentId_ContentType",
+                .CreateIndex("IDX_TimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -266,7 +266,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeField_DocumentId_Time",
+                .CreateIndex("IDX_TimeFieldIndex_DocumentId_Time",
                     "DocumentId",
                     "Time",
                     "Published",
@@ -292,7 +292,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkField_DocumentId",
+                .CreateIndex("IDX_LinkFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -301,7 +301,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkField_DocumentId_ContentType",
+                .CreateIndex("IDX_LinkFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -311,7 +311,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkField_DocumentId_Url",
+                .CreateIndex("IDX_LinkFieldIndex_DocumentId_Url",
                     "DocumentId",
                     "Url",
                     "Published",
@@ -319,7 +319,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkField_DocumentId_Text",
+                .CreateIndex("IDX_LinkFieldIndex_DocumentId_Text",
                     "DocumentId",
                     "Text",
                     "Published",
@@ -338,7 +338,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
-                .CreateIndex("IDX_HtmlField_DocumentId",
+                .CreateIndex("IDX_HtmlFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -347,7 +347,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
-                .CreateIndex("IDX_HtmlField_DocumentId_ContentType",
+                .CreateIndex("IDX_HtmlFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -369,7 +369,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextField_DocumentId",
+                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -378,7 +378,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextField_DocumentId_ContentType",
+                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -388,7 +388,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextField_DocumentId_Value",
+                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_Value",
                     "DocumentId",
                     "Value",
                     "Published",
@@ -433,7 +433,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
         public int UpdateFrom3()
         {
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextField_DocumentId",
+                .CreateIndex("IDX_TextFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -442,7 +442,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-                .CreateIndex("IDX_TextField_DocumentId_ContentType",
+                .CreateIndex("IDX_TextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -453,7 +453,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 
             // Can't be created on existing databases where the 'Text' may be of 768 chars.
             //SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
-            //    .CreateIndex("IDX_TextField_DocumentId_Text",
+            //    .CreateIndex("IDX_TextFieldIndex_DocumentId_Text",
             //        "DocumentId",
             //        "Text",
             //        "Published",
@@ -461,7 +461,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             //);
 
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
-                .CreateIndex("IDX_BooleanField_DocumentId",
+                .CreateIndex("IDX_BooleanFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -470,7 +470,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
-                .CreateIndex("IDX_BooleanField_DocumentId_ContentType",
+                .CreateIndex("IDX_BooleanFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -481,7 +481,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericField_DocumentId",
+                .CreateIndex("IDX_NumericFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -490,7 +490,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericField_DocumentId_ContentType",
+                .CreateIndex("IDX_NumericFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -500,7 +500,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
-                .CreateIndex("IDX_NumericField_DocumentId_Numeric",
+                .CreateIndex("IDX_NumericFieldIndex_DocumentId_Numeric",
                     "DocumentId",
                     "Numeric",
                     "Published",
@@ -508,7 +508,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeField_DocumentId",
+                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -517,7 +517,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeField_DocumentId_ContentType",
+                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -527,7 +527,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
-                .CreateIndex("IDX_DateTimeField_DocumentId_DateTime",
+                .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_DateTime",
                     "DocumentId",
                     "DateTime",
                     "Published",
@@ -535,7 +535,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateField_DocumentId",
+                .CreateIndex("IDX_DateFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -544,7 +544,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateField_DocumentId_ContentType",
+                .CreateIndex("IDX_DateFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -554,7 +554,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
-                .CreateIndex("IDX_DateField_DocumentId_Date",
+                .CreateIndex("IDX_DateFieldIndex_DocumentId_Date",
                     "DocumentId",
                     "Date",
                     "Published",
@@ -562,7 +562,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_CPickerField_DocumentId",
+                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -571,7 +571,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_CPickerField_DocumentId_ContentType",
+                .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -581,7 +581,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
-                .CreateIndex("IDX_CPickerField_DocumentId_SelectedContentItemId",
+                .CreateIndex("IDX_ContentPickerField_DocumentId_SelectedItemId",
                     "DocumentId",
                     "SelectedContentItemId",
                     "Published",
@@ -589,7 +589,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeField_DocumentId",
+                .CreateIndex("IDX_TimeFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -598,7 +598,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeField_DocumentId_ContentType",
+                .CreateIndex("IDX_TimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -608,7 +608,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
-                .CreateIndex("IDX_TimeField_DocumentId_Time",
+                .CreateIndex("IDX_TimeFieldIndex_DocumentId_Time",
                     "DocumentId",
                     "Time",
                     "Published",
@@ -616,7 +616,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkField_DocumentId",
+                .CreateIndex("IDX_LinkFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -625,7 +625,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-                .CreateIndex("IDX_LinkField_DocumentId_ContentType",
+                .CreateIndex("IDX_LinkFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -636,7 +636,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 
             // Can't be created on existing databases where the 'Url' may be of 768 chars.
             //SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-            //    .CreateIndex("IDX_LinkField_DocumentId_Url",
+            //    .CreateIndex("IDX_LinkFieldIndex_DocumentId_Url",
             //        "DocumentId",
             //        "Url",
             //        "Published",
@@ -645,7 +645,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 
             // Can't be created on existing databases where the 'Text' may be of 768 chars.
             //SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
-            //    .CreateIndex("IDX_LinkField_DocumentId_Text",
+            //    .CreateIndex("IDX_LinkFieldIndex_DocumentId_Text",
             //        "DocumentId",
             //        "Text",
             //        "Published",
@@ -653,7 +653,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             //);
 
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
-                .CreateIndex("IDX_HtmlField_DocumentId",
+                .CreateIndex("IDX_HtmlFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -662,7 +662,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
-                .CreateIndex("IDX_HtmlField_DocumentId_ContentType",
+                .CreateIndex("IDX_HtmlFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -672,7 +672,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextField_DocumentId",
+                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId",
                     "DocumentId",
                     "ContentItemId",
                     "ContentItemVersionId",
@@ -681,7 +681,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextField_DocumentId_ContentType",
+                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
                     "ContentType",
                     "ContentPart",
@@ -691,7 +691,7 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
-                .CreateIndex("IDX_MultiTextField_DocumentId_Value",
+                .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_Value",
                     "DocumentId",
                     "Value",
                     "Published",

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
@@ -68,7 +68,7 @@ namespace OrchardCore.Workflows
             );
 
             SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .CreateIndex("IDX_WFBA_DocumentId_ActivityId",
+                .CreateIndex("IDX_WFBlockingActivities_DocumentId_ActivityId",
                     "DocumentId",
                     "ActivityId",
                     "WorkflowTypeId",
@@ -76,7 +76,7 @@ namespace OrchardCore.Workflows
             );
 
             SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .CreateIndex("IDX_WFBA_DocumentId_ActivityName",
+                .CreateIndex("IDX_WFBlockingActivities_DocumentId_ActivityName",
                     "DocumentId",
                     "ActivityName",
                     "WorkflowTypeId",
@@ -129,7 +129,7 @@ namespace OrchardCore.Workflows
             );
 
             SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .CreateIndex("IDX_WFBA_DocumentId_ActivityId",
+                .CreateIndex("IDX_WFBlockingActivities_DocumentId_ActivityId",
                     "DocumentId",
                     "ActivityId",
                     "WorkflowTypeId",
@@ -137,7 +137,7 @@ namespace OrchardCore.Workflows
             );
 
             SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .CreateIndex("IDX_WFBA_DocumentId_ActivityName",
+                .CreateIndex("IDX_WFBlockingActivities_DocumentId_ActivityName",
                     "DocumentId",
                     "ActivityName",
                     "WorkflowTypeId",

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
@@ -84,7 +84,7 @@ namespace OrchardCore.Workflows
             );
 
             // Shortcut other migration steps on new content definition schemas.
-            return 4;
+            return 3;
         }
 
         // This code can be removed in a later version.
@@ -129,38 +129,6 @@ namespace OrchardCore.Workflows
             );
 
             SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .CreateIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityId",
-                    "DocumentId",
-                    "ActivityId",
-                    "WorkflowTypeId",
-                    "WorkflowId")
-            );
-
-            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .CreateIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityName",
-                    "DocumentId",
-                    "ActivityName",
-                    "WorkflowTypeId",
-                    "WorkflowCorrelationId")
-            );
-
-            return 3;
-        }
-
-        // This code can be removed in a later version.
-        public int UpdateFrom3()
-        {
-            //For PostgreSQL
-            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .DropIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_Activity"));
-
-            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .DropIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityId"));
-
-            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .DropIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityName"));
-
-            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
                 .CreateIndex("IDX_WFBA_DocumentId_ActivityId",
                     "DocumentId",
                     "ActivityId",
@@ -176,7 +144,7 @@ namespace OrchardCore.Workflows
                     "WorkflowCorrelationId")
             );
 
-            return 4;
+            return 3;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
@@ -84,7 +84,7 @@ namespace OrchardCore.Workflows
             );
 
             // Shortcut other migration steps on new content definition schemas.
-            return 3;
+            return 4;
         }
 
         // This code can be removed in a later version.

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Migrations.cs
@@ -68,7 +68,7 @@ namespace OrchardCore.Workflows
             );
 
             SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .CreateIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityId",
+                .CreateIndex("IDX_WFBA_DocumentId_ActivityId",
                     "DocumentId",
                     "ActivityId",
                     "WorkflowTypeId",
@@ -76,7 +76,7 @@ namespace OrchardCore.Workflows
             );
 
             SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
-                .CreateIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityName",
+                .CreateIndex("IDX_WFBA_DocumentId_ActivityName",
                     "DocumentId",
                     "ActivityName",
                     "WorkflowTypeId",
@@ -145,6 +145,38 @@ namespace OrchardCore.Workflows
             );
 
             return 3;
+        }
+
+        // This code can be removed in a later version.
+        public int UpdateFrom3()
+        {
+            //For PostgreSQL
+            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
+                .DropIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_Activity"));
+
+            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
+                .DropIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityId"));
+
+            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
+                .DropIndex("IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityName"));
+
+            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
+                .CreateIndex("IDX_WFBA_DocumentId_ActivityId",
+                    "DocumentId",
+                    "ActivityId",
+                    "WorkflowTypeId",
+                    "WorkflowId")
+            );
+
+            SchemaBuilder.AlterIndexTable<WorkflowBlockingActivitiesIndex>(table => table
+                .CreateIndex("IDX_WFBA_DocumentId_ActivityName",
+                    "DocumentId",
+                    "ActivityName",
+                    "WorkflowTypeId",
+                    "WorkflowCorrelationId")
+            );
+
+            return 4;
         }
     }
 }


### PR DESCRIPTION
Fixes #8545

## TODO 

Consider adding documentation on index name convention.
Right now, index names are redundant. We use the word "index" when they start with "IDX".
Maybe worth to at least name them, from now, consistently by using a convention.

Here in this PR for example I'm using

| Prefix        | Table Name (simplified) | Column Name | Column Name | 
| ------------- |:-------------:| -----:|-----:|
IDX | WFBA | DocumentId | ActivityId |
IDX | WFBA | DocumentId | ActivityName | 

| Name | Previous Name |
| ------------- |:-------------|
IDX_WFBA_DocumentId_ActivityId | IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityId |
IDX_WFBA_DocumentId_ActivityName | IDX_WorkflowBlockingActivitiesIndex_DocumentId_ActivityName |

## Functional Tests - all Databases

Before: https://github.com/OrchardCMS/OrchardCore/actions/runs/549629776
After: https://github.com/OrchardCMS/OrchardCore/actions/runs/549605287