### PR TITLE
Replaced reduce indexes per map index to avoid concurrency problems of reduce indexes

### DIFF
--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Indexes/OpenIdApplicationIndex.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Indexes/OpenIdApplicationIndex.cs
@@ -10,22 +10,19 @@ namespace OrchardCore.OpenId.YesSql.Indexes
         public string ClientId { get; set; }
     }
 
-    public class OpenIdAppByLogoutUriIndex : ReduceIndex
+    public class OpenIdAppByLogoutUriIndex : MapIndex
     {
         public string LogoutRedirectUri { get; set; }
-        public int Count { get; set; }
     }
 
-    public class OpenIdAppByRedirectUriIndex : ReduceIndex
+    public class OpenIdAppByRedirectUriIndex : MapIndex
     {
         public string RedirectUri { get; set; }
-        public int Count { get; set; }
     }
 
-    public class OpenIdAppByRoleNameIndex : ReduceIndex
+    public class OpenIdAppByRoleNameIndex : MapIndex
     {
         public string RoleName { get; set; }
-        public int Count { get; set; }
     }
 
     public class OpenIdApplicationIndexProvider : IndexProvider<OpenIdApplication>
@@ -47,56 +44,20 @@ namespace OrchardCore.OpenId.YesSql.Indexes
             context.For<OpenIdAppByLogoutUriIndex, string>()
                 .Map(application => application.PostLogoutRedirectUris.Select(uri => new OpenIdAppByLogoutUriIndex
                 {
-                    LogoutRedirectUri = uri,
-                    Count = 1
-                }))
-                .Group(index => index.LogoutRedirectUri)
-                .Reduce(group => new OpenIdAppByLogoutUriIndex
-                {
-                    LogoutRedirectUri = group.Key,
-                    Count = group.Sum(x => x.Count)
-                })
-                .Delete((index, map) =>
-                {
-                    index.Count -= map.Sum(x => x.Count);
-                    return index.Count > 0 ? index : null;
-                });
+                    LogoutRedirectUri = uri
+                }));
 
             context.For<OpenIdAppByRedirectUriIndex, string>()
                 .Map(application => application.RedirectUris.Select(uri => new OpenIdAppByRedirectUriIndex
                 {
-                    RedirectUri = uri,
-                    Count = 1
-                }))
-                .Group(index => index.RedirectUri)
-                .Reduce(group => new OpenIdAppByRedirectUriIndex
-                {
-                    RedirectUri = group.Key,
-                    Count = group.Sum(x => x.Count)
-                })
-                .Delete((index, map) =>
-                {
-                    index.Count -= map.Sum(x => x.Count);
-                    return index.Count > 0 ? index : null;
-                });
+                    RedirectUri = uri
+                }));
 
             context.For<OpenIdAppByRoleNameIndex, string>()
                 .Map(application => application.Roles.Select(role => new OpenIdAppByRoleNameIndex
                 {
-                    RoleName = role,
-                    Count = 1
-                }))
-                .Group(index => index.RoleName)
-                .Reduce(group => new OpenIdAppByRoleNameIndex
-                {
-                    RoleName = group.Key,
-                    Count = group.Sum(x => x.Count)
-                })
-                .Delete((index, map) =>
-                {
-                    index.Count -= map.Sum(x => x.Count);
-                    return index.Count > 0 ? index : null;
-                });
+                    RoleName = role
+                }));
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Migrations/OpenIdMigrations.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Migrations/OpenIdMigrations.cs
@@ -5,6 +5,8 @@ using OrchardCore.OpenId.YesSql.Models;
 using OrchardCore.OpenId.YesSql.Indexes;
 using YesSql;
 using YesSql.Sql;
+using OrchardCore.Environment.Shell.Scope;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace OrchardCore.OpenId.YesSql.Migrations
 {
@@ -37,35 +39,35 @@ namespace OrchardCore.OpenId.YesSql.Migrations
                 collection: OpenIdApplicationCollection
             );
 
