### PR TITLE
Extend graphQL API

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/ContentPickerFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/ContentPickerFieldQueryObjectType.cs
@@ -15,6 +15,29 @@ namespace OrchardCore.ContentFields.GraphQL
         {
             Name = nameof(ContentPickerField);
 
+            Field<StringGraphType>()
+                .Name("firstValue")
+                .Description("The first content item id in the content picker field.")
+                .Resolve(x => x.Source?.ContentItemIds?.FirstOrDefault());
+
+            Field<ContentItemInterface, ContentItem>()
+                .Name("firstContentItem")
+                .Description("The first content item in the content picker field.")
+                .ResolveAsync(async x =>
+                {
+                    var contentItemLoader = x.GetOrAddPublishedContentItemByIdDataLoader();
+                    if (x.Source.ContentItemIds != null && x.Source.ContentItemIds.Any())
+                    {
+                        var firstValue = x.Source.ContentItemIds.FirstOrDefault(x => x != null);
+                        if (firstValue == null) return null;
+                        var result = await contentItemLoader.LoadAsync(firstValue);
+
+                        return result;
+                    }
+
+                    return null;
+                });
+
             Field<ListGraphType<StringGraphType>, IEnumerable<string>>()
                 .Name("contentItemIds")
                 .Description("content item ids")


### PR DESCRIPTION
Some graphql APIs in orchardcore will be extended in this pr

- [X] support contentpickerfield, which can return the first value instead of an array, which is very useful when building list queries
- [ ] graphql mutation (for now  in my EasyOC project  I created an API method ，witch acept an Dicionary Model )
- [ ] support  query  `UserPickerField`
- [ ] support paging query of default index
