### PR TITLE
Move OpenID collection initialization to Core Startup

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -18,7 +18,6 @@ using OpenIddict.Validation.AspNetCore;
 using OpenIddict.Validation.DataProtection;
 using OrchardCore.Admin;
 using OrchardCore.BackgroundTasks;
-using OrchardCore.Data;
 using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Handlers;
@@ -62,7 +61,7 @@ namespace OrchardCore.OpenId
             {
                 ServiceDescriptor.Scoped<IPermissionProvider, Permissions>(),
                 ServiceDescriptor.Scoped<INavigationProvider, AdminMenu>(),
-            });
+            });         
         }
     }
 
@@ -317,9 +316,6 @@ namespace OrchardCore.OpenId
                 ServiceDescriptor.Singleton<IConfigureOptions<OpenIddictValidationOptions>, OpenIdValidationConfiguration>(),
                 ServiceDescriptor.Singleton<IConfigureOptions<OpenIddictValidationDataProtectionOptions>, OpenIdValidationConfiguration>()
             });
-
-            // Configure support for an OpenId collection.
-            services.Configure<StoreCollectionOptions>(o => o.Collections.Add("OpenId"));
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore/OrchardCore.OpenId.Core/OpenIdExtensions.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/OpenIdExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OpenIddict.Abstractions;
+using OrchardCore.Data;
 using OrchardCore.Data.Migration;
 using OrchardCore.OpenId.Abstractions.Managers;
 using OrchardCore.OpenId.Services.Managers;
@@ -24,6 +25,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             builder.Services.TryAddEnumerable(
                 ServiceDescriptor.Scoped<IDataMigration, OpenIdMigrations>());
+
+            // Configure support for an OpenId collection.
+            builder.Services.Configure<StoreCollectionOptions>(o => o.Collections.Add("OpenId"));  
 
             return builder;
         }


### PR DESCRIPTION
/cc @jtkech 

Yes, doesn't work right, if you don't enable token validation currently.

So I move it to where the migrations are registered.

If you are checking, and this is good, please merge, or I merge it tomorrow - the other pr will not be ready.