-            SchemaBuilder.CreateReduceIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri))
-                .Column<int>(nameof(OpenIdAppByLogoutUriIndex.Count)),
+            SchemaBuilder.CreateMapIndexTable<OpenIdAppByLogoutUriIndex>(table => table
+                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri)),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByLogoutUriIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdAppByLogoutUri_LogoutRedirectUri",
+                    "DocumentId",
                     nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri)),
                 collection: OpenIdApplicationCollection
             );
 
-            SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri))
-                .Column<int>(nameof(OpenIdAppByRedirectUriIndex.Count)),
+            SchemaBuilder.CreateMapIndexTable<OpenIdAppByRedirectUriIndex>(table => table
+                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri)),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRedirectUriIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdAppByRedirectUri_RedirectUri",
+                    "DocumentId",
                     nameof(OpenIdAppByRedirectUriIndex.RedirectUri)),
                 collection: OpenIdApplicationCollection
             );
 
-            SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName))
-                .Column<int>(nameof(OpenIdAppByRoleNameIndex.Count)),
+            SchemaBuilder.CreateMapIndexTable<OpenIdAppByRoleNameIndex>(table => table
+                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName)),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRoleNameIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdAppByRoleName_RoleName",
+                    "DocumentId",
                     nameof(OpenIdAppByRoleNameIndex.RoleName)),
                 collection: OpenIdApplicationCollection
             );
@@ -163,7 +165,7 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             );
 
             // Shortcut other migration steps on new content definition schemas.
-            return 8;
+            return 9;
         }
 
         // This code can be removed in a later version.
@@ -187,16 +189,13 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             SchemaBuilder.DropReduceIndexTable<OpenIdApplicationByRoleNameIndex>(null);
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri))
-                .Column<int>(nameof(OpenIdAppByLogoutUriIndex.Count)));
+                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri)));
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri))
-                .Column<int>(nameof(OpenIdAppByRedirectUriIndex.Count)));
+                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri)));
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName))
-                .Column<int>(nameof(OpenIdAppByRoleNameIndex.Count)));
+                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName)));
 
             return 3;
         }
