### PR TITLE
Widgets overwrite zone tag helper - log warning when the Zone isn't a Shape. (Lombiq Technologies: OCORE-90)

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ZoneTag.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/ZoneTag.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Fluid;
 using Fluid.Ast;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Layout;
 using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.Liquid;
@@ -14,10 +15,16 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
 {
     public class ZoneTag
     {
-        public static async ValueTask<Completion> WriteToAsync(List<FilterArgument> argumentsList, IReadOnlyList<Statement> statements, TextWriter writer, TextEncoder encoder, TemplateContext context)
+        public static async ValueTask<Completion> WriteToAsync(
+            List<FilterArgument> argumentsList,
+            IReadOnlyList<Statement> statements,
+            TextWriter writer,
+            TextEncoder encoder,
+            TemplateContext context)
         {
             var services = ((LiquidTemplateContext)context).Services;
             var layoutAccessor = services.GetRequiredService<ILayoutAccessor>();
+            var logger = services.GetRequiredService<ILogger<ZoneTag>>();
 
             string position = null;
             string name = null;
@@ -64,6 +71,14 @@ namespace OrchardCore.DisplayManagement.Liquid.Tags
                 if (zone is Shape shape)
                 {
                     await shape.AddAsync(content, position);
+                }
+                else
+                {
+                    logger.LogWarning(
+                        "Unable to add shape to the zone using the {{% zone %}} Liquid tag because the zone's type " +
+                        "is \"{ActualType}\" instead of the expected {ExpectedType}",
+                        zone.GetType().FullName,
+                        nameof(Shape));
                 }
             }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/ZoneTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/ZoneTagHelper.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.DisplayManagement.TagHelpers
             else
             {
                 _logger.LogWarning(
-                    "Unable to add shape to the zone using the <zone2> tag helper because the zone's type is " +
+                    "Unable to add shape to the zone using the <zone> tag helper because the zone's type is " +
                     "\"{ActualType}\" instead of the expected {ExpectedType}",
                     zone.GetType().FullName,
                     nameof(Shape));

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/ZoneTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/ZoneTagHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Logging;
 using OrchardCore.DisplayManagement.Layout;
 using OrchardCore.DisplayManagement.Shapes;
 
@@ -13,10 +14,12 @@ namespace OrchardCore.DisplayManagement.TagHelpers
         private const string NameAttribute = "name";
 
         private readonly ILayoutAccessor _layoutAccessor;
+        private readonly ILogger<ZoneTagHelper> _logger;
 
-        public ZoneTagHelper(ILayoutAccessor layoutAccessor)
+        public ZoneTagHelper(ILayoutAccessor layoutAccessor, ILogger<ZoneTagHelper> logger)
         {
             _layoutAccessor = layoutAccessor;
+            _logger = logger;
         }
 
         [HtmlAttributeName(PositionAttribute)]
@@ -40,6 +43,14 @@ namespace OrchardCore.DisplayManagement.TagHelpers
             if (zone is Shape shape)
             {
                 await shape.AddAsync(childContent, Position);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Unable to add shape to the zone using the <zone2> tag helper because the zone's type is " +
+                    "\"{ActualType}\" instead of the expected {ExpectedType}",
+                    zone.GetType().FullName,
+                    nameof(Shape));
             }
 
             // Don't render the zone tag or the inner content

--- a/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/ZoneTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/TagHelpers/ZoneTagHelper.cs
@@ -28,7 +28,7 @@ namespace OrchardCore.DisplayManagement.TagHelpers
         [HtmlAttributeName(NameAttribute)]
         public string Name { get; set; }
 
-        public async override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
         {
             if (String.IsNullOrEmpty(Name))
             {


### PR DESCRIPTION
Fixes #11481

Add warning logging when ZoneTagHelper can't be applied.