### PR TITLE
Null check on 'ISiteService' now used in background service

### DIFF
--- a/src/OrchardCore/OrchardCore/BackgroundTasks/BackgroundTaskScheduler.cs
+++ b/src/OrchardCore/OrchardCore/BackgroundTasks/BackgroundTaskScheduler.cs
@@ -6,13 +6,16 @@ namespace OrchardCore.BackgroundTasks
 {
     public class BackgroundTaskScheduler
     {
-        public BackgroundTaskScheduler(string tenant, string name, DateTime referenceTime)
+        private readonly IClock _clock;
+
+        public BackgroundTaskScheduler(string tenant, string name, DateTime referenceTime, IClock clock)
         {
             Name = name;
             Tenant = tenant;
             ReferenceTime = referenceTime;
             Settings = new BackgroundTaskSettings() { Name = name };
             State = new BackgroundTaskState() { Name = name };
+            _clock = clock;
         }
 
         public string Name { get; }
@@ -20,19 +23,19 @@ namespace OrchardCore.BackgroundTasks
         public DateTime ReferenceTime { get; set; }
         public BackgroundTaskSettings Settings { get; set; }
         public BackgroundTaskState State { get; set; }
+        public ITimeZone TimeZone { get; set; }
         public bool Released { get; set; }
         public bool Updated { get; set; }
-        public ITimeZone TimeZone { get; set; }
 
-        public bool CanRun(IClock clock)
+        public bool CanRun()
         {
             var now = DateTime.UtcNow;
             var referenceTime = ReferenceTime;
 
             if (TimeZone != null)
             {
-                now = clock.ConvertToTimeZone(DateTime.UtcNow, TimeZone).DateTime;
-                referenceTime = clock.ConvertToTimeZone(ReferenceTime, TimeZone).DateTime;
+                now = _clock.ConvertToTimeZone(DateTime.UtcNow, TimeZone).DateTime;
+                referenceTime = _clock.ConvertToTimeZone(ReferenceTime, TimeZone).DateTime;
             }
 
             var nextStartTime = CrontabSchedule.Parse(Settings.Schedule).GetNextOccurrence(referenceTime);

--- a/src/OrchardCore/OrchardCore/BackgroundTasks/BackgroundTaskScheduler.cs
+++ b/src/OrchardCore/OrchardCore/BackgroundTasks/BackgroundTaskScheduler.cs
@@ -6,15 +6,13 @@ namespace OrchardCore.BackgroundTasks
 {
     public class BackgroundTaskScheduler
     {
-        public BackgroundTaskScheduler(string tenant, string name, DateTime referenceTime, IClock clock, string timeZoneId)
+        public BackgroundTaskScheduler(string tenant, string name, DateTime referenceTime)
         {
             Name = name;
             Tenant = tenant;
             ReferenceTime = referenceTime;
             Settings = new BackgroundTaskSettings() { Name = name };
             State = new BackgroundTaskState() { Name = name };
-            Clock = clock;
-            TimeZone = Clock.GetTimeZone(timeZoneId);
         }
 
         public string Name { get; }
@@ -25,15 +23,21 @@ namespace OrchardCore.BackgroundTasks
         public bool Released { get; set; }
         public bool Updated { get; set; }
         public ITimeZone TimeZone { get; set; }
-        private IClock Clock { get; set; }
 
-        public bool CanRun()
+        public bool CanRun(IClock clock)
         {
-            var referenceTimeLocal = Clock.ConvertToTimeZone(ReferenceTime, TimeZone).DateTime;
-            var nextStartTime = CrontabSchedule.Parse(Settings.Schedule).GetNextOccurrence(referenceTimeLocal);
-            var nowLocal = Clock.ConvertToTimeZone(DateTime.UtcNow, TimeZone).DateTime;
+            var now = DateTime.UtcNow;
+            var referenceTime = ReferenceTime;
 
-            if (nowLocal >= nextStartTime)
+            if (TimeZone != null)
+            {
+                now = clock.ConvertToTimeZone(DateTime.UtcNow, TimeZone).DateTime;
+                referenceTime = clock.ConvertToTimeZone(ReferenceTime, TimeZone).DateTime;
+            }
+
+            var nextStartTime = CrontabSchedule.Parse(Settings.Schedule).GetNextOccurrence(referenceTime);
+
+            if (now >= nextStartTime)
             {
                 if (Settings.Enable && !Released && Updated)
                 {

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -200,6 +200,8 @@ namespace OrchardCore.Modules
                             _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime);
                         }
 
+                        scheduler.TimeZone = timeZone;
+
                         if (!scheduler.Released && scheduler.Updated)
                         {
                             continue;
@@ -227,7 +229,6 @@ namespace OrchardCore.Modules
                         }
 
                         scheduler.Settings = settings;
-                        scheduler.TimeZone = timeZone;
                         scheduler.Released = false;
                         scheduler.Updated = true;
                     }

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -187,7 +187,7 @@ namespace OrchardCore.Modules
                         }
                         catch (Exception ex) when (!ex.IsFatal())
                         {
-                            _logger.LogError(ex, "Error while getting the time zone of the site on tenant '{TenantName}'.", tenant);
+                            _logger.LogError(ex, "Error while getting the time zone of the tenant '{TenantName}'.", tenant);
                         }
                     }
 

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -197,7 +197,7 @@ namespace OrchardCore.Modules
 
                         if (!_schedulers.TryGetValue(tenant + taskName, out var scheduler))
                         {
-                            _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime);
+                            _schedulers[tenant + taskName] = scheduler = new BackgroundTaskScheduler(tenant, taskName, referenceTime, _clock);
                         }
 
                         scheduler.TimeZone = timeZone;
@@ -255,7 +255,7 @@ namespace OrchardCore.Modules
 
         private IEnumerable<ShellContext> GetShellsToRun(IEnumerable<ShellContext> shells)
         {
-            var tenantsToRun = _schedulers.Where(s => s.Value.CanRun(_clock)).Select(s => s.Value.Tenant).Distinct().ToArray();
+            var tenantsToRun = _schedulers.Where(s => s.Value.CanRun()).Select(s => s.Value.Tenant).Distinct().ToArray();
             return shells.Where(s => tenantsToRun.Contains(s.Settings.Name)).ToArray();
         }
 
@@ -283,7 +283,7 @@ namespace OrchardCore.Modules
 
         private IEnumerable<BackgroundTaskScheduler> GetSchedulersToRun(string tenant)
         {
-            return _schedulers.Where(s => s.Value.Tenant == tenant && s.Value.CanRun(_clock)).Select(s => s.Value).ToArray();
+            return _schedulers.Where(s => s.Value.Tenant == tenant && s.Value.CanRun()).Select(s => s.Value).ToArray();
         }
 
         private void UpdateSchedulers(IEnumerable<string> tenants, Action<BackgroundTaskScheduler> action)


### PR DESCRIPTION

The background service now use `ISiteService` to get the time zone of a given tenant

- Here we add a null check on `ISiteService` as using the background service doesn't ensure that it was registered.

- When a time zone is changed the related tenant is re-started but not the background service, so here we update the schedulers with the new time zone, not only through the constructor when there are created.

- Refactoring