### PR TITLE
Add store external tokens to OpenID Client recipe step

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdClientSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdClientSettingsStep.cs
@@ -40,6 +40,7 @@ namespace OrchardCore.OpenId.Recipes
             settings.ResponseType = model.ResponseType;
             settings.SignedOutCallbackPath = model.SignedOutCallbackPath;
             settings.SignedOutRedirectUri = model.SignedOutRedirectUri;
+            settings.StoreExternalTokens = model.StoreExternalTokens;
             settings.Parameters = model.Parameters;
 
             await _clientService.UpdateSettingsAsync(settings);
@@ -61,6 +62,7 @@ namespace OrchardCore.OpenId.Recipes
         public string Scopes { get; set; }
         public string ResponseType { get; set; }
         public string ResponseMode { get; set; }
+        public bool StoreExternalTokens { get; set; }
         public ParameterSetting[] Parameters { get; set; }
     }
 }


### PR DESCRIPTION
Allows to set the store external tokens property in a recipe