### PR TITLE
Fix default liquid script rendering

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptTag.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptTag.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Resources.Liquid
 {
     public class ScriptTag
     {
-        private static readonly char[] Separators = new[] {',', ' '};
+        private static readonly char[] Separators = new[] { ',', ' ' };
         public static async ValueTask<Completion> WriteToAsync(List<FilterArgument> argumentsList, TextWriter writer, TextEncoder encoder, TemplateContext context)
         {
             var services = ((LiquidTemplateContext)context).Services;
@@ -58,6 +58,7 @@ namespace OrchardCore.Resources.Liquid
 
             if (String.IsNullOrEmpty(name) && !String.IsNullOrEmpty(src))
             {
+                // {% script src:"~/TheBlogTheme/js/clean-blog.min.js" %}
                 RequireSettings setting;
 
                 if (String.IsNullOrEmpty(dependsOn))
@@ -141,7 +142,7 @@ namespace OrchardCore.Resources.Liquid
                     }
                 }
 
-                if (at == ResourceLocation.Inline)
+                if (at == ResourceLocation.Unspecified || at == ResourceLocation.Inline)
                 {
                     resourceManager.RenderLocalScript(setting, writer);
                 }
@@ -149,6 +150,7 @@ namespace OrchardCore.Resources.Liquid
             else if (!String.IsNullOrEmpty(name) && String.IsNullOrEmpty(src))
             {
                 // Resource required
+                // {% script name:"bootstrap" %}
 
                 var setting = resourceManager.RegisterResource("script", name);
 
@@ -191,6 +193,11 @@ namespace OrchardCore.Resources.Liquid
                 if (!String.IsNullOrEmpty(dependsOn))
                 {
                     setting.SetDependencies(dependsOn.Split(Separators, StringSplitOptions.RemoveEmptyEntries));
+                }
+
+                if (at == ResourceLocation.Unspecified || at == ResourceLocation.Inline)
+                {
+                    resourceManager.RenderLocalScript(setting, writer);
                 }
             }
             else if (!String.IsNullOrEmpty(name) && !String.IsNullOrEmpty(src))

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -52,6 +52,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
             if (String.IsNullOrEmpty(Name) && !String.IsNullOrEmpty(Src))
             {
+                // <script asp-src="~/TheBlogTheme/js/clean-blog.min.js"></script>
                 RequireSettings setting;
 
                 if (String.IsNullOrEmpty(DependsOn))
@@ -142,6 +143,7 @@ namespace OrchardCore.ResourceManagement.TagHelpers
             else if (!String.IsNullOrEmpty(Name) && String.IsNullOrEmpty(Src))
             {
                 // Resource required
+                // <script asp-name="bootstrap"></script>
 
                 var setting = _resourceManager.RegisterResource("script", Name);
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/9271

Fixes https://github.com/OrchardCMS/OrchardCore/issues/9266

This brings the liquid tags back into line with the razor tags and docs. https://docs.orchardcore.net/en/dev/docs/reference/modules/Resources/#specify-location

@agriffard can you check with your agency theme related issue?