### PR TITLE
Remove users default interface implementation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Handlers/UserEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Handlers/UserEventHandler.cs
@@ -6,7 +6,7 @@ using OrchardCore.Workflows.Services;
 
 namespace OrchardCore.Users.Workflows.Handlers
 {
-    public class UserEventHandler : IUserEventHandler
+    public class UserEventHandler : UserEventHandlerBase
     {
         private readonly IWorkflowManager _workflowManager;
 
@@ -15,27 +15,27 @@ namespace OrchardCore.Users.Workflows.Handlers
             _workflowManager = workflowManager;
         }
 
-        public Task CreatedAsync(UserContext context)
+        public override Task CreatedAsync(UserCreateContext context)
         {
             return TriggerWorkflowEventAsync(nameof(UserCreatedEvent), (User)context.User);
         }
 
-        public Task DeletedAsync(UserContext context)
+        public override Task DeletedAsync(UserDeleteContext context)
         {
             return TriggerWorkflowEventAsync(nameof(UserDeletedEvent), (User)context.User);
         }
 
-        public Task DisabledAsync(UserContext context)
+        public override Task DisabledAsync(UserContext context)
         {
             return TriggerWorkflowEventAsync(nameof(UserDisabledEvent), (User)context.User);
         }
 
-        public Task EnabledAsync(UserContext context)
+        public override Task EnabledAsync(UserContext context)
         {
             return TriggerWorkflowEventAsync(nameof(UserEnabledEvent), (User)context.User);
         }
 
-        public Task UpdatedAsync(UserContext context)
+        public override Task UpdatedAsync(UserUpdateContext context)
         {
             return TriggerWorkflowEventAsync(nameof(UserUpdatedEvent), (User)context.User);
         }

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/Handlers/IUserEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/Handlers/IUserEventHandler.cs
@@ -11,48 +11,48 @@ namespace OrchardCore.Users.Handlers
         /// Occurs before a user is created.
         /// </summary>
         /// <param name="context">The <see cref="UserCreateContext"/>.</param>
-        Task CreatingAsync(UserCreateContext context) => Task.CompletedTask;
+        Task CreatingAsync(UserCreateContext context);
 
         /// <summary>
         /// Occurs when a user is created.
         /// </summary>
         /// <param name="context">The <see cref="UserCreateContext"/>.</param>
-        Task CreatedAsync(UserCreateContext context) => Task.CompletedTask;
+        Task CreatedAsync(UserCreateContext context);
 
         /// <summary>
         /// Occurs before a user is deleted.
         /// </summary>
         /// <param name="context">The <see cref="UserDeleteContext"/>.</param>
-        Task DeletingAsync(UserDeleteContext context) => Task.CompletedTask;
+        Task DeletingAsync(UserDeleteContext context);
 
         /// <summary>
         /// Occurs when a user is deleted.
         /// </summary>
         /// <param name="context">The <see cref="UserDeleteContext"/>.</param>
-        Task DeletedAsync(UserDeleteContext context) => Task.CompletedTask;
+        Task DeletedAsync(UserDeleteContext context);
 
         /// <summary>
         /// Occurs before a user is updated.
         /// </summary>
         /// <param name="context">The <see cref="UserUpdateContext"/>.</param>
-        Task UpdatingAsync(UserUpdateContext context) => Task.CompletedTask;
+        Task UpdatingAsync(UserUpdateContext context);
 
         /// <summary>
         /// Occurs when a user is updated.
         /// </summary>
         /// <param name="context">The <see cref="UserUpdateContext"/>.</param>
-        Task UpdatedAsync(UserUpdateContext context) => Task.CompletedTask;
+        Task UpdatedAsync(UserUpdateContext context);
 
         /// <summary>
         /// Occurs when a user is disabled.
         /// </summary>
         /// <param name="context">The <see cref="UserContext"/>.</param>
-        Task DisabledAsync(UserContext context) => Task.CompletedTask;
+        Task DisabledAsync(UserContext context);
 
         /// <summary>
         /// Occurs when a user is enabled.
         /// </summary>
         /// <param name="context">The <see cref="UserContext"/>.</param>
-        Task EnabledAsync(UserContext context) => Task.CompletedTask;
+        Task EnabledAsync(UserContext context);
     }
 }

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/Handlers/UserEventHandlerBase.cs
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/Handlers/UserEventHandlerBase.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+
+namespace OrchardCore.Users.Handlers
+{
+    public abstract class UserEventHandlerBase : IUserEventHandler
+    {
+        /// <inheritdocs />
+        public virtual Task CreatingAsync(UserCreateContext context) => Task.CompletedTask;
+
+        /// <inheritdocs />
+        public virtual Task CreatedAsync(UserCreateContext context) => Task.CompletedTask;
+
+        /// <inheritdocs />
+        public virtual Task DeletingAsync(UserDeleteContext context) => Task.CompletedTask;
+
+        /// <inheritdocs />
+        public virtual Task DeletedAsync(UserDeleteContext context) => Task.CompletedTask;
+
+        /// <inheritdocs />
+        public virtual Task UpdatingAsync(UserUpdateContext context) => Task.CompletedTask;
+
+        /// <inheritdocs />
+        public virtual Task UpdatedAsync(UserUpdateContext context) => Task.CompletedTask;
+
+        /// <inheritdocs />
+        public virtual Task DisabledAsync(UserContext context) => Task.CompletedTask;
+
+        /// <inheritdocs />
+        public virtual Task EnabledAsync(UserContext context) => Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/9559

Removes the slightly dangerous default implemenations on the `IUserEventHandler`because it is was not obvious that it had changed,  no build errors where thrown and yet, because of it workflow events were completely broken, without any indication.

Still to do (on another pr) workflow implementations for the new creating etc events