### PR TITLE
Add net5.0 and netcoreapp3.1 target framework multi-targetting

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "Web App: Dotnet Build Debug",
-			"program": "${workspaceRoot}/src/OrchardCore.Cms.Web/bin/Debug/netcoreapp3.1/OrchardCore.Cms.Web.dll",
+			"program": "${workspaceRoot}/src/OrchardCore.Cms.Web/bin/Debug/net5.0/OrchardCore.Cms.Web.dll",
 			"args": [],
 			"cwd": "${workspaceRoot}/src/OrchardCore.Cms.Web",
 			"env": {
@@ -20,7 +20,7 @@
 			"request": "launch",
 			"internalConsoleOptions": "openOnSessionStart",
 			"preLaunchTask": "Web App: Dotnet Build Debug",
-			"program": "${workspaceRoot}/src/OrchardCore.Cms.Web/bin/Debug/netcoreapp3.1/OrchardCore.Cms.Web.dll",
+			"program": "${workspaceRoot}/src/OrchardCore.Cms.Web/bin/Debug/net5.0/OrchardCore.Cms.Web.dll",
 			"args": [],
 			"cwd": "${workspaceRoot}/src/OrchardCore.Cms.Web",
 			"env": {
@@ -47,7 +47,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "Web App: Dotnet Build Release",
-			"program": "${workspaceRoot}/src/OrchardCore.Cms.Web/bin/Release/netcoreapp3.1/OrchardCore.Cms.Web.dll",
+			"program": "${workspaceRoot}/src/OrchardCore.Cms.Web/bin/Release/net5.0/OrchardCore.Cms.Web.dll",
 			"args": [],
 			"cwd": "${workspaceRoot}/src/OrchardCore.Cms.Web",
       "env": {

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -9,6 +9,7 @@
     <When Condition=" '$(TargetFramework)' == 'net5.0' ">
       <PropertyGroup>
         <AspNetCoreVersion>5.0.3</AspNetCoreVersion>
+        <MicrosoftExtensionsVersion>5.0.1</MicrosoftExtensionsVersion>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -19,10 +20,12 @@
       -->
       <PropertyGroup>
         <AspNetCoreVersion>3.1.12</AspNetCoreVersion>
+        <MicrosoftExtensionsVersion>3.1.12</MicrosoftExtensionsVersion>
       </PropertyGroup>
     </Otherwise>
   </Choose>
 
+  <!-- Add all of the AspNetCore packages -->
   <ItemGroup>
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Facebook" Version="$(AspNetCoreVersion)" />
@@ -39,15 +42,10 @@
     <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
-  <!-- For .NET 5.0 packages that do not have a version number that matches $(AspNetCoreVersion) available -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-
-    <!-- Fixes error NU1102: Unable to find package Microsoft.Extensions.Http.Polly with version (>= 5.0.3), Found 50 version(s) in NuGet [ Nearest version: 5.0.1 ]-->
-    <PackageManagement Remove="Microsoft.Extensions.Http.Polly" />
-    <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
-
-    <!-- Fixes error NU1102: Unable to find package Microsoft.Extensions.Caching.StackExchangeRedis with version (>= 5.0.3), Found 45 version(s) in NuGet [ Nearest version: 5.0.1 ] -->
-    <PackageManagement Remove="Microsoft.Extensions.Caching.StackExchangeRedis" />
-    <PackageManagement Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
+  <!-- Add all Microsoft.Extensions packages -->
+  <ItemGroup>
+    <PackageManagement Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(MicrosoftExtensionsVersion)" />
+    <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
+
 </Project>

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -1,10 +1,32 @@
 <Project>
   <PropertyGroup>
-    <AspNetCoreVersion>3.1.12</AspNetCoreVersion>
-    <AspNetCoreTargetFramework>netcoreapp3.1</AspNetCoreTargetFramework>
+    <AspNetCoreTargetFrameworks>netcoreapp3.1;net5.0</AspNetCoreTargetFrameworks>
+    <TargetFrameworks>$(AspNetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
+  <Choose>
+    <When Condition=" '$(TargetFramework)' == 'net5.0' ">
+      <PropertyGroup>
+        <AspNetCoreVersion>5.0.1</AspNetCoreVersion>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <!--
+      Fallback when not targetting .net 5.0.
+      At this time, that would mean .net core 3.1.  If there are more target frameworks in the future,
+      this logic should change slightly.
+      -->
+      <PropertyGroup>
+        <AspNetCoreVersion>3.1.12</AspNetCoreVersion>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
   <ItemGroup>
-    <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="$(AspNetCoreVersion)" />
+    <!-- Needs to stay at older package due to items being obsoleted -->
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.12" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Facebook" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Google" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="$(AspNetCoreVersion)" />

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -38,8 +38,6 @@
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Owin" Version="$(AspNetCoreVersion)" />
-    <PackageManagement Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(AspNetCoreVersion)" />
-    <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
 
   <!-- Add all Microsoft.Extensions packages -->

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -1,12 +1,14 @@
 <Project>
   <PropertyGroup>
+    <!-- The default TFM for web app and console projects is net5.0 -->
+    <AspNetCoreTargetFramework>net5.0</AspNetCoreTargetFramework>
     <AspNetCoreTargetFrameworks>netcoreapp3.1;net5.0</AspNetCoreTargetFrameworks>
     <TargetFrameworks>$(AspNetCoreTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <Choose>
     <When Condition=" '$(TargetFramework)' == 'net5.0' ">
       <PropertyGroup>
-        <AspNetCoreVersion>5.0.1</AspNetCoreVersion>
+        <AspNetCoreVersion>5.0.3</AspNetCoreVersion>
       </PropertyGroup>
     </When>
     <Otherwise>
@@ -22,11 +24,7 @@
   </Choose>
 
   <ItemGroup>
-    <!-- Needs to stay at older package due to items being obsoleted -->
-    <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.12" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Facebook" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.Google" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="$(AspNetCoreVersion)" />
@@ -39,5 +37,23 @@
     <PackageManagement Include="Microsoft.AspNetCore.Owin" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(AspNetCoreVersion)" />
     <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="$(AspNetCoreVersion)" />
+  </ItemGroup>
+
+  <!-- For .NET 5.0 packages that do not have a version number that matches $(AspNetCoreVersion) available -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <!-- Fixes the following obsolete warnings used across multiple files in OrchardCore.Microsoft.Authentication
+      warning CS0618: 'AzureADOptions' is obsolete: 'This is obsolete and will be removed in a future version. Use Microsoft.Identity.Web instead. See https://aka.ms/ms-identity-web
+      warning CS0618: 'AzureADDefaults' is obsolete: 'This is obsolete and will be removed in a future version. Use Microsoft.Identity.Web instead. See https://aka.ms/ms-identity-web.
+    -->
+    <PackageManagement Remove="Microsoft.AspNetCore.Authentication.AzureAD.UI" />
+    <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.12" />
+
+    <!-- Fixes error NU1102: Unable to find package Microsoft.Extensions.Http.Polly with version (>= 5.0.3), Found 50 version(s) in NuGet [ Nearest version: 5.0.1 ]-->
+    <PackageManagement Remove="Microsoft.Extensions.Http.Polly" />
+    <PackageManagement Include="Microsoft.Extensions.Http.Polly" Version="5.0.1" />
+
+    <!-- Fixes error NU1102: Unable to find package Microsoft.Extensions.Caching.StackExchangeRedis with version (>= 5.0.3), Found 45 version(s) in NuGet [ Nearest version: 5.0.1 ] -->
+    <PackageManagement Remove="Microsoft.Extensions.Caching.StackExchangeRedis" />
+    <PackageManagement Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -41,12 +41,6 @@
 
   <!-- For .NET 5.0 packages that do not have a version number that matches $(AspNetCoreVersion) available -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-    <!-- Fixes the following obsolete warnings used across multiple files in OrchardCore.Microsoft.Authentication
-      warning CS0618: 'AzureADOptions' is obsolete: 'This is obsolete and will be removed in a future version. Use Microsoft.Identity.Web instead. See https://aka.ms/ms-identity-web
-      warning CS0618: 'AzureADDefaults' is obsolete: 'This is obsolete and will be removed in a future version. Use Microsoft.Identity.Web instead. See https://aka.ms/ms-identity-web.
-    -->
-    <PackageManagement Remove="Microsoft.AspNetCore.Authentication.AzureAD.UI" />
-    <PackageManagement Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.12" />
 
     <!-- Fixes error NU1102: Unable to find package Microsoft.Extensions.Http.Polly with version (>= 5.0.3), Found 50 version(s) in NuGet [ Nearest version: 5.0.1 ]-->
     <PackageManagement Remove="Microsoft.Extensions.Http.Polly" />

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -15,7 +15,7 @@
     <Otherwise>
       <!--
       Fallback when not targetting .net 5.0.
-      At this time, that would mean .net core 3.1.  If there are more target frameworks in the future,
+      At this time, that would mean .net core 3.1. If there are more target frameworks in the future,
       this logic should change slightly.
       -->
       <PropertyGroup>

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\OrchardCore\OrchardCore.Application.Cms.Core.Targets\OrchardCore.Application.Cms.Core.Targets.props" />
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -6,7 +6,6 @@
   <Import Project="..\OrchardCore\OrchardCore.Application.Cms.Core.Targets\OrchardCore.Application.Cms.Core.Targets.props" />
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -6,6 +6,7 @@
   <Import Project="..\OrchardCore\OrchardCore.Application.Cms.Core.Targets\OrchardCore.Application.Cms.Core.Targets.props" />
 
   <PropertyGroup>
+    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>

--- a/src/OrchardCore.Modules/OrchardCore.Admin/OrchardCore.Admin.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/OrchardCore.Admin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore.Modules/OrchardCore.Admin/OrchardCore.Admin.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/OrchardCore.Admin.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/OrchardCore.AdminDashboard.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/OrchardCore.AdminDashboard.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/OrchardCore.AdminDashboard.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/OrchardCore.AdminDashboard.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/OrchardCore.AdminMenu.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/OrchardCore.AdminMenu.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore AdminMenu</Title>

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/OrchardCore.AdminMenu.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/OrchardCore.AdminMenu.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore AdminMenu</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Alias</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Alias</Title>
     <Description>$(OCCMSDescription)
-    
+
     The alias module enables content items to have custom logical identifier.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/OrchardCore.Apis.GraphQL.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/OrchardCore.Apis.GraphQL.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore GraphQL Apis</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provies apis using the GraphQL Specification.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/OrchardCore.Apis.GraphQL.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/OrchardCore.Apis.GraphQL.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore GraphQL Apis</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/OrchardCore.Autoroute.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/OrchardCore.Autoroute.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Autoroute</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/OrchardCore.Autoroute.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/OrchardCore.Autoroute.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Autoroute</Title>
     <Description>$(OCCMSDescription)
-    
+
     This module allows you to specify custom URLs (permalinks) for your content items.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/OrchardCore.BackgroundTasks.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/OrchardCore.BackgroundTasks.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore BackgroundTasks</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     This module provides tools to manage background tasks.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/OrchardCore.BackgroundTasks.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/OrchardCore.BackgroundTasks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore BackgroundTasks</Title>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/OrchardCore.ContentFields.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/OrchardCore.ContentFields.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Content Fields</Title>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/OrchardCore.ContentFields.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/OrchardCore.ContentFields.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Content Fields</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides features to add content fields and indexing them for a content type.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/OrchardCore.ContentLocalization.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/OrchardCore.ContentLocalization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore ContentLocalization</Title>

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/OrchardCore.ContentLocalization.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/OrchardCore.ContentLocalization.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore ContentLocalization</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provide features to localize content.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Localization</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/OrchardCore.ContentPreview.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/OrchardCore.ContentPreview.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentPreview</Title>

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/OrchardCore.ContentPreview.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/OrchardCore.ContentPreview.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentPreview</Title>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/OrchardCore.ContentTypes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/OrchardCore.ContentTypes.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentTypes</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides custom content types management using admin section</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/OrchardCore.ContentTypes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/OrchardCore.ContentTypes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentTypes</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/OrchardCore.Contents.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/OrchardCore.Contents.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Contents</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides Content Management services.
     </Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
@@ -39,7 +38,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Settings.Core\OrchardCore.Settings.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Sitemaps.Abstractions\OrchardCore.Sitemaps.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Users.Abstractions\OrchardCore.Users.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />  
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/OrchardCore.Contents.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/OrchardCore.Contents.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Contents</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Cors/OrchardCore.Cors.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Cors/OrchardCore.Cors.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Cors/OrchardCore.Cors.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Cors/OrchardCore.Cors.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/OrchardCore.CustomSettings.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/OrchardCore.CustomSettings.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore CustomSettings</Title>

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/OrchardCore.CustomSettings.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/OrchardCore.CustomSettings.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore CustomSettings</Title>
     <Description>$(OCCMSDescription)
-    
+
     The custom settings modules enables content types to become custom site settings.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/OrchardCore.DataProtection.Azure.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/OrchardCore.DataProtection.Azure.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Azure DataProtection</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides Azure Blob Storage for data protection key rings.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/OrchardCore.DataProtection.Azure.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/OrchardCore.DataProtection.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Azure DataProtection</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/Startup.cs
@@ -66,17 +66,17 @@ namespace OrchardCore.DataProtection.Azure
             catch (Exception e)
             {
                 _logger.LogCritical(e, "Unable to parse data protection connection string.");
-                throw e;
+                throw;
             }
 
             var createContainer = _configuration.GetValue("OrchardCore_DataProtection_Azure:CreateContainer", true);
             if (createContainer)
-            {                
+            {
                 try
-                {      
+                {
                     _logger.LogDebug("Testing data protection container {ContainerName} existence", containerName);
                     var _blobContainer = new BlobContainerClient(connectionString, containerName);
-                    var response =  _blobContainer.CreateIfNotExistsAsync(PublicAccessType.None).GetAwaiter().GetResult();   
+                    var response =  _blobContainer.CreateIfNotExistsAsync(PublicAccessType.None).GetAwaiter().GetResult();
                     _logger.LogDebug("Data protection container {ContainerName} created.", containerName);
                 }
                 catch (Exception)
@@ -115,7 +115,7 @@ namespace OrchardCore.DataProtection.Azure
                 catch (Exception e)
                 {
                     _logger.LogCritical(e, "Unable to parse data protection blob name.");
-                    throw e;
+                    throw;
                 }
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Demo/OrchardCore.Demo.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/OrchardCore.Demo.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Demo Module </Title>
     <Description>$(OCCMSDescription)
-    
+
     Demo module for Orchard Core CMS.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Demo/OrchardCore.Demo.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/OrchardCore.Demo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Demo Module </Title>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/OrchardCore.Deployment.Remote.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/OrchardCore.Deployment.Remote.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
       <!-- NuGet properties-->
     <Title>OrchardCore Remote Deployment</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides Remote Deployment.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/OrchardCore.Deployment.Remote.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/OrchardCore.Deployment.Remote.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
       <!-- NuGet properties-->
     <Title>OrchardCore Remote Deployment</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/OrchardCore.Deployment.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/OrchardCore.Deployment.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Deployment</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/OrchardCore.Deployment.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/OrchardCore.Deployment.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Deployment</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides Deployment.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Diagnostics/OrchardCore.Diagnostics.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Diagnostics/OrchardCore.Diagnostics.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Diagnostics</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides services to handle application errors.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Infrastructure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Diagnostics/OrchardCore.Diagnostics.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Diagnostics/OrchardCore.Diagnostics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Diagnostics</Title>

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/OrchardCore.DynamicCache.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/OrchardCore.DynamicCache.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore DynamicCache</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/OrchardCore.DynamicCache.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/OrchardCore.DynamicCache.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore DynamicCache</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Email</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Email</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides email settings configuration and a default email service based on SMTP.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/OrchardCore.Facebook.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/OrchardCore.Facebook.csproj
@@ -1,12 +1,11 @@
   <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Facebook</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides Facebook Authentication and Social plugnin features.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/OrchardCore.Facebook.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/OrchardCore.Facebook.csproj
@@ -1,7 +1,7 @@
   <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Facebook</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Features/OrchardCore.Features.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Features/OrchardCore.Features.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Features</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Features/OrchardCore.Features.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Features/OrchardCore.Features.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Features</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Features module enables the administrator of the site to manage the installed modules as well as activate and de-activate features.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Feeds/OrchardCore.Feeds.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Feeds/OrchardCore.Feeds.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
      <!-- NuGet properties-->
     <Title>OrchardCore Feeds</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.Feeds/OrchardCore.Feeds.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Feeds/OrchardCore.Feeds.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
      <!-- NuGet properties-->
     <Title>OrchardCore Feeds</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.Flows/OrchardCore.Flows.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/OrchardCore.Flows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Flows</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Flows/OrchardCore.Flows.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/OrchardCore.Flows.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Flows</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides content parts to create content based on Widgets.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Forms/OrchardCore.Forms.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/OrchardCore.Forms.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore Forms</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides widgets and workflow activities to implement forms.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Forms/OrchardCore.Forms.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/OrchardCore.Forms.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore Forms</Title>

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/OrchardCore.GitHub.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/OrchardCore.GitHub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore GitHub</Title>

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/OrchardCore.GitHub.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/OrchardCore.GitHub.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore GitHub</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides features that allow users to Authenticates with their GitHub Account.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Google/OrchardCore.Google.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Google/OrchardCore.Google.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Google</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Google/OrchardCore.Google.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Google/OrchardCore.Google.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Google</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides features - Google Authentication and Google Analytics.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.HealthChecks/OrchardCore.HealthChecks.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.HealthChecks/OrchardCore.HealthChecks.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore HealthChecks</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     This module provides health check for the website.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Infrastructure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.HealthChecks/OrchardCore.HealthChecks.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.HealthChecks/OrchardCore.HealthChecks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore HealthChecks</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/OrchardCore.HomeRoute.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/OrchardCore.HomeRoute.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore HomeRoute</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides a way to set the route corresponding to the homepage of the site.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.HomeRoute/OrchardCore.HomeRoute.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.HomeRoute/OrchardCore.HomeRoute.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore HomeRoute</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore.Modules/OrchardCore.Html/OrchardCore.Html.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Html/OrchardCore.Html.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Html</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Html module enables content items to have rich content using Html syntax."</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Html/OrchardCore.Html.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Html/OrchardCore.Html.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Html</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Https/OrchardCore.Https.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Https/OrchardCore.Https.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Https</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Https/OrchardCore.Https.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Https/OrchardCore.Https.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Https</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     This module will ensure HTTPS is used when accessing the website.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/OrchardCore.Indexing.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/OrchardCore.Indexing.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Indexing</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides index management for content items.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/OrchardCore.Indexing.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/OrchardCore.Indexing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Indexing</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore.Modules/OrchardCore.Layers/OrchardCore.Layers.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/OrchardCore.Layers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Layers</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Layers/OrchardCore.Layers.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/OrchardCore.Layers.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Layers</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provies a way to render Widgets across pages of the site based on the rules. The rules can be set using url, culture, user and role.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/OrchardCore.Liquid.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/OrchardCore.Liquid.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Liquid</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/OrchardCore.Liquid.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/OrchardCore.Liquid.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Liquid</Title>
     <Description>$(OCCMSDescription)
-    
+
     The liquid module enables content items to have liquid syntax.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Lists/OrchardCore.Lists.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/OrchardCore.Lists.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Lists</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Lists/OrchardCore.Lists.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/OrchardCore.Lists.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Lists</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides container enabled List content type.  It allows to associate content items to a parent container. For example, A blog contains a list of blog posts.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Lists/OrchardCore.Lists.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/OrchardCore.Lists.csproj
@@ -6,7 +6,7 @@
     <Title>OrchardCore Lists</Title>
     <Description>$(OCCMSDescription)
 
-    Provides container enabled List content type.  It allows to associate content items to a parent container. For example, A blog contains a list of blog posts.</Description>
+    Provides container enabled List content type. It allows to associate content items to a parent container. For example, A blog contains a list of blog posts.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Localization</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides the infrastructure necessary to support localized string using the PO (Portable Object) localization file format.
     It also supports plural forms.
     </Description>

--- a/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Localization</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Lucene</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Lucene</Title>
     <Description>$(OCCMSDescription)
-    
+
     Creates Lucene indexes to support search scenarios, introduces a preconfigured container-enabled content type.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Markdown</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/OrchardCore.Markdown.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Markdown</Title>
     <Description>$(OCCMSDescription)
-    
+
     The markdown module enables content items to have markdown editors.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/OrchardCore.Media.Azure.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/OrchardCore.Media.Azure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Media Azure</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/OrchardCore.Media.Azure.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/OrchardCore.Media.Azure.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Media Azure</Title>
     <Description>$(OCCMSDescription)
-    
+
     Enables support for storing media files in Microsoft Azure Blob Storage</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Media</Title>
     <Description>$(OCCMSDescription)
-    
+
     The media module adds media management support.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Media</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/OrchardCore.Menu.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/OrchardCore.Menu.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Menu</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/OrchardCore.Menu.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/OrchardCore.Menu.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Menu</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Menu module provides menu management features.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>
@@ -27,5 +26,5 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs
@@ -14,7 +14,7 @@ using OrchardCore.Microsoft.Authentication.Services;
 using OrchardCore.Microsoft.Authentication.Settings;
 
 #pragma warning disable CS0618
-// The net5.0 5.0.3 build obsoletes AzureADOptions and AzureADDefaults.  Microsoft.Identity.Web should be used instead.
+// The net5.0 5.0.3 build obsoletes 'AzureADOptions' and 'AzureADDefaults', 'Microsoft.Identity.Web' should be used instead.
 // The build warning is disabled temporarily until the code can be migrated.
 
 namespace OrchardCore.Microsoft.Authentication.Configuration

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs
@@ -13,6 +13,10 @@ using OrchardCore.Environment.Shell.Models;
 using OrchardCore.Microsoft.Authentication.Services;
 using OrchardCore.Microsoft.Authentication.Settings;
 
+#pragma warning disable CS0618
+// The net5.0 5.0.3 build obsoletes AzureADOptions and AzureADDefaults.  Microsoft.Identity.Web should be used instead.
+// The build warning is disabled temporarily until the code can be migrated.
+
 namespace OrchardCore.Microsoft.Authentication.Configuration
 {
     public class AzureADOptionsConfiguration :
@@ -110,3 +114,6 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
         }
     }
 }
+
+// Restore the obsolete warning disabled above
+#pragma warning restore CS0618

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/CookieOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/CookieOptionsConfiguration.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
 
 #pragma warning disable CS0618
-// The net5.0 5.0.3 build obsoletes AzureADOptions and AzureADDefaults.  Microsoft.Identity.Web should be used instead.
+// The net5.0 5.0.3 build obsoletes 'AzureADOptions' and 'AzureADDefaults', 'Microsoft.Identity.Web' should be used instead.
 // The build warning is disabled temporarily until the code can be migrated.
 
 namespace OrchardCore.Microsoft.Authentication.Configuration

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/CookieOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/CookieOptionsConfiguration.cs
@@ -4,6 +4,10 @@ using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
 
+#pragma warning disable CS0618
+// The net5.0 5.0.3 build obsoletes AzureADOptions and AzureADDefaults.  Microsoft.Identity.Web should be used instead.
+// The build warning is disabled temporarily until the code can be migrated.
+
 namespace OrchardCore.Microsoft.Authentication.Configuration
 {
     internal class CookieOptionsConfiguration : IConfigureNamedOptions<CookieAuthenticationOptions>
@@ -31,3 +35,6 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
         public void Configure(CookieAuthenticationOptions options) => Debug.Fail("This infrastructure method shouldn't be called.");
     }
 }
+
+// Restore the obsolete warning disabled above
+#pragma warning restore CS0618

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/OpenIdConnectOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/OpenIdConnectOptionsConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 using OrchardCore.Microsoft.Authentication.Services;
 
 #pragma warning disable CS0618
-// The net5.0 5.0.3 build obsoletes AzureADOptions and AzureADDefaults.  Microsoft.Identity.Web should be used instead.
+// The net5.0 5.0.3 build obsoletes 'AzureADOptions' and 'AzureADDefaults', Microsoft.Identity.Web should be used instead.
 // The build warning is disabled temporarily until the code can be migrated.
 
 namespace OrchardCore.Microsoft.Authentication.Configuration

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/OpenIdConnectOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/OpenIdConnectOptionsConfiguration.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 using OrchardCore.Microsoft.Authentication.Services;
 
 #pragma warning disable CS0618
-// The net5.0 5.0.3 build obsoletes 'AzureADOptions' and 'AzureADDefaults', Microsoft.Identity.Web should be used instead.
+// The net5.0 5.0.3 build obsoletes 'AzureADOptions' and 'AzureADDefaults', 'Microsoft.Identity.Web' should be used instead.
 // The build warning is disabled temporarily until the code can be migrated.
 
 namespace OrchardCore.Microsoft.Authentication.Configuration

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/OpenIdConnectOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/OpenIdConnectOptionsConfiguration.cs
@@ -5,6 +5,10 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Extensions.Options;
 using OrchardCore.Microsoft.Authentication.Services;
 
+#pragma warning disable CS0618
+// The net5.0 5.0.3 build obsoletes AzureADOptions and AzureADDefaults.  Microsoft.Identity.Web should be used instead.
+// The build warning is disabled temporarily until the code can be migrated.
+
 namespace OrchardCore.Microsoft.Authentication.Configuration
 {
     internal class OpenIdConnectOptionsConfiguration : IConfigureNamedOptions<OpenIdConnectOptions>
@@ -43,3 +47,7 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
         public void Configure(OpenIdConnectOptions options) => Debug.Fail("This infrastructure method shouldn't be called.");
     }
 }
+
+// Restore the obsolete warning disabled above
+#pragma warning restore CS0618
+

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/OrchardCore.Microsoft.Authentication.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/OrchardCore.Microsoft.Authentication.csproj
@@ -1,7 +1,7 @@
   <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Microsoft Authentication</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/OrchardCore.Microsoft.Authentication.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/OrchardCore.Microsoft.Authentication.csproj
@@ -1,12 +1,11 @@
   <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Microsoft Authentication</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provide features to Authenticates users using  Microsoft Account, Azure Active Directory Account.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Startup.cs
@@ -56,10 +56,19 @@ namespace OrchardCore.Microsoft.Authentication
             services.TryAddEnumerable(new[]
             {
                 // Orchard-specific initializers:
+
+                #pragma warning disable CS0618
+                // The net5.0 5.0.3 build obsoletes AzureADOptions and AzureADDefaults.  Microsoft.Identity.Web should be used instead.
+                // The build warning is disabled temporarily until the code can be migrated.
+
                 ServiceDescriptor.Transient<IConfigureOptions<AuthenticationOptions>, AzureADOptionsConfiguration>(),
                 ServiceDescriptor.Transient<IConfigureOptions<AzureADOptions>, AzureADOptionsConfiguration>(),
                 ServiceDescriptor.Transient<IConfigureOptions<PolicySchemeOptions>, AzureADOptionsConfiguration>(),
                 ServiceDescriptor.Transient<IConfigureOptions<OpenIdConnectOptions>, OpenIdConnectOptionsConfiguration>(),
+
+                // Restore the obsolete warning disabled above
+                #pragma warning restore CS0618
+
                 // Built-in initializers:
                 ServiceDescriptor.Singleton<IPostConfigureOptions<OpenIdConnectOptions>, OpenIdConnectPostConfigureOptions>(),
             });

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Startup.cs
@@ -58,7 +58,7 @@ namespace OrchardCore.Microsoft.Authentication
                 // Orchard-specific initializers:
 
                 #pragma warning disable CS0618
-                // The net5.0 5.0.3 build obsoletes AzureADOptions and AzureADDefaults.  Microsoft.Identity.Web should be used instead.
+                // The net5.0 5.0.3 build obsoletes 'AzureADOptions' and 'AzureADDefaults', 'Microsoft.Identity.Web' should be used instead.
                 // The build warning is disabled temporarily until the code can be migrated.
 
                 ServiceDescriptor.Transient<IConfigureOptions<AuthenticationOptions>, AzureADOptionsConfiguration>(),

--- a/src/OrchardCore.Modules/OrchardCore.MiniProfiler/OrchardCore.MiniProfiler.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.MiniProfiler/OrchardCore.MiniProfiler.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore MiniProfiler</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provide features to add [Mini Profiler] to troubleshoot performance issues.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.MiniProfiler/OrchardCore.MiniProfiler.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.MiniProfiler/OrchardCore.MiniProfiler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore MiniProfiler</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Mvc.HelloWorld/OrchardCore.Mvc.HelloWorld.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Mvc.HelloWorld/OrchardCore.Mvc.HelloWorld.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Hello World MVC module </Title>

--- a/src/OrchardCore.Modules/OrchardCore.Mvc.HelloWorld/OrchardCore.Mvc.HelloWorld.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Mvc.HelloWorld/OrchardCore.Mvc.HelloWorld.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Hello World MVC module </Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Sample Orchard Core Framework module for MVC.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/OrchardCore.Navigation.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/OrchardCore.Navigation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Navigation</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/OrchardCore.Navigation.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/OrchardCore.Navigation.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Navigation</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     The Navigation module allows you to define menus and display them.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore OpenId</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides OpenId Connect client, server and management features.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS OpenId</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore OpenId</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Placements/OrchardCore.Placements.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/OrchardCore.Placements.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Placements</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Placements module provides a way to define shape placement in Admin UI.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Placements/OrchardCore.Placements.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/OrchardCore.Placements.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Placements</Title>

--- a/src/OrchardCore.Modules/OrchardCore.PublishLater/OrchardCore.PublishLater.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.PublishLater/OrchardCore.PublishLater.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore PublishLater</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Publish Later module adds the ability to schedule content items to be published at a given future date and time.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>
@@ -25,5 +24,5 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Infrastructure\OrchardCore.Infrastructure.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.PublishLater/OrchardCore.PublishLater.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.PublishLater/OrchardCore.PublishLater.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore PublishLater</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Queries</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Queries</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides querying capabilities for Content.
     </Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/OrchardCore.ReCaptcha.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/OrchardCore.ReCaptcha.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore ReCaptcha</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides ReCaptcha functionality.
     </Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/OrchardCore.ReCaptcha.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/OrchardCore.ReCaptcha.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore ReCaptcha</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/OrchardCore.Recipes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/OrchardCore.Recipes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Recipes</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/OrchardCore.Recipes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/OrchardCore.Recipes.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Recipes</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides ability to execute recipe steps from JSON files.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Infrastructure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Redis/OrchardCore.Redis.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/OrchardCore.Redis.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Redis</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.Redis/OrchardCore.Redis.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/OrchardCore.Redis.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Redis</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides Redis features for configuration, cache, bus and lock.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Infrastructure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Resources</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     The Resources module provides popular javascript libraries and stylesheet libraries.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Resources</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.ResponseCompression/OrchardCore.ResponseCompression.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ResponseCompression/OrchardCore.ResponseCompression.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Response Compression</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     The Response Compression module provides the gzip compression.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.ResponseCompression/OrchardCore.ResponseCompression.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ResponseCompression/OrchardCore.ResponseCompression.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Response Compression</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.ReverseProxy/OrchardCore.ReverseProxy.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ReverseProxy/OrchardCore.ReverseProxy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore ReverseProxy</Title>

--- a/src/OrchardCore.Modules/OrchardCore.ReverseProxy/OrchardCore.ReverseProxy.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.ReverseProxy/OrchardCore.ReverseProxy.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore ReverseProxy</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     The module enables configuration of hosting scenarios with a reverse proxy.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Roles/OrchardCore.Roles.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/OrchardCore.Roles.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Roles</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Roles/OrchardCore.Roles.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/OrchardCore.Roles.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Roles</Title>
     <Description>$(OCCMSDescription)
-    
+
     The roles module is adding the ability to assign roles to users. It's also providing a set of default roles for which other modules can define default permissions.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Rules/OrchardCore.Rules.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/OrchardCore.Rules.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Rules</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     The Rule module adds rule building capabilities.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Scripting/OrchardCore.Scripting.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Scripting/OrchardCore.Scripting.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Scripting</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     The Scripting module adds scripting capabilities.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Scripting/OrchardCore.Scripting.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Scripting/OrchardCore.Scripting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Scripting</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Modules/OrchardCore.Settings/OrchardCore.Settings.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/OrchardCore.Settings.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Settings</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Settings/OrchardCore.Settings.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/OrchardCore.Settings.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Settings</Title>
     <Description>$(OCCMSDescription)
-    
+
     The settings module creates site settings.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Setup/OrchardCore.Setup.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/OrchardCore.Setup.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Setup</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Setup/OrchardCore.Setup.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/OrchardCore.Setup.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Setup</Title>
     <Description>$(OCCMSDescription)
-    
+
     The setup module is creating the application's setup experience..</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/OrchardCore.Shortcodes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/OrchardCore.Shortcodes.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Shortcodes</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Shortcodes module adds shortcode capabilities to content editor.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/OrchardCore.Shortcodes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/OrchardCore.Shortcodes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Shortcodes</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/OrchardCore.Sitemaps.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/OrchardCore.Sitemaps.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Sitemaps</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Sitemaps module Provides dynamic sitemap generation.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/OrchardCore.Sitemaps.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/OrchardCore.Sitemaps.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Sitemaps</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/OrchardCore.Taxonomies.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/OrchardCore.Taxonomies.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Taxonomies</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/OrchardCore.Taxonomies.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/OrchardCore.Taxonomies.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Taxonomies</Title>
     <Description>$(OCCMSDescription)
-    
+
     The taxonomies module provides a way to categorize content items.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/OrchardCore.Templates.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/OrchardCore.Templates.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Templates</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides features to write custom shape templates from the Admin UI.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/OrchardCore.Templates.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/OrchardCore.Templates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Templates</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -319,11 +319,10 @@ namespace OrchardCore.Tenants.Controllers
                 pathString = pathString.Add('/' + shellSettings.RequestUrlPrefix);
             }
 
-            QueryString queryString;
-
+            var queryString = String.Empty;
             if (!String.IsNullOrEmpty(token))
             {
-                queryString = QueryString.Create("token", token);
+                queryString = QueryString.Create("token", token).ToString();
             }
 
             return $"{Request.Scheme}://{hostString + pathString + queryString}";

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -319,7 +319,7 @@ namespace OrchardCore.Tenants.Controllers
                 pathString = pathString.Add('/' + shellSettings.RequestUrlPrefix);
             }
 
-            QueryString queryString;
+            QueryString queryString = null;
             if (!String.IsNullOrEmpty(token))
             {
                 queryString = QueryString.Create("token", token);

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -319,10 +319,10 @@ namespace OrchardCore.Tenants.Controllers
                 pathString = pathString.Add('/' + shellSettings.RequestUrlPrefix);
             }
 
-            var queryString = String.Empty;
+            QueryString queryString;
             if (!String.IsNullOrEmpty(token))
             {
-                queryString = QueryString.Create("token", token).ToString();
+                queryString = QueryString.Create("token", token);
             }
 
             return $"{Request.Scheme}://{hostString + pathString + queryString}";

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -319,7 +319,7 @@ namespace OrchardCore.Tenants.Controllers
                 pathString = pathString.Add('/' + shellSettings.RequestUrlPrefix);
             }
 
-            QueryString queryString = null;
+            QueryString queryString = QueryString.Empty;
             if (!String.IsNullOrEmpty(token))
             {
                 queryString = QueryString.Create("token", token);

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/OrchardCore.Tenants.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/OrchardCore.Tenants.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Tenants</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/OrchardCore.Tenants.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/OrchardCore.Tenants.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Tenants</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides features to manage tenants from the Admin UI</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>
@@ -29,5 +28,5 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Setup.Core\OrchardCore.Setup.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
@@ -35,11 +35,10 @@
             pathString = pathString.Add('/' + shellSettings.RequestUrlPrefix);
         }
 
-        QueryString queryString;
-
-        if (!string.IsNullOrEmpty(shellSettingsEntry.Token))
+        var queryString = String.Empty;
+        if (!String.IsNullOrEmpty(shellSettingsEntry.Token))
         {
-            queryString = QueryString.Create("token", shellSettingsEntry.Token);
+            queryString = QueryString.Create("token", shellSettingsEntry.Token).ToString();
         }
 
         return $"{Context.Request.Scheme}://{hostString + pathString + queryString}";

--- a/src/OrchardCore.Modules/OrchardCore.Themes/OrchardCore.Themes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/OrchardCore.Themes.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Themes</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/OrchardCore.Themes.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/OrchardCore.Themes.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Themes</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Themes modules allows you to specify the Frontend and the Admin theme.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Title/OrchardCore.Title.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Title/OrchardCore.Title.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore Title</Title>
     <Description>$(OCCMSDescription)
-    
+
     The title module enables content items to have titles.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Title/OrchardCore.Title.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Title/OrchardCore.Title.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore Title</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/OrchardCore.Twitter.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/OrchardCore.Twitter.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore Twitter</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides Twitter related features.
     - TwitterClient and Workflow Activities to integrate with twitter.
     - Authenticates users with their Twitter Account.</Description>

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/OrchardCore.Twitter.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/OrchardCore.Twitter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
      <!-- NuGet properties-->
     <Title>OrchardCore Twitter</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
@@ -1,7 +1,7 @@
   <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Users</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
@@ -1,12 +1,11 @@
   <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Users</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Users module adds user management functionality.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/OrchardCore.Widgets.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/OrchardCore.Widgets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Widgets</Title>

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/OrchardCore.Widgets.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/OrchardCore.Widgets.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Widgets</Title>
     <Description>$(OCCMSDescription)
-    
+
     Provides a part allowing content items to render Widgets in theme zones.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <TypeScriptToolsVersion>2.3</TypeScriptToolsVersion>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <TypeScriptToolsVersion>2.3</TypeScriptToolsVersion>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <!-- NuGet properties-->
     <Title>OrchardCore Workflows</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Workflows module provides tools and APIs to create custom workflows.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.XmlRpc/OrchardCore.XmlRpc.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.XmlRpc/OrchardCore.XmlRpc.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore XmlRpc</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     The remote publishing feature enables creation of contents from client applications such as Open Live Writer.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Infrastructure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Modules/OrchardCore.XmlRpc/OrchardCore.XmlRpc.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.XmlRpc/OrchardCore.XmlRpc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore XmlRpc</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
+++ b/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
@@ -1,9 +1,8 @@
 <Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\OrchardCore.Build\Dependencies.props" />
-  
+
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
+++ b/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\OrchardCore.Build\Dependencies.props" />
 
   <PropertyGroup>
+    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
+++ b/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\OrchardCore.Build\Dependencies.props" />
   
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/src/OrchardCore.Themes/SafeMode/SafeMode.csproj
+++ b/src/OrchardCore.Themes/SafeMode/SafeMode.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
      <!-- NuGet properties-->
     <Title>OrchardCore SafeMode theme</Title>
     <Description>$(OCCMSDescription)
-    
+
     A fail-safe theme when no other themes are available.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Theme</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Themes/SafeMode/SafeMode.csproj
+++ b/src/OrchardCore.Themes/SafeMode/SafeMode.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
      <!-- NuGet properties-->

--- a/src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj
+++ b/src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj
+++ b/src/OrchardCore.Themes/TheAdmin/TheAdmin.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
     <!-- NuGet properties-->
     <Title>The Admin theme</Title>
     <Description>$(OCCMSDescription)
-    
+
     The default Admin theme of OrchardCore CMS</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Theme</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
+++ b/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
+++ b/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
     <!-- NuGet properties-->
     <Title>The Agency theme</Title>
     <Description>$(OCCMSDescription)
-    
+
     Orchard Core CMS theme adapted for agency websites.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Theme</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Themes/TheBlogTheme/TheBlogTheme.csproj
+++ b/src/OrchardCore.Themes/TheBlogTheme/TheBlogTheme.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore.Themes/TheBlogTheme/TheBlogTheme.csproj
+++ b/src/OrchardCore.Themes/TheBlogTheme/TheBlogTheme.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 
     <!-- NuGet properties-->
     <Title>The Blog theme</Title>
     <Description>$(OCCMSDescription)
-    
+
     Orchard Core CMS theme adapted for blogs.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Theme </PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Themes/TheComingSoonTheme/TheComingSoonTheme.csproj
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/TheComingSoonTheme.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     
     <!-- NuGet properties-->

--- a/src/OrchardCore.Themes/TheComingSoonTheme/TheComingSoonTheme.csproj
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/TheComingSoonTheme.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    
+
     <!-- NuGet properties-->
     <Title>The Coming Soon theme</Title>
     <Description>$(OCCMSDescription)
-    
+
     The Coming Soon Theme with Landing page for a project that is under construction</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Theme</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Themes/TheTheme/TheTheme.csproj
+++ b/src/OrchardCore.Themes/TheTheme/TheTheme.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
-    
+
     <!-- NuGet properties-->
     <Title>OrchardCore Default theme</Title>
     <Description>$(OCCMSDescription)
-    
+
     The default Theme - Can be used as base theme for new themes.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Theme</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore.Themes/TheTheme/TheTheme.csproj
+++ b/src/OrchardCore.Themes/TheTheme/TheTheme.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.Abstractions/OrchardCore.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Abstractions/OrchardCore.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions of OrchardCore ShellHost.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Abstractions/OrchardCore.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Abstractions/OrchardCore.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/OrchardCore.Admin.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/OrchardCore.Admin.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Admin</RootNamespace>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/OrchardCore.Admin.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/OrchardCore.Admin.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Admin</RootNamespace>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/OrchardCore.AdminMenu.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/OrchardCore.AdminMenu.Abstractions.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.AdminMenu</RootNamespace>
 
     <!-- NuGet properties-->
     <Title>OrchardCore AdminMenu Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for AdminMenu Module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/OrchardCore.AdminMenu.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/OrchardCore.AdminMenu.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.AdminMenu</RootNamespace>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/OrchardCore.Apis.GraphQL.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/OrchardCore.Apis.GraphQL.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Apis.GraphQL</RootNamespace>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/OrchardCore.Apis.GraphQL.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/OrchardCore.Apis.GraphQL.Abstractions.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Apis.GraphQL</RootNamespace>
 
     <!-- NuGet properties-->
     <Title>OrchardCore GraphQL Apis Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions for GraphQL Apis</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework GraphQL Apis Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/OrchardCore.Apis.GraphQL.Client.csproj
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/OrchardCore.Apis.GraphQL.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore GraphQL Client Abstractions</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/OrchardCore.Apis.GraphQL.Client.csproj
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Client/OrchardCore.Apis.GraphQL.Client.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore GraphQL Client Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions for GraphQL Client</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework GraphQL Client Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
      <!-- NuGet properties-->
     <Title>Target for Modular OrchardCore CMS Application</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
      <!-- NuGet properties-->
     <Title>Target for Modular OrchardCore CMS Application</Title>
     <Description>$(OCCMSDescription)
-    
+
     Converts the application into a modular OrchardCore CMS application with TheAdmin theme but without any front-end Themes.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS CMS</PackageTags>
   </PropertyGroup>
@@ -24,7 +23,7 @@
     When a package is not directly referenced, e.g only through the reference of this bundle package,
     the files in its build folder are not evaluated on building if this folder is marked as private.
     This can be defined by using the 'PrivateAssets' attribute.
-    
+
     Here, only project references are used but when packing the bundle they become package references,
     and with the same 'PrivateAssets' attribute.
   -->
@@ -32,8 +31,8 @@
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Application.Targets\OrchardCore.Application.Targets.csproj" PrivateAssets="none" />
 
-    <!-- 
-      When adding a reference to this list, please keep it ordered alphabetically, and set PrivateAssets="none" 
+    <!--
+      When adding a reference to this list, please keep it ordered alphabetically, and set PrivateAssets="none"
     -->
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.Admin\OrchardCore.Admin.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Modules\OrchardCore.AdminDashboard\OrchardCore.AdminDashboard.csproj" PrivateAssets="none" />

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.csproj
@@ -9,7 +9,20 @@
     <PackageTags>$(PackageTags) OrchardCoreCMS CMS</PackageTags>
   </PropertyGroup>
 
-  <!-- Add ".props" and ".targets" files in the package specific to the "Cms.Core" bundle -->
+  <!--
+    Add ".props" and ".targets" files in the package specific to the "Cms.Core" nuget package
+
+    When the OrchardCore.Application.Cms.Core.Targets package is referenced, the .props and .targets
+    files present in the build folder will also be referenced by the generated .props and .targets
+    files in the obj folder of the referencing project.
+
+    See: https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package#include-msbuild-props-and-targets-in-a-package
+    * The files in the build folder will be applied to any TFM.
+    * The files in the build\$(TargetFramework) folder will be applied to only referencing projects targeting that TFM
+    * The files in the buildMultiTargeting folder will only be applied when the referencing project's $(TargetFramework)
+      is empty
+  -->
+
   <ItemGroup>
     <None Include="OrchardCore.Application.Cms.Core.Targets.props" Pack="true">
       <PackagePath>build\OrchardCore.Application.Cms.Core.Targets.props</PackagePath>

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.csproj
@@ -12,10 +12,10 @@
   <!-- Add ".props" and ".targets" files in the package specific to the "Cms.Core" bundle -->
   <ItemGroup>
     <None Include="OrchardCore.Application.Cms.Core.Targets.props" Pack="true">
-      <PackagePath>build\$(TargetFramework)\OrchardCore.Application.Cms.Core.Targets.props</PackagePath>
+      <PackagePath>build\OrchardCore.Application.Cms.Core.Targets.props</PackagePath>
     </None>
     <None Include="OrchardCore.Application.Cms.Core.Targets.targets" Pack="true">
-      <PackagePath>build\$(TargetFramework)\OrchardCore.Application.Cms.Core.Targets.targets</PackagePath>
+      <PackagePath>build\OrchardCore.Application.Cms.Core.Targets.targets</PackagePath>
     </None>
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Application.Cms.Targets/OrchardCore.Application.Cms.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Targets/OrchardCore.Application.Cms.Targets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for Modular OrchardCore CMS Application</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Application.Cms.Targets/OrchardCore.Application.Cms.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Targets/OrchardCore.Application.Cms.Targets.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for Modular OrchardCore CMS Application</Title>
     <Description>$(OCCMSDescription)
-    
+
     Converts the application into a modular OrchardCore CMS application with following themes.
-    
+
     - TheAdmin Theme
     - SafeMode Theme
     - TheAgency Theme
@@ -21,7 +20,7 @@
     When a package is not directly referenced, e.g only through the reference of this bundle package,
     the files in its build folder are not evaluated on building if this folder is marked as private.
     This can be defined by using the 'PrivateAssets' attribute.
-    
+
     Here, only project references are used but when packing the bundle they become package references,
     and with the same 'PrivateAssets' attribute.
   -->
@@ -29,8 +28,8 @@
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Application.Cms.Core.Targets\OrchardCore.Application.Cms.Core.Targets.csproj" PrivateAssets="none" />
 
-    <!-- 
-      When adding a reference to this list, please keep it ordered alphabetically, and set PrivateAssets="none" 
+    <!--
+      When adding a reference to this list, please keep it ordered alphabetically, and set PrivateAssets="none"
     -->
     <ProjectReference Include="..\..\OrchardCore.Themes\SafeMode\SafeMode.csproj" PrivateAssets="none" />
     <ProjectReference Include="..\..\OrchardCore.Themes\TheAgencyTheme\TheAgencyTheme.csproj" PrivateAssets="none" />

--- a/src/OrchardCore/OrchardCore.Application.Mvc.Targets/OrchardCore.Application.Mvc.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Mvc.Targets/OrchardCore.Application.Mvc.Targets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for Modular OrchardCore Application with MVC</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Application.Mvc.Targets/OrchardCore.Application.Mvc.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Mvc.Targets/OrchardCore.Application.Mvc.Targets.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for Modular OrchardCore Application with MVC</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Converts the application into a modular application and adds Asp.Net MVC pipeline.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework MVC</PackageTags>
   </PropertyGroup>
@@ -18,7 +17,7 @@
     When a package is not directly referenced, e.g only through the reference of this bundle package,
     the files in its build folder are not evaluated on building if this folder is marked as private.
     This can be defined by using the 'PrivateAssets' attribute.
-    
+
     Here, only project references are used but when packing the bundle they become package references,
     and with the same 'PrivateAssets' attribute.
   -->

--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <None Include="OrchardCore.Application.Targets.targets" Pack="true">
-      <PackagePath>build\$(TargetFramework)\OrchardCore.Application.Targets.targets</PackagePath>
+      <PackagePath>build\OrchardCore.Application.Targets.targets</PackagePath>
     </None>
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for Modular OrchardCore Application</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Converts the application into a modular application.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>
@@ -19,10 +18,10 @@
   </ItemGroup>
 
   <!--
-    You can inject nuget targets and props via nuget. 
-    Say you have a package named “MyPackage”. NuGet will add an MSBuild import to 
-    build/$targetFramework/$packageId.props and build/$targetFramework/$packageId.targets. 
-    You can optionally leave out the $targetFramework subdirectory. 
+    You can inject nuget targets and props via nuget.
+    Say you have a package named “MyPackage”. NuGet will add an MSBuild import to
+    build/$targetFramework/$packageId.props and build/$targetFramework/$packageId.targets.
+    You can optionally leave out the $targetFramework subdirectory.
     Caution: this will make NuGet treat your packages as compatible with “any” target framework.
   -->
 

--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for Modular OrchardCore Application</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Application.Targets/OrchardCore.Application.Targets.csproj
@@ -18,13 +18,18 @@
   </ItemGroup>
 
   <!--
-    You can inject nuget targets and props via nuget.
-    Say you have a package named “MyPackage”. NuGet will add an MSBuild import to
-    build/$targetFramework/$packageId.props and build/$targetFramework/$packageId.targets.
-    You can optionally leave out the $targetFramework subdirectory.
-    Caution: this will make NuGet treat your packages as compatible with “any” target framework.
-  -->
+    Add ".props" and ".targets" files in the package specific to the "Application.Targets" nuget package
 
+    When the OrchardCore.Application.Targets package is referenced, the .props and .targets
+    files present in the build folder will also be referenced by the generated .props and .targets
+    files in the obj folder of the referencing project.
+
+    See: https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package#include-msbuild-props-and-targets-in-a-package
+    * The files in the build folder will be applied to any TFM.
+    * The files in the build\$(TargetFramework) folder will be applied to only referencing projects targeting that TFM
+    * The files in the buildMultiTargeting folder will only be applied when the referencing project's $(TargetFramework)
+      is empty
+  -->
   <ItemGroup>
     <None Include="OrchardCore.Application.Targets.targets" Pack="true">
       <PackagePath>build\OrchardCore.Application.Targets.targets</PackagePath>

--- a/src/OrchardCore/OrchardCore.Configuration.KeyVault/OrchardCore.Configuration.KeyVault.csproj
+++ b/src/OrchardCore/OrchardCore.Configuration.KeyVault/OrchardCore.Configuration.KeyVault.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
-  </PropertyGroup>
-
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>

--- a/src/OrchardCore/OrchardCore.Configuration.KeyVault/OrchardCore.Configuration.KeyVault.csproj
+++ b/src/OrchardCore/OrchardCore.Configuration.KeyVault/OrchardCore.Configuration.KeyVault.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardCore.ContentLocalization.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardCore.ContentLocalization.Abstractions.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ContentLocalization</RootNamespace>
-    
+
     <!-- NuGet properties-->
     <Title>OrchardCore ContentLocalization Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for ContentLocalization</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Localization Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardCore.ContentLocalization.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/OrchardCore.ContentLocalization.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ContentLocalization</RootNamespace>
     
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/OrchardCore.ContentManagement.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/OrchardCore.ContentManagement.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ContentManagement</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentManagement Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/OrchardCore.ContentManagement.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/OrchardCore.ContentManagement.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ContentManagement</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentManagement Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for ContentManagement</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/OrchardCore.ContentManagement.Display.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/OrchardCore.ContentManagement.Display.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore ContentManagement Display</Title>

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/OrchardCore.ContentManagement.Display.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/OrchardCore.ContentManagement.Display.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore ContentManagement Display</Title>

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/OrchardCore.ContentManagement.GraphQL.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/OrchardCore.ContentManagement.GraphQL.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
-    
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
+
     <!-- NuGet properties-->
     <Title>OrchardCore GraphQL for ContentManagement</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/OrchardCore.ContentManagement.GraphQL.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/OrchardCore.ContentManagement.GraphQL.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore GraphQL for ContentManagement</Title>

--- a/src/OrchardCore/OrchardCore.ContentManagement/OrchardCore.ContentManagement.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement/OrchardCore.ContentManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
      <!-- NuGet properties-->
     <Title>OrchardCore ContentManagement</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.ContentManagement/OrchardCore.ContentManagement.csproj
+++ b/src/OrchardCore/OrchardCore.ContentManagement/OrchardCore.ContentManagement.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
      <!-- NuGet properties-->
     <Title>OrchardCore ContentManagement</Title>
     <Description>$(OCCMSDescription)
-    
+
     Implementation for ContentManagement</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.ContentPreview.Abstractions/OrchardCore.ContentPreview.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentPreview.Abstractions/OrchardCore.ContentPreview.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ContentPreview</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentPreview Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.ContentPreview.Abstractions/OrchardCore.ContentPreview.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentPreview.Abstractions/OrchardCore.ContentPreview.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ContentPreview</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentPreview Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/OrchardCore.ContentTypes.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/OrchardCore.ContentTypes.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ContentTypes</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentTypes Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for ContentTypes</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/OrchardCore.ContentTypes.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/OrchardCore.ContentTypes.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ContentTypes</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ContentTypes Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Contents.Core/OrchardCore.Contents.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Contents.Core/OrchardCore.Contents.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Contents Core</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Contents.Core/OrchardCore.Contents.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Contents.Core/OrchardCore.Contents.Core.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Contents Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core implementation for OrchardCore Contents</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Contents.TagHelpers/OrchardCore.Contents.TagHelpers.csproj
+++ b/src/OrchardCore/OrchardCore.Contents.TagHelpers/OrchardCore.Contents.TagHelpers.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
-    
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
+
     <!-- NuGet properties-->
     <Title>OrchardCore Contents TagHelpers</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Contents.TagHelpers/OrchardCore.Contents.TagHelpers.csproj
+++ b/src/OrchardCore/OrchardCore.Contents.TagHelpers/OrchardCore.Contents.TagHelpers.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore Contents TagHelpers</Title>
     <Description>$(OCCMSDescription)
-    
+
     TagHelpers for Contents</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement TagHelpers</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Data</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Data Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Data</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Data Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for data access functionality</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Data Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Data/Documents/DocumentStore.cs
+++ b/src/OrchardCore/OrchardCore.Data/Documents/DocumentStore.cs
@@ -162,7 +162,7 @@ namespace OrchardCore.Data.Documents
                 }
                 else
                 {
-                    throw (exception);
+                    throw;
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore.Data/OrchardCore.Data.csproj
+++ b/src/OrchardCore/OrchardCore.Data/OrchardCore.Data.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Data</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Data/OrchardCore.Data.csproj
+++ b/src/OrchardCore/OrchardCore.Data/OrchardCore.Data.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Data</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Deployment.Abstractions/OrchardCore.Deployment.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Deployment.Abstractions/OrchardCore.Deployment.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Deployment</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Deployment Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for Deployment module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Deployment.Abstractions/OrchardCore.Deployment.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Deployment.Abstractions/OrchardCore.Deployment.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Deployment</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Deployment Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Deployment.Core/OrchardCore.Deployment.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Deployment.Core/OrchardCore.Deployment.Core.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore Deployment Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core Implementation for Deployment module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
 

--- a/src/OrchardCore/OrchardCore.Deployment.Core/OrchardCore.Deployment.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Deployment.Core/OrchardCore.Deployment.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore Deployment Core</Title>

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Abstractions/OrchardCore.DisplayManagement.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Abstractions/OrchardCore.DisplayManagement.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Mvc</RootNamespace>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Abstractions/OrchardCore.DisplayManagement.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Abstractions/OrchardCore.DisplayManagement.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Mvc</RootNamespace>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCore.DisplayManagement.Liquid.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCore.DisplayManagement.Liquid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore DisplayManagement Liquid</Title>

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCore.DisplayManagement.Liquid.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCore.DisplayManagement.Liquid.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore DisplayManagement Liquid</Title>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore DisplayManagement</Title>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore DisplayManagement</Title>

--- a/src/OrchardCore/OrchardCore.DynamicCache.Abstractions/OrchardCore.DynamicCache.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.DynamicCache.Abstractions/OrchardCore.DynamicCache.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore DynamicCache Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.DynamicCache.Abstractions/OrchardCore.DynamicCache.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.DynamicCache.Abstractions/OrchardCore.DynamicCache.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore DynamicCache Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Email</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Email Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/OrchardCore.Email.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Email</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Email Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions for Email.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Feeds.Abstractions/OrchardCore.Feeds.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Feeds.Abstractions/OrchardCore.Feeds.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Feeds</RootNamespace>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.Feeds.Abstractions/OrchardCore.Feeds.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Feeds.Abstractions/OrchardCore.Feeds.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Feeds</RootNamespace>
 
     <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.Feeds.Core/OrchardCore.Feeds.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Feeds.Core/OrchardCore.Feeds.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore Feeds Core </Title>

--- a/src/OrchardCore/OrchardCore.Feeds.Core/OrchardCore.Feeds.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Feeds.Core/OrchardCore.Feeds.Core.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore Feeds Core </Title>

--- a/src/OrchardCore/OrchardCore.FileStorage.Abstractions/OrchardCore.FileStorage.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.Abstractions/OrchardCore.FileStorage.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.FileStorage</RootNamespace>
 
      <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.FileStorage.Abstractions/OrchardCore.FileStorage.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.Abstractions/OrchardCore.FileStorage.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.FileStorage</RootNamespace>
 
      <!-- NuGet properties-->

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore FileStorage AzureBlob</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Implementation for AzureBlob FileStorage.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Azure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
-    
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
+
     <!-- NuGet properties-->
     <Title>OrchardCore FileStorage AzureBlob</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.FileStorage.FileSystem/OrchardCore.FileStorage.FileSystem.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.FileSystem/OrchardCore.FileStorage.FileSystem.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore FileStorage FileSystem</Title>

--- a/src/OrchardCore/OrchardCore.FileStorage.FileSystem/OrchardCore.FileStorage.FileSystem.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.FileSystem/OrchardCore.FileStorage.FileSystem.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore FileStorage FileSystem</Title>

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/OrchardCore.Indexing.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/OrchardCore.Indexing.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Indexing</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Indexing Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/OrchardCore.Indexing.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/OrchardCore.Indexing.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Indexing</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Indexing Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for Indexing.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/OrchardCore.Infrastructure.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/OrchardCore.Infrastructure.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Infrastructure</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Infrastructure Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for OrchardCoreCMS Infrastructure </Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Infrastructure Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/OrchardCore.Infrastructure.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/OrchardCore.Infrastructure.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Infrastructure</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Infrastructure Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Infrastructure/OrchardCore.Infrastructure.csproj
+++ b/src/OrchardCore/OrchardCore.Infrastructure/OrchardCore.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Infrastructure</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Infrastructure/OrchardCore.Infrastructure.csproj
+++ b/src/OrchardCore/OrchardCore.Infrastructure/OrchardCore.Infrastructure.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Infrastructure</Title>
     <Description>$(OCCMSDescription)
-    
+
     Implementation for OrchardCoreCMS Infrastructure </Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Infrastructure</PackageTags>
   </PropertyGroup>
@@ -18,7 +17,7 @@
     <PackageReference Include="HtmlSanitizer" />
     <PackageReference Include="MimeKit" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Data\OrchardCore.Data.csproj" />
     <ProjectReference Include="..\OrchardCore.Infrastructure.Abstractions\OrchardCore.Infrastructure.Abstractions.csproj" />

--- a/src/OrchardCore/OrchardCore.Liquid.Abstractions/OrchardCore.Liquid.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Liquid.Abstractions/OrchardCore.Liquid.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Liquid</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Liquid Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Liquid.Abstractions/OrchardCore.Liquid.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Liquid.Abstractions/OrchardCore.Liquid.Abstractions.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Liquid</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Liquid Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCore.Localization.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCore.Localization.Abstractions.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Localization</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Localization Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions for Localization
     </Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Localization</PackageTags>
@@ -15,5 +14,5 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCore.Localization.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCore.Localization.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Localization</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Localization Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Localization.Core/OrchardCore.Localization.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Localization.Core/OrchardCore.Localization.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Localization Core</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Localization.Core/OrchardCore.Localization.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Localization.Core/OrchardCore.Localization.Core.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Localization Core</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Core Implementation for Localization.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Localization</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Logging.NLog/OrchardCore.Logging.NLog.csproj
+++ b/src/OrchardCore/OrchardCore.Logging.NLog/OrchardCore.Logging.NLog.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Logging NLog</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Logging.NLog/OrchardCore.Logging.NLog.csproj
+++ b/src/OrchardCore/OrchardCore.Logging.NLog/OrchardCore.Logging.NLog.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Logging NLog</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides NLog logging for application.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Logging</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Logging.Serilog/OrchardCore.Logging.Serilog.csproj
+++ b/src/OrchardCore/OrchardCore.Logging.Serilog/OrchardCore.Logging.Serilog.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Logging Serilog</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Logging.Serilog/OrchardCore.Logging.Serilog.csproj
+++ b/src/OrchardCore/OrchardCore.Logging.Serilog/OrchardCore.Logging.Serilog.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Logging Serilog</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides Serilog logging for application.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Logging</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Lucene.Abstractions/OrchardCore.Lucene.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Lucene.Abstractions/OrchardCore.Lucene.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Lucene</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Lucene Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Lucene.Abstractions/OrchardCore.Lucene.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Lucene.Abstractions/OrchardCore.Lucene.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Lucene</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Lucene Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for Lucene.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Lucene.Core/OrchardCore.Lucene.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Lucene.Core/OrchardCore.Lucene.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Lucene</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Lucene Core</Title>

--- a/src/OrchardCore/OrchardCore.Lucene.Core/OrchardCore.Lucene.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Lucene.Core/OrchardCore.Lucene.Core.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Lucene</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Lucene Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core Implementation for Lucene module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Markdown.Abstractions/OrchardCore.Markdown.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Markdown.Abstractions/OrchardCore.Markdown.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Markdown</RootNamespace>
      <!-- NuGet properties-->
     <Title>OrchardCore Markdown Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for Markdown.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Markdown.Abstractions/OrchardCore.Markdown.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Markdown.Abstractions/OrchardCore.Markdown.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Markdown</RootNamespace>
      <!-- NuGet properties-->
     <Title>OrchardCore Markdown Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/OrchardCore.Media.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/OrchardCore.Media.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Media</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Media Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Media.Abstractions/OrchardCore.Media.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Media.Abstractions/OrchardCore.Media.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Media</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Media Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Media.Core/OrchardCore.Media.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Media.Core/OrchardCore.Media.Core.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Media Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core implementation for OrchardCore Media.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>
@@ -13,7 +12,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.FileStorage.Abstractions\OrchardCore.FileStorage.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.Media.Abstractions\OrchardCore.Media.Abstractions.csproj" />

--- a/src/OrchardCore/OrchardCore.Media.Core/OrchardCore.Media.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Media.Core/OrchardCore.Media.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Media Core</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.MetaWeblog.Abstractions/OrchardCore.MetaWeblog.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.MetaWeblog.Abstractions/OrchardCore.MetaWeblog.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.MetaWeblog</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore MetaWeblog</Title>

--- a/src/OrchardCore/OrchardCore.MetaWeblog.Abstractions/OrchardCore.MetaWeblog.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.MetaWeblog.Abstractions/OrchardCore.MetaWeblog.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.MetaWeblog</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore MetaWeblog</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for MetaWeblog.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Infrastructure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
@@ -13,7 +13,21 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <!-- Add the OrchardCore.Module.props file in the package -->
+  <!--
+    Add the OrchardCore.Module.Targets .props and .target files to the package.
+    Also add the Package.Build.props which is necessary for an assembly to be considered an
+    OrchardCore module.
+
+    When the OrchardCore.Module.Targets package is referenced, the .props and .targets files
+    present in the build folder will also be referenced by the generated .props and .targets
+    files in the obj folder of the referencing project.
+
+    See: https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package#include-msbuild-props-and-targets-in-a-package
+    * The files in the build folder will be applied to any TFM.
+    * The files in the build\$(TargetFramework) folder will be applied to only referencing projects targeting that TFM
+    * The files in the buildMultiTargeting folder will only be applied when the referencing project's $(TargetFramework)
+      is empty
+  -->
   <ItemGroup>
     <None Include="OrchardCore.Module.Targets.props" Pack="true">
       <PackagePath>build\OrchardCore.Module.Targets.props</PackagePath>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for OrchardCore Module</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
@@ -16,13 +16,13 @@
   <!-- Add the OrchardCore.Module.props file in the package -->
   <ItemGroup>
     <None Include="OrchardCore.Module.Targets.props" Pack="true">
-      <PackagePath>build\$(TargetFramework)\OrchardCore.Module.Targets.props</PackagePath>
+      <PackagePath>build\OrchardCore.Module.Targets.props</PackagePath>
     </None>
     <None Include="OrchardCore.Module.Targets.targets" Pack="true">
-      <PackagePath>build\$(TargetFramework)\OrchardCore.Module.Targets.targets</PackagePath>
+      <PackagePath>build\OrchardCore.Module.Targets.targets</PackagePath>
     </None>
     <None Include="Package.Build.props" Pack="true">
-      <PackagePath>build\$(TargetFramework)\Package.Build.props</PackagePath>
+      <PackagePath>build\Package.Build.props</PackagePath>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for OrchardCore Module</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Converts project/library into an OrchardCore Module that can be referenced in OrchardCore modular application.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)Package.Build.props" Pack="true">
-      <PackagePath>build\$(TargetFramework)\$(AssemblyName).props</PackagePath>
+      <PackagePath>build\$(AssemblyName).props</PackagePath>
     </None>
   </ItemGroup>
 

