### PR TITLE
Pager uses the reserved "page" route parameter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Html;
@@ -8,7 +7,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using OrchardCore.DisplayManagement;
@@ -216,7 +214,7 @@ namespace OrchardCore.Navigation
             var firstPage = Math.Max(1, Page - (numberOfPagesToShow / 2));
             var lastPage = Math.Min(totalPageCount, Page + (numberOfPagesToShow / 2));
 
-            var pageKey = String.IsNullOrEmpty(PagerId) ? "page" : PagerId;
+            var pageKey = String.IsNullOrEmpty(PagerId) ? "pageNum" : PagerId;
 
             shape.Classes.Add("pager");
             shape.Metadata.Alternates.Clear();
@@ -537,21 +535,7 @@ namespace OrchardCore.Navigation
             var routeValues = shape.GetProperty<RouteValueDictionary>("RouteValues") ?? new RouteValueDictionary();
             if (!Disabled)
             {
-                // The 'Pager' uses a route parameter named "page" which is now a reserved routing name.
-                // So, this route parameter is first removed and then added as a query string parameter.
-
-                if (routeValues.TryGetValue("page", out var value))
-                {
-                    routeValues.Remove("page");
-                }
-
-                var href = Url.Action((string)routeValues["action"], (string)routeValues["controller"], routeValues);
-                if (value != null && value is int page)
-                {
-                    href = QueryHelpers.AddQueryString(href, "page", page.ToString(CultureInfo.InvariantCulture));
-                }
-
-                shape.Attributes["href"] = href;
+                shape.Attributes["href"] = Url.Action((string)routeValues["action"], (string)routeValues["controller"], routeValues);
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
@@ -538,6 +538,8 @@ namespace OrchardCore.Navigation
             if (!Disabled)
             {
                 // The 'Pager' uses a route parameter named "page" which is now a reserved routing name.
+                // So, this route parameter is first removed and then added as a query string parameter.
+
                 if (routeValues.TryGetValue("page", out var value))
                 {
                     routeValues.Remove("page");

--- a/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapes.cs
@@ -214,7 +214,7 @@ namespace OrchardCore.Navigation
             var firstPage = Math.Max(1, Page - (numberOfPagesToShow / 2));
             var lastPage = Math.Min(totalPageCount, Page + (numberOfPagesToShow / 2));
 
-            var pageKey = String.IsNullOrEmpty(PagerId) ? "pageNum" : PagerId;
+            var pageKey = String.IsNullOrEmpty(PagerId) ? "pagenum" : PagerId;
 
             shape.Classes.Add("pager");
             shape.Metadata.Alternates.Clear();

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -278,7 +278,7 @@ namespace OrchardCore.Workflows.Controllers
                         throw new ArgumentOutOfRangeException();
                 }
             }
-            return RedirectToAction(nameof(Index), new { workflowTypeId, pageNum = pagerParameters.PageNum, pageSize = pagerParameters.PageSize });
+            return RedirectToAction(nameof(Index), new { workflowTypeId, pagenum = pagerParameters.Page, pageSize = pagerParameters.PageSize });
         }
 
         private async Task<dynamic> BuildActivityDisplayAsync(ActivityContext activityContext, int workflowTypeId, bool isBlocking, string displayType)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -278,7 +278,7 @@ namespace OrchardCore.Workflows.Controllers
                         throw new ArgumentOutOfRangeException();
                 }
             }
-            return RedirectToAction(nameof(Index), new { workflowTypeId, pagenum = pagerParameters.Page, pageSize = pagerParameters.PageSize });
+            return RedirectToAction(nameof(Index), new { workflowTypeId, pagenum = pagerParameters.Page, pagesize = pagerParameters.PageSize });
         }
 
         private async Task<dynamic> BuildActivityDisplayAsync(ActivityContext activityContext, int workflowTypeId, bool isBlocking, string displayType)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs
@@ -278,7 +278,7 @@ namespace OrchardCore.Workflows.Controllers
                         throw new ArgumentOutOfRangeException();
                 }
             }
-            return RedirectToAction(nameof(Index), new { workflowTypeId, page = pagerParameters.Page, pageSize = pagerParameters.PageSize });
+            return RedirectToAction(nameof(Index), new { workflowTypeId, pageNum = pagerParameters.PageNum, pageSize = pagerParameters.PageSize });
         }
 
         private async Task<dynamic> BuildActivityDisplayAsync(ActivityContext activityContext, int workflowTypeId, bool isBlocking, string displayType)

