### PR TITLE
Reduce some Liquid tags allocations

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentAnchorTag.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/ContentAnchorTag.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
-using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Liquid.Tags;
 using OrchardCore.Liquid;
 
@@ -208,30 +207,14 @@ namespace OrchardCore.Contents.Liquid
 
             tagBuilder.RenderStartTag().WriteTo(writer, (HtmlEncoder)encoder);
 
-            string content;
-            using (var sb = StringBuilderPool.GetInstance())
+            if (statements != null && statements.Count > 0)
             {
-                using (var output = new StringWriter(sb.Builder))
+                var completion = await statements.RenderStatementsAsync(writer, encoder, context);
+
+                if (completion != Completion.Normal)
                 {
-                    if (statements != null && statements.Count > 0)
-                    {
-                        var completion = await statements.RenderStatementsAsync(output, encoder, context);
-
-                        if (completion != Completion.Normal)
-                        {
-                            return completion;
-                        }
-                    }
-
-                    await output.FlushAsync();
+                    return completion;
                 }
-
-                content = sb.Builder.ToString();
-            }
-
-            if (content != null)
-            {
-                writer.Write(content);
             }
             else if (!String.IsNullOrEmpty(contentItem.DisplayText))
             {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Liquid/MediaAnchorTag.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Liquid/MediaAnchorTag.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Liquid.Tags;
 using OrchardCore.Liquid;
 
@@ -85,30 +84,14 @@ namespace OrchardCore.Media.Liquid
 
             tagBuilder.RenderStartTag().WriteTo(writer, (HtmlEncoder)encoder);
 
-            string content;
-            using (var sb = StringBuilderPool.GetInstance())
+            if (statements != null && statements.Count > 0)
             {
-                using (var output = new StringWriter(sb.Builder))
+                var completion = await statements.RenderStatementsAsync(writer, encoder, context);
+
+                if (completion != Completion.Normal)
                 {
-                    if (statements != null && statements.Count > 0)
-                    {
-                        var completion = await statements.RenderStatementsAsync(output, encoder, context);
-
-                        if (completion != Completion.Normal)
-                        {
-                            return completion;
-                        }
-                    }
-
-                    await output.FlushAsync();
+                    return completion;
                 }
-
-                content = sb.Builder.ToString();
-            }
-
-            if (content != null)
-            {
-                writer.Write(content);
             }
 
             tagBuilder.RenderEndTag().WriteTo(writer, (HtmlEncoder)encoder);

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Cache/CacheTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Cache/CacheTag.cs
@@ -34,7 +34,15 @@ namespace OrchardCore.DynamicCache.Liquid
                                         The contents of the cache block will not be cached.
                                         To enable caching, make sure that a feature that contains an implementation of IDynamicCacheService and ICacheScopeManager is enabled (for example, 'Dynamic Cache').");
 
-                await writer.WriteAsync(await EvaluateStatementsAsync(statements, encoder, context));
+                if (statements != null && statements.Count > 0)
+                {
+                    var completion = await statements.RenderStatementsAsync(writer, encoder, context);
+
+                    if (completion != Completion.Normal)
+                    {
+                        return completion;
+                    }
+                }
 
                 return Completion.Normal;
             }
@@ -74,11 +82,25 @@ namespace OrchardCore.DynamicCache.Liquid
             }
 
             cacheScopeManager.EnterScope(cacheContext);
-            String content;
 
+            var content = "";
             try
             {
-                content = await EvaluateStatementsAsync(statements, encoder, context);
+                if (statements != null || statements.Count > 0)
+                {
+                    using var sb = StringBuilderPool.GetInstance();
+                    using (var render = new StringWriter(sb.Builder))
+                    {
+                        foreach (var statement in statements)
+                        {
+                            await statement.WriteToAsync(render, encoder, context);
+                        }
+
+                        await render.FlushAsync();
+                    }
+
+                    content = sb.Builder.ToString();
+                }
             }
             finally
             {
@@ -111,24 +133,6 @@ namespace OrchardCore.DynamicCache.Liquid
             await writer.WriteAsync(content);
 
             return Completion.Normal;
-        }
-
-        private static async Task<string> EvaluateStatementsAsync(IReadOnlyList<Statement> statements, TextEncoder encoder, TemplateContext context)
-        {
-            using (var sb = StringBuilderPool.GetInstance())
-            {
-                using (var content = new StringWriter(sb.Builder))
-                {
-                    foreach (var statement in statements)
-                    {
-                        await statement.WriteToAsync(content, encoder, context);
-                    }
-
-                    await content.FlushAsync();
-                }
-
-                return sb.Builder.ToString();
-            }
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/AnchorTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/AnchorTag.cs
@@ -86,27 +86,6 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
                 }
             }
 
-            string content;
-            using (var sb = StringBuilderPool.GetInstance())
-            {
-                using (var output = new StringWriter(sb.Builder))
-                {
-                    if (statements != null && statements.Count > 0)
-                    {
-                        var completion = await statements.RenderStatementsAsync(output, encoder, context);
-
-                        if (completion != Completion.Normal)
-                        {
-                            return completion;
-                        }
-                    }
-
-                    await output.FlushAsync();
-                }
-
-                content = sb.Builder.ToString();
-            }
-
             // If "href" is already set, it means the user is attempting to use a normal anchor.
             if (!String.IsNullOrEmpty(href))
             {
@@ -200,9 +179,14 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
 
             tagBuilder.RenderStartTag().WriteTo(writer, (HtmlEncoder)encoder);
 
-            if (content != null)
+            if (statements != null && statements.Count > 0)
             {
-                writer.Write(content);
+                var completion = await statements.RenderStatementsAsync(writer, encoder, context);
+
+                if (completion != Completion.Normal)
+                {
+                    return completion;
+                }
             }
 
             tagBuilder.RenderEndTag().WriteTo(writer, (HtmlEncoder)encoder);


### PR DESCRIPTION
- For some tags, directly write the content to the passed writer in place of using a string builder

    This for the `AnchorTag`, `MediaAnchorTag` and `ContentAnchorTag`

- See what we can do for the `FluidTagHelper` and the `ShapeTag`
