### PR TITLE
Only one TFM by default under Visual Studio

### DIFF
--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -1,9 +1,14 @@
 <Project>
 
+  <!-- Default TFM (Singular) and TFMs (Plural) -->
   <PropertyGroup>
-    <!-- Default singular and multi-targeting TFMs -->
     <AspNetCoreTargetFramework>net5.0</AspNetCoreTargetFramework>
     <AspNetCoreTargetFrameworks>net5.0;netcoreapp3.1</AspNetCoreTargetFrameworks>
+  </PropertyGroup>
+
+  <!-- Default TFMs (Plural) inside Visual Studio -->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <AspNetCoreTargetFrameworks>$(AspNetCoreTargetFramework)</AspNetCoreTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Allows to specify in `Dependencies.AspNetCore.props` the TFMs while under Visual Studio

Here, by default we only build the default TFM being net5.0