### PR TITLE
Adjust OpenIdServerSettingsStep to parse same format as deployment output

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdServerSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdServerSettingsStep.cs
@@ -13,6 +13,7 @@ namespace OrchardCore.OpenId.Recipes
     /// </summary>
     public class OpenIdServerSettingsStep : IRecipeStepHandler
     {
+        private const string StepName = "OpenIdServer";
         private readonly IOpenIdServerService _serverService;
 
         public OpenIdServerSettingsStep(IOpenIdServerService serverService)
@@ -20,12 +21,12 @@ namespace OrchardCore.OpenId.Recipes
 
         public async Task ExecuteAsync(RecipeExecutionContext context)
         {
-            if (!String.Equals(context.Name, nameof(OpenIdServerSettings), StringComparison.OrdinalIgnoreCase))
+            if (!String.Equals(context.Name, StepName, StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }
 
-            var model = context.Step.ToObject<OpenIdServerSettingsStepModel>();
+            var model = context.Step.Property(StepName).Value.ToObject<OpenIdServerSettingsStepModel>();
             var settings = await _serverService.LoadSettingsAsync();
 
             settings.AccessTokenFormat = model.AccessTokenFormat;

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/recipe1.json
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/recipe1.json
@@ -1,0 +1,43 @@
+{
+  "name": "Recipe1",
+  "displayName": "Recipe 1",
+  "description": "",
+  "author": "Hisham Bin Ateya",
+  "website": "",
+  "version": "1.0.0",
+  "issetuprecipe": false,
+  "categories": [ "test" ],
+  "tags": [],
+  "variables": {
+    "messageContentItemId": "[js:uuid()]",
+    "now": "[js: new Date().toISOString()]"
+  },
+  "steps": [
+    {
+      "name": "OpenIdServer",
+      "OpenIdServer": {
+        "AccessTokenFormat": 1,
+        "Authority": "https://localhost",
+        "DisableAccessTokenEncryption": false,
+        "EncryptionCertificateStoreLocation": null,
+        "EncryptionCertificateStoreName": null,
+        "EncryptionCertificateThumbprint": null,
+        "SigningCertificateStoreLocation": null,
+        "SigningCertificateStoreName": null,
+        "SigningCertificateThumbprint": null,
+        "AuthorizationEndpointPath": "/connect/authorize",
+        "LogoutEndpointPath": "/connect/logout",
+        "TokenEndpointPath": "/connect/token",
+        "UserinfoEndpointPath": "/connect/userinfo",
+        "AllowPasswordFlow": false,
+        "AllowClientCredentialsFlow": false,
+        "AllowAuthorizationCodeFlow": true,
+        "AllowRefreshTokenFlow": true,
+        "AllowHybridFlow": false,
+        "AllowImplicitFlow": false,
+        "DisableRollingRefreshTokens": false,
+        "UseReferenceAccessTokens": false
+      }
+    }
+  ]
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipesTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipesTests.cs
@@ -1,27 +1,14 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Logging;
 using Moq;
 using Newtonsoft.Json.Linq;
-using OrchardCore.Environment.Shell;
-using OrchardCore.Environment.Shell.Builders;
-using OrchardCore.Environment.Shell.Models;
-using OrchardCore.Environment.Shell.Scope;
-using OrchardCore.Locking;
-using OrchardCore.Locking.Distributed;
 using OrchardCore.OpenId.Recipes;
 using OrchardCore.OpenId.Services;
 using OrchardCore.OpenId.Settings;
-using OrchardCore.Recipes.Events;
 using OrchardCore.Recipes.Models;
-using OrchardCore.Recipes.Services;
-using OrchardCore.Scripting;
 using Xunit;
 using static OrchardCore.OpenId.Settings.OpenIdServerSettings;
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipesTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipesTests.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json.Linq;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Builders;
+using OrchardCore.Environment.Shell.Models;
+using OrchardCore.Environment.Shell.Scope;
+using OrchardCore.Locking;
+using OrchardCore.Locking.Distributed;
+using OrchardCore.OpenId.Recipes;
+using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Settings;
+using OrchardCore.Recipes.Events;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Recipes.Services;
+using OrchardCore.Scripting;
+using Xunit;
+using static OrchardCore.OpenId.Settings.OpenIdServerSettings;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
+{
+    public class RecipesTests
+    {
+        [Fact]
+        public async Task OpenIdServerRecipeStepShouldBeParsed()
+        {
+            // Arrange
+            var expectedAuthority = new Uri("https://localhost");
+            var expectedAccessTokenFormat = TokenFormat.JsonWebToken;
+            var recipePath = $"Modules.OrchardCore.OpenId.RecipeFiles.recipe1.json";
+
+            var assembly = GetType().Assembly;
+            var recipeDescriptor = new RecipeDescriptor
+            {
+                RecipeFileInfo = new EmbeddedFileProvider(assembly).GetFileInfo(recipePath)
+            };
+
+            using var recipeStream = new StreamReader(recipeDescriptor.RecipeFileInfo.CreateReadStream());
+            var recipe = JObject.Parse(recipeStream.ReadToEnd());
+            var steps = recipe
+                .Property("steps", StringComparison.InvariantCultureIgnoreCase)
+                .Value as JArray;
+
+            var serverServiceMock = new Mock<IOpenIdServerService>();
+            var actualSettings = new OpenIdServerSettings();
+
+            serverServiceMock
+                .Setup(m => m.LoadSettingsAsync().Result).Returns(actualSettings);
+
+            var serverSettingsStep = new OpenIdServerSettingsStep(serverServiceMock.Object);
+            var context = new RecipeExecutionContext()
+            {
+                Name = "OpenIdServer",
+                Step = (JObject)steps.First()
+            };
+
+            // Act
+            await serverSettingsStep.ExecuteAsync(context);
+
+            // Assert
+            serverServiceMock.Verify(m => m.UpdateSettingsAsync(It.IsAny<OpenIdServerSettings>()));
+            Assert.Equal(expectedAuthority, actualSettings.Authority);
+            Assert.Equal(expectedAccessTokenFormat, actualSettings.AccessTokenFormat);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -31,6 +31,7 @@
     <None Remove="Localization\PoFiles\PoeditHeader.po" />
     <None Remove="Localization\PoFiles\SimpleEntry.po" />
     <None Remove="Apis\Lucene\Recipes\luceneQueryTest.json" />
+    <None Remove="Modules\OrchardCore.OpenId\recipe1.json" />
     <None Remove="Recipes\RecipeFiles\recipe1.json" />
     <None Remove="Recipes\RecipeFiles\recipe2.json" />
     <None Remove="Recipes\RecipeFiles\recipe3.json" />
@@ -50,6 +51,7 @@
     <EmbeddedResource Include="Localization\PoFiles\MultipleEntries.po" />
     <EmbeddedResource Include="Localization\PoFiles\PoeditHeader.po" />
     <EmbeddedResource Include="Localization\PoFiles\SimpleEntry.po" />
+    <EmbeddedResource Include="Modules\OrchardCore.OpenId\RecipeFiles\recipe1.json" />
     <EmbeddedResource Include="Recipes\RecipeFiles\recipe5.json" />
     <EmbeddedResource Include="Recipes\RecipeFiles\recipe4.json" />
     <EmbeddedResource Include="Recipes\RecipeFiles\recipe1.json" />


### PR DESCRIPTION
The following format is currently ignored, despite beeing generated by deployment. The pull request adjusts the recipe to match the deployment, and adds a test for this format:
```
  "steps": [
    "name": "OpenIdServer",
    "OpenIdServer": {
      ...
    }
  ]
```
