### PR TITLE
Allow to provide CdnUrl or CdnDebugUrl

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptTag.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/ScriptTag.cs
@@ -74,16 +74,30 @@ namespace OrchardCore.Resources.Liquid
                     var s = src.ToLowerInvariant();
 
                     var definition = resourceManager.InlineManifest.DefineScript(s);
-                    definition.SetUrl(src, debugSrc);
+
+                    if (String.IsNullOrEmpty(debugSrc))
+                    {
+                        definition.SetUrl(src);
+                    }
+                    else
+                    {
+                        definition.SetUrl(src, debugSrc);
+                    }
 
                     if (!String.IsNullOrEmpty(version))
                     {
                         definition.SetVersion(version);
                     }
 
-                    if (!String.IsNullOrEmpty(cdnSrc))
+                    if (!String.IsNullOrEmpty(cdnSrc) && !String.IsNullOrEmpty(debugCdnSrc))
                     {
                         definition.SetCdn(cdnSrc, debugCdnSrc);
+                    }
+                    else
+                    {
+                        var isDebug = !String.IsNullOrEmpty(debugCdnSrc);
+
+                        definition.SetCdn(isDebug ? debugCdnSrc : cdnSrc, debug: isDebug);
                     }
 
                     if (!String.IsNullOrEmpty(culture))
@@ -205,16 +219,30 @@ namespace OrchardCore.Resources.Liquid
                 // Inline declaration
 
                 var definition = resourceManager.InlineManifest.DefineScript(name);
-                definition.SetUrl(src, debugSrc);
+
+                if (String.IsNullOrEmpty(debugSrc))
+                {
+                    definition.SetUrl(src);
+                }
+                else
+                {
+                    definition.SetUrl(src, debugSrc);
+                }
 
                 if (!String.IsNullOrEmpty(version))
                 {
                     definition.SetVersion(version);
                 }
 
-                if (!String.IsNullOrEmpty(cdnSrc))
+                if (!String.IsNullOrEmpty(cdnSrc) && !String.IsNullOrEmpty(debugCdnSrc))
                 {
                     definition.SetCdn(cdnSrc, debugCdnSrc);
+                }
+                else
+                {
+                    var isDebug = !String.IsNullOrEmpty(debugCdnSrc);
+
+                    definition.SetCdn(isDebug ? debugCdnSrc : cdnSrc, debug: isDebug);
                 }
 
                 if (!String.IsNullOrEmpty(culture))

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/StyleTag.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/StyleTag.cs
@@ -178,7 +178,15 @@ namespace OrchardCore.Resources.Liquid
                 // Inline declaration
 
                 var definition = resourceManager.InlineManifest.DefineStyle(name);
-                definition.SetUrl(src, debugSrc);
+
+                if (String.IsNullOrEmpty(debugSrc))
+                {
+                    definition.SetUrl(src);
+                }
+                else
+                {
+                    definition.SetUrl(src, debugSrc);
+                }
 
                 if (customAttributes != null)
                 {
@@ -193,9 +201,15 @@ namespace OrchardCore.Resources.Liquid
                     definition.SetVersion(version);
                 }
 
-                if (!String.IsNullOrEmpty(cdnSrc))
+                if (!String.IsNullOrEmpty(cdnSrc) && !String.IsNullOrEmpty(debugCdnSrc))
                 {
                     definition.SetCdn(cdnSrc, debugCdnSrc);
+                }
+                else
+                {
+                    var isDebug = !String.IsNullOrEmpty(debugCdnSrc);
+
+                    definition.SetCdn(isDebug ? debugCdnSrc : cdnSrc, debug: isDebug);
                 }
 
                 if (!String.IsNullOrEmpty(culture))

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -67,9 +67,16 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
-        public ResourceDefinition SetUrl(string url)
+        public ResourceDefinition SetUrl(string url, bool debug = false)
         {
-            return SetUrl(url, null);
+            if (String.IsNullOrEmpty(url))
+            {
+                ThrowArgumentNullException(nameof(url));
+            }
+
+            return debug
+                ? SetUrlInternal(null, url)
+                : SetUrlInternal(url, null);
         }
 
         public ResourceDefinition SetUrl(string url, string urlDebug)
