### PR TITLE
Prevent some razor compilation stuff in production

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using OrchardCore.Modules;
 using OrchardCore.Mvc.LocationExpander;
@@ -29,10 +30,12 @@ namespace OrchardCore.Mvc
         public override int Order => -1000;
         public override int ConfigureOrder => 1000;
 
+        private readonly IHostEnvironment _hostingEnvironment;
         private readonly IServiceProvider _serviceProvider;
 
-        public Startup(IServiceProvider serviceProvider)
+        public Startup(IHostEnvironment hostingEnvironment, IServiceProvider serviceProvider)
         {
+            _hostingEnvironment = hostingEnvironment;
             _serviceProvider = serviceProvider;
         }
 
@@ -101,10 +104,10 @@ namespace OrchardCore.Mvc
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<RazorViewEngineOptions>, ModularRazorViewEngineOptionsSetup>());
 
-            // Support razor runtime compilation only if the 'refs' folder exists.
+            // Support razor runtime compilation only if in dev mode and if the 'refs' folder exists.
             var refsFolderExists = Directory.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "refs"));
 
-            if (refsFolderExists)
+            if (_hostingEnvironment.IsDevelopment() && refsFolderExists)
             {
                 builder.AddRazorRuntimeCompilation();
 


### PR DESCRIPTION
Fixes #9045 

@sebastienros 

So yes i saw this but keep it because normally there is no compilation if module views are pre-compiled in `.Views.dll`, hmm but yes we also embed their contents, so maybe some behaviors has changed after net5.0 or another 3.1 release.

But good catch to talk about it again !

Just did some apache benchmarks and now the result of my about page is close to what I had before ;)

I'm also working on #9005 to make the DocumentManager a tenant singleton, will be good to test the perf with both the changes of #9005 and this PR
