### PR TITLE
Fixing rendering of helper and block tag helper

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/TodoController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Controllers/TodoController.cs
@@ -93,7 +93,8 @@ namespace OrchardCore.Demo.Controllers
                 return RedirectToAction(nameof(Index), "Todo");
             }
 
-            return View(viewModel);
+            viewModel.DisplayMode = "Edit";
+            return View(nameof(Edit), viewModel);
         }
 
         public async Task<IActionResult> Delete(string todoId)

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Startup.cs
@@ -1,4 +1,6 @@
 using System;
+using Fluid;
+using Fluid.Values;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -121,6 +123,11 @@ namespace OrchardCore.Demo
             });
 
             services.AddTagHelpers(typeof(BazTagHelper).Assembly);
+
+            services.Configure<TemplateOptions>(o =>
+            {
+                o.MemberAccessStrategy.Register<OrchardCore.Demo.ViewModels.TodoViewModel>();
+            });
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Views/Todo.liquid
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Views/Todo.liquid
@@ -1,7 +1,7 @@
 <td>
-    {% a controller: "Todo", action: "Edit", route_todoid: Model.TodoId , route_returnurl: Request.Path %}
+    {% block name: "a", controller: "Todo", action: "Edit", route_todoid: Model.TodoId , route_returnurl: Request.Path %}
         {{ Model.Text }}
-    {% enda %}
+    {% endblock %}
 </td>
 
 <td>{{ Model.DueDate }}</td>
@@ -9,7 +9,7 @@
 <td>{{ Model.IsCompleted }}</td>
 
 <td>
-    {% a action: "Delete" , class: "btn btn-danger", route_todoid: Model.TodoId %}
+    {% block name:"a", action: "Delete" , class: "btn btn-danger", route_todoid: Model.TodoId %}
         Delete
-    {% enda %}
+    {% endblock %}
 </td>

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/FluidTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/FluidTagHelper.cs
@@ -92,6 +92,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
                     identifier,
                     outputAttributes, (_, e) => Task.FromResult(new DefaultTagHelperContent().AppendHtml(content))
                 );
+                tagHelperOutput.Content.AppendHtml(content);
             }
             else
             {
@@ -102,6 +103,7 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
             }
 
             await tagHelper.ProcessAsync(tagHelperContext, tagHelperOutput);
+            tagHelperOutput.WriteTo(writer, (HtmlEncoder)encoder);
 
             return Completion.Normal;
         }


### PR DESCRIPTION
Fixes #9883 -  Fixing rendering of ASP.NET core TagHelper bridge.  
Updated demo code to use ASP.NET Tag helper bridge instead of LiquidTag

// @jtkech  @giannik