### PR TITLE
Added support for Razor Component (*.razor files)

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
@@ -113,6 +113,10 @@ namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
                         {
                             value = mp.CreateModelExpression(vd, v.ToStringValue());
                         }
+                        else if (property.PropertyType == typeof(Type))
+                        {
+                            value = Type.GetType(v.ToStringValue(), true, false);
+                        }
                         else
                         {
                             value = v.ToObjectValue();

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.props
@@ -10,6 +10,7 @@
     <ModuleDefaultAssetExcludes>$(ModuleAssetExcludes);**\node_modules\**;node_modules\**</ModuleDefaultAssetExcludes>
     <ModuleDefaultAssetExcludes>$(ModuleDefaultAssetExcludes);**\jspm_packages\**;jspm_packages\**</ModuleDefaultAssetExcludes>
     <ModuleDefaultAssetExcludes>$(ModuleDefaultAssetExcludes);**\bower_components\**;bower_components\**</ModuleDefaultAssetExcludes>
+    <ModuleDefaultAssetExcludes>$(ModuleDefaultAssetExcludes);**\*.razor</ModuleDefaultAssetExcludes>
     <ModuleType Condition="'$(ModuleType)' == ''">Module</ModuleType>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
@@ -21,6 +22,7 @@
 
   <ItemGroup>
     <None Include="$(ModuleNoneIncludes)" Exclude="$(ModuleNoneExcludes)" />
+    <Content Include="**\*.razor" />
     <EmbeddedResource Include="**\*" Exclude="$(ModuleDefaultAssetExcludes);$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
     <RazorGenerate Include="@(EmbeddedResource->WithMetadataValue('Extension', '.cshtml'))" />
   </ItemGroup>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <None Remove="**\*.cshtml" />
+    <None Remove="**\*.razor" />
     <None Update="@(None)" CopyToPublishDirectory="Never" />
     <EmbeddedResource Update="@(EmbeddedResource)" CopyToPublishDirectory="Never" />
   </ItemGroup>

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -945,7 +945,7 @@ In following example, `route_todoid` adds `Model.TodoId` to hyperlink.
 Using `helper` invokes the `ComponentTagHelper` of ASP.NET Core to render Razor component
 
 ```liquid
-{% helper "component", type: "OrchardCore.Demo.Components.BlazorComponent, MyAssembly", render_mode: "Static", param_ParamString: "ParamValue1", param_ParamObject: Model.ParamValue2 %}
+{% helper "component", type: "MyAssembly.Components.BlazorComponent, MyAssembly", render_mode: "Static", param_ParamString: "ParamValue1", param_ParamObject: Model.ParamValue2 %}
 ```
 
 

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -941,6 +941,13 @@ In following example, `route_todoid` adds `Model.TodoId` to hyperlink.
 {% enda %}
 ```
 
+### `component`
+Using `helper` invokes the `ComponentTagHelper` of ASP.NET Core to render Razor component
+
+```liquid
+{% helper "component", type: "OrchardCore.Demo.Components.BlazorComponent, MyAssembly", render_mode: "Static", param_ParamString: "ParamValue1", param_ParamObject: Model.ParamValue2 %}
+```
+
 
 ### `antiforgerytoken`
 
@@ -952,7 +959,7 @@ Example
 {% antiforgerytoken %}
 ```
 
-### `helper` and `block`
+### `helper and block`
 
 Allows custom Razor [TagHelpers](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro?view=aspnetcore-3.0) to be called from liquid.
 


### PR DESCRIPTION
Added support for razor files and component tag helper

For example
```liquid
{% helper "component", type: "OrchardCore.Demo.Components.HelloBlazor, OrchardCore.Demo", render_mode: "Static", param_Title: Model.Title   %}
```

Fixes #10442