### PR TITLE
Ensure ViewBufferTextWriterContent is properly disposed and releasing pooled instances

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidTemplateManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Services/LiquidTemplateManager.cs
@@ -21,8 +21,8 @@ namespace OrchardCore.Liquid.Services
         private readonly IServiceProvider _serviceProvider;
 
         public LiquidTemplateManager(
-            IMemoryCache memoryCache, 
-            LiquidViewParser liquidViewParser, 
+            IMemoryCache memoryCache,
+            LiquidViewParser liquidViewParser,
             IOptions<TemplateOptions> templateOptions,
             IServiceProvider serviceProvider
             )
@@ -72,11 +72,9 @@ namespace OrchardCore.Liquid.Services
                 }
             }
 
-            var htmlContentWriter = new ViewBufferTextWriterContent();
-
+            using var htmlContentWriter = new ViewBufferTextWriterContent();
             await result.RenderAsync(htmlContentWriter, encoder, context, model);
-
-            return htmlContentWriter;
+            return new HtmlString(htmlContentWriter.ToString());
         }
 
         public Task RenderAsync(string source, TextWriter writer, TextEncoder encoder, object model = null, IEnumerable<KeyValuePair<string, FluidValue>> properties = null)

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/FluidTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/FluidTagHelper.cs
@@ -88,12 +88,14 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
 
             if (content != null)
             {
+                var output = content.ToString();
                 tagHelperOutput = new TagHelperOutput(
                     identifier,
-                    outputAttributes, (_, e) => Task.FromResult(new DefaultTagHelperContent().AppendHtml(content))
+                    outputAttributes, (_, e) => Task.FromResult(new DefaultTagHelperContent().AppendHtml(output))
                 );
 
-                tagHelperOutput.Content.AppendHtml(content);
+                tagHelperOutput.Content.AppendHtml(output);
+                content.Dispose();
             }
             else
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ZoneTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ZoneTag.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
 
             if (statements != null && statements.Count > 0)
             {
-                var content = new ViewBufferTextWriterContent();
+                using var content = new ViewBufferTextWriterContent();
 
                 var completion = await statements.RenderStatementsAsync(content, encoder, context);
 
@@ -50,7 +50,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
 
                 if (zone is Shape shape)
                 {
-                    await shape.AddAsync(content, position);
+                    await shape.AddAsync(content.ToString(), position);
                 }
             }
 


### PR DESCRIPTION
`ViewBufferTextWriterContent` is `IDisposable` and relies on somewhat luck to get disposed (`WriteTo`) needs to be called. The recent PR took the `IHtmlContent` to buffer but there's nobody to dispose such instances which have not had `WriteTo` called. Removing `IHtmlContent` as the life-cycle doesn't correspond to usage.

Changing the usage patterns to have `using` and materializing the produced string when needed.