### PR TITLE
Reduce allocations in MediaTokenService and improve performance

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageVersionProcessor.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageVersionProcessor.cs
@@ -17,8 +17,10 @@ namespace OrchardCore.Media.Processing
         /// </summary>
         public const string VersionCommand = "v";
 
+        private static readonly IEnumerable<string> VersionCommands = new[] { VersionCommand };
+
         public IEnumerable<string> Commands
-            => new[] { VersionCommand };
+            => VersionCommands;
 
         public FormattedImage Process(FormattedImage image, ILogger logger, IDictionary<string, string> commands, CommandParser parser, CultureInfo culture)
             => image;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenService.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Encodings.Web;
 using Cysharp.Text;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 using SixLabors.ImageSharp.Web.Processors;
 
 namespace OrchardCore.Media.Processing
@@ -15,7 +17,7 @@ namespace OrchardCore.Media.Processing
         private const string TokenCacheKeyPrefix = "MediaToken:";
         private readonly IMemoryCache _memoryCache;
 
-        private readonly HashSet<string> _knownCommands = new HashSet<string>();
+        private readonly HashSet<string> _knownCommands = new HashSet<string>(12);
         private readonly byte[] _hashKey;
 
         public MediaTokenService(
@@ -24,6 +26,7 @@ namespace OrchardCore.Media.Processing
             IEnumerable<IImageWebProcessor> processors)
         {
             _memoryCache = memoryCache;
+
             foreach (var processor in processors)
             {
                 foreach (var command in processor.Commands)
@@ -39,34 +42,24 @@ namespace OrchardCore.Media.Processing
         {
             var pathIndex = path.IndexOf('?');
 
-            var parsed = pathIndex != -1
-                ? QueryHelpers.ParseQuery(path.Substring(pathIndex + 1))
-                : null;
+            Dictionary<string, StringValues> processingCommands = null;
+            Dictionary<string, StringValues> otherCommands = null;
+
+            if (pathIndex != -1)
+            {
+                ParseQuery(path.Substring(pathIndex + 1), out processingCommands, out otherCommands);
+            }
 
             // If no commands or only a version command don't bother tokenizing.
-            if (parsed is null || parsed.Count == 0 || parsed.Count == 1 && parsed.ContainsKey(ImageVersionProcessor.VersionCommand))
+            if (processingCommands is null
+                || processingCommands.Count == 0
+                || processingCommands.Count == 1 && processingCommands.ContainsKey(ImageVersionProcessor.VersionCommand))
             {
                 return path;
             }
 
-            var processingCommands = new Dictionary<string, string>(parsed.Count);
-            Dictionary<string, string> otherCommands = null;
-
-            foreach (var command in parsed)
-            {
-                if (_knownCommands.Contains(command.Key))
-                {
-                    processingCommands[command.Key] = command.Value.ToString();
-                }
-                else
-                {
-                    otherCommands ??= new Dictionary<string, string>();
-                    otherCommands[command.Key] = command.Value.ToString();
-                }
-            }
-
             // Using the command values as a key retrieve from cache
-            var queryStringTokenKey = CreateQueryStringTokenKey(processingCommands.Values);
+            var queryStringTokenKey = CreateQueryStringTokenKey(processingCommands);
             var queryStringToken = GetHash(queryStringTokenKey);
 
             processingCommands["token"] = queryStringToken;
@@ -80,12 +73,75 @@ namespace OrchardCore.Media.Processing
                 }
             }
 
-            return QueryHelpers.AddQueryString(path.Substring(0, pathIndex), processingCommands);
+            return AddQueryString(path.AsSpan(0, pathIndex), processingCommands);
         }
