### PR TITLE
Add jQuery as a dependency of the ResourceManifest

### DIFF
--- a/src/OrchardCore.Themes/TheAdmin/ResourceManifestOptionsConfiguration.cs
+++ b/src/OrchardCore.Themes/TheAdmin/ResourceManifestOptionsConfiguration.cs
@@ -20,6 +20,7 @@ namespace OrchardCore.Themes.TheAdmin
 
             _manifest
                 .DefineScript("admin")
+                .SetDependencies("jQuery")
                 .SetUrl("~/TheAdmin/js/TheAdmin.min.js", "~/TheAdmin/js/TheAdmin.js")
                 .SetVersion("1.0.0");
 

--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
@@ -21,7 +21,7 @@
     <script asp-name="font-awesome" at="Head" version="5"></script>
     <script asp-name="font-awesome-v4-shims" at="Head" version="5"></script>
     <script asp-name="js-cookie" at="Foot" version="2"></script>
-    <script asp-name="admin" version="1" depends-on="jQuery" at="Foot"></script>
+    <script asp-name="admin" version="1" at="Foot"></script>
     <resources type="Header" />
 
     <!-- This script can't wait till the footer -->


### PR DESCRIPTION
This fixes a javascript error in some pages in the admin

` Bootstrap's JavaScript requires jQuery. jQuery must be included before Bootstrap's JavaScript.`