### PR TITLE
Shortcodes docs and rename razor helper

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Razor/OrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Razor/OrchardRazorHelperExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,12 +11,12 @@ using Shortcodes;
 public static class OrchardRazorHelperExtensions
 {
     /// <summary>
-    /// Applies shortcodes to html.
+    /// Processes shortcodes contained inside html.
     /// </summary>
     /// <param name="orchardHelper">The <see cref="IOrchardHelper"/></param>
-    /// <param name="html">The html to apply shortcodes.</param>
+    /// <param name="html">The html string contained shortcodes.</param>
     /// <param name="model">The ambient shape view model.</param>
-    public static async Task<IHtmlContent> HtmlToShortcodesAsync(this IOrchardHelper orchardHelper, string html, object model = null)
+    public static async Task<IHtmlContent> ShortcodesToHtmlAsync(this IOrchardHelper orchardHelper, string html, object model = null)
     {
         var shortcodeService = orchardHelper.HttpContext.RequestServices.GetRequiredService<IShortcodeService>();
 
@@ -35,4 +36,8 @@ public static class OrchardRazorHelperExtensions
 
         return new HtmlString(html);
     }
+
+    [Obsolete("Replaced by ShortcodesToHtmlAsync")]
+    public static Task<IHtmlContent> HtmlToShortcodesAsync(this IOrchardHelper orchardHelper, string html, object model = null)
+        => orchardHelper.ShortcodesToHtmlAsync(html, model);
 }

--- a/src/docs/reference/core/Razor/README.md
+++ b/src/docs/reference/core/Razor/README.md
@@ -34,6 +34,7 @@ Many extensions methods are available in Razor with `@Orchard`.
 | `ContentQueryAsync(string queryName, IDictionary<string, object> parameters)` | [OrchardCore.Queries](../../modules/Queries/README.md#razor-helpers) | Returns a List of Content items |
 | `QueryAsync(string liquid, object model)` | [OrchardCore.Queries](../../modules/Queries/README.md#razor-helpers) | Returns a List of objects |
 | `QueryAsync(string queryName, IDictionary<string, object> parameters)` | [OrchardCore.Queries](../../modules/Queries/README.md#razor-helpers) | Returns a List of objects |
+| `ShortcodesToHtmlAsync(string html, object model = null)` | [OrchardCore.Shortcodes](../../modules/Shortcodes/README.md#rendering-shortcodes) | Renders shortcodes. |
 | `GetTaxonomyTermAsync(string taxonomyContentItemId, string termContentItemId)` | [OrchardCore.Taxonomies](../../modules/Taxonomies/README.md#orchard-helpers) | Returns a the term from its content item id and taxonomy. |
 | `GetInheritedTermsAsync(string taxonomyContentItemId, string termContentItemId)` | [OrchardCore.Taxonomies](../../modules/Taxonomies/README.md#orchard-helpers) | Returns the list of terms including their parents. |
 | `QueryCategorizedContentItemsAsync(string taxonomy(Func<IQuery<ContentItem, TaxonomyIndex>, IQuery<ContentItem>> query)` | [OrchardCore.Taxonomies](../../modules/Taxonomies/README.md#orchard-helpers) | Query content items. |

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -186,6 +186,14 @@ Sanitizes some HTML content.
 {{ output | sanitize_html | raw }}
 ```
 
+### `shortcode`
+
+Renders Shortcodes. Should be combined with the `raw` filter.
+
+```liquid
+{{ Model.ContentItem.Content.RawHtml.Content.Html | shortcode | raw }}
+```
+
 ## Json Filters
 
 ### `json`

--- a/src/docs/reference/modules/Shortcodes/README.md
+++ b/src/docs/reference/modules/Shortcodes/README.md
@@ -142,6 +142,40 @@ For example, if the current locale is `en-CA` and you specified this shortcode: 
 You can disable this behavior by passing `false` as the second argument of the shortcode. 
 `[locale en false]English Text[/locale]` would render nothing if the current culture is not exactly `en`.
 
+## Rendering Shortcodes
+
+Shortcodes are automatically rendered when using a `Shape` produced by a display driver that supports Shortcodes.
+
+- `HtmlBodyPart`
+- `HtmlField`
+- `MarkdownBodyPart`
+- `MarkdownField`
+
+=== "Liquid"
+
+    ``` liquid
+    {{ Model.Content.HtmlBodyPart | shape_render }}
+    ```
+
+=== "Razor"
+
+    ``` html
+    @await DisplayAsync(Model.Content.HtmlBodyPart)
+    ```
+
+Shortcodes can also be rendered via a liquid filter or html helper
+
+=== "Liquid"
+
+    ``` liquid
+    {{ Model.ContentItem.Content.RawHtml.Content.Html | shortcode | raw }}
+    ```
+
+=== "Razor"
+
+    ``` html
+    @Html.Raw(@await Orchard.ShortcodesToHtmlAsync((string)Model.ContentItem.Content.RawHtml.Content.Html))
+    ```
 
 ## Video
 


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/9297

Also renames the razor helper to a more sensible name `ShortcodesToHtmlAsync` 

(obsolets the old one)