### PR TITLE
Correctly keep track of closing divs in the taxononmy field #9304

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
@@ -36,7 +36,7 @@
         for (var e = entry.Level; e < previousLevel; e++)
         {
             WriteLiteral("</div>");
-            closingDivs = 0;
+            closingDivs--;
         }
 
         @if (!settings.Unique)


### PR DESCRIPTION
Fix to correctly keep track of closing div tags in the taxonomy field editor as this can lead to tabs breaking in the editor is the DOM is broken.

Fixes [#9304](https://github.com/OrchardCMS/OrchardCore/issues/9304)