### PR TITLE
Add ability to export templates as files

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentSource.cs
@@ -28,17 +28,18 @@ namespace OrchardCore.Templates.Deployment
             var templateObjects = new JObject();
             var templates = await _templatesManager.GetTemplatesDocumentAsync();
 
-            if(allTemplatesStep.ExportAsFiles)
+            if (allTemplatesStep.ExportAsFiles)
             {
                 foreach (var template in templates.Templates)
                 {
-                    var fileName = "AdminTemplates/" + template.Key.Replace("__", "-").Replace("_",".") + ".liquid";
-                    var templateValue = new Template {Description = template.Value.Description, Content = $"[file:text('{fileName}')]"};
+                    var fileName = "AdminTemplates/" + template.Key.Replace("__", "-").Replace("_", ".") + ".liquid";
+                    var templateValue = new Template { Description = template.Value.Description, Content = $"[file:text('{fileName}')]" };
                     await result.FileBuilder.SetFileAsync(fileName, Encoding.UTF8.GetBytes(template.Value.Content));
                     templateObjects[template.Key] = JObject.FromObject(templateValue);
                 }
             }
-            else {
+            else
+            {
                 foreach (var template in templates.Templates)
                 {
                     templateObjects[template.Key] = JObject.FromObject(template.Value);

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentSource.cs
@@ -1,6 +1,8 @@
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Deployment;
+using OrchardCore.Templates.Models;
 using OrchardCore.Templates.Services;
 
 namespace OrchardCore.Templates.Deployment
@@ -26,9 +28,21 @@ namespace OrchardCore.Templates.Deployment
             var templateObjects = new JObject();
             var templates = await _templatesManager.GetTemplatesDocumentAsync();
 
-            foreach (var template in templates.Templates)
+            if(allTemplatesStep.ExportAsFiles)
             {
-                templateObjects[template.Key] = JObject.FromObject(template.Value);
+                foreach (var template in templates.Templates)
+                {
+                    var fileName = "AdminTemplates/" + template.Key.Replace("__", "-").Replace("_",".") + ".liquid";
+                    var templateValue = new Template {Description = template.Value.Description, Content = $"[file:text('{fileName}')]"};
+                    await result.FileBuilder.SetFileAsync(fileName, Encoding.UTF8.GetBytes(template.Value.Content));
+                    templateObjects[template.Key] = JObject.FromObject(templateValue);
+                }
+            }
+            else {
+                foreach (var template in templates.Templates)
+                {
+                    templateObjects[template.Key] = JObject.FromObject(template.Value);
+                }
             }
 
             result.Steps.Add(new JObject(

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentStep.cs
@@ -11,5 +11,6 @@ namespace OrchardCore.Templates.Deployment
         {
             Name = "AllAdminTemplates";
         }
+        public bool ExportAsFiles { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentStepDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentStepDriver.cs
@@ -1,6 +1,9 @@
+using System.Threading.Tasks;
 using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Templates.ViewModels;
 
 namespace OrchardCore.Templates.Deployment
 {
@@ -17,7 +20,13 @@ namespace OrchardCore.Templates.Deployment
 
         public override IDisplayResult Edit(AllAdminTemplatesDeploymentStep step)
         {
-            return View("AllAdminTemplatesDeploymentStep_Edit", step).Location("Content");
+            return Initialize<AllAdminTemplatesDeploymentStepViewModel>("AllAdminTemplatesDeploymentStep_Fields_Edit", model => model.ExportAsFiles = step.ExportAsFiles).Location("Content");
+        }
+        public override async Task<IDisplayResult> UpdateAsync(AllAdminTemplatesDeploymentStep step, IUpdateModel updater)
+        {
+            await updater.TryUpdateModelAsync(step, Prefix, x => x.ExportAsFiles);
+
+            return Edit(step);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentSource.cs
@@ -1,6 +1,8 @@
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Deployment;
+using OrchardCore.Templates.Models;
 using OrchardCore.Templates.Services;
 
 namespace OrchardCore.Templates.Deployment
@@ -26,9 +28,22 @@ namespace OrchardCore.Templates.Deployment
             var templateObjects = new JObject();
             var templates = await _templatesManager.GetTemplatesDocumentAsync();
 
-            foreach (var template in templates.Templates)
+            if(allTemplatesStep.ExportAsFiles)
             {
-                templateObjects[template.Key] = JObject.FromObject(template.Value);
+                foreach (var template in templates.Templates)
+                {
+                    var fileName = "Templates/" + template.Key.Replace("__", "-").Replace("_",".") + ".liquid";
+                    var templateValue = new Template {Description = template.Value.Description, Content = $"[file:text('{fileName}')]"};
+                    await result.FileBuilder.SetFileAsync(fileName, Encoding.UTF8.GetBytes(template.Value.Content));
+                    templateObjects[template.Key] = JObject.FromObject(templateValue);
+                }
+            }
+            else
+            {
+                foreach (var template in templates.Templates)
+                {
+                    templateObjects[template.Key] = JObject.FromObject(template.Value);
+                }
             }
 
             result.Steps.Add(new JObject(

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentSource.cs
@@ -28,12 +28,12 @@ namespace OrchardCore.Templates.Deployment
             var templateObjects = new JObject();
             var templates = await _templatesManager.GetTemplatesDocumentAsync();
 
-            if(allTemplatesStep.ExportAsFiles)
+            if (allTemplatesStep.ExportAsFiles)
             {
                 foreach (var template in templates.Templates)
                 {
-                    var fileName = "Templates/" + template.Key.Replace("__", "-").Replace("_",".") + ".liquid";
-                    var templateValue = new Template {Description = template.Value.Description, Content = $"[file:text('{fileName}')]"};
+                    var fileName = "Templates/" + template.Key.Replace("__", "-").Replace("_", ".") + ".liquid";
+                    var templateValue = new Template { Description = template.Value.Description, Content = $"[file:text('{fileName}')]" };
                     await result.FileBuilder.SetFileAsync(fileName, Encoding.UTF8.GetBytes(template.Value.Content));
                     templateObjects[template.Key] = JObject.FromObject(templateValue);
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentStep.cs
@@ -11,5 +11,6 @@ namespace OrchardCore.Templates.Deployment
         {
             Name = "AllTemplates";
         }
+        public bool ExportAsFiles { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentStepDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentStepDriver.cs
@@ -1,6 +1,9 @@
+using System.Threading.Tasks;
 using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Templates.ViewModels;
 
 namespace OrchardCore.Templates.Deployment
 {
@@ -17,7 +20,13 @@ namespace OrchardCore.Templates.Deployment
 
         public override IDisplayResult Edit(AllTemplatesDeploymentStep step)
         {
-            return View("AllTemplatesDeploymentStep_Edit", step).Location("Content");
+            return Initialize<AllTemplatesDeploymentStepViewModel>("AllTemplatesDeploymentStep_Fields_Edit", model => model.ExportAsFiles = step.ExportAsFiles).Location("Content");
+        }
+        public override async Task<IDisplayResult> UpdateAsync(AllTemplatesDeploymentStep step, IUpdateModel updater)
+        {
+            await updater.TryUpdateModelAsync(step, Prefix, x => x.ExportAsFiles);
+
+            return Edit(step);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/ViewModels/AllAdminTemplatesDeploymentStepViewModel copy.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/ViewModels/AllAdminTemplatesDeploymentStepViewModel copy.cs
@@ -1,0 +1,7 @@
+namespace OrchardCore.Templates.ViewModels
+{
+    public class AllAdminTemplatesDeploymentStepViewModel
+    {
+        public bool ExportAsFiles { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Templates/ViewModels/AllTemplatesDeploymentStepViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/ViewModels/AllTemplatesDeploymentStepViewModel.cs
@@ -1,0 +1,7 @@
+namespace OrchardCore.Templates.ViewModels
+{
+    public class AllTemplatesDeploymentStepViewModel
+    {
+        public bool ExportAsFiles { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Items/AllAdminTemplatesDeploymentStep.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Items/AllAdminTemplatesDeploymentStep.Edit.cshtml
@@ -1,3 +1,0 @@
-@model dynamic
-
-<h5>@T["All Admin Templates"]</h5>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Items/AllAdminTemplatesDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Items/AllAdminTemplatesDeploymentStep.Fields.Edit.cshtml
@@ -1,0 +1,11 @@
+@model AllAdminTemplatesDeploymentStepViewModel
+
+<h5>@T["All Admin Templates"]</h5>
+
+<div class="form-group">
+    <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" asp-for="ExportAsFiles" />
+        <label class="custom-control-label" asp-for="ExportAsFiles">@T["Export templates as files"]</label>
+        <span class="hint">@T["Check if the templates should be exported as files instead of inline."]</span>
+    </div>
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Items/AllTemplatesDeploymentStep.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Items/AllTemplatesDeploymentStep.Edit.cshtml
@@ -1,3 +1,0 @@
-@model dynamic
-
-<h5>@T["All Templates"]</h5>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Items/AllTemplatesDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Items/AllTemplatesDeploymentStep.Fields.Edit.cshtml
@@ -1,0 +1,11 @@
+@model AllTemplatesDeploymentStepViewModel
+
+<h5>@T["All Templates"]</h5>
+
+<div class="form-group">
+    <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" asp-for="ExportAsFiles" />
+        <label class="custom-control-label" asp-for="ExportAsFiles">@T["Export templates as files"]</label>
+        <span class="hint">@T["Check if the templates should be exported as files instead of inline."]</span>
+    </div>
+</div>


### PR DESCRIPTION
Adds a checkbox for the AllTemplates and AllAdminTemplates deployment steps that output the templates as files instead of inline in the Recipe.json file.