### PR TITLE
Redis InstancePrefix allowing to share a Redis instance

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -49,7 +49,8 @@
     //},
     // See https://stackexchange.github.io/StackExchange.Redis/Configuration.html
     //"OrchardCore_Redis": {
-    //  "Configuration": "192.168.99.100:6379,allowAdmin=true" // Redis Configuration string.
+    //  "Configuration": "192.168.99.100:6379,allowAdmin=true", // Redis Configuration string.
+    //  "InstancePrefix": "" // Optional prefix allowing unrelated tenants to share a Redis instance.
     //},
     // See https://docs.orchardcore.net/en/latest/docs/reference/core/Shells/#enable-azure-shells-configuration to configure shell and tenant configuration in Azure Blob Storage.
     // Add a reference to the OrchardCore.Shells.Azure NuGet package.

--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -50,7 +50,7 @@
     // See https://stackexchange.github.io/StackExchange.Redis/Configuration.html
     //"OrchardCore_Redis": {
     //  "Configuration": "192.168.99.100:6379,allowAdmin=true", // Redis Configuration string.
-    //  "InstancePrefix": "" // Optional prefix allowing unrelated tenants to share a Redis instance.
+    //  "InstancePrefix": "" // Optional prefix allowing a Redis instance to be shared.
     //},
     // See https://docs.orchardcore.net/en/latest/docs/reference/core/Shells/#enable-azure-shells-configuration to configure shell and tenant configuration in Azure Blob Storage.
     // Add a reference to the OrchardCore.Shells.Azure NuGet package.

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Options/RedisCacheOptionsSetup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Options/RedisCacheOptionsSetup.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Redis.Options
 
         public void Configure(RedisCacheOptions options)
         {
-            options.InstanceName = _tenant;
+            options.InstanceName = _redisOptions.Value.InstancePrefix + _tenant;
             options.ConfigurationOptions = _redisOptions.Value.ConfigurationOptions;
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Options/RedisKeyManagementOptionsSetup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Options/RedisKeyManagementOptionsSetup.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.Redis.Options
 
                 return redis.Database;
             }
-            , _tenant + ":DataProtection-Keys");
+            , redis.InstancePrefix + _tenant + ":DataProtection-Keys");
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisBus.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisBus.cs
@@ -21,7 +21,7 @@ namespace OrchardCore.Redis.Services
         {
             _redis = redis;
             _hostName = Dns.GetHostName() + ':' + Process.GetCurrentProcess().Id;
-            _channelPrefix = shellSettings.Name + ':';
+            _channelPrefix = redis.InstancePrefix + shellSettings.Name + ':';
             _messagePrefix = _hostName + '/';
             _logger = logger;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisLock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisLock.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Redis.Services
         {
             _redis = redis;
             _hostName = Dns.GetHostName() + ':' + Process.GetCurrentProcess().Id;
-            _prefix = shellSettings.Name + ':';
+            _prefix = redis.InstancePrefix + shellSettings.Name + ':';
             _logger = logger;
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisLock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisLock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +25,7 @@ namespace OrchardCore.Redis.Services
         public RedisLock(IRedisService redis, ShellSettings shellSettings, ILogger<RedisLock> logger)
         {
             _redis = redis;
-            _hostName = Dns.GetHostName() + ':' + System.Environment.ProcessId;
+            _hostName = Dns.GetHostName() + ':' + Process.GetCurrentProcess().Id;
             _prefix = redis.InstancePrefix + shellSettings.Name + ':';
             _logger = logger;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisLock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisLock.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +24,7 @@ namespace OrchardCore.Redis.Services
         public RedisLock(IRedisService redis, ShellSettings shellSettings, ILogger<RedisLock> logger)
         {
             _redis = redis;
-            _hostName = Dns.GetHostName() + ':' + Process.GetCurrentProcess().Id;
+            _hostName = Dns.GetHostName() + ':' + System.Environment.ProcessId;
             _prefix = redis.InstancePrefix + shellSettings.Name + ':';
             _logger = logger;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisService.cs
@@ -18,10 +18,12 @@ namespace OrchardCore.Redis.Services
         public RedisService(IOptions<RedisOptions> options, ILogger<RedisService> logger)
         {
             _options = options;
+            InstancePrefix = options.Value.InstancePrefix;
             _logger = logger;
         }
 
         public IConnectionMultiplexer Connection { get; private set; }
+        public string InstancePrefix { get; private set; }
         public IDatabase Database { get; private set; }
 
         public override Task ActivatingAsync() => ConnectAsync();

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisService.cs
@@ -18,8 +18,9 @@ namespace OrchardCore.Redis.Services
         public RedisService(IOptions<RedisOptions> options, ILogger<RedisService> logger)
         {
             _options = options;
-            InstancePrefix = options.Value.InstancePrefix;
             _logger = logger;
+
+            InstancePrefix = options.Value.InstancePrefix;
         }
 
         public IConnectionMultiplexer Connection { get; private set; }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisTagCache.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisTagCache.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.Redis.Services
             ILogger<RedisTagCache> logger)
         {
             _redis = redis;
-            _prefix = shellSettings.Name + ":Tag:";
+            _prefix = redis.InstancePrefix + shellSettings.Name + ":Tag:";
             _tagRemovedEventHandlers = tagRemovedEventHandlers;
             _logger = logger;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Startup.cs
@@ -35,7 +35,13 @@ namespace OrchardCore.Redis
             try
             {
                 var configurationOptions = ConfigurationOptions.Parse(_configuration["OrchardCore_Redis:Configuration"]);
-                services.Configure<RedisOptions>(options => options.ConfigurationOptions = configurationOptions);
+                var instancePrefix = _configuration["OrchardCore_Redis:InstancePrefix"];
+
+                services.Configure<RedisOptions>(options =>
+                {
+                    options.ConfigurationOptions = configurationOptions;
+                    options.InstancePrefix = instancePrefix;
+                });
             }
             catch (Exception e)
             {

--- a/src/OrchardCore/OrchardCore.Redis.Abstractions/IRedisService.cs
+++ b/src/OrchardCore/OrchardCore.Redis.Abstractions/IRedisService.cs
@@ -8,6 +8,7 @@ namespace OrchardCore.Redis
     {
         Task ConnectAsync();
         IConnectionMultiplexer Connection { get; }
+        string InstancePrefix { get; }
         IDatabase Database { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Redis.Abstractions/RedisOptions.cs
+++ b/src/OrchardCore/OrchardCore.Redis.Abstractions/RedisOptions.cs
@@ -11,5 +11,10 @@ namespace OrchardCore.Redis
         /// The configuration used to connect to Redis.
         /// </summary>
         public ConfigurationOptions ConfigurationOptions { get; set; }
+
+        /// <summary>
+        /// Prefix alowing unrelated tenants to share a Redis instance.
+        /// </summary>
+        public string InstancePrefix { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Redis.Abstractions/RedisOptions.cs
+++ b/src/OrchardCore/OrchardCore.Redis.Abstractions/RedisOptions.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Redis
         public ConfigurationOptions ConfigurationOptions { get; set; }
 
         /// <summary>
-        /// Prefix alowing unrelated tenants to share a Redis instance.
+        /// Prefix alowing a Redis instance to be shared.
         /// </summary>
         public string InstancePrefix { get; set; }
     }


### PR DESCRIPTION
Related to the #9497 PR

We already use prefixes to differentiate tenants, here the `InstancePrefix` allows a Redis instance to be shared by unrelated OC instances, e.g. not sharing the same database.