### PR TITLE
Add security hash to url in [image] shortcode to allow custom sizes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Shortcodes/ImageShortcodeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Shortcodes/ImageShortcodeProvider.cs
@@ -78,10 +78,10 @@ namespace OrchardCore.Media.Shortcodes
             var altText = string.Empty;
             if (arguments.Any())
             {
-                int? width = int.TryParse(arguments.Named("width"), out var widthValue) ? widthValue : null;
-                int? height = int.TryParse(arguments.Named("height"), out var heightValue) ? heightValue : null;
+                int? width = int.TryParse(arguments.Named("width"), out var widthValue) ? (int?)widthValue : null;
+                int? height = int.TryParse(arguments.Named("height"), out var heightValue) ? (int?)heightValue : null;
                 var mode = Enum.TryParse<ResizeMode>(arguments.Named("mode"), true, out var modeValue) ? modeValue : ResizeMode.Undefined;
-                int? quality = int.TryParse(arguments.Named("quality"), out var qualityValue) ? qualityValue : null;
+                int? quality = int.TryParse(arguments.Named("quality"), out var qualityValue) ? (int?)qualityValue : null;
                 var format = Enum.TryParse<Format>(arguments.Named("format"), true, out var formatValue) ? formatValue : Format.Undefined;
 
                 className = arguments.Named("class");

--- a/src/OrchardCore.Modules/OrchardCore.Media/Shortcodes/ImageShortcodeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Shortcodes/ImageShortcodeProvider.cs
@@ -78,10 +78,10 @@ namespace OrchardCore.Media.Shortcodes
             var altText = string.Empty;
             if (arguments.Any())
             {
-                int? width = int.TryParse(arguments.Named("width"), out var widthValue) ? (int?)widthValue : null;
-                int? height = int.TryParse(arguments.Named("height"), out var heightValue) ? (int?)heightValue : null;
+                var width = int.TryParse(arguments.Named("width"), out var widthValue) ? (int?)widthValue : null;
+                var height = int.TryParse(arguments.Named("height"), out var heightValue) ? (int?)heightValue : null;
                 var mode = Enum.TryParse<ResizeMode>(arguments.Named("mode"), true, out var modeValue) ? modeValue : ResizeMode.Undefined;
-                int? quality = int.TryParse(arguments.Named("quality"), out var qualityValue) ? (int?)qualityValue : null;
+                var quality = int.TryParse(arguments.Named("quality"), out var qualityValue) ? (int?)qualityValue : null;
                 var format = Enum.TryParse<Format>(arguments.Named("format"), true, out var formatValue) ? formatValue : Format.Undefined;
 
                 className = arguments.Named("class");

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/ImageShortcodeTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/ImageShortcodeTests.cs
@@ -84,7 +84,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media
         private static ServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            var mediaOptions = Options.Create(new MediaOptions { UseTokenizedQueryString = true });
+            var mediaOptions = Options.Create(new MediaOptions());
             services.AddTransient(p => { return mediaOptions; });
             return services.BuildServiceProvider();
         }


### PR DESCRIPTION
Use media razor helper so that security token is added to generated URL. This fixes #10406