### PR TITLE
Re-add tenant level AFT on setup

### DIFF
--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -312,29 +312,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 var settings = serviceProvider.GetRequiredService<ShellSettings>();
                 var cookieName = "__orchantiforgery_" + settings.VersionId;
 
-                // If uninitialized, we use the host services.
-                if (settings.State == TenantState.Uninitialized)
-                {
-                    // And delete a cookie that may have been created by another instance.
-                    var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
-
-                    // Use case when creating a container without ambient context.
-                    if (httpContextAccessor.HttpContext == null)
-                    {
-                        return;
-                    }
-
-                    // Use case when creating a container in a deferred task.
-                    if (httpContextAccessor.HttpContext.Response.HasStarted)
-                    {
-                        return;
-                    }
-
-                    httpContextAccessor.HttpContext.Response.Cookies.Delete(cookieName);
-
-                    return;
-                }
-
                 // Re-register the antiforgery services to be tenant-aware.
                 var collection = new ServiceCollection()
                     .AddAntiforgery(options =>
@@ -462,7 +439,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     .AddDataProtection()
                     .PersistKeysToFileSystem(directory)
                     .SetApplicationName(settings.Name)
-                    .AddKeyManagementOptions(o => o.XmlEncryptor = o.XmlEncryptor ?? new NullXmlEncryptor())
+                    .AddKeyManagementOptions(o => o.XmlEncryptor ??= new NullXmlEncryptor())
                     .Services;
 
                 // Remove any previously registered options setups.

--- a/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
@@ -378,6 +378,7 @@ namespace OrchardCore.Environment.Shell
                 // Creates a default shell settings based on the configuration.
                 var shellSettings = _shellSettingsManager.CreateDefaultSettings();
                 shellSettings.Name = ShellHelper.DefaultShellName;
+                shellSettings.VersionId = IdGenerator.GenerateId();
                 shellSettings.State = TenantState.Uninitialized;
                 defaultSettings = shellSettings;
             }

--- a/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
@@ -366,7 +366,7 @@ namespace OrchardCore.Environment.Shell
         /// <summary>
         /// Creates a transient shell for the default tenant's setup.
         /// </summary>
-        private Task<ShellContext> CreateSetupContextAsync(ShellSettings defaultSettings)
+        private async Task<ShellContext> CreateSetupContextAsync(ShellSettings defaultSettings)
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
@@ -378,12 +378,13 @@ namespace OrchardCore.Environment.Shell
                 // Creates a default shell settings based on the configuration.
                 var shellSettings = _shellSettingsManager.CreateDefaultSettings();
                 shellSettings.Name = ShellHelper.DefaultShellName;
-                shellSettings.VersionId = IdGenerator.GenerateId();
                 shellSettings.State = TenantState.Uninitialized;
                 defaultSettings = shellSettings;
+
+                await UpdateShellSettingsAsync(defaultSettings);
             }
 
-            return _shellContextFactory.CreateSetupContextAsync(defaultSettings);
+            return await _shellContextFactory.CreateSetupContextAsync(defaultSettings);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #11501 

Before we were using fixed cookie names, and to prevent some logged errors on setup, in place of registering tenant ATF while the tenant is not initialized, we just remove a possible existing cookie, and let the host level registrations being used.

- We don't need this anymore as we now use fixed cookie names based on the settings VersionId.

- Also, only for the default tenant, when first creating the setup context the VersionId was null, this leading up to an `__orchantiforgery_` cookie name which was no more unique.

Useful to still register tenant level AFT even if the tenant is in a setup context, in a multi instances env to setup tenants we may want to use a tenant level shared data protection, as tried in #11501 from the app by using `AddSetupFeatures()`, and then on setup we also need a tenant level AFT that will use this DP.
