### PR TITLE
Added error checking for decrypting facebook and twitter settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookSettingsDisplayDriver.cs
@@ -57,7 +57,8 @@ namespace OrchardCore.Facebook.Drivers
                     try
                     {
                         model.AppSecret = protector.Unprotect(settings.AppSecret);
-                    } catch (CryptographicException)
+                    }
+                    catch (CryptographicException)
                     {
                         model.AppSecret = string.Empty;
                         model.CouldNotDecryptSettings = true;

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookSettingsDisplayDriver.cs
@@ -61,7 +61,7 @@ namespace OrchardCore.Facebook.Drivers
                     catch (CryptographicException)
                     {
                         model.AppSecret = string.Empty;
-                        model.CouldNotDecryptSettings = true;
+                        model.HasDecryptionError = true;
                     }
                 }
             }).Location("Content:0").OnGroup(FacebookConstants.Features.Core);

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookSettingsDisplayDriver.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
@@ -53,7 +54,14 @@ namespace OrchardCore.Facebook.Drivers
                 model.SdkJs = settings.SdkJs;
                 if (!string.IsNullOrWhiteSpace(settings.AppSecret))
                 {
-                    model.AppSecret = protector.Unprotect(settings.AppSecret);
+                    try
+                    {
+                        model.AppSecret = protector.Unprotect(settings.AppSecret);
+                    } catch (CryptographicException)
+                    {
+                        model.AppSecret = string.Empty;
+                        model.CouldNotDecryptSettings = true;
+                    }
                 }
             }).Location("Content:0").OnGroup(FacebookConstants.Features.Core);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Drivers/FacebookSettingsDisplayDriver.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -20,19 +21,23 @@ namespace OrchardCore.Facebook.Drivers
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly ILogger _logger;
 
         public FacebookSettingsDisplayDriver(
             IAuthorizationService authorizationService,
             IDataProtectionProvider dataProtectionProvider,
             IHttpContextAccessor httpContextAccessor,
             IShellHost shellHost,
-            ShellSettings shellSettings)
+            ShellSettings shellSettings,
+            ILogger<FacebookSettingsDisplayDriver> logger
+            )
         {
             _authorizationService = authorizationService;
             _dataProtectionProvider = dataProtectionProvider;
             _httpContextAccessor = httpContextAccessor;
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            _logger = logger;
         }
 
         public override async Task<IDisplayResult> EditAsync(FacebookSettings settings, BuildEditorContext context)
