### PR TITLE
Add the list of content items being displayed on the list-page to the…

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -257,6 +257,8 @@ namespace OrchardCore.Contents.Controllers
             // Load items so that loading handlers are invoked.
             var pageOfContentItems = await query.Skip(pager.GetStartIndex()).Take(pager.PageSize).ListAsync(_contentManager);
 
+            _httpContextAccessor.HttpContext.Features.Set(new ContentItemListFeature(pageOfContentItems));
+
             // We prepare the content items SummaryAdmin shape
             var contentItemSummaries = new List<dynamic>();
             foreach (var contentItem in pageOfContentItems)

--- a/src/OrchardCore/OrchardCore.Contents.Core/Services/ContentItemListFeature.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/Services/ContentItemListFeature.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using OrchardCore.ContentManagement;
+
+namespace OrchardCore.Contents.Services;
+public class ContentItemListFeature
+{
+    public IEnumerable<ContentItem> ContentItems { get; set; }
+
+    public ContentItemListFeature(IEnumerable<ContentItem> contentItems)
+    {
+        ContentItems = contentItems;
+    }
+}


### PR DESCRIPTION
Fixed #11591 

### Summary
There is a need to change how the owner name appears on the Content List/index views. But in order to do that, we need a way to determine a list of the content owners then query the Users table to get info about each owner while avoiding select N+1 case. 
Adding the content items to the feature will provider a full list of the contents which contains the owner id.