### PR TITLE
Fix localization of the display name attribute when used in error messages and labels

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Startup.cs
@@ -100,6 +100,7 @@ namespace OrchardCore.Mvc
 
             // Adding localization
             builder.AddViewLocalization();
+            builder.AddDataAnnotationsLocalization();
 
             services.TryAddEnumerable(
                 ServiceDescriptor.Transient<IConfigureOptions<RazorViewEngineOptions>, ModularRazorViewEngineOptionsSetup>());


### PR DESCRIPTION
@hishamco, I made the fix that we discussed in #4675 to localize the display name attribute when used in error messages and labels. (See https://github.com/OrchardCMS/OrchardCore/pull/4675#issuecomment-863424382 and https://github.com/OrchardCMS/OrchardCore/pull/4675#issuecomment-863435842.)

To test out my changes, I added a Display attribute to SmtpSettings.DefaultSender and specified a display name.

```
public class SmtpSettings : IValidatableObject
{
    /// <summary>
    /// Gets or sets the default sender mail.
    /// </summary>
    [Required(AllowEmptyStrings = false), EmailAddress]
    [Display(Name = "Default Sender")]
    public string DefaultSender { get; set; }  
       ...
}
```

I added an en-US.po file that provided a translation for the default error message and the display name.

```
msgid "The {0} field is required."
msgstr "Translated message: {0} is required."

msgid "Default Sender"
msgstr "Translated Default Sender"
```

I modified SmtpSettings.Edit.cshtml, so the label for the default sender was not specified directly in the view and would be determined by the display name.

`<label asp-for="DefaultSender"></label>`

In the admin dashboard on the Configuration > Settings > Smtp page, I submitted the form without specifying a sender email address and verified the following:

- The localized error message used the localized display name ("Translated Default Sender").
- The label also used the localized display name ("Translated Default Sender").

![image](https://user-images.githubusercontent.com/15861981/122566431-89387000-d015-11eb-929e-525fad8e4cfa.png)

