### PR TITLE
Do not throw if input is blank for display_url

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.Contents.Liquid
                 routeValues = new RouteValueDictionary(_autorouteOptions.GlobalRouteValues);
                 if (string.IsNullOrEmpty(input.ToStringValue()))
                 {
-                    throw new ArgumentException("content_item_id is empty while invoking 'display_url'");
+                    return StringValue.Empty;
                 }
                 routeValues[_autorouteOptions.ContentItemIdKey] = input.ToStringValue();
             }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
@@ -32,11 +32,11 @@ namespace OrchardCore.Contents.Liquid
 
             if (contentItem == null)
             {
-                routeValues = new RouteValueDictionary(_autorouteOptions.GlobalRouteValues);
                 if (string.IsNullOrEmpty(input.ToStringValue()))
                 {
                     return StringValue.Empty;
                 }
+                routeValues = new RouteValueDictionary(_autorouteOptions.GlobalRouteValues);
                 routeValues[_autorouteOptions.ContentItemIdKey] = input.ToStringValue();
             }
             else


### PR DESCRIPTION
Simply return a blank string instead of throwing an exception for the `display_url` filter.