### PR TITLE
Align the Getting Started documentation with .NET 6. Fix #11888

### DIFF
--- a/src/docs/getting-started/README.md
+++ b/src/docs/getting-started/README.md
@@ -14,7 +14,61 @@ In Visual Studio, create a new empty .NET Core web application. Ex: `Cms.Web`. D
 
 To add a reference to the package, right-click on the project and click on `Manage NuGet packages...`, check `Include prerelease` if required. If you added the preview source above, select this from the `Package Source` selection in the top right.  In the `Browse` tab, search for `OrchardCore.Application.Cms.Targets` and `Install` the package.
 
-Open `Startup.cs` and modify the `ConfigureServices` method by adding this line:
+### Getting Started with `Program.cs` Only Using .NET 6 Framework?
+!!! tip
+    When starting a new project using `.NET 6` framework, you'll notice that the created project does not have a `Startup` class as it did in previous versions of the .NET framework.
+
+Open `Project.cs` file. Remove the following line "if exists"
+
+```csharp
+builder.Services.AddRazorPages();
+```
+
+Add the following line 
+
+```csharp
+builder.Services.AddOrchardCms()
+```
+
+Additionally, remove the following lines
+
+```csharp
+app.UseHttpsRedirection();
+app.UseRouting();
+app.UseAuthorization();
+app.MapRazorPages();
+```
+Lastly, add the following line to the request pipeline
+
+```csharp
+app.UseOrchardCore();
+```
+
+When you are done, the `Program.cs` file will something like this
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOrchardCms()
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseStaticFiles();
+app.UseOrchardCore();
+
+app.Run();
+```
+
+
+### Getting Started Using `Startup.cs` file?
+
+Open `Startup.cs` file, then modify the `ConfigureServices` method by adding this line:
 
 ```csharp
 services.AddOrchardCms();
@@ -37,6 +91,8 @@ with this line:
 ```csharp
 app.UseOrchardCore();
 ```
+
+Finally, remove the default `Pages` and/or `Views` folder to allow OrchardCore to render the views from the theme.
 
 ## Setup your application
 

--- a/src/docs/getting-started/README.md
+++ b/src/docs/getting-started/README.md
@@ -91,7 +91,7 @@ with this line:
 app.UseOrchardCore();
 ```
 
-Finally, remove the default `Pages` and/or `Views` folder to allow OrchardCore to render the views from the theme.
+Finally, remove the default `Pages` and/or `Views` folder to allow OrchardCore to render the views from the active theme.
 
 ## Setup your application
 

--- a/src/docs/getting-started/README.md
+++ b/src/docs/getting-started/README.md
@@ -18,7 +18,7 @@ To add a reference to the package, right-click on the project and click on `Mana
 !!! tip
     When starting a new project using `.NET 6` framework, you'll notice that the created project does not have a `Startup` class as it did in previous versions of the .NET framework.
 
-Open `Project.cs` file. Remove the following line "if exists"
+Open `Program.cs` file. Remove the following line "if exists"
 
 ```csharp
 builder.Services.AddRazorPages();
@@ -64,7 +64,6 @@ app.UseOrchardCore();
 
 app.Run();
 ```
-
 
 ### Getting Started Using `Startup.cs` file?
 


### PR DESCRIPTION
Fix #11888 