--- a/src/OrchardCore/OrchardCore.Navigation.Core/Pager.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/Pager.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Navigation
         /// <param name="pagerParameters">The pager parameters.</param>
         /// <param name="defaultPageSize">The default page size.</param>
         public Pager(PagerParameters pagerParameters, int defaultPageSize)
-            : this(pagerParameters.Page, pagerParameters.PageSize, defaultPageSize)
+            : this(pagerParameters.PageNum, pagerParameters.PageSize, defaultPageSize)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.Navigation.Core/Pager.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/Pager.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Navigation
         /// <param name="pagerParameters">The pager parameters.</param>
         /// <param name="defaultPageSize">The default page size.</param>
         public Pager(PagerParameters pagerParameters, int defaultPageSize)
-            : this(pagerParameters.PageNum, pagerParameters.PageSize, defaultPageSize)
+            : this(pagerParameters.Page, pagerParameters.PageSize, defaultPageSize)
         {
         }
 

--- a/src/OrchardCore/OrchardCore.Navigation.Core/PagerParameters.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/PagerParameters.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Navigation
         /// <summary>
         /// Gets or sets the current page number or null if none specified.
         /// </summary>
-        public int? Page { get; set; }
+        public int? PageNum { get; set; }
 
         /// <summary>
         /// Gets or sets the current page size or null if none specified.

--- a/src/OrchardCore/OrchardCore.Navigation.Core/PagerParameters.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/PagerParameters.cs
@@ -1,7 +1,15 @@
+using System;
+
 namespace OrchardCore.Navigation
 {
     public class PagerParameters
     {
+        /// <summary>
+        /// Gets or sets the current page number or null if none specified.
+        /// </summary>
+        [Obsolete("This property will be removed in a future version. Use PageNum instead.")]
+        public int? Page { get; set; }
+
         /// <summary>
         /// Gets or sets the current page number or null if none specified.
         /// </summary>

--- a/src/OrchardCore/OrchardCore.Navigation.Core/PagerParameters.cs
+++ b/src/OrchardCore/OrchardCore.Navigation.Core/PagerParameters.cs
@@ -1,4 +1,4 @@
-using System;
+using Microsoft.AspNetCore.Mvc;
 
 namespace OrchardCore.Navigation
 {
@@ -7,13 +7,8 @@ namespace OrchardCore.Navigation
         /// <summary>
         /// Gets or sets the current page number or null if none specified.
         /// </summary>
-        [Obsolete("This property will be removed in a future version. Use PageNum instead.")]
+        [BindProperty(Name = "PageNum")]
         public int? Page { get; set; }
-
-        /// <summary>
-        /// Gets or sets the current page number or null if none specified.
-        /// </summary>
-        public int? PageNum { get; set; }
 
         /// <summary>
         /// Gets or sets the current page size or null if none specified.


### PR DESCRIPTION
Fixes #10636

The bug only happens if you have at least one razor `@page` (not a razor view). In that case when you list the items of a given content type e.g. `/Admin/Contents/ContentItems/Article?admin=674211458`, the Pager links, in place of using our custom pattern `/Admin/Contents/ContentItems/Article?admin=674211458&page=2`, they use the default pattern where the content type is a query string parameter `/Admin/OC.Contents/Admin/List?contentTypeId=Article&admin=...&page=2`

At this point you can still go to a given Pager page. But then if you select a new filter option it removes the above query string `contentTypeId` parameter e.g. `/Admin/Contents/ContentItems?q=status%3APublished`. So in place of still listing the items of a specific content type, you go to the list of all content types in place of staying in the list of a specific type.

Removing the `contentTypeId` parameter is another issue, filtering should preserve the existing parameters, but here I'm only talking about the fact that the Pager links don't use the right custom pattern if at least a Razor `@page` is defined.

This is because the Pager uses a "page" route parameter to generate links urls, but this is a reserved aspnetcore routing name. The solution is to remove this route value in the `ActionLink` shape before generating an url and then explicitly add it as a query string parameter. Currently as a workaround I'm using a custom `IShapeTableProvider`.

**Updated**

The "page" route value key is also used here https://github.com/OrchardCMS/OrchardCore/blob/be8a3a59a7a6c9f1338244c3b67a81cee11f335b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowController.cs#L281

Hmm, finally I think that the right solution is to rename the pager `page` to `pageNum`.

DONE
