### PR TITLE
Cookie name per Application and accross its Instances

### DIFF
--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var settings = serviceProvider.GetRequiredService<ShellSettings>();
                 var environment = serviceProvider.GetRequiredService<IHostEnvironment>();
 
-                var cookieName = "orchantiforgery_" + settings.VersionId;
+                var cookieName = "__orchantiforgery_" + settings.VersionId;
 
                 // If uninitialized, we use the host services.
                 if (settings.State == TenantState.Uninitialized)

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -312,7 +312,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 var settings = serviceProvider.GetRequiredService<ShellSettings>();
                 var environment = serviceProvider.GetRequiredService<IHostEnvironment>();
 
-                var cookieName = "orchantiforgery_" + HttpUtility.UrlEncode(settings.Name + environment.ContentRootPath);
+                var cookieName = "orchantiforgery_" + settings.VersionId;
 
                 // If uninitialized, we use the host services.
                 if (settings.State == TenantState.Uninitialized)


### PR DESCRIPTION
Fixes #11489 
Maybe fixes #11501 

Here the copy of my last comment in #11526 

First I was asking to me if the cookie name itself needs to be encrypted if aspnetcore uses the right secure options / policies when building the cookie. So as i saw before they were using `Uri.UnescapeDataString(cookie.Name.Value)` to just encode (not encrypt) the cookie name which is no more the case.

About the new vulnerability, I saw that cookies can be prefixed with `__`, i.e. `__Host` and `__Secure`, meaning that the browser will use additional policies, but because they were decoding the whole including the cookie name, it was possible to use `__%48ost` and `__%53ecure` without involving the same policies.

https://github.com/dotnet/aspnetcore/issues/23578
https://fletchto99.dev/2020/december/cookie-vulnerability/

> the flaw allowed for a __%48ost- or __%53ecure- cookie to be set without meeting the required attributes (I.e. set without HTTPS, from root domain, or from a secure page). This means a malicious cookie set by an attacker could potentially craft a malicious __%48ost- and set it on their victim.

That's why now they don't encode / decode anymore. So my feeling is that we don't need to encrypt the cookie name, just escape it and avoid the not allowed chars as you are working on.

---

Just saw this data protection utility `GetApplicationUniqueIdentifier` https://github.com/dotnet/aspnetcore/blob/181db595bb11ef99e3a9167e7b940124363c1e36/src/DataProtection/DataProtection/src/DataProtectionUtilityExtensions.cs#L41 using `IApplicationDiscriminator` https://github.com/dotnet/aspnetcore/blob/a450cb69b5e4549f5515cdb057a68771f56cefd7/src/DataProtection/DataProtection/src/Internal/HostingApplicationDiscriminator.cs#L18-L23 which uses `ContentRootPath` ;)

---

That said I remembered that when I added `ContentRootPath` to the cookie name this was not to have the same name accross instances of the same application, but instead to have different cookie names to prevent logged errors when we run, i.e. on a local machine for development, different applications but with the same url.

> when we run an application from a given location and login to the admin, and then do the same from another application location but same url.

But somewhere it "broke" the use case where we want the same cookie name accross instances but for the same application, as discussed in #11501 and as you said where `ContentRootPath` may be different.

So yes, would be great to have an application identifier to be used as a suffix for each  tenant name, maybe a secret suffix from configuration whose default would be `ContentRootPath`.

**Oh yes, just remembered that we have a shell setting `Identifier`, renamed at some point to `VersionId`, and in a distributed env the `ShellSettings` are persisted in a shared store. So maybe we could use it in place of `ContentRootPath`, we may still need to escape the settings name, or just only use the `VersionId`.** as it varies per tenant for a given application. So one solution would be to just use.

    var cookieName = "orchantiforgery_" + settings.VersionId;
