### PR TITLE
Register DI of ShellFeaturesManager and ShellDescriptorFeaturesManager in AddExtensionServices instead of Infrastructure

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellOrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellOrchardCoreBuilderExtensions.cs
@@ -18,8 +18,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 .ConfigureServices(services =>
                 {
                     services.AddScoped<IShellDescriptorManager, ShellDescriptorManager>();
-                    services.AddScoped<IShellFeaturesManager, ShellFeaturesManager>();
-                    services.AddScoped<IShellDescriptorFeaturesManager, ShellDescriptorFeaturesManager>();
                 });
 
             return builder;

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -165,6 +165,8 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.ConfigureServices(services =>
             {
                 services.AddExtensionManager();
+                services.AddScoped<IShellFeaturesManager, ShellFeaturesManager>();
+                services.AddScoped<IShellDescriptorFeaturesManager, ShellDescriptorFeaturesManager>();
             });
         }
 


### PR DESCRIPTION
Fixes #10311

/cc @jtkech @sebastienros  @CrestApps 

Theming can be added in ASP.NET CORE Apps as following

```cs
         services
                .AddOrchardCore()
                .AddMvc()
                .AddTheming()
```