### PR TITLE
Fix buttons with same ids

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Placements/Views/PlacementSettings.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Views/PlacementSettings.cshtml
@@ -1,7 +1,7 @@
 @model OrchardCore.Placements.ViewModels.ContentSettingsViewModel
 
 <div class="btn-group">
-    <button class="btn btn-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button class="btn btn-info dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         @T["Edit placements"]
     </button>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/TemplateSettings.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/TemplateSettings.cshtml
@@ -1,7 +1,7 @@
 @model OrchardCore.Templates.ViewModels.ContentSettingsViewModel
 
 <div class="btn-group">
-    <button class="btn btn-info dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+    <button class="btn btn-info dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         @T["Edit templates"]
     </button>
 


### PR DESCRIPTION
When you edit a Content type, `Edit templates` and `Edit placements` have the same id.