### PR TITLE
Arrows for collapsible panels

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/ContentCard-BagPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/ContentCard-BagPart.Edit.cshtml
@@ -12,7 +12,7 @@
             <div class="widget-editor-handle"><i class="fas fa-arrows-alt"></i></div>
         }
         <button type="button" class="btn btn-outline-secondary btn-sm widget-editor-btn-toggle widget-editor-btn-collapse"><i class="fa fa-angle-down" aria-hidden="true"></i></button>
-        <button type="button" class="btn btn-outline-secondary btn-sm widget-editor-btn-toggle widget-editor-btn-expand"><i class="fa fa-angle-up" aria-hidden="true"></i></button>
+        <button type="button" class="btn btn-outline-secondary btn-sm widget-editor-btn-toggle widget-editor-btn-expand"><i class="fa fa-angle-right" aria-hidden="true"></i></button>
         @T["{0} <span class=\"hint dashed\">{1}</span>", contentItem.DisplayText, contentType]
         @if (Model.CanDelete != false)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard-WidgetsListPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard-WidgetsListPart.Edit.cshtml
@@ -13,7 +13,7 @@
             <div class="widget-editor-handle"><i class="fas fa-arrows-alt"></i></div>
         }
         <button type="button" class="btn btn-outline-secondary btn-sm widget-list-editor-btn-toggle widget-editor-btn-collapse"><i class="fa fa-angle-down" aria-hidden="true"></i></button>
-        <button type="button" class="btn btn-outline-secondary btn-sm widget-list-editor-btn-toggle widget-editor-btn-expand"><i class="fa fa-angle-up" aria-hidden="true"></i></button>
+        <button type="button" class="btn btn-outline-secondary btn-sm widget-list-editor-btn-toggle widget-editor-btn-expand"><i class="fa fa-angle-right" aria-hidden="true"></i></button>
         @contentType
         <div class="btn-widget-metadata border border-info w-100">
             <div class="btn-group">

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.Preview.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/ContentCard.Preview.cshtml
@@ -25,7 +25,7 @@
     </div>
     @if (Model.Footer != null)
     {
-        <div class="widget-editor-footer card-footer  text-muted">
+        <div class="widget-editor-footer card-footer text-muted">
             @await DisplayAsync(Model.Footer)
         </div>
     }


### PR DESCRIPTION
Use the same kind of arrows (Right if collapsed, Down if expanded) for all collapsible panels in admin.

![image](https://user-images.githubusercontent.com/703248/110844287-86591100-82a9-11eb-96b0-f8635605ae52.png)
