### PR TITLE
Fixes #9150 Search Liquid Views

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using Fluid;
 using Lucene.Net.Analysis.Standard;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
@@ -25,6 +26,7 @@ using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Navigation;
 using OrchardCore.Queries;
 using OrchardCore.Recipes;
+using OrchardCore.Search.Abstractions.ViewModels;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Settings;
 
@@ -44,6 +46,13 @@ namespace OrchardCore.Lucene
 
         public override void ConfigureServices(IServiceCollection services)
         {
+            services.Configure<TemplateOptions>(o =>
+            {
+                o.MemberAccessStrategy.Register<SearchIndexViewModel>();
+                o.MemberAccessStrategy.Register<SearchFormViewModel>();
+                o.MemberAccessStrategy.Register<SearchResultsViewModel>();
+            });
+
             services.AddSingleton<LuceneIndexingState>();
             services.AddSingleton<LuceneIndexSettingsService>();
             services.AddSingleton<LuceneIndexManager>();


### PR DESCRIPTION
Fixes #9150 

Now we don't register the access strategy of each model type automatically on the fly.

So we need to register them explicitly and the search view models were missing.
