### PR TITLE
Fix invalid cookie name caused by parenthesis in path name

### DIFF
--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var settings = serviceProvider.GetRequiredService<ShellSettings>();
                 var environment = serviceProvider.GetRequiredService<IHostEnvironment>();
 
-                var cookieName = "orchantiforgery_" + HttpUtility.UrlEncode(settings.Name + environment.ContentRootPath);
+                var cookieName = "orchantiforgery_" + HttpUtility.UrlEncode(settings.Name + environment.ContentRootPath.Replace("(", "").Replace(")", ""));
 
                 // If uninitialized, we use the host services.
                 if (settings.State == TenantState.Uninitialized)


### PR DESCRIPTION
Hi when the root path is a in a Windows directory that contains parenthesis I get the following antiforgery error
![Error](https://user-images.githubusercontent.com/6726578/161518240-f87d8a13-b06c-42d2-9281-0b74eef9d6ef.png)

I believe his happens since the project upgraded to a .NET Core version that no longer scapes characters in the antiforgery cookie (3 or 5 I don't remember the version). I encounter this error while deploying release version on Windows Server or while developing with Visual Studio when the project is inside a folder with parenthesis.

Repro steps:

1. Download OrchardCore project in a folder with parenthesis(or a parent folder) and launch OrchardCore.Cms.Web project. Then the error appears inmediately in the setup screen.

This pr fixes this error. I don't know if it could be more problematic characters since HttpUtility.UrlEncode method can get rid of them.

