### PR TITLE
Prevent confusing usage of IRunningShellTable.Match(HttpContext) (Lombiq Technologies: OCORE-69)

### DIFF
--- a/src/OrchardCore.Cms.Web/Program.cs
+++ b/src/OrchardCore.Cms.Web/Program.cs
@@ -15,10 +15,10 @@ namespace OrchardCore.Cms.Web
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureLogging(logging => logging.ClearProviders())
-                 .ConfigureWebHostDefaults(webBuilder =>
-                 {
-                     webBuilder.UseNLogWeb();
-                     webBuilder.UseStartup<Startup>();
-                 });
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseNLogWeb();
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/RunningShellTableExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/RunningShellTableExtensions.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.Modules
             // The same way .Scheme contains the protocol that the user set and not what a proxy
             // could be using (see X-Forwarded-Proto).
 
-            return table.Match(httpRequest.Host, httpRequest.PathBase + httpRequest.Path, true);
+            return table.Match(httpRequest.Host, httpRequest.Path, true);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/RunningShellTableExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/RunningShellTableExtensions.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.Modules
             // The same way .Scheme contains the protocol that the user set and not what a proxy
             // could be using (see X-Forwarded-Proto).
 
-            return table.Match(httpRequest.Host, httpRequest.Path, true);
+            return table.Match(httpRequest.Host, httpRequest.PathBase + httpRequest.Path, true);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/RunningShellTableExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/RunningShellTableExtensions.cs
@@ -4,7 +4,10 @@ using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.Modules
 {
-    public static class RunningShellTableExtensions
+    // Not public because it wouldn't match tenants with an URL prefix later in the request pipeline. Mostly to be used
+    // from ModularTenantContainerMiddleware.
+    // For details see: https://github.com/OrchardCMS/OrchardCore/pull/10779#discussion_r758741155.
+    internal static class RunningShellTableExtensions
     {
         public static ShellSettings Match(this IRunningShellTable table, HttpContext httpContext)
         {


### PR DESCRIPTION
The tenant's URL prefix is in `httpRequest.PathBase`, but it isn't taken into account. This is deliberate though, see the conversation below: https://github.com/OrchardCMS/OrchardCore/pull/10779#discussion_r758741155 However, this makes the method not usable generally, thus making its class `internal`.