### PR TITLE
Remove antiforgery token in Taxonomy Tags view

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
@@ -28,9 +28,6 @@
 
 <label>@Model.PartFieldDefinition.DisplayName()</label>
 
-@* Antiforgery token required for the ajax post to create a new tag *@
-@Html.AntiForgeryToken()
-
 @if (!String.IsNullOrEmpty(taxonomySettings.Hint))
 {
     <span class="hint dashed">@taxonomySettings.Hint</span>


### PR DESCRIPTION
Related to #8986

Antiforgery token is already added to request from parent form (tested on blog recipe and my custom site)