### PR TITLE
Forgot to remove unused var in Lucene AdminController

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/AdminController.cs
@@ -375,8 +375,6 @@ namespace OrchardCore.Lucene.Controllers
                 var analyzer = _luceneAnalyzerManager.CreateAnalyzer(await _luceneIndexSettingsService.GetIndexAnalyzerAsync(model.IndexName));
                 var context = new LuceneQueryContext(searcher, LuceneSettings.DefaultVersion, analyzer);
 
-                var templateContext = new LiquidTemplateContext(HttpContext.RequestServices, _templateOptions.Value);
-
                 var parameters = JsonConvert.DeserializeObject<Dictionary<string, object>>(model.Parameters);
 
                 var tokenizedContent = await _liquidTemplateManager.RenderStringAsync(model.DecodedQuery, _javaScriptEncoder, parameters.Select(x => new KeyValuePair<string, FluidValue>(x.Key, FluidValue.Create(x.Value, _templateOptions.Value))));


### PR DESCRIPTION
My fault. No need for a TemplateContext anymore in Liquid.