### PR TITLE
Serilog path

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/appsettings.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/appsettings.json
@@ -29,7 +29,7 @@
       {
         "Name": "File",
         "Args": {
-          "path": "App_Data/Logs/orchard-log.txt",
+          "path": "App_Data/logs/orchard-log.txt",
           "rollingInterval": "Day",
           "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.ffff}|{TenantName}|{MachineName}|{RequestId}|{SourceContext}|{Level:u3}|{Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Warning"

--- a/src/docs/reference/core/Logging.Serilog/README.md
+++ b/src/docs/reference/core/Logging.Serilog/README.md
@@ -30,7 +30,7 @@ Add a reference to `OrchardCore.Logging.Serilog`.
       {
         "Name": "File",
         "Args": {
-          "path": "App_Data/Logs/orchard-log.txt",
+          "path": "App_Data/logs/orchard-log.txt",
           "rollingInterval": "Day",
           "outputTemplate": "{Timestamp:yyyy-MM-dd HH:mm:ss.ffff}|{TenantName}|{RequestId}|{SourceContext}|{Level:u3}|{Message:lj}{NewLine}{Exception}",
           "restrictedToMinimumLevel": "Warning"


### PR DESCRIPTION
Related to #10268 that has been merged

And that replaced in the serilog path `app_data` by `App_Data` which is good

But also replaced `/logs` by `/Logs` and get merged before doing the same in other places

So here in fact I just reverted `/Logs` to `/logs` as before