+
+#if NET6_0_OR_GREATER // fast version with structs
+        private void ParseQuery(
+            string queryString,
+            out Dictionary<string, StringValues> processingCommands,
+            out Dictionary<string, StringValues> otherCommands)
+        {
+            processingCommands = null;
+            otherCommands = null;
+
+            var accumulator = new KeyValueAccumulator();
+            var otherCommandAccumulator = new KeyValueAccumulator();
+            var enumerable = new QueryStringEnumerable(queryString);
+
+            foreach (var pair in enumerable)
+            {
+                var key = pair.DecodeName().ToString();
+                var value = pair.DecodeValue().ToString();
+
+                if (_knownCommands.Contains(key))
+                {
+                    accumulator.Append(key, value);
+                }
+                else
+                {
+                    otherCommandAccumulator.Append(key, value);
+                }
+            }
+
+            if (accumulator.HasValues)
+            {
+                processingCommands = accumulator.GetResults();
+            }
+
+            if (otherCommandAccumulator.HasValues)
+            {
+                otherCommands = otherCommandAccumulator.GetResults();
+            }
+        }
+#else // slower version until NET 6 is the default
+        private void ParseQuery(
+            string queryString,
+            out Dictionary<string, StringValues> processingCommands,
+            out Dictionary<string, StringValues> otherCommands)
+        {
+            var parsed = QueryHelpers.ParseQuery(queryString);
+            processingCommands = new Dictionary<string, StringValues>();
+            otherCommands = null;
+
+            foreach (var command in parsed)
+            {
+                if (_knownCommands.Contains(command.Key))
+                {
+                    processingCommands[command.Key] = command.Value;
+                }
+                else
+                {
+                    otherCommands ??= new Dictionary<string, StringValues>();
+                    otherCommands[command.Key] = command.Value;
+                }
+            }
+        }
+#endif
 
         public bool TryValidateToken(IDictionary<string, string> commands, string token)
         {
-            var queryStringTokenKey = CreateQueryStringTokenKey(commands.Values);
+            var queryStringTokenKey = CreateQueryStringTokenKey(commands);
 
             // Store a hash of the valid query string commands.
             var queryStringToken = GetHash(queryStringTokenKey);
@@ -98,30 +154,97 @@ namespace OrchardCore.Media.Processing
             return false;
         }
 
-        private static string CreateQueryStringTokenKey(IEnumerable<string> values)
+        /// <summary>
+        /// Specialized version with fast enumeration and no StringValues string allocation.
+        /// </summary>
+        private static string CreateQueryStringTokenKey(Dictionary<string, StringValues> values)
         {
             using var builder = ZString.CreateStringBuilder();
             builder.Append(TokenCacheKeyPrefix);
-            foreach (var item in values)
+            foreach (var pair in values)
             {
-                builder.Append(item);
+                builder.Append(pair.Value.ToString());
+            }
+            return builder.ToString();
+        }
+
+        private static string CreateQueryStringTokenKey(IDictionary<string, string> values)
+        {
+            using var builder = ZString.CreateStringBuilder();
+            builder.Append(TokenCacheKeyPrefix);
+            foreach (var pair in values)
+            {
+                builder.Append(pair.Value);
             }
             return builder.ToString();
         }
 
         private string GetHash(string queryStringTokenKey)
