### PR TITLE
Shortcodes arguments should only return a value if it exists

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Startup.cs
@@ -48,7 +48,7 @@ namespace OrchardCore.Shortcodes
                     };
                 });
 
-                o.MemberAccessStrategy.Register<Sc.Arguments, object>((obj, name) => obj.NamedOrDefault(name));
+                o.MemberAccessStrategy.Register<Sc.Arguments, object>((obj, name) => obj.Named(name));
             });
 
             services.AddScoped<IShortcodeService, ShortcodeService>();


### PR DESCRIPTION
NamedOrDefault returns the named argument OR the argument at index 0.
This leads to confusing behavior if we want to only include an argument that exists.