### PR TITLE
Use extension method to update OpenId application descriptor

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -157,91 +157,27 @@ namespace OrchardCore.OpenId.Controllers
                 return View(model);
             }
 
-            var descriptor = new OpenIdApplicationDescriptor
+            var settings = new OpenIdApplicationSettings()
             {
+                AllowAuthorizationCodeFlow = model.AllowAuthorizationCodeFlow,
+                AllowClientCredentialsFlow = model.AllowClientCredentialsFlow,
+                AllowHybridFlow = model.AllowHybridFlow,
+                AllowImplicitFlow = model.AllowImplicitFlow,
+                AllowLogoutEndpoint = model.AllowLogoutEndpoint,
+                AllowPasswordFlow = model.AllowPasswordFlow,
+                AllowRefreshTokenFlow = model.AllowRefreshTokenFlow,
                 ClientId = model.ClientId,
                 ClientSecret = model.ClientSecret,
                 ConsentType = model.ConsentType,
                 DisplayName = model.DisplayName,
+                PostLogoutRedirectUris = model.PostLogoutRedirectUris,
+                RedirectUris = model.RedirectUris,
+                Roles = model.RoleEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
+                Scopes = model.ScopeEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
                 Type = model.Type
             };
 
-            if (model.AllowLogoutEndpoint)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
-            }
-            if (model.AllowAuthorizationCodeFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
-            }
-            if (model.AllowClientCredentialsFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.ClientCredentials);
-            }
-            if (model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Implicit);
-            }
-            if (model.AllowPasswordFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Password);
-            }
-            if (model.AllowRefreshTokenFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.RefreshToken);
-            }
-            if (model.AllowAuthorizationCodeFlow || model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Authorization);
-            }
-            if (model.AllowAuthorizationCodeFlow || model.AllowClientCredentialsFlow ||
-                model.AllowPasswordFlow || model.AllowRefreshTokenFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
-            }
-
-            if (model.AllowAuthorizationCodeFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);
-            }
-            if (model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdToken);
-
-                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
-                {
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Token);
-                }
-            }
-            if (model.AllowHybridFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdToken);
-
-                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
-                {
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
-                }
-            }
-
-            descriptor.PostLogoutRedirectUris.UnionWith(
-                from uri in model.PostLogoutRedirectUris?.Split(new[] { " ", "," }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()
-                select new Uri(uri, UriKind.Absolute));
-
-            descriptor.RedirectUris.UnionWith(
-                from uri in model.RedirectUris?.Split(new[] { " ", "," }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()
-                select new Uri(uri, UriKind.Absolute));
-
-            descriptor.Roles.UnionWith(model.RoleEntries
-                .Where(role => role.Selected)
-                .Select(role => role.Name));
-
-            descriptor.Permissions.UnionWith(model.ScopeEntries
-                .Where(scope => scope.Selected)
-                .Select(scope => OpenIddictConstants.Permissions.Prefixes.Scope + scope.Name));
-
-            await _applicationManager.CreateAsync(descriptor);
+            await _applicationManager.UpdateDescriptorFromSettings(settings);
 
             if (string.IsNullOrEmpty(returnUrl))
             {
@@ -364,183 +300,27 @@ namespace OrchardCore.OpenId.Controllers
                 return View(model);
             }
 
-            var descriptor = new OpenIdApplicationDescriptor();
-            await _applicationManager.PopulateAsync(descriptor, application);
+            var settings = new OpenIdApplicationSettings()
+            {
+                AllowAuthorizationCodeFlow = model.AllowAuthorizationCodeFlow,
+                AllowClientCredentialsFlow = model.AllowClientCredentialsFlow,
+                AllowHybridFlow = model.AllowHybridFlow,
+                AllowImplicitFlow = model.AllowImplicitFlow,
+                AllowLogoutEndpoint = model.AllowLogoutEndpoint,
+                AllowPasswordFlow = model.AllowPasswordFlow,
+                AllowRefreshTokenFlow = model.AllowRefreshTokenFlow,
+                ClientId = model.ClientId,
+                ClientSecret = model.ClientSecret,
+                ConsentType = model.ConsentType,
+                DisplayName = model.DisplayName,
+                PostLogoutRedirectUris = model.PostLogoutRedirectUris,
+                RedirectUris = model.RedirectUris,
+                Roles = model.RoleEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
+                Scopes = model.ScopeEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
+                Type = model.Type
+            };
 
-            descriptor.ClientId = model.ClientId;
-            descriptor.ConsentType = model.ConsentType;
-            descriptor.DisplayName = model.DisplayName;
-            descriptor.Type = model.Type;
-
-            if (!string.IsNullOrEmpty(model.ClientSecret))
-            {
-                descriptor.ClientSecret = model.ClientSecret;
-            }
-
-            if (string.Equals(descriptor.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
-            {
-                descriptor.ClientSecret = null;
-            }
-
-            if (model.AllowLogoutEndpoint)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Logout);
-            }
-
-            if (model.AllowAuthorizationCodeFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
-            }
-
-            if (model.AllowClientCredentialsFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.ClientCredentials);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.ClientCredentials);
-            }
-
-            if (model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Implicit);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.Implicit);
-            }
-
-            if (model.AllowPasswordFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Password);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.Password);
-            }
-
-            if (model.AllowRefreshTokenFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.RefreshToken);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.RefreshToken);
-            }
-
-            if (model.AllowAuthorizationCodeFlow || model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Authorization);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Authorization);
-            }
-
-            if (model.AllowAuthorizationCodeFlow || model.AllowClientCredentialsFlow ||
-                model.AllowPasswordFlow || model.AllowRefreshTokenFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Token);
-            }
-
-            if (model.AllowAuthorizationCodeFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.Code);
-            }
-
-            if (model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdToken);
-
-                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
-                {
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Token);
-                }
-                else
-                {
-                    descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
-                    descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.Token);
-                }
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.IdToken);
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.Token);
-            }
-            if (model.AllowHybridFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdToken);
-
-                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
-                {
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
-                }
-                else
-                {
-                    descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
-                    descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
-                }
-            }
-            else
-            {
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeIdToken);
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
-                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
-            }
-
-            descriptor.Roles.Clear();
-
-            foreach (var selectedRole in (model.RoleEntries
-                .Where(role => role.Selected)
-                .Select(role => role.Name)))
-            {
-                descriptor.Roles.Add(selectedRole);
-            }
-
-            descriptor.Permissions.RemoveWhere(permission => permission.StartsWith(OpenIddictConstants.Permissions.Prefixes.Scope));
-            foreach (var selectedScope in (model.ScopeEntries
-                .Where(scope => scope.Selected)
-                .Select(scope => scope.Name)))
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Prefixes.Scope + selectedScope);
-            }
-
-            descriptor.PostLogoutRedirectUris.Clear();
-            foreach (Uri uri in
-                (from uri in model.PostLogoutRedirectUris?.Split(new[] { " ", "," }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()
-                 select new Uri(uri, UriKind.Absolute)))
-            {
-                descriptor.PostLogoutRedirectUris.Add(uri);
-            }
-
-            descriptor.RedirectUris.Clear();
-            foreach (Uri uri in
-               (from uri in model.RedirectUris?.Split(new[] { " ", "," }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()
-                select new Uri(uri, UriKind.Absolute)))
-            {
-                descriptor.RedirectUris.Add(uri);
-            }
-
-            await _applicationManager.UpdateAsync(application, descriptor);
+            await _applicationManager.UpdateDescriptorFromSettings(settings, application);
 
             if (string.IsNullOrEmpty(returnUrl))
             {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OpenIdApplicationExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OpenIdApplicationExtensions.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OpenIddict.Abstractions;
+using OrchardCore.OpenId.Abstractions.Descriptors;
+using OrchardCore.OpenId.Abstractions.Managers;
+
+namespace OrchardCore.OpenId
+{
+    public class OpenIdApplicationSettings
+    {
+        public string ClientId { get; set; }
+        public string DisplayName { get; set; }
+        public string RedirectUris { get; set; }
+        public string PostLogoutRedirectUris { get; set; }
+        public string Type { get; set; }
+        public string ConsentType { get; set; }
+        public string ClientSecret { get; set; }
+        public string[] Roles { get; set; }
+        public string[] Scopes { get; set; }
+        public bool AllowPasswordFlow { get; set; }
+        public bool AllowClientCredentialsFlow { get; set; }
+        public bool AllowAuthorizationCodeFlow { get; set; }
+        public bool AllowRefreshTokenFlow { get; set; }
+        public bool AllowHybridFlow { get; set; }
+        public bool AllowImplicitFlow { get; set; }
+        public bool AllowLogoutEndpoint { get; set; }
+    }
+
+    internal static class OpenIdApplicationExtensions
+    {
+        public static async Task UpdateDescriptorFromSettings(this IOpenIdApplicationManager _applicationManager, OpenIdApplicationSettings model, object application = null)
+        {
+            var descriptor = new OpenIdApplicationDescriptor();
+
+            if (application != null)
+            {
+                await _applicationManager.PopulateAsync(descriptor, application);
+            }
+
+            descriptor.ClientId = model.ClientId;
+            descriptor.ConsentType = model.ConsentType;
+            descriptor.DisplayName = model.DisplayName;
+            descriptor.Type = model.Type;
+
+            if (!string.IsNullOrEmpty(model.ClientSecret))
+            {
+                descriptor.ClientSecret = model.ClientSecret;
+            }
+
+            if (string.Equals(descriptor.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
+            {
+                descriptor.ClientSecret = null;
+            }
+
+            if (model.AllowLogoutEndpoint)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Logout);
+            }
+
+            if (model.AllowAuthorizationCodeFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
+            }
+
+            if (model.AllowClientCredentialsFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.ClientCredentials);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.ClientCredentials);
+            }
+
+            if (model.AllowImplicitFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Implicit);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.Implicit);
+            }
+
+            if (model.AllowPasswordFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Password);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.Password);
+            }
+
+            if (model.AllowRefreshTokenFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.RefreshToken);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.GrantTypes.RefreshToken);
+            }
+
+            if (model.AllowAuthorizationCodeFlow || model.AllowImplicitFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Authorization);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Authorization);
+            }
+
+            if (model.AllowAuthorizationCodeFlow || model.AllowClientCredentialsFlow ||
+                model.AllowPasswordFlow || model.AllowRefreshTokenFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Token);
+            }
+
+            if (model.AllowAuthorizationCodeFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.Code);
+            }
+
+            if (model.AllowImplicitFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdToken);
+
+                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
+                {
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Token);
+                }
+                else
+                {
+                    descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
+                    descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.Token);
+                }
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.IdToken);
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.Token);
+            }
+            if (model.AllowHybridFlow)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdToken);
+
+                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
+                {
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
+                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
+                }
+                else
+                {
+                    descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
+                    descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
+                }
+            }
+            else
+            {
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeIdToken);
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
+                descriptor.Permissions.Remove(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
+            }
+
+            descriptor.Roles.Clear();
+
+            foreach (var role in model.Roles)
+            {
+                descriptor.Roles.Add(role);
+            }
+
+            descriptor.Permissions.RemoveWhere(permission => permission.StartsWith(OpenIddictConstants.Permissions.Prefixes.Scope));
+            foreach (var scope in model.Scopes)
+            {
+                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Prefixes.Scope + scope);
+            }
+
+            descriptor.PostLogoutRedirectUris.Clear();
+            foreach (Uri uri in
+                (from uri in model.PostLogoutRedirectUris?.Split(new[] { " ", "," }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()
+                 select new Uri(uri, UriKind.Absolute)))
+            {
+                descriptor.PostLogoutRedirectUris.Add(uri);
+            }
+
+            descriptor.RedirectUris.Clear();
+            foreach (Uri uri in
+               (from uri in model.RedirectUris?.Split(new[] { " ", "," }, StringSplitOptions.RemoveEmptyEntries) ?? Array.Empty<string>()
+                select new Uri(uri, UriKind.Absolute)))
+            {
+                descriptor.RedirectUris.Add(uri);
+            }
+
+            if (application == null)
+            {
+                await _applicationManager.CreateAsync(descriptor);
+            }
+            else
+            {
+                await _applicationManager.UpdateAsync(application, descriptor);
+            }
+
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -30,112 +30,28 @@ namespace OrchardCore.OpenId.Recipes
 
             var model = context.Step.ToObject<OpenIdApplicationStepModel>();
             var app = await _applicationManager.FindByClientIdAsync(model.ClientId);
-            var descriptor = new OpenIdApplicationDescriptor();
-            var isNew = true;
 
-            if (app != null)
+            var settings = new OpenIdApplicationSettings()
             {
-                isNew = false;
-                await _applicationManager.PopulateAsync(app, descriptor);
-            }
+                AllowAuthorizationCodeFlow = model.AllowAuthorizationCodeFlow,
+                AllowClientCredentialsFlow = model.AllowClientCredentialsFlow,
+                AllowHybridFlow = model.AllowHybridFlow,
+                AllowImplicitFlow = model.AllowImplicitFlow,
+                AllowLogoutEndpoint = model.AllowLogoutEndpoint,
+                AllowPasswordFlow = model.AllowPasswordFlow,
+                AllowRefreshTokenFlow = model.AllowRefreshTokenFlow,
+                ClientId = model.ClientId,
+                ClientSecret = model.ClientSecret,
+                ConsentType = model.ConsentType,
+                DisplayName = model.DisplayName,
+                PostLogoutRedirectUris = model.PostLogoutRedirectUris,
+                RedirectUris = model.RedirectUris,
+                Roles = model.RoleEntries.Select(x => x.Name).ToArray(),
+                Scopes = model.ScopeEntries.Select(x => x.Name).ToArray(),
+                Type = model.Type
+            };
 
