### PR TITLE
Allow custom editors for bag / flow / widgetsList parts

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
@@ -48,7 +48,7 @@ namespace OrchardCore.Flows.Drivers
 
         public override IDisplayResult Edit(BagPart bagPart, BuildPartEditorContext context)
         {
-            return Initialize<BagPartEditViewModel>("BagPart_Edit", m =>
+            return Initialize<BagPartEditViewModel>(GetEditorShapeType(context), m =>
             {
                 m.BagPart = bagPart;
                 m.Updater = context.Updater;

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.Flows.Drivers
 
         public override IDisplayResult Edit(FlowPart flowPart, BuildPartEditorContext context)
         {
-            return Initialize<FlowPartEditViewModel>("FlowPart_Edit", m =>
+            return Initialize<FlowPartEditViewModel>(GetEditorShapeType(context), m =>
             {
                 m.FlowPart = flowPart;
                 m.Updater = context.Updater;

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Option.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Option.cshtml
@@ -1,0 +1,4 @@
+@{
+    string currentEditor = Model.Editor;
+}
+<option value="" selected="@String.IsNullOrEmpty(currentEditor)">@T["Standard"]</option>

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Option.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Option.cshtml
@@ -1,0 +1,4 @@
+@{
+    string currentEditor = Model.Editor;
+}
+<option value="" selected="@String.IsNullOrEmpty(currentEditor)">@T["Standard"]</option>

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Drivers/WidgetsListPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Drivers/WidgetsListPartDisplayDriver.cs
@@ -73,7 +73,7 @@ namespace OrchardCore.Widgets.Drivers
 
         public override IDisplayResult Edit(WidgetsListPart widgetPart, BuildPartEditorContext context)
         {
-            return Initialize<WidgetsListPartEditViewModel>("WidgetsListPart_Edit", m =>
+            return Initialize<WidgetsListPartEditViewModel>(GetEditorShapeType(context), m =>
             {
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(widgetPart.ContentItem.ContentType);
                 var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(p => p.PartDefinition.Name == nameof(WidgetsListPart));

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/WidgetsListPart.Option.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/WidgetsListPart.Option.cshtml
@@ -1,0 +1,4 @@
+@{
+    string currentEditor = Model.Editor;
+}
+<option value="" selected="@String.IsNullOrEmpty(currentEditor)">@T["Standard"]</option>


### PR DESCRIPTION
Just by using `GetEditorShapeType()` in the related drivers

And providing the related default / standard options views.