### PR TITLE
Added missing namespace `OrchardCore.Taxonomies.Helper` to `TaxonomyOrchardHelperExtensions.cs`

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldTagsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldTagsDisplayDriver.cs
@@ -13,6 +13,7 @@ using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Taxonomies.Fields;
+using OrchardCore.Taxonomies.Helper;
 using OrchardCore.Taxonomies.Models;
 using OrchardCore.Taxonomies.Settings;
 using OrchardCore.Taxonomies.ViewModels;

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/GraphQL/TaxonomyFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/GraphQL/TaxonomyFieldQueryObjectType.cs
@@ -6,6 +6,7 @@ using OrchardCore.Apis.GraphQL;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.GraphQL.Queries.Types;
 using OrchardCore.Taxonomies.Fields;
+using OrchardCore.Taxonomies.Helper;
 
 namespace OrchardCore.Taxonomies.GraphQL
 {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Helper/TaxonomyOrchardHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Helper/TaxonomyOrchardHelperExtensions.cs
@@ -8,116 +8,119 @@ using OrchardCore.ContentManagement;
 using OrchardCore.Taxonomies.Indexing;
 using YesSql;
 
-public static class TaxonomyOrchardHelperExtensions
+namespace OrchardCore.Taxonomies.Helper
 {
-    /// <summary>
-    /// Returns a term from its content item id and taxonomy.
-    /// </summary>
-    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
-    /// <param name="taxonomyContentItemId">The taxonomy content item id.</param>
-    /// <param name="termContentItemId">The term content item id.</param>
-    /// <returns>A content item id <c>null</c> if it was not found.</returns>
-    public static async Task<ContentItem> GetTaxonomyTermAsync(this IOrchardHelper orchardHelper, string taxonomyContentItemId, string termContentItemId)
+    public static class TaxonomyOrchardHelperExtensions
     {
-        var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
-        var taxonomy = await contentManager.GetAsync(taxonomyContentItemId);
-
-        if (taxonomy == null)
+        /// <summary>
+        /// Returns a term from its content item id and taxonomy.
+        /// </summary>
+        /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
+        /// <param name="taxonomyContentItemId">The taxonomy content item id.</param>
+        /// <param name="termContentItemId">The term content item id.</param>
+        /// <returns>A content item id <c>null</c> if it was not found.</returns>
+        public static async Task<ContentItem> GetTaxonomyTermAsync(this IOrchardHelper orchardHelper, string taxonomyContentItemId, string termContentItemId)
         {
-            return null;
-        }
+            var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
+            var taxonomy = await contentManager.GetAsync(taxonomyContentItemId);
 
-        return FindTerm(taxonomy.Content.TaxonomyPart.Terms as JArray, termContentItemId);
-    }
-
-    /// <summary>
-    /// Returns the list of terms including their parents.
-    /// </summary>
-    /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
-    /// <param name="taxonomyContentItemId">The taxonomy content item id.</param>
-    /// <param name="termContentItemId">The term content item id.</param>
-    /// <returns>A list content items.</returns>
-    public static async Task<List<ContentItem>> GetInheritedTermsAsync(this IOrchardHelper orchardHelper, string taxonomyContentItemId, string termContentItemId)
-    {
-        var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
-        var taxonomy = await contentManager.GetAsync(taxonomyContentItemId);
-
-        if (taxonomy == null)
-        {
-            return null;
-        }
-
-        var terms = new List<ContentItem>();
-
-        FindTermHierarchy(taxonomy.Content.TaxonomyPart.Terms as JArray, termContentItemId, terms);
-
-        return terms;
-    }
-
-    /// <summary>
-    /// Query content items.
-    /// </summary>
-    public static async Task<IEnumerable<ContentItem>> QueryCategorizedContentItemsAsync(this IOrchardHelper orchardHelper, Func<IQuery<ContentItem, TaxonomyIndex>, IQuery<ContentItem>> query)
-    {
-        var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
-        var session = orchardHelper.HttpContext.RequestServices.GetService<ISession>();
-
-        var contentItems = await query(session.Query<ContentItem, TaxonomyIndex>()).ListAsync();
-
-        return await contentManager.LoadAsync(contentItems);
-    }
-
-    internal static ContentItem FindTerm(JArray termsArray, string termContentItemId)
-    {
-        foreach (JObject term in termsArray)
-        {
-            var contentItemId = term.GetValue("ContentItemId").ToString();
-
-            if (contentItemId == termContentItemId)
+            if (taxonomy == null)
             {
-                return term.ToObject<ContentItem>();
+                return null;
             }
 
-            if (term.GetValue("Terms") is JArray children)
-            {
-                var found = FindTerm(children, termContentItemId);
+            return FindTerm(taxonomy.Content.TaxonomyPart.Terms as JArray, termContentItemId);
+        }
 
-                if (found != null)
+        /// <summary>
+        /// Returns the list of terms including their parents.
+        /// </summary>
+        /// <param name="orchardHelper">The <see cref="IOrchardHelper"/>.</param>
+        /// <param name="taxonomyContentItemId">The taxonomy content item id.</param>
+        /// <param name="termContentItemId">The term content item id.</param>
+        /// <returns>A list content items.</returns>
+        public static async Task<List<ContentItem>> GetInheritedTermsAsync(this IOrchardHelper orchardHelper, string taxonomyContentItemId, string termContentItemId)
+        {
+            var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
+            var taxonomy = await contentManager.GetAsync(taxonomyContentItemId);
+
+            if (taxonomy == null)
+            {
+                return null;
+            }
+
+            var terms = new List<ContentItem>();
+
+            FindTermHierarchy(taxonomy.Content.TaxonomyPart.Terms as JArray, termContentItemId, terms);
+
+            return terms;
+        }
+
+        /// <summary>
+        /// Query content items.
+        /// </summary>
+        public static async Task<IEnumerable<ContentItem>> QueryCategorizedContentItemsAsync(this IOrchardHelper orchardHelper, Func<IQuery<ContentItem, TaxonomyIndex>, IQuery<ContentItem>> query)
+        {
+            var contentManager = orchardHelper.HttpContext.RequestServices.GetService<IContentManager>();
+            var session = orchardHelper.HttpContext.RequestServices.GetService<ISession>();
+
+            var contentItems = await query(session.Query<ContentItem, TaxonomyIndex>()).ListAsync();
+
+            return await contentManager.LoadAsync(contentItems);
+        }
+
+        internal static ContentItem FindTerm(JArray termsArray, string termContentItemId)
+        {
+            foreach (JObject term in termsArray)
+            {
+                var contentItemId = term.GetValue("ContentItemId").ToString();
+
+                if (contentItemId == termContentItemId)
                 {
-                    return found;
+                    return term.ToObject<ContentItem>();
+                }
+
+                if (term.GetValue("Terms") is JArray children)
+                {
+                    var found = FindTerm(children, termContentItemId);
+
+                    if (found != null)
+                    {
+                        return found;
+                    }
                 }
             }
+
+            return null;
         }
 
-        return null;
-    }
-
-    internal static bool FindTermHierarchy(JArray termsArray, string termContentItemId, List<ContentItem> terms)
-    {
-        foreach (JObject term in termsArray)
+        internal static bool FindTermHierarchy(JArray termsArray, string termContentItemId, List<ContentItem> terms)
         {
-            var contentItemId = term.GetValue("ContentItemId").ToString();
-
-            if (contentItemId == termContentItemId)
+            foreach (JObject term in termsArray)
             {
-                terms.Add(term.ToObject<ContentItem>());
+                var contentItemId = term.GetValue("ContentItemId").ToString();
 
-                return true;
-            }
-
-            if (term.GetValue("Terms") is JArray children)
-            {
-                var found = FindTermHierarchy(children, termContentItemId, terms);
-
-                if (found)
+                if (contentItemId == termContentItemId)
                 {
                     terms.Add(term.ToObject<ContentItem>());
 
                     return true;
                 }
-            }
-        }
 
-        return false;
+                if (term.GetValue("Terms") is JArray children)
+                {
+                    var found = FindTermHierarchy(children, termContentItemId, terms);
+
+                    if (found)
+                    {
+                        terms.Add(term.ToObject<ContentItem>());
+
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyFieldIndexHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyFieldIndexHandler.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.Indexing;
 using OrchardCore.Taxonomies.Fields;
+using OrchardCore.Taxonomies.Helper;
 
 namespace OrchardCore.Taxonomies.Indexing
 {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Liquid/InheritedTermFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Liquid/InheritedTermFilter.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.Liquid;
+using OrchardCore.Taxonomies.Helper;
 
 namespace OrchardCore.Taxonomies.Liquid
 {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Liquid/TaxonomyTermFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Liquid/TaxonomyTermFilter.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.Liquid;
 using OrchardCore.Taxonomies.Fields;
+using OrchardCore.Taxonomies.Helper;
 
 namespace OrchardCore.Taxonomies.Liquid
 {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.cshtml
@@ -1,4 +1,5 @@
 @model OrchardCore.Taxonomies.ViewModels.DisplayTaxonomyFieldViewModel
+@using OrchardCore.Taxonomies.Helper
 @using OrchardCore.Mvc.Utilities;
 
 @{


### PR DESCRIPTION
because it does not allow to reference global namespace in Razor views.