### PR TITLE
Auto enabling Feature dependencies

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
@@ -61,8 +61,7 @@ namespace OrchardCore.Environment.Shell.Data.Descriptors
                     _shellConfiguration.Bind(configuredFeatures);
 
                     var features = _alwaysEnabledFeatures
-                        .Concat(configuredFeatures.Features
-                            .Select(id => new ShellFeature(id) { AlwaysEnabled = true }))
+                        .Concat(configuredFeatures.Features.Select(id => new ShellFeature(id) { AlwaysEnabled = true }))
                         .Concat(_shellDescriptor.Features)
                         .Distinct();
 

--- a/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/ConfiguredFeaturesShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/ConfiguredFeaturesShellDescriptorManager.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
+using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Environment.Shell.Descriptor.Models;
 
@@ -14,33 +15,47 @@ namespace OrchardCore.Environment.Shell.Descriptor.Settings
     {
         private readonly IShellConfiguration _shellConfiguration;
         private readonly IEnumerable<ShellFeature> _alwaysEnabledFeatures;
+        private readonly IExtensionManager _extensionManager;
         private ShellDescriptor _shellDescriptor;
 
         public ConfiguredFeaturesShellDescriptorManager(
             IShellConfiguration shellConfiguration,
-            IEnumerable<ShellFeature> shellFeatures)
+            IEnumerable<ShellFeature> shellFeatures,
+            IExtensionManager extensionManager)
         {
             _shellConfiguration = shellConfiguration;
             _alwaysEnabledFeatures = shellFeatures.Where(f => f.AlwaysEnabled).ToArray();
+            _extensionManager = extensionManager;
         }
 
-        public Task<ShellDescriptor> GetShellDescriptorAsync()
+        public async Task<ShellDescriptor> GetShellDescriptorAsync()
         {
             if (_shellDescriptor == null)
             {
                 var configuredFeatures = new ConfiguredFeatures();
                 _shellConfiguration.Bind(configuredFeatures);
 
-                var features = _alwaysEnabledFeatures.Concat(configuredFeatures.Features
-                    .Select(id => new ShellFeature(id) { AlwaysEnabled = true })).Distinct();
+                var features = _alwaysEnabledFeatures
+                    .Concat(configuredFeatures.Features
+                        .Select(id => new ShellFeature(id) { AlwaysEnabled = true }))
+                    .Distinct();
+
+                var featureIds = features.Select(sf => sf.Id).ToArray();
+
+                var missingDependencies = (await _extensionManager.LoadFeaturesAsync(featureIds))
+                    .Select(entry => entry.FeatureInfo.Id)
+                    .Except(featureIds)
+                    .Select(id => new ShellFeature(id));
 
                 _shellDescriptor = new ShellDescriptor
                 {
-                    Features = features.ToList()
+                    Features = features
+                        .Concat(missingDependencies)
+                        .ToList()
                 };
             }
 
-            return Task.FromResult(_shellDescriptor);
+            return _shellDescriptor;
         }
 
         public Task UpdateShellDescriptorAsync(int priorSerialNumber, IEnumerable<ShellFeature> enabledFeatures, IEnumerable<ShellParameter> parameters)

--- a/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/ConfiguredFeaturesShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/ConfiguredFeaturesShellDescriptorManager.cs
@@ -16,6 +16,7 @@ namespace OrchardCore.Environment.Shell.Descriptor.Settings
         private readonly IShellConfiguration _shellConfiguration;
         private readonly IEnumerable<ShellFeature> _alwaysEnabledFeatures;
         private readonly IExtensionManager _extensionManager;
+
         private ShellDescriptor _shellDescriptor;
 
         public ConfiguredFeaturesShellDescriptorManager(
@@ -36,8 +37,7 @@ namespace OrchardCore.Environment.Shell.Descriptor.Settings
                 _shellConfiguration.Bind(configuredFeatures);
 
                 var features = _alwaysEnabledFeatures
-                    .Concat(configuredFeatures.Features
-                        .Select(id => new ShellFeature(id) { AlwaysEnabled = true }))
+                    .Concat(configuredFeatures.Features.Select(id => new ShellFeature(id) { AlwaysEnabled = true }))
                     .Distinct();
 
                 var featureIds = features.Select(sf => sf.Id).ToArray();

--- a/src/OrchardCore/OrchardCore/Shell/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ServiceCollectionExtensions.cs
@@ -45,11 +45,7 @@ namespace OrchardCore.Environment.Shell
 
         public static IServiceCollection AddSetFeaturesDescriptor(this IServiceCollection services)
         {
-            services.AddSingleton<IShellDescriptorManager>(sp =>
-            {
-                var shellFeatures = sp.GetServices<ShellFeature>();
-                return new SetFeaturesShellDescriptorManager(shellFeatures);
-            });
+            services.AddSingleton<IShellDescriptorManager, SetFeaturesShellDescriptorManager>();
 
             return services;
         }


### PR DESCRIPTION
Fixes #8942 

@deanmarcussen about the 2 points we discussed in some issues threads about features dependencies, here we fix the first one about auto-enabling the missing features after some changes in the hard coded feature dependencies.

This at the source through the `ShellDescriptor` that is already auto-composed e.g. with the `_alwaysEnabledFeatures` and other `configuredFeatures`.

I tried it by first removing from the `Layers` the `Rules` dependency, then by disabling the `Rules` feature through the Admin. Then i re-add the hard coded `Rules` dependency and restarted the site, the `Rules` feature was auto-enabled and you can see it as an enabled feature in the Admin.

You don't see it in the `ShellDescriptor` in the database until it is saved again by enabling / disabling any feature, but this is not a problem as it is internally enabled, even to keep in sync running instances in a distributed env, each instance will build a `ShellDescriptor` taking into account the hard coded dependencies.

---

Would be good to try it for the migrations from rc2 without enabling new dependencies through migration steps.

Next step: Fix the migration execution order issue with the `RequireFeatures` attribute, maybe a separate PR.

Maybe i will remove the ShellStateManager / Updater / Coordinator, less database accesses, and just call the `IFeatureEventHandler` maybe in `ShellDescriptorFeaturesManager`, maybe in a separate PR.