### PR TITLE
Update OrchardCore.Title Doc

### DIFF
--- a/src/docs/reference/modules/Title/README.md
+++ b/src/docs/reference/modules/Title/README.md
@@ -1,7 +1,6 @@
 # Title (`OrchardCore.Title`)
 
-The `Title` module provides a **Title Part** that lets you customize the DisplayText property of a content item.  
-The DisplayText property is used throughout the Admin interface to help you recognize your content items.
+The `Title` module provides a **Title Part** that lets you customize the DisplayText property of a content item. The DisplayText property is used throughout the Admin interface to help you recognize your content items.
 
 ## TitlePart
 
@@ -9,12 +8,11 @@ Attach this part to your content items to customize the DisplayText property of 
 
 ### TitlePart Settings
 
-By default, attaching the TitlePart will allow content editors to manually edit the DisplayText(title) of a ContentItem.
+By default, attaching the TitlePart will allow content editors to manually edit the DisplayText (title) of a ContentItem.
 
 You can also generate the Title by specifying a pattern using a Liquid expression.
 
-The Pattern has access the current ContentItem and is executed on ContentItem update.  
-For example, fields can be used to generate the pattern. The following example uses a __Text field__ named `Name`, on a `Product` content type.
+The Pattern has access to the current ContentItem and is executed on ContentItem update. For example, fields can be used to generate the pattern. The following example uses a __Text field__ named `Name`, on a `Product` content type.
 
 ```liquid
 {{ ContentItem.Content.Product.Name.Text }}


### PR DESCRIPTION
In addition to a missing word, "to," I noticed in general the Orchard Core docs have lots of single sentences with single newlines where it really should be either (1) all part of one paragraph, or (2) two newlines marking a new paragraph.  If you look at the first paragraph of this doc before my edit you have two sentences with a line break (but not a full paragraph space) which isn't really normal English writing style...  I'm not sure how much of this type of writing style suggestions you might be interested in getting but I find it a bit awkward to read as-is.  I'm happy to help a bit as I'm reading your docs but only want to do this type of edit if it is welcome...  please just let me know.