### PR TITLE
.NET December Update

### DIFF
--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -17,18 +17,18 @@
 
   <!-- These versions are used for the NuGet packages that are dependent on the current TFM (default = net6.0) -->
   <PropertyGroup>
-    <AspNetCorePackagesVersion>6.0.0</AspNetCorePackagesVersion>
-    <MicrosoftExtensionsPackagesVersion>6.0.0</MicrosoftExtensionsPackagesVersion>
+    <AspNetCorePackagesVersion>6.0.1</AspNetCorePackagesVersion>
+    <MicrosoftExtensionsPackagesVersion>6.0.1</MicrosoftExtensionsPackagesVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <AspNetCorePackagesVersion>5.0.12</AspNetCorePackagesVersion>
+    <AspNetCorePackagesVersion>5.0.13</AspNetCorePackagesVersion>
     <MicrosoftExtensionsPackagesVersion>5.0.1</MicrosoftExtensionsPackagesVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <AspNetCorePackagesVersion>3.1.21</AspNetCorePackagesVersion>
-    <MicrosoftExtensionsPackagesVersion>3.1.21</MicrosoftExtensionsPackagesVersion>
+    <AspNetCorePackagesVersion>3.1.22</AspNetCorePackagesVersion>
+    <MicrosoftExtensionsPackagesVersion>3.1.22</MicrosoftExtensionsPackagesVersion>
   </PropertyGroup>
 
   <!-- 'Microsoft.AspNetCore' packages that are not included in the ASP.NET Core shared framework -->


### PR DESCRIPTION
.NET December 2021 Updates – 6.0.1, 5.0.13 and 3.1.22
https://devblogs.microsoft.com/dotnet/december-2021-updates/