### PR TITLE
Added an AppSettings option to disable Sqlite connection pooling.

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -16,7 +16,7 @@
     //  "CookieLifeTime": 14 // Set the culture picker cookie life time (in days).
     //},
     //"OrchardCore_Data_Sqlite": {
-    //  "PoolConnections": false
+    //  "UseConnectionPooling": false
     //},
     // See https://docs.orchardcore.net/en/latest/docs/reference/modules/DataProtection.Azure/#configuration to configure data protection key storage in Azure Blob Storage.
     //"OrchardCore_DataProtection_Azure": {

--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -15,6 +15,9 @@
     //"OrchardCore_ContentLocalization_CulturePicker": {
     //  "CookieLifeTime": 14 // Set the culture picker cookie life time (in days).
     //},
+    //"OrchardCore_Data_Sqlite": {
+    //  "PoolConnections": false
+    //},
     // See https://docs.orchardcore.net/en/latest/docs/reference/modules/DataProtection.Azure/#configuration to configure data protection key storage in Azure Blob Storage.
     //"OrchardCore_DataProtection_Azure": {
     //  "ConnectionString": "", // Set to your Azure Storage account connection string.

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptions.cs
@@ -1,0 +1,7 @@
+namespace OrchardCore.Data
+{
+    public class SqliteOptions
+    {
+        public bool PoolConnections { get; set; } = true;
+    }
+}

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptions.cs
@@ -1,7 +1,19 @@
 namespace OrchardCore.Data
 {
+    /// <summary>
+    /// Sqlite-specific configuration for the Orchard Core database. 
+    /// See <see href="https://docs.orchardcore.net/en/latest/docs/reference/core/Data/#sqlite" />
+    /// </summary>
     public class SqliteOptions
     {
-        public bool PoolConnections { get; set; } = true;
+        /// <summary>
+        /// <para>By default in .Net 6, <c>Microsoft.Data.Sqlite</c> pools connections to the database. 
+        /// It achieves this by putting a lock on the database file and leaving connections open to be reused.
+        /// If the lock is preventing tasks like backups, this functionality can be disabled.</para>
+        /// 
+        /// <para>There may be a performance penalty associated with disabling connection pooling.</para>
+        /// <see href="https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/connection-strings#pooling" />
+        /// </summary>
+        public bool UseConnectionPooling { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptionsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptionsConfiguration.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Data
 {
     public class SqliteOptionsConfiguration : IConfigureOptions<SqliteOptions>
     {
-        private static readonly bool DefaultPoolConnections = true;
+        private static readonly bool DefaultUseConnectionPooling = true;
         private readonly IShellConfiguration _shellConfiguration;
 
         public SqliteOptionsConfiguration(IShellConfiguration shellConfiguration)
@@ -18,7 +18,7 @@ namespace OrchardCore.Data
         {
             var section = _shellConfiguration.GetSection("OrchardCore_Data_Sqlite");
 
-            options.PoolConnections = section.GetValue("PoolConnections", DefaultPoolConnections);
+            options.UseConnectionPooling = section.GetValue(nameof(options.UseConnectionPooling), DefaultUseConnectionPooling);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptionsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptionsConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Shell.Configuration;
+
+namespace OrchardCore.Data
+{
+    public class SqliteOptionsConfiguration : IConfigureOptions<SqliteOptions>
+    {
+        private static readonly bool DefaultPoolConnections = true;
+        private readonly IShellConfiguration _shellConfiguration;
+
+        public SqliteOptionsConfiguration(IShellConfiguration shellConfiguration)
+        {
+            _shellConfiguration = shellConfiguration;
+        }
+
+        public void Configure(SqliteOptions options)
+        {
+            var section = _shellConfiguration.GetSection("OrchardCore_Data_Sqlite");
+
+            options.PoolConnections = section.GetValue("PoolConnections", DefaultPoolConnections);
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Extensions.DependencyInjection
                             {
                                 DataSource = databaseFile,
                                 Cache = SqliteCacheMode.Shared,
-                                Pooling = sqliteOptions.PoolConnections
+                                Pooling = sqliteOptions.UseConnectionPooling
                             };
 
                             Directory.CreateDirectory(databaseFolder);

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Data;
 using System.IO;
 using System.Linq;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Options;
 using OrchardCore.Data;
 using OrchardCore.Data.Documents;
@@ -37,6 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddScoped<IModularTenantEvents, AutomaticDataMigrations>();
 
                 services.AddOptions<StoreCollectionOptions>();
+                services.AddTransient<IConfigureOptions<SqliteOptions>, SqliteOptionsConfiguration>();
 
                 // Adding supported databases
                 services.TryAddDataProvider(name: "Sql Server", value: "SqlConnection", hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
@@ -70,12 +72,20 @@ namespace Microsoft.Extensions.DependencyInjection
                             break;
                         case "Sqlite":
                             var shellOptions = sp.GetService<IOptions<ShellOptions>>();
+                            var sqliteOptions = sp.GetService<IOptions<SqliteOptions>>()?.Value ?? new SqliteOptions();
                             var option = shellOptions.Value;
                             var databaseFolder = Path.Combine(option.ShellsApplicationDataPath, option.ShellsContainerName, shellSettings.Name);
                             var databaseFile = Path.Combine(databaseFolder, "yessql.db");
+                            var connectionStringBuilder = new SqliteConnectionStringBuilder
+                            {
+                                DataSource = databaseFile,
+                                Cache = SqliteCacheMode.Shared,
+                                Pooling = sqliteOptions.PoolConnections
+                            };
+
                             Directory.CreateDirectory(databaseFolder);
                             storeConfiguration
-                                .UseSqLite($"Data Source={databaseFile};Cache=Shared", IsolationLevel.ReadUncommitted)
+                                .UseSqLite(connectionStringBuilder.ToString(), IsolationLevel.ReadUncommitted)
                                 .UseDefaultIdGenerator();
                             break;
                         case "MySql":

--- a/src/docs/reference/core/Data/README.md
+++ b/src/docs/reference/core/Data/README.md
@@ -6,9 +6,13 @@ Most database configuration is handled automatically, but there are limited opti
 
 ### Sqlite
 
-#### `PoolConnections` (boolean)
+#### `UseConnectionPooling` (boolean)
 
-By default in `.Net 6`, Sqlite pools connections to the database. It achieves this by putting a lock on the database file (`yessql.db`) and leaving connections open to be reused. If the lock is preventing tasks like backups, this functionality can be disabled. There may be a performance penalty associated with disabling connection pooling.
+By default in `.Net 6`, `Microsoft.Data.Sqlite` pools connections to the database. It achieves this by putting locking the database file and leaving connections open to be reused. If the lock is preventing tasks like backups, this functionality can be disabled.
+
+There may be a performance penalty associated with disabling connection pooling.
+
+See the [`Microsoft.Data.Sqlite` documentation](https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/connection-strings#pooling) for more details.
 
 ##### `appsettings.json`
 

--- a/src/docs/reference/core/Data/README.md
+++ b/src/docs/reference/core/Data/README.md
@@ -8,7 +8,7 @@ Most database configuration is handled automatically, but there are limited opti
 
 #### `UseConnectionPooling` (boolean)
 
-By default in `.Net 6`, `Microsoft.Data.Sqlite` pools connections to the database. It achieves this by putting locking the database file and leaving connections open to be reused. If the lock is preventing tasks like backups, this functionality can be disabled.
+By default in `.NET 6`, `Microsoft.Data.Sqlite` pools connections to the database. It achieves this by putting locking the database file and leaving connections open to be reused. If the lock is preventing tasks like backups, this functionality can be disabled.
 
 There may be a performance penalty associated with disabling connection pooling.
 

--- a/src/docs/reference/core/Data/README.md
+++ b/src/docs/reference/core/Data/README.md
@@ -1,5 +1,25 @@
 # Data (`OrchardCore.Data`)
 
+## Configuring Databases
+
+Most database configuration is handled automatically, but there are limited options which can affect the way the database works.
+
+### Sqlite
+
+#### `PoolConnections` (boolean)
+
+By default in `.Net 6`, Sqlite pools connections to the database. It achieves this by putting a lock on the database file (`yessql.db`) and leaving connections open to be reused. If the lock is preventing tasks like backups, this functionality can be disabled. There may be a performance penalty associated with disabling connection pooling.
+
+##### `appsettings.json`
+
+```json
+{
+    "OrchardCore_Data_Sqlite": {
+        "PoolConnections": false
+    }
+}
+```
+
 ## Running SQL queries
 
 ### Creating a `DbConnection` instance


### PR DESCRIPTION
closes #11387 

Sqlite locks the file when connection pooling is enabled, which can prevent certain backup processes, App Service cloning processes, etc from working. This PR adds an option to disable connection pooling and remove the lock from the Sqlite DB when it isn't being written to.

### Testing

- Pull this PR
- Launch .Net Core Launch (web debug)
- Install the site with an Sqlite Multitenant profile.
- Try to delete `App_Data/Sites/Default/yessql.db`
  > ❌ You'll get an error because the file is locked.
- Stop the application
- Open `OrchardCore.Cms.Web/appsettings.json` and uncomment these lines:
  ```json
  "OrchardCore_Data_Sqlite": {
    "UseConnectionPooling": false
  },
  ```
- Launch .Net again
- Delete `App_Data/Sites/Default/yessql.db`
  >  ✓ The file will be deleted.