### PR TITLE
Make Permission Name and ImpliedBy properties immutable.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Permissions.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Features
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ManageFeatures = new Permission("ManageFeatures") { Description = "Manage Features" };
+        public static readonly Permission ManageFeatures = new Permission("ManageFeatures", "Manage Features");
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Permissions.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Themes
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ApplyTheme = new Permission("ApplyTheme") { Description = "Apply a Theme" };
+        public static readonly Permission ApplyTheme = new Permission("ApplyTheme", "Apply a Theme");
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/Permission.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/Permissions/Permission.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
-using Newtonsoft.Json;
 
 namespace OrchardCore.Security.Permissions
 {
@@ -30,11 +29,11 @@ namespace OrchardCore.Security.Permissions
             ImpliedBy = impliedBy;
         }
 
-        public string Name { get; set; }
+        public string Name { get; }
         public string Description { get; set; }
         public string Category { get; set; }
-        public IEnumerable<Permission> ImpliedBy { get; set; }
-        public bool IsSecurityCritical { get; set; }
+        public IEnumerable<Permission> ImpliedBy { get; }
+        public bool IsSecurityCritical { get; }
 
         public static implicit operator Claim(Permission p)
         {

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/DefaultUserClaimsPrincipalFactory.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/DefaultUserClaimsPrincipalFactory.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Users.Services
     /// <summary>
     /// Custom implementation of <see cref="IUserClaimsPrincipalFactory{TUser}"/> adding email claims.
     /// </summary>
-    [Obsolete("The class 'DefaultUserClaimsPrincipalFactory' in obsolete, please implement 'IUserClaimsProvider' instead.")]
+    [Obsolete("The class 'DefaultUserClaimsPrincipalFactory' is obsolete, please implement 'IUserClaimsProvider' instead.")]
     public class DefaultUserClaimsPrincipalFactory : UserClaimsPrincipalFactory<IUser, IRole>
     {
         public DefaultUserClaimsPrincipalFactory(


### PR DESCRIPTION
These properties are security critical, although it's still possible to change them using Reflection.