### PR TITLE
StringHtmlContent to HtmlContentString

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
@@ -1,19 +1,17 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.DisplayManagement.Html;
 using OrchardCore.DisplayManagement.Implementation;
 using OrchardCore.DisplayManagement.Shapes;
 
@@ -573,15 +571,6 @@ namespace OrchardCore.Navigation
             }
 
             return new HtmlContentString(value.ToString());
-        }
-
-        private class HtmlContentString : IHtmlContent
-        {
-            private readonly string _value;
-
-            public HtmlContentString(string value) => _value = value;
-
-            public void WriteTo(TextWriter writer, HtmlEncoder encoder) => writer.Write(encoder.Encode(_value));
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
@@ -15,8 +15,13 @@ namespace OrchardCore.DisplayManagement.Html
     {
         private readonly string _value;
 
+        /// <summary>
+        /// Creates a new instance of <see cref="HtmlContentString"/>
+        /// </summary>
+        /// <param name="value"><see cref="string"/> to be HTML encoded when <see cref="WriteTo"/> is called.</param>
         public HtmlContentString(string value) => _value = value;
 
+        /// <inheritdoc />
         public void WriteTo(TextWriter writer, HtmlEncoder encoder) => writer.Write(encoder.Encode(_value));
 
         private string DebuggerToString()

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
@@ -1,0 +1,29 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace OrchardCore.DisplayManagement.Html
+{
+    /// <summary>
+    /// An optimization of <see cref="StringHtmlContent "/> that uses 'writer.Write(encoder.Encode(_value))', in place of using
+    /// 'encoder.Encode(writer, _value)' that calls 'writer.Write' on each char if the string has even a single char to encode.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerToString()}")]
+    public class HtmlContentString : IHtmlContent
+    {
+        private readonly string _value;
+
+        public HtmlContentString(string value) => _value = value;
+
+        public void WriteTo(TextWriter writer, HtmlEncoder encoder) => writer.Write(encoder.Encode(_value));
+
+        private string DebuggerToString()
+        {
+            using var writer = new StringWriter();
+            WriteTo(writer, HtmlEncoder.Default);
+            return writer.ToString();
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.DisplayManagement.Html;
 using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Modules;
@@ -58,7 +58,7 @@ namespace OrchardCore.DisplayManagement.Implementation
             // can't really cope with a shape that has no type information
             if (shapeMetadata == null || String.IsNullOrEmpty(shapeMetadata.Type))
             {
-                return new StringHtmlContent(context.Value.ToString());
+                return new HtmlContentString(context.Value.ToString());
             }
 
             // Copy the current context such that the rendering can customize it if necessary

--- a/src/OrchardCore/OrchardCore.DisplayManagement/PositionWrapper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/PositionWrapper.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using OrchardCore.DisplayManagement.Html;
 using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.DisplayManagement
@@ -36,7 +36,7 @@ namespace OrchardCore.DisplayManagement
 
         public PositionWrapper(string value, string position)
         {
-            _value = new StringHtmlContent(value);
+            _value = new HtmlContentString(value);
             Position = position;
         }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorPage.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.DisplayManagement.Html;
 using OrchardCore.DisplayManagement.Title;
 using OrchardCore.DisplayManagement.Zones;
 using OrchardCore.Settings;
@@ -94,7 +95,7 @@ namespace OrchardCore.DisplayManagement.Razor
 
             if (shape is string str)
             {
-                return Task.FromResult<IHtmlContent>(new StringHtmlContent(str));
+                return Task.FromResult<IHtmlContent>(new HtmlContentString(str));
             }
 
             throw new ArgumentException("DisplayAsync requires an instance of IShape");
@@ -238,7 +239,7 @@ namespace OrchardCore.DisplayManagement.Razor
         {
             if (!String.IsNullOrEmpty(segment))
             {
-                Title.AddSegment(new StringHtmlContent(segment), position);
+                Title.AddSegment(new HtmlContentString(segment), position);
             }
 
             return Title.GenerateTitle(separator);

--- a/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/RazorPages/Page.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.DisplayManagement.Html;
 using OrchardCore.DisplayManagement.Razor;
 using OrchardCore.DisplayManagement.Title;
 using OrchardCore.DisplayManagement.Zones;
@@ -90,7 +91,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
 
             if (shape is string str)
             {
-                return Task.FromResult<IHtmlContent>(new StringHtmlContent(str));
+                return Task.FromResult<IHtmlContent>(new HtmlContentString(str));
             }
 
             throw new ArgumentException("DisplayAsync requires an instance of IShape");
@@ -232,7 +233,7 @@ namespace OrchardCore.DisplayManagement.RazorPages
         /// <returns>And <see cref="IHtmlContent"/> instance representing the full title.</returns>
         public IHtmlContent RenderTitleSegments(string segment, string position = "0", IHtmlContent separator = null)
         {
-            Title.AddSegment(new StringHtmlContent(segment), position);
+            Title.AddSegment(new HtmlContentString(segment), position);
             return Title.GenerateTitle(separator);
         }
 


### PR DESCRIPTION
Suggest to replace all `StringHtmlContent` by a new `HtmlContentString` that uses `writer.Write(encoder.Encode(_value))`, in place of `encoder.Encode(writer, _value)` that calls `writer.Write()` on each char even if only one need to be encoded.

Not sure it optimizes something because currently i can't compare things on my too old machine

But at least it fixed an issue while using the pager under liquid, see #8894 

Same exception as reported in #8887 

@sebastienros just for info, regardless this PR,, when i do some apache tests i noticed that now the rps are better for the blog home page than for the about page, maybe due to my machine but i don't think so.