--- a/src/OrchardCore/OrchardCore.Module.Targets/Package.Build.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/Package.Build.props
@@ -1,8 +1,14 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
-  <!-- 
-    This file is included in the NuGet packages as "build\$(TargetFramework)\$(AssemblyName).props" file.
-    It contains the logic to be referenced as a module by the main application.
+
+  <!--
+    The ModulePackageNames item group will cause the application referencing this
+    assembly to treat this assembly as an Orchard Module.  Without this, the application
+    will not realize that the assembly is a module and the module will not be loaded and
+    available.
+
+    This is packaged into the nuget package in OrchardCore.Module.Targets and should
+    automatically be imported into the referencing project's generated msbuild files
+    in the obj folder.
   -->
   <ItemGroup>
     <ModulePackageNames Include="$(MSBuildThisFileName)" />

--- a/src/OrchardCore/OrchardCore.Mvc.Core/OrchardCore.Mvc.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/OrchardCore.Mvc.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Mvc</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Mvc Core</Title>

--- a/src/OrchardCore/OrchardCore.Mvc.Core/OrchardCore.Mvc.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/OrchardCore.Mvc.Core.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Mvc</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Mvc Core</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Core Implementation for MVC application.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Navigation.Core/OrchardCore.Navigation.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/OrchardCore.Navigation.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Navigation Core</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Navigation.Core/OrchardCore.Navigation.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/OrchardCore.Navigation.Core.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Navigation Core</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Core Implementation for OrchardCore Navigation.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.OpenId.Core/OrchardCore.OpenId.Core.csproj
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/OrchardCore.OpenId.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore OpenId Core</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.OpenId.Core/OrchardCore.OpenId.Core.csproj
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/OrchardCore.OpenId.Core.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore OpenId Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core implementation for OpenId.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS OpenId</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Queries.Abstractions/OrchardCore.Queries.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Queries.Abstractions/OrchardCore.Queries.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Queries</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Queries Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Queries.Abstractions/OrchardCore.Queries.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Queries.Abstractions/OrchardCore.Queries.Abstractions.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Queries</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Queries Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for Queries.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/OrchardCore.ReCaptcha.Core.csproj
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/OrchardCore.ReCaptcha.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ReCaptcha</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ReCaptcha Core</Title>

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/OrchardCore.ReCaptcha.Core.csproj
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/OrchardCore.ReCaptcha.Core.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ReCaptcha</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ReCaptcha Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core implementation for OrchardCore ReCaptcha</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS ContentManagement</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/OrchardCore.Recipes.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/OrchardCore.Recipes.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Recipes</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Recipes Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions for Recipes.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/OrchardCore.Recipes.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/OrchardCore.Recipes.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Recipes</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Recipes Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Recipes.Core/OrchardCore.Recipes.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/OrchardCore.Recipes.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Recipes</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Recipes Core</Title>

