### PR TITLE
Fix IsSectionDefined

### DIFF
--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -33,7 +33,7 @@
         @await RenderSectionAsync("Messages", required: false)
         @await RenderBodyAsync()
     </main>
-    @if (ThemeLayout.Zones["Footer"] != null) {
+    @if (IsSectionDefined("Footer")) {
     <footer>
         <div class="container">
             @await RenderSectionAsync("Footer", required: false)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -297,7 +297,7 @@ namespace OrchardCore.DisplayManagement.Razor
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var zone = ThemeLayout.Zones[name];
+            dynamic zone = ThemeLayout.Zones[name];
 
             return zone != null;
         }
@@ -365,7 +365,7 @@ namespace OrchardCore.DisplayManagement.Razor
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var zone = ThemeLayout.Zones[name];
+            dynamic zone = ThemeLayout.Zones[name];
 
             if (required && zone != null)
             {


### PR DESCRIPTION
Changes to Zone indexer broke the IsSectionDefined method.

Zone must dynamic for null check to work in case it is a ZoneOnDemand. The null check does not work if it is an IShape.