### PR TITLE
Adjust OpenId server settings deploy source to match recipe step, #6364

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentSource.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Deployment;
 using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Settings;
 
 namespace OrchardCore.OpenId.Deployment
 {
@@ -23,12 +24,19 @@ namespace OrchardCore.OpenId.Deployment
                 return;
             }
 
-            var serverSettings = await _openIdServerService.GetSettingsAsync();
+            var serverSettings = await _openIdServerService
+                .GetSettingsAsync();
 
-            result.Steps.Add(new JObject(
-                new JProperty("name", "OpenIdServer"),
-                new JProperty("OpenIdServer", JObject.FromObject(serverSettings))
-            ));
+            // Use nameof(OpenIdServerSettings) as name,
+            // to match the recipe step.
+            var obj = new JObject(
+                new JProperty(
+                    "name",
+                    nameof(OpenIdServerSettings)));
+
+            obj.Merge(JObject.FromObject(serverSettings));
+
+            result.Steps.Add(obj);
         }
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdServerDeploymentSourceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdServerDeploymentSourceTests.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
             };
         }
 
-        private static Mock<IOpenIdServerService> CreateServerServiceWithAuthorityMock(OpenIdServerSettings settings)
+        private static Mock<IOpenIdServerService> CreateServerServiceWithSettingsMock(OpenIdServerSettings settings)
         {
             var serverService = new Mock<IOpenIdServerService>();
 
@@ -48,10 +48,10 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
             var recipeFile = "Recipe.json";
 
             var expectedSettings = CreateSettings("https://deploy.localhost", TokenFormat.JsonWebToken);
-            var deployServerServiceMock = CreateServerServiceWithAuthorityMock(expectedSettings);
+            var deployServerServiceMock = CreateServerServiceWithSettingsMock(expectedSettings);
 
             var actualSettings = CreateSettings("https://recipe.localhost", TokenFormat.DataProtection);
-            var recipeServerServiceMock = CreateServerServiceWithAuthorityMock(actualSettings);
+            var recipeServerServiceMock = CreateServerServiceWithSettingsMock(actualSettings);
 
             Assert.NotEqual(expectedSettings.Authority, actualSettings.Authority);
             Assert.NotEqual(expectedSettings.AccessTokenFormat, actualSettings.AccessTokenFormat);

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdServerDeploymentSourceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdServerDeploymentSourceTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json.Linq;
+using OrchardCore.Deployment;
+using OrchardCore.OpenId.Deployment;
+using OrchardCore.OpenId.Recipes;
+using OrchardCore.OpenId.Services;
+using OrchardCore.OpenId.Settings;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Tests.Stubs;
+using Xunit;
+using static OrchardCore.OpenId.Settings.OpenIdServerSettings;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
+{
+    public class OpenIdServerDeploymentSourceTests
+    {
+        private static OpenIdServerSettings CreateSettings(string authority, TokenFormat tokenFormat)
+        {
+            return new OpenIdServerSettings
+            {
+                Authority = new Uri(authority),
+                AccessTokenFormat = tokenFormat
+            };
+        }
+
+        private static Mock<IOpenIdServerService> CreateServerServiceWithAuthorityMock(OpenIdServerSettings settings)
+        {
+            var serverService = new Mock<IOpenIdServerService>();
+
+            serverService
+                .Setup(m => m.GetSettingsAsync())
+                .ReturnsAsync(settings);
+
+            serverService
+                .Setup(m => m.LoadSettingsAsync())
+                .ReturnsAsync(settings);
+
+            return serverService;
+        }
+
+        [Fact]
+        public async Task ServerDeploymentSourceIsReadableByRecipe()
+        {
+            // Arrange
+            var recipeFile = "Recipe.json";
+
+            var expectedSettings = CreateSettings("https://deploy.localhost", TokenFormat.JsonWebToken);
+            var deployServerServiceMock = CreateServerServiceWithAuthorityMock(expectedSettings);
+
+            var actualSettings = CreateSettings("https://recipe.localhost", TokenFormat.DataProtection);
+            var recipeServerServiceMock = CreateServerServiceWithAuthorityMock(actualSettings);
+
+            Assert.NotEqual(expectedSettings.Authority, actualSettings.Authority);
+            Assert.NotEqual(expectedSettings.AccessTokenFormat, actualSettings.AccessTokenFormat);
+
+            var fileBuilder = new MemoryFileBuilder();
+            var descriptor = new RecipeDescriptor();
+            var result = new DeploymentPlanResult(fileBuilder, descriptor);
+
+            var deploymentSource = new OpenIdServerDeploymentSource(deployServerServiceMock.Object);
+
+            // Act
+            await deploymentSource.ProcessDeploymentStepAsync(new OpenIdServerDeploymentStep(), result);
+            await result.FinalizeAsync();
+
+            var deploy = JObject.Parse(
+                fileBuilder.GetFileContents(
+                    recipeFile,
+                    Encoding.UTF8));
+
+            var recipeContext = new RecipeExecutionContext
+            {
+                RecipeDescriptor = descriptor,
+                Name = deploy.Property("steps").Value.First.Value<string>("name"),
+                Step = (JObject)deploy.Property("steps").Value.First,
+            };
+
+            var recipeStep = new OpenIdServerSettingsStep(recipeServerServiceMock.Object);
+            await recipeStep.ExecuteAsync(recipeContext);
+
+            // Assert
+            Assert.Equal(expectedSettings.Authority, actualSettings.Authority);
+            Assert.Equal(expectedSettings.AccessTokenFormat, actualSettings.AccessTokenFormat);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Stubs/MemoryFileBuilder.cs
+++ b/test/OrchardCore.Tests/Stubs/MemoryFileBuilder.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using OrchardCore.Deployment;
+
+namespace OrchardCore.Tests.Stubs
+{
+    /// <summary>
+    /// In memory file builder that uses a dictionary as virtual file system.
+    /// Intended for unit testing.
+    /// </summary>
+    public class MemoryFileBuilder
+        : IFileBuilder
+    {
+        public Dictionary<string, byte[]> VirtualFiles { get; private set; } = new();
+
+        public async Task SetFileAsync(string subpath, Stream stream)
+        {
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms);
+            VirtualFiles[subpath] = ms.ToArray();
+        }
+
+        /// <summary>
+        /// Read the contents of a file built with this file builder, using the specified encoding.
+        /// </summary>
+        /// <param name="subpath">Path and/or file name</param>
+        /// <param name="encoding">Encoding used to convert the byte array to string</param>
+        /// <returns></returns>
+        public string GetFileContents(string subpath, Encoding encoding)
+        {
+            return encoding.GetString(VirtualFiles[subpath]);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Stubs/MemoryFileBuilder.cs
+++ b/test/OrchardCore.Tests/Stubs/MemoryFileBuilder.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Tests.Stubs
     public class MemoryFileBuilder
         : IFileBuilder
     {
-        public Dictionary<string, byte[]> VirtualFiles { get; private set; } = new();
+        public Dictionary<string, byte[]> VirtualFiles { get; private set; } = new Dictionary<string, byte[]>();
 
         public async Task SetFileAsync(string subpath, Stream stream)
         {


### PR DESCRIPTION
Refactor `OpenIdServerDeploymentSource` to be readable by the current implementation of `OpenIdServerSettingsStep`.

The server settings deployment source output is changed from:
```
...
"steps": [
  {
    "name": "OpenIdServer",
    "OpenIdServer": {
        ...
    }
  }
]
```
to:
```
...
"steps": [
  {
    "name": "OpenIdServerSettings",
    ...
  }
]
```
Partially deals with existing issue, see #6364