### PR TITLE
Support net6.0

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <!-- This feed should not be used when shipping on NuGet. It should just be used in the dev branch while dependencies are not available on NuGet.org -->
     <!--<add key="OrchardCore" value="https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json" />-->

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -3,7 +3,7 @@
   <!-- Default TFM (Singular) and TFMs (Plural) -->
   <PropertyGroup>
     <AspNetCoreTargetFramework>net5.0</AspNetCoreTargetFramework>
-    <AspNetCoreTargetFrameworks>net5.0;netcoreapp3.1</AspNetCoreTargetFrameworks>
+    <AspNetCoreTargetFrameworks>net6.0;net5.0;netcoreapp3.1</AspNetCoreTargetFrameworks>
   </PropertyGroup>
 
   <!-- Default TFMs (Plural) inside Visual Studio -->

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -6,6 +6,12 @@
     <AspNetCoreTargetFrameworks>net6.0;net5.0;netcoreapp3.1</AspNetCoreTargetFrameworks>
   </PropertyGroup>
 
+  <!-- Experimental TFM to allow for testing on net6.0 without impacting standard development -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <AspNetCoreTargetFramework>net6.0</AspNetCoreTargetFrameworks>
+    <AspNetCoreTargetFrameworks>net6.0</AspNetCoreTargetFrameworks>
+  </PropertyGroup>
+  
   <!-- Default TFMs (Plural) inside Visual Studio -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(BuildingByReSharper)' == 'true'">
     <AspNetCoreTargetFrameworks>$(AspNetCoreTargetFramework)</AspNetCoreTargetFrameworks>

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -1,20 +1,12 @@
 <Project>
 
-  <!-- Default TFM (Singular) and TFMs (Plural) -->
   <PropertyGroup>
-    <AspNetCoreTargetFramework>net5.0</AspNetCoreTargetFramework>
-    <AspNetCoreTargetFrameworks>net6.0;net5.0;netcoreapp3.1</AspNetCoreTargetFrameworks>
+    <DefaultTargetFramework>net5.0</DefaultTargetFramework>
+    <AspNetCoreTargetFrameworks>net5.0;netcoreapp3.1</AspNetCoreTargetFrameworks>
   </PropertyGroup>
 
-  <!-- Experimental TFM to allow for testing on net6.0 without impacting standard development -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <AspNetCoreTargetFramework>net6.0</AspNetCoreTargetFrameworks>
-    <AspNetCoreTargetFrameworks>net6.0</AspNetCoreTargetFrameworks>
-  </PropertyGroup>
-  
-  <!-- Default TFMs (Plural) inside Visual Studio -->
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(BuildingByReSharper)' == 'true'">
-    <AspNetCoreTargetFrameworks>$(AspNetCoreTargetFramework)</AspNetCoreTargetFrameworks>
+    <AspNetCoreTargetFrameworks>$(DefaultTargetFramework)</AspNetCoreTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <DefaultTargetFramework>net5.0</DefaultTargetFramework>
-    <AspNetCoreTargetFrameworks>net5.0;netcoreapp3.1</AspNetCoreTargetFrameworks>
+    <AspNetCoreTargetFrameworks Condition="'$(AspNetCoreTargetFrameworks)' == ''">net5.0;netcoreapp3.1</AspNetCoreTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' == 'true' or '$(BuildingByReSharper)' == 'true'">

--- a/src/OrchardCore/OrchardCore.Mvc.Core/ShellViewFeatureProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/ShellViewFeatureProvider.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
+using Microsoft.AspNetCore.Razor.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OrchardCore.Environment.Shell.Scope;
@@ -80,56 +81,74 @@ namespace OrchardCore.Mvc
 
             var modules = _applicationContext.Application.Modules;
             var moduleFeature = new ViewsFeature();
