### PR TITLE
Update autosetup examples / docs

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -95,11 +95,11 @@
     //      "DatabaseProvider": "Sqlite",
     //      "DatabaseConnectionString": "",
     //      "DatabaseTablePrefix": "",
-    //      "RecipeName": "Agency"
+    //      "RecipeName": "Saas"
     //    },
     //    {
     //      "ShellName": "AutoSetupTenant",
-    //      "SiteName": "AutoSetup Sub Tenant",
+    //      "SiteName": "AutoSetup Tenant",
     //      "SiteTimeZone": "Europe/Amsterdam",
     //      "AdminUsername": "tenantadmin",
     //      "AdminEmail": "tenant@orchardproject.net",

--- a/src/docs/reference/modules/AutoSetup/README.md
+++ b/src/docs/reference/modules/AutoSetup/README.md
@@ -18,11 +18,11 @@ The auto-setup module allows to automatically install the application/tenants on
             "DatabaseProvider": "Sqlite",
             "DatabaseConnectionString": "",
             "DatabaseTablePrefix": "",
-            "RecipeName": "Agency"
+            "RecipeName": "SaaS"
         },
         {
             "ShellName": "AutoSetupTenant",
-            "SiteName": "AutoSetup Sub Tenant",
+            "SiteName": "AutoSetup Tenant",
             "SiteTimeZone": "Europe/Amsterdam",
             "AdminUsername": "tenantadmin",
             "AdminEmail": "tenant@orchardproject.net",
@@ -80,10 +80,10 @@ Since JSON configuration contains admin-sensitive information, it is recommended
 "OrchardCore__OrchardCore_AutoSetup__Tenants__0__DatabaseProvider": "Sqlite"
 "OrchardCore__OrchardCore_AutoSetup__Tenants__0__DatabaseConnectionString": ""
 "OrchardCore__OrchardCore_AutoSetup__Tenants__0__DatabaseTablePrefix": ""
-"OrchardCore__OrchardCore_AutoSetup__Tenants__0__RecipeName": "Agency"
+"OrchardCore__OrchardCore_AutoSetup__Tenants__0__RecipeName": "SaaS"
 
 "OrchardCore__OrchardCore_AutoSetup__Tenants__1__ShellName": "AutoSetupTenant"
-"OrchardCore__OrchardCore_AutoSetup__Tenants__1__SiteName": "AutoSetup Sub Tenant"
+"OrchardCore__OrchardCore_AutoSetup__Tenants__1__SiteName": "AutoSetup Tenant"
 "OrchardCore__OrchardCore_AutoSetup__Tenants__1__SiteTimeZone": "Europe/Amsterdam"
 "OrchardCore__OrchardCore_AutoSetup__Tenants__1__AdminUsername": "tenantadmin"
 "OrchardCore__OrchardCore_AutoSetup__Tenants__1__AdminEmail": "tenant@orchardproject.net"


### PR DESCRIPTION
Slight updates to the autosetup docs as I reviewed them.

- Make the Default shell use the SaaS recipe. 

While it will work with the agency recipe, it doesn't get the tenants ui, which is an odd experience for a new user.