### PR TITLE
Shortcode / Liquid Content conflict

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Services/TemplateShortcodeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Services/TemplateShortcodeProvider.cs
@@ -14,9 +14,9 @@ namespace OrchardCore.Shortcodes.Services
         private readonly ShortcodeTemplatesManager _shortcodeTemplatesManager;
         private readonly ILiquidTemplateManager _liquidTemplateManager;
         private readonly HtmlEncoder _htmlEncoder;
-        private readonly HashSet<string> _identifiers = new HashSet<string>();
 
         private ShortcodeTemplatesDocument _shortcodeTemplatesDocument;
+        private readonly HashSet<string> _identifiers = new HashSet<string>();
 
         public TemplateShortcodeProvider(
             ShortcodeTemplatesManager shortcodeTemplatesManager,
@@ -53,25 +53,13 @@ namespace OrchardCore.Shortcodes.Services
                 Context = context
             };
 
-            var parameters = new Dictionary<string, FluidValue>();
-            parameters[identifier] = new StringValue("");
-
-            // TODO: Fix 'Content' property conflict differently, see #8259
-
-            // var c = context.GetValue("Content").ToObjectValue();
-            // if (c is LiquidContentAccessor contentAccessor)
-            // {
-            //     contentAccessor.Content = model.Content ?? "";
-            //     parameters["Content"] = contentAccessor;
-            // }
-            // else
-            // {
-            //     parameters["Content"] = model.Content ?? "";
-            // }
-
-            parameters["Args"] = new ObjectValue(model.Args);
-            parameters["Content"] = new StringValue(model.Content);
-            parameters["Context"] = new ObjectValue(model.Context);
+            var parameters = new Dictionary<string, FluidValue>
+            {
+                [identifier] = new StringValue(""),
+                ["Args"] = new ObjectValue(model.Args),
+                ["Content"] = new ObjectValue(new Content(model.Content)),
+                ["Context"] = new ObjectValue(model.Context)
+            };
 
             var result = await _liquidTemplateManager.RenderStringAsync(template.Content, _htmlEncoder, model, parameters);
 
@@ -79,6 +67,13 @@ namespace OrchardCore.Shortcodes.Services
             _identifiers.Remove(identifier);
 
             return result;
+        }
+
+        internal class Content : LiquidContentAccessor
+        {
+            public readonly string _content;
+            public Content(string content) => _content = content;
+            public override string ToString() => _content;
         }
     }
 }


### PR DESCRIPTION
This is a known conflict

I know that we could replace the `Queries`, `Site`, `User` and `Content` accessors to liquid filters as suggested in #8283

But in the meantine, maybe worth to still provide a workaround for the `Content` property

Knowing that it is only related to shortcodes templates that are defined by using liquid syntax.

Here we don't modify the `LiquidContentAccessor` marker class, we just define a new local derived one

Allowing to both use the shortcode content and the liquid content acessor.

    Hello {{ Content }} : {{ Content.ContentItemId['4pnytr3heyd9rshtsb7w96z1nk'].DisplayText }}

    [hello]world[/hello] => Hello world : About