### PR TITLE
Attachment.Stream -> Attachment.OpenStream

### DIFF
--- a/src/OrchardCore/OrchardCore.Email.Abstractions/MailMessageAttachment.cs
+++ b/src/OrchardCore/OrchardCore.Email.Abstractions/MailMessageAttachment.cs
@@ -15,6 +15,7 @@ namespace OrchardCore.Email
         /// <summary>
         /// Gets or sets the attachment file stream.
         /// </summary>
-        public Stream Stream { get; set; }
+        /// <remarks>The stream will not be closed after sending the email.</remarks>
+        public Stream OpenStream { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Email.Core/Services/SmtpService.cs
+++ b/src/OrchardCore/OrchardCore.Email.Core/Services/SmtpService.cs
@@ -145,9 +145,9 @@ namespace OrchardCore.Email.Services
             foreach (var attachment in message.Attachments)
             {
                 // Stream must not be null, otherwise it would try to get the filesystem path
-                if (attachment.Stream != null)
+                if (attachment.OpenStream != null)
                 {
-                    body.Attachments.Add(attachment.Filename, attachment.Stream);
+                    body.Attachments.Add(attachment.Filename, attachment.OpenStream);
                 }            
             }
 


### PR DESCRIPTION
Based on Seb's comment [here](https://github.com/OrchardCMS/OrchardCore/pull/9310#discussion_r624020716) the `MailMessageAttachment.Stream` should be renamed to `OpenStream` to remove the confusion whether the APIs should close the stream by default or not