### PR TITLE
Fix ChildContent rendering in liquid

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeRenderFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeRenderFilter.cs
@@ -22,7 +22,8 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
                 return new HtmlContentValue(await task);
             }
 
-            if (input.ToObjectValue() is IShape shape)
+            var obj = input.ToObjectValue();
+            if (obj is IShape shape)
             {
                 var task = _displayHelper.ShapeExecuteAsync(shape);
                 if (!task.IsCompletedSuccessfully)
@@ -31,6 +32,10 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
                 }
 
                 return new ValueTask<FluidValue>(new HtmlContentValue(task.Result));
+            }
+            else if (obj is IHtmlContent html)
+            {
+                return new ValueTask<FluidValue>(new HtmlContentValue(html));
             }
 
             return new ValueTask<FluidValue>(new HtmlContentValue(HtmlString.Empty));

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -117,6 +117,8 @@ namespace OrchardCore.DisplayManagement.Liquid
                         return shape.Attributes;
                     case "Items":
                         return shape.Items;
+                    case "Metadata":
+                        return shape.Metadata;
                     default:
                         if (shape.Properties.TryGetValue(n, out var result))
                         {


### PR DESCRIPTION
Map Shape's Metadata property and render IHtmlContent from ShapeRenderFilter

See #8021 and #8024

Sample usage with Form_Wrapper shape :
```liquid
{% assign formPart = Model.ContentItem.Content.FormPart %}
<form action="{{ formPart.Action }}" method="{{ formPart.Method }}" enctype="{{ formPart.EncType }}" class="form-content {{ formContentTypeClassName }}">
    {% if formPart.EnableAntiForgeryToken %}
        {% antiforgerytoken %}
    {% endif %}

  {{ Model.Metadata.ChildContent | shape_render }}
</form>
```