### PR TITLE
Allow for external validation of email address

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ControllerExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ControllerExtensions.cs
@@ -73,7 +73,7 @@ namespace OrchardCore.Users.Controllers
 
                     if (user != null && controller.ModelState.IsValid)
                     {
-                        if (settings.UsersMustValidateEmail)
+                        if (settings.UsersMustValidateEmail && !user.EmailConfirmed)
                         {
                             // For more information on how to enable account confirmation and password reset please visit http://go.microsoft.com/fwlink/?LinkID=532713
                             // Send an email with this link


### PR DESCRIPTION
After registration, if email validation is required, also check if user's email has already been confirmed.  This allows for external validation of email address during registration events.

Use Case: We are sending out an invitation link which includes a token which allows the validation of email address at registration time.  However currently despite being able to set EmailConfirmed to true during registration the validation email is still sent and the user not signed in.