### PR TITLE
Migrate menus to use Display Text property

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
@@ -232,6 +232,9 @@ namespace OrchardCore.Menu.Controllers
                 MergeNullValueHandling = MergeNullValueHandling.Merge
             });
 
+            // Merge doesn't copy the properties
+            menuItem[nameof(ContentItem.DisplayText)] = contentItem.DisplayText;
+
             await _contentManager.SaveDraftAsync(menu);
 
             return RedirectToAction("Edit", "Admin", new { area = "OrchardCore.Contents", contentItemId = menuContentItemId });

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/ContentMenuItemPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/ContentMenuItemPartDisplayDriver.cs
@@ -30,15 +30,23 @@ namespace OrchardCore.Menu.Drivers
         {
             return Initialize<ContentMenuItemPartEditViewModel>("ContentMenuItemPart_Edit", model =>
             {
-                model.Name = part.Name;
+                model.Name = part.ContentItem.DisplayText;
                 model.MenuItemPart = part;
             });
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ContentMenuItemPart part, IUpdateModel updater)
         {
-            //Update Part Name
-            await updater.TryUpdateModelAsync(part, Prefix, x => x.Name);
+            var model = new ContentMenuItemPartEditViewModel();
+
+            if (await updater.TryUpdateModelAsync(model, Prefix))
+            {
+                part.ContentItem.DisplayText = model.Name;
+// This code can be removed in a later release.
+#pragma warning disable 0618                
+                part.Name = model.Name;
+#pragma warning restore 0618
+            }
 
             return Edit(part);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/LinkMenuItemPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/LinkMenuItemPartDisplayDriver.cs
@@ -31,7 +31,7 @@ namespace OrchardCore.Menu.Drivers
         {
             return Initialize<LinkMenuItemPartEditViewModel>("LinkMenuItemPart_Edit", model =>
             {
-                model.Name = part.Name;
+                model.Name = part.ContentItem.DisplayText;
                 model.Url = part.Url;
                 model.MenuItemPart = part;
             });
@@ -39,8 +39,17 @@ namespace OrchardCore.Menu.Drivers
 
         public override async Task<IDisplayResult> UpdateAsync(LinkMenuItemPart part, IUpdateModel updater)
         {
-            await updater.TryUpdateModelAsync(part, Prefix, x => x.Name, x => x.Url);
+            var model = new LinkMenuItemPartEditViewModel();
 
+            if (await updater.TryUpdateModelAsync(model, Prefix))
+            {
+                part.Url = model.Url;
+                part.ContentItem.DisplayText = model.Name;
+// This code can be removed in a later release.
+#pragma warning disable 0618
+                part.Name = model.Name;
+#pragma warning restore 0618
+            }
             return Edit(part);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/GraphQL/LinkMenuItemQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/GraphQL/LinkMenuItemQueryObjectType.cs
@@ -9,7 +9,10 @@ namespace OrchardCore.Menu.GraphQL
         {
             Name = "LinkMenuItemPart";
 
-            Field(x => x.Name, nullable: true);
+            // This code can be removed in a later release.
+#pragma warning disable 0618
+            Field(x => x.Name, nullable: true).Description("Deprecated. Use displayText."); ;
+#pragma warning restore 0618
             Field(x => x.Url, nullable: true);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Migrations.cs
@@ -1,16 +1,23 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Records;
 using OrchardCore.Data.Migration;
+using OrchardCore.Menu.Models;
 using OrchardCore.Recipes.Services;
+using YesSql;
 
 namespace OrchardCore.Menu
 {
     public class Migrations : DataMigration
     {
         private readonly IRecipeMigrator _recipeMigrator;
+        private readonly ISession _session;
 
-        public Migrations(IRecipeMigrator recipeMigrator)
+        public Migrations(IRecipeMigrator recipeMigrator, ISession session)
         {
             _recipeMigrator = recipeMigrator;
+            _session = session;
         }
 
         public async Task<int> CreateAsync()
@@ -18,7 +25,7 @@ namespace OrchardCore.Menu
             await _recipeMigrator.ExecuteAsync("menu.recipe.json", this);
 
             // Shortcut other migration steps on new content definition schemas.
-            return 2;
+            return 3;
         }
 
         // Add content menu. This only needs to run on old content definition schemas.
@@ -28,6 +35,55 @@ namespace OrchardCore.Menu
             await _recipeMigrator.ExecuteAsync("content-menu-updatefrom1.recipe.json", this);
 
             return 2;
+        }
+
+        public async Task<int> UpdateFrom2Async()
+        {
+            var menus = await _session.Query<ContentItem, ContentItemIndex>(x => x.ContentType == "Menu").ListAsync();
+
+            foreach (var menu in menus)
+            {
+                var menuItemsListPart = menu.As<MenuItemsListPart>();
+                if (menuItemsListPart != null)
+                {
+                    MigrateMenuItems(menuItemsListPart.MenuItems);
+                    menu.Apply(menuItemsListPart);
+                }
+
+                _session.Save(menu);
+            }
+
+            return 3;
+        }
+
+        private static void MigrateMenuItems(List<ContentItem> menuItems)
+        {
+            foreach (var menuItem in menuItems)
+            {
+                var linkMenuItemPart = menuItem.As<LinkMenuItemPart>();
+                if (linkMenuItemPart != null)
+                {
+                    // This code can be removed in a later release.
+#pragma warning disable 0618
+                    menuItem.DisplayText = linkMenuItemPart.Name;
+#pragma warning restore 0618
+                }
+
+                var contentMenuItemPart = menuItem.As<ContentMenuItemPart>();
+                if (contentMenuItemPart != null)
+                {
+#pragma warning disable 0618
+                    menuItem.DisplayText = contentMenuItemPart.Name;
+#pragma warning restore 0618
+                }
+
+                var menuItemsListPart = menuItem.As<MenuItemsListPart>();
+                if (menuItemsListPart != null)
+                {
+                    MigrateMenuItems(menuItemsListPart.MenuItems);
+                    menuItem.Apply(menuItemsListPart);
+                }
+            }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Models/ContentMenuItemPart.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Models/ContentMenuItemPart.cs
@@ -1,12 +1,11 @@
+using System;
 using OrchardCore.ContentManagement;
 
 namespace OrchardCore.Menu.Models
 {
     public class ContentMenuItemPart : ContentPart
     {
-        /// <summary>
-        /// The name of the content menu
-        /// </summary>
+        [Obsolete("This property is obsolete and will be removed in a future version. Use 'DisplayText'")]
         public string Name { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Models/LinkMenuItemPart.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Models/LinkMenuItemPart.cs
@@ -1,12 +1,11 @@
-﻿using OrchardCore.ContentManagement;
+﻿using System;
+using OrchardCore.ContentManagement;
 
 namespace OrchardCore.Menu.Models
 {
     public class LinkMenuItemPart : ContentPart
     {
-        /// <summary>
-        /// The name of the link
-        /// </summary>
+        [Obsolete("This property is obsolete and will be removed in a future version. Use 'DisplayText'")]
         public string Name { get; set; }
 
         /// <summary>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/ContentMenuItemPart.Admin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/ContentMenuItemPart.Admin.cshtml
@@ -7,4 +7,4 @@
     var linkUrl = Url.RouteUrl(routeValues);
 }
 
-<span>@menuItemPart.Name <code>@linkUrl</code><span class="text-muted dashed">ContentLink</span></span>
+<span>@menuItemPart.ContentItem.DisplayText <code>@linkUrl</code><span class="text-muted dashed">ContentLink</span></span>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/LinkMenuItemPart.Admin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/LinkMenuItemPart.Admin.cshtml
@@ -2,4 +2,4 @@
     LinkMenuItemPart part = Model.MenuItemPart;
 }
 
-<span>@part.Name <code>@part.Url</code><span class="text-muted dashed">Link</span></span>
+<span>@part.ContentItem.DisplayText <code>@part.Url</code><span class="text-muted dashed">Link</span></span>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItemLink-ContentMenuItem.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItemLink-ContentMenuItem.cshtml
@@ -10,7 +10,7 @@
 
     TagBuilder tag = Tag(Model, "a");
     tag.Attributes["href"] = linkUrl;
-    tag.InnerHtml.Append(menuItemPart.Name);
+    tag.InnerHtml.Append(contentItem.DisplayText);
 }
 
 @tag

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItemLink-LinkMenuItem.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItemLink-LinkMenuItem.cshtml
@@ -17,6 +17,6 @@
     }
 
     tag.Attributes["href"] = url;
-    tag.InnerHtml.Append(linkMenuItemPart.Name);
+    tag.InnerHtml.Append(contentItem.DisplayText);
 }
 @tag

--- a/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
@@ -1091,6 +1091,7 @@
               {
                 "ContentType": "LinkMenuItem",
                 "ContentItemId": "[js:uuid()]",
+                "DisplayText": "Services",
                 "LinkMenuItemPart": {
                   "Name": "Services",
                   "Url": "~/#services"
@@ -1099,6 +1100,7 @@
               {
                 "ContentType": "LinkMenuItem",
                 "ContentItemId": "[js:uuid()]",
+                "DisplayText": "Portfolio",
                 "LinkMenuItemPart": {
                   "Name": "Portfolio",
                   "Url": "~/#portfolio"
@@ -1107,6 +1109,7 @@
               {
                 "ContentType": "LinkMenuItem",
                 "ContentItemId": "[js:uuid()]",
+                "DisplayText": "About",
                 "LinkMenuItemPart": {
                   "Name": "About",
                   "Url": "~/#about"
@@ -1115,6 +1118,7 @@
               {
                 "ContentType": "LinkMenuItem",
                 "ContentItemId": "[js:uuid()]",
+                "DisplayText": "Team",
                 "LinkMenuItemPart": {
                   "Name": "Team",
                   "Url": "~/#team"
@@ -1123,6 +1127,7 @@
               {
                 "ContentType": "LinkMenuItem",
                 "ContentItemId": "[js:uuid()]",
+                "DisplayText": "Contact",
                 "LinkMenuItemPart": {
                   "Name": "Contact",
                   "Url": "~/#contact"

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/MenuItemLink-ContentMenuItem.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/MenuItemLink-ContentMenuItem.liquid
@@ -1,3 +1,3 @@
 {% assign contentMenuItem = Model.ContentItem.Content.ContentMenuItemPart %}
 
-<a class="nav-link" href="{{ contentMenuItem.SelectedContentItem.ContentItemIds.first | display_url }}">{{ contentMenuItem.Name }}</a>
+<a class="nav-link" href="{{ contentMenuItem.SelectedContentItem.ContentItemIds.first | display_url }}">{{ Model.ContentItem.DisplayText }}</a>

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/MenuItemLink-LinkMenuItem.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/MenuItemLink-LinkMenuItem.liquid
@@ -1,2 +1,2 @@
 ﻿{% assign link = Model.ContentItem.Content.LinkMenuItemPart %}
-<a class="nav-link js-scroll-trigger" href="{{ link.Url | href }}">{{ link.Name }}</a>
+<a class="nav-link js-scroll-trigger" href="{{ link.Url | href }}">{{ Model.ContentItem.DisplayText }}</a>

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -984,6 +984,7 @@
               {
                 "ContentType": "LinkMenuItem",
                 "ContentItemId": "[js: uuid()]",
+                "DisplayText": "Home",
                 "LinkMenuItemPart": {
                   "Name": "Home",
                   "Url": "~/"
@@ -992,6 +993,7 @@
               {
                 "ContentType": "LinkMenuItem",
                 "ContentItemId": "[js: uuid()]",
+                "DisplayText": "About",
                 "LinkMenuItemPart": {
                   "Name": "About",
                   "Url": "~/about"

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/MenuItemLink-ContentMenuItem.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/MenuItemLink-ContentMenuItem.liquid
@@ -1,7 +1,7 @@
 {% assign contentMenuItem = Model.ContentItem.Content.ContentMenuItemPart %}
 
 {% if Model.HasItems %}
-    <a href="{{ contentMenuItem.SelectedContentItem.ContentItemIds.first | display_url }}" class="nav-link dropdown-toggle" data-toggle="dropdown">{{ contentMenuItem.Name }}<b class="caret"></b></a>
+    <a href="{{ contentMenuItem.SelectedContentItem.ContentItemIds.first | display_url }}" class="nav-link dropdown-toggle" data-toggle="dropdown">{{ Model.ContentItem.DisplayText }}<b class="caret"></b></a>
 {% else %}
-    <a class="nav-link" href="{{ contentMenuItem.SelectedContentItem.ContentItemIds.first | display_url }}">{{ contentMenuItem.Name }}</a>
+    <a class="nav-link" href="{{ contentMenuItem.SelectedContentItem.ContentItemIds.first | display_url }}">{{ Model.ContentItem.DisplayText }}</a>
 {% endif %}

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/MenuItemLink-LinkMenuItem.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/MenuItemLink-LinkMenuItem.liquid
@@ -1,7 +1,7 @@
 {% assign link = Model.ContentItem.Content.LinkMenuItemPart %}
 
 {% if Model.HasItems %}
-    <a href="{{ link.Url | href }}" class="nav-link dropdown-toggle" data-toggle="dropdown">{{ link.Name }}<b class="caret"></b></a>
+    <a href="{{ link.Url | href }}" class="nav-link dropdown-toggle" data-toggle="dropdown">{{ Model.ContentItem.DisplayText }}<b class="caret"></b></a>
 {% else %}
-    <a class="nav-link" href="{{ link.Url | href }}">{{ link.Name }}</a>
+    <a class="nav-link" href="{{ link.Url | href }}">{{ Model.ContentItem.DisplayText }}</a>
 {% endif %}

--- a/src/OrchardCore.Themes/TheTheme/Views/MenuItemLink-ContentMenuItem.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/MenuItemLink-ContentMenuItem.cshtml
@@ -8,7 +8,7 @@
 
     TagBuilder tag = Tag(Model, "a");
     tag.Attributes["href"] = linkUrl;
-    tag.InnerHtml.Append(menuItemPart.Name);
+    tag.InnerHtml.Append(contentItem.DisplayText);
 
     if (Model.Level == 0 && Model.HasItems)
     {

--- a/src/OrchardCore.Themes/TheTheme/Views/MenuItemLink-LinkMenuItem.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/MenuItemLink-LinkMenuItem.cshtml
@@ -18,7 +18,7 @@
     }
 
     tag.Attributes["href"] = url;
-    tag.InnerHtml.Append(linkMenuItemPart.Name);
+    tag.InnerHtml.Append(contentItem.DisplayText);
 
     if (Model.Level == 0 && Model.HasItems)
     {


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/7418

Non breaking. 
Migrates the value on the `part.Name` to `ContentItem.DisplayText`.
Leaves the value on `Name`.
Keeps updating both (as we did for the `TitlePart`)

Name property to be removed alter.

Also includes a small tweak to the controller, which is necessary for https://github.com/OrchardCMS/OrchardCore/pull/8438/files or you can't edit the display text afterwards.

The idea being to merge the two prs together for consistency.