### PR TITLE
Allow to edit TimeField Seconds and ms

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/TimeFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/TimeFieldSettings.cs
@@ -1,8 +1,11 @@
+using System;
+
 namespace OrchardCore.ContentFields.Settings
 {
     public class TimeFieldSettings
     {
         public string Hint { get; set; }
         public bool Required { get; set; }
+        public string Step { get; set; } = String.Empty;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/TimeFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/TimeFieldSettings.cs
@@ -6,6 +6,6 @@ namespace OrchardCore.ContentFields.Settings
     {
         public string Hint { get; set; }
         public bool Required { get; set; }
-        public string Step { get; set; } = String.Empty;
+        public string Step { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
@@ -8,7 +8,7 @@
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>
-            <input asp-for="Value" type="time" class="form-control content-preview-select" required="@settings.Required" />
+            <input asp-for="Value" type="time" class="form-control content-preview-select" step="@settings.Step" required="@settings.Required" />
         </div>
     </div>
     @if (!String.IsNullOrEmpty(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeFieldSettings.Edit.cshtml
@@ -13,7 +13,7 @@
         <input asp-for="Step" class="form-control" />
     </div>
         <span class="hint">@T["The step attribute of the time input allowing to edit seconds and ms."]</span>
-        <span class="hint">@T["For seconds use an integer from '1' to '30', for ms a decimal from '.001' to '.1'."]</span>
+        <span class="hint">@T["For seconds use a divisor of 60 e.g. '15', for ms a decimal equal to a divisor of 1000 divided by 1000 e.g. '0.250'."]</span>
 </div>
 
 <div class="form-group">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeFieldSettings.Edit.cshtml
@@ -7,6 +7,14 @@
         <span class="hint dashed">@T["Whether a value is required."]</span>
     </div>
 </div>
+<div class="form-group">
+    <div class="w-sm-75 w-md-50 w-lg-25 pr-md-3">
+        <label asp-for="Step">@T["Step"]</label>
+        <input asp-for="Step" class="form-control" />
+    </div>
+        <span class="hint">@T["The step attribute of the time input allowing to edit seconds and ms."]</span>
+        <span class="hint">@T["For seconds use an integer from '1' to '30', for ms a decimal from '.001' to '.1'."]</span>
+</div>
 
 <div class="form-group">
     <div class="w-md-75 w-xl-50 pr-md-3">


### PR DESCRIPTION
By using the step attribute of the html time input.

    The step attribute of the time input allowing to edit seconds and ms.
    For seconds use a divisor of 60 e.g. '15',
    for ms a decimal equal to a divisor of 1000 divided by 1000 e.g. '0.250'.

Work as before if leaved empty or an invalid value is inputed.

Tested on Chrome, Edge and FF (see below).

On FF it doesn't take the step value into account but it allows to edit the seconds / ms.
Note: On FF it was already allowing to edit the seconds after the first save, but not on the first editing.
