### PR TITLE
Add dotnet watch excludes

### DIFF
--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -13,6 +13,11 @@
     <RazorRuntimeCompilation>false</RazorRuntimeCompilation>
   </PropertyGroup>
 
+  <!-- Watcher include and excludes -->
+  <ItemGroup>
+      <Watch Include="**\*.cs" Exclude="Recipes\**;Assets\**;node_modules\**\*;**\*.js.map;obj\**\*;bin\**\*" />
+  </ItemGroup>
+
   <ItemGroup>
     <Folder Include="wwwroot\" />
     <Folder Include="Localization\" />

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/OrchardCore.Templates.Cms.Web.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/OrchardCore.Templates.Cms.Web.csproj
@@ -11,6 +11,11 @@
     <Folder Include="Localization\" />
   </ItemGroup>
 
+  <!-- Watcher include and excludes -->
+  <ItemGroup>
+      <Watch Include="**\*.cs" Exclude="Recipes\**;Assets\**;node_modules\**\*;**\*.js.map;obj\**\*;bin\**\*" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="$(TemplateOrchardPackageVersion)"
                       Condition="'$(RazorRuntimeCompilation)' == 'true'" />


### PR DESCRIPTION
To lighten the filewatcher process. It fixes the issue where it reports in the console that there are too many changes in a folder.