### PR TITLE
Added 'replace' parameter to meta tags

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/MetaTag.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Liquid/MetaTag.cs
@@ -23,6 +23,7 @@ namespace OrchardCore.Resources.Liquid
             string httpEquiv = null;
             string charset = null;
             string separator = null;
+            bool replace = false;
 
             Dictionary<string, string> customAttributes = null;
 
@@ -36,6 +37,7 @@ namespace OrchardCore.Resources.Liquid
                     case "http_equiv": httpEquiv = (await argument.Expression.EvaluateAsync(context)).ToStringValue(); break;
                     case "charset": charset = (await argument.Expression.EvaluateAsync(context)).ToStringValue(); break;
                     case "separator": separator = (await argument.Expression.EvaluateAsync(context)).ToStringValue(); break;
+                    case "replace": replace = (await argument.Expression.EvaluateAsync(context)).ToBooleanValue(); break;
                     default: (customAttributes ??= new Dictionary<string, string>())[argument.Name] = (await argument.Expression.EvaluateAsync(context)).ToStringValue(); break;
                 }
             }
@@ -50,7 +52,14 @@ namespace OrchardCore.Resources.Liquid
                 }
             }
 
-            resourceManager.AppendMeta(metaEntry, separator ?? ", ");
+            if (replace)
+            {
+                resourceManager.RegisterMeta(metaEntry);
+            }
+            else
+            {
+                resourceManager.AppendMeta(metaEntry, separator ?? ", ");
+            }
 
             return Completion.Normal;
         }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/MetaTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/TagHelpers/MetaTagHelper.cs
@@ -24,6 +24,8 @@ namespace OrchardCore.ResourceManagement.TagHelpers
 
         public string Separator { get; set; }
 
+        public bool Replace { get; set; }
+
         private readonly IResourceManager _resourceManager;
 
         public MetaTagHelper(IResourceManager resourceManager)
@@ -45,7 +47,14 @@ namespace OrchardCore.ResourceManagement.TagHelpers
                 metaEntry.SetAttribute(attribute.Name, attribute.Value.ToString());
             }
 
-            _resourceManager.AppendMeta(metaEntry, Separator ?? ", ");
+            if (Replace)
+            {
+                _resourceManager.RegisterMeta(metaEntry);
+            }
+            else
+            {
+                _resourceManager.AppendMeta(metaEntry, Separator ?? ", ");
+            }
 
             output.TagName = null;
         }

--- a/src/docs/reference/modules/Resources/README.md
+++ b/src/docs/reference/modules/Resources/README.md
@@ -525,6 +525,7 @@ These properties are available:
 | `httpequiv`                  | The `http-equiv` attribute of the tag                                 |
 | `charset`                    | The `charset` attribute of the tag                                    |
 | `separator`                  | The separator to use when multiple tags are defined for the same name |
+| `replace`                    | Replace instead of append if a tag with the same name already exists  |
 
 ### Rendering
 


### PR DESCRIPTION
Added a parameter to replace existing meta tags rather than append them.

My particular case: I've enabled the 'SEO' feature and set defaults in `Configuration > Settings > Social Meta Settings`. I did not add the SeoMeta part to products (to prevent a lot of extra input). Instead I would like to set (some) metatags in liquid (template Content__Product) with code like this:
```
{% meta property:"og:image", content:"<product image>" %}
```
This works but the rendered metatag contains both values:
```
<meta content="<default SEO image>, <product image>" property="og:image" />
```
Obviously this is not what I wanted to achieve.

This PR adds a `replace` parameter, making it possible to replace existing tags (if any):
```
{% meta property:"og:image", content:"<product image>", replace:true %}
```
This will render:
```
<meta content="<product image>" property="og:image" />
```
I did the same change for the Razor tag helper & updated the documentation.
