### PR TITLE
Add shortcut to change password from admin

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/ChangePassword.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/ChangePassword.cshtml
@@ -4,7 +4,7 @@
     ViewLayout = "Layout__Login";
 }
 
-<form asp-controller="Account" asp-action="ChangePassword" method="post" class="form-horizontal">
+<form asp-controller="Account" asp-action="ChangePassword" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="form-horizontal">
     <h4>@T["Change password"]</h4>
     <hr />
     <div asp-validation-summary="All" class="text-danger"></div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenu.cshtml
@@ -11,6 +11,7 @@
             {
                 <a class="dropdown-item" asp-area="OrchardCore.Users" asp-action="Edit" asp-controller="Admin" asp-route-returnUrl="@FullRequestPath"><span><i class="far fa-address-card" aria-hidden="true"></i></span>&nbsp;<span> @T["Profile"]</span></a>
             }
+            <a class="dropdown-item" asp-area="OrchardCore.Users" asp-controller="Account" asp-action="ChangePassword" asp-route-returnUrl="@FullRequestPath"><span><i class="fas fa-key" aria-hidden="true"></i></span>&nbsp;<span> @T["Change password"]</span></a>
             <button type="submit" class="dropdown-item"><span><i class="fa fa-sign-out-alt" aria-hidden="true"></i></span>&nbsp;<span> @T["Log off"]</span></button>
         </div>
     </form>

--- a/src/OrchardCore.Themes/TheTheme/Views/Shared/LoginMenu.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Shared/LoginMenu.cshtml
@@ -1,6 +1,4 @@
 @using Microsoft.AspNetCore.Identity
-@using Microsoft.Extensions.Options
-@using OrchardCore.Admin
 @using OrchardCore.Entities
 @using OrchardCore.Settings
 @using OrchardCore.Users
@@ -26,7 +24,7 @@
                 {
                     <a class="dropdown-item" asp-route-area="OrchardCore.Users" asp-controller="ChangeEmail" asp-action="Index"><i class="fa fa-envelope fa-fw"></i> @T["Change Email"]</a>
                 }
-                <a class="dropdown-item" asp-route-area="OrchardCore.Users" asp-controller="Account" asp-action="ChangePassword"><i class="fa fa-lock fa-fw"></i> @T["Change Password"]</a>
+                <a class="dropdown-item" asp-route-area="OrchardCore.Users" asp-controller="Account" asp-action="ChangePassword" asp-route-returnUrl="@FullRequestPath"><i class="fa fa-lock fa-fw"></i> @T["Change Password"]</a>
                 @if (externalAuthenticationSchemes.Count() > 0)
                 {
                     <a class="dropdown-item" asp-route-area="OrchardCore.Users" asp-controller="Account" asp-action="ExternalLogins"><i class="fa fa-user-lock fa-fw"></i> @T["External Logins"]</a>


### PR DESCRIPTION
Because if you don't know the route ('/ChangePassword' by default) you just can't change your password, unless you're admin...

- Add shortcut to change password from admin
- Redirect to returnUrl after password change