### PR TITLE
Fix Liquid QueryCollection access

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.DependencyInjection
                                 nameof(HttpRequest.ContentLength) => NumberValue.Create(request.ContentLength ?? 0),
                                 nameof(HttpRequest.Cookies) => new ObjectValue(new CookieCollectionWrapper(request.Cookies)),
                                 nameof(HttpRequest.Headers) => new ObjectValue(new HeaderDictionaryWrapper(request.Headers)),
-                                nameof(HttpRequest.Query) => new ObjectValue(request.Query),
+                                nameof(HttpRequest.Query) => new ObjectValue(new QueryCollection(request.Query.ToDictionary(kv => kv.Key, kv => kv.Value))),
                                 nameof(HttpRequest.Form) => request.HasFormContentType ? (FluidValue)new ObjectValue(request.Form) : NilValue.Instance,
                                 nameof(HttpRequest.Protocol) => new StringValue(request.Protocol),
                                 nameof(HttpRequest.Path) => new StringValue(request.Path.Value),


### PR DESCRIPTION
Fixes #10737 

The underlying type being a QueryCollectionInternal on which we don't have access

Fixed by creating a QueryCollection
