### PR TITLE
Improve loading flow/bag edit template

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/BagPart.Edit.cshtml
@@ -13,6 +13,8 @@
     var htmlFieldPrefix = ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix;
     var parentContentType = Model.BagPart.ContentItem.ContentType;
     string partName = ((dynamic)Model).Metadata.Name;
+
+    Context.Features.Set(new OrchardCore.ContentManagement.IgnoreContentFeature());
 }
 
 <script asp-name="jQuery-ui" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -13,6 +13,8 @@
     var htmlFieldPrefix = ViewContext.ViewData.TemplateInfo.HtmlFieldPrefix;
     var parentContentType = Model.FlowPart.ContentItem.ContentType;
     string partName = ((dynamic)Model).Metadata.Name;
+
+    Context.Features.Set(new OrchardCore.ContentManagement.IgnoreContentFeature());
 }
 
 <script asp-name="jQuery-ui" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Drivers/UserTaskEventContentDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/UserTasks/Drivers/UserTaskEventContentDriver.cs
@@ -44,8 +44,13 @@ namespace OrchardCore.Workflows.UserTasks.Drivers
             H = localizer;
         }
 
-        public override IDisplayResult Edit(ContentItem contentItem)
+        public override IDisplayResult Edit(ContentItem contentItem, IUpdateModel updater)
         {
+            if (_httpContextAccessor.HttpContext?.Features.Get<IgnoreContentFeature>()?.Ignore == true)
+            {
+                return null;
+            }
+
             var results = new List<IDisplayResult>
             {
                 Initialize<UserTaskEventContentViewModel>("Content_UserTaskButton", async model => {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IgnoreContentFeature.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IgnoreContentFeature.cs
@@ -1,0 +1,7 @@
+namespace OrchardCore.ContentManagement
+{
+    public class IgnoreContentFeature
+    {
+        public bool Ignore { get; set; } = true;
+    }
+}


### PR DESCRIPTION
When adding/editing a content item that contains a `FlowPart` or `BagPart`, each contained content type will trigger a query (shown below) to the database. Should be noted this only occurs when workflows is enabled.

![flow-bag-database-before](https://user-images.githubusercontent.com/651190/139466828-4db3e8aa-0192-4331-9147-ae6d9a93921a.png)

_Note: This example is a content type that contains a single `FlowPart` and their are 4 widget content types._

I've refactored the `FlowPart.Edit` & `BagPart.Edit` to no longer render a mock widget/content type in order to load the script resources. Any style/script assets are loaded when the widget/content type is being added to the flow/bag. Logic has been added to ensure that style/script assets are loaded multiple times.

Below is the SQL profiler for adding a new content item.

![flow-bag-database-after](https://user-images.githubusercontent.com/651190/139466973-55b78d18-5057-4e8a-bc22-31bac30b620f.png)

Another thing to highlight is when editing an existing content item that has a flow/bag part, rendering already contained widget/content type as a `ContentCard` will cause the database query to run.

