### PR TITLE
Add reference to Fluid under Liquid docs

### DIFF
--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -1,7 +1,8 @@
 # Liquid (`OrchardCore.Liquid`)
 
 This module provides a way to create templates securely from the admin site.  
-For more information about the Liquid syntax, please refer to this site: <https://shopify.github.io/liquid/>
+For more information about the Liquid syntax, please refer to this site: <https://shopify.github.io/liquid/>.
+Liquid syntax is powered by Fluid. Check <https://github.com/sebastienros/fluid> for extra examples and custom filters.
 
 ## General concepts
 


### PR DESCRIPTION
Was struggling to find how to format a number, only to find out that's been explained in Fluid web page. There's some other useful information there, so i chose to reference the fluid page instead of copying the content. I could go either way.