@@ -60,6 +65,7 @@ namespace OrchardCore.Facebook.Drivers
                     }
                     catch (CryptographicException)
                     {
+                        _logger.LogError("The app secret could not be decrypted. It may have been encrypted using a different key.");
                         model.AppSecret = string.Empty;
                         model.HasDecryptionError = true;
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/ViewModels/FacebookSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/ViewModels/FacebookSettingsViewModel.cs
@@ -19,6 +19,6 @@ namespace OrchardCore.Facebook.ViewModels
         [RegularExpression(@"(v)\d+\.\d+")]
         public string Version { get; set; }
 
-        public bool CouldNotDecryptSettings { get; set; } = false;
+        public bool HasDecryptionError { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/ViewModels/FacebookSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/ViewModels/FacebookSettingsViewModel.cs
@@ -18,5 +18,7 @@ namespace OrchardCore.Facebook.ViewModels
 
         [RegularExpression(@"(v)\d+\.\d+")]
         public string Version { get; set; }
+
+        public bool CouldNotDecryptSettings { get; set; } = false;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookSettings.Edit.cshtml
@@ -8,7 +8,7 @@
 
 @if (Model.CouldNotDecryptSettings)
 {
-    <p class="alert alert-danger">@T["An error occurred while decrypting the Secret Key, so it has been left blank. Anything using these settings will not currently work."]</p>
+    <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
 }
 
 <h3>@T["Facebook Integration"]</h3>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookSettings.Edit.cshtml
@@ -6,6 +6,11 @@
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Facebook/#core-components" target="_blank">@T["See documentation"]</a>
 </p>
 
+@if (Model.CouldNotDecryptSettings)
+{
+    <p class="alert alert-danger">@T["An error occurred while decrypting the Secret Key, so it has been left blank. Anything using these settings will not currently work."]</p>
+}
+
 <h3>@T["Facebook Integration"]</h3>
 
 <div class="form-group" asp-validation-class-for="AppId">

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Views/FacebookSettings.Edit.cshtml
@@ -6,7 +6,7 @@
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Facebook/#core-components" target="_blank">@T["See documentation"]</a>
 </p>
 
-@if (Model.CouldNotDecryptSettings)
+@if (Model.HasDecryptionError)
 {
     <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
 }

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Drivers/GithubAuthenticationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Drivers/GithubAuthenticationSettingsDisplayDriver.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -20,19 +21,22 @@ namespace OrchardCore.GitHub.Drivers
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly ILogger _logger;
 
         public GitHubAuthenticationSettingsDisplayDriver(
             IAuthorizationService authorizationService,
             IDataProtectionProvider dataProtectionProvider,
             IHttpContextAccessor httpContextAccessor,
             IShellHost shellHost,
-            ShellSettings shellSettings)
+            ShellSettings shellSettings,
+            ILogger<GitHubAuthenticationSettingsDisplayDriver> logger)
         {
             _authorizationService = authorizationService;
             _dataProtectionProvider = dataProtectionProvider;
             _httpContextAccessor = httpContextAccessor;
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            _logger = logger;
         }
 
         public override async Task<IDisplayResult> EditAsync(GitHubAuthenticationSettings settings, BuildEditorContext context)
@@ -55,8 +59,9 @@ namespace OrchardCore.GitHub.Drivers
                     }
                     catch (CryptographicException)
                     {
+                        _logger.LogError("The client secret could not be decrypted. It may have been encrypted using a different key.");
                         model.ClientSecret = string.Empty;
-                        model.CouldNotDecryptSettings = true;
+                        model.HasDecryptionError = true;
                     }
                 }
                 else

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Drivers/GithubAuthenticationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Drivers/GithubAuthenticationSettingsDisplayDriver.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
@@ -47,8 +48,16 @@ namespace OrchardCore.GitHub.Drivers
                 model.ClientID = settings.ClientID;
                 if (!string.IsNullOrWhiteSpace(settings.ClientSecret))
                 {
-                    var protector = _dataProtectionProvider.CreateProtector(GitHubConstants.Features.GitHubAuthentication);
-                    model.ClientSecret = protector.Unprotect(settings.ClientSecret);
+                    try
+                    {
+                        var protector = _dataProtectionProvider.CreateProtector(GitHubConstants.Features.GitHubAuthentication);
+                        model.ClientSecret = protector.Unprotect(settings.ClientSecret);
+                    }
+                    catch (CryptographicException)
+                    {
+                        model.ClientSecret = string.Empty;
+                        model.CouldNotDecryptSettings = true;
+                    }
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/ViewModels/GithubAuthenticationSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/ViewModels/GithubAuthenticationSettingsViewModel.cs
@@ -14,5 +14,7 @@ namespace OrchardCore.GitHub.ViewModels
         public string CallbackUrl { get; set; }
 
         public bool SaveTokens { get; set; }
+
+        public bool CouldNotDecryptSettings { get; set; } = false;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/ViewModels/GithubAuthenticationSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/ViewModels/GithubAuthenticationSettingsViewModel.cs
@@ -15,6 +15,6 @@ namespace OrchardCore.GitHub.ViewModels
 
         public bool SaveTokens { get; set; }
 
-        public bool CouldNotDecryptSettings { get; set; } = false;
+        public bool HasDecryptionError { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Views/GithubAuthenticationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Views/GithubAuthenticationSettings.Edit.cshtml
@@ -6,7 +6,7 @@
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/GitHub/#authenticate-with-github" target="_blank">@T["See documentation"]</a>
 </p>
 
-@if (Model.CouldNotDecryptSettings)
+@if (Model.HasDecryptionError)
 {
     <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
 }

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Views/GithubAuthenticationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Views/GithubAuthenticationSettings.Edit.cshtml
@@ -6,6 +6,10 @@
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/GitHub/#authenticate-with-github" target="_blank">@T["See documentation"]</a>
 </p>
 
+@if (Model.CouldNotDecryptSettings)
+{
+    <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
+}
 
 <h3>@T["GitHub Authentication Settings"]</h3>
 

--- a/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Drivers/GoogleAuthenticationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Drivers/GoogleAuthenticationSettingsDisplayDriver.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -20,19 +21,22 @@ namespace OrchardCore.Google.Authentication.Drivers
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly ILogger _logger;
 
         public GoogleAuthenticationSettingsDisplayDriver(
             IAuthorizationService authorizationService,
             IDataProtectionProvider dataProtectionProvider,
             IHttpContextAccessor httpContextAccessor,
             IShellHost shellHost,
-            ShellSettings shellSettings)
+            ShellSettings shellSettings,
+            ILogger<GoogleAuthenticationSettingsDisplayDriver> logger)
         {
             _authorizationService = authorizationService;
             _dataProtectionProvider = dataProtectionProvider;
             _httpContextAccessor = httpContextAccessor;
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            _logger = logger;
         }
 
         public override async Task<IDisplayResult> EditAsync(GoogleAuthenticationSettings settings, BuildEditorContext context)
@@ -55,6 +59,7 @@ namespace OrchardCore.Google.Authentication.Drivers
                     }
                     catch (CryptographicException)
                     {
+                        _logger.LogError("The client secret could not be decrypted. It may have been encrypted using a different key.");
                         model.ClientSecret = string.Empty;
                         model.HasDecryptionError = true;
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Drivers/GoogleAuthenticationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Drivers/GoogleAuthenticationSettingsDisplayDriver.cs
@@ -56,7 +56,7 @@ namespace OrchardCore.Google.Authentication.Drivers
                     catch (CryptographicException)
                     {
                         model.ClientSecret = string.Empty;
-                        model.CouldNotDecryptSettings = true;
+                        model.HasDecryptionError = true;
                     }
                 }
                 else

