### PR TITLE
BuildMultiTargeting 2

### DIFF
--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
@@ -32,6 +32,9 @@
     <None Include="OrchardCore.Module.Targets.props" Pack="true">
       <PackagePath>build\OrchardCore.Module.Targets.props</PackagePath>
     </None>
+    <None Include="buildMultiTargeting\OrchardCore.Module.Targets.props" Pack="true">
+      <PackagePath>buildMultitargeting\OrchardCore.Module.Targets.props</PackagePath>
+    </None>
     <None Include="OrchardCore.Module.Targets.targets" Pack="true">
       <PackagePath>build\OrchardCore.Module.Targets.targets</PackagePath>
     </None>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- NuGet properties-->
@@ -33,7 +33,7 @@
       <PackagePath>build\OrchardCore.Module.Targets.props</PackagePath>
     </None>
     <None Include="buildMultiTargeting\OrchardCore.Module.Targets.props" Pack="true">
-      <PackagePath>buildMultitargeting\OrchardCore.Module.Targets.props</PackagePath>
+      <PackagePath>buildMultiTargeting\OrchardCore.Module.Targets.props</PackagePath>
     </None>
     <None Include="OrchardCore.Module.Targets.targets" Pack="true">
       <PackagePath>build\OrchardCore.Module.Targets.targets</PackagePath>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -31,9 +31,6 @@
     <None Include="$(MSBuildThisFileDirectory)Package.Build.props" Pack="true">
       <PackagePath>build\$(AssemblyName).props</PackagePath>
     </None>
-    <None Include="$(MSBuildThisFileDirectory)Package.BuildMultiTargeting.props" Pack="true">
-      <PackagePath>buildMultitargeting\$(AssemblyName).props</PackagePath>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Module.Targets/buildMultiTargeting/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/buildMultiTargeting/OrchardCore.Module.Targets.props
@@ -1,0 +1,3 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\build\OrchardCore.Module.Targets.props" />
+</Project>


### PR DESCRIPTION
Related to #8734 when packing a module targeting multiple TFMs and that references `OC.Module.Targets` as a package.