### PR TITLE
Add migration for LocalizedContentItemIndex Latest column

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Migrations.cs
@@ -1,14 +1,11 @@
-using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentLocalization.Models;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
-using OrchardCore.ContentManagement.Records;
 using OrchardCore.Data.Migration;
 using OrchardCore.Environment.Shell.Scope;
 using YesSql;
-using YesSql.Services;
 using YesSql.Sql;
 
 namespace OrchardCore.ContentLocalization.Records

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Migrations.cs
@@ -88,9 +88,6 @@ namespace OrchardCore.ContentLocalization.Records
                 var session = scope.ServiceProvider.GetRequiredService<ISession>();
                 var localizedContentItems = await session.Query<ContentItem, LocalizedContentItemIndex>().ListAsync();
 
-                //var localizedContentItemsDict = localizedContentItems.ToDictionary(k => k.Id, v => v.Id);
-
-                //var contentItems = await session.Query<ContentItem, ContentItemIndex>(x => x.DocumentId.Equals(localizedContentItemsDict.Keys.ToList())).ListAsync();
                 foreach (var localizedContentItem in localizedContentItems)
                 {
                     localizedContentItem.Latest = localizedContentItem.ContentItem.Latest;

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Migrations.cs
@@ -86,15 +86,15 @@ namespace OrchardCore.ContentLocalization.Records
             ShellScope.AddDeferredTask(async scope =>
             {
                 var session = scope.ServiceProvider.GetRequiredService<ISession>();
-                var nullContentItems = await session.Query<ContentItem, LocalizedContentItemIndex>(c => c.Latest.Equals(null)).ListAsync();
+                var localizedContentItems = await session.Query<ContentItem, LocalizedContentItemIndex>().ListAsync();
 
-                var nullContentItemsDict = nullContentItems.ToDictionary(k => k.ContentItemId, v => v);
+                //var localizedContentItemsDict = localizedContentItems.ToDictionary(k => k.Id, v => v.Id);
 
-                var contentItems = await session.Query<ContentItem, ContentItemIndex>(c => c.Id.IsIn(nullContentItemsDict.Keys)).ListAsync();
-                foreach (var nullContentItem in nullContentItems)
+                //var contentItems = await session.Query<ContentItem, ContentItemIndex>(x => x.DocumentId.Equals(localizedContentItemsDict.Keys.ToList())).ListAsync();
+                foreach (var localizedContentItem in localizedContentItems)
                 {
-                    nullContentItem.Latest = contentItems.Where(c => c.Id == nullContentItem.Id).FirstOrDefault().Latest;
-                    session.Save(nullContentItem);
+                    localizedContentItem.Latest = localizedContentItem.ContentItem.Latest;
+                    session.Save(localizedContentItem);
                 }
             });
 


### PR DESCRIPTION
Fixes #10756 

So, this will remove every record that is not `Latest = true` in the `LocalizedContentItemIndex` because of the `LocalizedContentItemIndexProvider`.

Else solution will be to simply do a SQL Query snippet and add it to documentation. But I believe that this works fine since removed records should also be removed from the Index. I'm not sure what is the reason why we keep removed records in there. @jptissot

