### PR TITLE
Monaco loader aware of virtual folder

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Resources
             _siteService = siteService;
             _env = env;
             _httpContextAccessor = httpContextAccessor;
-            _tenantPrefix = string.IsNullOrEmpty(shellSettings.RequestUrlPrefix) ? string.Empty : "/" + shellSettings.RequestUrlPrefix;
+            _tenantPrefix = _httpContextAccessor.HttpContext.Request.PathBase;
         }
 
         ResourceManifest BuildManifest()

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Resources
         private readonly ISiteService _siteService;
         private readonly IHostEnvironment _env;
         private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly string _tenantPrefix;
+        private readonly string _pathBase;
 
         private const string cloudflareUrl = "https://cdnjs.cloudflare.com/ajax/libs/";
         // Versions
@@ -26,7 +26,7 @@ namespace OrchardCore.Resources
             _siteService = siteService;
             _env = env;
             _httpContextAccessor = httpContextAccessor;
-            _tenantPrefix = _httpContextAccessor.HttpContext.Request.PathBase;
+            _pathBase = _httpContextAccessor.HttpContext.Request.PathBase;
         }
 
         ResourceManifest BuildManifest()
@@ -475,7 +475,7 @@ namespace OrchardCore.Resources
 
             manifest
                 .DefineScript("monaco")
-                .SetAttribute("data-tenant-prefix", _tenantPrefix)
+                .SetAttribute("data-tenant-prefix", _pathBase)
                 .SetUrl("~/OrchardCore.Resources/Scripts/monaco/ocmonaco.js")
                 .SetDependencies("monaco-loader")
                 .SetVersion(monacoEditorVersion);


### PR DESCRIPTION
Fixes #11354 

We use the tenant prefix to set a `data-tenant-prefix` attribute that will be used by the monaco `loader.js` to load `editor.main.js`. But it doesn't take into account a possible virtual folder, so here we use the `PathBase` instead.

I kept the `data-tenant-prefix` attribute name to not break anything.

---

Just for info, I tried to use `tété` as a tenant prefix, then in the html source code we can see some attribute that are url encoded `t%C3%A9t%C3%A9` e.g. when `.RouteUrl()` is used, some are html encoded `t&#xE9;t&#xE9;` e.g. when `@Url.Content(~/...)` is used, and some that are not encoded `tété` e.g. those provided by resources tag helpers.

We already discussed of this and we know that the browser is able to do the right decoding/encoding (escaping is more important e.g. on server side redirections), so I let things as is to not break anything.

but here it is an html data-attribute used by a script, so here I opted to use the escaped `PathBase` by not using `.Value` so that the implicit `.ToString()` will encode it if needed.

---

**Updated for info**

Yes, `Url.Content("~/")` doesn't url encodes, so if you use `href="@Url.Content("~/")`, special chars that was not url encoded will be html encoded by the rendering.

https://github.com/dotnet/aspnetcore/blob/2b4a186c29667003d06bef8d629f5d3266b5804a/src/Mvc/Mvc.Core/src/Routing/UrlHelperBase.cs#L299-L315

You can see that line 312 it uses the non escaped `Path.Value`.
