### PR TITLE
Fix logging of the notification message

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/Notifier.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/Notifier.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.DisplayManagement.Notify
         {
             if (_logger.IsEnabled(LogLevel.Information))
             {
-                _logger.LogInformation("Notification '{NotificationType}' with message '{NotificationMessage}'", type, message);
+                _logger.LogInformation("Notification '{NotificationType}' with message '{NotificationMessage}'", type, message.Value);
             }
 
             _entries.Add(new NotifyEntry { Type = type, Message = message });


### PR DESCRIPTION
LocalizedHtmlString doesn't override ToString, so the fully qualified name is returned, rather than the actual notification message. Make sure the actual message is logged. Fixes #10320 