### PR TITLE
Display all users in the UserPickerField by default unless the user select specific role

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/UserPickerFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/UserPickerFieldSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 
 namespace OrchardCore.ContentFields.Settings
 {
@@ -7,6 +8,8 @@ namespace OrchardCore.ContentFields.Settings
         public string Hint { get; set; }
         public bool Required { get; set; }
         public bool Multiple { get; set; }
+
+        [DefaultValue(true)]
         public bool DisplayAllUsers { get; set; } = true;
         public string[] DisplayedRoles { get; set; } = Array.Empty<string>();
     }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/UserPickerFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/UserPickerFieldSettings.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.ContentFields.Settings
         public string Hint { get; set; }
         public bool Required { get; set; }
         public bool Multiple { get; set; }
-        public bool DisplayAllUsers { get; set; }
+        public bool DisplayAllUsers { get; set; } = true;
         public string[] DisplayedRoles { get; set; } = Array.Empty<string>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/UserPickerFieldSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/UserPickerFieldSettingsDriver.cs
@@ -26,10 +26,14 @@ namespace OrchardCore.ContentFields.Settings
                 model.Hint = settings.Hint;
                 model.Required = settings.Required;
                 model.Multiple = settings.Multiple;
-
                 var roles = (await _roleService.GetRoleNamesAsync())
                     .Except(new[] { "Anonymous", "Authenticated" }, StringComparer.OrdinalIgnoreCase)
-                    .Select(x => new RoleEntry { Role = x, IsSelected = settings.DisplayedRoles.Contains(x, StringComparer.OrdinalIgnoreCase) }).ToArray();
+                    .Select(roleName => new RoleEntry
+                    {
+                        Role = roleName,
+                        IsSelected = settings.DisplayedRoles.Contains(roleName, StringComparer.OrdinalIgnoreCase)
+                    })
+                    .ToArray();
 
                 model.Roles = roles;
                 model.DisplayAllUsers = settings.DisplayAllUsers || roles.Length == 0;
@@ -49,7 +53,7 @@ namespace OrchardCore.ContentFields.Settings
                 settings.Multiple = model.Multiple;
                 var selectedRoles = model.Roles.Where(x => x.IsSelected).Select(x => x.Role).ToArray();
 
-                if (model.DisplayAllUsers || !selectedRoles.Any())
+                if (model.DisplayAllUsers || selectedRoles.Length == 0)
                 {
                     // No selected role should have the same effect as display all users
                     settings.DisplayedRoles = Array.Empty<string>();


### PR DESCRIPTION
Fix #11878

When a user attaches a `UserPickerField` to a content type, the field settings does not have default roles selected or have the `DisplayAllUsers` set to true so in this case, the search for a user return no records. The fix is to display all users in the `UserPickerField`  by default to allow all users to show up. If the user want to override that behavior, then they can specific roles to select from. Without this, no users will show up in  `UserPickerField` unless the user edit the field and set the settings.