### PR TITLE
Add user approval feature

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
@@ -393,18 +393,18 @@ namespace OrchardCore.Users.Controllers
             }
 
             var registrationSettings = (await _siteService.GetSiteSettingsAsync()).As<RegistrationSettings>();
-            var user = await _userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
+            var iUser = await _userManager.FindByLoginAsync(info.LoginProvider, info.ProviderKey);
 
-            if (user != null)
+            if (iUser != null)
             {
-                if (!await AddConfirmEmailError(user) && !AddUserEnabledError(user))
+                if (!await AddConfirmEmailError(iUser) && !AddUserEnabledError(iUser))
                 {
-                    await _accountEvents.InvokeAsync((e, user, modelState) => e.LoggingInAsync(user.UserName, (key, message) => modelState.AddModelError(key, message)), user, ModelState, _logger);
+                    await _accountEvents.InvokeAsync((e, user, modelState) => e.LoggingInAsync(user.UserName, (key, message) => modelState.AddModelError(key, message)), iUser, ModelState, _logger);
 
-                    var signInResult = await ExternalLoginSignInAsync(user, info);
+                    var signInResult = await ExternalLoginSignInAsync(iUser, info);
                     if (signInResult.Succeeded)
                     {
-                        return await LoggedInActionResult(user, returnUrl, info);
+                        return await LoggedInActionResult(iUser, returnUrl, info);
                     }
                     else
                     {
@@ -417,15 +417,15 @@ namespace OrchardCore.Users.Controllers
                 var email = info.Principal.FindFirstValue(ClaimTypes.Email) ?? info.Principal.FindFirstValue("email");
 
                 if (!string.IsNullOrWhiteSpace(email))
-                    user = await _userManager.FindByEmailAsync(email);
+                    iUser = await _userManager.FindByEmailAsync(email);
 
                 ViewData["ReturnUrl"] = returnUrl;
                 ViewData["LoginProvider"] = info.LoginProvider;
 
-                if (user != null)
+                if (iUser != null)
                 {
                     // Link external login to an existing user
-                    ViewData["UserName"] = user.UserName;
+                    ViewData["UserName"] = iUser.UserName;
                     ViewData["Email"] = email;
 
                     return View(nameof(LinkExternalLogin));
@@ -459,7 +459,7 @@ namespace OrchardCore.Users.Controllers
 
                         if (noInformationRequired)
                         {
-                            user = await this.RegisterUser(new RegisterViewModel()
+                            iUser = await this.RegisterUser(new RegisterViewModel()
                             {
                                 UserName = externalLoginViewModel.UserName,
                                 Email = externalLoginViewModel.Email,
@@ -468,19 +468,33 @@ namespace OrchardCore.Users.Controllers
                             }, S["Confirm your account"], _logger);
 
                             // If the registration was successful we can link the external provider and redirect the user
-                            if (user != null)
+                            if (iUser != null)
                             {
-                                var identityResult = await _signInManager.UserManager.AddLoginAsync(user, new UserLoginInfo(info.LoginProvider, info.ProviderKey, info.ProviderDisplayName));
+                                var identityResult = await _signInManager.UserManager.AddLoginAsync(iUser, new UserLoginInfo(info.LoginProvider, info.ProviderKey, info.ProviderDisplayName));
                                 if (identityResult.Succeeded)
                                 {
                                     _logger.LogInformation(3, "User account linked to {LoginProvider} provider.", info.LoginProvider);
 
+                                    // The login info must be linked before we consider a redirect, or the login info is lost.
+                                    if (iUser is User user)
+                                    {
+                                        if (registrationSettings.UsersMustValidateEmail && !user.EmailConfirmed)
+                                        {
+                                            return RedirectToAction("ConfirmEmailSent", new { Area = "OrchardCore.Users", Controller = "Registration", ReturnUrl = returnUrl });
+                                        }
+
+                                        if (registrationSettings.UsersAreModerated && !user.IsEnabled)
+                                        {
+                                            return RedirectToAction("RegistrationPending", new { Area = "OrchardCore.Users", Controller = "Registration", ReturnUrl = returnUrl });
+                                        }
+                                    }
+
                                     // We have created/linked to the local user, so we must verify the login.
                                     // If it does not succeed, the user is not allowed to login
-                                    var signInResult = await ExternalLoginSignInAsync(user, info);
+                                    var signInResult = await ExternalLoginSignInAsync(iUser, info);
                                     if (signInResult.Succeeded)
                                     {
-                                        return await LoggedInActionResult(user, returnUrl, info);
+                                        return await LoggedInActionResult(iUser, returnUrl, info);
                                     }
                                     else
                                     {
@@ -491,10 +505,12 @@ namespace OrchardCore.Users.Controllers
                                 AddIdentityErrors(identityResult);
                             }
                         }
+
                         return View("RegisterExternalLogin", externalLoginViewModel);
                     }
                 }
             }
+
             return RedirectToLogin(returnUrl);
         }
 
@@ -516,7 +532,7 @@ namespace OrchardCore.Users.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> RegisterExternalLogin(RegisterExternalLoginViewModel model, string returnUrl = null)
         {
-            IUser user = null;
+            IUser iUser = null;
             var settings = (await _siteService.GetSiteSettingsAsync()).As<RegistrationSettings>();
             var info = await _signInManager.GetExternalLoginInfoAsync();
 
@@ -559,24 +575,38 @@ namespace OrchardCore.Users.Controllers
 
             if (TryValidateModel(model) && ModelState.IsValid)
             {
-                user = await this.RegisterUser(new RegisterViewModel() { UserName = model.UserName, Email = model.Email, Password = model.Password, ConfirmPassword = model.ConfirmPassword }, S["Confirm your account"], _logger);
-                if (user is null)
+                iUser = await this.RegisterUser(new RegisterViewModel() { UserName = model.UserName, Email = model.Email, Password = model.Password, ConfirmPassword = model.ConfirmPassword }, S["Confirm your account"], _logger);
+                if (iUser is null)
                 {
                     ModelState.AddModelError(string.Empty, "Registration Failed.");
                 }
                 else
                 {
-                    var identityResult = await _signInManager.UserManager.AddLoginAsync(user, new UserLoginInfo(info.LoginProvider, info.ProviderKey, info.ProviderDisplayName));
+                    var identityResult = await _signInManager.UserManager.AddLoginAsync(iUser, new UserLoginInfo(info.LoginProvider, info.ProviderKey, info.ProviderDisplayName));
                     if (identityResult.Succeeded)
                     {
                         _logger.LogInformation(3, "User account linked to {provider} provider.", info.LoginProvider);
 
+                        // The login info must be linked before we consider a redirect, or the login info is lost.
+                        if (iUser is User user)
+                        {
+                            if (settings.UsersMustValidateEmail && !user.EmailConfirmed)
+                            {
+                                return RedirectToAction("ConfirmEmailSent", new { Area = "OrchardCore.Users", Controller = "Registration", ReturnUrl = returnUrl });
+                            }
+
+                            if (settings.UsersAreModerated && !user.IsEnabled)
+                            {
+                                return RedirectToAction("RegistrationPending", new { Area = "OrchardCore.Users", Controller = "Registration", ReturnUrl = returnUrl });
+                            }
+                        }
+
                         // we have created/linked to the local user, so we must verify the login. If it does not succeed,
                         // the user is not allowed to login
-                        var signInResult = await ExternalLoginSignInAsync(user, info);
+                        var signInResult = await ExternalLoginSignInAsync(iUser, info);
                         if (signInResult.Succeeded)
                         {
-                            return await LoggedInActionResult(user, returnUrl, info);
+                            return await LoggedInActionResult(iUser, returnUrl, info);
                         }
                     }
                     AddIdentityErrors(identityResult);

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ControllerExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ControllerExtensions.cs
@@ -69,7 +69,7 @@ namespace OrchardCore.Users.Controllers
 
                 if (controller.ModelState.IsValid)
                 {
-                    var user = await userService.CreateUserAsync(new User { UserName = model.UserName, Email = model.Email, EmailConfirmed = !settings.UsersMustValidateEmail }, model.Password, (key, message) => controller.ModelState.AddModelError(key, message)) as User;
+                    var user = await userService.CreateUserAsync(new User { UserName = model.UserName, Email = model.Email, EmailConfirmed = !settings.UsersMustValidateEmail, IsEnabled = !settings.UsersAreModerated }, model.Password, (key, message) => controller.ModelState.AddModelError(key, message)) as User;
 
                     if (user != null && controller.ModelState.IsValid)
                     {
@@ -79,7 +79,7 @@ namespace OrchardCore.Users.Controllers
                             // Send an email with this link
                             await controller.SendEmailConfirmationTokenAsync(user, confirmationEmailSubject);
                         }
-                        else
+                        else if (!(settings.UsersAreModerated && !user.IsEnabled))
                         {
                             await signInManager.SignInAsync(user, isPersistent: false);
                         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/RegistrationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/RegistrationController.cs
@@ -98,9 +98,19 @@ namespace OrchardCore.Users.Controllers
 
             if (TryValidateModel(model) && ModelState.IsValid)
             {
+                var iUser = await this.RegisterUser(model, S["Confirm your account"], _logger);
                 // If we get a user, redirect to returnUrl
-                if (await this.RegisterUser(model, S["Confirm your account"], _logger) != null)
+                if (iUser is User user)
                 {
+                    if (settings.UsersMustValidateEmail && !user.EmailConfirmed)
+                    {
+                        return RedirectToAction("ConfirmEmailSent", new { ReturnUrl = returnUrl });
+                    }
+                    if (settings.UsersAreModerated && !user.IsEnabled)
+                    {
+                        return RedirectToAction("RegistrationPending", new { ReturnUrl = returnUrl });
+                    }
+
                     return RedirectToLocal(returnUrl);
                 }
             }
@@ -134,6 +144,16 @@ namespace OrchardCore.Users.Controllers
 
             return NotFound();
         }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult ConfirmEmailSent(string returnUrl = null)
+            => View(new { ReturnUrl = returnUrl });
+
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult RegistrationPending(string returnUrl = null)
+            => View(new { ReturnUrl = returnUrl });
 
         [Authorize]
         [HttpPost]

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
@@ -37,6 +37,7 @@ namespace OrchardCore.Users.Drivers
             {
                 model.UsersCanRegister = settings.UsersCanRegister;
                 model.UsersMustValidateEmail = settings.UsersMustValidateEmail;
+                model.UsersAreModerated = settings.UsersAreModerated;
                 model.UseSiteTheme = settings.UseSiteTheme;
                 model.NoPasswordForExternalUsers = settings.NoPasswordForExternalUsers;
                 model.NoUsernameForExternalUsers = settings.NoUsernameForExternalUsers;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Models/RegistrationSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Models/RegistrationSettings.cs
@@ -4,6 +4,7 @@ namespace OrchardCore.Users.Models
     {
         public UserRegistrationType UsersCanRegister { get; set; }
         public bool UsersMustValidateEmail { get; set; }
+        public bool UsersAreModerated { get; set; }
         public bool UseSiteTheme { get; set; }
         public bool NoPasswordForExternalUsers { get; set; }
         public bool NoUsernameForExternalUsers { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -366,15 +366,31 @@ namespace OrchardCore.Users
     [Feature("OrchardCore.Users.Registration")]
     public class RegistrationStartup : StartupBase
     {
-        private const string RegisterPath = "Register";
+        private const string RegisterPath = nameof(RegistrationController.Register);
+        private const string ConfirmEmailSent = nameof(RegistrationController.ConfirmEmailSent);
+        private const string RegistrationPending = nameof(RegistrationController.RegistrationPending);
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
         {
             routes.MapAreaControllerRoute(
-                name: "Register",
+                name: RegisterPath,
                 areaName: "OrchardCore.Users",
                 pattern: RegisterPath,
-                defaults: new { controller = "Registration", action = "Register" }
+                defaults: new { controller = "Registration", action = RegisterPath }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: ConfirmEmailSent,
+                areaName: "OrchardCore.Users",
+                pattern: ConfirmEmailSent,
+                defaults: new { controller = "Registration", action = ConfirmEmailSent }
+            );
+
+            routes.MapAreaControllerRoute(
+                name: RegistrationPending,
+                areaName: "OrchardCore.Users",
+                pattern: RegistrationPending,
+                defaults: new { controller = "Registration", action = RegistrationPending }
             );
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/RegisterUserTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/RegisterUserTask.Fields.Edit.cshtml
@@ -22,3 +22,9 @@
     <span asp-validation-for="ConfirmationEmailTemplate"></span>
     <span class="hint">@T["The message to send. Access email confirmation url with Workflow.Properties.EmailConfirmationUrl liquid property."]</span>
 </div>
+
+<div class="form-group form-check" asp-validation-class-for="RequireModeration">
+    <input type="checkbox" asp-for="RequireModeration" class="form-check-input" />
+    <span asp-validation-for="RequireModeration"></span>
+    <label asp-for="RequireModeration" class="form-check-label">@T["Users must be approved before they can log in"]</label>
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Registration/ConfirmEmailSent.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Registration/ConfirmEmailSent.cshtml
@@ -1,0 +1,21 @@
+﻿@{
+    ViewLayout = "Layout__Login";
+    var returnUrl = Context.Request.Query["ReturnUrl"];
+}
+
+<h2>@T["Email confirmation sent"]</h2>
+<div>
+    <p>
+        @T["An email has been sent to you. Please click on the link it contains in order to have access on this site."]
+    </p>
+    <p>
+        @if (!String.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
+        {
+            <a href="@returnUrl">@T["Previous Page"]</a>
+        }
+        else
+        {
+            <a href="@Url.Content("~/")">@T["Home"]</a>
+        }
+    </p>
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Registration/RegistrationPending.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Registration/RegistrationPending.cshtml
@@ -1,0 +1,19 @@
+﻿
+@{
+    ViewLayout = "Layout__Login";
+    var returnUrl = Context.Request.Query["ReturnUrl"];
+}
+
+<h2>@T["User Registration Pending"]</h2>
+<div>
+    <p>@T["Your user account has been created but has to be approved before it can be used."]</p>
+
+    @if (!String.IsNullOrWhiteSpace(returnUrl) && Url.IsLocalUrl(returnUrl))
+    {
+        <a href="@returnUrl">@T["Previous Page"]</a>
+    }
+    else
+    {
+        <a href="@Url.Content("~/")">@T["Home"]</a>
+    }
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/RegistrationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/RegistrationSettings.Edit.cshtml
@@ -38,6 +38,14 @@
 
 <div class="alert alert-warning collapse" id="warnEmailValidation">@T["The users whose email address has not been confirmed will not be able to login or reset their password."]</div>
 
+<div class="form-group" asp-validation-class-for="UsersAreModerated">
+    <div class="custom-control custom-checkbox">
+        <input type="checkbox" class="custom-control-input" asp-for="UsersAreModerated" />
+        <span asp-validation-for="UsersAreModerated"></span>
+        <label class="custom-control-label" asp-for="UsersAreModerated">@T["Users must be approved before they can log in"]</label>
+    </div>
+</div>
+
 <div class="form-group" asp-validation-class-for="UseSiteTheme">
     <div class="custom-control custom-checkbox">
         <input type="checkbox" class="custom-control-input" asp-for="UseSiteTheme" />

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Activities/RegisterUserTask.cs
@@ -55,7 +55,7 @@ namespace OrchardCore.Users.Workflows.Activities
         public override LocalizedString DisplayText => S["Register User Task"];
 
         // The category to which this activity belongs. The activity picker groups activities by this category.
-        public override LocalizedString Category => S["Content"];
+        public override LocalizedString Category => S["User"];
 
         // The message to display.
         public bool SendConfirmationEmail
@@ -74,6 +74,11 @@ namespace OrchardCore.Users.Workflows.Activities
         public WorkflowExpression<string> ConfirmationEmailTemplate
         {
             get => GetProperty(() => new WorkflowExpression<string>());
+            set => SetProperty(value);
+        }
+        public bool RequireModeration
+        {
+            get => GetProperty(() => false);
             set => SetProperty(value);
         }
 
@@ -101,10 +106,12 @@ namespace OrchardCore.Users.Workflows.Activities
             {
                 var userName = form["UserName"];
                 if (string.IsNullOrWhiteSpace(userName))
-                    userName = email;
+                {
+                    userName = email.Replace('@', '+');
+                }
 
                 var errors = new Dictionary<string, string>();
-                var user = (User)await _userService.CreateUserAsync(new User() { UserName = userName, Email = email }, null, (key, message) => errors.Add(key, message));
+                var user = (User)await _userService.CreateUserAsync(new User() { UserName = userName, Email = email, IsEnabled = !RequireModeration }, null, (key, message) => errors.Add(key, message));
                 if (errors.Count > 0)
                 {
                     var updater = _updateModelAccessor.ModelUpdater;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Drivers/RegisterUserTaskDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/Drivers/RegisterUserTaskDisplayDriver.cs
@@ -12,6 +12,7 @@ namespace OrchardCore.Users.Workflows.Drivers
             model.SendConfirmationEmail = activity.SendConfirmationEmail;
             model.ConfirmationEmailSubject = activity.ConfirmationEmailSubject.Expression;
             model.ConfirmationEmailTemplate = activity.ConfirmationEmailTemplate.Expression;
+            model.RequireModeration = activity.RequireModeration;
         }
 
         protected override void UpdateActivity(RegisterUserTaskViewModel model, RegisterUserTask activity)
@@ -19,6 +20,7 @@ namespace OrchardCore.Users.Workflows.Drivers
             activity.SendConfirmationEmail = model.SendConfirmationEmail;
             activity.ConfirmationEmailSubject = new WorkflowExpression<string>(model.ConfirmationEmailSubject);
             activity.ConfirmationEmailTemplate = new WorkflowExpression<string>(model.ConfirmationEmailTemplate);
+            activity.RequireModeration = model.RequireModeration;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Workflows/ViewModels/RegisterUserTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Workflows/ViewModels/RegisterUserTaskViewModel.cs
@@ -11,5 +11,7 @@ namespace OrchardCore.Users.Workflows.ViewModels
 
         [Required]
         public string ConfirmationEmailTemplate { get; set; }
+
+        public bool RequireModeration { get; set; }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/9869
Fixes https://github.com/OrchardCMS/OrchardCore/issues/9868

This adds a `UsersAreModerated` setting to the user registration feature.

When set true all users, whether registering via an external provider, or direct through the registration controller, will require approval, i.e. their account set `IsEnabled = true` before they are logged into the site.

It also prevents external users being automatically logged in, if they have not confirmed their email address (if the confirm email setting is set true)

Register user workflow updated to support the feature as well.