--- a/src/OrchardCore/OrchardCore.Recipes.Core/OrchardCore.Recipes.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/OrchardCore.Recipes.Core.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Recipes</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Recipes Core</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Core Implementation for OrchardCore Recipes.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Infrastructure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Redis.Abstractions/OrchardCore.Redis.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Redis.Abstractions/OrchardCore.Redis.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Redis</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Redis Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Redis.Abstractions/OrchardCore.Redis.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Redis.Abstractions/OrchardCore.Redis.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Redis</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Redis Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions for Redis.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/OrchardCore.ResourceManagement.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/OrchardCore.ResourceManagement.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ResourceManagement</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ResourceManagement Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/OrchardCore.ResourceManagement.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/OrchardCore.ResourceManagement.Abstractions.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.ResourceManagement</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore ResourceManagement Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions for ResourceManagement.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.ResourceManagement/OrchardCore.ResourceManagement.csproj
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/OrchardCore.ResourceManagement.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore ResourceManagement</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides Resource Management capabilities and useful TagHelpers for commonly used resources like JavaScript libraries and CSS files.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.ResourceManagement/OrchardCore.ResourceManagement.csproj
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/OrchardCore.ResourceManagement.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore ResourceManagement</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Rules.Abstractions/OrchardCore.Rules.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Rules.Abstractions/OrchardCore.Rules.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
     <RootNamespace>OrchardCore.Rules</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Rules Abstractions</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Abstractions for rules.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>
