### PR TITLE
ZoneOnDemand tweaks

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
@@ -541,7 +541,7 @@ namespace OrchardCore.Navigation
 
         private IHtmlContent CoerceHtmlString(object value)
         {
-            if (value == null || value is ZoneOnDemand)
+            if (value == null)
             {
                 return HtmlString.Empty;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
@@ -14,7 +14,6 @@ using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Implementation;
 using OrchardCore.DisplayManagement.Shapes;
-using OrchardCore.DisplayManagement.Zones;
 
 namespace OrchardCore.Navigation
 {

--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -33,7 +33,8 @@
         @await RenderSectionAsync("Messages", required: false)
         @await RenderBodyAsync()
     </main>
-    @if (ThemeLayout.Zones["Footer"] != null) {
+    @if (IsSectionDefined("Footer"))
+    {
     <footer>
         <div class="container">
             @await RenderSectionAsync("Footer", required: false)

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/RenderSectionTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/RenderSectionTag.cs
@@ -5,10 +5,8 @@ using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Ast;
-using Microsoft.AspNetCore.Html;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.DisplayManagement.Layout;
-using OrchardCore.DisplayManagement.Zones;
 using OrchardCore.Liquid;
 
 namespace OrchardCore.DisplayManagement.Liquid.Tags
@@ -32,7 +30,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
 
             var zone = layout.Zones[name];
 
-            if (zone is ZoneOnDemand)
+            if (zone.IsNullOrEmpty())
             {
                 if (required)
                 {
@@ -42,7 +40,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
                 return Completion.Normal;
             }
 
-            IHtmlContent htmlContent = await displayHelper.ShapeExecuteAsync(zone);
+            var htmlContent = await displayHelper.ShapeExecuteAsync(zone);
             htmlContent.WriteTo(writer, (HtmlEncoder)encoder);
 
             return Completion.Normal;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/IShape.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/IShape.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OrchardCore.DisplayManagement.Shapes;
+using OrchardCore.DisplayManagement.Zones;
 
 namespace OrchardCore.DisplayManagement
 {
@@ -28,6 +29,8 @@ namespace OrchardCore.DisplayManagement
 
     public static class IShapeExtensions
     {
+        public static bool IsNullOrEmpty(this IShape shape) => shape == null || shape is ZoneOnDemand;
+
         public static bool TryGetProperty<T>(this IShape shape, string key, out T value)
         {
             if (shape.Properties != null && shape.Properties.TryGetValue(key, out var result))
@@ -45,7 +48,7 @@ namespace OrchardCore.DisplayManagement
 
         public static object GetProperty(this IShape shape, string key)
         {
-            return GetProperty(shape, key, (object) null);
+            return GetProperty(shape, key, (object)null);
         }
 
         public static T GetProperty<T>(this IShape shape, string key)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.DisplayManagement.Theming;
-using OrchardCore.DisplayManagement.Zones;
 using OrchardCore.Modules;
 
 namespace OrchardCore.DisplayManagement.Implementation
@@ -42,12 +41,13 @@ namespace OrchardCore.DisplayManagement.Implementation
         {
             var shape = context.Value;
 
-            // A null or empty shape is returned as a no-op.
+            // Check if the shape is null or empty.
             if (shape.IsNullOrEmpty())
             {
                 return HtmlString.Empty;
             }
 
+            // Check if the shape is pre-rendered.
             if (shape is IHtmlContent htmlContent)
             {
                 return htmlContent;
@@ -58,7 +58,7 @@ namespace OrchardCore.DisplayManagement.Implementation
             // can't really cope with a shape that has no type information
             if (shapeMetadata == null || String.IsNullOrEmpty(shapeMetadata.Type))
             {
-                return CoerceHtmlString(context.Value);
+                return new StringHtmlContent(context.Value.ToString());
             }
 
             // Copy the current context such that the rendering can customize it if necessary
@@ -258,22 +258,6 @@ namespace OrchardCore.DisplayManagement.Implementation
             return null;
         }
 
-        private static IHtmlContent CoerceHtmlString(object value)
-        {
-            if (value == null || value is ZoneOnDemand)
-            {
-                return HtmlString.Empty;
-            }
-
-            if (value is IHtmlContent result)
-            {
-                return result;
-            }
-
-            // Convert to a string and HTML-encode it
-            return new StringHtmlContent(value.ToString());
-        }
-
         private static bool TryGetParentShapeTypeName(ref string shapeTypeScan)
         {
             var delimiterIndex = shapeTypeScan.LastIndexOf("__", StringComparison.Ordinal);
@@ -289,12 +273,12 @@ namespace OrchardCore.DisplayManagement.Implementation
         {
             static async ValueTask<IHtmlContent> Awaited(Task<IHtmlContent> task)
             {
-                return CoerceHtmlString(await task);
+                return (await task) ?? HtmlString.Empty;
             }
 
             if (shapeBinding?.BindingAsync == null)
             {
-                // todo: create result from all child shapes
+                // Todo: create result from all child shapes.
                 return new ValueTask<IHtmlContent>(shape.Metadata.ChildContent ?? HtmlString.Empty);
             }
 
@@ -305,7 +289,7 @@ namespace OrchardCore.DisplayManagement.Implementation
                 return Awaited(task);
             }
 
-            return new ValueTask<IHtmlContent>(CoerceHtmlString(task.Result));
+            return new ValueTask<IHtmlContent>(task.Result ?? HtmlString.Empty);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
@@ -43,7 +43,7 @@ namespace OrchardCore.DisplayManagement.Implementation
             var shape = context.Value;
 
             // non-shape arguments are returned as a no-op
-            if (shape == null || shape is ZoneOnDemand)
+            if (shape.IsNullOrEmpty())
             {
                 return HtmlString.Empty;
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
@@ -42,10 +42,15 @@ namespace OrchardCore.DisplayManagement.Implementation
         {
             var shape = context.Value;
 
-            // non-shape arguments are returned as a no-op
+            // A null or empty shape is returned as a no-op.
             if (shape.IsNullOrEmpty())
             {
                 return HtmlString.Empty;
+            }
+
+            if (shape is IHtmlContent htmlContent)
+            {
+                return htmlContent;
             }
 
             var shapeMetadata = shape.Metadata;
@@ -263,16 +268,6 @@ namespace OrchardCore.DisplayManagement.Implementation
             if (value is IHtmlContent result)
             {
                 return result;
-
-                // To prevent the result from being rendered lately, we can
-                // serialize it right away. But performance seems to be better
-                // like this, until we find this is an issue.
-
-                // using (var html = new StringWriter())
-                // {
-                //     result.WriteTo(html, htmlEncoder);
-                //     return new HtmlString(html.ToString());
-                // }
             }
 
             // Convert to a string and HTML-encode it

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DisplayHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DisplayHelper.cs
@@ -40,7 +40,7 @@ namespace OrchardCore.DisplayManagement.Implementation
 
         public Task<IHtmlContent> InvokeAsync(string name, INamedEnumerable<object> parameters)
         {
-            if (!string.IsNullOrEmpty(name))
+            if (!String.IsNullOrEmpty(name))
             {
                 return ShapeTypeExecuteAsync(name, parameters);
             }
@@ -67,7 +67,7 @@ namespace OrchardCore.DisplayManagement.Implementation
 
         public Task<IHtmlContent> ShapeExecuteAsync(IShape shape)
         {
-            if (shape == null || shape is ZoneOnDemand)
+            if (shape.IsNullOrEmpty())
             {
                 return Task.FromResult<IHtmlContent>(HtmlString.Empty);
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DisplayHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DisplayHelper.cs
@@ -44,12 +44,12 @@ namespace OrchardCore.DisplayManagement.Implementation
                 return ShapeTypeExecuteAsync(name, parameters);
             }
 
-            if (parameters.Positional.Count() == 1)
+            if (parameters.Positional.Count == 1)
             {
                 return ShapeExecuteAsync(parameters.Positional.First() as IShape);
             }
 
-            if (parameters.Positional.Any())
+            if (parameters.Positional.Count > 0)
             {
                 return ShapeExecuteAsync(parameters.Positional.Cast<IShape>());
             }
@@ -66,11 +66,13 @@ namespace OrchardCore.DisplayManagement.Implementation
 
         public Task<IHtmlContent> ShapeExecuteAsync(IShape shape)
         {
+            // Check if the shape is null or empty.
             if (shape.IsNullOrEmpty())
             {
                 return Task.FromResult<IHtmlContent>(HtmlString.Empty);
             }
 
+            // Check if the shape is pre-rendered.
             if (shape is IHtmlContent htmlContent)
             {
                 return Task.FromResult(htmlContent);

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DisplayHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DisplayHelper.cs
@@ -4,7 +4,6 @@ using System.Dynamic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using OrchardCore.DisplayManagement.Zones;
 
 namespace OrchardCore.DisplayManagement.Implementation
 {
@@ -70,6 +69,11 @@ namespace OrchardCore.DisplayManagement.Implementation
             if (shape.IsNullOrEmpty())
             {
                 return Task.FromResult<IHtmlContent>(HtmlString.Empty);
+            }
+
+            if (shape is IHtmlContent htmlContent)
+            {
+                return Task.FromResult(htmlContent);
             }
 
             var context = new DisplayContext

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -297,9 +297,7 @@ namespace OrchardCore.DisplayManagement.Razor
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var zone = ThemeLayout.Zones[name];
-
-            return !zone.IsNullOrEmpty();
+            return ThemeLayout.Zones.IsEmpty(name);
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -299,7 +299,7 @@ namespace OrchardCore.DisplayManagement.Razor
 
             var zone = ThemeLayout.Zones[name];
 
-            return zone != null;
+            return !(zone is ZoneOnDemand);
         }
 
         /// <summary>
@@ -367,7 +367,7 @@ namespace OrchardCore.DisplayManagement.Razor
 
             var zone = ThemeLayout.Zones[name];
 
-            if (required && zone != null)
+            if (required && zone is ZoneOnDemand)
             {
                 throw new InvalidOperationException("Zone not found: " + name);
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -297,7 +297,7 @@ namespace OrchardCore.DisplayManagement.Razor
                 throw new ArgumentNullException(nameof(name));
             }
 
-            return !ThemeLayout.Zones.IsEmpty(name);
+            return ThemeLayout.Zones.IsNotEmpty(name);
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -297,7 +297,7 @@ namespace OrchardCore.DisplayManagement.Razor
                 throw new ArgumentNullException(nameof(name));
             }
 
-            return ThemeLayout.Zones.IsEmpty(name);
+            return !ThemeLayout.Zones.IsEmpty(name);
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -299,7 +299,7 @@ namespace OrchardCore.DisplayManagement.Razor
 
             var zone = ThemeLayout.Zones[name];
 
-            return !(zone is ZoneOnDemand);
+            return !zone.IsNullOrEmpty();
         }
 
         /// <summary>
@@ -367,7 +367,7 @@ namespace OrchardCore.DisplayManagement.Razor
 
             var zone = ThemeLayout.Zones[name];
 
-            if (required && zone is ZoneOnDemand)
+            if (required && zone.IsNullOrEmpty())
             {
                 throw new InvalidOperationException("Zone not found: " + name);
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
@@ -273,7 +273,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
 
             var zone = ThemeLayout.Zones[name];
 
-            return !(zone is ZoneOnDemand);
+            return !zone.IsNullOrEmpty();
         }
 
         /// <summary>
@@ -304,7 +304,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
 
             var zone = ThemeLayout.Zones[name];
 
-            if (required && zone is ZoneOnDemand)
+            if (required && zone.IsNullOrEmpty())
             {
                 throw new InvalidOperationException("Zone not found: " + name);
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
@@ -271,7 +271,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
                 throw new ArgumentNullException(nameof(name));
             }
 
-            return ThemeLayout.Zones.IsEmpty(name);
+            return !ThemeLayout.Zones.IsEmpty(name);
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
@@ -271,7 +271,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
                 throw new ArgumentNullException(nameof(name));
             }
 
-            return !ThemeLayout.Zones.IsEmpty(name);
+            return ThemeLayout.Zones.IsNotEmpty(name);
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
@@ -273,7 +273,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
 
             var zone = ThemeLayout.Zones[name];
 
-            return zone != null;
+            return !(zone is ZoneOnDemand);
         }
 
         /// <summary>
@@ -304,7 +304,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
 
             var zone = ThemeLayout.Zones[name];
 
-            if (required && zone != null)
+            if (required && zone is ZoneOnDemand)
             {
                 throw new InvalidOperationException("Zone not found: " + name);
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
@@ -271,9 +271,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
                 throw new ArgumentNullException(nameof(name));
             }
 
-            var zone = ThemeLayout.Zones[name];
-
-            return !zone.IsNullOrEmpty();
+            return ThemeLayout.Zones.IsEmpty(name);
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using OrchardCore.DisplayManagement.Zones;
 
 namespace OrchardCore.DisplayManagement.Theming
 {
@@ -17,30 +18,28 @@ namespace OrchardCore.DisplayManagement.Theming
     {
         public override async Task ExecuteAsync()
         {
-            // The View's body is rendered
+            // The View's body is rendered.
             var body = RenderLayoutBody();
 
             if (ThemeLayout != null)
             {
-                // Then is added to the Content zone of the Layout shape
+                // Then is added to the Content zone of the Layout shape.
                 await ThemeLayout.Zones["Content"].AddAsync(body);
 
-                // Pre-render all shapes and replace the zone content with it
+                // Pre-render all shapes and replace the zone content with it.
                 ThemeLayout.Zones["Content"] = new PositionWrapper(await DisplayAsync(ThemeLayout.Zones["Content"]), "");
 
-                // Render each layout zone
+                // Render each layout zone.
                 foreach (var zone in ThemeLayout.Properties.ToArray())
                 {
-                    if (zone.Value != null) // zone is not empty
+                    // Check if the zone hasn't been processed and is not empty.
+                    if (zone.Value is IShape shape && !(shape is ZoneOnDemand))
                     {
-                        if (zone.Value is IShape shape) // zone hasn't been processed already
-                        {
-                            ThemeLayout.Zones[zone.Key] = new PositionWrapper(await DisplayAsync(shape), "");
-                        }
+                        ThemeLayout.Zones[zone.Key] = new PositionWrapper(await DisplayAsync(shape), "");
                     }
                 }
 
-                // Finally we render the Layout Shape's HTML to the page's output
+                // Finally we render the Layout Shape's HTML to the page's output.
                 Write(await DisplayAsync(ThemeLayout));
             }
             else

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.DisplayManagement.Theming
                 foreach (var zone in ThemeLayout.Properties.ToArray())
                 {
                     // Check if the zone hasn't been processed and is not empty.
-                    if (zone.Value is IShape shape && !(shape is ZoneOnDemand))
+                    if (zone.Value is IShape shape && !shape.IsNullOrEmpty())
                     {
                         ThemeLayout.Zones[zone.Key] = new PositionWrapper(await DisplayAsync(shape), "");
                     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
-using OrchardCore.DisplayManagement.Zones;
+using Microsoft.AspNetCore.Html;
 
 namespace OrchardCore.DisplayManagement.Theming
 {
@@ -32,8 +32,8 @@ namespace OrchardCore.DisplayManagement.Theming
                 // Render each layout zone.
                 foreach (var zone in ThemeLayout.Properties.ToArray())
                 {
-                    // Check if the zone hasn't been processed and is not empty.
-                    if (zone.Value is IShape shape && !shape.IsNullOrEmpty())
+                    // Check if the zone hasn't been processed already and is not empty.
+                    if (zone.Value is IShape shape && !(shape is IHtmlContent) && !shape.IsNullOrEmpty())
                     {
                         ThemeLayout.Zones[zone.Key] = new PositionWrapper(await DisplayAsync(shape), "");
                     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Theming/ThemeLayout.cs
@@ -32,9 +32,20 @@ namespace OrchardCore.DisplayManagement.Theming
                 // Render each layout zone.
                 foreach (var zone in ThemeLayout.Properties.ToArray())
                 {
-                    // Check if the zone hasn't been processed already and is not empty.
-                    if (zone.Value is IShape shape && !(shape is IHtmlContent) && !shape.IsNullOrEmpty())
+                    if (zone.Value is IShape shape)
                     {
+                        // Check if the shape is null or empty.
+                        if (shape.IsNullOrEmpty())
+                        {
+                            continue;
+                        }
+
+                        // Check if the shape is pre-rendered.
+                        if (shape is IHtmlContent)
+                        {
+                            continue;
+                        }
+
                         ThemeLayout.Zones[zone.Key] = new PositionWrapper(await DisplayAsync(shape), "");
                     }
                 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
@@ -63,7 +63,7 @@ namespace OrchardCore.DisplayManagement.Zones
         private readonly Func<ValueTask<IShape>> _zoneFactory;
         private readonly ZoneHolding _parent;
 
-        public bool IsEmpty(string name) => !(this[name] is ZoneOnDemand);
+        public bool IsEmpty(string name) => this[name] is ZoneOnDemand;
 
         public Zones(Func<ValueTask<IShape>> zoneFactory, ZoneHolding parent)
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
@@ -63,6 +63,8 @@ namespace OrchardCore.DisplayManagement.Zones
         private readonly Func<ValueTask<IShape>> _zoneFactory;
         private readonly ZoneHolding _parent;
 
+        public bool IsEmpty(string name) => !(this[name] is ZoneOnDemand);
+
         public Zones(Func<ValueTask<IShape>> zoneFactory, ZoneHolding parent)
         {
             _zoneFactory = zoneFactory;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
@@ -63,7 +63,7 @@ namespace OrchardCore.DisplayManagement.Zones
         private readonly Func<ValueTask<IShape>> _zoneFactory;
         private readonly ZoneHolding _parent;
 
-        public bool IsEmpty(string name) => this[name] is ZoneOnDemand;
+        public bool IsNotEmpty(string name) => !(this[name] is ZoneOnDemand);
 
         public Zones(Func<ValueTask<IShape>> zoneFactory, ZoneHolding parent)
         {


### PR DESCRIPTION
@sebastienros 

- Okay good, now `IShape` has an `AddAsync()`, so we don't need anymore to check if it is a ZOD before calling it.

- I thought about getting rid of ZOD, but in many places where we get a zone to add a shape, we would need a null check and if null create a ZOD to be able to add a shape on it, so seems to be still useful to auto create a zone on demand.

- So here, for now i just added some `is ZoneOnDemand` checks where it seems they were missing.

- Then just created an `IShape.IsNullOrEmpty()` extension that i will start to use.

- For info in `RenderSectionAsync()` of `RazorPage` and `Page`, before it was

            var zone = ThemeLayout[name]; <= dynamic

            if (required && zone != null && zone is Shape && zone.Items.Count == 0)
            {
                throw new InvalidOperationException("Zone not found: " + name);
            }

    Maybe `zone != null` was added to not throw precisely if it is a ZOD (here as dynamic) so with no items, and `zone is Shape` for pre-rendered zones, that now are `PositionWrapper` that fail when accessing the `Items` property. Anyway looks good to have removed all these checks.

    But as it is now, it always fails if required and if zone (here an `IShape`) is not null     

            var zone = ThemeLayout.Zones[name]; <= IShape

            if (required && zone != null)
            {
                throw new InvalidOperationException("Zone not found: " + name);
            }
  
    So at least we would need to check `if (required && zone == null)`, but because zone is now an `IShape` that is at least a ZOD, for now i used the following. Note: If we still want to not fail on a ZOD, this check would become useless, otherwise, that's why we should not pre-render a ZOD in `ThemeLayout.cs` to be able to check it here.

            if (required && zone is ZoneOnDemand)
            {
                throw new InvalidOperationException("Zone not found: " + name);
            }
