### PR TITLE
Added Total support for Lucene API queries

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/ApiController.cs
@@ -27,7 +27,9 @@ namespace OrchardCore.Queries.Controllers
         [Route("{name}")]
         public async Task<IActionResult> Query(
             string name,
-            string parameters)
+            string parameters,
+            bool? withTotal
+            )
         {
             var query = await _queryManager.GetQueryAsync(name);
 
@@ -47,8 +49,24 @@ namespace OrchardCore.Queries.Controllers
                 JsonConvert.DeserializeObject<Dictionary<string, object>>(parameters)
                 : new Dictionary<string, object>();
 
-            var result = await _queryManager.ExecuteQueryAsync(query, queryParameters);
-            return new ObjectResult(result.Items);
+            try
+            {
+                var result = await _queryManager.ExecuteQueryAsync(query, queryParameters);
+                if (withTotal ?? false && result is LuceneQueryResults)
+                {
+                    return new ObjectResult(result);
+                }
+                else
+                {
+                    return new ObjectResult(result.Items);
+                }
+            }
+            catch (System.Exception ex)
+            {
+                return new ObjectResult(ex.Message);
+            }
+
+
         }
     }
 }


### PR DESCRIPTION
sample:
`/api/queries/LQueryName?parameters={from:0,size:20}&withTotal=true`

Result:
```
{
  items:[...],
  count:1231
}
```