### PR TITLE
Fix route ChangePasswordConfirmation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -75,6 +75,14 @@ namespace OrchardCore.Users
                 pattern: userOptions.ChangePasswordUrl,
                 defaults: new { controller = accountControllerName, action = nameof(AccountController.ChangePassword) }
             );
+
+            routes.MapAreaControllerRoute(
+                name: "ChangePasswordConfirmation",
+                areaName: "OrchardCore.Users",
+                pattern: userOptions.ChangePasswordConfirmation,
+                defaults: new { controller = accountControllerName, action = nameof(AccountController.ChangePasswordConfirmation) }
+            );
+
             routes.MapAreaControllerRoute(
                 name: "UsersLogOff",
                 areaName: "OrchardCore.Users",

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -79,7 +79,7 @@ namespace OrchardCore.Users
             routes.MapAreaControllerRoute(
                 name: "ChangePasswordConfirmation",
                 areaName: "OrchardCore.Users",
-                pattern: userOptions.ChangePasswordConfirmationPath,
+                pattern: userOptions.ChangePasswordConfirmationUrl,
                 defaults: new { controller = accountControllerName, action = nameof(AccountController.ChangePasswordConfirmation) }
             );
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -79,7 +79,7 @@ namespace OrchardCore.Users
             routes.MapAreaControllerRoute(
                 name: "ChangePasswordConfirmation",
                 areaName: "OrchardCore.Users",
-                pattern: userOptions.ChangePasswordConfirmation,
+                pattern: userOptions.ChangePasswordConfirmationPath,
                 defaults: new { controller = accountControllerName, action = nameof(AccountController.ChangePasswordConfirmation) }
             );
 

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/UserOptions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/UserOptions.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Users
         private string _logoffPath = "Users/LogOff";
         private string _changePasswordUrl = "ChangePassword";
         private string _externalLoginsUrl = "ExternalLogins";
-        private string _changePasswordConfirmation = "ChangePasswordConfirmation";
+        private string _changePasswordConfirmationPath = "ChangePasswordConfirmation";
 
         public string LoginPath
         {
@@ -32,10 +32,10 @@ namespace OrchardCore.Users
             set => _externalLoginsUrl = value.Trim(' ', '/');
         }
 
-        public string ChangePasswordConfirmation
+        public string ChangePasswordConfirmationPath
         {
-            get => _changePasswordConfirmation;
-            set => _changePasswordConfirmation = value.Trim(' ', '/');
+            get => _changePasswordConfirmationPath;
+            set => _changePasswordConfirmationPath = value.Trim(' ', '/');
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/UserOptions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/UserOptions.cs
@@ -5,8 +5,8 @@ namespace OrchardCore.Users
         private string _loginPath = "Login";
         private string _logoffPath = "Users/LogOff";
         private string _changePasswordUrl = "ChangePassword";
+        private string _changePasswordConfirmationUrl = "ChangePasswordConfirmation";
         private string _externalLoginsUrl = "ExternalLogins";
-        private string _changePasswordConfirmationPath = "ChangePasswordConfirmation";
 
         public string LoginPath
         {
@@ -26,16 +26,16 @@ namespace OrchardCore.Users
             set => _changePasswordUrl = value.Trim(' ', '/');
         }
 
+        public string ChangePasswordConfirmationUrl
+        {
+            get => _changePasswordConfirmationUrl;
+            set => _changePasswordConfirmationUrl = value.Trim(' ', '/');
+        }
+
         public string ExternalLoginsUrl
         {
             get => _externalLoginsUrl;
             set => _externalLoginsUrl = value.Trim(' ', '/');
-        }
-
-        public string ChangePasswordConfirmationPath
-        {
-            get => _changePasswordConfirmationPath;
-            set => _changePasswordConfirmationPath = value.Trim(' ', '/');
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Users.Abstractions/UserOptions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Abstractions/UserOptions.cs
@@ -6,6 +6,7 @@ namespace OrchardCore.Users
         private string _logoffPath = "Users/LogOff";
         private string _changePasswordUrl = "ChangePassword";
         private string _externalLoginsUrl = "ExternalLogins";
+        private string _changePasswordConfirmation = "ChangePasswordConfirmation";
 
         public string LoginPath
         {
@@ -29,6 +30,12 @@ namespace OrchardCore.Users
         {
             get => _externalLoginsUrl;
             set => _externalLoginsUrl = value.Trim(' ', '/');
+        }
+
+        public string ChangePasswordConfirmation
+        {
+            get => _changePasswordConfirmation;
+            set => _changePasswordConfirmation = value.Trim(' ', '/');
         }
     }
 }

--- a/src/docs/reference/modules/Users/README.md
+++ b/src/docs/reference/modules/Users/README.md
@@ -22,8 +22,8 @@ If you want to specify custom paths to access the authentication related urls, y
       "LoginPath": "Login",
       "LogoffPath": "Users/LogOff",
       "ChangePasswordUrl": "ChangePassword",
-      "ExternalLoginsUrl": "ExternalLogins",
-      "ChangePasswordConfirmationPath": "ChangePasswordConfirmation"
+      "ChangePasswordConfirmationUrl": "ChangePasswordConfirmation",
+      "ExternalLoginsUrl": "ExternalLogins"
     }
   }
 ```

--- a/src/docs/reference/modules/Users/README.md
+++ b/src/docs/reference/modules/Users/README.md
@@ -22,7 +22,8 @@ If you want to specify custom paths to access the authentication related urls, y
       "LoginPath": "Login",
       "LogoffPath": "Users/LogOff",
       "ChangePasswordUrl": "ChangePassword",
-      "ExternalLoginsUrl": "ExternalLogins"
+      "ExternalLoginsUrl": "ExternalLogins",
+      "ChangePasswordConfirmationPath": "ChangePasswordConfirmation"
     }
   }
 ```


### PR DESCRIPTION
Mapped the action **OrchardCore.Users.Controllers.ChangePasswordConfirmation()** to **/ChangePasswordConfirmation**, because that action was mapped to **/OrchardCore.Users/ChangePasswordConfirmation**.