### PR TITLE
Sitemaps fix null reference when no content types

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesSitemapSource.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesSitemapSource.SummaryAdmin.cshtml
@@ -10,7 +10,7 @@
         .Select(x => x.DisplayName);
 
     var limitedDisplayName = allRoutableContentTypes
-        .FirstOrDefault(cdt => cdt.Name == Model.Value.LimitedContentType.ContentTypeName)
+        .FirstOrDefault(cdt => cdt.Name == Model.Value.LimitedContentType.ContentTypeName)?
         .DisplayName;
 }
 


### PR DESCRIPTION
Because @sebastienros likes to try random things.