### PR TITLE
Fix admin dashboard migration

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Migrations.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.AdminDashboard
             return 1;
         }
 
-        public async Task<int> UpdateFrom1()
+        public async Task<int> UpdateFrom1Async()
         {
             await _recipeMigrator.ExecuteAsync("dashboard-widgets.recipe.json", this);
 


### PR DESCRIPTION
As found by @deanmarcussen.

The admin dashboard's recipe migration update step needs to be run asynchronously, otherwise the db isn't updated by migration steps when a new module has a dependency on the AdminDashboard module.