@@ -424,8 +423,7 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri))
-                .Column<int>(nameof(OpenIdAppByLogoutUriIndex.Count)),
+                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri)),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByLogoutUriIndex>(table => table
@@ -435,8 +433,7 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri))
-                .Column<int>(nameof(OpenIdAppByRedirectUriIndex.Count)),
+                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri)),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRedirectUriIndex>(table => table
@@ -446,8 +443,7 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName))
-                .Column<int>(nameof(OpenIdAppByRoleNameIndex.Count)),
+                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName)),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRoleNameIndex>(table => table
@@ -520,6 +516,66 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             SchemaBuilder.DropReduceIndexTable<OpenIdScopeByResourceIndex>();
 
             return 8;
+        }
+        public int UpdateFrom8Async()
+        {
+            SchemaBuilder.AlterIndexTable<OpenIdAppByLogoutUriIndex>(table => table
+                .DropIndex("IDX_UserByRoleNameIndex_RoleName")
+            );
+            SchemaBuilder.DropReduceIndexTable<OpenIdAppByLogoutUriIndex>(collection: OpenIdApplicationCollection);
+
+            SchemaBuilder.CreateMapIndexTable<OpenIdAppByLogoutUriIndex>(table => table
+                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri)),
+                collection: OpenIdApplicationCollection);
+            SchemaBuilder.AlterIndexTable<OpenIdAppByLogoutUriIndex>(table => table
+                .CreateIndex("IDX_COL_OpenIdAppByLogoutUri_LogoutRedirectUri",
+                    "DocumentId",
+                    nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri)),
+                collection: OpenIdApplicationCollection
+            );
+
+            SchemaBuilder.AlterIndexTable<OpenIdAppByRedirectUriIndex>(table => table
+                .DropIndex("IDX_COL_OpenIdAppByRedirectUri_RedirectUri")
+            );
+            SchemaBuilder.DropReduceIndexTable<OpenIdAppByRedirectUriIndex>(collection: OpenIdApplicationCollection);
+
+            SchemaBuilder.CreateMapIndexTable<OpenIdAppByRedirectUriIndex>(table => table
+                            .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri)),
+                            collection: OpenIdApplicationCollection);
+
+            SchemaBuilder.AlterIndexTable<OpenIdAppByRedirectUriIndex>(table => table
+                .CreateIndex("IDX_COL_OpenIdAppByRedirectUri_RedirectUri",
+                    "DocumentId",
+                    nameof(OpenIdAppByRedirectUriIndex.RedirectUri)),
+                collection: OpenIdApplicationCollection
+            );
+
+            SchemaBuilder.AlterIndexTable<OpenIdAppByRoleNameIndex>(table => table
+                .DropIndex("IDX_COL_OpenIdAppByRoleName_RoleName")
+            );
+            SchemaBuilder.DropReduceIndexTable<OpenIdAppByRoleNameIndex>(collection: OpenIdApplicationCollection);
+            SchemaBuilder.CreateMapIndexTable<OpenIdAppByRoleNameIndex>(table => table
+                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName)),
+                collection: OpenIdApplicationCollection);
+
+            SchemaBuilder.AlterIndexTable<OpenIdAppByRoleNameIndex>(table => table
+                .CreateIndex("IDX_COL_OpenIdAppByRoleName_RoleName",
+                    "DocumentId",
+                    nameof(OpenIdAppByRoleNameIndex.RoleName)),
+                collection: OpenIdApplicationCollection
+            );
+
+            ShellScope.AddDeferredTask(async scope =>
+            {
+                var session = scope.ServiceProvider.GetRequiredService<ISession>();
+                foreach (var openIdApp in await session.Query<OpenIdApplication>(collection: OpenIdApplicationCollection).ListAsync())
+                {
+                    session.Save(openIdApp, collection: OpenIdApplicationCollection);
+                }
+                await session.SaveChangesAsync();
+            });
+
+            return 9;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Users.Core/Indexes/UserByRoleNameIndex.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Indexes/UserByRoleNameIndex.cs
@@ -5,10 +5,9 @@ using YesSql.Indexes;
 
 namespace OrchardCore.Users.Indexes
 {
-    public class UserByRoleNameIndex : ReduceIndex
+    public class UserByRoleNameIndex : MapIndex
     {
         public string RoleName { get; set; }
-        public int Count { get; set; }
     }
 
     public class UserByRoleNameIndexProvider : IndexProvider<User>
@@ -33,7 +32,6 @@ namespace OrchardCore.Users.Indexes
                             new UserByRoleNameIndex
                             {
                                 RoleName = NormalizeKey("Authenticated"),
-                                Count = 1
                             }
                         };
                     }
@@ -41,19 +39,7 @@ namespace OrchardCore.Users.Indexes
                     return user.RoleNames.Select(x => new UserByRoleNameIndex
                     {
                         RoleName = NormalizeKey(x),
-                        Count = 1
                     });
-                })
-                .Group(index => index.RoleName)
-                .Reduce(group => new UserByRoleNameIndex
-                {
-                    RoleName = group.Key,
-                    Count = group.Sum(x => x.Count)
-                })
-                .Delete((index, map) =>
-                {
-                    index.Count -= map.Sum(x => x.Count);
-                    return index.Count > 0 ? index : null;
                 });
         }
 


### PR DESCRIPTION
It replaces current reduce indexes per map indexes, because indeed the aggregated count value they store is not used anywhere, so we don't need the extra work needed to maintain a reduce index. And by the way it solves in a quick way this orchard problem cause by an issue at YesQL. 

In order to support concurrent updates in future reduce indexes we could need at Orchard, I have filed an issue at YesSql repo for fixing that problem https://github.com/sebastienros/yessql/issues/395 

Fixes #9639