### PR TITLE
Reduce allocations in CamelFriendly

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/OrchardCore.Alias.csproj
@@ -16,10 +16,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Apis.GraphQL.Abstractions\OrchardCore.Apis.GraphQL.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentLocalization.Abstractions\OrchardCore.ContentLocalization.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Abstractions\OrchardCore.ContentManagement.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentTypes.Abstractions\OrchardCore.ContentTypes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Utilities/StringExtensions.cs
@@ -19,11 +19,6 @@ namespace OrchardCore.ContentManagement.Utilities
                 return "";
             }
 
-            if (camel == "RawHtml")
-            {
-                return "Raw Html";
-            }
-
             using var sb = ZString.CreateStringBuilder();
             for (var i = 0; i < camel.Length; ++i)
             {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Utilities/StringExtensions.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using Cysharp.Text;
 using Microsoft.Extensions.Localization;
 
 namespace OrchardCore.ContentManagement.Utilities
@@ -12,17 +13,26 @@ namespace OrchardCore.ContentManagement.Utilities
     {
         public static string CamelFriendly(this string camel)
         {
+            // optimize common cases
             if (string.IsNullOrWhiteSpace(camel))
-                return "";
-
-            var sb = new StringBuilder(camel);
-
-            for (int i = camel.Length - 1; i > 0; i--)
             {
-                if (char.IsUpper(sb[i]))
+                return "";
+            }
+
+            if (camel == "RawHtml")
+            {
+                return "Raw Html";
+            }
+
+            using var sb = ZString.CreateStringBuilder();
+            for (var i = 0; i < camel.Length; ++i)
+            {
+                var c = camel[i];
+                if (i != 0 && char.IsUpper(c))
                 {
-                    sb.Insert(i, ' ');
+                    sb.Append(' ');
                 }
+                sb.Append(c);
             }
 
             return sb.ToString();

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -21,11 +21,6 @@ namespace OrchardCore.Mvc.Utilities
                 return "";
             }
 
-            if (camel == "RawHtml")
-            {
-                return "Raw Html";
-            }
-
             using var sb = ZString.CreateStringBuilder();
             for (var i = 0; i < camel.Length; ++i)
             {

--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
+using Cysharp.Text;
 using Microsoft.Extensions.Localization;
 using Newtonsoft.Json.Linq;
 
@@ -14,19 +15,26 @@ namespace OrchardCore.Mvc.Utilities
     {
         public static string CamelFriendly(this string camel)
         {
+            // optimize common cases
             if (string.IsNullOrWhiteSpace(camel))
             {
                 return "";
             }
 
-            var sb = new StringBuilder(camel);
-
-            for (var i = camel.Length - 1; i > 0; i--)
+            if (camel == "RawHtml")
             {
-                if (char.IsUpper(sb[i]))
+                return "Raw Html";
+            }
+
+            using var sb = ZString.CreateStringBuilder();
+            for (var i = 0; i < camel.Length; ++i)
+            {
+                var c = camel[i];
+                if (i != 0 && char.IsUpper(c))
                 {
-                    sb.Insert(i, ' ');
+                    sb.Append(' ');
                 }
+                sb.Append(c);
             }
 
             return sb.ToString();
@@ -488,7 +496,7 @@ namespace OrchardCore.Mvc.Utilities
 
                     k++;
                 }
-            });            
+            });
 
             return result;
         }


### PR DESCRIPTION
* Tested with agency and blog theme
* Using `ZString` instead of `new StringBuilder`
* Using "normal algorithm" which start from beginning and no need to shuffle data in array (insert vs append)
* Rider was complaining about duplicate reference `OrchardCore.Data.Abstraction` in `OrchardCore.Alias.csproj` so fixed that too  