### PR TITLE
ZString 2.4.2

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -48,7 +48,7 @@
     <PackageManagement Include="YesSql.Core" Version="3.0.2" />
     <PackageManagement Include="YesSql.Abstractions" Version="3.0.2" />
     <PackageManagement Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
-    <PackageManagement Include="ZString" Version="2.4.1" />
+    <PackageManagement Include="ZString" Version="2.4.2" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Handlers/FullTextAspectContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Handlers/FullTextAspectContentHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Cysharp.Text;
 using Fluid;
 using Fluid.Values;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -63,8 +64,7 @@ namespace OrchardCore.Contents.Handlers
 
                     if (bodyAspect != null && bodyAspect.Body != null)
                     {
-                        using var stringBuilderPool = StringBuilderPool.GetInstance();
-                        using var sw = new StringWriter(stringBuilderPool.Builder);
+                        using var sw = new ZStringWriter();
                         // Don't encode the body
                         bodyAspect.Body.WriteTo(sw, NullHtmlEncoder.Default);
                         fullTextAspect.Segments.Add(sw.ToString());

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/CommandStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/CommandStep.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using Cysharp.Text;
 using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Environment.Commands;
@@ -42,8 +43,7 @@ namespace OrchardCore.Recipes.RecipeSteps
 
             foreach (var command in step.Commands)
             {
-                using var stringBuilderPool = StringBuilderPool.GetInstance();
-                using (var output = new StringWriter(stringBuilderPool.Builder))
+                using (var output = new ZStringWriter())
                 {
                     _logger.LogInformation("Executing command: {Command}", command);
                     var commandParameters = _commandParameterParser.Parse(_commandParser.Parse(command));

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptBlock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptBlock.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Cysharp.Text;
 using Fluid;
 using Fluid.Ast;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -97,8 +98,7 @@ namespace OrchardCore.Resources.Liquid
 
                     if (statements != null && statements.Count > 0)
                     {
-                        using var stringBuilderPool = StringBuilderPool.GetInstance();
-                        using var sw = new StringWriter(stringBuilderPool.Builder);
+                        using var sw = new ZStringWriter();
                         var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                         if (completion != Completion.Normal)
@@ -134,8 +134,7 @@ namespace OrchardCore.Resources.Liquid
 
                 if (statements != null && statements.Count > 0)
                 {
-                    using var stringBuilderPool = StringBuilderPool.GetInstance();
-                    await using var sw = new StringWriter(stringBuilderPool.Builder);
+                    using var sw = new ZStringWriter();
                     var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                     if (completion != Completion.Normal)

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/StyleBlock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/StyleBlock.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Cysharp.Text;
 using Fluid;
 using Fluid.Ast;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -98,8 +99,7 @@ namespace OrchardCore.Resources.Liquid
 
                 if (statements != null && statements.Count > 0)
                 {
-                    using var stringBuilderPool = StringBuilderPool.GetInstance();
-                    using var sw = new StringWriter(stringBuilderPool.Builder);
+                    using var sw = new ZStringWriter();
                     var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                     if (completion != Completion.Normal)
@@ -129,8 +129,7 @@ namespace OrchardCore.Resources.Liquid
 
                 if (statements != null && statements.Count > 0)
                 {
-                    using var stringBuilderPool = StringBuilderPool.GetInstance();
-                    await using var sw = new StringWriter(stringBuilderPool.Builder);
+                    using var sw = new ZStringWriter();
                     var completion = await statements.RenderStatementsAsync(sw, encoder, context);
 
                     if (completion != Completion.Normal)

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeStringifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/ShapeStringifyFilter.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
+using Cysharp.Text;
 using Fluid;
 using Fluid.Values;
 using Microsoft.AspNetCore.Html;
@@ -21,8 +22,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
         {
             static async ValueTask<FluidValue> Awaited(Task<IHtmlContent> task)
             {
-                using var stringBuilderPool = StringBuilderPool.GetInstance();
-                using var writer = new StringWriter(stringBuilderPool.Builder);
+                using var writer = new ZStringWriter();
                 (await task).WriteTo(writer, NullHtmlEncoder.Default);
                 return new StringValue(writer.ToString(), false);
             }
@@ -35,8 +35,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Filters
                     return Awaited(task);
                 }
 
-                using var stringBuilderPool = StringBuilderPool.GetInstance();
-                using var writer = new StringWriter(stringBuilderPool.Builder);
+                using var writer = new ZStringWriter();
                 task.Result.WriteTo(writer, NullHtmlEncoder.Default);
                 return new ValueTask<FluidValue>(new StringValue(writer.ToString(), false));
             }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Html/HtmlContentString.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Text.Encodings.Web;
+using Cysharp.Text;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
@@ -26,8 +27,7 @@ namespace OrchardCore.DisplayManagement.Html
 
         private string DebuggerToString()
         {
-            using var stringBuilderPool = StringBuilderPool.GetInstance();
-            var writer = new StringWriter(stringBuilderPool.Builder);
+            var writer = new ZStringWriter();
             WriteTo(writer, HtmlEncoder.Default);
             return writer.ToString();
         }

--- a/src/docs/resources/libraries/README.md
+++ b/src/docs/resources/libraries/README.md
@@ -28,6 +28,7 @@ The below table lists the different .NET libraries used in Orchard Core:
 | [Serilog.AspNetCore](https://github.com/serilog/serilog-aspnetcore) | Serilog integration for ASP.NET Core. | 4.1.0 | [Apache-2.0](https://github.com/serilog/serilog-aspnetcore/blob/dev/LICENSE) |
 | [Shortcodes](https://github.com/sebastienros/shortcodes) | Shortcodes processor for .NET. | 1.0.0-beta-175913881 | [MIT](https://github.com/sebastienros/shortcodes/blob/dev/LICENSE) |
 | [YesSql](https://github.com/sebastienros/yessql) | .NET document database working on any RDBMS. | 3.0.2 | [MIT](https://github.com/sebastienros/yessql/blob/dev/LICENSE) |
+| [ZString](https://github.com/Cysharp/ZString) | Zero Allocation StringBuilder for .NET Core and Unity. | 2.4.2 | [MIT](https://github.com/Cysharp/ZString/blob/master/LICENSE) |
 
 The below table lists the different libraries used as Resources:
 


### PR DESCRIPTION
Use `ZStringWriter` available in the new version of ZString.

Related to #9202

`StringBuilderPool` is still used in ViewBufferTextWriterContent and CacheTag.

/cc @lahma 