### PR TITLE
Don't enable FileContentDefinition feature by default in our themes

### DIFF
--- a/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
@@ -40,7 +40,6 @@
         "OrchardCore.ContentFields",
         "OrchardCore.ContentPreview",
         "OrchardCore.Contents",
-        "OrchardCore.Contents.FileContentDefinition",
         "OrchardCore.ContentTypes",
         "OrchardCore.CustomSettings",
         "OrchardCore.Deployment",

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -50,7 +50,6 @@
         "OrchardCore.ContentFields",
         "OrchardCore.ContentPreview",
         "OrchardCore.Contents",
-        "OrchardCore.Contents.FileContentDefinition",
         "OrchardCore.ContentTypes",
         "OrchardCore.CustomSettings",
         "OrchardCore.Deployment",

--- a/src/docs/guides/content-definitions/README.md
+++ b/src/docs/guides/content-definitions/README.md
@@ -1,15 +1,15 @@
 # Understanding Content Definition Stores
 
-Content Definitions are a record of the Content Types, Content Parts, and Content Fields used by a tenant.
+`Content Definitions` are a record of the `Content Types`, `Content Parts`, and `Content Fields` used by a tenant.
 
 By default the `Content Definitions` are stored in the database.
 
 When the `File Content Definition` feature is enabled it stores content definitions in a `ContentDefinition.json` file 
 at the root of each tenants `App_Data` folder, e.g. `App_Data/Sites/Default/ContentDefinition.json` for the default tenant.
 
-The `File Content Definition` feature can be very useful during the Development phase of a project.
+The `File Content Definition` feature can be very useful during the `Development` phase of a project.
 
-As you move your site to a Production phase you may wish to disable the feature and store the Content Definitions in the database.
+As you move your site to a `Production` phase you may wish to disable the feature and store the `Content Definitions` in the database.
 
 To migrate your `ContentDefinition.json` file to the database use the following procedure:
 
@@ -38,5 +38,5 @@ This will download a file called `ContentDefinitions.zip` to your computer.
 
 ## Summary
 
-You just learnt how to create a Deployment Plan to migrate from the `File Content Definition` feature.
+You just learnt how to create a `Deployment Plan` to migrate from the `File Content Definition` feature.
 

--- a/src/docs/guides/content-definitions/README.md
+++ b/src/docs/guides/content-definitions/README.md
@@ -2,10 +2,12 @@
 
 Content Definitions are a record of the Content Types, Content Parts, and Content Fields used by a tenant.
 
-By default the `File Content Definition` feature is enabled, and stores content definitions in a `ContentDefinition.json` file 
+By default the `Content Definitions` are stored in the database.
+
+When the `File Content Definition` feature is enabled it stores content definitions in a `ContentDefinition.json` file 
 at the root of each tenants `App_Data` folder, e.g. `App_Data/Sites/Default/ContentDefinition.json` for the default tenant.
 
-The `File Content Definition` feature is enabled by default, and can be very useful during the Development phase of a project.
+The `File Content Definition` can be very useful during the Development phase of a project.
 
 As you move your site to a Production phase you may wish to disable the feature and store the Content Definitions in the database.
 

--- a/src/docs/guides/content-definitions/README.md
+++ b/src/docs/guides/content-definitions/README.md
@@ -7,7 +7,7 @@ By default the `Content Definitions` are stored in the database.
 When the `File Content Definition` feature is enabled it stores content definitions in a `ContentDefinition.json` file 
 at the root of each tenants `App_Data` folder, e.g. `App_Data/Sites/Default/ContentDefinition.json` for the default tenant.
 
-The `File Content Definition` can be very useful during the Development phase of a project.
+The `File Content Definition` feature can be very useful during the Development phase of a project.
 
 As you move your site to a Production phase you may wish to disable the feature and store the Content Definitions in the database.
 


### PR DESCRIPTION
Because it is not consistent with other themes we have. And it should be the other way around. If you want to have your own Content Definitions locally then, enable this module for yourself. Then, commit to the database later on.

Related to #10794