-            descriptor.ClientId = model.ClientId;
-            descriptor.ClientSecret = model.ClientSecret;
-            descriptor.ConsentType = model.ConsentType;
-            descriptor.DisplayName = model.DisplayName;
-            descriptor.Type = model.Type;
-
-            if (model.AllowAuthorizationCodeFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode);
-            }
-            if (model.AllowClientCredentialsFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.ClientCredentials);
-            }
-            if (model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Implicit);
-            }
-            if (model.AllowPasswordFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.Password);
-            }
-            if (model.AllowRefreshTokenFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.GrantTypes.RefreshToken);
-            }
-            if (model.AllowAuthorizationCodeFlow || model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Authorization);
-            }
-            if (model.AllowLogoutEndpoint)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Logout);
-            }
-            if (model.AllowAuthorizationCodeFlow || model.AllowClientCredentialsFlow ||
-                model.AllowPasswordFlow || model.AllowRefreshTokenFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Token);
-            }
-            if (model.AllowAuthorizationCodeFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Code);
-            }
-            if (model.AllowImplicitFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdToken);
-
-                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
-                {
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.IdTokenToken);
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.Token);
-                }
-            }
-            if (model.AllowHybridFlow)
-            {
-                descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdToken);
-
-                if (string.Equals(model.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
-                {
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeIdTokenToken);
-                    descriptor.Permissions.Add(OpenIddictConstants.Permissions.ResponseTypes.CodeToken);
-                }
-            }
-            if (!string.IsNullOrWhiteSpace(model.PostLogoutRedirectUris))
-            {
-                descriptor.PostLogoutRedirectUris.UnionWith(
-                    model.PostLogoutRedirectUris
-                        .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-                        .Select(u => new Uri(u, UriKind.Absolute)));
-            }
-            if (!string.IsNullOrWhiteSpace(model.RedirectUris))
-            {
-                descriptor.RedirectUris.UnionWith(
-                    model.RedirectUris
-                        .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-                        .Select(u => new Uri(u, UriKind.Absolute)));
-            }
-            if (model.RoleEntries != null)
-            {
-                descriptor.Roles.UnionWith(
-                    model.RoleEntries
-                        .Select(role => role.Name));
-            }
-            if (model.ScopeEntries != null)
-            {
-                descriptor.Permissions.UnionWith(
-                    model.ScopeEntries
-                        .Select(scope => OpenIddictConstants.Permissions.Prefixes.Scope + scope.Name));
-            }
-            if (isNew)
-            {
-                await _applicationManager.CreateAsync(descriptor);
-            }
-            else
-            {
-                await _applicationManager.UpdateAsync(app, descriptor);
-            }
+            await _applicationManager.UpdateDescriptorFromSettings(settings, app);
         }
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
@@ -119,8 +119,8 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
 
             appManagerMock.Setup(m =>
                 m.PopulateAsync(
-                    It.IsAny<object>(),
                     It.IsAny<OpenIddictApplicationDescriptor>(),
+                    It.IsAny<object>(),
                     It.IsAny<CancellationToken>()))
                 .Returns(
                     new ValueTask());


### PR DESCRIPTION
reuse logic used in ```ApplicationController.Edit()``` also in ```ApplicationController.Create()``` and ```OpenIdApplicationStep```

closes #11720 