### PR TITLE
Markdig 0.29.0

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -25,7 +25,7 @@
     <PackageManagement Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />
     <PackageManagement Include="Lucene.Net.Spatial" Version="4.8.0-beta00016" />
     <PackageManagement Include="MailKit" Version="3.2.0" />
-    <PackageManagement Include="Markdig" Version="0.28.1" />
+    <PackageManagement Include="Markdig" Version="0.29.0" />
     <PackageManagement Include="MessagePack" Version="2.2.60" />
     <PackageManagement Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageManagement Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />

--- a/src/docs/resources/libraries/README.md
+++ b/src/docs/resources/libraries/README.md
@@ -18,7 +18,7 @@ The below table lists the different .NET libraries used in Orchard Core:
 | [Jint](https://github.com/sebastienros/jint) | Javascript Interpreter for .NET. | 3.0.0-beta-2037 | [MIT](https://github.com/sebastienros/jint/blob/dev/LICENSE) |
 | [Lucene.Net](https://github.com/apache/lucenenet) | .NET full-text search engine. | 4.8.0-beta00016 | [Apache-2.0](https://github.com/apache/lucenenet/blob/master/LICENSE.txt) |
 | [MailKit](https://github.com/jstedfast/MailKit) | A cross-platform .NET library for IMAP, POP3, and SMTP. | 3.2.0 | [MIT](https://github.com/jstedfast/MailKit/blob/master/LICENSE) |
-| [Markdig](https://github.com/lunet-io/markdig) | .NET Markdown engine. | 0.28.1 | [BSD-2-Clause](https://github.com/lunet-io/markdig/blob/master/license.txt) |
+| [Markdig](https://github.com/lunet-io/markdig) | .NET Markdown engine. | 0.29.0 | [BSD-2-Clause](https://github.com/lunet-io/markdig/blob/master/license.txt) |
 | [MessagePack](https://github.com/neuecc/MessagePack-CSharp) | Extremely Fast MessagePack Serializer for C# | 2.2.60 | [MIT](https://github.com/neuecc/MessagePack-CSharp/blob/master/LICENSE) |
 | [Microsoft.SourceLink.GitHub](https://github.com/dotnet/sourcelink) | Source Link enables a great source debugging experience. | 1.1.1 | [MIT](https://github.com/dotnet/sourcelink/blob/main/License.txt) |
 | [MimeKit](https://github.com/jstedfast/MailKit) | A cross-platform .NET library for IMAP, POP3, and SMTP. | 3.2.0 | [MIT](https://github.com/jstedfast/MailKit/blob/master/LICENSE) |


### PR DESCRIPTION
https://github.com/xoofx/markdig/releases/tag/0.29.0