### PR TITLE
Link field escaping

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/LinkFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/LinkFieldDisplayDriver.cs
@@ -65,7 +65,7 @@ namespace OrchardCore.ContentFields.Drivers
                 var settings = context.PartFieldDefinition.GetSettings<LinkFieldSettings>();
 
                 var urlToValidate = field.Url;
-                if (!String.IsNullOrWhiteSpace(urlToValidate))
+                if (!String.IsNullOrEmpty(urlToValidate))
                 {
                     var indexAnchor = urlToValidate.IndexOf('#');
                     if (indexAnchor > -1)

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.cshtml
@@ -33,7 +33,7 @@
     }
 
     var href = Model.Url;
-    if (!string.IsNullOrWhiteSpace(href))
+    if (!string.IsNullOrEmpty(href))
     {
         if (href.StartsWith("~/", StringComparison.Ordinal))
         {

--- a/src/OrchardCore/OrchardCore.Abstractions/StringUriExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/StringUriExtensions.cs
@@ -4,7 +4,7 @@ namespace System
     {
         public static string ToUriComponents(this string url)
         {
-            if (String.IsNullOrWhiteSpace(url))
+            if (String.IsNullOrEmpty(url))
             {
                 return url;
             }


### PR DESCRIPTION
Fixes #10520

So that a link with the following href works

    /τροφιμα/ψαρια

Note: Currently an url starting with a tilde `~`doesn't work, should we support it?