### PR TITLE
PagerShapes: Use IShapeFactory and cleanup

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
@@ -577,11 +577,11 @@ namespace OrchardCore.Navigation
 
         private class HtmlContentString : IHtmlContent
         {
-            private readonly string _input;
+            private readonly string _value;
 
-            public HtmlContentString(string input) => _input = input;
+            public HtmlContentString(string value) => _value = value;
 
-            public void WriteTo(TextWriter writer, HtmlEncoder encoder) => writer.Write(encoder.Encode(_input));
+            public void WriteTo(TextWriter writer, HtmlEncoder encoder) => writer.Write(encoder.Encode(_value));
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
@@ -121,7 +121,7 @@ namespace OrchardCore.DisplayManagement.Liquid
             /// <inheritdoc />
             public override string ToString()
             {
-                return new String(Value);
+                return new string(Value);
             }
         }
 
@@ -150,7 +150,7 @@ namespace OrchardCore.DisplayManagement.Liquid
             /// <inheritdoc />
             public override string ToString()
             {
-                return new String(Value, Index, Length);
+                return new string(Value, Index, Length);
             }
         }
     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/PositionWrapper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/PositionWrapper.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.DisplayManagement
         public IDictionary<string, string> Attributes { get; }
 
         private Dictionary<string, object> _properties;
-        public IDictionary<string, object> Properties => _properties = _properties ?? new Dictionary<string, object>();
+        public IDictionary<string, object> Properties => _properties ??= new Dictionary<string, object>();
 
         public IReadOnlyList<IPositioned> Items => throw new System.NotImplementedException();
 


### PR DESCRIPTION
Maybe related to #8887

In my case to repro

- Setup with the blog recipe
- Create more than 10 blog posts
- Go to the blog home page that list the first 10 blog posts
- Click on Older posts => you get the following exception

Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware|ERROR|An unhandled exception has occurred while executing the request. System.**ArgumentOutOfRangeException**: Specified argument was out of the range of valid values. (Parameter 'index')
   at Microsoft.AspNetCore.Mvc.ViewFeatures.Buffers.ViewBufferTextWriter.Write(Char[] buffer, Int32 index, Int32 count)
   at System.IO.TextWriter.Write(ReadOnlySpan`1 buffer)
   at System.IO.TextWriterExtensions.WritePartialString(TextWriter writer, String value, Int32 offset, Int32 count)
   at System.Text.Encodings.Web.TextEncoder.Encode(TextWriter output, String value, Int32 startIndex, Int32 characterCount)
   at System.Text.Encodings.Web.TextEncoder.Encode(TextWriter output, String value)
   at Microsoft.AspNetCore.Mvc.ViewFeatures.**StringHtmlContent.WriteTo**(TextWriter writer, HtmlEncoder encoder)
   at Microsoft.AspNetCore.Html.**HtmlContentBuilder.WriteTo**(TextWriter writer, HtmlEncoder encoder)
   at Microsoft.AspNetCore.Mvc.Rendering.**TagBuilder.WriteTo**(TagBuilder tagBuilder, TextWriter writer, HtmlEncoder encoder, TagRenderMode tagRenderMode)

So in `PagerShapes` it fails when adding an `StringHtmlContent` in the inner `HtmlContentBuilder` of a `TagBuilder`

It fails under liquid, i also tried it with the dev branch before Fluid 2.0, it also fails so not related.

Replacing the `StringHtmlContent` by a copy here named `HtmlContentString` fixed the issue

The only difference is that the original `StringHtmlContent` does in its `WriteTo()`

    encoder.Encode(writer, _input);

With our new `HtmlContentString` here we do

    writer.Write(encoder.Encode(_value))



