### PR TITLE
BuildMultiTargeting package folder

### DIFF
--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -31,6 +31,9 @@
     <None Include="$(MSBuildThisFileDirectory)Package.Build.props" Pack="true">
       <PackagePath>build\$(AssemblyName).props</PackagePath>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)Package.BuildMultiTargeting.props" Pack="true">
+      <PackagePath>buildMultitargeting\$(AssemblyName).props</PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Module.Targets/Package.BuildMultiTargeting.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/Package.BuildMultiTargeting.props
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!--
+    This file is included in the NuGet packages as "buildMultitargeting\$(AssemblyName).props" file.
+    It contains the logic to be referenced as a module by the main application.
+  -->
+  <ItemGroup>
+    <ModulePackageNames Include="$(MSBuildThisFileName)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Related to #8734 when packing a module targeting multiple TFMs and that references `OC.Module.Targets` as a package.