--- a/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Drivers/GoogleAuthenticationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Drivers/GoogleAuthenticationSettingsDisplayDriver.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
@@ -47,8 +48,16 @@ namespace OrchardCore.Google.Authentication.Drivers
                 model.ClientID = settings.ClientID;
                 if (!string.IsNullOrWhiteSpace(settings.ClientSecret))
                 {
-                    var protector = _dataProtectionProvider.CreateProtector(GoogleConstants.Features.GoogleAuthentication);
-                    model.ClientSecret = protector.Unprotect(settings.ClientSecret);
+                    try
+                    {
+                        var protector = _dataProtectionProvider.CreateProtector(GoogleConstants.Features.GoogleAuthentication);
+                        model.ClientSecret = protector.Unprotect(settings.ClientSecret);
+                    }
+                    catch (CryptographicException)
+                    {
+                        model.ClientSecret = string.Empty;
+                        model.CouldNotDecryptSettings = true;
+                    }
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Google/Authentication/ViewModels/GoogleAuthenticationSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Authentication/ViewModels/GoogleAuthenticationSettingsViewModel.cs
@@ -15,6 +15,6 @@ namespace OrchardCore.Google.Authentication.ViewModels
 
         public bool SaveTokens { get; set; }
 
-        public bool CouldNotDecryptSettings { get; set; } = false;
+        public bool HasDecryptionError { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Google/Authentication/ViewModels/GoogleAuthenticationSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Authentication/ViewModels/GoogleAuthenticationSettingsViewModel.cs
@@ -14,5 +14,7 @@ namespace OrchardCore.Google.Authentication.ViewModels
         public string CallbackPath { get; set; }
 
         public bool SaveTokens { get; set; }
+
+        public bool CouldNotDecryptSettings { get; set; } = false;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Google/Views/GoogleAuthenticationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Views/GoogleAuthenticationSettings.Edit.cshtml
@@ -6,6 +6,10 @@
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Google/#google-authentication" target="_blank">@T["See documentation"]</a>
 </p>
 
+@if (Model.CouldNotDecryptSettings)
+{
+    <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
+}
 
 <h3>@T["Google Authentication Settings"]</h3>
 

--- a/src/OrchardCore.Modules/OrchardCore.Google/Views/GoogleAuthenticationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Views/GoogleAuthenticationSettings.Edit.cshtml
@@ -6,7 +6,7 @@
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Google/#google-authentication" target="_blank">@T["See documentation"]</a>
 </p>
 
-@if (Model.CouldNotDecryptSettings)
+@if (Model.HasDecryptionError)
 {
     <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Drivers/MicrosoftAccountSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Drivers/MicrosoftAccountSettingsDisplayDriver.cs
@@ -55,7 +55,7 @@ namespace OrchardCore.Microsoft.Authentication.Drivers
                     } catch (CryptographicException)
                     {
                         model.AppSecret = string.Empty;
-                        model.CouldNotDecryptSettings = true;
+                        model.HasDecryptionError = true;
                     } 
                 }
                 else

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Drivers/MicrosoftAccountSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Drivers/MicrosoftAccountSettingsDisplayDriver.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
@@ -47,8 +48,15 @@ namespace OrchardCore.Microsoft.Authentication.Drivers
                 model.AppId = settings.AppId;
                 if (!string.IsNullOrWhiteSpace(settings.AppSecret))
                 {
-                    var protector = _dataProtectionProvider.CreateProtector(MicrosoftAuthenticationConstants.Features.MicrosoftAccount);
-                    model.AppSecret = protector.Unprotect(settings.AppSecret);
+                    try
+                    {
+                        var protector = _dataProtectionProvider.CreateProtector(MicrosoftAuthenticationConstants.Features.MicrosoftAccount);
+                        model.AppSecret = protector.Unprotect(settings.AppSecret);
+                    } catch (CryptographicException)
+                    {
+                        model.AppSecret = string.Empty;
+                        model.CouldNotDecryptSettings = true;
+                    } 
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Drivers/MicrosoftAccountSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Drivers/MicrosoftAccountSettingsDisplayDriver.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -20,19 +21,22 @@ namespace OrchardCore.Microsoft.Authentication.Drivers
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly ILogger _logger;
 
         public MicrosoftAccountSettingsDisplayDriver(
             IAuthorizationService authorizationService,
             IDataProtectionProvider dataProtectionProvider,
             IHttpContextAccessor httpContextAccessor,
             IShellHost shellHost,
-            ShellSettings shellSettings)
+            ShellSettings shellSettings,
+            ILogger<MicrosoftAccountSettingsDisplayDriver> logger)
         {
             _authorizationService = authorizationService;
             _dataProtectionProvider = dataProtectionProvider;
             _httpContextAccessor = httpContextAccessor;
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            _logger = logger;
         }
 
         public override async Task<IDisplayResult> EditAsync(MicrosoftAccountSettings settings, BuildEditorContext context)
@@ -54,6 +58,7 @@ namespace OrchardCore.Microsoft.Authentication.Drivers
                         model.AppSecret = protector.Unprotect(settings.AppSecret);
                     } catch (CryptographicException)
                     {
+                        _logger.LogError("The app secret could not be decrypted. It may have been encrypted using a different key.");
                         model.AppSecret = string.Empty;
                         model.HasDecryptionError = true;
                     } 

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/ViewModels/MicrosoftAccountSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/ViewModels/MicrosoftAccountSettingsViewModel.cs
@@ -14,5 +14,7 @@ namespace OrchardCore.Microsoft.Authentication.ViewModels
         public string CallbackPath { get; set; }
 
         public bool SaveTokens { get; set; }
