### PR TITLE
DetailAdmin Titles Tweaks

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.DetailAdmin.cshtml
@@ -11,7 +11,7 @@
     var tag = Tag(Model, "article");
 }
 
-<zone Name="Title"><h1>@RenderTitleSegments(contentItem.DisplayText)</h1></zone>
+<zone Name="Title"><h1>@RenderTitleSegments(T["Admin Details of {0}", contentItem.DisplayText])</h1></zone>
 
 <article>
     <header>

--- a/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePart.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Views/TitlePart.DetailAdmin.cshtml
@@ -1,0 +1,1 @@
+<h5 style="display:inline-block">@Model.ContentItem.DisplayText</h5>


### PR DESCRIPTION
Not to be merged, just to show the difference

So because in the blog page i saw that the title is rendered twice with the same size (Title segment and part) while in the DetailAdmin display type.

![DetailAdmin1](https://user-images.githubusercontent.com/8586360/111888480-34b53280-89dd-11eb-8232-6cd95bb3dbe6.png)

Here naively, but just to show the difference, i updated the Title segment text, and for the Title part i just added a view template for this display type, as already done specifically for the dashboard module.

![DetailAdmin2](https://user-images.githubusercontent.com/8586360/111888488-4696d580-89dd-11eb-93dc-1fcd2b6e54bd.png)

