### PR TITLE
Fix rule conditions localization

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Rules/Services/ConditionOperatorConfigureOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Services/ConditionOperatorConfigureOptions.cs
@@ -1,80 +1,63 @@
 using System.Collections.Generic;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Localization;
 using OrchardCore.Rules.Models;
 
 namespace OrchardCore.Rules.Services
 {
     public class ConditionOperatorConfigureOptions : IConfigureOptions<ConditionOperatorOptions>
     {
-        private readonly IStringLocalizer S;
-
-        public ConditionOperatorConfigureOptions(IStringLocalizer<ConditionOperatorOptions> stringLocalizer)
-        {
-            S = stringLocalizer;
-        }
-
         public void Configure(ConditionOperatorOptions options)
         {
             options.Operators.AddRange(new List<ConditionOperatorOption>
             {
-                new ConditionOperatorOption
-                {
-                    DisplayText = S["Equals"],
-                    Operator = typeof(StringEqualsOperator),
-                    Comparer = new StringEqualsOperatorComparer(),
-                    Factory = new ConditionOperatorFactory<StringEqualsOperator>()
-                },
-                new ConditionOperatorOption
-                {
-                    DisplayText = S["Does not equal"],
-                    Operator = typeof(StringNotEqualsOperator),
-                    Comparer = new StringNotEqualsOperatorComparer(),
-                    Factory = new ConditionOperatorFactory<StringNotEqualsOperator>()
-                },                
-                new ConditionOperatorOption
-                {
-                    DisplayText = S["Starts with"],
-                    Operator = typeof(StringStartsWithOperator),
-                    Comparer = new StringStartsWithOperatorComparer(),
-                    Factory = new ConditionOperatorFactory<StringStartsWithOperator>()
-                },           
-                new ConditionOperatorOption
-                {
-                    DisplayText = S["Does not start with"],
-                    Operator = typeof(StringNotStartsWithOperator),
-                    Comparer = new StringNotStartsWithOperatorComparer(),
-                    Factory = new ConditionOperatorFactory<StringNotStartsWithOperator>()
-                },
-                new ConditionOperatorOption
-                {
-                    DisplayText = S["Ends with"],
-                    Operator = typeof(StringEndsWithOperator),
-                    Comparer = new StringEndsWithOperatorComparer(),
-                    Factory = new ConditionOperatorFactory<StringEndsWithOperator>()
-                },
-                new ConditionOperatorOption
-                {
-                    DisplayText = S["Does not end with"],
-                    Operator = typeof(StringNotEndsWithOperator),
-                    Comparer = new StringNotEndsWithOperatorComparer(),
-                    Factory = new ConditionOperatorFactory<StringNotEndsWithOperator>()
-                },                
-                new ConditionOperatorOption
-                {
-                    DisplayText = S["Contains"],
-                    Operator = typeof(StringContainsOperator),
-                    Comparer = new StringContainsOperatorComparer(),
-                    Factory = new ConditionOperatorFactory<StringContainsOperator>()
-                },
-                new ConditionOperatorOption
-                {
-                    DisplayText = S["Does not contain"],
-                    Operator = typeof(StringNotContainsOperator),
-                    Comparer = new StringNotContainsOperatorComparer(),
-                    Factory = new ConditionOperatorFactory<StringNotContainsOperator>()
-                }                
+                new ConditionOperatorOption<ConditionOperatorConfigureOptions>(
+                    (S) => S["Equals"],
+                    new StringEqualsOperatorComparer(),
+                    typeof(StringEqualsOperator),
+                    new ConditionOperatorFactory<StringEqualsOperator>()
+                ),
+                new ConditionOperatorOption<ConditionOperatorConfigureOptions>(
+                    (S) => S["Does not equal"],
+                    new StringNotEqualsOperatorComparer(),
+                    typeof(StringNotEqualsOperator),
+                    new ConditionOperatorFactory<StringNotEqualsOperator>()
+                ),                
+                new ConditionOperatorOption<ConditionOperatorConfigureOptions>(
+                    (S) => S["Starts with"],
+                    new StringStartsWithOperatorComparer(),
+                    typeof(StringStartsWithOperator),
+                    new ConditionOperatorFactory<StringStartsWithOperator>()
+                ),           
+                new ConditionOperatorOption<ConditionOperatorConfigureOptions>(
+                    (S) => S["Does not start with"],
+                    new StringNotStartsWithOperatorComparer(),
+                    typeof(StringNotStartsWithOperator),
+                    new ConditionOperatorFactory<StringNotStartsWithOperator>()
+                ),
+                new ConditionOperatorOption<ConditionOperatorConfigureOptions>(
+                    (S) => S["Ends with"],
+                    new StringEndsWithOperatorComparer(),
+                    typeof(StringEndsWithOperator),
+                    new ConditionOperatorFactory<StringEndsWithOperator>()
+                ),
+                new ConditionOperatorOption<ConditionOperatorConfigureOptions>(
+                    (S) => S["Does not end with"],
+                    new StringNotEndsWithOperatorComparer(),
+                    typeof(StringNotEndsWithOperator),
+                    new ConditionOperatorFactory<StringNotEndsWithOperator>()
+                ),                
+                new ConditionOperatorOption<ConditionOperatorConfigureOptions>(
+                    (S) => S["Contains"],
+                    new StringContainsOperatorComparer(),
+                    typeof(StringContainsOperator),
+                    new ConditionOperatorFactory<StringContainsOperator>()
+                ),
+                new ConditionOperatorOption<ConditionOperatorConfigureOptions>(
+                    (S) => S["Does not contain"],
+                    new StringNotContainsOperatorComparer(),
+                    typeof(StringNotContainsOperator),
+                    new ConditionOperatorFactory<StringNotContainsOperator>()
+                )                
             });
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Rules/ViewComponents/SelectStringOperationViewComponent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/ViewComponents/SelectStringOperationViewComponent.cs
@@ -11,10 +11,12 @@ namespace OrchardCore.Rules.ViewComponents
     public class SelectStringOperationViewComponent : ViewComponent
     {
         private readonly ConditionOperatorOptions _options;
+        private readonly IServiceProvider _serviceProvider;
 
-        public SelectStringOperationViewComponent(IOptions<ConditionOperatorOptions> options)
+        public SelectStringOperationViewComponent(IOptions<ConditionOperatorOptions> options, IServiceProvider serviceProvider)
         {
             _options = options.Value;
+            _serviceProvider = serviceProvider;
         }
 
         public IViewComponentResult Invoke(string selectedOperation, string htmlName)
@@ -24,7 +26,7 @@ namespace OrchardCore.Rules.ViewComponents
             var items = stringOperators
                 .Select(x => 
                     new SelectListItem(
-                        x.DisplayText, 
+                        x.DisplayText(_serviceProvider), 
                         x.Operator.Name, 
                         String.Equals(x.Factory.Name, selectedOperation, StringComparison.OrdinalIgnoreCase))
                 ).ToList();

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/ContentTypeCondition.Fields.Summary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/ContentTypeCondition.Fields.Summary.cshtml
@@ -1,11 +1,11 @@
 @model ShapeViewModel<ContentTypeCondition>
 @using Microsoft.Extensions.Options
-@inject IOptions<ConditionOperatorOptions> Options;
+@inject IOptions<ConditionOperatorOptions> Options
 @{
     var displayText = String.Empty;
     if (Model.Value.Operation != null && Options.Value.ConditionOperatorOptionByType.TryGetValue(Model.Value.Operation.GetType(), out var option))
     {
-        displayText = option.DisplayText;
+        displayText = option.DisplayText(Context.RequestServices);
     }
 }
 <span>@T["Content type"]</span><span class="ml-2 hint dashed">@displayText @Model.Value.Value</span>

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/CultureCondition.Fields.Summary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/CultureCondition.Fields.Summary.cshtml
@@ -1,10 +1,10 @@
 @model ShapeViewModel<CultureCondition>
-@inject IOptions<ConditionOperatorOptions> Options;
+@inject IOptions<ConditionOperatorOptions> Options
 @{
     var displayText = String.Empty;
     if (Model.Value.Operation != null && Options.Value.ConditionOperatorOptionByType.TryGetValue(Model.Value.Operation.GetType(), out var option))
     {
-        displayText = option.DisplayText;
+        displayText = option.DisplayText(Context.RequestServices);
     }
 }
 <span>@T["Culture"]</span><span class="ml-2 hint dashed">@displayText @Model.Value.Value</span>

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/RoleCondition.Fields.Summary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/RoleCondition.Fields.Summary.cshtml
@@ -1,10 +1,10 @@
 @model ShapeViewModel<RoleCondition>
-@inject IOptions<ConditionOperatorOptions> Options;
+@inject IOptions<ConditionOperatorOptions> Options
 @{
     var displayText = String.Empty;
     if (Model.Value.Operation != null && Options.Value.ConditionOperatorOptionByType.TryGetValue(Model.Value.Operation.GetType(), out var option))
     {
-        displayText = option.DisplayText;
+        displayText = option.DisplayText(Context.RequestServices);
     }
 }
 <span>@T["Role"]</span><span class="ml-2 hint dashed">@displayText @Model.Value.Value</span>

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/UrlCondition.Fields.Summary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Views/Items/UrlCondition.Fields.Summary.cshtml
@@ -1,10 +1,10 @@
 @model ShapeViewModel<UrlCondition>
-@inject IOptions<ConditionOperatorOptions> Options;
+@inject IOptions<ConditionOperatorOptions> Options
 @{
     var displayText = String.Empty;
     if (Model.Value.Operation != null && Options.Value.ConditionOperatorOptionByType.TryGetValue(Model.Value.Operation.GetType(), out var option))
     {
-        displayText = option.DisplayText;
+        displayText = option.DisplayText(Context.RequestServices);
     }
 }
 <span>@T["Url"]</span><span class="ml-2 hint dashed">@displayText @Model.Value.Value</span>

--- a/src/OrchardCore/OrchardCore.Rules.Abstractions/ConditionOperatorOptions.cs
+++ b/src/OrchardCore/OrchardCore.Rules.Abstractions/ConditionOperatorOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Extensions.Localization;
 
 namespace OrchardCore.Rules
 {
@@ -11,16 +12,43 @@ namespace OrchardCore.Rules
         public IReadOnlyDictionary<string, IConditionOperatorFactory> Factories => _factories ??= Operators.ToDictionary(x => x.Factory.Name, x => x.Factory);
 
         private Dictionary<Type, ConditionOperatorOption> _conditionOperatorOptionByType;
-        public IReadOnlyDictionary<Type, ConditionOperatorOption> ConditionOperatorOptionByType => _conditionOperatorOptionByType ??= Operators.ToDictionary(x => x.Operator, x => x);        
+        public IReadOnlyDictionary<Type, ConditionOperatorOption> ConditionOperatorOptionByType => _conditionOperatorOptionByType ??= Operators.ToDictionary(x => x.Operator, x => x);
 
         public List<ConditionOperatorOption> Operators { get; set; } = new List<ConditionOperatorOption>();
     }
 
+    public class ConditionOperatorOption<TLocalizer> : ConditionOperatorOption where TLocalizer : class
+    {
+        public ConditionOperatorOption(
+            Func<IStringLocalizer, LocalizedString> displayText,
+            IOperatorComparer comparer,
+            Type operatorType,
+            IConditionOperatorFactory factory) : base(
+                (sp) => displayText((IStringLocalizer)sp.GetService(typeof(IStringLocalizer<>).MakeGenericType(typeof(TLocalizer)))),
+                comparer,
+                operatorType,
+                factory)
+        {
+        }
+    }
+
     public class ConditionOperatorOption
     {
-        public string DisplayText { get; set; }
-        public IOperatorComparer Comparer { get; set; }
-        public Type Operator { get; set; }
-        public IConditionOperatorFactory Factory { get; set; }
+        public ConditionOperatorOption(
+            Func<IServiceProvider, LocalizedString> displayText,
+            IOperatorComparer comparer,
+            Type operatorType,
+            IConditionOperatorFactory factory)
+        {
+            DisplayText = displayText;
+            Comparer = comparer;
+            Operator = operatorType;
+            Factory = factory;
+        }
+
+        public Func<IServiceProvider, LocalizedString> DisplayText { get; }
+        public IOperatorComparer Comparer { get; }
+        public Type Operator { get; }
+        public IConditionOperatorFactory Factory { get; }
     }
 }


### PR DESCRIPTION
For some reason I forgot that `IConfigureOptions` are singletons, so there is no point injecting a string localizer to them.

So fixing the localization to be scoped.