### PR TITLE
Fix OpenIdApplicationStep to include ResponseType rst: permissions

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -73,6 +73,30 @@ namespace OrchardCore.OpenId.Recipes
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
             }
+            if (model.AllowAuthorizationCodeFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);
+            }
+            if (model.AllowImplicitFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdToken);
+
+                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
+                {
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Token);
+                }
+            }
+            if (model.AllowHybridFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdToken);
+
+                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
+                {
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
+                }
+            }
 
             descriptor.PostLogoutRedirectUris.UnionWith(
                 from uri in model.PostLogoutRedirectUris?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -73,6 +73,7 @@ namespace OrchardCore.OpenId.Recipes
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
             }
+            
             if (model.AllowAuthorizationCodeFlow)
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);


### PR DESCRIPTION
… in [ApplicationController.cs](https://github.com/OrchardCMS/OrchardCore/blob/620d7f3e4ee1178f015fcf2b2939c056abec51cd/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs#L203)

Without this, the `rst:` prefixed permissions are only added to the OpenIdApplication instance upon first "save" via Admin UI.