### PR TITLE
Search Form : Allow to override Index used

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/SearchController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/SearchController.cs
@@ -74,15 +74,11 @@ namespace OrchardCore.Lucene.Controllers
 
             var siteSettings = await _siteService.GetSiteSettingsAsync();
             var searchSettings = siteSettings.As<LuceneSettings>();
+            var searchIndex = !String.IsNullOrWhiteSpace(viewModel.Index) ? viewModel.Index : searchIndex;
 
-            if(!String.IsNullOrWhiteSpace(viewModel.Index))
+            if (permissions.FirstOrDefault(x => x.Name == "QueryLucene" + searchIndex + "Index") != null)
             {
-                searchSettings.SearchIndex = viewModel.Index;
-            }
-
-            if (permissions.FirstOrDefault(x => x.Name == "QueryLucene" + searchSettings.SearchIndex + "Index") != null)
-            {
-                if (!await _authorizationService.AuthorizeAsync(User, permissions.FirstOrDefault(x => x.Name == "QueryLucene" + searchSettings.SearchIndex + "Index")))
+                if (!await _authorizationService.AuthorizeAsync(User, permissions.FirstOrDefault(x => x.Name == "QueryLucene" + searchIndex + "Index")))
                 {
                     return this.ChallengeOrForbid();
                 }
@@ -93,7 +89,7 @@ namespace OrchardCore.Lucene.Controllers
                 return BadRequest("Search is not configured.");
             }
 
-            if (searchSettings.SearchIndex != null && !_luceneIndexProvider.Exists(searchSettings.SearchIndex))
+            if (searchIndex != null && !_luceneIndexProvider.Exists(searchIndex))
             {
                 _logger.LogInformation("Couldn't execute search. The search index doesn't exist.");
                 return BadRequest("Search is not configured.");
@@ -107,12 +103,12 @@ namespace OrchardCore.Lucene.Controllers
                 return BadRequest("Search is not configured.");
             }
 
-            var luceneIndexSettings = await _luceneIndexSettingsService.GetSettingsAsync(searchSettings.SearchIndex);
+            var luceneIndexSettings = await _luceneIndexSettingsService.GetSettingsAsync(searchIndex);
 
             if (luceneIndexSettings == null)
             {
-                _logger.LogInformation($"Couldn't execute search. No Lucene index settings was defined for ({searchSettings.SearchIndex}) index.");
-                return BadRequest($"Search index ({searchSettings.SearchIndex}) is not configured.");
+                _logger.LogInformation($"Couldn't execute search. No Lucene index settings was defined for ({searchIndex}) index.");
+                return BadRequest($"Search index ({searchIndex}) is not configured.");
             }
 
             if (string.IsNullOrWhiteSpace(viewModel.Terms))
@@ -154,7 +150,7 @@ namespace OrchardCore.Lucene.Controllers
             try
             {
                 var query = queryParser.Parse(terms);
-                contentItemIds = (await _searchQueryService.ExecuteQueryAsync(query, searchSettings.SearchIndex, start, end))
+                contentItemIds = (await _searchQueryService.ExecuteQueryAsync(query, searchIndex, start, end))
                     .ToList();
             }
             catch (ParseException e)

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/SearchController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/SearchController.cs
@@ -74,7 +74,7 @@ namespace OrchardCore.Lucene.Controllers
 
             var siteSettings = await _siteService.GetSiteSettingsAsync();
             var searchSettings = siteSettings.As<LuceneSettings>();
-            var searchIndex = !String.IsNullOrWhiteSpace(viewModel.Index) ? viewModel.Index : searchIndex;
+            var searchIndex = !String.IsNullOrWhiteSpace(viewModel.Index) ? viewModel.Index : searchSettings.SearchIndex;
 
             if (permissions.FirstOrDefault(x => x.Name == "QueryLucene" + searchIndex + "Index") != null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/SearchController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Controllers/SearchController.cs
@@ -75,6 +75,11 @@ namespace OrchardCore.Lucene.Controllers
             var siteSettings = await _siteService.GetSiteSettingsAsync();
             var searchSettings = siteSettings.As<LuceneSettings>();
 
+            if(!String.IsNullOrWhiteSpace(viewModel.Index))
+            {
+                searchSettings.SearchIndex = viewModel.Index;
+            }
+
             if (permissions.FirstOrDefault(x => x.Name == "QueryLucene" + searchSettings.SearchIndex + "Index") != null)
             {
                 if (!await _authorizationService.AuthorizeAsync(User, permissions.FirstOrDefault(x => x.Name == "QueryLucene" + searchSettings.SearchIndex + "Index")))
@@ -161,7 +166,7 @@ namespace OrchardCore.Lucene.Controllers
                 return View(new SearchIndexViewModel
                 {
                     Terms = viewModel.Terms,
-                    SearchForm = new SearchFormViewModel("Search__Form") { Terms = viewModel.Terms },
+                    SearchForm = new SearchFormViewModel("Search__Form") { Terms = viewModel.Terms, Index = viewModel.Index },
                 });
             }
 
@@ -209,7 +214,7 @@ namespace OrchardCore.Lucene.Controllers
             var model = new SearchIndexViewModel
             {
                 Terms = viewModel.Terms,
-                SearchForm = new SearchFormViewModel("Search__Form") { Terms = viewModel.Terms },
+                SearchForm = new SearchFormViewModel("Search__Form") { Terms = viewModel.Terms, Index = viewModel.Index },
                 SearchResults = new SearchResultsViewModel("Search__Results") { ContentItems = containedItems.Take(pager.PageSize) },
                 Pager = (await New.PagerSlim(pager)).UrlParams(new Dictionary<string, string>() { { "Terms", viewModel.Terms } })
             };

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Search-Form.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Views/Search-Form.cshtml
@@ -2,6 +2,7 @@
 
 <form action="@Url.Action("Search", "Search")" method="get">
     <div class="input-group mb-3 mt-5">
+        <input type="hidden" value="@Model.Index" />
         <input name="Terms" type="text" value="@Model.Terms" class="form-control form-control-lg" placeholder="@T["Enter your search term(s)"]" autofocus />
         <div class="input-group-append">
             <button type="submit" class="btn btn-primary btn-sm">@T["Search"]</button>

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/ViewModels/SearchFormViewModel.cs
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/ViewModels/SearchFormViewModel.cs
@@ -9,5 +9,7 @@ namespace OrchardCore.Search.Abstractions.ViewModels
         }
 
         public string Terms { get; set; }
+
+        public string Index { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/ViewModels/SearchIndexViewModel.cs
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/ViewModels/SearchIndexViewModel.cs
@@ -10,6 +10,8 @@ namespace OrchardCore.Search.Abstractions.ViewModels
     {
         public string Terms { get; set; }
 
+        public string Index { get; set; }
+
         [BindNever]
         public SearchFormViewModel SearchForm { get; set; }
 


### PR DESCRIPTION
Fixes #11164 

Allows passing a QueryString param in the search form page to override the current default Index used for displaying results. This can also be set as a hidden form input fixed value if used from a different form. These Indices are protected by permissions so it should be fine to allow to do this instead of needing to create a different controller per index required to be searched from.

Usage : /search?Terms=moon&Index=BlogIndex