@@ -18,5 +17,5 @@
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Infrastructure.Abstractions\OrchardCore.Infrastructure.Abstractions.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/OrchardCore.Scripting.JavaScript.csproj
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/OrchardCore.Scripting.JavaScript.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Scripting JavaScript</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Provides javascript scripting capabilities.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/OrchardCore.Scripting.JavaScript.csproj
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/OrchardCore.Scripting.JavaScript.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Scripting JavaScript</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/OrchardCore.Search.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/OrchardCore.Search.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Search.Abstractions</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Search Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for search.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/OrchardCore.Search.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/OrchardCore.Search.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Search.Abstractions</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Search Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Settings.Core/OrchardCore.Settings.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Settings.Core/OrchardCore.Settings.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Settings Core</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Settings.Core/OrchardCore.Settings.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Settings.Core/OrchardCore.Settings.Core.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Settings Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core implementation for settings module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Setup.Abstractions/OrchardCore.Setup.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Setup.Abstractions/OrchardCore.Setup.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Setup</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Setup Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Setup.Abstractions/OrchardCore.Setup.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Setup.Abstractions/OrchardCore.Setup.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Setup</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Setup Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for setup module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Setup.Core/OrchardCore.Setup.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Setup.Core/OrchardCore.Setup.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Setup Core</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Setup.Core/OrchardCore.Setup.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Setup.Core/OrchardCore.Setup.Core.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Setup Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core implementation for setup module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Shells.Azure/OrchardCore.Shells.Azure.csproj
+++ b/src/OrchardCore/OrchardCore.Shells.Azure/OrchardCore.Shells.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Shells Azure</Title>
     <Description>$(OCFrameworkDescription)

