### PR TITLE
Revert "Non awaited task in GraphQL DataLoaderExtensions (#11536)"

### DIFF
--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Extensions/DataLoaderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Extensions/DataLoaderExtensions.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using GraphQL.DataLoader;
 
@@ -18,15 +19,9 @@ namespace OrchardCore.Apis.GraphQL
             return Task.WhenAll(tasks);
         }
 
-        public static async Task<T[]> LoadAsync<TKey, T>(this IDataLoader<TKey, T> dataLoader, params TKey[] keys)
+        public static Task<T[]> LoadAsync<TKey, T>(this IDataLoader<TKey, T> dataLoader, params TKey[] keys)
         {
-            var tasks = new T[keys.Length];
-            for (var i = 0; i < keys.Length; i++)
-            {
-                tasks[i] = await dataLoader.LoadAsync(keys[i]);
-            }
-
-            return tasks;
+            return dataLoader.LoadAsync(keys.AsEnumerable());
         }
     }
 }


### PR DESCRIPTION
This reverts commit 5ba889e56d9e6e8ff817ae24f48d0135094143cf.

@sebastienros I reverted #11536 because first I didn't updated the right method, the one that uses a Task.WhenAll(), anyway If I remove the Task.WhenAll in the right extension method it works for a CPField with only one item (only CPField uses this method) otherwise it was blocking, you already tried to do exactly the same in #9769.

I noticed that the Task.WhenAll is not used to do concurrent queries but to grab all needed Ids, maybe this is here that concurrent accesses are done on our ContentItem Elements, notice that I was not able to repro #9330. If I remove the Task.WhenAll() and add some await, it tries to do a query for each Id and it is blocking on the 2nd one.

As I read GraphQL is more intended to provide a single item or a collection but both by an unique key, to support a multiple keys input they introduced an extension that exactly does what we do, i.e. they also use a Task.WhenAll().

For ListPart we use a CollectionBatchLoader that returns a collection but each group set being related to an unique key, the `ContainedPart.ListContentItemId`. For a CPField I could mimic the behavior of a ListPart by scope caching a relation between a guid and the item Ids of a given CPField, then I used this uid to retrieve the items. It works but for now if 2 CPFields reference the same item, this item is rendered once.

Let me know if it is worth to work on it, maybe not as it seems that there is an incoming version upgrade of GraphQL.
