### PR TITLE
Fix case sensitive recipe name for auto setup

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -95,7 +95,7 @@
     //      "DatabaseProvider": "Sqlite",
     //      "DatabaseConnectionString": "",
     //      "DatabaseTablePrefix": "",
-    //      "RecipeName": "Saas"
+    //      "RecipeName": "SaaS"
     //    },
     //    {
     //      "ShellName": "AutoSetupTenant",


### PR DESCRIPTION
Because recipe names are case sensitive `Saas` is not equal to `SaaS`