### PR TITLE
Remove unnecessary role attributes (Lombiq Technologies: OCORE-64)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
@@ -20,7 +20,7 @@
                     <input id="search-box" asp-for="Options.Search" class="form-control" placeholder="@T["Search"]" type="search" autofocus />
                 </div>
                 <div class="btn-group float-right">
-                    <button type="button" class="btn btn-sm btn-secondary float-right create" role="button" data-toggle="modal" data-target="#modalAddQuery">@T["Add Query"]</button>
+                    <button type="button" class="btn btn-sm btn-secondary float-right create" data-toggle="modal" data-target="#modalAddQuery">@T["Add Query"]</button>
                 </div>
             </div>
         </div>
@@ -38,19 +38,19 @@
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>
-                        <div class="form-group col-2 mb-n1" style="display:none" id="actions">
-                            <span class="dropdown float-right mt-1">
-                                <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    @T["Actions"]
-                                </button>
-                                <span class="dropdown-menu dropdown-menu-right" aria-labelledby="bulk-action-menu-button">
-                                    @foreach (var item in Model.Options.ContentsBulkAction)
-                                    {
-                                        <a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a>
-                                    }
-                                </span>
+                    <div class="form-group col-2 mb-n1" style="display:none" id="actions">
+                        <span class="dropdown float-right mt-1">
+                            <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                @T["Actions"]
+                            </button>
+                            <span class="dropdown-menu dropdown-menu-right" aria-labelledby="bulk-action-menu-button">
+                                @foreach (var item in Model.Options.ContentsBulkAction)
+                                {
+                                    <a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a>
+                                }
                             </span>
-                        </div>
+                        </span>
+                    </div>
                 </div>
             </li>
             @foreach (var entry in Model.Queries)

--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -28,17 +28,17 @@
         </div>
     </nav>
     @await RenderSectionAsync("Header", required: false)
-    <main role="main" class="container">
+    <main class="container">
         @await RenderSectionAsync("Messages", required: false)
         @await RenderBodyAsync()
     </main>
     @if (IsSectionDefined("Footer"))
     {
-    <footer>
-        <div class="container">
-            @await RenderSectionAsync("Footer", required: false)
-        </div>
-    </footer>
+        <footer>
+            <div class="container">
+                @await RenderSectionAsync("Footer", required: false)
+            </div>
+        </footer>
     }
     <resources type="FootScript" />
 </body>

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Views/Layout.cshtml
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Views/Layout.cshtml
@@ -16,7 +16,7 @@
 </head>
 <body dir="@Orchard.CultureDir()">
     @await RenderSectionAsync("Header", required: false)
-    <main role="main" class="container">
+    <main class="container">
         @await RenderSectionAsync("Messages", required: false)
         @await RenderBodyAsync()
     </main>


### PR DESCRIPTION
Some HTML5 elements have implied WAI-ARIA roles so setting the implied roles on them explicitly is invalid HTML. See: https://html-validate.org/rules/no-redundant-role.html

Removed those few that I could find.