### PR TITLE
JSON Recipe Deployment Step

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Deployment/DeploymentPlanDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Deployment/DeploymentPlanDeploymentStep.cs
@@ -1,7 +1,7 @@
 namespace OrchardCore.Deployment.Deployment
 {
     /// <summary>
-    /// Adds layers to a <see cref="DeploymentPlanResult"/>.
+    /// Adds deployment plans to a <see cref="DeploymentPlanResult"/>.
     /// </summary>
     public class DeploymentPlanDeploymentStep : DeploymentStep
     {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Startup.cs
@@ -60,6 +60,10 @@ namespace OrchardCore.Deployment
             services.AddTransient<IDeploymentSource, DeploymentPlanDeploymentSource>();
             services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<DeploymentPlanDeploymentStep>());
             services.AddScoped<IDisplayDriver<DeploymentStep>, DeploymentPlanDeploymentStepDriver>();
+
+            services.AddTransient<IDeploymentSource, JsonRecipeDeploymentSource>();
+            services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<JsonRecipeDeploymentStep>());
+            services.AddScoped<IDisplayDriver<DeploymentStep>, JsonRecipeDeploymentStepDriver>();
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentSource.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+
+namespace OrchardCore.Deployment.Steps
+{
+    public class JsonRecipeDeploymentSource : IDeploymentSource
+    {
+        public Task ProcessDeploymentStepAsync(DeploymentStep deploymentStep, DeploymentPlanResult result)
+        {
+            if (deploymentStep is not JsonRecipeDeploymentStep jsonRecipeStep)
+            {
+                return Task.CompletedTask;
+            }
+
+            result.Steps.Add(JObject.Parse(jsonRecipeStep.Json));
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentSource.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Deployment.Steps
     {
         public Task ProcessDeploymentStepAsync(DeploymentStep deploymentStep, DeploymentPlanResult result)
         {
-            if (deploymentStep is not JsonRecipeDeploymentStep jsonRecipeStep)
+            if (!(deploymentStep is JsonRecipeDeploymentStep jsonRecipeStep))
             {
                 return Task.CompletedTask;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentStep.cs
@@ -1,0 +1,15 @@
+namespace OrchardCore.Deployment.Steps
+{
+    /// <summary>
+    /// Adds a JSON recipe to a <see cref="DeploymentPlanResult"/>.
+    /// </summary>
+    public class JsonRecipeDeploymentStep : DeploymentStep
+    {
+        public JsonRecipeDeploymentStep()
+        {
+            Name = "JsonRecipe";
+        }
+
+        public string Json { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentStepDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentStepDriver.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Newtonsoft.Json.Linq;
+using OrchardCore.Deployment.ViewModels;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Mvc.ModelBinding;
+
+namespace OrchardCore.Deployment.Steps
+{
+    public class JsonRecipeDeploymentStepDriver : DisplayDriver<DeploymentStep, JsonRecipeDeploymentStep>
+    {
+        private readonly IStringLocalizer S;
+
+        public JsonRecipeDeploymentStepDriver(IStringLocalizer<JsonRecipeDeploymentStepDriver> stringLocalizer)
+        {
+            S = stringLocalizer;
+        }
+
+        public override IDisplayResult Display(JsonRecipeDeploymentStep step)
+        {
+            return
+                Combine(
+                    View("JsonRecipeDeploymentStep_Fields_Summary", step).Location("Summary", "Content"),
+                    View("JsonRecipeDeploymentStep_Fields_Thumbnail", step).Location("Thumbnail", "Content")
+                );
+        }
+
+        public override IDisplayResult Edit(JsonRecipeDeploymentStep step)
+        {
+            return Initialize<JsonRecipeDeploymentStepViewModel>("JsonRecipeDeploymentStep_Fields_Edit", model =>
+            {
+                model.Json = step.Json;
+            }).Location("Content");
+        }
+
+        public override async Task<IDisplayResult> UpdateAsync(JsonRecipeDeploymentStep step, IUpdateModel updater)
+        {
+            var model = new JsonRecipeDeploymentStepViewModel();
+
+            if (await updater.TryUpdateModelAsync(model, Prefix))
+            {
+                try
+                {
+                    var jObject = JObject.Parse(model.Json);
+                    if (!jObject.ContainsKey("name"))
+                    {
+
+                        updater.ModelState.AddModelError(Prefix, nameof(JsonRecipeDeploymentStepViewModel.Json), S["The recipe must have a name property"]);
+                    }
+
+                }
+                catch (Exception)
+                {
+                    updater.ModelState.AddModelError(Prefix, nameof(JsonRecipeDeploymentStepViewModel.Json), S["Invalid JSON supplied"]);
+
+                }
+                step.Json = model.Json;
+            }
+
+            return Edit(step);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentStepDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentStepDriver.cs
@@ -12,6 +12,25 @@ namespace OrchardCore.Deployment.Steps
 {
     public class JsonRecipeDeploymentStepDriver : DisplayDriver<DeploymentStep, JsonRecipeDeploymentStep>
     {
+        /// <summary>
+        /// A limited schema for recipe steps. Does not include any step data.
+        /// </summary>
+        public const string Schema = @"
+{
+  ""$schema"": ""http://json-schema.org/draft-04/schema#"",
+  ""type"": ""object"",
+  ""title"": ""JSON Recipe deployment plan"",
+  ""properties"": {
+    ""name"": {
+      ""type"": ""string""
+    }
+  },
+  ""required"": [
+    ""name""
+  ]
+}
+";
+
         private readonly IStringLocalizer S;
 
         public JsonRecipeDeploymentStepDriver(IStringLocalizer<JsonRecipeDeploymentStepDriver> stringLocalizer)
@@ -33,6 +52,7 @@ namespace OrchardCore.Deployment.Steps
             return Initialize<JsonRecipeDeploymentStepViewModel>("JsonRecipeDeploymentStep_Fields_Edit", model =>
             {
                 model.Json = step.Json;
+                model.Schema = Schema;
             }).Location("Content");
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/JsonRecipeDeploymentStepViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/JsonRecipeDeploymentStepViewModel.cs
@@ -1,0 +1,7 @@
+namespace OrchardCore.Deployment.ViewModels
+{
+    public class JsonRecipeDeploymentStepViewModel
+    {
+        public string Json { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/JsonRecipeDeploymentStepViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/JsonRecipeDeploymentStepViewModel.cs
@@ -1,7 +1,12 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
 namespace OrchardCore.Deployment.ViewModels
 {
     public class JsonRecipeDeploymentStepViewModel
     {
         public string Json { get; set; }
+
+        [BindNever]
+        public string Schema { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Edit.cshtml
@@ -1,0 +1,85 @@
+@using Newtonsoft.Json.Linq;
+
+@model JsonRecipeDeploymentStepViewModel
+@inject IStringLocalizer<ViewContext> S
+
+@{
+    var schema = new JObject
+    {
+        new JProperty("$schema", "http://json-schema.org/draft-04/schema#"),
+        new JProperty("type", "object"),
+        new JProperty("title", S["JSON Recipe deployment plan"].ToString()),
+        new JProperty("properties", new JObject
+        {
+            new JProperty("name", new JObject
+            {
+                new JProperty("type", "string")
+            })
+        }),
+        new JProperty("required", new JArray
+        {
+            new JValue("name")
+        })
+    };
+}
+
+<h5>@T["JSON Recipe"]</h5>
+
+<div class="row">
+    <div class="col">
+        <div class="form-group" asp-validation-class-for="Json">
+            <label asp-for="Json">@T["Recipe"]</label>
+            <div class="form-control" style="min-height: 400px;">
+                <div id="@Html.IdFor(x => x.Json)_editor" asp-for="FeatureRules" style="min-height: 385px;" dir="@Orchard.CultureDir()" data-schema='@schema.ToString()'></div>
+            </div>
+            <textarea asp-for="Json" hidden></textarea>
+            <span class="hint">@T["The json recipe."]</span>
+            <span asp-validation-for="Json"></span>
+        </div>
+    </div>
+</div>
+
+<script at="Foot" asp-name="jsonrecipe-editor" depends-on="monaco, admin">
+    $(document).ready(function () {
+        require(['vs/editor/editor.main'], function () {
+
+            var html = document.getElementsByTagName("html")[0];
+            const mutationObserver = new MutationObserver(setTheme);
+            mutationObserver.observe(html, { attributes: true });
+
+            function setTheme() {
+                var theme = html.dataset.theme;
+                if (theme === "darkmode") {
+                    monaco.editor.setTheme('vs-dark')
+                } else {
+                    monaco.editor.setTheme('vs')
+                }
+            }
+
+            setTheme();
+
+            var modelUri = monaco.Uri.parse("x://orchardcore.deployments.steps.jsonrecipe.json");
+            var editor = document.getElementById('@Html.IdFor(x => x.Json)_editor');
+            var textArea = document.getElementById('@Html.IdFor(x => x.Json)');
+            var schema = JSON.parse(editor.dataset.schema)
+            var model = monaco.editor.createModel(textArea.value, "json", modelUri);
+
+            monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+                validate: true,
+                schemas: [{
+                    uri: "x://orchardcore.deployments.steps.jsonrecipe.schema.json",
+                    fileMatch: [modelUri.toString()],
+                    schema: schema
+                }]
+            });
+
+            var editor = monaco.editor.create(editor, {
+                model: model
+            });
+
+            window.addEventListener("submit", function () {
+                textArea.value = editor.getValue();
+            });
+        });
+    });
+</script>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Edit.cshtml
@@ -1,27 +1,4 @@
-@using Newtonsoft.Json.Linq;
-
 @model JsonRecipeDeploymentStepViewModel
-@inject IStringLocalizer<ViewContext> S
-
-@{
-    var schema = new JObject
-    {
-        new JProperty("$schema", "http://json-schema.org/draft-04/schema#"),
-        new JProperty("type", "object"),
-        new JProperty("title", S["JSON Recipe deployment plan"].ToString()),
-        new JProperty("properties", new JObject
-        {
-            new JProperty("name", new JObject
-            {
-                new JProperty("type", "string")
-            })
-        }),
-        new JProperty("required", new JArray
-        {
-            new JValue("name")
-        })
-    };
-}
 
 <h5>@T["JSON Recipe"]</h5>
 
@@ -30,7 +7,7 @@
         <div class="form-group" asp-validation-class-for="Json">
             <label asp-for="Json">@T["Recipe"]</label>
             <div class="form-control" style="min-height: 400px;">
-                <div id="@Html.IdFor(x => x.Json)_editor" asp-for="FeatureRules" style="min-height: 385px;" dir="@Orchard.CultureDir()" data-schema='@schema.ToString()'></div>
+                <div id="@Html.IdFor(x => x.Json)_editor" style="min-height: 385px;" dir="@Orchard.CultureDir()" data-schema='@Model.Schema'></div>
             </div>
             <textarea asp-for="Json" hidden></textarea>
             <span class="hint">@T["The json recipe."]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Summary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Summary.cshtml
@@ -1,0 +1,3 @@
+@model ShapeViewModel<JsonRecipeDeploymentStep>
+
+<h5>@T["JSON Recipe"]</h5>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/Items/JsonRecipeDeploymentStep.Fields.Thumbnail.cshtml
@@ -1,0 +1,4 @@
+@model ShapeViewModel<JsonRecipeDeploymentStep>
+
+<h4 class="card-title">@T["JSON Recipe"]</h4>
+<p>@T["Exports a JSON Recipe."]</p>


### PR DESCRIPTION
Adds a deployment step where you can just write a JSON Recipe and add it to the plan.

Useful to create ad-hoc steps
![image](https://user-images.githubusercontent.com/13782679/133925240-4ea89237-3b5d-4cae-8948-564e12fd6df1.png)
