### PR TITLE
Use step model for OpenId server settings deploy

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentSource.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Deployment;
+using OrchardCore.OpenId.Recipes;
 using OrchardCore.OpenId.Services;
 using OrchardCore.OpenId.Settings;
 
@@ -24,8 +25,40 @@ namespace OrchardCore.OpenId.Deployment
                 return;
             }
 
-            var serverSettings = await _openIdServerService
+            var settings = await _openIdServerService
                 .GetSettingsAsync();
+
+            var settingsModel = new OpenIdServerSettingsStepModel
+            {
+                AccessTokenFormat = settings.AccessTokenFormat,
+                Authority = settings.Authority?.AbsoluteUri,
+
+                EncryptionCertificateStoreLocation = settings.EncryptionCertificateStoreLocation,
+                EncryptionCertificateStoreName = settings.EncryptionCertificateStoreName,
+                EncryptionCertificateThumbprint = settings.EncryptionCertificateThumbprint,
+
+                SigningCertificateStoreLocation = settings.SigningCertificateStoreLocation,
+                SigningCertificateStoreName = settings.SigningCertificateStoreName,
+                SigningCertificateThumbprint = settings.SigningCertificateThumbprint,
+
+                // The recipe step only reads these flags, and uses constants for the paths.
+                // Conversely, we export true for endpoints with a path, false for those without.
+                EnableAuthorizationEndpoint = !string.IsNullOrWhiteSpace(settings.AuthorizationEndpointPath),
+                EnableLogoutEndpoint = !string.IsNullOrWhiteSpace(settings.LogoutEndpointPath),
+                EnableTokenEndpoint = !string.IsNullOrWhiteSpace(settings.TokenEndpointPath),
+                EnableUserInfoEndpoint = !string.IsNullOrWhiteSpace(settings.UserinfoEndpointPath),
+
+                AllowAuthorizationCodeFlow = settings.AllowAuthorizationCodeFlow,
+                AllowClientCredentialsFlow = settings.AllowClientCredentialsFlow,
+                AllowHybridFlow = settings.AllowHybridFlow,
+                AllowImplicitFlow = settings.AllowImplicitFlow,
+                AllowPasswordFlow = settings.AllowPasswordFlow,
+                AllowRefreshTokenFlow = settings.AllowRefreshTokenFlow,
+
+                DisableAccessTokenEncryption = settings.DisableAccessTokenEncryption,
+                DisableRollingRefreshTokens = settings.DisableRollingRefreshTokens,
+                UseReferenceAccessTokens = settings.UseReferenceAccessTokens,
+            };
 
             // Use nameof(OpenIdServerSettings) as name,
             // to match the recipe step.
@@ -34,7 +67,7 @@ namespace OrchardCore.OpenId.Deployment
                     "name",
                     nameof(OpenIdServerSettings)));
 
-            obj.Merge(JObject.FromObject(serverSettings));
+            obj.Merge(JObject.FromObject(settingsModel));
 
             result.Steps.Add(obj);
         }


### PR DESCRIPTION
This is another part of #6364

The deployment source currently exports `OpenIdServerSettings` directly, whereas the recipe step parses `OpenIdServerSettingsStepModel`.

Most properties work fine anyway, but the endpoint settings are ignored by the recipe step.

Example of previous export (ignored by recipe import):
```
...
"AuthorizationEndpointPath": "/connect/authorize",
"LogoutEndpointPath": "/connect/logout",
"TokenEndpointPath": "/connect/token",
"UserinfoEndpointPath": null,
...
```

Example of fixed export:
```
...
"EnableTokenEndpoint": true,
"EnableAuthorizationEndpoint": true,
"EnableLogoutEndpoint": true,
"EnableUserInfoEndpoint": false,
...
```
The endpoint paths are no longer exported at all, because the recipe step only reads the boolean values, and  uses constants for the paths if a flag is true.

The UI does not allow to edit the endpoint paths either, so I'm hoping this fix is fine.