### PR TITLE
Fix dev feed build number

### DIFF
--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -32,7 +32,7 @@ jobs:
         dotnet-version: 5.0.*
     - name: Set build number 
       if: matrix.os == 'ubuntu-latest'
-      run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 15471 ))" >> $GITHUB_ENV
+      run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 16368 ))" >> $GITHUB_ENV
     - name: Build
       run: |
         dotnet build --configuration Release --framework net5.0


### PR DESCRIPTION
We renamed the preview action last night, which caused the run number to reset to 0
so the cloudsmith version number is now wrong.

This when merged will be build number 4
latest on cloudsmith is 16371 

4 + 16368 = 16372

w / any luck
