### PR TITLE
Redirect escapeUrl parameter was not used

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ControllerExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Extensions/ControllerExtensions.cs
@@ -35,6 +35,11 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="escapeUrl">Whether to escape the url.</param>
         public static ActionResult LocalRedirect(this Controller controller, string localUrl, bool escapeUrl)
         {
+            if (!escapeUrl)
+            {
+                return controller.LocalRedirect(localUrl);
+            }
+
             return controller.LocalRedirect(EscapeLocationHeader(localUrl));
         }
 
@@ -47,6 +52,11 @@ namespace Microsoft.AspNetCore.Mvc
         /// <param name="escapeUrl">Whether to escape the url.</param>
         public static ActionResult Redirect(this Controller controller, string url, bool escapeUrl)
         {
+            if (!escapeUrl)
+            {
+                return controller.Redirect(url);
+            }
+
             return controller.Redirect(EscapeLocationHeader(url));
         }
 


### PR DESCRIPTION
So currently, in the new `Redirect()` extensions the `bool escapeUrl` parameter is not used.

I thought about passing it to `EscapeLocationHeader()` and then call `GetComponents()` with `UriFormat.Unescaped` if `escapeUrl` is false. But this option doesn't mean do nothing, in that case `GetComponents()` **really unescape the url** which is not good for a location header. Note: But good to know when we want to retrieve an url for display only.

I thought about not using `bool escapeUrl` anymore but then we retrieve the same signature as the regular `Redirect()`.

So here I used it and if set to false we just return the regular controller `Redirect()`.

Finally I tried to find some places where we could set it to false `Redirect(url, false)`. Yes, when we generate an url and we are sure that it is correctly escaped, we could use `Redirect(url, false)`, e.g. when we use `HostString`, `PathString` and `QueryString` and their inner escapings, but in the first place I checked it I saw one trap.

When you add KVPs to a `QueryString` they are escaped, but if you build yourself a query string and then use `new QueryString(string queryString)`, here the `queryString` needs to be already escaped, I know it is a shame. So I think that for now it is safer to let `escapeUrl = true` in all places, or maybe I'm too lazy ;)

---

The other option is to remove the new `Redirect()` extensions and then use everywhere

    Redirect(EscapeLocationHeader(url));
