### PR TITLE
Remove liquid type from recipes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Permissions.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.ContentTypes
     public class Permissions : IPermissionProvider
     {
         public static readonly Permission ViewContentTypes = new Permission("ViewContentTypes", "View content types.");
-        public static readonly Permission EditContentTypes = new Permission("EditContentTypes", "Edit content types.");
+        public static readonly Permission EditContentTypes = new Permission("EditContentTypes", "Edit content types.", isSecurityCritical: true);
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Permissions.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Shortcodes
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageShortcodeTemplates = new Permission("ManageShortcodeTemplates", "Manage shortcode templates");
+        public static readonly Permission ManageShortcodeTemplates = new Permission("ManageShortcodeTemplates", "Manage shortcode templates", isSecurityCritical: true);
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {

--- a/src/OrchardCore.Modules/OrchardCore.Templates/AdminTemplatesPermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/AdminTemplatesPermissions.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Templates
 {
     public class AdminTemplatesPermissions : IPermissionProvider
     {
-        public static readonly Permission ManageAdminTemplates = new Permission("ManageAdminTemplates", "Manage admin templates");
+        public static readonly Permission ManageAdminTemplates = new Permission("ManageAdminTemplates", "Manage admin templates", isSecurityCritical: true);
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Permissions.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Templates
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageTemplates = new Permission("ManageTemplates", "Manage templates");
+        public static readonly Permission ManageTemplates = new Permission("ManageTemplates", "Manage templates", isSecurityCritical: true);
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {

--- a/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
@@ -87,85 +87,6 @@
       "name": "ContentDefinition",
       "ContentTypes": [
         {
-          "Name": "LiquidPage",
-          "DisplayName": "Liquid Page",
-          "Hidden": false,
-          "Settings": {
-            "ContentTypeSettings": {
-              "Creatable": true,
-              "Draftable": true,
-              "Versionable": true,
-              "Listable": true
-            }
-          },
-          "ContentTypePartDefinitionRecords": [
-            {
-              "PartName": "LiquidPage",
-              "Name": "LiquidPage",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "2"
-                }
-              }
-            },
-            {
-              "PartName": "AutoroutePart",
-              "Name": "AutoroutePart",
-              "Settings": {
-                "AutoroutePartSettings": {
-                  "AllowCustomPath": true,
-                  "Pattern": "{{ Model.ContentItem | display_text | slugify }}",
-                  "ShowHomepageOption": true
-                },
-                "ContentTypePartSettings": {
-                  "Position": "1"
-                }
-              }
-            },
-            {
-              "PartName": "LiquidPart",
-              "Name": "LiquidPart",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "3"
-                }
-              }
-            },
-            {
-              "PartName": "TitlePart",
-              "Name": "TitlePart",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
-          "Name": "HtmlWidget",
-          "DisplayName": "Html",
-          "Settings": {
-            "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
-              "Stereotype": "Widget"
-            }
-          },
-          "ContentTypePartDefinitionRecords": [
-            {
-              "PartName": "HtmlWidget",
-              "Name": "HtmlWidget",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
           "Name": "Page",
           "DisplayName": "Page",
           "Settings": {
@@ -496,13 +417,50 @@
           ]
         },
         {
+          "Name": "HtmlWidget",
+          "DisplayName": "Html",
+          "Settings": {
+            "ContentTypeSettings": {
+              "Stereotype": "Widget"
+            }
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "HtmlWidget",
+              "Name": "HtmlWidget",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "Name": "Blockquote",
+          "DisplayName": "Blockquote",
+          "Settings": {
+            "ContentTypeSettings": {
+              "Stereotype": "Widget"
+            }
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "Blockquote",
+              "Name": "Blockquote",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            }
+          ]
+        },
+        {
           "Name": "Container",
           "DisplayName": "Container",
           "Settings": {
             "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
               "Stereotype": "Widget"
             }
           },
@@ -528,81 +486,10 @@
           ]
         },
         {
-          "Name": "Blockquote",
-          "DisplayName": "Blockquote",
-          "Settings": {
-            "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
-              "Stereotype": "Widget"
-            }
-          },
-          "ContentTypePartDefinitionRecords": [
-            {
-              "PartName": "Blockquote",
-              "Name": "Blockquote",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
-          "Name": "ImageWidget",
-          "DisplayName": "Image",
-          "Settings": {
-            "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
-              "Stereotype": "Widget"
-            }
-          },
-          "ContentTypePartDefinitionRecords": [
-            {
-              "PartName": "Image",
-              "Name": "Image",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
-          "Name": "LiquidWidget",
-          "DisplayName": "Liquid",
-          "Settings": {
-            "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
-              "Stereotype": "Widget"
-            }
-          },
-          "ContentTypePartDefinitionRecords": [
-            {
-              "PartName": "LiquidPart",
-              "Name": "LiquidPart",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
           "Name": "Image",
           "DisplayName": "Image",
           "Settings": {
             "ContentTypeSettings": {
-              "Versionable": true,
-              "Securable": true,
               "Stereotype": "Widget"
             }
           },
@@ -632,9 +519,6 @@
           "DisplayName": "Paragraph",
           "Settings": {
             "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
               "Stereotype": "Widget"
             }
           },
@@ -652,39 +536,6 @@
         }
       ],
       "ContentParts": [
-        {
-          "Name": "HtmlWidget",
-          "Settings": {},
-          "ContentPartFieldDefinitionRecords": [
-            {
-              "FieldName": "HtmlField",
-              "Name": "Content",
-              "Settings": {
-                "ContentPartFieldSettings": {
-                  "DisplayName": "Content",
-                  "Editor": "Multiline",
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
-          "Name": "MenuItem",
-          "Settings": {},
-          "ContentPartFieldDefinitionRecords": [
-            {
-              "FieldName": "TextField",
-              "Name": "Link",
-              "Settings": {
-                "ContentPartFieldSettings": {
-                  "DisplayName": "Link",
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
         {
           "Name": "Service",
           "Settings": {},
@@ -861,6 +712,23 @@
                 "ContentPartFieldSettings": {
                   "DisplayName": "Url",
                   "Position": "1"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "Name": "HtmlWidget",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "HtmlField",
+              "Name": "Content",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Content",
+                  "Editor": "Multiline",
+                  "Position": "0"
                 }
               }
             }

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -157,62 +157,6 @@
           ]
         },
         {
-          "Name": "LiquidPage",
-          "DisplayName": "Liquid Page",
-          "Hidden": false,
-          "Settings": {
-            "ContentTypeSettings": {
-              "Creatable": true,
-              "Draftable": true,
-              "Versionable": true,
-              "Listable": true
-            }
-          },
-          "ContentTypePartDefinitionRecords": [
-            {
-              "PartName": "LiquidPage",
-              "Name": "LiquidPage",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "2"
-                }
-              }
-            },
-            {
-              "PartName": "AutoroutePart",
-              "Name": "AutoroutePart",
-              "Settings": {
-                "AutoroutePartSettings": {
-                  "AllowCustomPath": true,
-                  "Pattern": "{{ Model.ContentItem | display_text | slugify }}",
-                  "ShowHomepageOption": true
-                },
-                "ContentTypePartSettings": {
-                  "Position": "1"
-                }
-              }
-            },
-            {
-              "PartName": "LiquidPart",
-              "Name": "LiquidPart",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "3"
-                }
-              }
-            },
-            {
-              "PartName": "TitlePart",
-              "Name": "TitlePart",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
           "Name": "BlogPost",
           "DisplayName": "Blog Post",
           "Hidden": false,
@@ -352,9 +296,6 @@
           "DisplayName": "Container",
           "Settings": {
             "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
               "Stereotype": "Widget"
             }
           },
@@ -384,9 +325,6 @@
           "DisplayName": "Blockquote",
           "Settings": {
             "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
               "Stereotype": "Widget"
             }
           },
@@ -403,73 +341,17 @@
           ]
         },
         {
-          "Name": "ImageWidget",
-          "DisplayName": "Image",
-          "Settings": {
-            "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
-              "Stereotype": "Widget"
-            }
-          },
-          "ContentTypePartDefinitionRecords": [
-            {
-              "PartName": "Image",
-              "Name": "Image",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
-          "Name": "LiquidWidget",
-          "DisplayName": "Liquid",
-          "Settings": {
-            "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
-              "Listable": true,
-              "Stereotype": "Widget"
-            }
-          },
-          "ContentTypePartDefinitionRecords": [
-            {
-              "PartName": "LiquidPart",
-              "Name": "LiquidPart",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            }
-          ]
-        },
-        {
           "Name": "Image",
           "DisplayName": "Image",
           "Settings": {
             "ContentTypeSettings": {
-              "Versionable": true
+              "Stereotype": "Widget"
             }
           },
           "ContentTypePartDefinitionRecords": [
             {
               "PartName": "Image",
               "Name": "Image",
-              "Settings": {
-                "ContentTypePartSettings": {
-                  "Position": "0"
-                }
-              }
-            },
-            {
-              "PartName": "TitlePart",
-              "Name": "TitlePart",
               "Settings": {
                 "ContentTypePartSettings": {
                   "Position": "0"
@@ -483,9 +365,6 @@
           "DisplayName": "Paragraph",
           "Settings": {
             "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
               "Stereotype": "Widget"
             }
           },
@@ -506,9 +385,6 @@
           "DisplayName": "Raw Html",
           "Settings": {
             "ContentTypeSettings": {
-              "Draftable": true,
-              "Versionable": true,
-              "Securable": true,
               "Stereotype": "Widget"
             }
           },
@@ -925,8 +801,6 @@
               "Input",
               "Label",
               "LinkMenuItem",
-              "LiquidWidget",
-              "LiquidPage",
               "Menu",
               "Page",
               "Paragraph",


### PR DESCRIPTION
Due to concerns about sanitization it was decided to remove the Liquid Content Type, and Liquid Widget Type from the sample recipes.

This because liquid is not sanitizable, as you can do too many things with it.

The liquid part still exists, but the type needs to be created at the discretion of an administrator.

On this pr also, I have cleaned up the recipes, removing a duplicate Image Widget, and duplicate MenuItemPart that had managed to sneak into the agency theme.

So what looks like lots of changes, is mostly cleaning them up.
