### PR TITLE
Use pooled StringBuilder instances with StringWriter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Handlers/FullTextAspectContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Handlers/FullTextAspectContentHandler.cs
@@ -64,7 +64,7 @@ namespace OrchardCore.Contents.Handlers
                     if (bodyAspect != null && bodyAspect.Body != null)
                     {
                         using var stringBuilderPool = StringBuilderPool.GetInstance();
-                        await using var sw = new StringWriter(stringBuilderPool.Builder);
+                        using var sw = new StringWriter(stringBuilderPool.Builder);
                         // Don't encode the body
                         bodyAspect.Body.WriteTo(sw, NullHtmlEncoder.Default);
                         fullTextAspect.Segments.Add(sw.ToString());

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Handlers/FullTextAspectContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Handlers/FullTextAspectContentHandler.cs
@@ -11,6 +11,7 @@ using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Models;
 using OrchardCore.Contents.Models;
+using OrchardCore.DisplayManagement;
 using OrchardCore.Liquid;
 
 namespace OrchardCore.Contents.Handlers
@@ -62,12 +63,11 @@ namespace OrchardCore.Contents.Handlers
 
                     if (bodyAspect != null && bodyAspect.Body != null)
                     {
-                        using (var sw = new StringWriter())
-                        {
-                            // Don't encode the body
-                            bodyAspect.Body.WriteTo(sw, NullHtmlEncoder.Default);
-                            fullTextAspect.Segments.Add(sw.ToString());
-                        }
+                        using var stringBuilderPool = StringBuilderPool.GetInstance();
+                        await using var sw = new StringWriter(stringBuilderPool.Builder);
+                        // Don't encode the body
+                        bodyAspect.Body.WriteTo(sw, NullHtmlEncoder.Default);
+                        fullTextAspect.Segments.Add(sw.ToString());
                     }
                 }
 

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/CommandStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/CommandStep.cs
@@ -43,7 +43,7 @@ namespace OrchardCore.Recipes.RecipeSteps
             foreach (var command in step.Commands)
             {
                 using var stringBuilderPool = StringBuilderPool.GetInstance();
-                await using (var output = new StringWriter(stringBuilderPool.Builder))
+                using (var output = new StringWriter(stringBuilderPool.Builder))
                 {
                     _logger.LogInformation("Executing command: {Command}", command);
                     var commandParameters = _commandParameterParser.Parse(_commandParser.Parse(command));

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/CommandStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/CommandStep.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using OrchardCore.DisplayManagement;
 using OrchardCore.Environment.Commands;
 using OrchardCore.Environment.Commands.Parameters;
 using OrchardCore.Recipes.Models;
@@ -41,7 +42,8 @@ namespace OrchardCore.Recipes.RecipeSteps
 
             foreach (var command in step.Commands)
             {
-                using (var output = new StringWriter())
+                using var stringBuilderPool = StringBuilderPool.GetInstance();
+                await using (var output = new StringWriter(stringBuilderPool.Builder))
                 {
                     _logger.LogInformation("Executing command: {Command}", command);
                     var commandParameters = _commandParameterParser.Parse(_commandParser.Parse(command));

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptBlock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptBlock.cs
@@ -7,6 +7,7 @@ using Fluid;
 using Fluid.Ast;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.DisplayManagement;
 using OrchardCore.Liquid;
 using OrchardCore.ResourceManagement;
 
@@ -96,7 +97,8 @@ namespace OrchardCore.Resources.Liquid
 
                     if (statements != null && statements.Count > 0)
                     {
-                        using var sw = new StringWriter();
+                        using var stringBuilderPool = StringBuilderPool.GetInstance();
+                        await using var sw = new StringWriter(stringBuilderPool.Builder);
                         var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                         if (completion != Completion.Normal)
@@ -132,7 +134,8 @@ namespace OrchardCore.Resources.Liquid
 
                 if (statements != null && statements.Count > 0)
                 {
-                    using var sw = new StringWriter();
+                    using var stringBuilderPool = StringBuilderPool.GetInstance();
+                    await using var sw = new StringWriter(stringBuilderPool.Builder);
                     var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                     if (completion != Completion.Normal)

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptBlock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptBlock.cs
@@ -98,7 +98,7 @@ namespace OrchardCore.Resources.Liquid
                     if (statements != null && statements.Count > 0)
                     {
                         using var stringBuilderPool = StringBuilderPool.GetInstance();
-                        await using var sw = new StringWriter(stringBuilderPool.Builder);
+                        using var sw = new StringWriter(stringBuilderPool.Builder);
                         var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                         if (completion != Completion.Normal)

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/StyleBlock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/StyleBlock.cs
@@ -99,7 +99,7 @@ namespace OrchardCore.Resources.Liquid
                 if (statements != null && statements.Count > 0)
                 {
                     using var stringBuilderPool = StringBuilderPool.GetInstance();
-                    await using var sw = new StringWriter(stringBuilderPool.Builder);
+                    using var sw = new StringWriter(stringBuilderPool.Builder);
                     var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                     if (completion != Completion.Normal)

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/StyleBlock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/StyleBlock.cs
@@ -7,6 +7,7 @@ using Fluid;
 using Fluid.Ast;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.DisplayManagement;
 using OrchardCore.Liquid;
 using OrchardCore.ResourceManagement;
 
@@ -97,7 +98,8 @@ namespace OrchardCore.Resources.Liquid
 
                 if (statements != null && statements.Count > 0)
                 {
-                    using var sw = new StringWriter();
+                    using var stringBuilderPool = StringBuilderPool.GetInstance();
+                    await using var sw = new StringWriter(stringBuilderPool.Builder);
                     var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                     if (completion != Completion.Normal)
@@ -127,7 +129,8 @@ namespace OrchardCore.Resources.Liquid
 
                 if (statements != null && statements.Count > 0)
                 {
-                    using var sw = new StringWriter();
+                    using var stringBuilderPool = StringBuilderPool.GetInstance();
+                    await using var sw = new StringWriter(stringBuilderPool.Builder);
                     var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                     if (completion != Completion.Normal)

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeStringifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeStringifyFilter.cs
@@ -21,7 +21,8 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         {
             static async ValueTask<FluidValue> Awaited(Task<IHtmlContent> task)
             {
-                using var writer = new StringWriter();
+                using var stringBuilderPool = StringBuilderPool.GetInstance();
+                await using var writer = new StringWriter(stringBuilderPool.Builder);
                 (await task).WriteTo(writer, NullHtmlEncoder.Default);
                 return new StringValue(writer.ToString(), false);
             }
@@ -34,7 +35,8 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
                     return Awaited(task);
                 }
 
-                using var writer = new StringWriter();
+                using var stringBuilderPool = StringBuilderPool.GetInstance();
+                using var writer = new StringWriter(stringBuilderPool.Builder);
                 task.Result.WriteTo(writer, NullHtmlEncoder.Default);
                 return new ValueTask<FluidValue>(new StringValue(writer.ToString(), false));
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeStringifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeStringifyFilter.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
             static async ValueTask<FluidValue> Awaited(Task<IHtmlContent> task)
             {
                 using var stringBuilderPool = StringBuilderPool.GetInstance();
-                await using var writer = new StringWriter(stringBuilderPool.Builder);
+                using var writer = new StringWriter(stringBuilderPool.Builder);
                 (await task).WriteTo(writer, NullHtmlEncoder.Default);
                 return new StringValue(writer.ToString(), false);
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.DisplayManagement.Html
         private string DebuggerToString()
         {
             using var stringBuilderPool = StringBuilderPool.GetInstance();
-            using var writer = new StringWriter(stringBuilderPool.Builder);
+            var writer = new StringWriter(stringBuilderPool.Builder);
             WriteTo(writer, HtmlEncoder.Default);
             return writer.ToString();
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
@@ -26,7 +26,8 @@ namespace OrchardCore.DisplayManagement.Html
 
         private string DebuggerToString()
         {
-            using var writer = new StringWriter();
+            using var stringBuilderPool = StringBuilderPool.GetInstance();
+            using var writer = new StringWriter(stringBuilderPool.Builder);
             WriteTo(writer, HtmlEncoder.Default);
             return writer.ToString();
         }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
     [HtmlTargetElement("style", Attributes = AtAttributeName)]
     public class StyleTagHelper : TagHelper
     {
+        private static readonly char[] splitSeparators = { ',', ' ' };
         private const string NameAttributeName = "asp-name";
         private const string SrcAttributeName = "asp-src";
         private const string AtAttributeName = "at";
@@ -91,7 +92,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
                 if (!String.IsNullOrEmpty(DependsOn))
                 {
-                    setting.SetDependencies(DependsOn.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
+                    setting.SetDependencies(DependsOn.Split(splitSeparators, StringSplitOptions.RemoveEmptyEntries));
                 }
 
                 if (At == ResourceLocation.Inline)
@@ -154,7 +155,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 // This allows additions to the pre registered style dependencies.
                 if (!String.IsNullOrEmpty(DependsOn))
                 {
-                    setting.SetDependencies(DependsOn.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries));
+                    setting.SetDependencies(DependsOn.Split(splitSeparators, StringSplitOptions.RemoveEmptyEntries));
                 }
 
                 var childContent = await output.GetChildContentAsync();


### PR DESCRIPTION
`StringWriter`s were always using their own `StringBuilder`, now using the pool. `ScriptTagHelper` still uses new'ed builders as it cannot see `StringBuilderPool`, maybe future improvement. @sebastienros can you please run benchmarks for this.