### PR TITLE
Add descriptions to content-type Fix #11827

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/ContentTypeSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/ContentTypeSettingsDisplayDriver.cs
@@ -30,6 +30,7 @@ namespace OrchardCore.ContentTypes.Editors
                 model.Versionable = settings.Versionable;
                 model.Securable = settings.Securable;
                 model.Stereotype = settings.Stereotype;
+                model.Description = settings.Description;
             }).Location("Content:5");
         }
 
@@ -44,6 +45,8 @@ namespace OrchardCore.ContentTypes.Editors
                 context.Builder.Draftable(model.Draftable);
                 context.Builder.Versionable(model.Versionable);
                 context.Builder.Securable(model.Securable);
+                context.Builder.WithDescription(model.Description);
+
                 var stereotype = model.Stereotype?.Trim();
                 context.Builder.Stereotype(stereotype);
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/ViewModels/ContentTypeSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/ViewModels/ContentTypeSettingsViewModel.cs
@@ -8,5 +8,6 @@ namespace OrchardCore.ContentTypes.ViewModels
         public bool Versionable { get; set; }
         public bool Securable { get; set; }
         public string Stereotype { get; set; }
+        public string Description { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
@@ -1,6 +1,14 @@
 @model ContentTypeSettingsViewModel
 
 <div class="mb-3">
+    <div class="w-md-75 w-xl-50">
+        <label asp-for="Description">@T["Description"]</label>
+        <input asp-for="Description" type="text" class="form-control">
+    </div>
+    <span class="hint">@T["(Optional) Description of the type"]</span>
+</div>
+
+<div class="mb-3">
     <div class="form-check">
         <input type="checkbox" class="form-check-input" asp-for="Creatable">
         <label class="form-check-label" asp-for="Creatable">@T["Creatable"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
@@ -5,7 +5,7 @@
         <label asp-for="Description">@T["Description"]</label>
         <input asp-for="Description" type="text" class="form-control">
     </div>
-    <span class="hint">@T["(Optional) Description of the type"]</span>
+    <span class="hint">@T["(Optional) Description of the content type"]</span>
 </div>
 
 <div class="mb-3">

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Shared/DisplayTemplates/EditTypeViewModel.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Shared/DisplayTemplates/EditTypeViewModel.cshtml
@@ -3,18 +3,28 @@
 @{
     var settings = Model.TypeDefinition.GetSettings<ContentTypeSettings>();
 }
-<div class="w-100">
-    <a asp-route-action="Edit" asp-route-area="OrchardCore.ContentTypes" asp-route-id="@Model.Name">@Model.DisplayName</a>
-    <div class="float-end">
-        @if (settings.Creatable)
+<div class="d-flex">
+    <div class="me-auto">
+        <a asp-route-action="Edit" asp-route-area="OrchardCore.ContentTypes" asp-route-id="@Model.Name">@Model.DisplayName</a>
+
+        <span class="badge rounded-pill ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Technical Name"]"><i class="fas fa-file-alt text-danger" aria-hidden="true"></i> @Model.Name</span>
+
+        @if (!string.IsNullOrWhiteSpace(settings.Stereotype))
         {
-            <a id="btn-create-@Model.Name" asp-route-area="OrchardCore.Contents" asp-route-action="Create" asp-route-id="@Model.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-success btn-sm">@T["Create New {0}", Model.DisplayName]</a>
+            <span class="badge rounded-pill ta-badge font-weight-normal" data-bs-toggle="tooltip" title="Stereotype"><i class="fa fa-file text-info" aria-hidden="true"></i> @settings.Stereotype</span>
         }
-        <a role="btn-list-@Model.Name" asp-route-action="List" asp-route-area="OrchardCore.Contents" asp-route-contentTypeId="@Model.Name" class="btn btn-secondary btn-sm">@T["List Items"]</a>
-        <a role="btn-edit-@Model.Name" asp-route-action="Edit" asp-route-area="OrchardCore.ContentTypes" asp-route-id="@Model.Name" class="btn btn-primary btn-sm">@T["Edit"]</a>
     </div>
-    @if (!string.IsNullOrWhiteSpace(settings.Stereotype))
+
+    @if (settings.Creatable)
     {
-        <span class="badge rounded-pill ta-badge font-weight-normal" data-bs-toggle="tooltip" title="Stereotype"><i class="fa fa-file text-info" aria-hidden="true"></i> @settings.Stereotype</span>
+        <a id="btn-create-@Model.Name" asp-route-area="OrchardCore.Contents" asp-route-action="Create" asp-route-id="@Model.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-success btn-sm">@T["Create New {0}", Model.DisplayName]</a>
     }
+    <a role="btn-list-@Model.Name" asp-route-action="List" asp-route-area="OrchardCore.Contents" asp-route-contentTypeId="@Model.Name" class="btn btn-secondary btn-sm">@T["List Items"]</a>
+    <a role="btn-edit-@Model.Name" asp-route-action="Edit" asp-route-area="OrchardCore.ContentTypes" asp-route-id="@Model.Name" class="btn btn-primary btn-sm">@T["Edit"]</a>
+
 </div>
+
+@if (!string.IsNullOrWhiteSpace(settings.Description))
+{
+    <div class="row"><div class="col hint"> @settings.Description</div></div>
+}

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Shared/DisplayTemplates/EditTypeViewModel.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Shared/DisplayTemplates/EditTypeViewModel.cshtml
@@ -14,17 +14,21 @@
             <span class="badge rounded-pill ta-badge font-weight-normal" data-bs-toggle="tooltip" title="Stereotype"><i class="fa fa-file text-info" aria-hidden="true"></i> @settings.Stereotype</span>
         }
     </div>
