### PR TITLE
Provide admin user id and other properties to recipes.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -26,36 +26,33 @@ namespace OrchardCore.Recipes.Controllers
         private readonly IExtensionManager _extensionManager;
         private readonly IAuthorizationService _authorizationService;
         private readonly IEnumerable<IRecipeHarvester> _recipeHarvesters;
-        private readonly INotifier _notifier;
         private readonly IRecipeExecutor _recipeExecutor;
-        private readonly ISiteService _siteService;
         private readonly IEnumerable<IRecipeEnvironmentProvider> _environmentProviders;
-        private readonly ILogger _logger;
+        private readonly INotifier _notifier;
         private readonly IHtmlLocalizer H;
+        private readonly ILogger _logger;
 
         public AdminController(
             IShellHost shellHost,
             ShellSettings shellSettings,
-            ISiteService siteService,
             IExtensionManager extensionManager,
-            IHtmlLocalizer<AdminController> localizer,
             IAuthorizationService authorizationService,
             IEnumerable<IRecipeHarvester> recipeHarvesters,
             IRecipeExecutor recipeExecutor,
-            INotifier notifier,
             IEnumerable<IRecipeEnvironmentProvider> environmentProviders,
+            INotifier notifier,
+            IHtmlLocalizer<AdminController> localizer,
             ILogger<AdminController> logger)
         {
             _shellHost = shellHost;
             _shellSettings = shellSettings;
-            _siteService = siteService;
-            _recipeExecutor = recipeExecutor;
             _extensionManager = extensionManager;
             _authorizationService = authorizationService;
             _recipeHarvesters = recipeHarvesters;
+            _recipeExecutor = recipeExecutor;
+            _environmentProviders = environmentProviders;
             _notifier = notifier;
             H = localizer;
-            _environmentProviders = environmentProviders;
             _logger = logger;
         }
 
@@ -107,8 +104,6 @@ namespace OrchardCore.Recipes.Controllers
                 _notifier.Error(H["Recipe was not found."]);
                 return RedirectToAction("Index");
             }
-
-            var site = await _siteService.GetSiteSettingsAsync();
 
             var environment = new Dictionary<string, object>();
             await _environmentProviders.InvokeAsync((provider, env) => provider.SetEnvironmentAsync(env), environment, _logger);

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -106,7 +106,7 @@ namespace OrchardCore.Recipes.Controllers
             }
 
             var environment = new Dictionary<string, object>();
-            await _environmentProviders.InvokeAsync((provider, env) => provider.SetEnvironmentAsync(env), environment, _logger);
+            await _environmentProviders.InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
 
             var executionId = Guid.NewGuid().ToString("n");
 

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -106,7 +106,7 @@ namespace OrchardCore.Recipes.Controllers
             }
 
             var environment = new Dictionary<string, object>();
-            await _environmentProviders.InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
+            await _environmentProviders.OrderBy(x => x.Order).InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
 
             var executionId = Guid.NewGuid().ToString("n");
 

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
@@ -43,7 +43,7 @@ namespace OrchardCore.Recipes.Services
             };
 
             var environment = new Dictionary<string, object>();
-            await _environmentProviders.InvokeAsync((provider, env) => provider.SetEnvironmentAsync(env), environment, _logger);
+            await _environmentProviders.InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
 
             await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, environment, CancellationToken.None);
 

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
@@ -19,8 +19,8 @@ namespace OrchardCore.Recipes.Services
         private readonly IEnumerable<IRecipeEnvironmentProvider> _environmentProviders;
         private readonly ILogger _logger;
 
-        public RecipeDeploymentTargetHandler(IShellHost shellHost, 
-            ShellSettings shellSettings, 
+        public RecipeDeploymentTargetHandler(IShellHost shellHost,
+            ShellSettings shellSettings,
             IRecipeExecutor recipeExecutor,
             IEnumerable<IRecipeEnvironmentProvider> environmentProviders,
             ILogger<RecipeDeploymentTargetHandler> logger)
@@ -45,7 +45,7 @@ namespace OrchardCore.Recipes.Services
             var environment = new Dictionary<string, object>();
             await _environmentProviders.InvokeAsync((provider, env) => provider.SetEnvironmentAsync(env), environment, _logger);
 
-            await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, new Dictionary<string, object>(), CancellationToken.None);
+            await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, environment, CancellationToken.None);
 
             await _shellHost.ReleaseShellContextAsync(_shellSettings);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
 using OrchardCore.Deployment;
 using OrchardCore.Environment.Shell;
