### PR TITLE
Remove state machine from RazorViewActionFilter for common case

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorViewActionFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Razor/RazorViewActionFilter.cs
@@ -14,10 +14,18 @@ namespace OrchardCore.DisplayManagement.Razor
     /// </summary>
     public class RazorViewActionFilter : IAsyncViewActionFilter
     {
-        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        public Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
         {
-            await OnActionExecutionAsync(context);
-            await next();
+            static async Task Awaited(Task task, ActionExecutionDelegate next)
+            {
+                await task;
+                await next();
+            }
+
+            var task = OnActionExecutionAsync(context);
+            return !task.IsCompletedSuccessfully
+                ? Awaited(task, next)
+                : next();
         }
 
         public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)


### PR DESCRIPTION
Seems to be a common case that `RazorViewActionFilter.OnActionExecutionAsync` completes without need of async state machine, method is also dead simple to optimize. Now checking if task already completed and returning next without state machine allocations, otherwise slower path.