### PR TITLE
Prevent VStudio Missing Components Warning

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -5,7 +5,6 @@
         "Component.Microsoft.VisualStudio.RazorExtension",
         "Microsoft.Component.MSBuild",
         "Microsoft.Net.ComponentGroup.DevelopmentPrerequisites",
-        "Microsoft.NetCore.ComponentGroup.Web.2.1",
         "Microsoft.VisualStudio.Component.Common.Azure.Tools",
         "Microsoft.VisualStudio.Component.CoreEditor",
         "Microsoft.VisualStudio.Component.JavaScript.TypeScript",
@@ -15,14 +14,12 @@
         "Microsoft.VisualStudio.Component.NuGet",
         "Microsoft.VisualStudio.Component.Roslyn.Compiler",
         "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
-        "Microsoft.VisualStudio.Component.TypeScript.3.5",
         "Microsoft.VisualStudio.Component.TextTemplating",
         "Microsoft.VisualStudio.Component.Web",
         "Microsoft.VisualStudio.Component.WebDeploy",
         "Microsoft.VisualStudio.ComponentGroup.Web",
         "Microsoft.VisualStudio.ComponentGroup.WebToolsExtensions",
         "Microsoft.VisualStudio.Workload.CoreEditor",
-        "Microsoft.VisualStudio.Workload.NetWeb",
-        "Microsoft.VisualStudio.Workload.NetCoreTools"
+        "Microsoft.VisualStudio.Workload.NetWeb"
     ]
 }


### PR DESCRIPTION
Since I installed VStudio Community 2022 I didn't need to install any additional components. So, maybe we could just remove the `.vsconfig` file. But maybe still useful to keep it, so from this file I first removed `...ComponentGroup.Web.2.1` the only one that was causing the missing components warning. Then finally I removed the 3 ones that I didn't find [in this doc](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=vs-2022) or marked as no more supported.