### PR TITLE
Fix previewing content in Chromium browsers.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -111,8 +111,8 @@
                     if (iframe && iframe.contentWindow) {
                         iframe.contentWindow.document.open();
                         iframe.contentWindow.document.write(data);
-                        iframe.contentWindow.document.close();
                         previewRenderData = data;
+                        iframe.contentWindow.document.close();
                     }
                     $(serverErrorWarning).hide();
                 })


### PR DESCRIPTION
#10812 Fix an issue when you try to preview an un-published page in a Chromium Browser (Edge, Chrome, Brave) the preview simply displays "undefined".