### PR TITLE
Fixes #9606 ZoneOnDemand behavior (Lombiq Technologies: OCORE-58)

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
@@ -128,8 +128,7 @@ namespace OrchardCore.DisplayManagement.Notify
             {
                 foreach (var messageEntry in _existingEntries)
                 {
-                    // Also retrieve the actual zone in case it was only a temporary empty zone created on demand.
-                    zone = await zone.AddAsync(await _shapeFactory.CreateAsync("Message", Arguments.From(messageEntry)));
+                    await zone.AddAsync(await _shapeFactory.CreateAsync("Message", Arguments.From(messageEntry)));
                 }
             }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
@@ -230,7 +230,7 @@ namespace OrchardCore.DisplayManagement.Zones
                 _parent.Properties[_potentialZoneName] = _zone;
             }
 
-            return await _zone.AddAsync(item, position);
+            return _zone = await _zone.AddAsync(item, position);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneHoldingBehavior.cs
@@ -118,6 +118,7 @@ namespace OrchardCore.DisplayManagement.Zones
         private readonly Func<ValueTask<IShape>> _zoneFactory;
         private readonly ZoneHolding _parent;
         private readonly string _potentialZoneName;
+        private IShape _zone;
 
         public ZoneOnDemand(Func<ValueTask<IShape>> zoneFactory, ZoneHolding parent, string potentialZoneName)
         {
@@ -213,15 +214,23 @@ namespace OrchardCore.DisplayManagement.Zones
         {
             if (item == null)
             {
-                return _parent;
+                if (_zone != null)
+                {
+                    return _zone;
+                }
+
+                return this;
             }
 
-            var zone = await _zoneFactory();
-            zone.Properties["Parent"] = _parent;
-            zone.Properties["ZoneName"] = _potentialZoneName;
-            _parent.Properties[_potentialZoneName] = zone;
+            if (_zone == null)
+            {
+                _zone = await _zoneFactory();
+                _zone.Properties["Parent"] = _parent;
+                _zone.Properties["ZoneName"] = _potentialZoneName;
+                _parent.Properties[_potentialZoneName] = _zone;
+            }
 
-            return await zone.AddAsync(item, position);
+            return await _zone.AddAsync(item, position);
         }
     }
 }


### PR DESCRIPTION
Fixes #9606

If `zone` is a `ZoneOnDemand`, allows to use.

    await zone.AddAsync(shape1);
    await zone.AddAsync(shape2);

In place of having to use

    zone = await zone.AddAsync(shape1);
    await zone.AddAsync(shape2);