### PR TITLE
Bump ImageSharp.Web to v1.0.5

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -42,7 +42,7 @@
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.1.0" />
     <PackageManagement Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageManagement Include="Shortcodes" Version="1.3.0" />
-    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.4" />
+    <PackageManagement Include="SixLabors.ImageSharp.Web" Version="1.0.5" />
     <PackageManagement Include="System.Linq.Async" Version="5.1.0" />
     <PackageManagement Include="xunit.analyzers" Version="0.10.0" />
     <PackageManagement Include="xunit" Version="2.4.1" />

--- a/src/docs/resources/libraries/README.md
+++ b/src/docs/resources/libraries/README.md
@@ -13,7 +13,7 @@ The below table lists the different .NET libraries used in Orchard Core:
 | [Fluid.Core](https://github.com/sebastienros/fluid) | .NET Liquid template engine. | 2.2.8 | [MIT](https://github.com/sebastienros/fluid/blob/dev/LICENSE) |
 | [GraphQL](https://github.com/graphql/graphiql) | GraphiQL & GraphQL. | 2.4.0 | [MIT](https://github.com/graphql/graphiql/blob/main/LICENSE) |
 | [HtmlSanitizer](https://github.com/mganss/HtmlSanitizer) | Cleans HTML to avoid XSS attacks. | 6.0.453 | [MIT](https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md) |
-| [Image Sharp](https://github.com/SixLabors/ImageSharp.Web) | Middleware for ASP.NET-Core for image manipulation. | 1.0.4 |[Apache-2.0](https://github.com/SixLabors/ImageSharp.Web/blob/master/LICENSE) |
+| [Image Sharp](https://github.com/SixLabors/ImageSharp.Web) | Middleware for ASP.NET-Core for image manipulation. | 1.0.5 |[Apache-2.0](https://github.com/SixLabors/ImageSharp.Web/blob/master/LICENSE) |
 | [Irony.Core](https://github.com/daxnet/irony) | A modified version of the Irony project with .NET Core support | 1.0.7 | [MIT](https://github.com/daxnet/irony/blob/master/LICENSE) |
 | [Jint](https://github.com/sebastienros/jint) | Javascript Interpreter for .NET. | 3.0.0-beta-2037 | [MIT](https://github.com/sebastienros/jint/blob/dev/LICENSE) |
 | [Lucene.Net](https://github.com/apache/lucenenet) | .NET full-text search engine. | 4.8.0-beta00015 | [Apache-2.0](https://github.com/apache/lucenenet/blob/master/LICENSE.txt) |


### PR DESCRIPTION
https://github.com/SixLabors/ImageSharp.Web/releases/tag/v1.0.5