### PR TITLE
Ignore duplicate content item version ids when importing batches

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -488,7 +488,7 @@ namespace OrchardCore.ContentManagement
 
                         await Handlers.InvokeAsync((handler, context) => handler.ImportingAsync(context), context, _logger);
 
-                        var evictionVersions = versionsThatMaybeEvicted.Where(x => String.Equals(x.ContentItemId, importingItem.ContentItemId, StringComparison.OrdinalIgnoreCase));                       
+                        var evictionVersions = versionsThatMaybeEvicted.Where(x => String.Equals(x.ContentItemId, importingItem.ContentItemId, StringComparison.OrdinalIgnoreCase));
                         var result = await CreateContentItemVersionAsync(importingItem, evictionVersions);
                         if (!result.Succeeded)
                         {

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
@@ -179,7 +179,6 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
         }
 
         [Fact]
-        
         public async Task ShouldIgnoreDuplicateContentItems()
         {
             using (var context = new BlogPostDeploymentContext())
@@ -187,7 +186,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 // Setup
                 await context.InitializeAsync();
 
-                // Create a recipe with two content items and the same id.
+                // Create a recipe with two content items and the same version id.
                 var firstRecipe = context.GetContentStepRecipe(context.OriginalBlogPost, jItem =>
                 {
                     jItem[nameof(ContentItem.ContentItemId)] = "newcontentitemid";
@@ -202,7 +201,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                     jItem[nameof(ContentItem.ContentItemVersionId)] = "dupversion";
                     jItem[nameof(ContentItem.DisplayText)] = "duplicate version";
                     jItem[nameof(AutoroutePart)][nameof(AutoroutePart.Path)] = "blog/another";
-                });                
+                });
 
                 var firstRecipeData = firstRecipe.SelectToken("steps[0].Data") as JArray;
 
@@ -223,6 +222,6 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                     Assert.Equal(1, blogPostsCount);
                 });
             }
-        }        
+        }
     }
 }

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
@@ -1,6 +1,8 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
 using OrchardCore.Autoroute.Models;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Records;
@@ -168,12 +170,59 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
-                    var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
-                        x.ContentType == "BlogPost").ListAsync();
+                    var blogPostsCount = await session.Query<ContentItem, ContentItemIndex>(x =>
+                        x.ContentType == "BlogPost").CountAsync();
 
-                    Assert.Equal(2, blogPosts.Count());
+                    Assert.Equal(2, blogPostsCount);
                 });
             }
         }
+
+        [Fact]
+        
+        public async Task ShouldIgnoreDuplicateContentItems()
+        {
+            using (var context = new BlogPostDeploymentContext())
+            {
+                // Setup
+                await context.InitializeAsync();
+
+                // Create a recipe with two content items and the same id.
+                var firstRecipe = context.GetContentStepRecipe(context.OriginalBlogPost, jItem =>
+                {
+                    jItem[nameof(ContentItem.ContentItemId)] = "newcontentitemid";
+                    jItem[nameof(ContentItem.ContentItemVersionId)] = "dupversion";
+                    jItem[nameof(ContentItem.DisplayText)] = "duplicate version";
+                    jItem[nameof(AutoroutePart)][nameof(AutoroutePart.Path)] = "blog/another";
+                });
+
+                var secondRecipe = context.GetContentStepRecipe(context.OriginalBlogPost, jItem =>
+                {
+                    jItem[nameof(ContentItem.ContentItemId)] = "newcontentitemid";
+                    jItem[nameof(ContentItem.ContentItemVersionId)] = "dupversion";
+                    jItem[nameof(ContentItem.DisplayText)] = "duplicate version";
+                    jItem[nameof(AutoroutePart)][nameof(AutoroutePart.Path)] = "blog/another";
+                });                
+
+                var firstRecipeData = firstRecipe.SelectToken("steps[0].Data") as JArray;
+
+                var secondContentItem = secondRecipe.SelectToken("steps[0].Data[0]");
+
+                firstRecipeData.Add(secondContentItem);
+
+                await context.PostRecipeAsync(firstRecipe);
+
+                // Test
+                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                await shellScope.UsingAsync(async scope =>
+                {
+                    var session = scope.ServiceProvider.GetRequiredService<ISession>();
+                    var blogPostsCount = await session.Query<ContentItem, ContentItemIndex>(x =>
+                        x.ContentType == "BlogPost" && x.ContentItemVersionId == "dupversion").CountAsync();
+
+                    Assert.Equal(1, blogPostsCount);
+                });
+            }
+        }        
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/9023

when a version has already been imported, don't import it twice.

I was going to put this on the content manager session, but actually I think it can only occur during importing of batches, because the query to check the current session is done at the start of the routine, before any items actually get added to the YesSql session.

