### PR TITLE
Use H1 on login page for SEO

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/Login.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/Login.cshtml
@@ -23,7 +23,7 @@
     {
         <div class="col-md-6 @(loginProviders.Count == 0 ? "offset-md-3" : String.Empty)">
             <form asp-controller="Account" asp-action="Login" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="auth-form no-multisubmit">
-                <h4>@T["Log in"]</h4>
+                <h1 class="fs-4">@T["Log in"]</h1>
                 <hr />
                 <div asp-validation-summary="All" class="text-danger"></div>
                 <div class="form-group">

--- a/test/OrchardCore.Tests.Functional/cms-tests/cypress/integration/headless-test.js
+++ b/test/OrchardCore.Tests.Functional/cms-tests/cypress/integration/headless-test.js
@@ -11,7 +11,7 @@ describe('Headless Recipe test', function () {
 
     it('Displays the login screen when accessing the root of the Headless theme', function(){
         cy.visit(`${tenant.prefix}`);
-        cy.get('h4').should('contain.text', 'Log in');
+        cy.get('h1').should('contain.text', 'Log in');
      })
 
     it('Headless admin login should work', function(){


### PR DESCRIPTION
The login page was missing a H1 tag for SEO and it gets reported in Google and Bing Webmaster tools.