### PR TITLE
Change HttpResponseTask  support "text/html"

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
@@ -11,11 +11,12 @@
 <div class="form-group" asp-validation-class-for="ContentType">
     <label asp-for="ContentType">@T["Content Type"]</label>
     <select asp-for="ContentType" class="form-control">
+        <option>text/html</option>
         <option>text/plain</option>
         <option>application/x-www-form-urlencoded</option>
         <option>application/json</option>
         <option>application/xml</option>
-    </select>
+    </select> 
     <span asp-validation-for="ContentType"></span>
     <span class="hint">@T["The content type of the response body."]</span>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/HttpResponseTask.Fields.Edit.cshtml
@@ -16,7 +16,7 @@
         <option>application/x-www-form-urlencoded</option>
         <option>application/json</option>
         <option>application/xml</option>
-    </select> 
+    </select>
     <span asp-validation-for="ContentType"></span>
     <span class="hint">@T["The content type of the response body."]</span>
 </div>


### PR DESCRIPTION
This change allows workflow submissions to return web content directly

![image](https://user-images.githubusercontent.com/15613121/142184652-76733c5a-cc8f-47e3-bd8d-5581ad69b8a3.png)
