### PR TITLE
Updating Github Actions to Node 15

### DIFF
--- a/.github/workflows/functional_all_db.yml
+++ b/.github/workflows/functional_all_db.yml
@@ -13,6 +13,9 @@ jobs:
       image: cypress/included:6.8.0
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: "15"
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/functional_all_db.yml
+++ b/.github/workflows/functional_all_db.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "15.12.0"
+        node-version: "15"
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/functional_all_db.yml
+++ b/.github/workflows/functional_all_db.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "15"
+        node-version: "15.12.0"
     - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
-        with:
-          node-version: "15.x"
+      with:
+        node-version: "15"
     - name: Setup .NET Core 3.1 on ${{ matrix.os }}
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "15.12.0"
+        node-version: "15"
     - name: Setup .NET Core 3.1 on ${{ matrix.os }}
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "15"
+        node-version: "15.12.0"
     - name: Setup .NET Core 3.1 on ${{ matrix.os }}
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -20,6 +20,9 @@ jobs:
     name: Build & Test
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+        with:
+          node-version: "15.x"
     - name: Setup .NET Core 3.1 on ${{ matrix.os }}
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "15.12.0"
+        node-version: "15"
     - name: Setup .NET Core 3.1 on ${{ matrix.os }}
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -20,6 +20,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: "15"
     - name: Setup .NET Core 3.1 on ${{ matrix.os }}
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: "15"
+        node-version: "15.12.0"
     - name: Setup .NET Core 3.1 on ${{ matrix.os }}
       uses: actions/setup-dotnet@v1
       with:

--- a/test/Functional/package-lock.json
+++ b/test/Functional/package-lock.json
@@ -5,13 +5,14 @@
   "packages": {
     "": {
       "devDependencies": {
-        "cypress": "^6.7.1",
+        "cypress": "^6.8.0",
         "cypress-orchardcore": "file:cypress-commands",
         "faker": "^5.4.0",
         "fs-extra": "^9.1.0"
       }
     },
     "cypress-commands": {
+      "name": "cypress-orchardcore",
       "version": "0.4.5",
       "dev": true,
       "license": "MIT",
@@ -573,9 +574,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.7.1.tgz",
-      "integrity": "sha512-MC9yt1GqpL4WVDQ0STI89K+PdLeC3T3NuAb2N61d6vYGR9pJy8w3Fqe0OWZwaRTJtg9eAyHXPGmFsyKeNQ3tmg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.8.0.tgz",
+      "integrity": "sha512-W2e9Oqi7DmF48QtOD0LfsOLVq6ef2hcXZvJXI/E3PgFNmZXEVwBefhAxVCW9yTPortjYA2XkM20KyC4HRkOm9w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -908,19 +909,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "extraneous": true,
-      "hasInstallScript": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -3171,12 +3159,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "extraneous": true
     },
     "function-bind": {
       "version": "1.1.1",


### PR DESCRIPTION
Missing update file from my last PR. https://github.com/OrchardCMS/OrchardCore/pull/8892

Updating Cypress package-lock.json file to 6.8.0

Specifying Node version 15 in Github Actions (was previously defaulting to 14 LTS)