### PR TITLE
Remove unnecessary check when set HttpsPort

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Https/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Https/Startup.cs
@@ -50,10 +50,7 @@ namespace OrchardCore.Https
                         options.RedirectStatusCode = StatusCodes.Status308PermanentRedirect;
                     }
 
-                    if (settings.SslPort != null)
-                    {
-                        options.HttpsPort = settings.SslPort;
-                    }
+                    options.HttpsPort = settings.SslPort;
                 });
 
             services.AddHsts(options =>


### PR DESCRIPTION
The ASP.NET Core will do the necessary look up when the `HttpsPort` is not set, it will look into the environment variables, then `IServerAddressFeature`