### PR TITLE
Fix audit trail date parsing (greater than or equal to)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DateTimeParser.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DateTimeParser.cs
@@ -164,7 +164,7 @@ namespace OrchardCore.AuditTrail.Services
 
         static DateTimeParser()
         {
-            var operators = OneOf(Literals.Text(">"), Literals.Text(">="), Literals.Text("<"), Literals.Text("<="));
+            var operators = OneOf(Literals.Text(">="), Literals.Text(">"), Literals.Text("<="), Literals.Text("<"));
 
             var arithmetic = Terms.Integer(NumberOptions.AllowSign);
             var range = Literals.Text("..");

--- a/test/OrchardCore.Tests/Modules/OrchardCore.AuditTrail/DateTimeParserTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.AuditTrail/DateTimeParserTests.cs
@@ -15,10 +15,11 @@ namespace OrchardCore.Tests.Modules.OrchardCore.AuditTrail
         [InlineData("@now-2..@now-1", "@now-2..@now-1")]
         [InlineData("@now+2", "@now2")]
         [InlineData(">@now", ">@now")]
-        // [InlineData("2019-10-12", "2019-10-12T00:00:00.0000000")]
-        // [InlineData(">2019-10-12", ">2019-10-12T00:00:00.0000000")]
-        // [InlineData("2017-01-01T01:00:00+07:00", "2017-01-01T01:00:00.0000000+07:00")]
-        // [InlineData("2017-01-01T01:00:00+07:00..2017-01-01T01:00:00+07:00", "2017-01-01T01:00:00.0000000+07:00..2017-01-01T01:00:00.0000000+07:00")]
+        [InlineData(">=@now", ">=@now")]
+        //[InlineData("2019-10-12", "2019-10-12T00:00:00.0000000")]
+        //[InlineData(">2019-10-12", ">2019-10-12T00:00:00.0000000")]
+        //[InlineData("2017-01-01T01:00:00+07:00", "2017-01-01T01:00:00.0000000+07:00")]
+        //[InlineData("2017-01-01T01:00:00+07:00..2017-01-01T01:00:00+07:00", "2017-01-01T01:00:00.0000000+07:00..2017-01-01T01:00:00.0000000+07:00")]
         public void DateParserTests(string text, string expected)
         {
             var context = new DateTimeParseContext(CultureInfo.InvariantCulture, Mock.Of<IClock>(), Mock.Of<ITimeZone>(), new Scanner(text));


### PR DESCRIPTION
Working on something else and realised the `>=` literals need to be parsed first.

Should really fix the other tests at some point to (but they work in actual real life, so another pr).