### PR TITLE
Change media controller profile options and expand enum to allow WebP

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
@@ -350,6 +350,7 @@ namespace OrchardCore.Media.Controllers
             model.AvailableFormats.Add(new SelectListItem() { Text = S["Jpg"], Value = ((int)Format.Jpg).ToString() });
             model.AvailableFormats.Add(new SelectListItem() { Text = S["Png"], Value = ((int)Format.Png).ToString() });
             model.AvailableFormats.Add(new SelectListItem() { Text = S["Tga"], Value = ((int)Format.Tga).ToString() });
+            model.AvailableFormats.Add(new SelectListItem() { Text = S["WebP"], Value = ((int)Format.WebP).ToString() });
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -24,7 +24,8 @@ namespace OrchardCore.Media.Processing
         Gif,
         Jpg,
         Png,
-        Tga
+        Tga,
+        WebP
     }
 
     internal class ImageSharpUrlFormatter


### PR DESCRIPTION
Tested fine with agency theme and a rather large property site with many custom modules. Simple change since OC has been moved to ImageSharp 2.0