@@ -78,43 +85,43 @@ namespace OrchardCore.ResourceManagement
             {
                 ThrowArgumentNullException(nameof(url));
             }
-            Url = url;
-            if (urlDebug != null)
+
+            if (String.IsNullOrEmpty(urlDebug))
             {
-                UrlDebug = urlDebug;
+                ThrowArgumentNullException(nameof(urlDebug));
             }
-            return this;
+
+            return SetUrlInternal(url, urlDebug);
         }
 
-        public ResourceDefinition SetCdn(string cdnUrl)
+        public ResourceDefinition SetCdn(string cdnUrl, bool debug = false, bool supportsSsl = false)
         {
-            return SetCdn(cdnUrl, null, null);
-        }
-
-        public ResourceDefinition SetCdn(string cdnUrl, string cdnUrlDebug)
-        {
-            return SetCdn(cdnUrl, cdnUrlDebug, null);
-        }
-
-        public ResourceDefinition SetCdnIntegrity(string cdnIntegrity)
-        {
-            return SetCdnIntegrity(cdnIntegrity, null);
-        }
-
-        public ResourceDefinition SetCdnIntegrity(string cdnIntegrity, string cdnDebugIntegrity)
-        {
-            if (String.IsNullOrEmpty(cdnIntegrity))
+            if (String.IsNullOrEmpty(cdnUrl))
             {
-                ThrowArgumentNullException(nameof(cdnIntegrity));
+                ThrowArgumentNullException(nameof(cdnUrl));
             }
-            CdnIntegrity = cdnIntegrity;
-            if (cdnDebugIntegrity != null)
-            {
-                CdnDebugIntegrity = cdnDebugIntegrity;
-            }
-            return this;
+
+            return debug
+                ? SetCdnInternal(null, cdnUrl, supportsSsl)
+                : SetCdnInternal(cdnUrl, null, supportsSsl);
         }
 
+        public ResourceDefinition SetCdn(string cdnUrl, string cdnUrlDebug, bool supportsSsl = false)
+        {
+            if (String.IsNullOrEmpty(cdnUrl))
+            {
+                ThrowArgumentNullException(nameof(cdnUrl));
+            }
+
+            if (String.IsNullOrEmpty(cdnUrlDebug))
+            {
+                ThrowArgumentNullException(nameof(cdnUrlDebug));
+            }
+
+            return SetCdnInternal(cdnUrl, cdnUrlDebug, supportsSsl);
+        }
+
+        [Obsolete("This method is deprecated, please use SetCdnIntegrity(string, string, bool) instead.")]
         public ResourceDefinition SetCdn(string cdnUrl, string cdnUrlDebug, bool? cdnSupportsSsl)
         {
             if (String.IsNullOrEmpty(cdnUrl))
@@ -131,6 +138,33 @@ namespace OrchardCore.ResourceManagement
                 CdnSupportsSsl = cdnSupportsSsl.Value;
             }
             return this;
+        }
+
+        public ResourceDefinition SetCdnIntegrity(string cdnIntegrity, bool debug = false)
+        {
+            if (String.IsNullOrEmpty(cdnIntegrity))
+            {
+                ThrowArgumentNullException(nameof(cdnIntegrity));
+            }
+
+            return debug
+                ? SetCdnIntegrityInternal(null, cdnIntegrity)
+                : SetCdnIntegrityInternal(cdnIntegrity, null);
+        }
+
+        public ResourceDefinition SetCdnIntegrity(string cdnIntegrity, string cdnDebugIntegrity)
+        {
+            if (String.IsNullOrEmpty(cdnIntegrity))
+            {
+                ThrowArgumentNullException(nameof(cdnIntegrity));
+            }
+
+            if (String.IsNullOrEmpty(cdnDebugIntegrity))
+            {
+                ThrowArgumentNullException(nameof(cdnDebugIntegrity));
+            }
+
+            return SetCdnIntegrityInternal(cdnIntegrity, cdnDebugIntegrity);
         }
 
         /// <summary>