+using OrchardCore.Modules;
 using OrchardCore.Recipes.Models;
 
 namespace OrchardCore.Recipes.Services
@@ -14,12 +16,20 @@ namespace OrchardCore.Recipes.Services
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
         private readonly IRecipeExecutor _recipeExecutor;
+        private readonly IEnumerable<IRecipeEnvironmentProvider> _environmentProviders;
+        private readonly ILogger _logger;
 
-        public RecipeDeploymentTargetHandler(IShellHost shellHost, ShellSettings shellSettings, IRecipeExecutor recipeExecutor)
+        public RecipeDeploymentTargetHandler(IShellHost shellHost, 
+            ShellSettings shellSettings, 
+            IRecipeExecutor recipeExecutor,
+            IEnumerable<IRecipeEnvironmentProvider> environmentProviders,
+            ILogger<RecipeDeploymentTargetHandler> logger)
         {
             _shellHost = shellHost;
             _shellSettings = shellSettings;
             _recipeExecutor = recipeExecutor;
+            _environmentProviders = environmentProviders;
+            _logger = logger;
         }
 
         public async Task ImportFromFileAsync(IFileProvider fileProvider)
@@ -31,6 +41,9 @@ namespace OrchardCore.Recipes.Services
                 BasePath = "",
                 RecipeFileInfo = fileProvider.GetFileInfo("Recipe.json")
             };
+
+            var environment = new Dictionary<string, object>();
+            await _environmentProviders.InvokeAsync((provider, env) => provider.SetEnvironmentAsync(env), environment, _logger);
 
             await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, new Dictionary<string, object>(), CancellationToken.None);
 

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Services/RecipeDeploymentTargetHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.FileProviders;
@@ -43,7 +44,7 @@ namespace OrchardCore.Recipes.Services
             };
 
             var environment = new Dictionary<string, object>();
-            await _environmentProviders.InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
+            await _environmentProviders.OrderBy(x => x.Order).InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
 
             await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, environment, CancellationToken.None);
 

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Services/RecipeEnvironmentSiteNameProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Services/RecipeEnvironmentSiteNameProvider.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.Settings
             _siteService = siteService;
         }
 
-        public async Task SetEnvironmentAsync(IDictionary<string, object> environment)
+        public async Task PopulateEnvironmentAsync(IDictionary<string, object> environment)
         {
             // When these have already been set by another provider, do not reset them.
             if (!environment.ContainsKey(nameof(ISite.SiteName)))

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Services/RecipeEnvironmentSiteNameProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Services/RecipeEnvironmentSiteNameProvider.cs
@@ -14,16 +14,14 @@ namespace OrchardCore.Settings
             _siteService = siteService;
         }
 
