### PR TITLE
authorization fix for searching in userpicker

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/UserPickerAdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/UserPickerAdminController.cs
@@ -48,7 +48,8 @@ namespace OrchardCore.ContentFields.Controllers
             var contentItem = await _contentManager.NewAsync(contentType);
             contentItem.Owner = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
-            if (!await _authorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem))
+            if (!await _authorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem) &&
+                !await _authorizationService.AuthorizeAsync(User, CommonPermissions.EditOwnContent, contentItem))
             {
                 return Forbid();
             }


### PR DESCRIPTION
Fixes #11878

You can't pick users when you only have permissions to edit your own content. For example: I have a content type  "Project" with a user content picker field. I'm only authorizated to edit my own created projects. When I create a new project I currently can't select users with the user picker field.