### PR TITLE
Fixes #9008 view buffer already rendered

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/EventHandlers/DynamicCacheShapeDisplayEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/EventHandlers/DynamicCacheShapeDisplayEvents.cs
@@ -86,15 +86,18 @@ namespace OrchardCore.DynamicCache.EventHandlers
             if (!_cached.ContainsKey(cacheContext.CacheId) && context.ChildContent != null)
             {
                 // The content is pre-encoded in the cache so we don't have to do it every time it's rendered
-                using (var sb = StringBuilderPool.GetInstance())
-                {
-                    using (var sw = new StringWriter(sb.Builder))
-                    {
-                        context.ChildContent.WriteTo(sw, _htmlEncoder);
-                        await _dynamicCacheService.SetCachedValueAsync(cacheContext, sw.ToString());
-                        await sw.FlushAsync();
-                    }
-                }
+                using var sb = StringBuilderPool.GetInstance();
+                using var sw = new StringWriter(sb.Builder);
+
+                context.ChildContent.WriteTo(sw, _htmlEncoder);
+
+                // 'ChildContent' may be a 'ViewBufferTextWriterContent' on which we can't
+                // call 'WriteTo()' twice, so here we update it with a new 'HtmlString()'.
+                var contentHtmlString = new HtmlString(sw.ToString());
+                context.ChildContent = contentHtmlString;
+
+                await _dynamicCacheService.SetCachedValueAsync(cacheContext, contentHtmlString.Value);
+                await sw.FlushAsync();
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.DynamicCache/EventHandlers/DynamicCacheShapeDisplayEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DynamicCache/EventHandlers/DynamicCacheShapeDisplayEvents.cs
@@ -89,10 +89,9 @@ namespace OrchardCore.DynamicCache.EventHandlers
                 using var sb = StringBuilderPool.GetInstance();
                 using var sw = new StringWriter(sb.Builder);
 
-                context.ChildContent.WriteTo(sw, _htmlEncoder);
-
                 // 'ChildContent' may be a 'ViewBufferTextWriterContent' on which we can't
                 // call 'WriteTo()' twice, so here we update it with a new 'HtmlString()'.
+                context.ChildContent.WriteTo(sw, _htmlEncoder);
                 var contentHtmlString = new HtmlString(sw.ToString());
                 context.ChildContent = contentHtmlString;
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
@@ -207,14 +207,14 @@ namespace OrchardCore.DisplayManagement.Liquid
                 {
                     foreach (var chunk in pooledBuilder.Builder.GetChunks())
                     {
-                        writer.Write(chunk);
+                        writer.Write(chunk.Span);
                     }
                 }
             }
 
             foreach (var chunk in _builder.GetChunks())
             {
-                writer.Write(chunk);
+                writer.Write(chunk.Span);
             }
 
             ReleasePooledBuffer();


### PR DESCRIPTION
Fixes #9008 

When we cache a shape we do a `WriteTo()` on the `ChildContent` but it may be a `ViewBufferTextWriterContent` on which we can't call `WriteTo()` a 2nd time which will happen when rendering

This happens when a shape is cached and provided by a template defined through the admin, in that case the `TemplatesShapeBindingResolver` calls the liquid template manager `RenderHtmlContentAsync()` where a `ViewBufferTextWriterContent` is used.

So here when we cache the `ChildContent`, we update it with a new `HtmlString()`.