--- a/src/OrchardCore/OrchardCore.Shells.Azure/OrchardCore.Shells.Azure.csproj
+++ b/src/OrchardCore/OrchardCore.Shells.Azure/OrchardCore.Shells.Azure.csproj
@@ -1,11 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>OrchardCore Shells Azure</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     Enables support for loading site and shell settings from Azure Blob Storage.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Azure</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Shortcodes.Abstractions/OrchardCore.Shortcodes.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Shortcodes.Abstractions/OrchardCore.Shortcodes.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Shortcodes</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Shortcodes Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for Shortcodes module</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Shortcodes.Abstractions/OrchardCore.Shortcodes.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Shortcodes.Abstractions/OrchardCore.Shortcodes.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Shortcodes</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Shortcodes Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Sitemaps.Abstractions/OrchardCore.Sitemaps.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Sitemaps.Abstractions/OrchardCore.Sitemaps.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Sitemaps</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Sitemaps Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for the Sitemaps module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Sitemaps.Abstractions/OrchardCore.Sitemaps.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Sitemaps.Abstractions/OrchardCore.Sitemaps.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Sitemaps</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Sitemaps Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
@@ -16,7 +16,7 @@
   <!-- Add a ".props" file in the package specific to the "Theme" module type -->
   <ItemGroup>
     <None Include="OrchardCore.Theme.Targets.props" Pack="true">