-
+            
             foreach (var module in modules)
             {
-                var precompiledAssemblyPath = Path.Combine(Path.GetDirectoryName(module.Assembly.Location),
-                    module.Assembly.GetName().Name + ".Views.dll");
+                var assembliesWithViews = new List<Assembly>();
 
-                if (File.Exists(precompiledAssemblyPath))
+                var relatedAssemblyAttribute = module.Assembly.GetCustomAttribute<RelatedAssemblyAttribute>();
+
+                // Is there a dedicated Views assembly (< net6.0)
+                if (relatedAssemblyAttribute != null)
                 {
-                    try
+                    var precompiledAssemblyPath = Path.Combine(Path.GetDirectoryName(module.Assembly.Location), relatedAssemblyAttribute.AssemblyFileName + ".dll");
+
+                    if (File.Exists(precompiledAssemblyPath))
                     {
-                        var assembly = Assembly.LoadFile(precompiledAssemblyPath);
+                        try
+                        {
+                            var assembly = Assembly.LoadFile(precompiledAssemblyPath);
+                            assembliesWithViews.Add(assembly);
+                        }
+                        catch (FileLoadException)
+                        {
+                            // Don't throw if assembly cannot be loaded. This can happen if the file is not a managed assembly.
+                        }
+                    }
+                }
 
-                        var applicationPart = new ApplicationPart[] { new CompiledRazorAssemblyPart(assembly) };
+                // Look for compiled views in the same assembly as the module
 
+                if (module.Assembly.GetCustomAttributes<RazorCompiledItemAttribute>().Any())
+                {
+                    assembliesWithViews.Add(module.Assembly);
+                }
+
+                foreach (var assembly in assembliesWithViews)
+                {
+                    var applicationPart = new ApplicationPart[] { new CompiledRazorAssemblyPart(assembly) };
+
+                    foreach (var provider in mvcFeatureProviders)
+                    {
+                        provider.PopulateFeature(applicationPart, moduleFeature);
+                    }
+
+                    // Razor views are precompiled in the context of their modules, but at runtime
+                    // their paths need to be relative to the virtual "Areas/{ModuleId}" folders.
+                    // Note: For the app's module this folder is "Areas/{env.ApplicationName}".
+                    foreach (var descriptor in moduleFeature.ViewDescriptors)
+                    {
+                        descriptor.RelativePath = '/' + module.SubPath + descriptor.RelativePath;
+                        feature.ViewDescriptors.Add(descriptor);
+                    }
+
+                    // For the app's module we still allow to explicitly specify view paths relative to the app content root.
+                    // So for the application's module we re-apply the feature providers without updating the relative paths.
+                    // Note: This is only needed in prod mode if app's views are precompiled and views files no longer exist.
+                    if (module.Name == _hostingEnvironment.ApplicationName)
+                    {
                         foreach (var provider in mvcFeatureProviders)
                         {
                             provider.PopulateFeature(applicationPart, moduleFeature);
                         }
 
-                        // Razor views are precompiled in the context of their modules, but at runtime
-                        // their paths need to be relative to the virtual "Areas/{ModuleId}" folders.
-                        // Note: For the app's module this folder is "Areas/{env.ApplicationName}".
                         foreach (var descriptor in moduleFeature.ViewDescriptors)
                         {
-                            descriptor.RelativePath = '/' + module.SubPath + descriptor.RelativePath;
                             feature.ViewDescriptors.Add(descriptor);
                         }
-
-                        // For the app's module we still allow to explicitly specify view paths relative to the app content root.
-                        // So for the application's module we re-apply the feature providers without updating the relative paths.
-                        // Note: This is only needed in prod mode if app's views are precompiled and views files no longer exist.
-                        if (module.Name == _hostingEnvironment.ApplicationName)
-                        {
-                            foreach (var provider in mvcFeatureProviders)
-                            {
-                                provider.PopulateFeature(applicationPart, moduleFeature);
-                            }
-
-                            foreach (var descriptor in moduleFeature.ViewDescriptors)
-                            {
-                                feature.ViewDescriptors.Add(descriptor);
-                            }
-                        }
-
-                        moduleFeature.ViewDescriptors.Clear();
                     }
-                    catch (FileLoadException)
-                    {
-                        // Don't throw if assembly cannot be loaded. This can happen if the file is not a managed assembly.
-                    }
+
+                    moduleFeature.ViewDescriptors.Clear();
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
@@ -91,8 +91,9 @@ namespace OrchardCore.Mvc
             // System.Text.Json. Here, we manually add JSON.NET based formatters.
             builder.AddNewtonsoftJson();
 
+#if !NET6_0_OR_GREATER
             builder.SetCompatibilityVersion(CompatibilityVersion.Latest);
-
+#endif
             services.AddModularRazorPages();
 
             AddModularFrameworkParts(_serviceProvider, builder.PartManager);

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -65,7 +65,7 @@
     </Task>
   </UsingTask>
 
-  <Target Name="TransformTemplateConfigs" BeforeTargets="Build" Condition="'$(TargetFramework)' == '$(AspNetCoreTargetFramework)'">
+  <Target Name="TransformTemplateConfigs" BeforeTargets="Build" Condition="'$(TargetFramework)' == '$(DefaultTargetFramework)'">
     <!--
       For each template, copy its '.template.config.src' directory to '.template.config',
       removing any earlier output at that location.


### PR DESCRIPTION
Add special code paths when net6.0 is used, without adding any new target since this can be done from build command line arguments. Renamed a property to make it clearer.