### PR TITLE
Lucene : Fix RangeQuery when parsing integer values from JSON

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Services/LuceneIndexManager.cs
@@ -231,9 +231,9 @@ namespace OrchardCore.Lucene
                         break;
 
                     case DocumentIndex.Types.Integer:
-                        if (entry.Value != null && Int32.TryParse(entry.Value.ToString(), out var value))
+                        if (entry.Value != null && Int64.TryParse(entry.Value.ToString(), out var value))
                         {
-                            doc.Add(new Int32Field(entry.Name, value, store));
+                            doc.Add(new Int64Field(entry.Name, value, store));
                         }
                         else
                         {


### PR DESCRIPTION
Fixes #10172

See : https://github.com/OrchardCMS/OrchardCore/blob/8ff2453b72b3bcfc3e2c0181b220be5bc720fd96/src/OrchardCore/OrchardCore.Lucene.Core/QueryProviders/RangeQueryProvider.cs#L70

As you can see it evaluates a Int64 value but we store a Int32 value so it always returns no results.