### PR TITLE
Fix NRE with TaxonomyIndex

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -87,7 +87,8 @@ namespace OrchardCore.Taxonomies.Indexing
                             continue;
                         }
 
-                        var jField = (JObject)jPart[fieldDefinition.Name] ?? null;
+                        var jField = jPart[fieldDefinition.Name] ?? null;
+                        jField = (JObject)jField;
 
                         if (jField == null)
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -88,6 +88,12 @@ namespace OrchardCore.Taxonomies.Indexing
                         }
 
                         var jToken = jPart[fieldDefinition.Name] ?? null;
+
+                        if (jToken == null)
+                        {
+                            continue;
+                        }
+
                         var jField = jToken as JObject;
 
                         if (jField == null)

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -87,8 +87,8 @@ namespace OrchardCore.Taxonomies.Indexing
                             continue;
                         }
 
-                        var jField = jPart[fieldDefinition.Name] ?? null;
-                        jField = (JObject)jField;
+                        var jToken = jPart[fieldDefinition.Name] ?? null;
+                        var jField = (JObject)jToken;
 
                         if (jField == null)
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -87,7 +87,7 @@ namespace OrchardCore.Taxonomies.Indexing
                             continue;
                         }
 
-                        var jField = (JObject)jPart[fieldDefinition.Name];
+                        var jField = jPart[fieldDefinition.Name] ?? null;
 
                         if (jField == null)
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -87,14 +87,7 @@ namespace OrchardCore.Taxonomies.Indexing
                             continue;
                         }
 
-                        var jToken = jPart[fieldDefinition.Name] ?? null;
-
-                        if (jToken == null)
-                        {
-                            continue;
-                        }
-
-                        var jField = jToken as JObject;
+                        var jField = jPart[fieldDefinition.Name] as JObject;
 
                         if (jField == null)
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -87,7 +87,7 @@ namespace OrchardCore.Taxonomies.Indexing
                             continue;
                         }
 
-                        var jField = jPart[fieldDefinition.Name] ?? null;
+                        var jField = (JObject)jPart[fieldDefinition.Name] ?? null;
 
                         if (jField == null)
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Indexing/TaxonomyIndex.cs
@@ -88,7 +88,7 @@ namespace OrchardCore.Taxonomies.Indexing
                         }
 
                         var jToken = jPart[fieldDefinition.Name] ?? null;
-                        var jField = (JObject)jToken;
+                        var jField = jToken as JObject;
 
                         if (jField == null)
                         {


### PR DESCRIPTION
When a Taxonomy Field is removed from a Content Type. Cloning the content item may fail with an NRE.

/cc @ns8482e 