### PR TITLE
Remove PreserveCompilationReferences from decoupled CMS documentation

### DIFF
--- a/src/docs/guides/decoupled-cms/README.md
+++ b/src/docs/guides/decoupled-cms/README.md
@@ -60,7 +60,6 @@ The newly created website should be able to run, and look like this:
 ```xml
 <PropertyGroup>
   <TargetFramework>net6.0</TargetFramework>
-  <PreserveCompilationReferences>true</PreserveCompilationReferences>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
Remove PreserveCompilationReferences from docs as it does not work with NET6.

related to https://github.com/OrchardCMS/OrchardCore/discussions/11185