### PR TITLE
Fixes contained item routes unicity

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -231,7 +231,7 @@ namespace OrchardCore.Autoroute.Handlers
         private async Task GenerateContainedPathsFromPatternAsync(ContentItem contentItem, AutoroutePart part)
         {
             // Validate contained content item routes if container has valid path.
-            if (!String.IsNullOrWhiteSpace(part.Path) || !part.RouteContainedItems)
+            if (String.IsNullOrWhiteSpace(part.Path) || !part.RouteContainedItems)
             {
                 return;
             }
@@ -262,7 +262,7 @@ namespace OrchardCore.Autoroute.Handlers
                         var path = handlerAspect.Path;
                         if (!handlerAspect.Absolute)
                         {
-                            path = (basePath.EndsWith('/') ? basePath : basePath + '/') + handlerAspect.Path;
+                            path = (basePath.EndsWith('/') ? basePath : basePath + '/') + handlerAspect.Path.TrimStart('/');
                         }
 
                         entries.Add(new AutorouteEntry(containerContentItemId, path, contentItem.ContentItemId, jItem.Path)
@@ -271,7 +271,7 @@ namespace OrchardCore.Autoroute.Handlers
                         });
                     }
 
-                    var itemBasePath = (basePath.EndsWith('/') ? basePath : basePath + '/') + handlerAspect.Path;
+                    var itemBasePath = (basePath.EndsWith('/') ? basePath : basePath + '/') + handlerAspect.Path.TrimStart('/');
                     var childrenAspect = await _contentManager.PopulateAspectAsync<ContainedContentItemsAspect>(contentItem);
                     await PopulateContainedContentItemRoutesAsync(entries, containerContentItemId, childrenAspect, jItem, itemBasePath);
                 }
@@ -311,7 +311,7 @@ namespace OrchardCore.Autoroute.Handlers
                         else
                         {
                             var currentItemBasePath = basePath.EndsWith('/') ? basePath : basePath + '/';
-                            path = currentItemBasePath + containedAutoroutePart.Path;
+                            path = currentItemBasePath + containedAutoroutePart.Path.TrimStart('/');
                             if (!IsRelativePathUnique(entries, path, containedAutoroutePart))
                             {
                                 path = GenerateRelativeUniquePath(entries, path, containedAutoroutePart);
@@ -340,7 +340,7 @@ namespace OrchardCore.Autoroute.Handlers
 
         private static bool IsRelativePathUnique(List<AutorouteEntry> entries, string path, AutoroutePart context)
         {
-            var result = !entries.Any(e => context.ContentItem.ContentItemId != e.ContainedContentItemId && String.Equals(e.Path, path, StringComparison.OrdinalIgnoreCase));
+            var result = !entries.Any(e => context.ContentItem.ContentItemId != e.ContainedContentItemId && String.Equals(e.Path.Trim('/'), path.Trim('/'), StringComparison.OrdinalIgnoreCase));
             return result;
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
@@ -173,7 +173,7 @@ namespace OrchardCore.ContentManagement.Records
                         var path = handlerAspect.Path;
                         if (!handlerAspect.Absolute)
                         {
-                            path = (basePath.EndsWith('/') ? basePath : basePath + '/') + handlerAspect.Path;
+                            path = (basePath.EndsWith('/') ? basePath : basePath + '/') + handlerAspect.Path.TrimStart('/');
                         }
 
                         results.Add(new AutoroutePartIndex
@@ -187,7 +187,7 @@ namespace OrchardCore.ContentManagement.Records
                         });
                     }
 
-                    var itemBasePath = (basePath.EndsWith('/') ? basePath : basePath + '/') + handlerAspect.Path;
+                    var itemBasePath = (basePath.EndsWith('/') ? basePath : basePath + '/') + handlerAspect.Path.TrimStart('/');
                     var childrenAspect = await _contentManager.PopulateAspectAsync<ContainedContentItemsAspect>(contentItem);
 
                     await PopulateContainedContentItemIndexesAsync(results, containerContentItem, childrenAspect, jItem, itemBasePath);


### PR DESCRIPTION
Fixes #9948

- In a given container, contained items routes unicity was not checked.

- If the above is fixed, the unicity check was not taking into account the leading / trailing slashes as we do for the container routes. E.g. `/parent/child` was not considered as a possible conflict with `parent/child/`.

- A contained route having a leading `/` combined to the container one was producing an Autoroute with a double `//` .
