### PR TITLE
Check implied permissions

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
@@ -268,16 +268,19 @@ namespace OrchardCore.Roles.Controllers
         {
             // Create a fake user to check the actual permissions. If the role is anonymous
             // IsAuthenticated needs to be false.
-            var fakeUser = new ClaimsPrincipal(
-                new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, role.RoleName) },
-                role.RoleName != "Anonymous" ? "FakeAuthenticationType" : null)
-            );
+            var fakeIdentity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, role.RoleName) },
+                role.RoleName != "Anonymous" ? "FakeAuthenticationType" : null);
+
+            // Add role claims
+            fakeIdentity.AddClaims(role.RoleClaims.Select(c => c.ToClaim()));
+
+            var fakePrincipal = new ClaimsPrincipal(fakeIdentity);
 
             var result = new List<string>();
 
             foreach (var permission in allPermissions)
             {
-                if (await _authorizationService.AuthorizeAsync(fakeUser, permission))
+                if (await _authorizationService.AuthorizeAsync(fakePrincipal, permission))
                 {
                     result.Add(permission.Name);
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RolesPermissionsHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RolesPermissionsHandler.cs
@@ -9,17 +9,22 @@ using OrchardCore.Security;
 namespace OrchardCore.Roles
 {
     /// <summary>
-    /// This authorization handler ensures that implied permissions are checked.
+    /// This authorization handler ensures that Anonymous and Authenticated permissions are checked.
     /// </summary>
     public class RolesPermissionsHandler : AuthorizationHandler<PermissionRequirement>
     {
         private readonly RoleManager<IRole> _roleManager;
+        private readonly IPermissionGrantingService _permissionGrantingService;
+
 
         private IEnumerable<RoleClaim> _anonymousClaims = null, _authenticatedClaims = null;
 
-        public RolesPermissionsHandler(RoleManager<IRole> roleManager)
+        public RolesPermissionsHandler(
+            RoleManager<IRole> roleManager,
+            IPermissionGrantingService permissionGrantingService)
         {
             _roleManager = roleManager;
+            _permissionGrantingService = permissionGrantingService;
         }
 
         protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
@@ -44,7 +49,7 @@ namespace OrchardCore.Roles
                 }
             }
 
-            if (requirement.Permission.IsGranted(claims))
+            if (_permissionGrantingService.IsGranted(requirement, claims))
             {
                 context.Succeed(requirement);
                 return;

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/IPermissionGrantingService.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/IPermissionGrantingService.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace OrchardCore.Security
+{
+    public interface IPermissionGrantingService
+    {
+        /// <summary>
+        /// Evaluates if the specified <see cref="PermissionRequirement"/> is granted by provided claims.
+        /// </summary>
+        /// <param name="requirement">The <see cref="PermissionRequirement"/> to challenge</param>
+        /// <param name="claims">Provided claims.</param>
+        /// <returns>True if the permission is granted, otherwise false.</returns>
+        public bool IsGranted(PermissionRequirement requirement, IEnumerable<Claim> claims);
+    }
+}

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/PermissionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/PermissionExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using OrchardCore.Security.Permissions;
+
+namespace OrchardCore.Security
+{
+    public static class PermissionExtensions
+    {
+        /// <summary>
+        /// Evaluates if the specified <see cref="Permission"/> is granted by provided claims.
+        /// </summary>
+        /// <param name="permission">The <see cref="Permission"/> to test</param>
+        /// <param name="claims">Provided claims.</param>
+        /// <returns>True if the permission is granted, otherwise false.</returns>
+        public static bool IsGranted(this Permission permission, IEnumerable<Claim> claims)
+        {
+            if (claims == null || !claims.Any())
+            {
+                return false;
+            }
+
+            var grantingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            GetGrantingNamesInternal(permission, grantingNames);
+
+            // SiteOwner permission grants them all
+            grantingNames.Add(StandardPermissions.SiteOwner.Name);
+
+            return claims.Any(claim => String.Equals(claim.Type, Permission.ClaimType, StringComparison.OrdinalIgnoreCase)
+                && grantingNames.Contains(claim.Value));
+        }
+
+        private static void GetGrantingNamesInternal(this Permission permission, HashSet<string> stack)
+        {
+            // The given name is tested
+            stack.Add(permission.Name);
+
+            // Iterate implied permissions to grant, it present
+            if (permission.ImpliedBy != null && permission.ImpliedBy.Any())
+            {
+                foreach (var impliedBy in permission.ImpliedBy)
+                {
+                    // Avoid potential recursion
+                    if (stack.Contains(impliedBy.Name))
+                    {
+                        continue;
+                    }
+
+                    // Otherwise accumulate the implied permission names recursively
+                    GetGrantingNamesInternal(impliedBy, stack);
+                }
+            }
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/RoleClaim.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Security/RoleClaim.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Claims;
+using System.Security.Claims;
 
 namespace OrchardCore.Security
 {
@@ -20,6 +20,11 @@ namespace OrchardCore.Security
         public Claim ToClaim()
         {
             return new Claim(ClaimType, ClaimValue);
+        }
+
+        public static implicit operator Claim(RoleClaim claim)
+        {
+            return claim.ToClaim();
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Security/AuthorizationHandlers/PermissionHandler.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Security/AuthorizationHandlers/PermissionHandler.cs
@@ -8,13 +8,20 @@ namespace OrchardCore.Security.AuthorizationHandlers
     /// </summary>
     public class PermissionHandler : AuthorizationHandler<PermissionRequirement>
     {
+        private readonly IPermissionGrantingService _permissionGrantingService;
+
+        public PermissionHandler(IPermissionGrantingService permissionGrantingService)
+        {
+            _permissionGrantingService = permissionGrantingService;
+        }
+
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
         {
             if (context.HasSucceeded || !(context?.User?.Identity?.IsAuthenticated ?? false))
             {
                 return Task.CompletedTask;
             }
-            else if (requirement.Permission.IsGranted(context.User.Claims))
+            else if (_permissionGrantingService.IsGranted(requirement, context.User.Claims))
             {
                 context.Succeed(requirement);
             }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Security/AuthorizationHandlers/PermissionHandler.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Security/AuthorizationHandlers/PermissionHandler.cs
@@ -1,6 +1,5 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
-using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Security.AuthorizationHandlers
 {
@@ -11,11 +10,11 @@ namespace OrchardCore.Security.AuthorizationHandlers
     {
         protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
         {
-            if (!(context?.User?.Identity?.IsAuthenticated ?? false))
+            if (context.HasSucceeded || !(context?.User?.Identity?.IsAuthenticated ?? false))
             {
                 return Task.CompletedTask;
             }
-            else if (context.User.HasClaim(Permission.ClaimType, requirement.Permission.Name))
+            else if (requirement.Permission.IsGranted(context.User.Claims))
             {
                 context.Succeed(requirement);
             }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Security/DefaultPermissionGrantingService.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Security/DefaultPermissionGrantingService.cs
@@ -6,15 +6,13 @@ using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Security
 {
-    public static class PermissionExtensions
+    /// <summary>
+    /// Default implementation if <see cref="IPermissionGrantingService"/>.
+    /// It is responsible for checking implied permissions.
+    /// </summary>
+    public class DefaultPermissionGrantingService : IPermissionGrantingService
     {
-        /// <summary>
-        /// Evaluates if the specified <see cref="Permission"/> is granted by provided claims.
-        /// </summary>
-        /// <param name="permission">The <see cref="Permission"/> to test</param>
-        /// <param name="claims">Provided claims.</param>
-        /// <returns>True if the permission is granted, otherwise false.</returns>
-        public static bool IsGranted(this Permission permission, IEnumerable<Claim> claims)
+        public bool IsGranted(PermissionRequirement requirement, IEnumerable<Claim> claims)
         {
             if (claims == null || !claims.Any())
             {
@@ -23,7 +21,7 @@ namespace OrchardCore.Security
 
             var grantingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-            GetGrantingNamesInternal(permission, grantingNames);
+            GetGrantingNamesInternal(requirement.Permission, grantingNames);
 
             // SiteOwner permission grants them all
             grantingNames.Add(StandardPermissions.SiteOwner.Name);
@@ -32,7 +30,7 @@ namespace OrchardCore.Security
                 && grantingNames.Contains(claim.Value));
         }
 
-        private static void GetGrantingNamesInternal(this Permission permission, HashSet<string> stack)
+        private void GetGrantingNamesInternal(Permission permission, HashSet<string> stack)
         {
             // The given name is tested
             stack.Add(permission.Name);

--- a/src/OrchardCore/OrchardCore.Infrastructure/Security/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Security/OrchardCoreBuilderExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
                 });
 
+                services.AddScoped<IPermissionGrantingService, DefaultPermissionGrantingService>();
                 services.AddScoped<IAuthorizationHandler, PermissionHandler>();
             });
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Roles/RolesMockHelper.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Roles/RolesMockHelper.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Moq;
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Roles/RolesMockHelper.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Roles/RolesMockHelper.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Roles
+{
+    public static class RolesMockHelper
+    {
+        public static Mock<RoleManager<TRole>> MockRoleManager<TRole>()
+            where TRole : class
+        {
+            var store = new Mock<IRoleStore<TRole>>().Object;
+            var validators = new List<IRoleValidator<TRole>>();
+            validators.Add(new RoleValidator<TRole>());
+
+            return new Mock<RoleManager<TRole>>(store, validators, new UpperInvariantLookupNormalizer(), new IdentityErrorDescriber(), null);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Roles/RolesPermissionsHandlerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Roles/RolesPermissionsHandlerTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using OrchardCore.Roles;
+using OrchardCore.Security;
+using OrchardCore.Security.Permissions;
+using OrchardCore.Tests.Security;
+using Xunit;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Roles
+{
+    public class RolesPermissionsHandlerTests
+    {
+        [Theory]
+        [InlineData("AllowAnonymous", true, true)]
+        [InlineData("AllowAnonymous", false, true)]
+        [InlineData("AllowAuthenticated", true, true)]
+        [InlineData("AllowAuthenticated", false, false)]
+        public async Task GrantsRolesPermissions(string required, bool authenticated, bool success)
+        {
+            // Arrange
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission(required), authenticated: authenticated);
+            var roleManager = RolesMockHelper.MockRoleManager<IRole>();
+
+            var anonymousRole = new Role
+            {
+                RoleName = "Anonymous",
+                RoleClaims = new List<RoleClaim> {
+                    new RoleClaim { ClaimType = Permission.ClaimType, ClaimValue = "AllowAnonymous" }
+                }
+            };
+            roleManager.Setup(m => m.FindByNameAsync(anonymousRole.RoleName)).ReturnsAsync(anonymousRole);
+
+            var authenticatedRole = new Role
+            {
+                RoleName = "Authenticated",
+                RoleClaims = new List<RoleClaim> {
+                    new RoleClaim { ClaimType = Permission.ClaimType, ClaimValue = "AllowAuthenticated" }
+                }
+            };
+            roleManager.Setup(m => m.FindByNameAsync(authenticatedRole.RoleName)).ReturnsAsync(authenticatedRole);
+
+            var permissionHandler = new RolesPermissionsHandler(roleManager.Object);
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.Equal(success, context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task DontRevokeExistingGrants()
+        {
+            // Arrange
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission("Required"), new[] { "Other" }, true);
+            var roleManager = RolesMockHelper.MockRoleManager<IRole>();
+            var permissionHandler = new RolesPermissionsHandler(roleManager.Object);
+
+            await context.SuccessAsync("Required");
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task GrantsInheritedPermissions()
+        {
+            // Arrange
+            var level2 = new Permission("Implicit2");
+            var level1 = new Permission("Implicit1", "Foo", new[] { level2 });
+            var required = new Permission("Required", "Foo", new[] { level1 });
+
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(required);
+            var roleManager = RolesMockHelper.MockRoleManager<IRole>();
+
+            var anonymousRole = new Role
+            {
+                RoleName = "Anonymous",
+                RoleClaims = new List<RoleClaim> {
+                    new RoleClaim { ClaimType = Permission.ClaimType, ClaimValue = "Implicit2" }
+                }
+            };
+            roleManager.Setup(m => m.FindByNameAsync(anonymousRole.RoleName)).ReturnsAsync(anonymousRole);
+
+            var permissionHandler = new RolesPermissionsHandler(roleManager.Object);
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Theory]
+        [InlineData("AllowAnonymous", true)]
+        [InlineData("AllowAuthenticated", true)]
+        public async Task IsCaseIsensitive(string required, bool authenticated)
+        {
+            // Arrange
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission(required), authenticated: authenticated);
+            var roleManager = RolesMockHelper.MockRoleManager<IRole>();
+
+            var anonymousRole = new Role
+            {
+                RoleName = "Anonymous",
+                RoleClaims = new List<RoleClaim> {
+                    new RoleClaim { ClaimType = Permission.ClaimType, ClaimValue = "aLlOwAnOnYmOuS" }
+                }
+            };
+            roleManager.Setup(m => m.FindByNameAsync(anonymousRole.RoleName)).ReturnsAsync(anonymousRole);
+
+            var authenticatedRole = new Role
+            {
+                RoleName = "Authenticated",
+                RoleClaims = new List<RoleClaim> {
+                    new RoleClaim { ClaimType = Permission.ClaimType, ClaimValue = "aLlOwAuThEnTiCaTeD" }
+                }
+            };
+            roleManager.Setup(m => m.FindByNameAsync(authenticatedRole.RoleName)).ReturnsAsync(authenticatedRole);
+
+            var permissionHandler = new RolesPermissionsHandler(roleManager.Object);
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Security/PermissionHandlerHelper.cs
+++ b/test/OrchardCore.Tests/Security/PermissionHandlerHelper.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using OrchardCore.Security;
+using OrchardCore.Security.Permissions;
+
+namespace OrchardCore.Tests.Security
+{
+    public static class PermissionHandlerHelper
+    {
+        public static AuthorizationHandlerContext CreateTestAuthorizationHandlerContext(Permission required, string[] allowed = null, bool authenticated = false)
+        {
+            var identity = authenticated ? new ClaimsIdentity("Test") : new ClaimsIdentity();
+
+            if (allowed != null)
+            {
+                foreach (var permissionName in allowed)
+                {
+                    var permission = new Permission(permissionName);
+                    identity.AddClaim(permission);
+                }
+
+            }
+
+            var principal = new ClaimsPrincipal(identity);
+
+            return new AuthorizationHandlerContext(
+                new[] { new PermissionRequirement(required) },
+                principal,
+                null);
+        }
+
+        public static async Task SuccessAsync(this AuthorizationHandlerContext context, params string[] permissionNames)
+        {
+            var handler = new FakePermissionHandler(permissionNames);
+            await handler.HandleAsync(context);
+        }
+
+        private class FakePermissionHandler : AuthorizationHandler<PermissionRequirement>
+        {
+            private readonly HashSet<string> _permissionNames;
+
+            public FakePermissionHandler(string[] permissionNames)
+            {
+                _permissionNames = new HashSet<string>(permissionNames, StringComparer.OrdinalIgnoreCase);
+            }
+
+            protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
+            {
+                if (_permissionNames.Contains(requirement.Permission.Name))
+                {
+                    context.Succeed(requirement);
+                }
+
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Security/PermissionHandlerTests.cs
+++ b/test/OrchardCore.Tests/Security/PermissionHandlerTests.cs
@@ -73,7 +73,7 @@ namespace OrchardCore.Tests.Security
         }
 
         [Fact]
-        public async Task IsCaseIsensitive()
+        public async Task IsCaseInsensitive()
         {
             // Arrange
             var required = new Permission("required");

--- a/test/OrchardCore.Tests/Security/PermissionHandlerTests.cs
+++ b/test/OrchardCore.Tests/Security/PermissionHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using OrchardCore.Security;
 using OrchardCore.Security.AuthorizationHandlers;
 using OrchardCore.Security.Permissions;
 using Xunit;
@@ -14,7 +15,7 @@ namespace OrchardCore.Tests.Security
         {
             // Arrange
             var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission(required), new[] { "Allowed" }, true);
-            var permissionHandler = new PermissionHandler();
+            var permissionHandler = CreatePermissionHandler();
 
             // Act
             await permissionHandler.HandleAsync(context);
@@ -28,7 +29,7 @@ namespace OrchardCore.Tests.Security
         {
             // Arrange
             var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission("Required"), new[] { "Other" }, true);
-            var permissionHandler = new PermissionHandler();
+            var permissionHandler = CreatePermissionHandler();
 
             await context.SuccessAsync("Required");
 
@@ -44,7 +45,7 @@ namespace OrchardCore.Tests.Security
         {
             // Arrange
             var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission("Allowed"), new[] { "Allowed" });
-            var permissionHandler = new PermissionHandler();
+            var permissionHandler = CreatePermissionHandler();
 
             // Act
             await permissionHandler.HandleAsync(context);
@@ -62,7 +63,7 @@ namespace OrchardCore.Tests.Security
             var required = new Permission("Required", "Foo", new[] { level1 });
 
             var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(required, new[] { "Implicit2" }, true);
-            var permissionHandler = new PermissionHandler();
+            var permissionHandler = CreatePermissionHandler();
 
             // Act
             await permissionHandler.HandleAsync(context);
@@ -78,13 +79,19 @@ namespace OrchardCore.Tests.Security
             var required = new Permission("required");
 
             var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(required, new[] { "ReQuIrEd" }, true);
-            var permissionHandler = new PermissionHandler();
+            var permissionHandler = CreatePermissionHandler();
 
             // Act
             await permissionHandler.HandleAsync(context);
 
             // Assert
             Assert.True(context.HasSucceeded);
+        }
+
+        private static PermissionHandler CreatePermissionHandler()
+        {
+            var permissionGrantingService = new DefaultPermissionGrantingService();
+            return new PermissionHandler(permissionGrantingService);
         }
     }
 }

--- a/test/OrchardCore.Tests/Security/PermissionHandlerTests.cs
+++ b/test/OrchardCore.Tests/Security/PermissionHandlerTests.cs
@@ -1,0 +1,90 @@
+using System.Threading.Tasks;
+using OrchardCore.Security.AuthorizationHandlers;
+using OrchardCore.Security.Permissions;
+using Xunit;
+
+namespace OrchardCore.Tests.Security
+{
+    public class PermissionHandlerTests
+    {
+        [Theory]
+        [InlineData("Allowed", true)]
+        [InlineData("NotAllowed", false)]
+        public async Task GrantsClaimsPermissions(string required, bool success)
+        {
+            // Arrange
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission(required), new[] { "Allowed" }, true);
+            var permissionHandler = new PermissionHandler();
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.Equal(success, context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task DontRevokeExistingGrants()
+        {
+            // Arrange
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission("Required"), new[] { "Other" }, true);
+            var permissionHandler = new PermissionHandler();
+
+            await context.SuccessAsync("Required");
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task DontHandleNonAuthenticated()
+        {
+            // Arrange
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(new Permission("Allowed"), new[] { "Allowed" });
+            var permissionHandler = new PermissionHandler();
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.False(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task GrantsInheritedPermissions()
+        {
+            // Arrange
+            var level2 = new Permission("Implicit2");
+            var level1 = new Permission("Implicit1", "Foo", new[] { level2 });
+            var required = new Permission("Required", "Foo", new[] { level1 });
+
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(required, new[] { "Implicit2" }, true);
+            var permissionHandler = new PermissionHandler();
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+        }
+
+        [Fact]
+        public async Task IsCaseIsensitive()
+        {
+            // Arrange
+            var required = new Permission("required");
+
+            var context = PermissionHandlerHelper.CreateTestAuthorizationHandlerContext(required, new[] { "ReQuIrEd" }, true);
+            var permissionHandler = new PermissionHandler();
+
+            // Act
+            await permissionHandler.HandleAsync(context);
+
+            // Assert
+            Assert.True(context.HasSucceeded);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #9362

`PermissionHandler` should check ImpliedBy permissions.
`RolesPermissionsHandler` don't have to check all user roles permissions, just "Anonymous" and "Authenticated" if applicable.
`RolesPermissionsHandler` is scoped, so I assume we can cache "Anonymous" and "Authenticated" permissions and not query them for each permission evaluation.