-      <PackagePath>build\$(TargetFramework)\OrchardCore.Theme.Targets.props</PackagePath>
+      <PackagePath>build\OrchardCore.Theme.Targets.props</PackagePath>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for OrchardCore Theme</Title>
     <Description>$(OCCMSDescription)
-    
+
     Converts project/library into an OrchardCore Theme that can be referenced in OrchardCore CMS application.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
@@ -13,7 +13,19 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <!-- Add a ".props" file in the package specific to the "Theme" module type -->
+  <!--
+    Add a ".props" file in the package specific to the "Theme" module type
+
+    When the OrchardCore.Theme.Targets package is referenced, the .props and .targets files
+    present in the build folder will also be referenced by the generated .props and .targets
+    files in the obj folder of the referencing project.
+
+    See: https://docs.microsoft.com/en-us/nuget/create-packages/creating-a-package#include-msbuild-props-and-targets-in-a-package
+    * The files in the build folder will be applied to any TFM.
+    * The files in the build\$(TargetFramework) folder will be applied to only referencing projects targeting that TFM
+    * The files in the buildMultiTargeting folder will only be applied when the referencing project's $(TargetFramework)
+      is empty
+  -->
   <ItemGroup>
     <None Include="OrchardCore.Theme.Targets.props" Pack="true">
       <PackagePath>build\OrchardCore.Theme.Targets.props</PackagePath>