@@ -378,6 +412,53 @@ namespace OrchardCore.ResourceManagement
         private static void ThrowArgumentNullException(string paramName)
         {
             throw new ArgumentNullException(paramName);
+        }
+
+        private ResourceDefinition SetUrlInternal(string url, string urlDebug)
+        {
+            if (url != null)
+            {
+                Url = url;
+            }
+
+            if (urlDebug != null)
+            {
+                UrlDebug = urlDebug;
+            }
+
+            return this;
+        }
+
+        private ResourceDefinition SetCdnInternal(string cdnUrl, string cdnDebugUrl, bool supportsSsl = false)
+        {
+            if (cdnUrl != null)
+            {
+                UrlCdn = cdnUrl;
+            }
+
+            if (cdnDebugUrl != null)
+            {
+                UrlCdnDebug = cdnDebugUrl;
+            }
+
+            CdnSupportsSsl = supportsSsl;
+
+            return this;
+        }
+
+        private ResourceDefinition SetCdnIntegrityInternal(string cdnIntegrity, string cdnDebugIntegrity)
+        {
+            if (cdnIntegrity != null)
+            {
+                CdnIntegrity = cdnIntegrity;
+            }
+
+            if (cdnDebugIntegrity != null)
+            {
+                CdnDebugIntegrity = cdnDebugIntegrity;
+            }
+
+            return this;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -90,9 +90,22 @@ namespace OrchardCore.ResourceManagement
                 resourceDebugPath = _options.ContentBasePath + resourceDebugPath.Substring(1);
             }
 
-            return RegisterResource(
-                resourceType,
-                GetResourceKey(resourcePath, resourceDebugPath)).Define(d => d.SetUrl(resourcePath, resourceDebugPath));
+            if (!String.IsNullOrEmpty(resourcePath) && !String.IsNullOrEmpty(resourceDebugPath))
+            {
+                return RegisterResource(
+                    resourceType,
+                    GetResourceKey(resourcePath, resourceDebugPath))
+                        .Define(d => d.SetUrl(resourcePath, resourceDebugPath));
+            }
+            else
+            {
+                var isDebug = !String.IsNullOrEmpty(resourceDebugPath);
+
+                return RegisterResource(
+                    resourceType,
+                    GetResourceKey(resourcePath, resourceDebugPath))
+                        .Define(d => d.SetUrl(isDebug ? resourceDebugPath : resourcePath, debug: isDebug));
+            }
         }
 
         public void RegisterHeadScript(IHtmlContent script)

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/ScriptTagHelper.cs
@@ -68,16 +68,29 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     var name = Src.ToLowerInvariant();
 
                     var definition = _resourceManager.InlineManifest.DefineScript(name);
-                    definition.SetUrl(Src, DebugSrc);
+
+                    if (String.IsNullOrEmpty(DebugSrc))
+                    {
+                        definition.SetUrl(Src);
+                    }
+                    else
+                    {
+                        definition.SetUrl(Src, DebugSrc);
+                    }
 
                     if (!String.IsNullOrEmpty(Version))
                     {
                         definition.SetVersion(Version);
                     }
 
-                    if (!String.IsNullOrEmpty(CdnSrc))
+                    if (!String.IsNullOrEmpty(CdnSrc) && !String.IsNullOrEmpty(DebugCdnSrc))
                     {
                         definition.SetCdn(CdnSrc, DebugCdnSrc);
+                    }
+                    else
+                    {
+                        var isDebug = !String.IsNullOrEmpty(DebugCdnSrc);
+                        definition.SetCdn(isDebug ? DebugCdnSrc : CdnSrc, debug: isDebug);
                     }
 
                     if (!String.IsNullOrEmpty(Culture))