+        public int Order => 0;
+
         public async Task PopulateEnvironmentAsync(IDictionary<string, object> environment)
         {
-            // When these have already been set by another provider, do not reset them.
-            if (!environment.ContainsKey(nameof(ISite.SiteName)))
+            var siteSettings = await _siteService.GetSiteSettingsAsync();
+            if (!String.IsNullOrEmpty(siteSettings.SiteName))
             {
-                var siteSettings = await _siteService.GetSiteSettingsAsync();
-                if (!String.IsNullOrEmpty(siteSettings.SiteName))
-                {
-                    environment[nameof(SiteSettings.SiteName)] = siteSettings.SiteName;
-                }
+                environment[nameof(SiteSettings.SiteName)] = siteSettings.SiteName;
             }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Services/RecipeEnvironmentSiteNameProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Services/RecipeEnvironmentSiteNameProvider.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OrchardCore.Recipes.Services;
+
+namespace OrchardCore.Settings
+{
+    public class RecipeEnvironmentSiteNameProvider : IRecipeEnvironmentProvider
+    {
+        private readonly ISiteService _siteService;
+
+        public RecipeEnvironmentSiteNameProvider(ISiteService siteService)
+        {
+            _siteService = siteService;
+        }
+
+        public async Task SetEnvironmentAsync(IDictionary<string, object> environment)
+        {
+            // When these have already been set by another provider, do not reset them.
+            if (!environment.ContainsKey(nameof(ISite.SiteName)))
+            {
+                var siteSettings = await _siteService.GetSiteSettingsAsync();
+                if (!String.IsNullOrEmpty(siteSettings.SiteName))
+                {
+                    environment[nameof(SiteSettings.SiteName)] = siteSettings.SiteName;
+                }
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Startup.cs
@@ -11,6 +11,7 @@ using OrchardCore.Liquid;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
+using OrchardCore.Recipes.Services;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Settings.Deployment;
 using OrchardCore.Settings.Drivers;
@@ -53,6 +54,8 @@ namespace OrchardCore.Settings
             services.AddTransient<IDeploymentSource, SiteSettingsDeploymentSource>();
             services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<SiteSettingsDeploymentStep>());
             services.AddScoped<IDisplayDriver<DeploymentStep>, SiteSettingsDeploymentStepDriver>();
+
+            services.AddScoped<IRecipeEnvironmentProvider, RecipeEnvironmentSiteNameProvider>();
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
@@ -27,10 +27,10 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Users.Core\OrchardCore.Users.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Settings.Core\OrchardCore.Settings.Core.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Setup.Abstractions\OrchardCore.Setup.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Settings.Core\OrchardCore.Settings.Core.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Setup.Abstractions\OrchardCore.Setup.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />
   </ItemGroup>
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Users/OrchardCore.Users.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Settings.Core\OrchardCore.Settings.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Setup.Abstractions\OrchardCore.Setup.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Workflows.Abstractions\OrchardCore.Workflows.Abstractions.csproj" />
   </ItemGroup>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/RecipeEnvironmentSuperUserProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/RecipeEnvironmentSuperUserProvider.cs
@@ -17,20 +17,17 @@ namespace OrchardCore.Users.Services
             _userService = userService;
         }
 
+        public int Order => 0;
+
         public async Task PopulateEnvironmentAsync(IDictionary<string, object> environment)
         {
-            // When these have already been set by another provider, do not reset them.
-            if (!environment.ContainsKey("AdminUserId") && !environment.ContainsKey("AdminUsername"))
+            var siteSettings = await _siteService.GetSiteSettingsAsync();
+            if (!String.IsNullOrEmpty(siteSettings.SuperUser))
             {
-                var siteSettings = await _siteService.GetSiteSettingsAsync();
-                if (!String.IsNullOrEmpty(siteSettings.SuperUser))
+                var superUser = await _userService.GetUserByUniqueIdAsync(siteSettings.SuperUser);
+                if (superUser != null)
                 {
-                    var superUser = await _userService.GetUserByUniqueIdAsync(siteSettings.SuperUser);
-                    if (superUser != null)
-                    {
-                        environment["AdminUserId"] = siteSettings.SuperUser;
-                        environment["AdminUsername"] = superUser.UserName;
-                    }
+                    environment["AdminUserId"] = siteSettings.SuperUser;
                 }
             }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/RecipeEnvironmentSuperUserProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/RecipeEnvironmentSuperUserProvider.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Users.Services
             _userService = userService;
         }
 
-        public async Task SetEnvironmentAsync(IDictionary<string, object> environment)
+        public async Task PopulateEnvironmentAsync(IDictionary<string, object> environment)
         {
             // When these have already been set by another provider, do not reset them.
             if (!environment.ContainsKey("AdminUserId") && !environment.ContainsKey("AdminUsername"))

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/RecipeEnvironmentSuperUserProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/RecipeEnvironmentSuperUserProvider.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using OrchardCore.Recipes.Services;
+using OrchardCore.Settings;
+
+namespace OrchardCore.Users.Services
+{
+    public class RecipeEnvironmentSuperUserProvider : IRecipeEnvironmentProvider
+    {
+        private readonly ISiteService _siteService;
+        private readonly IUserService _userService;
+
+        public RecipeEnvironmentSuperUserProvider(ISiteService siteService, IUserService userService)
+        {
+            _siteService = siteService;
+            _userService = userService;
+        }
+
+        public async Task SetEnvironmentAsync(IDictionary<string, object> environment)
+        {
+            // When these have already been set by another provider, do not reset them.
+            if (!environment.ContainsKey("AdminUserId") && !environment.ContainsKey("AdminUsername"))
+            {
+                var siteSettings = await _siteService.GetSiteSettingsAsync();
+                if (!String.IsNullOrEmpty(siteSettings.SuperUser))
+                {
+                    var superUser = await _userService.GetUserByUniqueIdAsync(siteSettings.SuperUser);
+                    if (superUser != null)
+                    {
+                        environment["AdminUserId"] = siteSettings.SuperUser;
+                        environment["AdminUsername"] = superUser.UserName;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -24,6 +24,7 @@ using OrchardCore.Liquid;
 using OrchardCore.Modules;
 using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Navigation;
+using OrchardCore.Recipes.Services;
 using OrchardCore.Security;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Settings;
@@ -197,6 +198,8 @@ namespace OrchardCore.Users
             services.AddScoped<IDisplayDriver<User>, UserButtonsDisplayDriver>();
 
             services.AddScoped<IThemeSelector, UsersThemeSelector>();
+
+            services.AddScoped<IRecipeEnvironmentProvider, RecipeEnvironmentSuperUserProvider>();
         }
     }
 

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/Models/RecipeEnvironmentFeature.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/Models/RecipeEnvironmentFeature.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace OrchardCore.Recipes.Models
+{
+    public class RecipeEnvironmentFeature
+    {
+        public Dictionary<string, object> Properties { get; } = new Dictionary<string, object>();
+    }
+}

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/Services/IRecipeEnvironmentProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/Services/IRecipeEnvironmentProvider.cs
@@ -5,6 +5,6 @@ namespace OrchardCore.Recipes.Services
 {
     public interface IRecipeEnvironmentProvider
     {
-        Task SetEnvironmentAsync(IDictionary<string, object> environment);
+        Task PopulateEnvironmentAsync(IDictionary<string, object> environment);
     }
 }

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/Services/IRecipeEnvironmentProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/Services/IRecipeEnvironmentProvider.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace OrchardCore.Recipes.Services
+{
+    public interface IRecipeEnvironmentProvider
+    {
+        Task SetEnvironmentAsync(IDictionary<string, object> environment);
+    }
+}

--- a/src/OrchardCore/OrchardCore.Recipes.Abstractions/Services/IRecipeEnvironmentProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Abstractions/Services/IRecipeEnvironmentProvider.cs
@@ -6,5 +6,6 @@ namespace OrchardCore.Recipes.Services
     public interface IRecipeEnvironmentProvider
     {
         Task PopulateEnvironmentAsync(IDictionary<string, object> environment);
+        int Order { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Recipes.Core/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace OrchardCore.Recipes
             services.AddTransient<IRecipeExecutor, RecipeExecutor>();
             services.AddScoped<IRecipeMigrator, RecipeMigrator>();
             services.AddScoped<IRecipeReader, RecipeReader>();
+            services.AddScoped<IRecipeEnvironmentProvider, RecipeEnvironmentFeatureProvider>();
 
             return services;
         }

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeEnvironmentFeatureProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeEnvironmentFeatureProvider.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.Recipes.Services
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public Task SetEnvironmentAsync(IDictionary<string, object> environment)
+        public Task PopulateEnvironmentAsync(IDictionary<string, object> environment)
         {
             // When a migration is executed during setup these properties are available on the feature.
             // They should always override any current values.

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeEnvironmentFeatureProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeEnvironmentFeatureProvider.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.Recipes.Models;
+
+namespace OrchardCore.Recipes.Services
+{
+    public class RecipeEnvironmentFeatureProvider : IRecipeEnvironmentProvider
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public RecipeEnvironmentFeatureProvider(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public Task SetEnvironmentAsync(IDictionary<string, object> environment)
+        {
+            // When a migration is executed during setup these properties are available on the feature.
+            // They should always override any current values.
+            var feature = _httpContextAccessor.HttpContext.Features.Get<RecipeEnvironmentFeature>();
+            if (feature != null)
+            {
+                if (feature.Properties.TryGetValue("AdminUserId", out object adminUserId))
+                {
+                    environment["AdminUserId"] = adminUserId;
+                }
+                if (feature.Properties.TryGetValue("AdminUsername", out object adminUserName))
+                {
+                    environment["AdminUsername"] = adminUserName;
+                }
+                if (feature.Properties.TryGetValue("SiteName", out object siteName))
+                {
+                    environment["SiteName"] = siteName;
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeEnvironmentFeatureProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeEnvironmentFeatureProvider.cs
@@ -21,15 +21,15 @@ namespace OrchardCore.Recipes.Services
             var feature = _httpContextAccessor.HttpContext.Features.Get<RecipeEnvironmentFeature>();
             if (feature != null)
             {
-                if (feature.Properties.TryGetValue("AdminUserId", out object adminUserId))
+                if (feature.Properties.TryGetValue("AdminUserId", out var adminUserId))
                 {
                     environment["AdminUserId"] = adminUserId;
                 }
-                if (feature.Properties.TryGetValue("AdminUsername", out object adminUserName))
+                if (feature.Properties.TryGetValue("AdminUsername", out var adminUserName))
                 {
                     environment["AdminUsername"] = adminUserName;
                 }
-                if (feature.Properties.TryGetValue("SiteName", out object siteName))
+                if (feature.Properties.TryGetValue("SiteName", out var siteName))
                 {
                     environment["SiteName"] = siteName;
                 }

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeEnvironmentFeatureProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeEnvironmentFeatureProvider.cs
@@ -14,10 +14,12 @@ namespace OrchardCore.Recipes.Services
             _httpContextAccessor = httpContextAccessor;
         }
 
+        // Set later to override any pre existing values.
+        public int Order => 1000;
+
         public Task PopulateEnvironmentAsync(IDictionary<string, object> environment)
         {
             // When a migration is executed during setup these properties are available on the feature.
-            // They should always override any current values.
             var feature = _httpContextAccessor.HttpContext.Features.Get<RecipeEnvironmentFeature>();
             if (feature != null)
             {

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -39,7 +39,7 @@ namespace OrchardCore.Recipes.Services
             _logger = logger;
         }
 
-        public async Task<string> ExecuteAsync(string executionId, RecipeDescriptor recipeDescriptor, IDictionary<string,object> environment, CancellationToken cancellationToken)
+        public async Task<string> ExecuteAsync(string executionId, RecipeDescriptor recipeDescriptor, IDictionary<string, object> environment, CancellationToken cancellationToken)
         {
             await _recipeEventHandlers.InvokeAsync((handler, executionId, recipeDescriptor) => handler.RecipeExecutingAsync(executionId, recipeDescriptor), executionId, recipeDescriptor, _logger);
 

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeMigrator.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeMigrator.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.Recipes.Services
             recipeDescriptor.RequireNewScope = false;
 
             var environment = new Dictionary<string, object>();
-            await _environmentProviders.InvokeAsync((provider, env) => provider.SetEnvironmentAsync(env), environment, _logger);
+            await _environmentProviders.InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
 
             var executionId = Guid.NewGuid().ToString("n");
             return await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, environment, CancellationToken.None);

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeMigrator.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeMigrator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -47,7 +48,8 @@ namespace OrchardCore.Recipes.Services
             recipeDescriptor.RequireNewScope = false;
 
             var environment = new Dictionary<string, object>();
-            await _environmentProviders.InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
+
+            await _environmentProviders.OrderBy(x => x.Order).InvokeAsync((provider, env) => provider.PopulateEnvironmentAsync(env), environment, _logger);
 
             var executionId = Guid.NewGuid().ToString("n");
             return await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, environment, CancellationToken.None);

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeMigrator.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeMigrator.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using OrchardCore.Data.Migration;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Modules;
-using OrchardCore.Recipes.Models;
 
 namespace OrchardCore.Recipes.Services
 {
@@ -51,7 +50,6 @@ namespace OrchardCore.Recipes.Services
             await _environmentProviders.InvokeAsync((provider, env) => provider.SetEnvironmentAsync(env), environment, _logger);
 
             var executionId = Guid.NewGuid().ToString("n");
-            
             return await _recipeExecutor.ExecuteAsync(executionId, recipeDescriptor, environment, CancellationToken.None);
         }
     }

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Localization;
@@ -32,6 +33,7 @@ namespace OrchardCore.Setup.Services
         private readonly ILogger _logger;
         private readonly IStringLocalizer S;
         private readonly IHostApplicationLifetime _applicationLifetime;
+        private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly string _applicationName;
         private IEnumerable<RecipeDescriptor> _recipes;
 
@@ -46,6 +48,7 @@ namespace OrchardCore.Setup.Services
         /// <param name="logger">The <see cref="ILogger"/>.</param>
         /// <param name="stringLocalizer">The <see cref="IStringLocalizer"/>.</param>
         /// <param name="applicationLifetime">The <see cref="IHostApplicationLifetime"/>.</param>
+        /// <param name="httpContextAccessor">The <see cref="IHttpContextAccessor"/>.</param>
         public SetupService(
             IShellHost shellHost,
             IHostEnvironment hostingEnvironment,
@@ -54,8 +57,8 @@ namespace OrchardCore.Setup.Services
             IEnumerable<IRecipeHarvester> recipeHarvesters,
             ILogger<SetupService> logger,
             IStringLocalizer<SetupService> stringLocalizer,
-            IHostApplicationLifetime applicationLifetime
-            )
+            IHostApplicationLifetime applicationLifetime,
+            IHttpContextAccessor httpContextAccessor)
         {
             _shellHost = shellHost;
             _applicationName = hostingEnvironment.ApplicationName;
@@ -65,6 +68,7 @@ namespace OrchardCore.Setup.Services
             _logger = logger;
             S = stringLocalizer;
             _applicationLifetime = applicationLifetime;
+            _httpContextAccessor = httpContextAccessor;
         }
 
         /// <inheridoc />
@@ -127,6 +131,22 @@ namespace OrchardCore.Setup.Services
             // Due to database collation we normalize the userId to lower invariant.
             // During setup there are no users so we do not need to check unicity.
             context.Properties[SetupConstants.AdminUserId] = _setupUserIdGenerator.GenerateUniqueId().ToLowerInvariant();
+
+            var recipeEnvironmentFeature = new RecipeEnvironmentFeature();
+            if (context.Properties.TryGetValue(SetupConstants.AdminUserId, out var adminUserId))
+            {
+                recipeEnvironmentFeature.Properties[SetupConstants.AdminUserId] = adminUserId;
+            }
+            if (context.Properties.TryGetValue(SetupConstants.AdminUsername, out var adminUsername))
+            {
+                recipeEnvironmentFeature.Properties[SetupConstants.AdminUsername] = adminUsername;
+            } 
+            if (context.Properties.TryGetValue(SetupConstants.SiteName, out var siteName))
+            {
+                recipeEnvironmentFeature.Properties[SetupConstants.SiteName] = siteName;
+            }
+
+            _httpContextAccessor.HttpContext.Features.Set(recipeEnvironmentFeature);
 
             var shellSettings = new ShellSettings(context.ShellSettings);
 

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -140,7 +140,7 @@ namespace OrchardCore.Setup.Services
             if (context.Properties.TryGetValue(SetupConstants.AdminUsername, out var adminUsername))
             {
                 recipeEnvironmentFeature.Properties[SetupConstants.AdminUsername] = adminUsername;
-            } 
+            }
             if (context.Properties.TryGetValue(SetupConstants.SiteName, out var siteName))
             {
                 recipeEnvironmentFeature.Properties[SetupConstants.SiteName] = siteName;
@@ -152,9 +152,9 @@ namespace OrchardCore.Setup.Services
 
             if (string.IsNullOrEmpty(shellSettings["DatabaseProvider"]))
             {
-                shellSettings["DatabaseProvider"] = context.Properties.TryGetValue(SetupConstants.DatabaseProvider, out var databaseProvider)? databaseProvider?.ToString(): String.Empty ;
-                shellSettings["ConnectionString"] = context.Properties.TryGetValue(SetupConstants.DatabaseConnectionString, out var databaseConnectionString ) ? databaseConnectionString?.ToString(): String.Empty;
-                shellSettings["TablePrefix"] = context.Properties.TryGetValue(SetupConstants.DatabaseTablePrefix, out var databaseTablePrefix)? databaseTablePrefix?.ToString():String.Empty;
+                shellSettings["DatabaseProvider"] = context.Properties.TryGetValue(SetupConstants.DatabaseProvider, out var databaseProvider) ? databaseProvider?.ToString() : String.Empty;
+                shellSettings["ConnectionString"] = context.Properties.TryGetValue(SetupConstants.DatabaseConnectionString, out var databaseConnectionString) ? databaseConnectionString?.ToString() : String.Empty;
+                shellSettings["TablePrefix"] = context.Properties.TryGetValue(SetupConstants.DatabaseTablePrefix, out var databaseTablePrefix) ? databaseTablePrefix?.ToString() : String.Empty;
             }
 
             if (String.IsNullOrWhiteSpace(shellSettings["DatabaseProvider"]))


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7603

Provides a `Feature` allowing setup to pass the admin user id to recipe migrations.

And then uses similar to make sure that all things that execute recipes, get the basic environment information they need.

This is almost an event handler, but it isn't quite, because it has to run before the recipeexecutor, and shouldn't be run when running nested recipes.

