### PR TITLE
Maintain route data on contents admin list pager

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -224,9 +224,10 @@ namespace OrchardCore.Contents.Controllers
                 pager.PageSize = maxPagedCount;
             }
 
-            // We prepare the pager
-            var routeData = new RouteData();
-            routeData.Values.Add("DisplayText", model.Options.DisplayText);
+            // Populate route values to maintain previous route data when generating page links
+            await _contentOptionsDisplayManager.UpdateEditorAsync(model.Options, _updateModelAccessor.ModelUpdater, false);
+
+            var routeData = new RouteData(model.Options.RouteValues);
 
             var pagerShape = (await New.Pager(pager)).TotalItemCount(maxPagedCount > 0 ? maxPagedCount : await query.CountAsync()).RouteData(routeData);
             var pageOfContentItems = await query.Skip(pager.GetStartIndex()).Take(pager.PageSize).ListAsync();

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -224,7 +224,7 @@ namespace OrchardCore.Contents.Controllers
                 pager.PageSize = maxPagedCount;
             }
 
-            // Populate route values to maintain previous route data when generating page links
+            // Populate route values to maintain previous route data when generating page links.
             await _contentOptionsDisplayManager.UpdateEditorAsync(model.Options, _updateModelAccessor.ModelUpdater, false);
 
             var routeData = new RouteData(model.Options.RouteValues);


### PR DESCRIPTION
Noticed while doing the user filters that we can maintain all the route data from the content filters when building the pager.