### PR TITLE
Rename "web" launchsetting profile to "Kestrel"

### DIFF
--- a/src/OrchardCore.Cms.Web/Properties/launchSettings.json
+++ b/src/OrchardCore.Cms.Web/Properties/launchSettings.json
@@ -15,7 +15,7 @@
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "web": {
+    "Kestrel": {
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "https://localhost:5001",


### PR DESCRIPTION
Seems more appropriate as it is more descriptive when debugging from Visual Studio.