### PR TITLE
blueimp-file-upload 10.32.0 :arrow_up:

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/package-lock.json
+++ b/src/OrchardCore.Modules/OrchardCore.Media/package-lock.json
@@ -8,7 +8,7 @@
       "name": "orchardcore.media",
       "version": "1.0.0",
       "dependencies": {
-        "blueimp-file-upload": "10.31.0",
+        "blueimp-file-upload": "10.32.0",
         "bootstrap": "4.6.0"
       }
     },
@@ -19,13 +19,16 @@
       "optional": true
     },
     "node_modules/blueimp-file-upload": {
-      "version": "10.31.0",
-      "resolved": "https://registry.npmjs.org/blueimp-file-upload/-/blueimp-file-upload-10.31.0.tgz",
-      "integrity": "sha512-dGAxOf9+SsMDvZPTsIUpe0cOk57taMJYE3FocHEUebhn5BnDbu1hcWOmrP8oswIe6V61Qcm9UDuhq/Pv1t/eRw==",
+      "version": "10.32.0",
+      "resolved": "https://registry.npmjs.org/blueimp-file-upload/-/blueimp-file-upload-10.32.0.tgz",
+      "integrity": "sha512-3WMJw5Cbfz94Adl1OeyH+rRpGwHiNHzja+CR6aRWPoAtwrUwvP5gXKo0XdX+sdPE+iCU63Xmba88hoHQmzY8RQ==",
       "optionalDependencies": {
         "blueimp-canvas-to-blob": "3",
         "blueimp-load-image": "5",
         "blueimp-tmpl": "3"
+      },
+      "peerDependencies": {
+        "jquery": ">=1.7"
       }
     },
     "node_modules/blueimp-load-image": {
@@ -47,6 +50,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
       "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
+    },
+    "node_modules/jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
     }
   },
   "dependencies": {
@@ -57,9 +66,9 @@
       "optional": true
     },
     "blueimp-file-upload": {
-      "version": "10.31.0",
-      "resolved": "https://registry.npmjs.org/blueimp-file-upload/-/blueimp-file-upload-10.31.0.tgz",
-      "integrity": "sha512-dGAxOf9+SsMDvZPTsIUpe0cOk57taMJYE3FocHEUebhn5BnDbu1hcWOmrP8oswIe6V61Qcm9UDuhq/Pv1t/eRw==",
+      "version": "10.32.0",
+      "resolved": "https://registry.npmjs.org/blueimp-file-upload/-/blueimp-file-upload-10.32.0.tgz",
+      "integrity": "sha512-3WMJw5Cbfz94Adl1OeyH+rRpGwHiNHzja+CR6aRWPoAtwrUwvP5gXKo0XdX+sdPE+iCU63Xmba88hoHQmzY8RQ==",
       "requires": {
         "blueimp-canvas-to-blob": "3",
         "blueimp-load-image": "5",
@@ -82,6 +91,12 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
       "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
+    },
+    "jquery": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+      "peer": true
     }
   }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/package.json
+++ b/src/OrchardCore.Modules/OrchardCore.Media/package.json
@@ -2,7 +2,7 @@
   "name": "orchardcore.media",
   "version": "1.0.0",
   "dependencies": {
-    "blueimp-file-upload": "10.31.0",
+    "blueimp-file-upload": "10.32.0",
     "bootstrap": "4.6.0"
   }
 }

--- a/src/docs/resources/libraries/README.md
+++ b/src/docs/resources/libraries/README.md
@@ -66,6 +66,7 @@ The below table lists the different Client side libraries:
 | [GraphQL](https://github.com/graphql/graphql-js) | A reference implementation of GraphQL for JavaScript. | 15.5.1 | [MIT](https://github.com/graphql/graphql-js/blob/main/LICENSE) |
 | [Gulp](https://github.com/gulpjs/gulp) | A toolkit to automate & enhance your workflow. | 4.0.2 | [MIT](https://github.com/gulpjs/gulp/blob/master/LICENSE) |
 | [Gulp](https://github.com/gulpjs/gulp-cli) | Command Line Interface for gulp. | 2.3.0 | [MIT](https://github.com/gulpjs/gulp-cli/blob/master/LICENSE) |
+| [jQuery-File-Upload](https://github.com/blueimp/jQuery-File-Upload) | File Upload widget for jQuery. | 10.32.0 | [MIT](https://github.com/blueimp/jQuery-File-Upload/blob/master/LICENSE.txt) |
 | [jsPlumb](https://github.com/jsplumb/jsplumb) | Visual connectivity for webapps. | 2.15.6 | [MIT and GPLv2](https://github.com/jsplumb/jsplumb/blob/master/jsPlumb-LICENSE.txt) |
 | [React](https://github.com/facebook/react) | JavaScript library for building user interface. | 17.0.2 | [MIT](https://github.com/facebook/react/blob/master/LICENSE) |
 | [TypeScript](https://github.com/microsoft/TypeScript) | Superset of JavaScript that compiles to clean JavaScript output. | 4.2.4 | [Apache-2.0](https://github.com/microsoft/TypeScript/blob/master/LICENSE.txtE) |


### PR DESCRIPTION
https://github.com/blueimp/jQuery-File-Upload/releases/tag/v10.32.0
https://www.npmjs.com/package/blueimp-file-upload/v/10.32.0

Even if it does not seem it has changed.
Add license in Libraries.