+
+        public bool CouldNotDecryptSettings { get; set; } = true;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/ViewModels/MicrosoftAccountSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/ViewModels/MicrosoftAccountSettingsViewModel.cs
@@ -15,6 +15,6 @@ namespace OrchardCore.Microsoft.Authentication.ViewModels
 
         public bool SaveTokens { get; set; }
 
-        public bool CouldNotDecryptSettings { get; set; } = true;
+        public bool HasDecryptionError { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Views/MicrosoftAccountSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Views/MicrosoftAccountSettings.Edit.cshtml
@@ -6,7 +6,7 @@
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Microsoft.Authentication/#microsoft-account" target="_blank">@T["See documentation"]</a>
 </p>
 
-@if (Model.CouldNotDecryptSettings)
+@if (Model.HasDecryptionError)
 {
     <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Views/MicrosoftAccountSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Views/MicrosoftAccountSettings.Edit.cshtml
@@ -6,6 +6,11 @@
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Microsoft.Authentication/#microsoft-account" target="_blank">@T["See documentation"]</a>
 </p>
 
+@if (Model.CouldNotDecryptSettings)
+{
+    <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
+}
+
 <h3>@T["Microsoft Account Authentication Settings"]</h3>
 
 <div class="form-group" asp-validation-class-for="AppId">

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Drivers/TwitterSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Drivers/TwitterSettingsDisplayDriver.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
@@ -41,30 +42,43 @@ namespace OrchardCore.Twitter.Drivers
             {
                 return null;
             }
-
-            return Initialize<TwitterSettingsViewModel>("TwitterSettings_Edit", model =>
-            {
-                model.APIKey = settings.ConsumerKey;
-                if (!string.IsNullOrWhiteSpace(settings.ConsumerSecret))
+                return Initialize<TwitterSettingsViewModel>("TwitterSettings_Edit", model =>
                 {
-                    var protector = _dataProtectionProvider.CreateProtector(TwitterConstants.Features.Twitter);
-                    model.APISecretKey = protector.Unprotect(settings.ConsumerSecret);
-                }
-                else
-                {
-                    model.APISecretKey = string.Empty;
-                }
-                model.AccessToken = settings.AccessToken;
-                if (!string.IsNullOrWhiteSpace(settings.AccessTokenSecret))
-                {
-                    var protector = _dataProtectionProvider.CreateProtector(TwitterConstants.Features.Twitter);
-                    model.AccessTokenSecret = protector.Unprotect(settings.AccessTokenSecret);
-                }
-                else
-                {
-                    model.AccessTokenSecret = string.Empty;
-                }
-            }).Location("Content:5").OnGroup(TwitterConstants.Features.Twitter);
+                    model.APIKey = settings.ConsumerKey;
+                    if (!string.IsNullOrWhiteSpace(settings.ConsumerSecret))
+                    {
+                        try
+                        {
+                            var protector = _dataProtectionProvider.CreateProtector(TwitterConstants.Features.Twitter);
+                            model.APISecretKey = protector.Unprotect(settings.ConsumerSecret);
+                        } catch (CryptographicException)
+                        {
+                            model.APISecretKey = string.Empty;
+                            model.CouldNotDecryptSettings = true;
+                        }
+                    }
+                    else
+                    {
+                        model.APISecretKey = string.Empty;
+                    }
+                    model.AccessToken = settings.AccessToken;
+                    if (!string.IsNullOrWhiteSpace(settings.AccessTokenSecret))
+                    {
+                        try
+                        {
+                            var protector = _dataProtectionProvider.CreateProtector(TwitterConstants.Features.Twitter);
+                            model.AccessTokenSecret = protector.Unprotect(settings.AccessTokenSecret);
+                        } catch (CryptographicException)
+                        {
+                            model.AccessTokenSecret = string.Empty;
+                            model.CouldNotDecryptSettings = true;
+                        }
+                    }
+                    else
+                    {
+                        model.AccessTokenSecret = string.Empty;
+                    }
+                }).Location("Content:5").OnGroup(TwitterConstants.Features.Twitter);
         }
 
         public override async Task<IDisplayResult> UpdateAsync(TwitterSettings settings, BuildEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Drivers/TwitterSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Drivers/TwitterSettingsDisplayDriver.cs
@@ -55,7 +55,7 @@ namespace OrchardCore.Twitter.Drivers
                         catch (CryptographicException)
                         {
                             model.APISecretKey = string.Empty;
-                            model.CouldNotDecryptSettings = true;
+                            model.HasDecryptionError = true;
                         }
                     }
                     else
