### PR TITLE
Fix OpenId prune operations

### DIFF
--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdAuthorizationStore.cs
@@ -377,7 +377,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
 
             IList<Exception> exceptions = null;
 
-            for (var offset = 0; offset < 100_000; offset += 1_000)
+            for (var i = 0; i < 1000; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -388,7 +388,12 @@ namespace OrchardCore.OpenId.YesSql.Stores
                                      authorization.AuthorizationId.IsNotIn<OpenIdTokenIndex>(
                                          token => token.AuthorizationId,
                                          token => token.Id != 0))),
-                    collection: OpenIdCollection).Skip(offset).Take(1_000).ListAsync();
+                    collection: OpenIdCollection).Take(100).ListAsync();
+
+                if (!authorizations.Any())
+                {
+                    return;
+                }
 
                 foreach (var authorization in authorizations)
                 {

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
@@ -431,7 +431,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
 
             IList<Exception> exceptions = null;
 
-            for (var offset = 0; offset < 100_000; offset += 1_000)
+            for (var i = 0; i < 1000; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -441,7 +441,11 @@ namespace OrchardCore.OpenId.YesSql.Stores
                              token.AuthorizationId.IsNotIn<OpenIdAuthorizationIndex>(
                                 authorization => authorization.AuthorizationId,
                                 authorization => authorization.Status == Statuses.Valid) ||
-                             token.ExpirationDate < DateTime.UtcNow), collection: OpenIdCollection).Skip(offset).Take(1_000).ListAsync();
+                             token.ExpirationDate < DateTime.UtcNow), collection: OpenIdCollection).Take(100).ListAsync();
+                if (!tokens.Any())
+                {
+                    return;
+                }
 
                 foreach (var token in tokens)
                 {


### PR DESCRIPTION
Current prune operations of authorizations and tokens used at openid background tasks have a bug.
They do a loop with an offset for query the database that is incremented. But in fact it is a mistake, cause on each iteration those records are removed from the db, so on the query of the next iteration it has no sense to use an offset for the query.

By the way I've harnessed the fix to reduce que pagination to only 100 records per query, cause I've experienced problems with saving chagnes of 1000 records.

Finally, I've added code to finish the loop if the query doesn't return records. I didn't find any reason to continue looping in that case.