### PR TITLE
Add OC version to X-Powered-By http header

### DIFF
--- a/src/OrchardCore/OrchardCore/Modules/PoweredByMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/PoweredByMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using OrchardCore.Modules.Manifest;
 
 namespace OrchardCore.Modules
 {
@@ -21,7 +22,7 @@ namespace OrchardCore.Modules
         {
             if (_options.Enabled)
             {
-                httpContext.Response.Headers[_options.HeaderName] = _options.HeaderValue;
+                httpContext.Response.Headers[_options.HeaderName] = $"{_options.HeaderValue}/{ManifestConstants.OrchardCoreVersion}";
             }
 
             return _next.Invoke(httpContext);

--- a/test/OrchardCore.Tests/Modules/PoweredByMiddlewareTests.cs
+++ b/test/OrchardCore.Tests/Modules/PoweredByMiddlewareTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 using Moq;
 using OrchardCore.Modules;
+using OrchardCore.Modules.Manifest;
 using Xunit;
 
 namespace OrchardCore.Tests.Modules
@@ -35,7 +36,7 @@ namespace OrchardCore.Tests.Modules
             await middleware.Invoke(httpContextMock.Object);
 
             // Assert
-            Assert.Equal(value, headersArray[key]);
+            Assert.Equal($"{value}/{ManifestConstants.OrchardCoreVersion}", headersArray[key]);
             httpResponseMock.Verify(r => r.Headers, Times.Once);
         }
 


### PR DESCRIPTION
PHP for instance adding a version alongside with the product name, I think it would be nice to add the OC version