### PR TITLE
Preview: RenderBody needs to be called before RenderBodyAsync

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/_Layout.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/_Layout.cshtml
@@ -6,6 +6,6 @@
       <title>@RenderTitleSegments(Site.SiteName, "before")</title>
   </head>
   <body dir="@Orchard.CultureDir()">
-          @await RenderBodyAsync()
+          @RenderBody()
   </body>
 </html>


### PR DESCRIPTION
RenderBodyAsync() seems to be throwing the following:

InvalidOperationException: RenderBody has not been called for the page at '/Areas/OrchardCore.ContentPreview/Views/_Layout.cshtml'. To ignore call IgnoreBody().

From looking at previous PRs, this is expected if RenderBody() has never been called, even if the _ViewImports.cshtml include `@inherits OrchardCore.DisplayManagement.Razor.RazorPage<TModel>`

This creates the initial RenderBody call