### PR TITLE
Update code generation templates for zsh on MacOS

### DIFF
--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -12,10 +12,22 @@ Once the .NET Core SDK has been installed, type the following command to install
 dotnet new -i OrchardCore.ProjectTemplates::1.0.0-rc2-*
 ```
 
+With the zsh shell on MacOS
+
+```CMD
+dotnet new -i "OrchardCore.ProjectTemplates::1.0.0-rc2-*"
+```
+
 This will use the most stable release of Orchard Core. In order to use the latest `dev` branch of Orchard Core, the following command can be used:
 
 ```CMD
 dotnet new -i OrchardCore.ProjectTemplates::1.0.0-rc2-* --nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json  
+```
+
+With the zsh shell on MacOS
+
+```CMD
+dotnet new -i "OrchardCore.ProjectTemplates::1.0.0-rc2-*" --nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json  
 ```
 
 ## Create a new website

--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -9,22 +9,10 @@ More information about `dotnet new` can be found at <https://docs.microsoft.com/
 Once the .NET Core SDK has been installed, type the following command to install the templates for creating Orchard Core web applications:
 
 ```CMD
-dotnet new -i OrchardCore.ProjectTemplates::1.0.0-rc2-*
-```
-
-With the zsh shell on MacOS
-
-```CMD
 dotnet new -i "OrchardCore.ProjectTemplates::1.0.0-rc2-*"
 ```
 
 This will use the most stable release of Orchard Core. In order to use the latest `dev` branch of Orchard Core, the following command can be used:
-
-```CMD
-dotnet new -i OrchardCore.ProjectTemplates::1.0.0-rc2-* --nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json  
-```
-
-With the zsh shell on MacOS
 
 ```CMD
 dotnet new -i "OrchardCore.ProjectTemplates::1.0.0-rc2-*" --nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json  


### PR DESCRIPTION
The newer zsh shell is picky about * in a cmd and needs to be wrapped in quotes.

Think a few users have complained about this on gitter.

can someone try the new command on windows and check if it works with the quotes (it does with bash the old shell). If it does I'll just update the cmd to be used for both. @agriffard if you have time?

`dotnet new -i "OrchardCore.ProjectTemplates::1.0.0-rc2-*"`

and

`dotnet new -i "OrchardCore.ProjectTemplates::1.0.0-rc2-*" --nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json `
