### PR TITLE
Features search

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -153,13 +153,25 @@
             // On ESC, clear the search box and display all features
             if (e.keyCode == 27 || search == '') {
                 searchBox.val('');
-                elementsToFilter.toggle(true);
-            }
-            else {
+                elementsToFilter.removeClass("d-none first-child-visible last-child-visible");
+            } else {
                 elementsToFilter.each(function () {
                     var text = $(this).data('filter-value').toLowerCase();
                     var found = text.indexOf(search) > -1;
-                    $(this).toggle(found);
+
+                    if (found)
+                    {
+                        $(this).removeClass("d-none first-child-visible last-child-visible");
+                    }
+                    else
+                    {
+                        $(this).addClass("d-none");
+                    }
+                });
+
+                $('ul.list-group').each(function () {
+                    $(this).find('li').filter(":not(.d-none)").first().addClass("first-child-visible");
+                    $(this).find('li').filter(":not(.d-none)").last().addClass("last-child-visible");
                 });
 
                 var visible = $('.list-group > li:visible');


### PR DESCRIPTION
Correctly displays a top border for the first found feature and a bottom border for the last one in each group when you filter.

Fixes #9044

![image](https://user-images.githubusercontent.com/703248/114006830-12d30100-9861-11eb-8f60-7b19d7510ffd.png)
