### PR TITLE
Code generation template: Module with Part

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Drivers/MyTestPartDisplayDriver.cs
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Drivers/MyTestPartDisplayDriver.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.Templates.Cms.Module.Drivers
 
         public override IDisplayResult Edit(MyTestPart part, BuildPartEditorContext context)
         {
-            return Initialize<TestPartViewModel>(GetEditorShapeType(context), model =>
+            return Initialize<MyTestPartViewModel>(GetEditorShapeType(context), model =>
             {
                 model.Show = part.Show;
                 model.ContentItem = part.ContentItem;

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Drivers/MyTestPartDisplayDriver.cs
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Drivers/MyTestPartDisplayDriver.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
@@ -19,42 +19,34 @@ namespace OrchardCore.Templates.Cms.Module.Drivers
             _contentDefinitionManager = contentDefinitionManager;
         }
 
-        public override IDisplayResult Display(MyTestPart MyTestPart)
+        public override IDisplayResult Display(MyTestPart part, BuildPartDisplayContext context)
         {
-            return Combine(
-                Initialize<MyTestPartViewModel>("MyTestPart", m => BuildViewModel(m, MyTestPart))
-                    .Location("Detail", "Content:20"),
-                Initialize<MyTestPartViewModel>("MyTestPart_Summary", m => BuildViewModel(m, MyTestPart))
-                    .Location("Summary", "Meta:5")
-            );
+            return Initialize<TestPartViewModel>(GetDisplayShapeType(context), m => BuildViewModel(m, part, context))
+                .Location("Detail", "Content:10")
+                .Location("Summary", "Content:10")
+                ;
         }
-        
-        public override IDisplayResult Edit(MyTestPart MyTestPart)
+
+        public override IDisplayResult Edit(MyTestPart part, BuildPartEditorContext context)
         {
-            return Initialize<MyTestPartViewModel>("MyTestPart_Edit", m => BuildViewModel(m, MyTestPart));
+            return Initialize<TestPartViewModel>(GetEditorShapeType(context), model =>
+            {
+                model.Show = part.Show;
+                model.ContentItem = part.ContentItem;
+                model.MyTestPart = part;
+            });
         }
 
         public override async Task<IDisplayResult> UpdateAsync(MyTestPart model, IUpdateModel updater)
         {
-            var settings = GetMyTestPartSettings(model);
-
             await updater.TryUpdateModelAsync(model, Prefix, t => t.Show);
-            
+
             return Edit(model);
         }
 
-        public MyTestPartSettings GetMyTestPartSettings(MyTestPart part)
+        private Task BuildViewModel(MyTestPartViewModel model, MyTestPart part, BuildPartDisplayContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(p => p.PartDefinition.Name == nameof(MyTestPart));
-            var settings = contentTypePartDefinition.GetSettings<MyTestPartSettings>();
-
-            return settings;
-        }
-
-        private Task BuildViewModel(MyTestPartViewModel model, MyTestPart part)
-        {
-            var settings = GetMyTestPartSettings(part);
+            var settings = context.TypePartDefinition.GetSettings<MyTestPartSettings>();
 
             model.ContentItem = part.ContentItem;
             model.MySetting = settings.MySetting;

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Startup.cs
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using Fluid;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,6 +13,7 @@ using OrchardCore.Templates.Cms.Module.Drivers;
 using OrchardCore.Templates.Cms.Module.Handlers;
 using OrchardCore.Templates.Cms.Module.Models;
 using OrchardCore.Templates.Cms.Module.Settings;
+using OrchardCore.Templates.Cms.Module.ViewModels;
 #endif
 using OrchardCore.Modules;
 
@@ -22,6 +24,11 @@ namespace OrchardCore.Templates.Cms.Module
         public override void ConfigureServices(IServiceCollection services)
         {
 #if (AddPart)
+            services.Configure<TemplateOptions>(o =>
+            {
+                o.MemberAccessStrategy.Register<MyTestPartViewModel>();
+            });
+
             services.AddContentPart<MyTestPart>()
                 .UseDisplayDriver<MyTestPartDisplayDriver>()
                 .AddHandler<MyTestPartHandler>();

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Views/MyTestPart.liquid
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Views/MyTestPart.liquid
@@ -1,3 +1,3 @@
-﻿{% if Model.Show %}
+{% if Model.Show %}
 {{ Model.MySetting }} {{ Model.ContentItem.ContentItemId }}
 {% endif %}

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Views/MyTestPart_Summary.liquid
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Views/MyTestPart_Summary.liquid
@@ -1,2 +1,2 @@
-﻿{{ Model.MySetting }}
-<a href="{{ Model.ContentItem | display_url }}>{{ Model.ContentItem.ContentItemId }}</a>
+{{ Model.MySetting }}
+<a href="{{ Model.ContentItem | display_url }}">{{ Model.ContentItem.ContentItemId }}</a>


### PR DESCRIPTION
Update the driver to use the same syntax as the other ones in the source code.

Add registration of the viewModel in Startup or else, it won't be rendered using a Liquid template.

```
services.Configure<TemplateOptions>(o =>
            {
                o.MemberAccessStrategy.Register<MyTestPartViewModel>();
            });
```

We should add this note somewhere in the documentation and check that we didn't forget to register some view models in other modules.