### PR TITLE
Fixes #11904 TypeFeatureProvider throws if a Razor Page has no PageModel

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Demo/Pages/HelloWorld.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Pages/HelloWorld.cshtml
@@ -1,0 +1,25 @@
+@page "/helloworld"
+
+@functions
+{
+    public Task<IActionResult> OnGetAsync()
+    {
+        return Task.FromResult<IActionResult>(Page());
+    }
+}
+
+@{
+    var title = "This is a razor 'Page' coming from OrchardCore.Demo that doesn't define any 'PageModel'.";
+    var message = $"Date and time on the server: { DateTime.Now.ToString() }";
+}
+
+@await Html.PartialAsync("Header", new { Title = title })
+
+<h2>Hello World from @ViewContext.RouteData.Values["page"]</h2>
+
+<p>
+    @message
+</p>
+<p>
+    Date using the DateTimeShape: @await DisplayAsync(await New.DateTime(Utc: null, Format: T["MMMM dd, yyyy"].Value))
+</p>

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageApplicationModelProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/ModularPageApplicationModelProvider.cs
@@ -1,28 +1,25 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using OrchardCore.Environment.Extensions;
-using OrchardCore.Environment.Extensions.Features;
 using OrchardCore.Environment.Shell.Descriptor.Models;
+using OrchardCore.Modules;
 
 namespace OrchardCore.Mvc.RazorPages
 {
     public class ModularPageApplicationModelProvider : IPageApplicationModelProvider
     {
-        private IEnumerable<IFeatureInfo> _features;
-        private readonly ITypeFeatureProvider _typeFeatureProvider;
+        private readonly ILookup<string, string> _featureIdsByArea;
 
         public ModularPageApplicationModelProvider(
-            ITypeFeatureProvider typeFeatureProvider,
             IExtensionManager extensionManager,
             ShellDescriptor shellDescriptor)
         {
-            // Available features in the current shell.            
-            _features = extensionManager.GetFeatures().Where(f => shellDescriptor.Features.Any(sf =>
-                sf.Id == f.Id)).Select(f => f);
-
-            _typeFeatureProvider = typeFeatureProvider;
+            // Available features by area in the current shell.            
+            _featureIdsByArea = extensionManager.GetFeatures()
+                .Where(f => shellDescriptor.Features.Any(sf => sf.Id == f.Id))
+                .ToLookup(f => f.Extension.Id, f => f.Id);
         }
 
         public int Order => -1000 + 10;
@@ -34,40 +31,23 @@ namespace OrchardCore.Mvc.RazorPages
         // Called the 1st time a page is requested or if any page has been updated.
         public void OnProvidersExecuted(PageApplicationModelProviderContext context)
         {
-            // Check if the page belongs to an enabled module.
-            var relativePath = context.ActionDescriptor.RelativePath;
+            // Check if the page belongs to an enabled feature.
             var found = false;
-            var featureForPath = _features.Where(f =>
-               relativePath.StartsWith('/' + f.Extension.SubPath + "/Pages/", StringComparison.Ordinal))
-                .OrderBy(f => f.Id == f.Extension.Id ? 1 : 0).ToArray();
 
-            // All pages with internal model types are available to module
-            var pageModelType = context.PageApplicationModel.ModelType.AsType();
-            if (!IsComponentType(pageModelType))
+            var area = context.PageApplicationModel.AreaName;
+            if (_featureIdsByArea.Contains(area))
             {
-                found = featureForPath.Any(f => f.Id == f.Extension.Id);
-            }
-            else
-            {
-                // Pages with public model types containing [Feature] attribute
-                // are available only if feature is enabled 
-                foreach (var feature in featureForPath)
+                found = true;
+
+                var pageModelType = context.PageApplicationModel.ModelType.AsType();
+                var attribute = pageModelType.GetCustomAttributes<FeatureAttribute>(false).FirstOrDefault();
+                if (attribute != null)
                 {
-                    var blueprint = _typeFeatureProvider.GetFeatureForDependency(pageModelType);
-                    if (blueprint != null && feature.Id == blueprint.Id)
-                    {
-                        found = true;
-                        break;
-                    }
+                    found = _featureIdsByArea[area].Contains(attribute.FeatureName);
                 }
             }
 
             context.PageApplicationModel.Filters.Add(new ModularPageViewEnginePathFilter(found));
-        }
-
-        private bool IsComponentType(Type type)
-        {
-            return type.IsClass && !type.IsAbstract && type.IsPublic;
         }
     }
 }


### PR DESCRIPTION
Fixes #11904 

We now can use the `[Feature()]` attribute on a razor `PageModel` if it is a **component**, meaning a non abstract public class, e.g. not an internal class when defined in a razor page itself, and we use the `ITypeFeatureProvider` to retrieve the feature related to a given `PageModel`.

The problem is that when no `PageModel` is defined for a razor page, e.g. only `@functions` handlers, the related page `ModelType` is then of type `Object` which is non abstract and public, so considered as a **component**.

In that case `ITypeFeatureProvider.GetFeatureForDependency(pageModelType)` throw an exception.

A quick solution was to change the following by also checking the `Object` type.

        private bool IsComponentType(Type type)
        {
            return type.IsClass && !type.IsAbstract && type.IsPublic &&
                type != typeof(Object); <= The change
        }

But I think it is better and simpler to just check if the page `ModelType` has a custom attribute of type `FeatureAttribute`, and if so just use it to retrieve the related feature.

@ns8482e if you can take a look ;)
