### PR TITLE
Fix async enumerable issue in media api (#9604)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -59,7 +59,7 @@ namespace OrchardCore.Media.Controllers
             return View();
         }
 
-        public async Task<ActionResult<IAsyncEnumerable<IFileStoreEntry>>> GetFolders(string path)
+        public async Task<ActionResult<IEnumerable<IFileStoreEntry>>> GetFolders(string path)
         {
             if (!await _authorizationService.AuthorizeAsync(User, Permissions.ManageMedia))
             {
@@ -79,10 +79,10 @@ namespace OrchardCore.Media.Controllers
             var allowed = _mediaFileStore.GetDirectoryContentAsync(path)
                 .WhereAwait(async e => e.IsDirectory && await _authorizationService.AuthorizeAsync(User, Permissions.ManageAttachedMediaFieldsFolder, (object)e.Path));
 
-            return Ok(allowed);
+            return Ok(await allowed.ToListAsync());
         }
 
-        public async Task<ActionResult<IAsyncEnumerable<object>>> GetMediaItems(string path)
+        public async Task<ActionResult<IEnumerable<object>>> GetMediaItems(string path)
         {
             if (string.IsNullOrEmpty(path))
             {
@@ -104,7 +104,7 @@ namespace OrchardCore.Media.Controllers
                 .WhereAwait(async e => !e.IsDirectory && await _authorizationService.AuthorizeAsync(User, Permissions.ManageAttachedMediaFieldsFolder, (object)e.Path))
                 .Select(e => CreateFileResult(e));
 
-            return Ok(allowed);
+            return Ok(await allowed.ToListAsync());
         }
 
         public async Task<ActionResult<object>> GetMediaItem(string path)


### PR DESCRIPTION
Fix #9604

This seems to be due to the changes made to `IAsyncEnumerable` in .NET 6.0 preview 4.

See:

https://github.com/aspnet/Announcements/issues/463
https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-preview-4/#async-streaming