### PR TITLE
Fixes index cursors management

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
@@ -147,7 +147,10 @@ namespace OrchardCore.Autoroute.Services
             {
                 if (_stateIdentifier != state.Identifier)
                 {
-                    var indexes = await Session.QueryIndex<AutoroutePartIndex>(i => i.Id > _lastIndexId).ListAsync();
+                    var indexes = await Session
+                        .QueryIndex<AutoroutePartIndex>(i => i.Id > _lastIndexId)
+                        .OrderBy(i => i.Id)
+                        .ListAsync();
 
                     // A draft is indexed to check for conflicts, and to remove an entry, but only if an item is unpublished,
                     // so only if the entry 'DocumentId' matches, this because when a draft is saved more than once, the index
@@ -199,7 +202,11 @@ namespace OrchardCore.Autoroute.Services
                 {
                     var state = await _autorouteStateManager.GetOrCreateImmutableAsync();
 
-                    var indexes = await Session.QueryIndex<AutoroutePartIndex>(i => i.Published && i.Path != null).ListAsync();
+                    var indexes = await Session
+                        .QueryIndex<AutoroutePartIndex>(i => i.Published && i.Path != null)
+                        .OrderBy(i => i.Id)
+                        .ListAsync();
+
                     var entries = indexes.Select(i => new AutorouteEntry(i.ContentItemId, i.Path, i.ContainedContentItemId, i.JsonPath)
                     {
                         DocumentId = i.DocumentId

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Services/AutorouteEntries.cs
@@ -81,14 +81,15 @@ namespace OrchardCore.Autoroute.Services
 
         protected void AddEntries(IEnumerable<AutorouteEntry> entries)
         {
-            var entriesByContainer = _paths.Values
-                .Where(x => !String.IsNullOrEmpty(x.ContainedContentItemId))
-                .ToLookup(x => x.ContentItemId);
-
             // Evict all entries related to a container item from autoroute entries.
             // This is necessary to account for deletions, disabling of an item, or disabling routing of contained items.
+            ILookup<string, AutorouteEntry> entriesByContainer = null;
             foreach (var entry in entries.Where(x => String.IsNullOrEmpty(x.ContainedContentItemId)))
             {
+                entriesByContainer ??= _paths.Values
+                    .Where(x => !String.IsNullOrEmpty(x.ContainedContentItemId))
+                    .ToLookup(x => x.ContentItemId);
+
                 if (!entriesByContainer.Contains(entry.ContentItemId))
                 {
                     continue;

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Services/LocalizationEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Services/LocalizationEntries.cs
@@ -135,7 +135,10 @@ namespace OrchardCore.ContentLocalization.Services
             {
                 if (_stateIdentifier != state.Identifier)
                 {
-                    var indexes = await Session.QueryIndex<LocalizedContentItemIndex>(i => i.Id > _lastIndexId).ListAsync();
+                    var indexes = await Session
+                        .QueryIndex<LocalizedContentItemIndex>(i => i.Id > _lastIndexId)
+                        .OrderBy(i => i.Id)
+                        .ListAsync();
 
                     // A draft is indexed to check for conflicts, and to remove an entry, but only if an item is unpublished,
                     // so only if the entry 'DocumentId' matches, this because when a draft is saved more than once, the index
@@ -189,7 +192,11 @@ namespace OrchardCore.ContentLocalization.Services
                 {
                     var state = await _localizationStateManager.GetOrCreateImmutableAsync();
 
-                    var indexes = await Session.QueryIndex<LocalizedContentItemIndex>(i => i.Published && i.Culture != null).ListAsync();
+                    var indexes = await Session
+                        .QueryIndex<LocalizedContentItemIndex>(i => i.Published && i.Culture != null)
+                        .OrderBy(i => i.Id)
+                        .ListAsync();
+
                     var entries = indexes.Select(i => new LocalizationEntry
                     {
                         DocumentId = i.DocumentId,

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/IndexingTaskManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/IndexingTaskManager.cs
@@ -200,6 +200,7 @@ namespace OrchardCore.Indexing.Services
                     }
 
                     sqlBuilder.WhereAnd($"{dialect.QuoteForColumnName("Id")} > @Id");
+                    sqlBuilder.OrderBy($"{dialect.QuoteForColumnName("Id")}");
 
                     return await connection.QueryAsync<IndexingTask>(sqlBuilder.ToSqlString(), new { Id = afterTaskId });
                 }


### PR DESCRIPTION
Fixes #10937

When there are hundreds of thousands rows the results returned by `QueryIndex()` may not be ordered by `Id` by default. In that case services as `AutorouteEntries` using an index cursor on the `Id` column are not working properly, the `_lastIndexId` being not well managed. In my case when first publishing an item having an Autoroute, in place of only adding one Autoroute entry, it was trying to add thousands of Autoroute entries in an unordered way and was taking a very long time.

**Updated**

Also enhances the lookup of Autoroute entries to evict, the ones related to contained items of a given container.
