### PR TITLE
Allow to input seconds in TimeField editor

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
@@ -8,7 +8,7 @@
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>
-            <input asp-for="Value" type="time" class="form-control content-preview-select" required="@settings.Required" />
+            <input asp-for="Value" type="time" class="form-control content-preview-select" step="1" required="@settings.Required" />
         </div>
     </div>
     @if (!String.IsNullOrEmpty(settings.Hint))


### PR DESCRIPTION
Just by setting the step attribute to 1, otherwise the seconds are not editable.

If it is not a problem to have the seconds editable by default.

Otherwise would need to be a setting, knowing that if you set the step to e.g. `0.2` the milliseconds will be editable, so maybe for the step value we could only use an integer value < 60 (that only acts on the seconds), or for simplicity only allow `step=1` as done here. If so the setting could be a boolean => `Whether the seconds are editable`.