### PR TITLE
At the solution level, build each TFM separately

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -30,7 +30,8 @@ jobs:
         dotnet-version: 5.0.102
     - name: Build
       run: |
-        dotnet build --configuration Release
+        dotnet build --configuration Release --framework net5.0
+        dotnet build --configuration Release --framework netcoreapp3.1
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -33,7 +33,8 @@ jobs:
       run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 15471 ))" >> $GITHUB_ENV
     - name: Build
       run: |
-        dotnet build --configuration Release
+        dotnet build --configuration Release --framework net5.0
+        dotnet build --configuration Release --framework netcoreapp3.1
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -4,7 +4,7 @@
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />
   </ItemGroup>
   <PropertyGroup>
-    <TargetFramework>$(AspNetCoreTargetFramework)</TargetFramework>
+    <TargetFrameworks>$(AspNetCoreTargetFrameworks)</TargetFrameworks>
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <IncludeSource>False</IncludeSource>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>

--- a/src/docs/OrchardCore.Docs.csproj
+++ b/src/docs/OrchardCore.Docs.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Functional/OrchardCore.Tests.Functional.csproj
+++ b/test/Functional/OrchardCore.Tests.Functional.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
+++ b/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>OrchardCore.Benchmark</RootNamespace>
     <OutputType>Exe</OutputType>
   </PropertyGroup>


### PR DESCRIPTION
There are some opened issues on the dotnet / msbuild repos about multi-targeting build, particularly when building at the solution level a clean solution, and when an application is referenced by another application as we do for unit tests.

We prevented to execute the target copying translation files concurrently when building a multi-targets application, but not when building concurrently applications using the same target, or referencing another app using this target.

Here, at the solution level we build each TFM separately, each step still building project dependencies in parallel.

Note: So i needed to define multi TFMs for all app projects.