### PR TITLE
Fixes AliasPartIndexProvider registration

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Startup.cs
@@ -11,6 +11,7 @@ using OrchardCore.Alias.Settings;
 using OrchardCore.Alias.ViewModels;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
+using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data;
 using OrchardCore.Data.Migration;
@@ -53,7 +54,11 @@ namespace OrchardCore.Alias
                     });
                 });
             });
-            services.AddScoped<IScopedIndexProvider, AliasPartIndexProvider>();
+
+            services.AddScoped<AliasPartIndexProvider>();
+            services.AddScoped<IScopedIndexProvider>(sp => sp.GetRequiredService<AliasPartIndexProvider>());
+            services.AddScoped<IContentHandler>(sp => sp.GetRequiredService<AliasPartIndexProvider>());
+
             services.AddScoped<IDataMigration, Migrations>();
             services.AddScoped<IContentHandleProvider, AliasPartContentHandleProvider>();
 


### PR DESCRIPTION
Fixes #9932

`AliasPartIndexProvider` is an `IScopedIndexProvider` and also an `IContentHandler`.

Only the first one was registered