### PR TITLE
Fixes #10211: Localization feature not listed in the admin

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Manifest.cs
@@ -4,16 +4,23 @@ using OrchardCore.Modules.Manifest;
     Name = "Localization",
     Author = ManifestConstants.OrchardCoreTeam,
     Website = ManifestConstants.OrchardCoreWebsite,
-    Version = ManifestConstants.OrchardCoreVersion,
-    Description = "Provides support for UI localization.",
-    Category = "Internationalization",
-    Dependencies = new[] { "OrchardCore.Settings" }
+    Version = ManifestConstants.OrchardCoreVersion
 )]
-#if (NET5_0 || NET5_0_OR_GREATER)
+
+[assembly: Feature(
+    Id = "OrchardCore.Localization",
+    Name = "Localization",
+    Description = "Provides support for UI localization.",
+    Dependencies = new[] { "OrchardCore.Settings" },
+    Category = "Internationalization"
+)]
+
+#if NET5_0_OR_GREATER
 [assembly: Feature(
     Id = "OrchardCore.Localization.ContentLanguageHeader",
     Name = "Content Language Header",
     Description = "Adds the Content-Language HTTP header, which describes the language(s) intended for the audience.",
+    Dependencies = new[] { "OrchardCore.Localization" },
     Category = "Internationalization"
 )]
 #endif

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
@@ -62,21 +62,14 @@ namespace OrchardCore.Localization
             services.AddSiteSettingsPropertyDeploymentStep<LocalizationSettings, LocalizationDeploymentStartup>(S => S["Culture settings"], S => S["Exports the culture settings."]);
         }
     }
-#if (NET5_0 || NET5_0_OR_GREATER)
+
+#if NET5_0_OR_GREATER
     [Feature("OrchardCore.Localization.ContentLanguageHeader")]
     public class ContentLanguageHeaderStartup : StartupBase
     {
         public override void ConfigureServices(IServiceCollection services)
         {
             services.Configure<RequestLocalizationOptions>(options => options.ApplyCurrentCultureToResponseHeaders = true);
-        }
-
-        /// <inheritdocs />
-        public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
-        {
-            var options = serviceProvider.GetService<IOptions<RequestLocalizationOptions>>().Value;
-
-            app.UseRequestLocalization(options);
         }
     }
 #endif


### PR DESCRIPTION
Fixes #10211

Also if both `OC.Localization` and `OC.Localization.ContentLanguageHeader` are enabled, `UseRequestLocalization()` may be call twice resulting in 2 middlewares in the pipeline.

I will merge this PR as it fixes the related issue.

And for now I added to the new feature a dependency on `OC.Localization` and removed its call to `UseRequestLocalization()`.