### PR TITLE
Fixes #9039 view buffer OutOfRangeException

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeStringifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeStringifyFilter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using Fluid;

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -45,17 +45,18 @@ namespace OrchardCore.DisplayManagement.Liquid
             var liquidViewParser = services.GetRequiredService<LiquidViewParser>();
             var path = Path.ChangeExtension(page.ViewContext.ExecutingFilePath, ViewExtension);
             var templateOptions = services.GetRequiredService<IOptions<TemplateOptions>>().Value;
-            var isDevelopment = services.GetRequiredService<IHostEnvironment>().IsDevelopment();
 
+            var isDevelopment = services.GetRequiredService<IHostEnvironment>().IsDevelopment();
             var template = await ParseAsync(liquidViewParser, path, templateOptions.FileProvider, Cache, isDevelopment);
             var context = new LiquidTemplateContext(services, templateOptions);
-
             var htmlEncoder = services.GetRequiredService<HtmlEncoder>();
 
             try
             {
+                var content = new ViewBufferTextWriterContent();
                 await context.EnterScopeAsync(page.ViewContext, (object)page.Model);
-                await template.FluidTemplate.RenderAsync(page.Output, htmlEncoder, context);
+                await template.FluidTemplate.RenderAsync(content, htmlEncoder, context);
+                content.WriteTo(page.Output, htmlEncoder);
             }
             finally
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/AntiForgeryTokenTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/AntiForgeryTokenTag.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -16,7 +15,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
         public static ValueTask<Completion> WriteToAsync(TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             var services = ((LiquidTemplateContext)context).Services;
-            
+
             var antiforgery = services.GetRequiredService<IAntiforgery>();
             var httpContextAccessor = services.GetRequiredService<IHttpContextAccessor>();
 
@@ -24,9 +23,9 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
             var tokenSet = antiforgery.GetAndStoreTokens(httpContext);
 
             writer.Write("<input name=\"");
-            encoder.Encode(writer, tokenSet.FormFieldName);
+            writer.Write(encoder.Encode(tokenSet.FormFieldName));
             writer.Write("\" type=\"hidden\" value=\"");
-            encoder.Encode(writer, tokenSet.RequestToken);
+            writer.Write(encoder.Encode(tokenSet.RequestToken));
             writer.Write("\" />");
 
             return new ValueTask<Completion>(Completion.Normal);

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
@@ -207,14 +207,20 @@ namespace OrchardCore.DisplayManagement.Liquid
                 {
                     foreach (var chunk in pooledBuilder.Builder.GetChunks())
                     {
-                        writer.Write(chunk.Span);
+                        if (!chunk.IsEmpty)
+                        {
+                            writer.Write(chunk.Span);
+                        }
                     }
                 }
             }
 
             foreach (var chunk in _builder.GetChunks())
             {
-                writer.Write(chunk.Span);
+                if (!chunk.IsEmpty)
+                {
+                    writer.Write(chunk.Span);
+                }
             }
 
             ReleasePooledBuffer();


### PR DESCRIPTION
Fixes #9039

@sebastienros 

When rendering a liquid view we write directly to the underlying razor page output. So, when we faced the aspnetcore (encoding / buffer) issue, i first tried to render it through our custom view buffer before writing to the page output.

But our view buffer had another issue (because of rented chars), so as a temporary workaround i was rendering the liquid template in an intermediate string, which is not good in term of allocations.

In the meantime you fixed our view buffer writer, so we re-used it in the liquid template manager and some other places as the `FluidTagHelper` and `ZoneTag`. But still not when rendering a Liquid view where we now write again directly to the underlying razor page output.

**So, because in aspnetcore there are still some components that encode directly to the writer in place of using an intermediate string, mainly the `HtmlContentBuilder` and the `TagBuilder`, we still have some use cases where the aspnetcore view buffer writer throws an `ArgumentOutOfRangeException`.**

I could repro #9039 and other ones e.g. when a liquid view renders a razor view using e.g. a `TagBuilder`.

So, to fix these issues one by one, i needed to add in many places the following, in `ResourcesTag`, `ScriptTag`, `StyleTag`, also in the `ShapeRenderFilter` and / or in `HtmlContentValue`, and so on.

            var content = new ViewBufferTextWriterContent();
            buffer.WriteTo(content, (HtmlEncoder)encoder);
            content.WriteTo(writer, (HtmlEncoder)encoder);

We only face this issue under Liquid because aspnetcore uses intermediate writers / buffers and / or check if it is a view buffer writer to behave differently. **So to have a more global solution in this PR, in place of doing the above in many places, here i just did it when rendering a Liquid view page.**

            var content = new ViewBufferTextWriterContent();
            await context.EnterScopeAsync(page.ViewContext, (object)page.Model);
            await template.FluidTemplate.RenderAsync(content, htmlEncoder, context);
            content.WriteTo(page.Output, htmlEncoder);

For me it makes sense to use our view buffer writer as a relay before writing to the page output, and only once per liquid page in place of having to use it in many other places, and maybe more in the future, and because it seems to fix all the issues i could repro before. **Let me know if you think it's okay in term of perfs / allocations**.