@@ -224,16 +237,29 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 // Inline declaration
 
                 var definition = _resourceManager.InlineManifest.DefineScript(Name);
-                definition.SetUrl(Src, DebugSrc);
+
+                if (String.IsNullOrEmpty(DebugSrc))
+                {
+                    definition.SetUrl(Src);
+                }
+                else
+                {
+                    definition.SetUrl(Src, DebugSrc);
+                }
 
                 if (!String.IsNullOrEmpty(Version))
                 {
                     definition.SetVersion(Version);
                 }
 
-                if (!String.IsNullOrEmpty(CdnSrc))
+                if (!String.IsNullOrEmpty(CdnSrc) && !String.IsNullOrEmpty(DebugCdnSrc))
                 {
                     definition.SetCdn(CdnSrc, DebugCdnSrc);
+                }
+                else
+                {
+                    var isDebug = !String.IsNullOrEmpty(DebugCdnSrc);
+                    definition.SetCdn(isDebug ? DebugCdnSrc : CdnSrc, debug: isDebug);
                 }
 
                 if (!String.IsNullOrEmpty(Culture))

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/StyleTagHelper.cs
@@ -190,9 +190,14 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                     definition.SetVersion(Version);
                 }
 
-                if (!String.IsNullOrEmpty(CdnSrc))
+                if (!String.IsNullOrEmpty(CdnSrc) && !String.IsNullOrEmpty(DebugCdnSrc))
                 {
                     definition.SetCdn(CdnSrc, DebugCdnSrc);
+                }
+                else
+                {
+                    var isDebug = !String.IsNullOrEmpty(DebugCdnSrc);
+                    definition.SetCdn(isDebug ? DebugCdnSrc : CdnSrc, debug: isDebug);
                 }
 
                 if (!String.IsNullOrEmpty(Culture))

--- a/test/OrchardCore.Tests/ResourceManagement/ResourceDefinitionTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/ResourceDefinitionTests.cs
@@ -345,7 +345,7 @@ namespace OrchardCore.Tests.ResourceManagement
             // Act
             _resourceManifest
                 .DefineScript("test")
-                .SetCdn(cdnUrl);
+                .SetCdn(cdnUrl, supportsSsl: supportsSSL);
 
             // Assert
             var resource = _resourceManifest.GetResources("script").Values.ElementAt(0).ElementAt(0);
@@ -365,7 +365,7 @@ namespace OrchardCore.Tests.ResourceManagement
             // Act
             _resourceManifest
                 .DefineScript("test")
-                .SetCdn(cdnUrl, debug: true);
+                .SetCdn(cdnUrl, debug: true, supportsSsl: supportsSSL);
 
             // Assert
             var resource = _resourceManifest.GetResources("script").Values.ElementAt(0).ElementAt(0);
@@ -385,7 +385,7 @@ namespace OrchardCore.Tests.ResourceManagement
             // Act
             _resourceManifest
                 .DefineScript("test")
-                .SetCdn(cdnUrl, cdnDebugUrl);
+                .SetCdn(cdnUrl, cdnDebugUrl, supportsSsl: supportsSSL);
 
             // Assert
             var resource = _resourceManifest.GetResources("script").Values.ElementAt(0).ElementAt(0);


### PR DESCRIPTION
The `ResourceDefinition` fluent APIs allow us to set the Cdn Url & Cdn Debug Url if we have both the original and minified versions, also have an overload to accept Cdn Url in case the minified version is not present. In some cases we may have the minified version but the original resource is missing a real example is `jquery-ui-i18n.js`

https://code.jquery.com/ui/1.7.2/i18n/jquery-ui-i18n.js is missing
https://code.jquery.com/ui/1.7.2/i18n/jquery-ui-i18n.min.js is present

So, there's no way to support this currently, unless you provide the Cdn Debug for both source and debug versions which is wrong. This PR introduces a new parameter `debug` which is optional to avoid breaking-changes