@@ -73,7 +73,7 @@ namespace OrchardCore.Twitter.Drivers
                         catch (CryptographicException)
                         {
                             model.AccessTokenSecret = string.Empty;
-                            model.CouldNotDecryptSettings = true;
+                            model.HasDecryptionError = true;
                         }
                     }
                     else

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Drivers/TwitterSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Drivers/TwitterSettingsDisplayDriver.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -20,19 +21,22 @@ namespace OrchardCore.Twitter.Drivers
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IShellHost _shellHost;
         private readonly ShellSettings _shellSettings;
+        private readonly ILogger _logger;
 
         public TwitterSettingsDisplayDriver(
             IAuthorizationService authorizationService,
             IDataProtectionProvider dataProtectionProvider,
             IHttpContextAccessor httpContextAccessor,
             IShellHost shellHost,
-            ShellSettings shellSettings)
+            ShellSettings shellSettings,
+            ILogger<TwitterSettingsDisplayDriver> logger)
         {
             _authorizationService = authorizationService;
             _dataProtectionProvider = dataProtectionProvider;
             _httpContextAccessor = httpContextAccessor;
             _shellHost = shellHost;
             _shellSettings = shellSettings;
+            _logger = logger;
         }
 
         public override async Task<IDisplayResult> EditAsync(TwitterSettings settings, BuildEditorContext context)