--- a/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <!-- NuGet properties-->
     <Title>Target for OrchardCore Theme</Title>
     <Description>$(OCCMSDescription)

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/OrchardCore.Users.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/OrchardCore.Users.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Users</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Users Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for Users module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/OrchardCore.Users.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/OrchardCore.Users.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Users</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Users Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Users.Core/OrchardCore.Users.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Users.Core/OrchardCore.Users.Core.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Users</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Users Core</Title>
     <Description>$(OCCMSDescription)
-    
+
     Core implementation for Users module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.Users.Core/OrchardCore.Users.Core.csproj
+++ b/src/OrchardCore/OrchardCore.Users.Core/OrchardCore.Users.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Users</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Users Core</Title>

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/OrchardCore.Workflows.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/OrchardCore.Workflows.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Workflows</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Workflows Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/OrchardCore.Workflows.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/OrchardCore.Workflows.Abstractions.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.Workflows</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Workflows Abstractions</Title>
     <Description>$(OCCMSDescription)
-    
+
     Abstractions for the Workflows module.</Description>
     <PackageTags>$(PackageTags) OrchardCoreCMS Abstractions</PackageTags>
   </PropertyGroup>

--- a/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/OrchardCore.XmlRpc.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/OrchardCore.XmlRpc.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.XmlRpc</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore XmlRpc Abstractions</Title>

--- a/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/OrchardCore.XmlRpc.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/OrchardCore.XmlRpc.Abstractions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <RootNamespace>OrchardCore.XmlRpc</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore XmlRpc Abstractions</Title>

--- a/src/OrchardCore/OrchardCore/OrchardCore.csproj
+++ b/src/OrchardCore/OrchardCore/OrchardCore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore</Title>

--- a/src/OrchardCore/OrchardCore/OrchardCore.csproj
+++ b/src/OrchardCore/OrchardCore/OrchardCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
 
     <!-- NuGet properties-->
     <Title>OrchardCore</Title>

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -19,8 +19,8 @@
     <!--
       The previous code used a nuget package to allow the "RoslynCodeTaskFactory" (see the ReplaceFileText task definition below) to be used.
       The latest versions of the build tooling have now incorporated the RoslynCodeTaskFactory into its own codebase, and thus no package references are needed now.
-      This led to the NU5128 warning, which is now being ignored.  See the following error message.
-      The error message is not accurate, as it indicates there is no content.  It should say assemblies instead, since we have content but no assemblies.
+      This led to the NU5128 warning, which is now being ignored. See the following error message.
+      The error message is not accurate, as it indicates there is no content. It should say assemblies instead, since we have content but no assemblies.
         NU5128 warning: Ignore since the project template package doesn't contain content or references to other packages
     -->
     <NoWarn>CS8021,CS2008,NU5128</NoWarn>

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -10,23 +10,23 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <EnableDefaultItems>False</EnableDefaultItems>
     <!--
-      By default, nuget will not pack files/folders that being with a '.'
-      This setting changes that so that the .template.config folder will be included
+      By default, nuget will not pack files / folders that being with a '.'.
+      This setting changes that so that the .template.config folder will be included.
     -->
     <NoDefaultExcludes>True</NoDefaultExcludes>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <PackageType>Template</PackageType>
     <!--
-      The previous code used a nuget package to allow the "RoslynCodeTaskFactory" (see the ReplaceFileText task definition below) to be used.
-      The latest versions of the build tooling have now incorporated the RoslynCodeTaskFactory into its own codebase, and thus no package references are needed now.
+      The previous code used a nuget package to allow the 'RoslynCodeTaskFactory' (see the ReplaceFileText task definition below) to be used.
+      The latest versions of the build tooling have now incorporated the 'RoslynCodeTaskFactory' into its own codebase, and thus no package references are needed now.
       This led to the NU5128 warning, which is now being ignored. See the following error message.
       The error message is not accurate, as it indicates there is no content. It should say assemblies instead, since we have content but no assemblies.
-        NU5128 warning: Ignore since the project template package doesn't contain content or references to other packages
+        NU5128 warning: Ignore since the project template package doesn't contain content or references to other packages.
     -->
     <NoWarn>CS8021,CS2008,NU5128</NoWarn>
     <!--
-      Prevent the symbol package from being created as this nuget package doesn't have package refs or assemblies
-      Otherwise, the following error will be thrown by `dotnet pack`: error NU5017: Cannot create a package that has no dependencies nor content
+      Prevent the symbol package from being created as this nuget package doesn't have package refs or assemblies.
+      Otherwise, the following error will be thrown by `dotnet pack`: error NU5017: Cannot create a package that has no dependencies nor content.
     -->
     <IncludeSymbols>False</IncludeSymbols>
     <!-- NuGet properties-->
@@ -68,7 +68,7 @@
   <Target Name="TransformTemplateConfigs" BeforeTargets="Build">
     <!--
       For each template, copy its '.template.config.src' directory to '.template.config',
-      removing any earlier output at that location
+      removing any earlier output at that location.
     -->
     <ItemGroup>
       <_TemplateProjectFile Include="content\**\*.csproj" />
@@ -82,7 +82,7 @@
     <Copy SourceFiles="@(_TemplateConfigFileToCopy)" DestinationFolder="%(DestDir)" />
 
     <!--
-      Modify the .json files in the .template.config dirs to stamp MSBuild properties into them
+      Modify the .json files in the .template.config dirs to stamp MSBuild properties into them.
     -->
     <ItemGroup>
       <GeneratedContent Include="@(_TemplateConfigFileToCopy)" Condition="'%(Extension)'=='.json'">
@@ -90,7 +90,7 @@
       </GeneratedContent>
     </ItemGroup>
 
-    <!-- Update the OrchardVersion in the templates to reflect the newly built version number -->
+    <!-- Update the OrchardVersion in the templates to reflect the newly built version number. -->
     <ReplaceFileText InputFilename="%(GeneratedContent.OutputPath)" OutputFilename="%(GeneratedContent.OutputPath)" MatchExpression="\$\{TemplateOrchardVersion\}" ReplacementText="$(Version)" />
     <!-- Replace the default target framework for the template based on which TFM is being built. The resulting nuget package should have templates with the correct corresponding TFM defaulted in the template. -->
     <ReplaceFileText InputFilename="%(GeneratedContent.OutputPath)" OutputFilename="%(GeneratedContent.OutputPath)" MatchExpression="\$\{TemplateTargetFramework\}" ReplacementText="$(TargetFramework)" />

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -92,7 +92,7 @@
 
     <!-- Update the OrchardVersion in the templates to reflect the newly built version number -->
     <ReplaceFileText InputFilename="%(GeneratedContent.OutputPath)" OutputFilename="%(GeneratedContent.OutputPath)" MatchExpression="\$\{TemplateOrchardVersion\}" ReplacementText="$(Version)" />
-    <!-- Replace the default target framework for the template based on which TFM is being built.  The resulting nuget package should have templates with the correct corresponding TFM defaulted in the template. -->
+    <!-- Replace the default target framework for the template based on which TFM is being built. The resulting nuget package should have templates with the correct corresponding TFM defaulted in the template. -->
     <ReplaceFileText InputFilename="%(GeneratedContent.OutputPath)" OutputFilename="%(GeneratedContent.OutputPath)" MatchExpression="\$\{TemplateTargetFramework\}" ReplacementText="$(TargetFramework)" />
   </Target>
 </Project>

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -4,13 +4,31 @@
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />
   </ItemGroup>
   <PropertyGroup>
+    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <IncludeSource>False</IncludeSource>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <EnableDefaultItems>False</EnableDefaultItems>
+    <!--
+      By default, nuget will not pack files/folders that being with a '.'
+      This setting changes that so that the .template.config folder will be included
+    -->
+    <NoDefaultExcludes>True</NoDefaultExcludes>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <PackageType>Template</PackageType>
-    <NoWarn>CS8021,CS2008</NoWarn>
+    <!--
+      The previous code used a nuget package to allow the "RoslynCodeTaskFactory" (see the ReplaceFileText task definition below) to be used.
+      The latest versions of the build tooling have now incorporated the RoslynCodeTaskFactory into its own codebase, and thus no package references are needed now.
+      This led to the NU5128 warning, which is now being ignored.  See the following error message.
+      The error message is not accurate, as it indicates there is no content.  It should say assemblies instead, since we have content but no assemblies.
+        NU5128 warning: Ignore since the project template package doesn't contain content or references to other packages
+    -->
+    <NoWarn>CS8021,CS2008,NU5128</NoWarn>
+    <!--
+      Prevent the symbol package from being created as this nuget package doesn't have package refs or assemblies
+      Otherwise, the following error will be thrown by `dotnet pack`: error NU5017: Cannot create a package that has no dependencies nor content
+    -->
+    <IncludeSymbols>False</IncludeSymbols>
     <!-- NuGet properties-->
     <Title>OrchardCore Code Generation Templates</Title>
     <Description>$(OCFrameworkDescription)
@@ -25,11 +43,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
-  </ItemGroup>
-
-  <UsingTask TaskName="ReplaceFileText" TaskFactory="CodeTaskFactory" AssemblyFile="$(RoslynCodeTaskFactory)" Condition=" '$(RoslynCodeTaskFactory)' != '' ">
+  <UsingTask TaskName="ReplaceFileText" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
     <ParameterGroup>
       <InputFilename ParameterType="System.String" Required="true" />
       <OutputFilename ParameterType="System.String" Required="true" />
@@ -37,7 +51,6 @@
       <ReplacementText ParameterType="System.String" Required="true" />
     </ParameterGroup>
     <Task>
-      <Reference Include="System.Core" />
       <Using Namespace="System" />
       <Using Namespace="System.IO" />
       <Using Namespace="System.Text.RegularExpressions" />
@@ -52,7 +65,7 @@
     </Task>
   </UsingTask>
 
-  <Target Name="TransformTemplateConfigs" BeforeTargets="CoreBuild">
+  <Target Name="TransformTemplateConfigs" BeforeTargets="Build">
     <!--
       For each template, copy its '.template.config.src' directory to '.template.config',
       removing any earlier output at that location
@@ -71,14 +84,15 @@
     <!--
       Modify the .json files in the .template.config dirs to stamp MSBuild properties into them
     -->
-
     <ItemGroup>
       <GeneratedContent Include="@(_TemplateConfigFileToCopy)" Condition="'%(Extension)'=='.json'">
         <OutputPath>%(DestDir)%(RecursiveDir)%(Filename)%(Extension)</OutputPath>
       </GeneratedContent>
     </ItemGroup>
 
+    <!-- Update the OrchardVersion in the templates to reflect the newly built version number -->
     <ReplaceFileText InputFilename="%(GeneratedContent.OutputPath)" OutputFilename="%(GeneratedContent.OutputPath)" MatchExpression="\$\{TemplateOrchardVersion\}" ReplacementText="$(Version)" />
-
+    <!-- Replace the default target framework for the template based on which TFM is being built.  The resulting nuget package should have templates with the correct corresponding TFM defaulted in the template. -->
+    <ReplaceFileText InputFilename="%(GeneratedContent.OutputPath)" OutputFilename="%(GeneratedContent.OutputPath)" MatchExpression="\$\{TemplateTargetFramework\}" ReplacementText="$(TargetFramework)" />
   </Target>
 </Project>

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -4,7 +4,7 @@
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />
   </ItemGroup>
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <IncludeSource>False</IncludeSource>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -4,7 +4,6 @@
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />
   </ItemGroup>
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <IncludeSource>False</IncludeSource>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
@@ -15,7 +14,7 @@
     <!-- NuGet properties-->
     <Title>OrchardCore Code Generation Templates</Title>
     <Description>$(OCFrameworkDescription)
-    
+
     OrchardCore Code Templates for dotnet new template configurations for creating new websites, themes and modules from the command shell.</Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework</PackageTags>
   </PropertyGroup>

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/template.json
@@ -23,8 +23,8 @@
           "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp3.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "$(TemplateTargetPackageFramework)",
