### PR TITLE
Fix admin menu links to 403 forbidden pages

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Permissions.cs
@@ -30,11 +30,6 @@ namespace OrchardCore.Localization
                 {
                     Name = "Administrator",
                     Permissions = new[] { ManageCultures }
-                },
-                new PermissionStereotype
-                {
-                    Name = "Editor",
-                    Permissions = new[] { ManageCultures }
                 }
             };
         }

--- a/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
@@ -34,7 +34,7 @@ namespace OrchardCore.Media
                 .Add(S["Media"], S["Media"].PrefixPosition(), media => media
                     .Add(S["Media Options"], S["Media Options"].PrefixPosition(), options => options
                         .Action("Options", "Admin", new { area = "OrchardCore.Media" })
-                        .Permission(Permissions.ManageMedia)
+                        .Permission(Permissions.ViewMediaOptions)
                         .LocalNav())
                     .Add(S["Media Profiles"], S["Media Profiles"].PrefixPosition(), mediaProfiles => mediaProfiles
                         .Action("Index", "MediaProfiles", new { area = "OrchardCore.Media" })


### PR DESCRIPTION
Fix a couple of admin menu issues for roles other than Administrator where the menu shows a link to a page but the user has no permissions so is presented with 403 forbidden page. Namely:

- Media options page - permissions where different between `AdminController.cs` and `adminmenu.cs`. Corrected the permission name on menu to match controller.
- Culture settings page - editor has `ManageCultures` but does not have `ManageSettings`. The Cultures page being a settings page needs both permissions to view. Removed Editor from the `ManageCultures` permission.

Tested and fixes the issues