### PR TITLE
localize AdminTemplates 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Templates/AdminTemplatesAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/AdminTemplatesAdminMenu.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Templates
     {
         private readonly IStringLocalizer S;
 
-        public AdminTemplatesAdminMenu(IStringLocalizer<AdminMenu> localizer)
+        public AdminTemplatesAdminMenu(IStringLocalizer<AdminTemplatesAdminMenu> localizer)
         {
             S = localizer;
         }


### PR DESCRIPTION
I ran into a problem when localizing admin templates.
It is necessary to use "AdminTemplatesAdminMenu" intead  "AdminMenu" in Localizer.