-
-    @if (settings.Creatable)
-    {
-        <a id="btn-create-@Model.Name" asp-route-area="OrchardCore.Contents" asp-route-action="Create" asp-route-id="@Model.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-success btn-sm">@T["Create New {0}", Model.DisplayName]</a>
-    }
-    <a role="btn-list-@Model.Name" asp-route-action="List" asp-route-area="OrchardCore.Contents" asp-route-contentTypeId="@Model.Name" class="btn btn-secondary btn-sm">@T["List Items"]</a>
-    <a role="btn-edit-@Model.Name" asp-route-action="Edit" asp-route-area="OrchardCore.ContentTypes" asp-route-id="@Model.Name" class="btn btn-primary btn-sm">@T["Edit"]</a>
-
+    <div>
+        @if (settings.Creatable)
+        {
+            <a id="btn-create-@Model.Name" asp-route-area="OrchardCore.Contents" asp-route-action="Create" asp-route-id="@Model.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-success btn-sm">@T["Create New {0}", Model.DisplayName]</a>
+        }
+        <a role="btn-list-@Model.Name" asp-route-action="List" asp-route-area="OrchardCore.Contents" asp-route-contentTypeId="@Model.Name" class="btn btn-secondary btn-sm">@T["List Items"]</a>
+        <a role="btn-edit-@Model.Name" asp-route-action="Edit" asp-route-area="OrchardCore.ContentTypes" asp-route-id="@Model.Name" class="btn btn-primary btn-sm">@T["Edit"]</a>
+    </div>
 </div>
 
 @if (!string.IsNullOrWhiteSpace(settings.Description))
 {
-    <div class="row"><div class="col hint"> @settings.Description</div></div>
+    <div class="row">
+        <div class="col">
+            <p class="mb-0"><small class="text-muted">@settings.Description</small></p>
+        </div>
+    </div>
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettings.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettings.cs
@@ -31,5 +31,10 @@ namespace OrchardCore.ContentManagement.Metadata.Settings
         /// Used to determine if this content type supports custom permissions
         /// </summary>
         public bool Securable { get; set; }
+
+        /// <summary>
+        /// Gets or sets the description name of the type.
+        /// </summary>
+        public string Description { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettings.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettings.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.ContentManagement.Metadata.Settings
         public bool Securable { get; set; }
 
         /// <summary>
-        /// Gets or sets the description name of the type.
+        /// Gets or sets the description name of this content type.
         /// </summary>
         public string Description { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettingsExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Settings/ContentTypeSettingsExtensions.cs
@@ -33,5 +33,10 @@ namespace OrchardCore.ContentManagement.Metadata.Settings
         {
             return builder.MergeSettings<ContentTypeSettings>(x => x.Stereotype = stereotype);
         }
+
+        public static ContentTypeDefinitionBuilder WithDescription(this ContentTypeDefinitionBuilder builder, string description)
+        {
+            return builder.MergeSettings<ContentTypeSettings>(x => x.Description = description);
+        }
     }
 }


### PR DESCRIPTION
Add content description to the content-type just like we have for content-parts.

Accommodate #11827 

Here are some screenshots of the change

![Screenshot_1](https://user-images.githubusercontent.com/24724371/172953184-06a3506a-400e-4f07-85c0-c177e815edfa.png)
7
![Screenshot_2](https://user-images.githubusercontent.com/24724371/172953189-977e3561-1920-449f-b858-2947364685f4.png)

