### PR TITLE
Fix docker image missing localization files in 1.1.0 release

### DIFF
--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -32,12 +32,13 @@
       DestinationFolder="Localization\%(RecursiveDir)"
       Condition="'@(PackageTranslationFiles)' != ''"
       SkipUnchangedFiles="true" />
+  </Target>
 
+  <Target Name="PublishTranslationFiles" BeforeTargets="GetCopyToPublishDirectoryItems">
+    <Message Text="Publishing translation files: $(MSBuildProjectName)" Importance="high" />
     <ItemGroup>
-      <LocalizationFiles Include="Localization\**" Exclude="$(DefaultItemExcludes)" />
-      <ResolvedFileToPublish Include="@(LocalizationFiles)">
-        <RelativePath>Localization\%(RecursiveDir)%(Filename)%(Extension)</RelativePath>
-      </ResolvedFileToPublish>
+      <_WebProjectGeneratedContent Include="Localization\**" Exclude="$(DefaultItemExcludes)">
+      </_WebProjectGeneratedContent>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
As @jtkech suggested.

Will require that we change the release Tag on the repository to a different commit.