### PR TITLE
Fix Roles module documentation(Lombiq Technologies: OCORE-89) 

### DIFF
--- a/src/docs/reference/modules/Roles/README.md
+++ b/src/docs/reference/modules/Roles/README.md
@@ -4,7 +4,7 @@ Enabling the `OrchardCore.Roles` module will allow you to manage the user roles.
 
 ## Predefined Roles
 
-Orchard Core come up with the following predefined roles:
+Orchard Core come up with the following predefined permission stereotypes:
 
 | Name | Description |
 | --- | --- |
@@ -18,7 +18,7 @@ Orchard Core come up with the following predefined roles:
 
 ## Roles Configuration
 
-Roles can be configured through the roles menu in the admin dashboard, but also through a recipe step.
+Roles can be created and configured through the roles menu in the admin dashboard, but also through a recipe step. Note that the above-mentioned predefined permission stereotypes alone do not create the roles.
 
 A sample of a roles configuration step:
 


### PR DESCRIPTION
Orchard doesn't actually "come with predefined roles". The roles themselves are actually not created anywhere by default. Permissions corresponding to them are but without roles, they don't do anything. The roles all just come from recipes.

I updated the description of the documentation to reflect that.