### PR TITLE
Removed instanceId which is not used for anything important

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/RecipesStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/RecipesStep.cs
@@ -29,23 +29,16 @@ namespace OrchardCore.Recipes.RecipeSteps
             var step = context.Step.ToObject<InternalStep>();
             var recipesDictionary = new Dictionary<string, IDictionary<string, RecipeDescriptor>>();
             IList<RecipeDescriptor> innerRecipes = new List<RecipeDescriptor>();
+            IDictionary<string, RecipeDescriptor> recipes;
+            var recipeCollections = await Task.WhenAll(_recipeHarvesters.Select(x => x.HarvestRecipesAsync()));
+            recipes = recipeCollections.SelectMany(x => x).ToDictionary(x => x.Name);
 
             foreach (var recipe in step.Values)
             {
-                IDictionary<string, RecipeDescriptor> recipes;
-
-                if (!recipesDictionary.TryGetValue(recipe.ExecutionId, out recipes))
-                {
-                    var recipeCollections = await Task.WhenAll(_recipeHarvesters.Select(x => x.HarvestRecipesAsync()));
-                    recipes = recipeCollections.SelectMany(x => x).ToDictionary(x => x.Name);
-                    recipesDictionary[recipe.ExecutionId] = recipes;
-                }
-
                 if (!recipes.ContainsKey(recipe.Name))
                 {
-                    throw new ArgumentException($"No recipe named '{recipe.Name}' was found in extension '{recipe.ExecutionId}'.");
+                    throw new ArgumentException($"No recipe named '{recipe.Name}' was found.");
                 }
-
                 innerRecipes.Add(recipes[recipe.Name]);
             }
 
@@ -59,7 +52,6 @@ namespace OrchardCore.Recipes.RecipeSteps
 
         private class InternalStepValue
         {
-            public string ExecutionId { get; set; }
             public string Name { get; set; }
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/RecipesStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/RecipesStep.cs
@@ -31,13 +31,15 @@ namespace OrchardCore.Recipes.RecipeSteps
             var recipes = recipeCollections.SelectMany(x => x).ToDictionary(x => x.Name);
 
             IList<RecipeDescriptor> innerRecipes = new List<RecipeDescriptor>();
-            foreach (var recipe in step.Values)
+            foreach (var stepValue in step.Values)
             {
-                if (!recipes.ContainsKey(recipe.Name))
+                if (recipes.TryGetValue(stepValue.Name, out var recipeDescriptor))
                 {
-                    throw new ArgumentException($"No recipe named '{recipe.Name}' was found.");
+                    innerRecipes.Add(recipeDescriptor);
                 }
-                innerRecipes.Add(recipes[recipe.Name]);
+                else
+                    throw new ArgumentException($"No recipe named '{stepValue.Name}' was found.");
+
             }
 
             context.InnerRecipes = innerRecipes;

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/RecipesStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/RecipesStep.cs
@@ -27,12 +27,10 @@ namespace OrchardCore.Recipes.RecipeSteps
             }
 
             var step = context.Step.ToObject<InternalStep>();
-            var recipesDictionary = new Dictionary<string, IDictionary<string, RecipeDescriptor>>();
-            IList<RecipeDescriptor> innerRecipes = new List<RecipeDescriptor>();
-            IDictionary<string, RecipeDescriptor> recipes;
             var recipeCollections = await Task.WhenAll(_recipeHarvesters.Select(x => x.HarvestRecipesAsync()));
-            recipes = recipeCollections.SelectMany(x => x).ToDictionary(x => x.Name);
+            var recipes = recipeCollections.SelectMany(x => x).ToDictionary(x => x.Name);
 
+            IList<RecipeDescriptor> innerRecipes = new List<RecipeDescriptor>();
             foreach (var recipe in step.Values)
             {
                 if (!recipes.ContainsKey(recipe.Name))

--- a/src/docs/reference/modules/Recipes/README.md
+++ b/src/docs/reference/modules/Recipes/README.md
@@ -368,18 +368,16 @@ The Recipes step allows you to execute other recipes from the current recipe. Yo
       "name": "recipes",
       "Values": [
         {
-          "executionid": "MyApp",
           "name": "MyApp.Pages"
         },
         {
-          "executionid": "MyApp",
           "name": "MyApp.Blog"
         }
       ]
     }
 ```
 
-As `executionid` use a custom identifier to distinguish these recipe executions from others. As `name` use the `name` field from the given recipe's head (this is left blank when you export to recipes).
+As `name` use the `name` field from the given recipe's head (this is left blank when you export to recipes).
 
 ### Other settings Step
 

--- a/test/OrchardCore.Tests/Recipes/RecipeStepTests.cs
+++ b/test/OrchardCore.Tests/Recipes/RecipeStepTests.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json.Linq;
+using OrchardCore.Recipes.Models;
+using OrchardCore.Recipes.RecipeSteps;
+using OrchardCore.Recipes.Services;
+using Xunit;
+
+namespace OrchardCore.Tests.Email
+{
+    public class RecipeStepTests
+    {
+        [Fact]
+        public async Task ReplyTo_ShouldHaveAuthors_IfNotSet()
+        {
+            var step = CreateRecipeStepExecutor();
+            var context = new RecipeExecutionContext()
+            {
+                Name = "Recipes",
+                Step = JObject.Parse(@"{""values"":[
+                                                    {""name"":""subrecipe"",""executionid"":""something""},
+                                                    {""name"":""subrecipe2""},
+                                                ]}")
+            };
+            await step.ExecuteAsync(context);
+            Assert.Collection(context.InnerRecipes,
+                item => Assert.Equal("subrecipe", item.Name),
+                item2 => Assert.Equal("subrecipe2", item2.Name)
+            );
+        }
+
+        private static RecipesStep CreateRecipeStepExecutor()
+        {
+            var options = new Mock<IRecipeHarvester>();
+            options.Setup(o => o.HarvestRecipesAsync()).ReturnsAsync(new[] { new RecipeDescriptor { Name = "subrecipe" }, new RecipeDescriptor { Name = "subrecipe2" } });
+            var smtp = new RecipesStep(new[] { options.Object });
+            return smtp;
+        }
+    }
+}

--- a/test/OrchardCore.Tests/Recipes/RecipeStepTests.cs
+++ b/test/OrchardCore.Tests/Recipes/RecipeStepTests.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Tests.Email
     public class RecipeStepTests
     {
         [Fact]
-        public async Task ReplyTo_ShouldHaveAuthors_IfNotSet()
+        public async Task RecipesShouldBeCapturedIntoContext()
         {
             var step = CreateRecipeStepExecutor();
             var context = new RecipeExecutionContext()


### PR DESCRIPTION
I've noticed that instanceId is not being used inside recipeStep for anything other than creating separate recipe dictionaries if you're using separate instanceIds, but without changing the context (basically the same collection twice).