### PR TITLE
UseNLogHost() to be used on IHostBuilder

### DIFF
--- a/src/OrchardCore/OrchardCore.Logging.NLog/HostBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Logging.NLog/HostBuilderExtensions.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using Microsoft.Extensions.Hosting;
+using NLog;
+using NLog.LayoutRenderers;
+using NLog.Web;
+
+namespace OrchardCore.Logging;
+
+public static class HostBuilderExtensions
+{
+    public static IHostBuilder UseNLogHost(this IHostBuilder builder)
+    {
+        LayoutRenderer.Register<TenantLayoutRenderer>(TenantLayoutRenderer.LayoutRendererName);
+        builder.UseNLog();
+        builder.ConfigureAppConfiguration((context, _) =>
+        {
+            var environment = context.HostingEnvironment;
+            environment.ConfigureNLog($"{environment.ContentRootPath}{Path.DirectorySeparatorChar}NLog.config");
+            LogManager.Configuration.Variables["configDir"] = environment.ContentRootPath;
+        });
+
+        return builder;
+    }
+}

--- a/src/OrchardCore/OrchardCore.Logging.NLog/WebHostBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Logging.NLog/WebHostBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Logging
         {
             LayoutRenderer.Register<TenantLayoutRenderer>(TenantLayoutRenderer.LayoutRendererName);
             builder.UseNLog();
-            builder.ConfigureAppConfiguration((context, configuration) =>
+            builder.ConfigureAppConfiguration((context, _) =>
             {
                 var environment = context.HostingEnvironment;
                 environment.ConfigureNLog($"{environment.ContentRootPath}{Path.DirectorySeparatorChar}NLog.config");
@@ -26,7 +26,6 @@ namespace OrchardCore.Logging
         }
     }
 
-    // Waiting for NLog to use `IHostEnvironment`.
     internal static class AspNetExtensions
     {
         public static LoggingConfiguration ConfigureNLog(this IHostEnvironment env, string configFileRelativePath)


### PR DESCRIPTION
For example with the minimal hosting model in 6.0.

    ...
    using OrchardCore.Logging;

    var builder = WebApplication.CreateBuilder(args);
    builder.Logging.ClearProviders();
    builder.Host.UseNLogHost();
    ...
