### PR TITLE
Fix NRE when DisplayText is null

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Extensions/ContentOrchardHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Extensions/ContentOrchardHelperExtensions.cs
@@ -1,9 +1,8 @@
-using System.Text.Encodings.Web;
+using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
@@ -13,13 +12,19 @@ namespace OrchardCore.Contents.AuditTrail.Extensions
 {
     public static class ContentOrchardHelperExtensions
     {
-        public static async Task<IHtmlContent> EditForLinkAsync(this IOrchardHelper orchardHelper, string linkText, ContentItem contentItem)
+        public static async Task<IHtmlContent> EditForLinkAsync(this IOrchardHelper orchardHelper, string displayText, ContentItem contentItem)
         {
             var viewContextAccessor = orchardHelper.HttpContext.RequestServices.GetRequiredService<ViewContextAccessor>();
             var viewContext = viewContextAccessor.ViewContext;
             var helper = MakeHtmlHelper(viewContext, viewContext.ViewData);
             var contentManager = orchardHelper.HttpContext.RequestServices.GetRequiredService<IContentManager>();
             var metadata = await contentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
+            var linkText = displayText;
+
+            if(String.IsNullOrEmpty(linkText))
+            {
+                linkText = contentItem.ContentType;
+            }
 
             return helper.ActionLink(linkText, metadata.EditorRouteValues["action"].ToString(), metadata.EditorRouteValues);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Extensions/ContentOrchardHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Extensions/ContentOrchardHelperExtensions.cs
@@ -12,16 +12,15 @@ namespace OrchardCore.Contents.AuditTrail.Extensions
 {
     public static class ContentOrchardHelperExtensions
     {
-        public static async Task<IHtmlContent> EditForLinkAsync(this IOrchardHelper orchardHelper, string displayText, ContentItem contentItem)
+        public static async Task<IHtmlContent> EditForLinkAsync(this IOrchardHelper orchardHelper, string linkText, ContentItem contentItem)
         {
             var viewContextAccessor = orchardHelper.HttpContext.RequestServices.GetRequiredService<ViewContextAccessor>();
             var viewContext = viewContextAccessor.ViewContext;
             var helper = MakeHtmlHelper(viewContext, viewContext.ViewData);
             var contentManager = orchardHelper.HttpContext.RequestServices.GetRequiredService<IContentManager>();
             var metadata = await contentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
-            var linkText = displayText;
 
-            if(String.IsNullOrEmpty(linkText))
+            if (String.IsNullOrEmpty(linkText))
             {
                 linkText = contentItem.ContentType;
             }


### PR DESCRIPTION
I am unable to repro on my local environment but one of our deployments has a NRE when linkText is null.

Edit: I was able to finally repro.

1- Create Page with blank title
2- Save draft
3- Go to AuditTrail

![image](https://user-images.githubusercontent.com/4681586/125960609-a8d02ee1-18fa-46a1-bc3a-d943ec860a5f.png)
