### PR TITLE
Not use a current culture when checking invalid autoroute path

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs
@@ -18,8 +18,7 @@ namespace OrchardCore.Autoroute.Models
             if (HasInvalidCharacters(autoroute.Path))
             {
                 var invalidCharactersForMessage = string.Join(", ", AutoroutePart.InvalidCharactersForPath.Select(c => $"\"{c}\""));
-                const string errorMessage = "Please do not use any of the following characters in your permalink: {0}. No spaces, or consecutive slashes, are allowed (please use dashes or underscores instead).";
-                yield return new ValidationResult(S[errorMessage, invalidCharactersForMessage], new[] { nameof(autoroute.Path) });
+                yield return new ValidationResult(S["Please do not use any of the following characters in your permalink: {0}. No spaces, or consecutive slashes, are allowed (please use dashes or underscores instead).", invalidCharactersForMessage], new[] { nameof(autoroute.Path) });
             }
 
             if (autoroute.Path?.Length > AutoroutePart.MaxPathLength)
@@ -30,9 +29,21 @@ namespace OrchardCore.Autoroute.Models
 
         private static bool HasInvalidCharacters(string path)
         {
-            if (path?.IndexOfAny(AutoroutePart.InvalidCharactersForPath) > -1) return true; // IndexOfAny performs culture-insensitive search.
-            if (path?.IndexOf(' ', StringComparison.Ordinal) > -1) return true;
-            if (path?.IndexOf("//", StringComparison.Ordinal) > -1) return true;
+            // IndexOfAny performs culture-insensitive and case-sensitive search.
+            if (path?.IndexOfAny(AutoroutePart.InvalidCharactersForPath) > -1)
+            {
+                return true;
+            }
+
+            if (path?.IndexOf(' ', StringComparison.Ordinal) > -1)
+            {
+                return true;
+            }
+
+            if (path?.IndexOf("//", StringComparison.Ordinal) > -1)
+            {
+                return true;
+            }
 
             return false;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -14,16 +15,26 @@ namespace OrchardCore.Autoroute.Models
                 yield return new ValidationResult(S["Your permalink can't be set to the homepage, please use the homepage option instead."], new[] { nameof(autoroute.Path) });
             }
 
-            if (autoroute.Path?.IndexOfAny(AutoroutePart.InvalidCharactersForPath) > -1 || autoroute.Path?.IndexOf(' ') > -1 || autoroute.Path?.IndexOf("//") > -1)
+            if (HasInvalidCharacters(autoroute.Path))
             {
                 var invalidCharactersForMessage = string.Join(", ", AutoroutePart.InvalidCharactersForPath.Select(c => $"\"{c}\""));
-                yield return new ValidationResult(S["Please do not use any of the following characters in your permalink: {0}. No spaces, or consecutive slashes, are allowed (please use dashes or underscores instead).", invalidCharactersForMessage], new[] { nameof(autoroute.Path) });
+                const string errorMessage = "Please do not use any of the following characters in your permalink: {0}. No spaces, or consecutive slashes, are allowed (please use dashes or underscores instead).";
+                yield return new ValidationResult(S[errorMessage, invalidCharactersForMessage], new[] { nameof(autoroute.Path) });
             }
 
             if (autoroute.Path?.Length > AutoroutePart.MaxPathLength)
             {
                 yield return new ValidationResult(S["Your permalink is too long. The permalink can only be up to {0} characters.", AutoroutePart.MaxPathLength], new[] { nameof(autoroute.Path) });
             }
+        }
+
+        private static bool HasInvalidCharacters(string path)
+        {
+            if (path?.IndexOfAny(AutoroutePart.InvalidCharactersForPath) > -1) return true; // IndexOfAny performs culture-insensitive search.
+            if (path?.IndexOf(' ', StringComparison.Ordinal) > -1) return true;
+            if (path?.IndexOf("//", StringComparison.Ordinal) > -1) return true;
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
# Existing issue:
If you enable Localization module and set a default culture to non en-US culture, e.g. th-TH, you will get a validation error when trying to save a content item with an Autoroute part.

Here is the screenshot when trying to save a content item and a default culture is `th-TH`.

![image](https://user-images.githubusercontent.com/2938310/127115579-31604a26-2b31-4503-9fac-509e7bee3c30.png)

Note, you can switch to any culture by appending culture=<culture-name> query string to a current URL.


# Root cause
- This issue is from [AutoroutePartExtensions.ValidatePathFieldValue method](https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs#L17)
- Inside the method, there is a call of `autoroute.Path?.IndexOf("//")`  which returns 0 instead of -1 when a current culture is `th-TH`.
- According to the [MS document](https://docs.microsoft.com/en-us/dotnet/api/system.string.indexof?view=net-5.0#System_String_IndexOf_System_String_), `IndexOf(String)` search a word by using culture and case sensitive.
- Please check `IndexOf` test cases that I've made https://github.com/codesanook/codesanook-examples/blob/master/Codesanook.Examples.DotNet/Localization/LocalizationTest.cs#L24. 

# How this PR fixes
- Refer to [Recommendations for string usage
](https://docs.microsoft.com/en-us/dotnet/standard/base-types/best-practices-strings#recommendations-for-string-usage), we should use StringComparison.Ordinal or StringComparison.OrdinalIgnoreCase for the non-linguistic string search.
- There is no case in `a space` and `//`, so I pick `StringComparison.Ordinal` and to match IndexOf which is `case-sensitive`.