-            => _memoryCache.GetOrCreate(queryStringTokenKey, entry =>
-               {
-                   entry.SlidingExpiration = TimeSpan.FromHours(5);
+        {
+            if (!_memoryCache.TryGetValue(queryStringTokenKey, out var result))
+            {
+                using var entry = _memoryCache.CreateEntry(queryStringTokenKey);
 
-                   using var hmac = new HMACSHA256(_hashKey);
+                entry.SlidingExpiration = TimeSpan.FromHours(5);
 
-                   // queryStringTokenKey also contains prefix
-                   var bytes = Encoding.UTF8.GetBytes(queryStringTokenKey, TokenCacheKeyPrefix.Length, queryStringTokenKey.Length - TokenCacheKeyPrefix.Length);
+                using var hmac = new HMACSHA256(_hashKey);
 
-                   var hash = hmac.ComputeHash(bytes);
+                // queryStringTokenKey also contains prefix
+                var chars = queryStringTokenKey.AsSpan(TokenCacheKeyPrefix.Length);
 
-                   return Convert.ToBase64String(hash);
-               });
+                // only allocate on stack if it's small enough
+                var requiredLength = Encoding.UTF8.GetByteCount(chars);
+                var stringBytes = requiredLength < 1024
+                    ? stackalloc byte[requiredLength]
+                    : new byte[requiredLength];
+
+                // 256 for SHA-256, fits in stack nicely
+                Span<byte> hashBytes = stackalloc byte[hmac.HashSize];
+
+                var stringBytesLength = Encoding.UTF8.GetBytes(chars, stringBytes);
+
+                hmac.TryComputeHash(stringBytes.Slice(0, stringBytesLength), hashBytes, out var hashBytesLength);
+
+                entry.Value = result = Convert.ToBase64String(hashBytes.Slice(0, hashBytesLength));
+            }
+
+            return (string) result;
+        }
+
+        /// <summary>
+        /// Custom version of <see cref="QueryHelpers.AddQueryString(string,string,string)"/> that takes our pre-built
+        /// dictionary, uri as ReadOnlySpan&lt;char&gt; and uses ZString. Otherwise same logic.
+        /// </summary>
+        private static string AddQueryString(
+            ReadOnlySpan<char> uri,
+            Dictionary<string, StringValues> queryString)
+        {
+            var anchorIndex = uri.IndexOf('#');
+            var uriToBeAppended = uri;
+            var anchorText = ReadOnlySpan<char>.Empty;
+            // If there is an anchor, then the query string must be inserted before its first occurrence.
+            if (anchorIndex != -1)
+            {
+                anchorText = uri.Slice(anchorIndex);
+                uriToBeAppended = uri.Slice(0, anchorIndex);
+            }
+
+            var queryIndex = uriToBeAppended.IndexOf('?');
+            var hasQuery = queryIndex != -1;
+
+            using var sb = ZString.CreateStringBuilder();
+            sb.Append(uriToBeAppended);
+            foreach (var parameter in queryString)
+            {
+                sb.Append(hasQuery ? '&' : '?');
+                sb.Append(UrlEncoder.Default.Encode(parameter.Key));
+                sb.Append('=');
+                sb.Append(UrlEncoder.Default.Encode(parameter.Value));
+                hasQuery = true;
+            }
+
+            sb.Append(anchorText);
+            return sb.ToString();
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/TokenCommandProcessor.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/TokenCommandProcessor.cs
@@ -17,8 +17,10 @@ namespace OrchardCore.Media.Processing
         /// </summary>
         public const string TokenCommand = "token";
 
+        private static readonly IEnumerable<string> TokenCommands = new[] { TokenCommand };
+
         public IEnumerable<string> Commands
-            => new[] { TokenCommand };
+            => TokenCommands;
 
         public FormattedImage Process(FormattedImage image, ILogger logger, IDictionary<string, string> commands, CommandParser parser, CultureInfo culture)
             => image;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -137,7 +137,7 @@ namespace OrchardCore.Media
                 .AddProcessor<TokenCommandProcessor>();
 
             services.AddScoped<MediaTokenSettingsUpdater>();
-            services.AddScoped<IMediaTokenService, MediaTokenService>();
+            services.AddSingleton<IMediaTokenService, MediaTokenService>();
             services.AddTransient<IConfigureOptions<MediaTokenOptions>, MediaTokenOptionsConfiguration>();
             services.AddScoped<IFeatureEventHandler>(sp => sp.GetRequiredService<MediaTokenSettingsUpdater>());
             services.AddScoped<IModularTenantEvents>(sp => sp.GetRequiredService<MediaTokenSettingsUpdater>());

--- a/test/OrchardCore.Benchmarks/MediaTokenServiceBenchmark.cs
+++ b/test/OrchardCore.Benchmarks/MediaTokenServiceBenchmark.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using OrchardCore.Media.Processing;
+using SixLabors.ImageSharp.Web.Middleware;
+using SixLabors.ImageSharp.Web.Processors;
+
+namespace OrchardCore.Benchmark
+{
+    [MemoryDiagnoser]
+    public class MediaTokenServiceBenchmark
+    {
+        private static readonly MediaTokenService _mediaTokenService;
+        private static readonly MediaTokenService _mediaTokenServiceWithoutCache;
+
+        static MediaTokenServiceBenchmark()
+        {
+            IMemoryCache memoryCache = new MemoryCache(Options.Create(new MemoryCacheOptions()));
+            IMemoryCache nullCache = new NullCache();
+
+            using var rng = RandomNumberGenerator.Create();
+            var hashKey = new byte[64];
+            rng.GetBytes(hashKey);
+
+            // mimic default configuration
+            var options = Options.Create(new MediaTokenOptions { HashKey = hashKey });
+            var processors = new IImageWebProcessor[]
+            {
+                new ResizeWebProcessor(),
+                new FormatWebProcessor(Options.Create(new ImageSharpMiddlewareOptions())),
+                new BackgroundColorWebProcessor(),
+                new JpegQualityWebProcessor(),
+                new ImageVersionProcessor(),
+                new TokenCommandProcessor()
+            };
+
+            _mediaTokenService = new MediaTokenService(memoryCache, options, processors);
+            _mediaTokenServiceWithoutCache = new MediaTokenService(nullCache, options, processors);
+        }
+
+        [Benchmark]
+        public string AddTokenToPath()
+        {
+            return _mediaTokenService.AddTokenToPath("/media/portfolio/1.jpg?width=600&height=480&rmode=stretch");
+        }
+
+        [Benchmark]
+        public string AddTokenToPath_NoCache()
+        {
+            return _mediaTokenServiceWithoutCache.AddTokenToPath("/media/portfolio/1.jpg?width=600&height=480&rmode=stretch");
+        }
+
+        [Benchmark]
+        public string AddTokenToPath_LongPath()
+        {
+            return _mediaTokenService.AddTokenToPath("/media/portfolio/1.jpg?width=LOOOOOOOOOOOOOOONG&height=LOOOOOOOOOOOOOOONG&rmode=LOOOOOOOOOOOOOOONG&rxy=LOOOOOOOOOOOOOOONG&rsampler=LOOOOOOOOOOOOOOONG&ranchor=LOOOOOOOOOOOOOOONG&compand=LOOOOOOOOOOOOOOONG&token=LOOOOOOOOOOOOOOONG&quality=LOOOOOOOOOOOOOOONG");
+        }
+
+        [Benchmark]
+        public string AddTokenToPath_LongPath_NoCache()
+        {
+            return _mediaTokenServiceWithoutCache.AddTokenToPath("/media/portfolio/1.jpg?width=LOOOOOOOOOOOOOOONG&height=LOOOOOOOOOOOOOOONG&rmode=LOOOOOOOOOOOOOOONG&rxy=LOOOOOOOOOOOOOOONG&rsampler=LOOOOOOOOOOOOOOONG&ranchor=LOOOOOOOOOOOOOOONG&compand=LOOOOOOOOOOOOOOONG&token=LOOOOOOOOOOOOOOONG&quality=LOOOOOOOOOOOOOOONG");
+        }
+    }
+
+    public class NullCache : IMemoryCache
+    {
+        public ICacheEntry CreateEntry(object key)
+        {
+            return new NullCacheEntry();
+        }
+
+        public void Remove(object key)
+        {
+        }
+
+        public bool TryGetValue(object key, out object value)
+        {
+            value = default;
+            return false;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class NullCacheEntry : ICacheEntry
+        {
+            public DateTimeOffset? AbsoluteExpiration { get; set; }
+            public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
+            public IList<IChangeToken> ExpirationTokens { get; set; }
+            public object Key { get; set; }
+            public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks { get; set; }
+            public CacheItemPriority Priority { get; set; }
+            public long? Size { get; set; }
+            public TimeSpan? SlidingExpiration { get; set; }
+            public object Value { get; set; }
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -16,24 +15,35 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media
     public class MediaTokenTests
     {
         private readonly MediaTokenSettings _mediaTokenSettings;
+
+        // use static value for repeatable tests
+        private readonly byte[] _hashKey =
+        {
+            88, 204, 124, 2, 54, 72, 44, 8, 207, 85, 88, 9, 245, 129, 200, 41, 13, 169, 54, 213, 202, 118, 197, 9, 26,
+            20, 108, 197, 123, 168, 140, 79, 32, 184, 144, 72, 254, 201, 91, 73, 230, 56, 190, 40, 11, 21, 229, 94, 118,
+            120, 84, 75, 174, 181, 168, 94, 30, 191, 169, 41, 222, 12, 239, 106
+        };
+
         public MediaTokenTests()
         {
-            var rng = RandomNumberGenerator.Create();
             _mediaTokenSettings = new MediaTokenSettings();
-            _mediaTokenSettings.HashKey = new byte[64];
-            rng.GetBytes(_mediaTokenSettings.HashKey);
+            _mediaTokenSettings.HashKey = _hashKey;
         }
 
-        [Fact]
-        public void ShouldAddToken()
+        [Theory]
+        [InlineData("/media/blog.jpg?width=100&height=100", "/media/blog.jpg?width=100&height=100&token=eVmmj09NoysPASEiuhCuUHJR%2BSrUtSafBo738SuL2eU%3D")]
+        [InlineData("/media/blog.jpg?width=100&height=100&foo=bar", "/media/blog.jpg?width=100&height=100&token=eVmmj09NoysPASEiuhCuUHJR%2BSrUtSafBo738SuL2eU%3D&foo=bar")]
+        public void ShouldAddToken(string path, string expected)
         {
             var serviceProvider = CreateServiceProvider();
             var mediaTokenService = serviceProvider.GetRequiredService<IMediaTokenService>();
-            var path = "/media/blog.jpg?width=100&height=100";
 
-            var tokenizedPath = mediaTokenService.AddTokenToPath(path);
-
-            Assert.True(tokenizedPath.Contains("token", StringComparison.OrdinalIgnoreCase));
+            // make sure we also hit cache
+            for (var i = 0; i < 2; ++i)
+            {
+                var tokenizedPath = mediaTokenService.AddTokenToPath(path);
+                Assert.Equal(expected, tokenizedPath);
+            }
         }
 
         [Theory]


### PR DESCRIPTION
One has to have hobbies, right? Felt like a fun exercise as Orchard can use all .NET 6 goodness. 

`MediaTokenService` does some unnecessary allocations and is called on every request which has images served.

* ~~tweak constructor to iterate array, DI gives array and it's fastest to traverse - constructor takes considerable amount of time (see scope note below)~~
  * no need after changing service to singleton, shaved off extra 200ns without the constructor invoke
* don't `ToString` `StringValues`, keep them as-is as in dictionary once built
* parse commands and others commands with one pass using constructs that `QueryHelpers` uses
* allocate static command arrays to return from processors, some of them were always returning new ones
* change `GetHash` not to allocation anonymous closure each time by using `Try`/`Set `construct, uses same logic that extension method `GetOrCreate` uses
* change hash calculation to use stackalloc and spans for workloads < 1024 bytes (common case)
* use custom `AddQueryString `method that understands spans and concrete dictionary type

`MediaTokenService` seems to be scoped service and thus known commands need to be initialized for every request, is this a tenancy things and cannot be made singleton?

## Benchmarks

``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.101
  [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT


```

### Before

|                          Method |     Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Allocated |
|-------------------------------- |---------:|----------:|----------:|-------:|-------:|----------:|
|                  AddTokenToPath | 1.335 us | 0.0097 us | 0.0091 us | 0.1984 |      - |      3 KB |
|          AddTokenToPath_NoCache | 1.993 us | 0.0089 us | 0.0083 us | 0.2441 |      - |      4 KB |
|         AddTokenToPath_LongPath | 2.474 us | 0.0157 us | 0.0139 us | 0.4005 | 0.0038 |      7 KB |
| AddTokenToPath_LongPath_NoCache | 3.135 us | 0.0098 us | 0.0091 us | 0.4578 | 0.0038 |      7 KB |

### After

Now testing with singleton - unlike main branch!

|                          Method |       Mean |   Error |  StdDev |  Gen 0 | Allocated |
|-------------------------------- |-----------:|--------:|--------:|-------:|----------:|
|                  AddTokenToPath |   696.1 ns | 1.18 ns | 1.05 ns | 0.0715 |      1 KB |
|          AddTokenToPath_NoCache | 1,309.6 ns | 2.28 ns | 1.91 ns | 0.1087 |      2 KB |
|         AddTokenToPath_LongPath | 1,556.8 ns | 4.93 ns | 4.37 ns | 0.2060 |      3 KB |
| AddTokenToPath_LongPath_NoCache | 2,248.9 ns | 6.70 ns | 6.27 ns | 0.2441 |      4 KB |