### PR TITLE
Add default text for dynamically created menu item

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItem.Admin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/MenuItem.Admin.cshtml
@@ -46,6 +46,11 @@
             {
                 @await DisplayAsync(Model.Content)
             }
+            else
+            {
+              @*For dynamically created menus that do not have a driver*@
+              <span>@contentItem.DisplayText <span class="text-muted dashed">@contentItem.ContentType</span></span>
+            }
         </div>
     </div>
 


### PR DESCRIPTION
When creating menu items types from recipes or the admin interface, the menu item does not display it's title in the admin.

Before:
![image](https://user-images.githubusercontent.com/4681586/116462735-cd8a6980-a837-11eb-9b68-8b56043dfbc8.png)

After:
This displays the DisplayText property of the MenuItem and the type of menu item
![image](https://user-images.githubusercontent.com/4681586/116462857-f579cd00-a837-11eb-9980-88f9bb8a6f3e.png)
