### PR TITLE
Ignore IUpdateModel and BuildPartDisplayContext in console_log

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartEditViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartEditViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
@@ -16,8 +17,7 @@ namespace OrchardCore.Flows.ViewModels
         [BindNever]
         public BagPart BagPart { get; set; }
 
-        [System.Text.Json.Serialization.JsonIgnore]
-        [Newtonsoft.Json.JsonIgnore]
+        [IgnoreDataMember]
         [BindNever]
         public IUpdateModel Updater { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartEditViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartEditViewModel.cs
@@ -16,6 +16,8 @@ namespace OrchardCore.Flows.ViewModels
         [BindNever]
         public BagPart BagPart { get; set; }
 
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
         [BindNever]
         public IUpdateModel Updater { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.Models;
@@ -10,9 +12,8 @@ namespace OrchardCore.Flows.ViewModels
     {
         public BagPart BagPart { get; set; }
         public IEnumerable<ContentItem> ContentItems => BagPart.ContentItems;
-        
-        [System.Text.Json.Serialization.JsonIgnore]
-        [Newtonsoft.Json.JsonIgnore]
+
+        [IgnoreDataMember]
         [BindNever]
         public BuildPartDisplayContext BuildPartDisplayContext { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.Flows.Models;
@@ -9,7 +10,12 @@ namespace OrchardCore.Flows.ViewModels
     {
         public BagPart BagPart { get; set; }
         public IEnumerable<ContentItem> ContentItems => BagPart.ContentItems;
+        
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [BindNever]
         public BuildPartDisplayContext BuildPartDisplayContext { get; set; }
+
         public BagPartSettings Settings { get; set; }
         public string DisplayType => Settings?.DisplayType;
     }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartEditViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartEditViewModel.cs
@@ -21,6 +21,8 @@ namespace OrchardCore.Flows.ViewModels
         [BindNever]
         public FlowPart FlowPart { get; set; }
 
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
         [BindNever]
         public IUpdateModel Updater { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartEditViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartEditViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
@@ -21,8 +22,7 @@ namespace OrchardCore.Flows.ViewModels
         [BindNever]
         public FlowPart FlowPart { get; set; }
 
-        [System.Text.Json.Serialization.JsonIgnore]
-        [Newtonsoft.Json.JsonIgnore]
+        [IgnoreDataMember]
         [BindNever]
         public IUpdateModel Updater { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartViewModel.cs
@@ -1,4 +1,5 @@
-﻿using OrchardCore.ContentManagement.Display.Models;
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.Flows.Models;
 
 namespace OrchardCore.Flows.ViewModels
@@ -6,6 +7,10 @@ namespace OrchardCore.Flows.ViewModels
     public class FlowPartViewModel
     {
         public FlowPart FlowPart { get; set; }
+
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        [BindNever]
         public BuildPartDisplayContext BuildPartDisplayContext { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/FlowPartViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+﻿using System.Runtime.Serialization;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.Flows.Models;
 
@@ -8,8 +9,7 @@ namespace OrchardCore.Flows.ViewModels
     {
         public FlowPart FlowPart { get; set; }
 
-        [System.Text.Json.Serialization.JsonIgnore]
-        [Newtonsoft.Json.JsonIgnore]
+        [IgnoreDataMember]
         [BindNever]
         public BuildPartDisplayContext BuildPartDisplayContext { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/ViewModels/WidgetsListPartEditViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/ViewModels/WidgetsListPartEditViewModel.cs
@@ -16,6 +16,8 @@ namespace OrchardCore.Widgets.ViewModels
 
         public WidgetsListPart WidgetsListPart { get; set; }
 
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
         [BindNever]
         public IUpdateModel Updater { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/ViewModels/WidgetsListPartEditViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/ViewModels/WidgetsListPartEditViewModel.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.Widgets.Models;
@@ -16,8 +17,7 @@ namespace OrchardCore.Widgets.ViewModels
 
         public WidgetsListPart WidgetsListPart { get; set; }
 
-        [System.Text.Json.Serialization.JsonIgnore]
-        [Newtonsoft.Json.JsonIgnore]
+        [IgnoreDataMember]
         [BindNever]
         public IUpdateModel Updater { get; set; }
     }


### PR DESCRIPTION
Ignore `IUpdateModel` and `BuildPartDisplayContext` properties in console_log for Shape json

Fixes #11260