### PR TITLE
Use NotContains() in query in place of IsNotIn<>() when applied on the same index.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListFilterProvider.cs
@@ -187,7 +187,7 @@ namespace OrchardCore.AuditTrail.Services
                             var context = (AuditTrailQueryContext)ctx;
                             var lookupNormalizer = context.ServiceProvider.GetRequiredService<ILookupNormalizer>();
                             var normalizedUserName = lookupNormalizer.NormalizeName(val);
-                            query.With<AuditTrailEventIndex>(x => x.NormalizedUserName.IsNotIn<AuditTrailEventIndex>(s => s.NormalizedUserName, w => w.NormalizedUserName.Contains(normalizedUserName)));
+                            query.With<AuditTrailEventIndex>(x => x.NormalizedUserName.NotContains(normalizedUserName));
 
                             return new ValueTask<IQuery<AuditTrailEvent>>(query);
                         }
@@ -203,7 +203,7 @@ namespace OrchardCore.AuditTrail.Services
                         },
                         (val, query) =>
                         {
-                            query.With<AuditTrailEventIndex>(x => x.UserId.IsNotIn<AuditTrailEventIndex>(s => s.UserId, w => w.UserId.Contains(val)));
+                            query.With<AuditTrailEventIndex>(x => x.UserId.NotContains(val));
 
                             return query;
                         }

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListFilterProvider.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.AuditTrail.Services
         {
             builder
                 .WithNamedTerm("id", builder => builder
-                    .OneCondition<AuditTrailEvent>((val, query) =>
+                    .OneCondition((val, query) =>
                     {
                         if (!String.IsNullOrEmpty(val))
                         {
@@ -53,7 +53,7 @@ namespace OrchardCore.AuditTrail.Services
                     })
                 )
                 .WithNamedTerm("category", builder => builder
-                    .OneCondition<AuditTrailEvent>((val, query) =>
+                    .OneCondition((val, query) =>
                     {
                         if (!String.IsNullOrEmpty(val))
                         {
@@ -99,7 +99,7 @@ namespace OrchardCore.AuditTrail.Services
                     })
                 )
                 .WithNamedTerm("date", builder => builder
-                    .OneCondition<AuditTrailEvent>(async (val, query, ctx) =>
+                    .OneCondition(async (val, query, ctx) =>
                     {
                         if (String.IsNullOrEmpty(val))
                         {
@@ -139,7 +139,7 @@ namespace OrchardCore.AuditTrail.Services
                     })
                 )
                 .WithNamedTerm("sort", builder => builder
-                    .OneCondition<AuditTrailEvent>((val, query, ctx) =>
+                    .OneCondition((val, query, ctx) =>
                     {
                         var context = (AuditTrailQueryContext)ctx;
                         var options = context.ServiceProvider.GetRequiredService<IOptions<AuditTrailAdminListOptions>>().Value;
@@ -172,7 +172,7 @@ namespace OrchardCore.AuditTrail.Services
                     .AlwaysRun()
                 )
                 .WithDefaultTerm("username", builder => builder
-                    .ManyCondition<AuditTrailEvent>(
+                    .ManyCondition(
                         (val, query, ctx) =>
                         {
                             var context = (AuditTrailQueryContext)ctx;
@@ -194,7 +194,7 @@ namespace OrchardCore.AuditTrail.Services
                     )
                 )
                 .WithNamedTerm("userid", builder => builder
-                    .ManyCondition<AuditTrailEvent>(
+                    .ManyCondition(
                         (val, query) =>
                         {
                             query.With<AuditTrailEventIndex>(x => x.UserId.Contains(val));

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListFilterProvider.cs
@@ -5,15 +5,15 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using OrchardCore.AuditTrail.Models;
 using OrchardCore.AuditTrail.Indexes;
+using OrchardCore.AuditTrail.Models;
 using OrchardCore.AuditTrail.Services.Models;
 using OrchardCore.AuditTrail.ViewModels;
 using OrchardCore.Modules;
+using Parlot;
 using YesSql;
 using YesSql.Filters.Query;
 using YesSql.Services;
-using Parlot;
 
 namespace OrchardCore.AuditTrail.Services
 {

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListFilterProvider.cs
@@ -76,7 +76,7 @@ namespace OrchardCore.AuditTrail.Services
                     })
                 )
                 .WithNamedTerm("event", builder => builder
-                    .OneCondition<AuditTrailEvent>((val, query) =>
+                    .OneCondition((val, query) =>
                     {
                         if (!String.IsNullOrEmpty(val))
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
@@ -13,8 +13,8 @@ using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.Contents.Security;
 using OrchardCore.Contents.ViewModels;
-using YesSql.Filters.Query;
 using YesSql;
+using YesSql.Filters.Query;
 using YesSql.Services;
 
 namespace OrchardCore.Contents.Services
@@ -48,13 +48,13 @@ namespace OrchardCore.Contents.Services
                                     break;
                                 default:
                                     query.With<ContentItemIndex>(x => x.Latest);
-                                    break;                                    
+                                    break;
                             }
                         }
                         else
                         {
                             // Draft is the default value.
-                            query.With<ContentItemIndex>(x => x.Latest);                        
+                            query.With<ContentItemIndex>(x => x.Latest);
                         }
 
                         return new ValueTask<IQuery<ContentItem>>(query);
@@ -215,7 +215,7 @@ namespace OrchardCore.Contents.Services
 
                         return query;
                     })
-                    .MapTo<ContentOptionsViewModel>((val, model) => 
+                    .MapTo<ContentOptionsViewModel>((val, model) =>
                     {
                         if (!String.IsNullOrEmpty(val))
                         {
@@ -234,11 +234,11 @@ namespace OrchardCore.Contents.Services
                     .AlwaysRun()
                 )
                 .WithDefaultTerm("text", builder => builder
-                        .ManyCondition<ContentItem>(
-                            ((val, query) => query.With<ContentItemIndex>(x => x.DisplayText.Contains(val))),
-                            ((val, query) => query.With<ContentItemIndex>(x => x.DisplayText.IsNotIn<ContentItemIndex>(s => s.DisplayText, w => w.DisplayText.Contains(val))))
-                        )
-                    );
+                    .ManyCondition<ContentItem>(
+                        (val, query) => query.With<ContentItemIndex>(x => x.DisplayText.Contains(val)),
+                        (val, query) => query.With<ContentItemIndex>(x => x.DisplayText.NotContains(val))
+                    )
+                );
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Contents.Services
         {
             builder
                 .WithNamedTerm("status", builder => builder
-                    .OneCondition<ContentItem>((val, query, ctx) =>
+                    .OneCondition((val, query, ctx) =>
                     {
                         var context = (ContentQueryContext)ctx;
                         if (Enum.TryParse<ContentsStatus>(val, true, out var contentsStatus))
@@ -78,7 +78,7 @@ namespace OrchardCore.Contents.Services
                     .AlwaysRun()
                 )
                 .WithNamedTerm("sort", builder => builder
-                    .OneCondition<ContentItem>((val, query) =>
+                    .OneCondition((val, query) =>
                     {
                         if (Enum.TryParse<ContentsOrder>(val, true, out var contentsOrder))
                         {
@@ -125,7 +125,7 @@ namespace OrchardCore.Contents.Services
                     .AlwaysRun()
                 )
                 .WithNamedTerm("type", builder => builder
-                    .OneCondition<ContentItem>(async (contentType, query, ctx) =>
+                    .OneCondition(async (contentType, query, ctx) =>
                     {
                         var context = (ContentQueryContext)ctx;
                         var httpContextAccessor = context.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
@@ -234,7 +234,7 @@ namespace OrchardCore.Contents.Services
                     .AlwaysRun()
                 )
                 .WithDefaultTerm("text", builder => builder
-                    .ManyCondition<ContentItem>(
+                    .ManyCondition(
                         (val, query) => query.With<ContentItemIndex>(x => x.DisplayText.Contains(val)),
                         (val, query) => query.With<ContentItemIndex>(x => x.DisplayText.NotContains(val))
                     )

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
@@ -17,7 +17,7 @@ namespace OrchardCore.Users.Services
         {
             builder
                 .WithNamedTerm("status", builder => builder
-                    .OneCondition<User>((val, query) =>
+                    .OneCondition((val, query) =>
                     {
                         if (Enum.TryParse<UsersFilter>(val, true, out var usersStatus))
                         {
@@ -55,7 +55,7 @@ namespace OrchardCore.Users.Services
                     })
                 )
                 .WithNamedTerm("sort", builder => builder
-                    .OneCondition<User>((val, query) =>
+                    .OneCondition((val, query) =>
                     {
                         if (Enum.TryParse<UsersOrder>(val, true, out var usersOrder))
                         {
@@ -95,7 +95,7 @@ namespace OrchardCore.Users.Services
                     .AlwaysRun()
                 )
                 .WithNamedTerm("role", builder => builder
-                    .OneCondition<User>((val, query, ctx) =>
+                    .OneCondition((val, query, ctx) =>
                     {
                         var context = (UserQueryContext)ctx;
                         var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
@@ -108,7 +108,7 @@ namespace OrchardCore.Users.Services
                     .MapFrom<UserIndexOptions>((model) => (!String.IsNullOrEmpty(model.SelectedRole), model.SelectedRole))
                 )
                 .WithDefaultTerm("name", builder => builder
-                    .ManyCondition<User>(
+                    .ManyCondition(
                         ((val, query, ctx) =>
                         {
                             var context = (UserQueryContext)ctx;
@@ -130,7 +130,7 @@ namespace OrchardCore.Users.Services
                     )
                 )
                 .WithNamedTerm("email", builder => builder
-                    .ManyCondition<User>(
+                    .ManyCondition(
                         ((val, query, ctx) =>
                         {
                             var context = (UserQueryContext)ctx;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
@@ -2,9 +2,9 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Users.Indexes;
 using OrchardCore.Users.Models;
 using OrchardCore.Users.ViewModels;
-using OrchardCore.Users.Indexes;
 using YesSql;
 using YesSql.Filters.Query;
 using YesSql.Services;
@@ -60,7 +60,7 @@ namespace OrchardCore.Users.Services
                         if (Enum.TryParse<UsersOrder>(val, true, out var usersOrder))
                         {
                             switch (usersOrder)
-                            {   
+                            {
                                 case UsersOrder.Name:
                                     query.With<UserIndex>().OrderBy(u => u.NormalizedUserName);
                                     break;
@@ -71,7 +71,7 @@ namespace OrchardCore.Users.Services
                         }
                         else
                         {
-                            query.With<UserIndex>().OrderBy(u => u.NormalizedUserName);                        
+                            query.With<UserIndex>().OrderBy(u => u.NormalizedUserName);
                         }
 
                         return query;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
@@ -123,7 +123,7 @@ namespace OrchardCore.Users.Services
                             var context = (UserQueryContext)ctx;
                             var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
                             var normalizedUserName = userManager.NormalizeName(val);
-                            query.With<UserIndex>(x => x.NormalizedUserName.IsNotIn<UserIndex>(s => s.NormalizedUserName, w => w.NormalizedUserName.Contains(normalizedUserName)));
+                            query.With<UserIndex>(x => x.NormalizedUserName.NotContains(normalizedUserName));
 
                             return new ValueTask<IQuery<User>>(query);
                         })
@@ -145,7 +145,7 @@ namespace OrchardCore.Users.Services
                             var context = (UserQueryContext)ctx;
                             var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
                             var normalizedEmail = userManager.NormalizeEmail(val);
-                            query.With<UserIndex>(x => x.NormalizedEmail.IsNotIn<UserIndex>(s => s.NormalizedEmail, w => w.NormalizedEmail.Contains(normalizedEmail)));
+                            query.With<UserIndex>(x => x.NormalizedEmail.NotContains(normalizedEmail));
 
                             return new ValueTask<IQuery<User>>(query);
                         })

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
@@ -109,7 +109,7 @@ namespace OrchardCore.Users.Services
                 )
                 .WithDefaultTerm("name", builder => builder
                     .ManyCondition(
-                        ((val, query, ctx) =>
+                        (val, query, ctx) =>
                         {
                             var context = (UserQueryContext)ctx;
                             var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
@@ -117,8 +117,8 @@ namespace OrchardCore.Users.Services
                             query.With<UserIndex>(x => x.NormalizedUserName.Contains(normalizedUserName));
 
                             return new ValueTask<IQuery<User>>(query);
-                        }),
-                        ((val, query, ctx) =>
+                        },
+                        (val, query, ctx) =>
                         {
                             var context = (UserQueryContext)ctx;
                             var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
@@ -126,12 +126,12 @@ namespace OrchardCore.Users.Services
                             query.With<UserIndex>(x => x.NormalizedUserName.NotContains(normalizedUserName));
 
                             return new ValueTask<IQuery<User>>(query);
-                        })
+                        }
                     )
                 )
                 .WithNamedTerm("email", builder => builder
                     .ManyCondition(
-                        ((val, query, ctx) =>
+                        (val, query, ctx) =>
                         {
                             var context = (UserQueryContext)ctx;
                             var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
@@ -139,8 +139,8 @@ namespace OrchardCore.Users.Services
                             query.With<UserIndex>(x => x.NormalizedEmail.Contains(normalizedEmail));
 
                             return new ValueTask<IQuery<User>>(query);
-                        }),
-                        ((val, query, ctx) =>
+                        },
+                        (val, query, ctx) =>
                         {
                             var context = (UserQueryContext)ctx;
                             var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
@@ -148,7 +148,7 @@ namespace OrchardCore.Users.Services
                             query.With<UserIndex>(x => x.NormalizedEmail.NotContains(normalizedEmail));
 
                             return new ValueTask<IQuery<User>>(query);
-                        })
+                        }
                     )
                 );
 


### PR DESCRIPTION
Tested on the contentItem and user admin list filters.

But maybe there is a good reason to use `IsNotIn<>()` ;)

Maybe for perf if something is cached somewhere.