### PR TITLE
Remove unecessary casts from liquid filters

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Liquid/SwitchCultureUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Liquid/SwitchCultureUrlFilter.cs
@@ -20,9 +20,8 @@ namespace OrchardCore.ContentLocalization.Liquid
             _httpContextAccessor = httpContextAccessor;
         }
 
-        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext ctx)
+        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
         {
-            var context = (LiquidTemplateContext)ctx;
             var urlHelper = _urlHelperFactory.GetUrlHelper(context.ViewContext);
 
             var request = _httpContextAccessor.HttpContext?.Request;
@@ -42,7 +41,7 @@ namespace OrchardCore.ContentLocalization.Liquid
                     contentItemUrl = request.Path.Value,
                     queryStringValue = request.QueryString.Value
                 });
-            return new ValueTask<FluidValue>(FluidValue.Create(url, ctx.Options));
+            return new ValueTask<FluidValue>(FluidValue.Create(url, context.Options));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
@@ -25,9 +25,8 @@ namespace OrchardCore.Contents.Liquid
             _urlHelperFactory = urlHelperFactory;
         }
 
-        public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext ctx)
+        public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
         {
-            var context = (LiquidTemplateContext)ctx;
             var contentItem = input.ToObjectValue() as ContentItem;
             RouteValueDictionary routeValues;
 

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/AbsoluteUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/AbsoluteUrlFilter.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.Liquid.Filters
         {
             _urlHelperFactory = urlHelperFactory;
         }
-        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext ctx)
+        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
         {
             var relativePath = input.ToStringValue();
 
@@ -23,7 +23,6 @@ namespace OrchardCore.Liquid.Filters
                 return new ValueTask<FluidValue>(input);
             }
 
-            var context = (LiquidTemplateContext)ctx;
             var urlHelper = _urlHelperFactory.GetUrlHelper(context.ViewContext);
 
             var result = new StringValue(urlHelper.ToAbsoluteUrl(relativePath));

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/ContentUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/ContentUrlFilter.cs
@@ -15,9 +15,8 @@ namespace OrchardCore.Liquid.Filters
             _urlHelperFactory = urlHelperFactory;
         }
 
-        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext ctx)
+        public ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
         {
-            var context = (LiquidTemplateContext)ctx;
             var urlHelper = _urlHelperFactory.GetUrlHelper(context.ViewContext);
 
             return new ValueTask<FluidValue>(new StringValue((urlHelper).Content(input.ToStringValue())));


### PR DESCRIPTION
Because it's already `LiquidTemplateContext`