### PR TITLE
Admin user tooltip

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenu.cshtml
@@ -1,7 +1,7 @@
 @inject IAuthorizationService AuthorizationService
 <div class="dropdown">
     <form asp-route-area="OrchardCore.Users" asp-controller="Account" asp-action="LogOff" method="post" class="form-inline">
-        <a class="ml-3 dropdown-toggle" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button">
+        <a class="ml-3 dropdown-toggle" id="navbarDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" role="button" data-toggle-tooltip="tooltip" title="@User.Identity.Name">
             <i class="fa fa-fw fa-user" aria-hidden="true"></i>
         </a>
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
@@ -15,3 +15,6 @@
         </div>
     </form>
 </div>
+<script at="Foot">
+    $('[data-toggle-tooltip="tooltip"]').tooltip();
+</script>


### PR DESCRIPTION
Display a tooltip on hover the user icon in admin with the current user name:

![image](https://user-images.githubusercontent.com/703248/107391984-8672bf00-6af9-11eb-8dff-d383cf57aa3c.png)

so you don't need to toggle the dropdown to check the user.
