### PR TITLE
better error message for failed Github Authentication requests

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubHandler.cs
@@ -72,7 +72,7 @@ namespace OrchardCore.GitHub.Configuration
             var response = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
             if (response.IsSuccessStatusCode)
             {
-                var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+                var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
 
                 if(payload.RootElement.TryGetProperty("error", out var error))

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubHandler.cs
@@ -1,13 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
 
 namespace OrchardCore.GitHub.Configuration
 {
@@ -35,6 +43,66 @@ namespace OrchardCore.GitHub.Configuration
 
             await Events.CreatingTicket(context);
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
+        }
+
+        protected override async Task<OAuthTokenResponse> ExchangeCodeAsync(OAuthCodeExchangeContext context)
+        {
+            var tokenRequestParameters = new Dictionary<string, string>()
+            {
+                { "client_id", Options.ClientId },
+                { "redirect_uri", context.RedirectUri },
+                { "client_secret", Options.ClientSecret },
+                { "code", context.Code },
+                { "grant_type", "authorization_code" },
+            };
+
+            // PKCE https://tools.ietf.org/html/rfc7636#section-4.5, see BuildChallengeUrl
+            if (context.Properties.Items.TryGetValue(OAuthConstants.CodeVerifierKey, out var codeVerifier))
+            {
+                tokenRequestParameters.Add(OAuthConstants.CodeVerifierKey, codeVerifier!);
+                context.Properties.Items.Remove(OAuthConstants.CodeVerifierKey);
+            }
+
+            var requestContent = new FormUrlEncodedContent(tokenRequestParameters!);
+
+            var requestMessage = new HttpRequestMessage(HttpMethod.Post, Options.TokenEndpoint);
+            requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            requestMessage.Content = requestContent;
+            requestMessage.Version = Backchannel.DefaultRequestVersion;
+            var response = await Backchannel.SendAsync(requestMessage, Context.RequestAborted);
+            if (response.IsSuccessStatusCode)
+            {
+                var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Context.RequestAborted));
+
+
+                if(payload.RootElement.TryGetProperty("error", out var error))
+                {
+                    var output = new StringBuilder();
+                    output.Append(error);
+
+                    if(payload.RootElement.TryGetProperty("error_description", out var description))
+                    {
+                        output.Append(" ");
+                        output.Append(description);
+                    }
+                    return OAuthTokenResponse.Failed(new Exception(output.ToString()));
+                }
+
+                return OAuthTokenResponse.Success(payload);
+            }
+            else
+            {
+                var error = "OAuth token endpoint failure: " + await Display(response);
+                return OAuthTokenResponse.Failed(new Exception(error));
+            }
+        }
+        private static async Task<string> Display(HttpResponseMessage response)
+        {
+            var output = new StringBuilder();
+            output.Append("Status: " + response.StatusCode + ";");
+            output.Append("Headers: " + response.Headers.ToString() + ";");
+            output.Append("Body: " + await response.Content.ReadAsStringAsync() + ";");
+            return output.ToString();
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubHandler.cs
@@ -45,6 +45,11 @@ namespace OrchardCore.GitHub.Configuration
             return new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name);
         }
 
+        /// <summary>
+        /// This code was copied from the aspnetcore repository . We should keep it in sync with it.
+        /// https://github.com/dotnet/aspnetcore/blob/fcd4ed7c46083cc408417763867637f232928f9b/src/Security/Authentication/OAuth/src/OAuthHandler.cs#L193
+        /// This can be removed or modified when the https://github.com/dotnet/aspnetcore/issues/33351 is resolved
+        /// </summary>
         protected override async Task<OAuthTokenResponse> ExchangeCodeAsync(OAuthCodeExchangeContext context)
         {
             var tokenRequestParameters = new Dictionary<string, string>()
@@ -74,7 +79,7 @@ namespace OrchardCore.GitHub.Configuration
             {
                 var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
 
-
+                // This was added to support better error messages from the GitHub OAuth provider
                 if(payload.RootElement.TryGetProperty("error", out var error))
                 {
                     var output = new StringBuilder();
@@ -82,7 +87,7 @@ namespace OrchardCore.GitHub.Configuration
 
                     if(payload.RootElement.TryGetProperty("error_description", out var description))
                     {
-                        output.Append(" ");
+                        output.Append(' ');
                         output.Append(description);
                     }
                     return OAuthTokenResponse.Failed(new Exception(output.ToString()));


### PR DESCRIPTION
fix #9575

I am not sure if this should be in Orchard's code or not but it outputs a better exception message

![image](https://user-images.githubusercontent.com/4681586/120019207-2889ba80-bfb6-11eb-9a53-f30b7beae801.png)
