### PR TITLE
Media cache : Azure Blob Storage issue with 0 byte files

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
@@ -107,7 +108,16 @@ namespace OrchardCore.Media.Services
             }, LazyThreadSafetyMode.ExecutionAndPublication)).Value;
 
             // Always call next, this middleware always passes.
-            await _next(context);
+            if (await _mediaFileStoreCache.IsCachedAsync(subPathValue))
+            { 
+                await _next(context);
+            }
+
+            if (!context.Response.HasStarted)
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+            }
+
             return;
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
@@ -107,8 +107,8 @@ namespace OrchardCore.Media.Services
                 }
             }, LazyThreadSafetyMode.ExecutionAndPublication)).Value;
 
+            // Always call next, this middleware always passes.
             await _next(context);
-
             return;
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
@@ -109,13 +109,8 @@ namespace OrchardCore.Media.Services
 
             // Always call next, this middleware always passes.
             if (await _mediaFileStoreCache.IsCachedAsync(subPathValue))
-            { 
-                await _next(context);
-            }
-
-            if (!context.Response.HasStarted)
             {
-                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
+                await _next(context);
             }
 
             return;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
@@ -107,11 +107,7 @@ namespace OrchardCore.Media.Services
                 }
             }, LazyThreadSafetyMode.ExecutionAndPublication)).Value;
 
-            // Always call next, this middleware always passes.
-            if (await _mediaFileStoreCache.IsCachedAsync(subPathValue))
-            {
-                await _next(context);
-            }
+            await _next(context);
 
             return;
         }

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -71,7 +71,6 @@ namespace OrchardCore.Media.Core
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error saving file {Path}", cachePath);
                 if (File.Exists(cachePath))
                 {
                     try
@@ -84,7 +83,12 @@ namespace OrchardCore.Media.Core
                         throw;
                     }
                 }
-                throw;
+
+                if(!cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogError(ex, "Error saving file {Path}", cachePath);
+                    throw;
+                }
             }
         }
 

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -67,7 +67,8 @@ namespace OrchardCore.Media.Core
                 using (var fileStream = File.Create(cachePath))
                 {
                     await stream.CopyToAsync(fileStream, StreamCopyBufferSize);
-
+                    await stream.FlushAsync();
+                    
                     if (fileStream.Length == 0)
                     {
                         throw new Exception($"Error retrieving file (length equals 0 byte) : {cachePath}");

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -67,10 +67,16 @@ namespace OrchardCore.Media.Core
                 using (var fileStream = File.Create(cachePath))
                 {
                     await stream.CopyToAsync(fileStream, StreamCopyBufferSize, cancellationToken);
+
+                    if (fileStream.Length == 0)
+                    {
+                        throw new Exception($"Error retrieving file (length equals 0 byte) : {cachePath}");
+                    }
                 }
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Error saving file {Path}", cachePath);
                 if (File.Exists(cachePath))
                 {
                     try
@@ -83,12 +89,7 @@ namespace OrchardCore.Media.Core
                         throw;
                     }
                 }
-
-                if (!cancellationToken.IsCancellationRequested)
-                {
-                    _logger.LogError(ex, "Error saving file {Path}", cachePath);
-                    throw;
-                }
+                throw;
             }
         }
 

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -66,7 +66,7 @@ namespace OrchardCore.Media.Core
                 }
                 using (var fileStream = File.Create(cachePath))
                 {
-                    await stream.CopyToAsync(fileStream, StreamCopyBufferSize, cancellationToken);
+                    await stream.CopyToAsync(fileStream, StreamCopyBufferSize);
 
                     if (fileStream.Length == 0)
                     {

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -84,7 +84,7 @@ namespace OrchardCore.Media.Core
                     }
                 }
 
-                if(!cancellationToken.IsCancellationRequested)
+                if (!cancellationToken.IsCancellationRequested)
                 {
                     _logger.LogError(ex, "Error saving file {Path}", cachePath);
                     throw;


### PR DESCRIPTION
Fixes partially #8715

In the MediaFileStoreResolverMiddleware, if the request is cancelled it should throw a 404 response and not move to any next middleware (ImageSharp). This is basically adding a new line in the log everytime we request an image that doesn't exist to get resized. This adds a line in the logs because ImageSharp can't get the file. (A bot could fill the logs by requesting a wrong image filename).

Do not throw when we have a request cancellation in the DefaultMediaFileStoreCacheFileProvider. (Same thing, here, it is filling the logs for nothing).

To repro the issue, just stop a page request manually when you are loading a page with a lot of images. It will log a lot of different things. This is cleaning most of them. Now, it doesn't fix the entire #8715 issue though, but it fixes issues that I came across while reviewing that code.

Still need to see if I can get 0 byte files from cancelled requests. Technically, we remove any files that gets a cancellationToken but for some reason these files did not get removed maybe because of the `if (File.Exists(cachePath)) ... then remove file` in the `catch`. I did not get any 0 byte files last night so the issue is intermittent.