### PR TITLE
Don't allocate for page output writing in LiquidViewTemplate

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -56,6 +56,11 @@ namespace OrchardCore.DisplayManagement.Liquid
                 var content = new ViewBufferTextWriterContent();
                 await context.EnterScopeAsync(page.ViewContext, (object)page.Model);
                 await template.FluidTemplate.RenderAsync(content, htmlEncoder, context);
+                
+                // Use ViewBufferTextWriter.Write(object) from ASP.NET directly since it will use a special code path
+                // for IHtmlContent. This prevent the TextWriter methods from copying the content from our buffer 
+                // if we did content.WriteTo(page.Output)
+                
                 page.Output.Write(content);
             }
             finally

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -56,7 +56,7 @@ namespace OrchardCore.DisplayManagement.Liquid
                 var content = new ViewBufferTextWriterContent();
                 await context.EnterScopeAsync(page.ViewContext, (object)page.Model);
                 await template.FluidTemplate.RenderAsync(content, htmlEncoder, context);
-                content.WriteTo(page.Output, htmlEncoder);
+                page.Output.Write(content);
             }
             finally
             {


### PR DESCRIPTION
We had a little performance tuning session with @sebastienros  and tried to figure out why so many string allocations were necessary for liquid page output. With his help I was able to narrow it down to inefficient output strategy.