@@ -54,6 +58,7 @@ namespace OrchardCore.Twitter.Drivers
                         }
                         catch (CryptographicException)
                         {
+                            _logger.LogError("The API secret key could not be decrypted. It may have been encrypted using a different key.");
                             model.APISecretKey = string.Empty;
                             model.HasDecryptionError = true;
                         }
@@ -72,6 +77,7 @@ namespace OrchardCore.Twitter.Drivers
                         }
                         catch (CryptographicException)
                         {
+                            _logger.LogError("The access token secret could not be decrypted. It may have been encrypted using a different key.");
                             model.AccessTokenSecret = string.Empty;
                             model.HasDecryptionError = true;
                         }

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Drivers/TwitterSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Drivers/TwitterSettingsDisplayDriver.cs
@@ -51,7 +51,8 @@ namespace OrchardCore.Twitter.Drivers
                         {
                             var protector = _dataProtectionProvider.CreateProtector(TwitterConstants.Features.Twitter);
                             model.APISecretKey = protector.Unprotect(settings.ConsumerSecret);
-                        } catch (CryptographicException)
+                        }
+                        catch (CryptographicException)
                         {
                             model.APISecretKey = string.Empty;
                             model.CouldNotDecryptSettings = true;
@@ -68,7 +69,8 @@ namespace OrchardCore.Twitter.Drivers
                         {
                             var protector = _dataProtectionProvider.CreateProtector(TwitterConstants.Features.Twitter);
                             model.AccessTokenSecret = protector.Unprotect(settings.AccessTokenSecret);
-                        } catch (CryptographicException)
+                        }
+                        catch (CryptographicException)
                         {
                             model.AccessTokenSecret = string.Empty;
                             model.CouldNotDecryptSettings = true;

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/ViewModels/TwitterSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/ViewModels/TwitterSettingsViewModel.cs
@@ -15,5 +15,7 @@ namespace OrchardCore.Twitter.ViewModels
 
         [Required(AllowEmptyStrings = false, ErrorMessage = "Access token secret is required")]
         public string AccessTokenSecret { get; set; }
+
+        public bool CouldNotDecryptSettings { get; set; } = false;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/ViewModels/TwitterSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/ViewModels/TwitterSettingsViewModel.cs
@@ -16,6 +16,6 @@ namespace OrchardCore.Twitter.ViewModels
         [Required(AllowEmptyStrings = false, ErrorMessage = "Access token secret is required")]
         public string AccessTokenSecret { get; set; }
 
-        public bool HasDecryptionError { get; set; };
+        public bool HasDecryptionError { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/ViewModels/TwitterSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/ViewModels/TwitterSettingsViewModel.cs
@@ -16,6 +16,6 @@ namespace OrchardCore.Twitter.ViewModels
         [Required(AllowEmptyStrings = false, ErrorMessage = "Access token secret is required")]
         public string AccessTokenSecret { get; set; }
 
-        public bool CouldNotDecryptSettings { get; set; } = false;
+        public bool HasDecryptionError { get; set; };
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Views/TwitterSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Views/TwitterSettings.Edit.cshtml
@@ -4,7 +4,7 @@
 <p class="alert alert-warning">@T["The current tenant will be reloaded when the settings are saved."]
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Twitter/#twitter-integration" target="_blank">@T["See documentation"]</a></p>
 
-@if (Model.CouldNotDecryptSettings)
+@if (Model.HasDecryptionError)
 {
     <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Views/TwitterSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Views/TwitterSettings.Edit.cshtml
@@ -4,6 +4,11 @@
 <p class="alert alert-warning">@T["The current tenant will be reloaded when the settings are saved."]
     <a class="seedoc" href="@(OrchardCore.Admin.Constants.DocsUrl)reference/modules/Twitter/#twitter-integration" target="_blank">@T["See documentation"]</a></p>
 
+@if (Model.CouldNotDecryptSettings)
+{
+    <p class="alert alert-danger">@T["An error occurred while decrypting some settings, so they have been left blank. Anything using these settings will not currently work."]</p>
+}
+
 <h3>@T["Twitter Integration Settings"]</h3>
 
 <div class="form-group row" asp-validation-class-for="APIKey">

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Views/TwitterSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Views/TwitterSettings.Edit.cshtml
@@ -6,7 +6,7 @@
 
 @if (Model.CouldNotDecryptSettings)
 {
-    <p class="alert alert-danger">@T["An error occurred while decrypting some settings, so they have been left blank. Anything using these settings will not currently work."]</p>
+    <p class="alert alert-danger">@T["An error occurred while decrypting a setting. Please apply and save."]</p>
 }
 
 <h3>@T["Twitter Integration Settings"]</h3>

--- a/src/OrchardCore/OrchardCore.Lucene.Core/QueryProviders/SimpleQueryStringQueryProvider.cs
+++ b/src/OrchardCore/OrchardCore.Lucene.Core/QueryProviders/SimpleQueryStringQueryProvider.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Globalization;
 using Lucene.Net.QueryParsers.Simple;
 using Lucene.Net.Search;
 using Newtonsoft.Json.Linq;
@@ -24,10 +23,12 @@ namespace OrchardCore.Lucene.QueryProviders
 
             foreach(var field in fields)
             {
-                if(field.Contains('^', StringComparison.Ordinal) && Single.TryParse(field.Split("^").Last(), out weight))
+                var fieldWeightArray = field.Split('^', 2);
+
+                if(fieldWeightArray.Length > 1 && Single.TryParse(fieldWeightArray[1], out weight))
                 {
                     weights.Remove(field);
-                    weights.Add(field.Split("^").First(), weight);
+                    weights.Add(fieldWeightArray[0], weight);
                 }
             }
 


### PR DESCRIPTION
In the situation where a data protection key gets deleted or is otherwise unavailable, both the Twitter and Facebook settings screens only show a "Save" button. This update allows the settings to be edited, showing an error that some settings could not be decrypted.
