### PR TITLE
OpenID Recipes: use step model instead of view model, support update

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -29,12 +29,8 @@ namespace OrchardCore.OpenId.Recipes
             }
 
             var model = context.Step.ToObject<OpenIdApplicationStepModel>();
-
-            var app = await _applicationManager
-                .FindByClientIdAsync(model.ClientId);
-
+            var app = await _applicationManager.FindByClientIdAsync(model.ClientId);
             var descriptor = new OpenIdApplicationDescriptor();
-
             var isNew = true;
 
             if (app != null)
@@ -82,7 +78,6 @@ namespace OrchardCore.OpenId.Recipes
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
             }
-            
             if (model.AllowAuthorizationCodeFlow)
             {
                 descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);
@@ -107,7 +102,6 @@ namespace OrchardCore.OpenId.Recipes
                     descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
                 }
             }
-
             if (!string.IsNullOrWhiteSpace(model.PostLogoutRedirectUris))
             {
                 descriptor.PostLogoutRedirectUris.UnionWith(
@@ -115,7 +109,6 @@ namespace OrchardCore.OpenId.Recipes
                         .Split(' ', StringSplitOptions.RemoveEmptyEntries)
                         .Select(u => new Uri(u, UriKind.Absolute)));
             }
-
             if (!string.IsNullOrWhiteSpace(model.RedirectUris))
             {
                 descriptor.RedirectUris.UnionWith(
@@ -123,21 +116,18 @@ namespace OrchardCore.OpenId.Recipes
                         .Split(' ', StringSplitOptions.RemoveEmptyEntries)
                         .Select(u => new Uri(u, UriKind.Absolute)));
             }
-
             if (model.RoleEntries != null)
             {
                 descriptor.Roles.UnionWith(
                     model.RoleEntries
                         .Select(role => role.Name));
             }
-
             if (model.ScopeEntries != null)
             {
                 descriptor.Permissions.UnionWith(
                     model.ScopeEntries
                         .Select(scope => OpenIddictConstants.Permissions.Prefixes.Scope + scope.Name));
             }
-
             if (isNew)
             {
                 await _applicationManager.CreateAsync(descriptor);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using OpenIddict.Abstractions;
 using OrchardCore.OpenId.Abstractions.Descriptors;
 using OrchardCore.OpenId.Abstractions.Managers;
-using OrchardCore.OpenId.ViewModels;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Recipes.Services;
 
@@ -29,16 +28,26 @@ namespace OrchardCore.OpenId.Recipes
                 return;
             }
 
-            var model = context.Step.ToObject<CreateOpenIdApplicationViewModel>();
+            var model = context.Step.ToObject<OpenIdApplicationStepModel>();
 
-            var descriptor = new OpenIdApplicationDescriptor
+            var app = await _applicationManager
+                .FindByClientIdAsync(model.ClientId);
+
+            var descriptor = new OpenIdApplicationDescriptor();
+
+            var isNew = true;
+
+            if (app != null)
             {
-                ClientId = model.ClientId,
-                ClientSecret = model.ClientSecret,
-                ConsentType = model.ConsentType,
-                DisplayName = model.DisplayName,
-                Type = model.Type
-            };
+                isNew = false;
+                await _applicationManager.PopulateAsync(app, descriptor);
+            }
+
+            descriptor.ClientId = model.ClientId;
+            descriptor.ClientSecret = model.ClientSecret;
+            descriptor.ConsentType = model.ConsentType;
+            descriptor.DisplayName = model.DisplayName;
+            descriptor.Type = model.Type;
 
             if (model.AllowAuthorizationCodeFlow)
             {
@@ -99,19 +108,44 @@ namespace OrchardCore.OpenId.Recipes
                 }
             }
 
-            descriptor.PostLogoutRedirectUris.UnionWith(
-                from uri in model.PostLogoutRedirectUris?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()
-                select new Uri(uri, UriKind.Absolute));
+            if (!string.IsNullOrWhiteSpace(model.PostLogoutRedirectUris))
+            {
+                descriptor.PostLogoutRedirectUris.UnionWith(
+                    model.PostLogoutRedirectUris
+                        .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(u => new Uri(u, UriKind.Absolute)));
+            }
 
