### PR TITLE
Fix build on net6.0

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/Shape.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/Shape.cs
@@ -182,8 +182,7 @@ namespace OrchardCore.DisplayManagement.Shapes
         {
             result = Items;
 
-            if (binder.ReturnType == typeof(IEnumerable<object>) ||
-                binder.ReturnType == typeof(IEnumerable<dynamic>))
+            if (binder.ReturnType == typeof(IEnumerable<object>))
             {
                 return true;
             }


### PR DESCRIPTION
`IEnumerable<dynamic>` is mapped to `IEnumerable<object>` and the compiler now generates an error.