### PR TITLE
Fixes #9209 FluidTagHelper reuse of buffer

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewParser.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewParser.cs
@@ -51,8 +51,6 @@ namespace OrchardCore.DisplayManagement.Liquid
 
             RegisteredTags["a"] = ArgumentsList.AndSkip(TagEnd).And(Parsers.ZeroOrOne(AnyTagsList.AndSkip(CreateTag("enda")))).Then<Statement>(x => new ParserBlockStatement<List<FilterArgument>>(x.Item1, x.Item2, DefaultAnchorTag.WriteToAsync));
             RegisterParserBlock("form", ArgumentsList, (list, statements, writer, encoder, context) => FluidTagHelper.WriteToAsync("form", list, statements, writer, encoder, context));
-            RegisterParserBlock("scriptblock", ArgumentsList, (list, statements, writer, encoder, context) => FluidTagHelper.WriteToAsync("scriptblock", list, statements, writer, encoder, context));
-            RegisterParserBlock("styleblock", ArgumentsList, (list, statements, writer, encoder, context) => FluidTagHelper.WriteToAsync("styleblock", list, statements, writer, encoder, context));
 
             // Dynamic caching
             RegisterParserBlock("cache", ArgumentsList, CacheTag.WriteToAsync);

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/FluidTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/FluidTagHelper.cs
@@ -92,8 +92,6 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
                     identifier,
                     outputAttributes, (_, e) => Task.FromResult(new DefaultTagHelperContent().AppendHtml(content))
                 );
-
-                tagHelperOutput.Content.AppendHtml(content);
             }
             else
             {
@@ -104,8 +102,6 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
             }
 
             await tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput);
-
-            tagHelperOutput.WriteTo(writer, (HtmlEncoder)encoder);
 
             return Completion.Normal;
         }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/ViewBufferTextWriterContent.cs
@@ -195,6 +195,20 @@ namespace OrchardCore.DisplayManagement.Liquid
             }
         }
 
+        public override void Write(StringBuilder value)
+        {
+            if (value != null)
+            {
+                foreach (var chunk in value.GetChunks())
+                {
+                    if (!chunk.IsEmpty)
+                    {
+                        Write(chunk.Span);
+                    }
+                }
+            }
+        }
+
         public void WriteTo(TextWriter writer, HtmlEncoder encoder)
         {
             if (_builder == null)


### PR DESCRIPTION
Fixes #9209 

So the `FluidTagHelper` only needs to call `ProcessAsync()` on a given tag helper, not call `WriteTo()` on the `TagHelperOutput`, nor set its `Content` property.

I also added to our `ViewBufferTextWriterContent` a new `Write(StringBuilder value)` overload, because the base implementation of the `TextWriter` doesn't check `chunk.IsEmpty` before writing a `chunk.Span`, and i had an issue with this but don't remember the details.

