### PR TITLE
Update nlog defaults

### DIFF
--- a/src/OrchardCore.Cms.Web/NLog.config
+++ b/src/OrchardCore.Cms.Web/NLog.config
@@ -26,7 +26,7 @@
         <!-- all warnings and above go to the file target -->
         <logger name="*" minlevel="Warn" writeTo="file" />
 
-        <!-- the hosting lifetime events go to the console -->
-        <logger name="Microsoft.Hosting.Lifetime" minlevel="Info" writeTo="console" />
+        <!-- the hosting lifetime events go to the console and file targets -->
+        <logger name="Microsoft.Hosting.Lifetime" minlevel="Info" writeTo="file, console" />
     </rules>
 </nlog>

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/NLog.config
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/NLog.config
@@ -26,7 +26,7 @@
         <!-- all warnings and above go to the file target -->
         <logger name="*" minlevel="Warn" writeTo="file" />
 
-        <!-- the hosting lifetime events go to the console -->
-        <logger name="Microsoft.Hosting.Lifetime" minlevel="Info" writeTo="console" />
+        <!-- the hosting lifetime events go to the console and file targets -->
+        <logger name="Microsoft.Hosting.Lifetime" minlevel="Info" writeTo="file, console" />
     </rules>
 </nlog>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/10475

logs the hosting environment name to the file as well, to help people discover that they are running the wrong environment in Azure or other hosting environments.

Also catches server restarts, which is useful to have logged