### PR TITLE
Added stronger clarification on placement.json property names

### DIFF
--- a/src/docs/reference/core/Placement/README.md
+++ b/src/docs/reference/core/Placement/README.md
@@ -11,7 +11,7 @@ Any module or theme can contain an optional `placement.json` file providing cust
 
 ### Format
 
-A `placement.json` file contains an object whose properties are shape names. Each of these properties is an array of placement rules.
+A `placement.json` file contains an object whose properties are shape types. Each of these properties is an array of placement rules.
 
 In the following example, we describe the placement for the `TextField` and `Parts_Contents_Publish` shapes.
 
@@ -29,9 +29,21 @@ A placement rule contains two sets of data:
 
 Currently you can filter shapes by:
 
-- Their original type, which is the property name of the placement rule, like `TextField`.
+- Their original type, which is the property name of the placement rule, like `TextField` or `ContentPart`.
 - `displayType` (Optional): The display type, like `Summary` and `Detail` for the most common ones.
 - `differentiator` (Optional): The differentiator which is used to distinguish shape types that are reused for multiple elements, like field names.
+
+!!! note
+    Shape type (placement.json property name) DOES NOT necessarily align with with your part type. For instance, if you created a Content Part `GalleryPart` without a part driver, your shape type will be `ContentPart` with differentiator `GalleryPart`. So your placement.json would look like
+```json
+{
+  "ContentPart": [{
+  "place":"SomeZone"
+  "differentiator":"GalleryPart"
+  }],
+  "GalleryPart": [{...}], //this wont work unless you registered a driver for the part
+}
+```
 
 Additional custom filter providers can be added by implementing `IPlacementNodeFilterProvider`.
 


### PR DESCRIPTION
... but honestly, i've been burned on this already way too many times, the way placement.json works is really unintuitive.
I just couldnt understand why my part placement wasnt getting picked up until I checked shapeTracer (which is also not included by default).

I love orchard but DX has to be simplified.
1. find a way to simplify placement: this should be done somewhere else, my suggestion is to have property names not only as types but as part names too.
2.  inline placements inside templates would also be great that override json placement
```
@placement { "GalleryPart":"GalleryZone"}
```
not sure if this is possible, but i think that Shapes are lazily evaluated, so i could see this being a great help, and it would keep everthing at 1 place.
3. Include shapetracing out-of-box. This is indinspensible for understanding and debugging this stuff.
