### PR TITLE
Using ILocalClock instead of IClock (BackgroundTaskScheduler)

### DIFF
--- a/src/OrchardCore/OrchardCore/BackgroundTasks/BackgroundTaskScheduler.cs
+++ b/src/OrchardCore/OrchardCore/BackgroundTasks/BackgroundTaskScheduler.cs
@@ -1,17 +1,20 @@
 using System;
 using NCrontab;
+using OrchardCore.Modules;
 
 namespace OrchardCore.BackgroundTasks
 {
     public class BackgroundTaskScheduler
     {
-        public BackgroundTaskScheduler(string tenant, string name, DateTime referenceTime)
+        public BackgroundTaskScheduler(string tenant, string name, DateTime referenceTime, IClock clock, string timeZoneId)
         {
             Name = name;
             Tenant = tenant;
             ReferenceTime = referenceTime;
             Settings = new BackgroundTaskSettings() { Name = name };
             State = new BackgroundTaskState() { Name = name };
+            Clock = clock;
+            TimeZone = Clock.GetTimeZone(timeZoneId);
         }
 
         public string Name { get; }
@@ -21,12 +24,16 @@ namespace OrchardCore.BackgroundTasks
         public BackgroundTaskState State { get; set; }
         public bool Released { get; set; }
         public bool Updated { get; set; }
+        public ITimeZone TimeZone { get; set; }
+        private IClock Clock { get; set; }
 
         public bool CanRun()
         {
-            var nextStartTime = CrontabSchedule.Parse(Settings.Schedule).GetNextOccurrence(ReferenceTime);
+            var referenceTimeLocal = Clock.ConvertToTimeZone(ReferenceTime, TimeZone).DateTime;
+            var nextStartTime = CrontabSchedule.Parse(Settings.Schedule).GetNextOccurrence(referenceTimeLocal);
+            var nowLocal = Clock.ConvertToTimeZone(DateTime.UtcNow, TimeZone).DateTime;
 
-            if (DateTime.UtcNow >= nextStartTime)
+            if (nowLocal >= nextStartTime)
             {
                 if (Settings.Enable && !Released && Updated)
                 {

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -14,7 +14,6 @@ using OrchardCore.BackgroundTasks;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Models;
-using OrchardCore.Settings;
 
 namespace OrchardCore.Modules
 {
@@ -172,9 +171,7 @@ namespace OrchardCore.Modules
 
                     var settingsProvider = scope.ServiceProvider.GetService<IBackgroundTaskSettingsProvider>();
 
-                    var siteService = scope.ServiceProvider.GetService<ISiteService>();
-                    var siteSettings = await siteService.GetSiteSettingsAsync();
-                    var clock = scope.ServiceProvider.GetService<IClock>();
+                    var localClock = scope.ServiceProvider.GetService<ILocalClock>();
 
                     _changeTokens[tenant] = settingsProvider?.ChangeToken ?? NullChangeToken.Singleton;
 
@@ -184,8 +181,7 @@ namespace OrchardCore.Modules
 
                         if (!_schedulers.TryGetValue(tenant + taskName, out var scheduler))
                         {
-                            _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime,
-                                clock, siteSettings.TimeZoneId);
+                            _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime, localClock);
                         }
 
                         if (!scheduler.Released && scheduler.Updated)

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -14,6 +14,7 @@ using OrchardCore.BackgroundTasks;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Models;
+using OrchardCore.Settings;
 
 namespace OrchardCore.Modules
 {
@@ -171,6 +172,10 @@ namespace OrchardCore.Modules
 
                     var settingsProvider = scope.ServiceProvider.GetService<IBackgroundTaskSettingsProvider>();
 
+                    var siteService = scope.ServiceProvider.GetService<ISiteService>();
+                    var siteSettings = await siteService.GetSiteSettingsAsync();
+                    var clock = scope.ServiceProvider.GetService<IClock>();
+
                     _changeTokens[tenant] = settingsProvider?.ChangeToken ?? NullChangeToken.Singleton;
 
                     foreach (var task in tasks)
@@ -179,7 +184,8 @@ namespace OrchardCore.Modules
 
                         if (!_schedulers.TryGetValue(tenant + taskName, out var scheduler))
                         {
-                            _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime);
+                            _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime,
+                                clock, siteSettings.TimeZoneId);
                         }
 
                         if (!scheduler.Released && scheduler.Updated)

--- a/src/OrchardCore/OrchardCore/OrchardCore.csproj
+++ b/src/OrchardCore/OrchardCore/OrchardCore.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Abstractions\OrchardCore.Abstractions.csproj" />
+    <ProjectReference Include="..\OrchardCore.Infrastructure.Abstractions\OrchardCore.Infrastructure.Abstractions.csproj" />
     <ProjectReference Include="..\OrchardCore.Localization.Abstractions\OrchardCore.Localization.Abstractions.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Using ILocalClock instead of IClock.

fixes https://github.com/OrchardCMS/OrchardCore/issues/7518