### PR TITLE
URI components Liquid accessors

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Extensions.DependencyInjection
                                 nameof(HttpRequest.Method) => new StringValue(request.Method),
                                 nameof(HttpRequest.RouteValues) => new ObjectValue(new RouteValueDictionaryWrapper(request.RouteValues)),
 
-                                // Escaped string of each uri component for use in a URI or an HTTP header.
+                                // Provides correct escaping to reconstruct a request or redirect URI.
                                 "UriHost" => new StringValue(request.Host.ToUriComponent(), encode: false),
                                 "UriPath" => new StringValue(request.Path.ToUriComponent(), encode: false),
                                 "UriPathBase" => new StringValue(request.PathBase.ToUriComponent(), encode: false),

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -102,6 +102,13 @@ namespace Microsoft.Extensions.DependencyInjection
                                 nameof(HttpRequest.Scheme) => new StringValue(request.Scheme),
                                 nameof(HttpRequest.Method) => new StringValue(request.Method),
                                 nameof(HttpRequest.RouteValues) => new ObjectValue(new RouteValueDictionaryWrapper(request.RouteValues)),
+
+                                // Escaped string of each uri component for use in a URI or an HTTP header.
+                                "UriHost" => new StringValue(request.Host.ToUriComponent(), encode: false),
+                                "UriPath" => new StringValue(request.Path.ToUriComponent(), encode: false),
+                                "UriPathBase" => new StringValue(request.PathBase.ToUriComponent(), encode: false),
+                                "UriQueryString" => new StringValue(request.QueryString.ToUriComponent(), encode: false),
+
                                 _ => NilValue.Instance
                             };
                         }


### PR DESCRIPTION
Related to #9617 and #9618

Provides correct escaping to reconstruct a request or redirect URI.
