### PR TITLE
Fixes #9270 DI Deadlock

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
@@ -93,6 +93,15 @@ namespace OrchardCore.Documents
 
         public async Task<TDocument> GetOrCreateImmutableAsync(Func<Task<TDocument>> factoryAsync = null)
         {
+            // If called from a constructor, e.g. through an 'IConfigureOptions', the 'IDocumentStore' should
+            // be resolved before any async IO operation to prevent a DI dead lock. So, only if the store may
+            // be used (if non volatile) and an async IO may be done before (if a distributed cache is used).
+
+            if (!_isVolatile && _isDistributed)
+            {
+                _ = DocumentStore;
+            }
+
             var document = await GetInternalAsync();
 
             if (document == null)

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
@@ -99,9 +99,11 @@ namespace OrchardCore.Documents
 
             if (!_isVolatile && _isDistributed)
             {
+                // Resolve the 'IDocumentStore' and hold it in a scoped cache.
                 _ = DocumentStore;
             }
 
+            // May call an async IO if using a distributed cache.
             var document = await GetInternalAsync();
 
             if (document == null)


### PR DESCRIPTION
Fixes #9270 

- So as commented in the code of the `IDocumentManager.GetOrCreateImmutableAsync()`

      // If called from a constructor, e.g. through an 'IConfigureOptions', the 'IDocumentStore' should
      // be resolved before any async IO operation to prevent a DI dead lock. So, only if the store may
      // be used (if non volatile) and an async IO may be done before (if a distributed cache is used).

- So any `IDocumentManager` is still a singleton and then still injects some other singletons once, only the scoped `IDocumentStore` may be lazily resolved even if it is not used, but see below.

- But only if a distributed cache is used because this is in this case that an async IO operation may be done before we may do a lazy resolution of the `IDocumentStore` if we need it (knowing that we scope cache it).

- And only for non volatile `IDocumentManager` so it doesn't concern e.g. `Àutoroute` and `Layers` documents that are not persisted, they are initialized localy in memory and updated based on shared states that are also not persisted.

- Finally, when a given `IDocumentStore` is lazily resolved, it is scope cached so that in a given scope this resolution will be shared by any `IDocumentManager` using the same `IDocumentStore`, which is the case for most of them.

So i think it is a good compromise, this in place of adding a parameter to `GetOrCreateImmutableAsync()` saying that we call it from a constructor, and having to update all interfaces / classes using an `IDocumentManager`.

Note: We already had this DI deadlock even if not using a distributed cache, this because at some point we were not caching the `IDocumentStore` resolution, so the first resolution to use it was correctly done, but then a second resolution could fail depending on the async IO done by the `IDocumentStore` and that may depend on the database provider.