### PR TITLE
Fallback to the "Default" Picker Field Result Provider

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/ContentPickerAdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/ContentPickerAdminController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -28,7 +29,7 @@ namespace OrchardCore.ContentFields.Controllers
 
         public async Task<IActionResult> SearchContentItems(string part, string field, string query)
         {
-            if (string.IsNullOrWhiteSpace(part) || string.IsNullOrWhiteSpace(field))
+            if (string.IsNullOrWhiteSpace(part) || String.IsNullOrWhiteSpace(field))
             {
                 return BadRequest("Part and field are required parameters");
             }
@@ -43,7 +44,10 @@ namespace OrchardCore.ContentFields.Controllers
             }
 
             var editor = partFieldDefinition.Editor() ?? "Default";
-            var resultProvider = _resultProviders.FirstOrDefault(p => p.Name == editor);
+
+            var resultProvider = _resultProviders.FirstOrDefault(p => p.Name == editor)
+                ?? _resultProviders.FirstOrDefault(p => p.Name == "Default");
+
             if (resultProvider == null)
             {
                 return new ObjectResult(new List<ContentPickerResult>());

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/UserPickerAdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/UserPickerAdminController.cs
@@ -1,18 +1,18 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Admin;
-using OrchardCore.Contents;
 using OrchardCore.ContentFields.Settings;
-using OrchardCore.ContentFields.Services;
 using OrchardCore.ContentFields.ViewModels;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.Contents;
 using OrchardCore.Modules;
-using System.Security.Claims;
 
 namespace OrchardCore.ContentFields.Controllers
 {
@@ -40,7 +40,7 @@ namespace OrchardCore.ContentFields.Controllers
 
         public async Task<IActionResult> SearchUsers(string part, string field, string contentType, string query)
         {
-            if (string.IsNullOrWhiteSpace(part) || string.IsNullOrWhiteSpace(field) || string.IsNullOrWhiteSpace(contentType))
+            if (string.IsNullOrWhiteSpace(part) || String.IsNullOrWhiteSpace(field) || string.IsNullOrWhiteSpace(contentType))
             {
                 return BadRequest("Part, field and contentType are required parameters");
             }
@@ -63,7 +63,10 @@ namespace OrchardCore.ContentFields.Controllers
             }
 
             var editor = partFieldDefinition.Editor() ?? "Default";
-            var resultProvider = _resultProviders.FirstOrDefault(p => p.Name == editor);
+
+            var resultProvider = _resultProviders.FirstOrDefault(p => p.Name == editor)
+                ?? _resultProviders.FirstOrDefault(p => p.Name == "Default");
+
             if (resultProvider == null)
             {
                 return new ObjectResult(new List<UserPickerResult>());


### PR DESCRIPTION
Fixes #10084 

For the Content and User Picker fields, when you define a custom editor with a given name (and its related driver), you should also register a custom `IXxxPickerResultProvider` with the same name as the editor.

The problem is when you just want to have a custom editor / driver without changing the way that items are searched to populate the picker, so here I suggest to fallback to the default `IXxxPickerResultProvider` whose name is `Default`.