+      "defaultValue": "${TemplateTargetFramework}"
     },
     "AddPart": {
       "type": "parameter",

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/OrchardCore.Templates.Cms.Module.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/OrchardCore.Templates.Cms.Module.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(TemplateTargetPackageFramework)</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/.template.config.src/template.json
@@ -23,8 +23,8 @@
           "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp3.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "$(TemplateTargetPackageFramework)",
+      "defaultValue": "${TemplateTargetFramework}"
     },
     "Logger": {
       "type": "parameter",

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/OrchardCore.Templates.Cms.Web.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/OrchardCore.Templates.Cms.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(TemplateTargetPackageFramework)</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <PreserveCompilationReferences>true</PreserveCompilationReferences>
   </PropertyGroup>

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/.template.config.src/template.json
@@ -23,8 +23,8 @@
           "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp3.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "$(TemplateTargetPackageFramework)",
+      "defaultValue": "${TemplateTargetFramework}"
     },
     "OrchardVersion": {
       "type": "parameter",

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/OrchardCore.Templates.Mvc.Module.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/OrchardCore.Templates.Mvc.Module.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(TemplateTargetPackageFramework)</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/.template.config.src/template.json
@@ -23,8 +23,8 @@
           "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp3.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "$(TemplateTargetPackageFramework)",
+      "defaultValue": "${TemplateTargetFramework}"
     },
     "OrchardVersion": {
       "type": "parameter",

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/OrchardCore.Templates.Mvc.Web.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/OrchardCore.Templates.Mvc.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(TemplateTargetPackageFramework)</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Theme/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Theme/.template.config.src/template.json
@@ -23,8 +23,8 @@
           "description": "Target net5.0"
         }
       ],
-      "replaces": "netcoreapp3.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "$(TemplateTargetPackageFramework)",
+      "defaultValue": "${TemplateTargetFramework}"
     },
     "AddLiquid": {
       "type": "parameter",

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Theme/OrchardCore.Templates.Theme.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Theme/OrchardCore.Templates.Theme.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>$(TemplateTargetPackageFramework)</TargetFramework>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/src/docs/OrchardCore.Docs.csproj
+++ b/src/docs/OrchardCore.Docs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/docs/guides/decoupled-cms/README.md
+++ b/src/docs/guides/decoupled-cms/README.md
@@ -59,7 +59,7 @@ The newly created website should be able to run, and look like this:
 
 ```xml
 <PropertyGroup>
-  <TargetFramework>netcoreapp3.1</TargetFramework>
+  <TargetFramework>net5.0</TargetFramework>
   <PreserveCompilationReferences>true</PreserveCompilationReferences>
 </PropertyGroup>
 ```

--- a/test/Functional/OrchardCore.Tests.Functional.csproj
+++ b/test/Functional/OrchardCore.Tests.Functional.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Functional/cypress-commands/dist/test-runner.js
+++ b/test/Functional/cypress-commands/dist/test-runner.js
@@ -25,7 +25,7 @@ function deleteDirectory(dir) {
 }
 
 // Host the dotnet application, does not rebuild
-function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersion='netcoreapp3.1' }={}) {
+function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersion='net5.0' }={}) {
   if (fs.existsSync(path.join(dir, `bin/Release/${dotnetVersion}/`, assembly))) {
     global.log("Application already built, skipping build");
   } else {
@@ -57,7 +57,7 @@ function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersion='netc
 }
 
 // combines the functions above, useful when triggering tests from CI
-function e2e(dir, assembly, { dotnetVersion='netcoreapp3.1' }={}) {
+function e2e(dir, assembly, { dotnetVersion='net5.0' }={}) {
   deleteDirectory(path.join(dir, "App_Data_Tests"));
   var server = host(dir, assembly, { appDataLocation: "./App_Data_Tests", dotnetVersion });
 

--- a/test/Functional/cypress-commands/dist/test-runner.mjs
+++ b/test/Functional/cypress-commands/dist/test-runner.mjs
@@ -21,7 +21,7 @@ function deleteDirectory(dir) {
 }
 
 // Host the dotnet application, does not rebuild
-function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersion='netcoreapp3.1' }={}) {
+function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersion='net5.0' }={}) {
   if (fs.existsSync(path.join(dir, `bin/Release/${dotnetVersion}/`, assembly))) {
     global.log("Application already built, skipping build");
   } else {
@@ -53,7 +53,7 @@ function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersion='netc
 }
 
 // combines the functions above, useful when triggering tests from CI
-function e2e(dir, assembly, { dotnetVersion='netcoreapp3.1' }={}) {
+function e2e(dir, assembly, { dotnetVersion='net5.0' }={}) {
   deleteDirectory(path.join(dir, "App_Data_Tests"));
   var server = host(dir, assembly, { appDataLocation: "./App_Data_Tests", dotnetVersion });
 

--- a/test/Functional/cypress-commands/src/test-runner.js
+++ b/test/Functional/cypress-commands/src/test-runner.js
@@ -21,7 +21,7 @@ export function deleteDirectory(dir) {
 }
 
 // Host the dotnet application, does not rebuild
-export function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersion='netcoreapp3.1' }={}) {
+export function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersion='net5.0' }={}) {
   if (fs.existsSync(path.join(dir, `bin/Release/${dotnetVersion}/`, assembly))) {
     global.log("Application already built, skipping build");
   } else {
@@ -53,7 +53,7 @@ export function host(dir, assembly, { appDataLocation='./App_Data', dotnetVersio
 }
 
 // combines the functions above, useful when triggering tests from CI
-export function e2e(dir, assembly, { dotnetVersion='netcoreapp3.1' }={}) {
+export function e2e(dir, assembly, { dotnetVersion='net5.0' }={}) {
   deleteDirectory(path.join(dir, "App_Data_Tests"));
   var server = host(dir, assembly, { appDataLocation: "./App_Data_Tests", dotnetVersion });
 

--- a/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
+++ b/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>OrchardCore.Benchmark</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/test/OrchardCore.Tests.Modules/BaseThemeSample/BaseThemeSample.csproj
+++ b/test/OrchardCore.Tests.Modules/BaseThemeSample/BaseThemeSample.csproj
@@ -4,9 +4,6 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.props" />
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
-  <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.csproj" />

--- a/test/OrchardCore.Tests.Modules/BaseThemeSample/BaseThemeSample.csproj
+++ b/test/OrchardCore.Tests.Modules/BaseThemeSample/BaseThemeSample.csproj
@@ -5,7 +5,7 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Modules/BaseThemeSample2/BaseThemeSample2.csproj
+++ b/test/OrchardCore.Tests.Modules/BaseThemeSample2/BaseThemeSample2.csproj
@@ -4,9 +4,6 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.props" />
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
-  <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.csproj" />

--- a/test/OrchardCore.Tests.Modules/BaseThemeSample2/BaseThemeSample2.csproj
+++ b/test/OrchardCore.Tests.Modules/BaseThemeSample2/BaseThemeSample2.csproj
@@ -5,7 +5,7 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Modules/DerivedThemeSample/DerivedThemeSample.csproj
+++ b/test/OrchardCore.Tests.Modules/DerivedThemeSample/DerivedThemeSample.csproj
@@ -4,9 +4,6 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.props" />
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
-  <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
-  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.csproj" />

--- a/test/OrchardCore.Tests.Modules/DerivedThemeSample/DerivedThemeSample.csproj
+++ b/test/OrchardCore.Tests.Modules/DerivedThemeSample/DerivedThemeSample.csproj
@@ -5,7 +5,7 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Modules/DerivedThemeSample2/DerivedThemeSample2.csproj
+++ b/test/OrchardCore.Tests.Modules/DerivedThemeSample2/DerivedThemeSample2.csproj
@@ -5,7 +5,7 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Modules/DerivedThemeSample2/DerivedThemeSample2.csproj
+++ b/test/OrchardCore.Tests.Modules/DerivedThemeSample2/DerivedThemeSample2.csproj
@@ -4,10 +4,6 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.props" />
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
-  <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.csproj" />
     <ProjectReference Include="..\..\..\src\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />

--- a/test/OrchardCore.Tests.Modules/ModuleSample/ModuleSample.csproj
+++ b/test/OrchardCore.Tests.Modules/ModuleSample/ModuleSample.csproj
@@ -3,10 +3,6 @@
   <Import Project="..\..\..\src\OrchardCore.Build\Dependencies.props" />
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
-  <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
   </ItemGroup>

--- a/test/OrchardCore.Tests.Modules/ModuleSample/ModuleSample.csproj
+++ b/test/OrchardCore.Tests.Modules/ModuleSample/ModuleSample.csproj
@@ -4,7 +4,7 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/OrchardCore.Application.Pages.csproj
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/OrchardCore.Application.Pages.csproj
@@ -6,7 +6,6 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Application.Cms.Core.Targets\OrchardCore.Application.Cms.Core.Targets.props" />
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <PreserveCompilationReferences>true</PreserveCompilationReferences>

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/OrchardCore.Application.Pages.csproj
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/OrchardCore.Application.Pages.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Application.Cms.Core.Targets\OrchardCore.Application.Cms.Core.Targets.props" />
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <PreserveCompilationReferences>true</PreserveCompilationReferences>

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Modules.Pages/Module.Pages/Module.Pages.csproj
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Modules.Pages/Module.Pages/Module.Pages.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Modules.Pages/Module.Pages/Module.Pages.csproj
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Modules.Pages/Module.Pages/Module.Pages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Theme.Pages.csproj
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Theme.Pages.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Theme.Pages.csproj
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Theme.Pages.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
   </PropertyGroup>
 

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\src\OrchardCore.Build\Dependencies.props" />
 
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>OrchardCore.Tests</AssemblyName>
     <PackageId>OrchardCore.Tests</PackageId>

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -58,7 +58,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\OrchardCore.Cms.Web\OrchardCore.Cms.Web.csproj" />
+    <!--
+      The test project should also be multi-targeted so that tests are run under both TFMs.
+      Since we want to default the TFM for the OrchardCore.Cms.Web project, we need to specify
+      the TFM from the <ProjectReference> here to force the project to use the specified TFM and
+      not the default one.
+    -->
+    <ProjectReference Include="..\..\src\OrchardCore.Cms.Web\OrchardCore.Cms.Web.csproj" SetTargetFramework="TargetFramework=$(TargetFramework)" />
     <ProjectReference Include="..\..\src\OrchardCore\OrchardCore.Apis.GraphQL.Client\OrchardCore.Apis.GraphQL.Client.csproj" />
   </ItemGroup>
 

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -3,7 +3,6 @@
   <Import Project="..\..\src\OrchardCore.Build\Dependencies.props" />
 
   <PropertyGroup>
-    <!-- <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework> -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>OrchardCore.Tests</AssemblyName>
     <PackageId>OrchardCore.Tests</PackageId>

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -80,7 +80,7 @@
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+    <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.analyzers" />


### PR DESCRIPTION
This PR enables the built nuget packages to target both .NET 5.0 and .NET Core 3.1.

It does this by updating the `src/OrchardCore.Build/Dependencies.AspNetCore.props` to target multiple frameworks instead of a single one.

Significant changes include:

1) Removing the `<TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>` from all projects.  Due to the `Directory.Build.props` files in the source structure, the `Dependencies.AspNetCore.props` file is always imported in project builds.  This makes the TF node declaration in each project redundant and possibly increases maintenance effort.

    This was done in stages, the first being commenting them out, the second being removing the comment in its own commit.  This allows an easy revert to have the project nodes without removing the other changes in the .props file.  This could be useful for testing if needed.

1) Several code changes needed to be made to support the .NET 5.0 SDK tool changes.  In particular, code analysis complained of using `throw ex` in favor `throw`, thus the change in cfb396994d1404b0091f742ce1810636adc631b6.  In addition, the compiler complained when using the `QueryString` struct potentially without initializing it.  A simple fix was to using a string with the same logic instead.

1)  When running dotnet pack, projects in the `OrchardCore.Modules` folder failed with a NU5129 error indicating the <AssemblyName>.props file for the project was missing from the `build\` folder.  Using a msbuild binary log (`dotnet pack --no-build /bl`) and MSBuild Structure Log Viewer (in my case, the Blazor version at https://github.com/laurenprinn/MSBuildStructuredLog due to being on a mac...awesome job on this Lauren!) I was able to track it down to the fact that the props file was being placed in the TFM specific folders.  Multi-targetting needs the .props file to be in the non-TFM parent folder, so the fix was to simply remove the `$(TargetFramework)` path segment in the different files (see f6fed10).

# Known Issues and follow-up
* The `Microsoft.AspNetCore.Authentication.AzureAD.UI` package when updated to 5.0.1 indicated that some api's in use had been deprecated.  Rather than fix the warnings and test that package, the warnings were ignored via pragma statements and need to be addressed in the future.
*  During testing, random build failures occurred when building the Templates due to a template.config directory not being able to be deleted.  This could be due to a timing issue, but I haven't been able to track down why this happened.  Repeating the build generally solves the problem.
*  Comprehensive integration testing has not been performed locally.  Small tests will be started shortly.
