### PR TITLE
Revert "Using ILocalClock instead of IClock (BackgroundTaskScheduler)"

### DIFF
--- a/src/OrchardCore/OrchardCore/BackgroundTasks/BackgroundTaskScheduler.cs
+++ b/src/OrchardCore/OrchardCore/BackgroundTasks/BackgroundTaskScheduler.cs
@@ -6,14 +6,15 @@ namespace OrchardCore.BackgroundTasks
 {
     public class BackgroundTaskScheduler
     {
-        public BackgroundTaskScheduler(string tenant, string name, DateTime referenceTime, ILocalClock localClock)
+        public BackgroundTaskScheduler(string tenant, string name, DateTime referenceTime, IClock clock, string timeZoneId)
         {
             Name = name;
             Tenant = tenant;
             ReferenceTime = referenceTime;
             Settings = new BackgroundTaskSettings() { Name = name };
             State = new BackgroundTaskState() { Name = name };
-            LocalClock = localClock;
+            Clock = clock;
+            TimeZone = Clock.GetTimeZone(timeZoneId);
         }
 
         public string Name { get; }
@@ -23,13 +24,14 @@ namespace OrchardCore.BackgroundTasks
         public BackgroundTaskState State { get; set; }
         public bool Released { get; set; }
         public bool Updated { get; set; }
-        private ILocalClock LocalClock { get; set; }
+        public ITimeZone TimeZone { get; set; }
+        private IClock Clock { get; set; }
 
         public bool CanRun()
         {
-            var referenceTimeLocal = LocalClock.ConvertToLocalAsync(ReferenceTime).Result.DateTime;
+            var referenceTimeLocal = Clock.ConvertToTimeZone(ReferenceTime, TimeZone).DateTime;
             var nextStartTime = CrontabSchedule.Parse(Settings.Schedule).GetNextOccurrence(referenceTimeLocal);
-            var nowLocal = LocalClock.LocalNowAsync.Result.DateTime;
+            var nowLocal = Clock.ConvertToTimeZone(DateTime.UtcNow, TimeZone).DateTime;
 
             if (nowLocal >= nextStartTime)
             {

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -14,6 +14,7 @@ using OrchardCore.BackgroundTasks;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Models;
+using OrchardCore.Settings;
 
 namespace OrchardCore.Modules
 {
@@ -171,7 +172,9 @@ namespace OrchardCore.Modules
 
                     var settingsProvider = scope.ServiceProvider.GetService<IBackgroundTaskSettingsProvider>();
 
-                    var localClock = scope.ServiceProvider.GetService<ILocalClock>();
+                    var siteService = scope.ServiceProvider.GetService<ISiteService>();
+                    var siteSettings = await siteService.GetSiteSettingsAsync();
+                    var clock = scope.ServiceProvider.GetService<IClock>();
 
                     _changeTokens[tenant] = settingsProvider?.ChangeToken ?? NullChangeToken.Singleton;
 
@@ -181,7 +184,8 @@ namespace OrchardCore.Modules
 
                         if (!_schedulers.TryGetValue(tenant + taskName, out var scheduler))
                         {
-                            _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime, localClock);
+                            _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime,
+                                clock, siteSettings.TimeZoneId);
                         }
 
                         if (!scheduler.Released && scheduler.Updated)


### PR DESCRIPTION
Reverts OrchardCMS/OrchardCore#8552

@sebastienros 

I will revert #8552 where `ILocalClock` which is scoped service (and need to be executed in a tenant context) that is held by the `BackgroundTaskScheduler` that are held by a dictionary of the `ModularBackgroundService` that is an application level singleton. So, when you start a background task you get the following exception (see below).

The previous PR #8548 was using `IClock` that doesn't use time zone selectors, but that is at least an app level singleton, didn't try this previous PR yet but i will do

    2021-02-10 04:15:48.9035||||OrchardCore.Modules.ModularBackgroundService|ERROR|Error while executing 'ModularBackgroundService' System.ArgumentNullException: Value cannot be null. (Parameter 'provider')
    at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
    at OrchardCore.Settings.Services.SiteService.get_DocumentManager() in C:\Sources\OrchardCore\src\OrchardCore.Modules\OrchardCore.Settings\Services\SiteService.cs:line 50
    at OrchardCore.Settings.Services.SiteService.GetSiteSettingsAsync() in C:\Sources\OrchardCore\src\OrchardCore.Modules\OrchardCore.Settings\Services\SiteService.cs:line 29
    at OrchardCore.Settings.Services.DefaultTimeZoneSelector.<GetTimeZoneAsync>b__2_0() in C:\Sources\OrchardCore\src\OrchardCore.Modules\OrchardCore.Settings\Services\DefaultTimeZoneSelector.cs:line 25
    at OrchardCore.Modules.LocalClock.LoadLocalTimeZoneAsync() in C:\Sources\OrchardCore\src\OrchardCore\OrchardCore\Modules\Services\LocalClock.cs:line 90
    at OrchardCore.Modules.LocalClock.GetLocalTimeZoneAsync() in C:\Sources\OrchardCore\src\OrchardCore\OrchardCore\Modules\Services\LocalClock.cs:line 41
    at OrchardCore.Modules.LocalClock.ConvertToLocalAsync(DateTimeOffset dateTimeOffSet) in C:\Sources\OrchardCore\src\OrchardCore\OrchardCore\Modules\Services\LocalClock.cs:line 49    at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
    at OrchardCore.Settings.Services.SiteService.get_DocumentManager() in C:\Sources\OrchardCore\src\OrchardCore.Modules\OrchardCore.Settings\Services\SiteService.cs:line 50
    at OrchardCore.Settings.Services.SiteService.GetSiteSettingsAsync() in C:\Sources\OrchardCore\src\OrchardCore.Modules\OrchardCore.Settings\Services\SiteService.cs:line 29
    at OrchardCore.Settings.Services.DefaultTimeZoneSelector.<GetTimeZoneAsync>b__2_0() in C:\Sources\OrchardCore\src\OrchardCore.Modules\OrchardCore.Settings\Services\DefaultTimeZoneSelector.cs:line 25
    at OrchardCore.Modules.LocalClock.LoadLocalTimeZoneAsync() in C:\Sources\OrchardCore\src\OrchardCore\OrchardCore\Modules\Services\LocalClock.cs:line 90
    at OrchardCore.Modules.LocalClock.GetLocalTimeZoneAsync() in C:\Sources\OrchardCore\src\OrchardCore\OrchardCore\Modules\Services\LocalClock.cs:line 41
    at OrchardCore.Modules.LocalClock.ConvertToLocalAsync(DateTimeOffset dateTimeOffSet) in C:\Sources\OrchardCore\src\OrchardCore\OrchardCore\Modules\Services\LocalClock.cs:line 49
