### PR TITLE
Async write / read of the Request.Body is mandatory

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Scripting/HttpMethodsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Scripting/HttpMethodsProvider.cs
@@ -95,7 +95,7 @@ namespace OrchardCore.Workflows.Http.Scripting
                     using (var sr = new StreamReader(httpContextAccessor.HttpContext.Request.Body))
                     {
                         // Async read of the request body is mandatory.
-                        return sr.ReadToEnd();
+                        return sr.ReadToEndAsync().GetAwaiter().GetResult(); ;
                     }
                 })
             };
@@ -180,7 +180,7 @@ namespace OrchardCore.Workflows.Http.Scripting
                                 using (var sr = new StreamReader(httpContextAccessor.HttpContext.Request.Body))
                                 {
                                     // Async read of the request body is mandatory.
-                                    json = sr.ReadToEnd();
+                                    json = sr.ReadToEndAsync().GetAwaiter().GetResult(); ;
                                 }
 
                                 try


### PR DESCRIPTION
@sebastienros 

To revert one change done in #10674 

Just tried, it now fails if using `ReadToEnd()`, but works with `ReadToEndAsync().GetAwaiter().GetResult()`.

Using an async method is mandatory even if we use it synchronously by using `GetAwaiter()`