-            descriptor.RedirectUris.UnionWith(
-                from uri in model.RedirectUris?.Split(' ', StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()
-                select new Uri(uri, UriKind.Absolute));
+            if (!string.IsNullOrWhiteSpace(model.RedirectUris))
+            {
+                descriptor.RedirectUris.UnionWith(
+                    model.RedirectUris
+                        .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(u => new Uri(u, UriKind.Absolute)));
+            }
 
-            descriptor.Roles.UnionWith(model.RoleEntries
-                .Where(role => role.Selected)
-                .Select(role => role.Name));
+            if (model.RoleEntries != null)
+            {
+                descriptor.Roles.UnionWith(
+                    model.RoleEntries
+                        .Select(role => role.Name));
+            }
 
-            await _applicationManager.CreateAsync(descriptor);
+            if (model.ScopeEntries != null)
+            {
+                descriptor.Permissions.UnionWith(
+                    model.ScopeEntries
+                        .Select(scope => OpenIddictConstants.Permissions.Prefixes.Scope + scope.Name));
+            }
+
+            if (isNew)
+            {
+                await _applicationManager.CreateAsync(descriptor);
+            }
+            else
+            {
+                await _applicationManager.UpdateAsync(app, descriptor);
+            }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStepModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStepModel.cs
@@ -25,6 +25,7 @@ namespace OrchardCore.OpenId.Recipes
         {
             public string Name { get; set; }
         }
+
         public class ScopeEntry
         {
             public string Name { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStepModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStepModel.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace OrchardCore.OpenId.Recipes
+{
+    public class OpenIdApplicationStepModel
+    {
+        public string ClientId { get; set; }
+        public string DisplayName { get; set; }
+        public string RedirectUris { get; set; }
+        public string PostLogoutRedirectUris { get; set; }
+        public string Type { get; set; }
+        public string ConsentType { get; set; }
+        public string ClientSecret { get; set; }
+        public RoleEntry[] RoleEntries { get; set; } = Array.Empty<RoleEntry>();
+        public ScopeEntry[] ScopeEntries { get; set; } = Array.Empty<ScopeEntry>();
+        public bool AllowPasswordFlow { get; set; }
+        public bool AllowClientCredentialsFlow { get; set; }
+        public bool AllowAuthorizationCodeFlow { get; set; }
+        public bool AllowRefreshTokenFlow { get; set; }
+        public bool AllowHybridFlow { get; set; }
+        public bool AllowImplicitFlow { get; set; }
+        public bool AllowLogoutEndpoint { get; set; }
+
+        public class RoleEntry
+        {
+            public string Name { get; set; }
+        }
+        public class ScopeEntry
+        {
+            public string Name { get; set; }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdScopeStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdScopeStep.cs
@@ -27,10 +27,7 @@ namespace OrchardCore.OpenId.Recipes
             }
 
             var model = context.Step.ToObject<OpenIdScopeStepModel>();
-
-            var scope = await _scopeManager
-                .FindByNameAsync(model.ScopeName);
-
+            var scope = await _scopeManager.FindByNameAsync(model.ScopeName);
             var descriptor = new OpenIdScopeDescriptor();
             var isNew = true;
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdScopeStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdScopeStep.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.OpenId.Recipes
                 return;
             }
 
-            var model = context.Step.ToObject<OpenIdScopeStepViewModel>();
+            var model = context.Step.ToObject<OpenIdScopeStepModel>();
             var descriptor = new OpenIdScopeDescriptor
             {
                 Description = model.Description,

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdScopeStepModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdScopeStepModel.cs
@@ -1,0 +1,10 @@
+namespace OrchardCore.OpenId.Recipes
+{
+    public class OpenIdScopeStepModel
+    {
+        public string Description { get; set; }
+        public string DisplayName { get; set; }
+        public string ScopeName { get; set; }
+        public string Resources { get; set; }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileProviders;
+using Moq;
+using Newtonsoft.Json.Linq;
+using OpenIddict.Abstractions;
+using OrchardCore.OpenId.Abstractions.Descriptors;
+using OrchardCore.OpenId.Abstractions.Managers;
+using OrchardCore.OpenId.Recipes;
+using OrchardCore.OpenId.YesSql.Models;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Tests.Utilities;
+using Xunit;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
+{
+    public class OpenIdApplicationStepTests
+    {
+        private string GetRecipeFileContent(string recipeName)
+        {
+            return new EmbeddedFileProvider(GetType().Assembly)
+                .GetFileInfo($"Modules.OrchardCore.OpenId.RecipeFiles.{recipeName}.json")
+                .ReadToEnd();
+        }
+
+        [Theory]
+        [ClassData(typeof(OpenIdApplicationStepTestsData))]
+        public async Task OpenIdApplicationCanBeParsed(string recipeName, OpenIdApplicationDescriptor expected)
+        {
+            // Arrange
+            OpenIdApplicationDescriptor actual = null;
+
+            var appManagerMock = new Mock<IOpenIdApplicationManager>(MockBehavior.Strict);
+
+            appManagerMock.Setup(m =>
+                m.FindByClientIdAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(
+                    new ValueTask<object>(actual));
+
+            appManagerMock.Setup(m =>
+                m.CreateAsync(
+                    It.IsAny<OpenIdApplicationDescriptor>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<object, CancellationToken>((app, c) =>
+                    actual = (OpenIdApplicationDescriptor)app)
+                .Returns(
+                    new ValueTask<object>(actual));
+
+            var step = new OpenIdApplicationStep(appManagerMock.Object);
+
+            var recipe = JObject.Parse(
+                GetRecipeFileContent(recipeName));
+
+            var context = new RecipeExecutionContext
+            {
+                Name = recipe.Property("steps").Value.First.Value<string>("name"),
+                Step = (JObject)recipe.Property("steps").Value.First,
+            };
+
+            // Act
+            await step.ExecuteAsync(context);
+
+            // Assert
+            appManagerMock.Verify(m =>
+                m.FindByClientIdAsync(
+                    It.Is<string>(ci => ci == expected.ClientId),
+                    It.IsAny<CancellationToken>()));
+
+            appManagerMock.Verify(m =>
+                m.CreateAsync(
+                    It.IsAny<OpenIdApplicationDescriptor>(),
+                    It.IsAny<CancellationToken>()));
+
+            Assert.Equal(expected.ClientId, actual.ClientId);
+            Assert.Equal(expected.ClientSecret, actual.ClientSecret);
+            Assert.Equal(expected.ConsentType, actual.ConsentType);
+            Assert.Equal(expected.DisplayName, actual.DisplayName);
+            Assert.Equal(expected.Type, actual.Type);
+            Assert.Equal(expected.Permissions, actual.Permissions);
+            Assert.Equal(expected.PostLogoutRedirectUris, actual.PostLogoutRedirectUris);
+            Assert.Equal(expected.RedirectUris, actual.RedirectUris);
+            Assert.Equal(expected.Roles, actual.Roles);
+        }
+
+        [Fact]
+        public async Task OpenIdApplicationCanBeUpdated()
+        {
+            // Arrange
+            var recipeName = "app-recipe3";
+            var clientId = "a1";
+            var expected = new OpenIdApplicationDescriptor
+            {
+                ClientId = clientId,
+                DisplayName = "Expected Name"
+            };
+            expected.RedirectUris.UnionWith(new[] { new Uri("https://localhost/redirect") });
+
+            var actual = new OpenIdApplicationDescriptor
+            {
+                ClientId = clientId,
+                DisplayName = "Actual Name"
+            };
+            actual.RedirectUris.UnionWith(new[] { new Uri("https://localhost/x") });
+            actual.Roles.UnionWith(new[] { "x" });
+            actual.Permissions.UnionWith(new[] { $"{Permissions.Prefixes.Scope}x" });
+
+            var actualDb = new OpenIdApplication
+            {
+                ClientId = actual.ClientId,
+                DisplayName = actual.DisplayName,
+                RedirectUris = actual.RedirectUris.Select(u => u.AbsoluteUri).ToImmutableArray(),
+                Roles = actual.Roles.ToImmutableArray(),
+                Permissions = actual.Permissions.ToImmutableArray()
+            };
+
+            var appManagerMock = new Mock<IOpenIdApplicationManager>(MockBehavior.Strict);
+
+            appManagerMock.Setup(m =>
+                m.FindByClientIdAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(
+                    new ValueTask<object>(actualDb));
+
+            appManagerMock.Setup(m =>
+                m.PopulateAsync(
+                    It.IsAny<object>(),
+                    It.IsAny<OpenIddictApplicationDescriptor>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(
+                    new ValueTask());
+
+            appManagerMock.Setup(m =>
+                m.UpdateAsync(
+                    It.IsAny<object>(),
+                    It.IsAny<OpenIdApplicationDescriptor>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<object, OpenIddictApplicationDescriptor, CancellationToken>((app, desc, c) =>
+                    actual = (OpenIdApplicationDescriptor)desc)
+                .Returns(
+                    new ValueTask());
+
+            var step = new OpenIdApplicationStep(appManagerMock.Object);
+
+            var recipe = JObject.Parse(
+                GetRecipeFileContent(recipeName));
+
+            var context = new RecipeExecutionContext
+            {
+                Name = recipe.Property("steps").Value.First.Value<string>("name"),
+                Step = (JObject)recipe.Property("steps").Value.First,
+            };
+
+            // Act
+            await step.ExecuteAsync(context);
+
+            // Assert
+            appManagerMock.Verify(m =>
+                m.FindByClientIdAsync(
+                    It.Is<string>(ci => ci == expected.ClientId),
+                    It.IsAny<CancellationToken>()));
+
+            appManagerMock.Verify(m =>
+                m.UpdateAsync(
+                    It.IsAny<object>(),
+                    It.IsAny<OpenIdApplicationDescriptor>(),
+                    It.IsAny<CancellationToken>()));
+
+            Assert.Equal(expected.ClientId, actual.ClientId);
+            Assert.Equal(expected.ClientSecret, actual.ClientSecret);
+            Assert.Equal(expected.ConsentType, actual.ConsentType);
+            Assert.Equal(expected.DisplayName, actual.DisplayName);
+            Assert.Equal(expected.Type, actual.Type);
+            Assert.Equal(expected.Permissions, actual.Permissions);
+            Assert.Equal(expected.PostLogoutRedirectUris, actual.PostLogoutRedirectUris);
+            Assert.Equal(expected.RedirectUris, actual.RedirectUris);
+            Assert.Equal(expected.Roles, actual.Roles);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
@@ -20,20 +20,12 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
 {
     public class OpenIdApplicationStepTests
     {
-        private string GetRecipeFileContent(string recipeName)
-        {
-            return new EmbeddedFileProvider(GetType().Assembly)
-                .GetFileInfo($"Modules.OrchardCore.OpenId.RecipeFiles.{recipeName}.json")
-                .ReadToEnd();
-        }
-
         [Theory]
         [ClassData(typeof(OpenIdApplicationStepTestsData))]
         public async Task OpenIdApplicationCanBeParsed(string recipeName, OpenIdApplicationDescriptor expected)
         {
             // Arrange
             OpenIdApplicationDescriptor actual = null;
-
             var appManagerMock = new Mock<IOpenIdApplicationManager>(MockBehavior.Strict);
 
             appManagerMock.Setup(m =>
@@ -53,10 +45,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
                     new ValueTask<object>(actual));
 
             var step = new OpenIdApplicationStep(appManagerMock.Object);
-
-            var recipe = JObject.Parse(
-                GetRecipeFileContent(recipeName));
-
+            var recipe = JObject.Parse(GetRecipeFileContent(recipeName));
             var context = new RecipeExecutionContext
             {
                 Name = recipe.Property("steps").Value.First.Value<string>("name"),
@@ -147,10 +136,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
                     new ValueTask());
 
             var step = new OpenIdApplicationStep(appManagerMock.Object);
-
-            var recipe = JObject.Parse(
-                GetRecipeFileContent(recipeName));
-
+            var recipe = JObject.Parse(GetRecipeFileContent(recipeName));
             var context = new RecipeExecutionContext
             {
                 Name = recipe.Property("steps").Value.First.Value<string>("name"),
@@ -181,6 +167,13 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
             Assert.Equal(expected.PostLogoutRedirectUris, actual.PostLogoutRedirectUris);
             Assert.Equal(expected.RedirectUris, actual.RedirectUris);
             Assert.Equal(expected.Roles, actual.Roles);
+        }
+
+        private string GetRecipeFileContent(string recipeName)
+        {
+            return new EmbeddedFileProvider(GetType().Assembly)
+                .GetFileInfo($"Modules.OrchardCore.OpenId.RecipeFiles.{recipeName}.json")
+                .ReadToEnd();
         }
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using OrchardCore.OpenId.Abstractions.Descriptors;
+using Xunit;
+using static OpenIddict.Abstractions.OpenIddictConstants.Permissions;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
+{
+    internal class OpenIdApplicationStepTestsData
+        : TheoryData<string, OpenIdApplicationDescriptor>
+    {
+        public OpenIdApplicationStepTestsData()
+        {
+            AddWithHashsets(
+                "app-recipe1",
+                new OpenIdApplicationDescriptor
+                {
+                    ClientId = "a1",
+                    ClientSecret = "test-secret",
+                    ConsentType = "explicit",
+                    DisplayName = "Test Application",
+                    Type = "confidential",
+                },
+                new[] { new Uri("https://localhost:111/logout-redirect"), new Uri("https://localhost:222/logout-redirect") },
+                new[] { new Uri("https://localhost:111/redirect"), new Uri("https://localhost:222/redirect") },
+                null,
+                new[] {
+                    GrantTypes.AuthorizationCode,
+                    GrantTypes.RefreshToken,
+                    Endpoints.Authorization,
+                    Endpoints.Logout,
+                    Endpoints.Token,
+                    ResponseTypes.Code,
+                });
+
+            AddWithHashsets(
+                "app-recipe2",
+                new OpenIdApplicationDescriptor
+                {
+                    ClientId = "a2",
+                    ClientSecret = "test-secret",
+                    ConsentType = "explicit",
+                    DisplayName = "Test Application",
+                    Type = "confidential",
+                },
+                new[] { new Uri("https://localhost/logout-redirect") },
+                new[] { new Uri("https://localhost/redirect") },
+                new[] { "role1", "role2" },
+                new[] {
+                    GrantTypes.ClientCredentials,
+                    Endpoints.Token,
+                    $"{Prefixes.Scope}scope1"
+                });
+        }
+
+        private void UnionIfNotNull<TItem>(ISet<TItem> itemSet, IEnumerable<TItem> items)
+        {
+            if (items != null)
+            {
+                itemSet.UnionWith(items);
+            }
+        }
+
+        private void AddWithHashsets(
+            string recipeFile,
+            OpenIdApplicationDescriptor app,
+            IEnumerable<Uri> postLogoutRedirectUris,
+            IEnumerable<Uri> redirectUris,
+            IEnumerable<string> roles,
+            IEnumerable<string> permissions)
+        {
+            UnionIfNotNull(app.PostLogoutRedirectUris, postLogoutRedirectUris);
+            UnionIfNotNull(app.RedirectUris, redirectUris);
+            UnionIfNotNull(app.Roles, roles);
+            UnionIfNotNull(app.Permissions, permissions);
+
+            Add(recipeFile, app);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
@@ -73,7 +73,6 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
             UnionIfNotNull(app.RedirectUris, redirectUris);
             UnionIfNotNull(app.Roles, roles);
             UnionIfNotNull(app.Permissions, permissions);
-
             Add(recipeFile, app);
         }
     }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdScopeStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdScopeStepTests.cs
@@ -33,7 +33,6 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
                 DisplayName = $"Test Scope {suffix}",
                 Description = $"Unit test scope {suffix}."
             };
-
             scope.Resources.UnionWith(resources);
             return scope;
         }
@@ -46,9 +45,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
             // Match expected with scope-recipe.json
             var expected = CreateScopeDescriptor(
                 "test_scope", "A", "res1", "res2", "res3");
-
             OpenIdScopeDescriptor actual = null;
-
             var scopeManagerMock = new Mock<IOpenIdScopeManager>(MockBehavior.Strict);
 
             scopeManagerMock.Setup(m =>
@@ -68,10 +65,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
                     new ValueTask<object>());
 
             var step = new OpenIdScopeStep(scopeManagerMock.Object);
-
-            var recipe = JObject.Parse(
-                GetRecipeFileContent("scope-recipe"));
-
+            var recipe = JObject.Parse(GetRecipeFileContent("scope-recipe"));
             var context = new RecipeExecutionContext
             {
                 Name = recipe.Property("steps").Value.First.Value<string>("name"),
@@ -107,16 +101,13 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
             var scopeName = "test_scope";
             var expected = CreateScopeDescriptor(
                 scopeName, "A", "res1", "res2", "res3");
-
             var actual = CreateScopeDescriptor(
                 scopeName, "B", "res");
-
             var dbActual = new OpenIdScope
             {
                 Name = actual.Name,
                 Resources = actual.Resources.ToImmutableArray()
             };
-
             var scopeManagerMock = new Mock<IOpenIdScopeManager>(MockBehavior.Strict);
 
             scopeManagerMock.Setup(m =>
@@ -145,10 +136,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
                     new ValueTask());
 
             var step = new OpenIdScopeStep(scopeManagerMock.Object);
-
-            var recipe = JObject.Parse(
-                GetRecipeFileContent("scope-recipe"));
-
+            var recipe = JObject.Parse(GetRecipeFileContent("scope-recipe"));
             var context = new RecipeExecutionContext
             {
                 Name = recipe.Property("steps").Value.First.Value<string>("name"),

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdScopeStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdScopeStepTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileProviders;
+using Moq;
+using Newtonsoft.Json.Linq;
+using OrchardCore.OpenId.Abstractions.Descriptors;
+using OrchardCore.OpenId.Abstractions.Managers;
+using OrchardCore.OpenId.Recipes;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Tests.Utilities;
+using Xunit;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
+{
+    public class OpenIdScopeStepTests
+    {
+        private string GetRecipeFileContent(string recipeName)
+        {
+            return new EmbeddedFileProvider(GetType().Assembly)
+                .GetFileInfo($"Modules.OrchardCore.OpenId.RecipeFiles.{recipeName}.json")
+                .ReadToEnd();
+        }
+
+        private static OpenIdScopeDescriptor CreateScopeDescriptor(string name, string suffix, params string[] resources)
+        {
+            var scope = new OpenIdScopeDescriptor
+            {
+                Name = name,
+                DisplayName = $"Test Scope {suffix}",
+                Description = $"Unit test scope {suffix}."
+            };
+
+            scope.Resources.UnionWith(resources);
+            return scope;
+        }
+
+        [Fact]
+        public async Task OpenIdScopeCanBeParsed()
+        {
+            // Arrange
+
+            // Match expected with scope-recipe.json
+            var expected = CreateScopeDescriptor(
+                "test_scope", "A", "res1", "res2", "res3");
+
+            OpenIdScopeDescriptor actual = null;
+
+            var scopeManagerMock = new Mock<IOpenIdScopeManager>(MockBehavior.Strict);
+
+            scopeManagerMock.Setup(m =>
+                m.FindByNameAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(
+                    new ValueTask<object>(actual));
+
+            scopeManagerMock.Setup(m =>
+                m.CreateAsync(
+                    It.IsAny<OpenIdScopeDescriptor>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<object, CancellationToken>((r, c) =>
+                    actual = (OpenIdScopeDescriptor)r)
+                .Returns(
+                    new ValueTask<object>(actual));
+
+            var step = new OpenIdScopeStep(scopeManagerMock.Object);
+
+            var recipe = JObject.Parse(
+                GetRecipeFileContent("scope-recipe"));
+
+            var context = new RecipeExecutionContext
+            {
+                Name = recipe.Property("steps").Value.First.Value<string>("name"),
+                Step = (JObject)recipe.Property("steps").Value.First,
+            };
+
+            // Act
+            await step.ExecuteAsync(context);
+
+            // Assert
+            scopeManagerMock.Verify(m =>
+                m.FindByNameAsync(
+                    It.Is<string>(v => v == expected.Name),
+                    It.IsAny<CancellationToken>()));
+
+            scopeManagerMock.Verify(m =>
+                m.CreateAsync(
+                    It.IsAny<OpenIdScopeDescriptor>(),
+                    It.IsAny<CancellationToken>()));
+
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.DisplayName, actual.DisplayName);
+            Assert.Equal(expected.Description, actual.Description);
+            Assert.Equal(expected.Resources, actual.Resources);
+        }
+
+        [Fact]
+        public async Task OpenIdScopeCanBeUpdated()
+        {
+            // Arrange
+
+            // Match expected with scope-recipe.json
+            var scopeName = "test_scope";
+            var expected = CreateScopeDescriptor(
+                scopeName, "A", "res1", "res2", "res3");
+
+            var actual = CreateScopeDescriptor(
+                scopeName, "B", "res");
+
+            var scopeManagerMock = new Mock<IOpenIdScopeManager>(MockBehavior.Strict);
+
+            scopeManagerMock.Setup(m =>
+                m.FindByNameAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(
+                    new ValueTask<object>(actual));
+
+            scopeManagerMock.Setup(m =>
+                m.UpdateAsync(
+                    It.IsAny<OpenIdScopeDescriptor>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<object, CancellationToken>((r, c) =>
+                    actual = (OpenIdScopeDescriptor)r)
+                .Returns(
+                    new ValueTask());
+
+            var step = new OpenIdScopeStep(scopeManagerMock.Object);
+
+            var recipe = JObject.Parse(
+                GetRecipeFileContent("scope-recipe"));
+
+            var context = new RecipeExecutionContext
+            {
+                Name = recipe.Property("steps").Value.First.Value<string>("name"),
+                Step = (JObject)recipe.Property("steps").Value.First,
+            };
+
+            // Act
+            await step.ExecuteAsync(context);
+
+            // Assert
+            scopeManagerMock.Verify(m =>
+                m.FindByNameAsync(
+                    It.Is<string>(v => v == expected.Name),
+                    It.IsAny<CancellationToken>()));
+
+            scopeManagerMock.Verify(m =>
+                m.UpdateAsync(
+                    It.IsAny<OpenIdScopeDescriptor>(),
+                    It.IsAny<CancellationToken>()));
+
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.DisplayName, actual.DisplayName);
+            Assert.Equal(expected.Description, actual.Description);
+            Assert.Equal(expected.Resources, actual.Resources);
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/app-recipe1.json
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/app-recipe1.json
@@ -1,0 +1,26 @@
+{
+  "name": "AppRecipe",
+  "displayName": "Application Recipe",
+  "description": "",
+  "author": "",
+  "website": "",
+  "version": "1.0.0",
+  "issetuprecipe": false,
+  "categories": [ "test" ],
+  "tags": [],
+  "steps": [
+    {
+      "name": "OpenIdApplication",
+      "clientId": "a1",
+      "clientSecret": "test-secret",
+      "displayName": "Test Application",
+      "type": "confidential",
+      "consentType": "explicit",
+      "allowAuthorizationCodeFlow": true,
+      "allowRefreshTokenFlow": true,
+      "allowLogoutEndpoint": true,
+      "redirectUris": "https://localhost:111/redirect https://localhost:222/redirect",
+      "postLogoutRedirectUris": "https://localhost:111/logout-redirect https://localhost:222/logout-redirect"
+    }
+  ]
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/app-recipe2.json
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/app-recipe2.json
@@ -1,0 +1,39 @@
+{
+  "name": "AppRecipe",
+  "displayName": "Application Recipe",
+  "description": "",
+  "author": "",
+  "website": "",
+  "version": "1.0.0",
+  "issetuprecipe": false,
+  "categories": [ "test" ],
+  "tags": [],
+  "steps": [
+    {
+      "name": "OpenIdApplication",
+      "clientId": "a2",
+      "clientSecret": "test-secret",
+      "displayName": "Test Application",
+      "type": "confidential",
+      "consentType": "explicit",
+      "allowClientCredentialsFlow": true,
+      "redirectUris": "https://localhost/redirect",
+      "postLogoutRedirectUris": "https://localhost/logout-redirect",
+      "roleEntries": [
+        {
+          "name": "role1",
+          "selected": true
+        },
+        {
+          "name": "role2"
+        }
+      ],
+      "scopeEntries": [
+        {
+          "name": "scope1",
+          "selected":  true
+        }
+      ]
+    }
+  ]
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/app-recipe3.json
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/app-recipe3.json
@@ -1,0 +1,19 @@
+{
+  "name": "AppRecipe",
+  "displayName": "Application Recipe",
+  "description": "",
+  "author": "",
+  "website": "",
+  "version": "1.0.0",
+  "issetuprecipe": false,
+  "categories": [ "test" ],
+  "tags": [],
+  "steps": [
+    {
+      "name": "OpenIdApplication",
+      "clientId": "a1",
+      "displayName": "Expected Name",
+      "redirectUris": "https://localhost/redirect"
+    }
+  ]
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/scope-recipe.json
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/RecipeFiles/scope-recipe.json
@@ -1,0 +1,20 @@
+{
+  "name": "ScopeRecipe",
+  "displayName": "Scope Recipe",
+  "description": "",
+  "author": "",
+  "website": "",
+  "version": "1.0.0",
+  "issetuprecipe": false,
+  "categories": [ "test" ],
+  "tags": [],
+  "steps": [
+    {
+      "name": "OpenIdScope",
+      "scopeName": "test_scope",
+      "displayName": "Test Scope A",
+      "description": "Unit test scope A.",
+      "resources": "res1 res2 res3"
+    }
+  ]
+}

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -31,6 +31,7 @@
     <None Remove="Localization\PoFiles\PoeditHeader.po" />
     <None Remove="Localization\PoFiles\SimpleEntry.po" />
     <None Remove="Apis\Lucene\Recipes\luceneQueryTest.json" />
+    <None Remove="Modules\OrchardCore.OpenId\RecipeFiles\scope-recipe.json" />
     <None Remove="Recipes\RecipeFiles\recipe1.json" />
     <None Remove="Recipes\RecipeFiles\recipe2.json" />
     <None Remove="Recipes\RecipeFiles\recipe3.json" />
@@ -50,6 +51,7 @@
     <EmbeddedResource Include="Localization\PoFiles\MultipleEntries.po" />
     <EmbeddedResource Include="Localization\PoFiles\PoeditHeader.po" />
     <EmbeddedResource Include="Localization\PoFiles\SimpleEntry.po" />
+    <EmbeddedResource Include="Modules\OrchardCore.OpenId\RecipeFiles\scope-recipe.json" />
     <EmbeddedResource Include="Recipes\RecipeFiles\recipe5.json" />
     <EmbeddedResource Include="Recipes\RecipeFiles\recipe4.json" />
     <EmbeddedResource Include="Recipes\RecipeFiles\recipe1.json" />

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -31,6 +31,9 @@
     <None Remove="Localization\PoFiles\PoeditHeader.po" />
     <None Remove="Localization\PoFiles\SimpleEntry.po" />
     <None Remove="Apis\Lucene\Recipes\luceneQueryTest.json" />
+    <None Remove="Modules\OrchardCore.OpenId\RecipeFiles\app-recipe1.json" />
+    <None Remove="Modules\OrchardCore.OpenId\RecipeFiles\app-recipe2.json" />
+    <None Remove="Modules\OrchardCore.OpenId\RecipeFiles\app-recipe3.json" />
     <None Remove="Modules\OrchardCore.OpenId\RecipeFiles\scope-recipe.json" />
     <None Remove="Recipes\RecipeFiles\recipe1.json" />
     <None Remove="Recipes\RecipeFiles\recipe2.json" />
@@ -51,6 +54,9 @@
     <EmbeddedResource Include="Localization\PoFiles\MultipleEntries.po" />
     <EmbeddedResource Include="Localization\PoFiles\PoeditHeader.po" />
     <EmbeddedResource Include="Localization\PoFiles\SimpleEntry.po" />
+    <EmbeddedResource Include="Modules\OrchardCore.OpenId\RecipeFiles\app-recipe3.json" />
+    <EmbeddedResource Include="Modules\OrchardCore.OpenId\RecipeFiles\app-recipe2.json" />
+    <EmbeddedResource Include="Modules\OrchardCore.OpenId\RecipeFiles\app-recipe1.json" />
     <EmbeddedResource Include="Modules\OrchardCore.OpenId\RecipeFiles\scope-recipe.json" />
     <EmbeddedResource Include="Recipes\RecipeFiles\recipe5.json" />
     <EmbeddedResource Include="Recipes\RecipeFiles\recipe4.json" />

--- a/test/OrchardCore.Tests/Utilities/FileInfoExtensions.cs
+++ b/test/OrchardCore.Tests/Utilities/FileInfoExtensions.cs
@@ -1,0 +1,15 @@
+using System.IO;
+using Microsoft.Extensions.FileProviders;
+
+namespace OrchardCore.Tests.Utilities
+{
+    public static class FileInfoExtensions
+    {
+        public static string ReadToEnd(this IFileInfo fileInfo)
+        {
+            using var stream = fileInfo.CreateReadStream();
+            using var streamReader = new StreamReader(stream);
+            return streamReader.ReadToEnd();
+        }
+    }
+}


### PR DESCRIPTION
## Changes in the pull request
- Add unit tests for OpenID scopes
- Add unit tests for OpenID apps
- Replace `OpenIdScopeStepViewModel` with `OpenIdScopeStepModel` in recipe
- Replace `CreateOpenIdApplicationViewModel` with `OpenIdApplicationStepModel` in recipe
- Adjust `OpenIdScopeStep` to support `update`
- Adjust `OpenIdApplicationStep` to support `update`
- Adjust `OpenIdApplicationStep` to include importing scopes, which were not imported before

This is another part of #6364