### PR TITLE
Prevent Trumbowyg from converting div to p element

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
@@ -64,25 +64,13 @@ else
             <text>
             var settings = @Html.Raw(trumbowygSettings.Options);
             settings['lang'] = '@culture.TwoLetterISOLanguageName';
-            settings['semantic'] = {
-                'b': 'strong',
-                'i': 'em',
-                's': 'del',
-                'strike': 'del'
-            };
             </text>
         }
         else
         {   
             <text>
             var settings = { 
-                lang: '@culture.TwoLetterISOLanguageName',
-                semantic: {
-                    'b': 'strong',
-                    'i': 'em',
-                    's': 'del',
-                    'strike': 'del'
-                }
+                lang: '@culture.TwoLetterISOLanguageName'
             }
             </text>
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
@@ -27,12 +27,12 @@ else
     @if (culture.IsRightToLeft())
     {
         <div style="text-align:right">
-            <textarea asp-for="Html" class="form-control"></textarea>
+            <textarea asp-for="Html"></textarea>
         </div>
     }
     else
     {
-        <textarea asp-for="Html" class="form-control"></textarea>
+        <textarea asp-for="Html"></textarea>
     }
 
     @if (!String.IsNullOrEmpty(settings.Hint))
@@ -64,13 +64,25 @@ else
             <text>
             var settings = @Html.Raw(trumbowygSettings.Options);
             settings['lang'] = '@culture.TwoLetterISOLanguageName';
+            settings['semantic'] = {
+                'b': 'strong',
+                'i': 'em',
+                's': 'del',
+                'strike': 'del'
+            };
             </text>
         }
         else
         {   
             <text>
             var settings = { 
-                lang: '@culture.TwoLetterISOLanguageName'
+                lang: '@culture.TwoLetterISOLanguageName',
+                semantic: {
+                    'b': 'strong',
+                    'i': 'em',
+                    's': 'del',
+                    'strike': 'del'
+                }
             }
             </text>
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
@@ -18,12 +18,12 @@
     @if (culture.IsRightToLeft())
     {
         <div style="text-align:right">
-            <textarea asp-for="Html" class="form-control"></textarea>
+            <textarea asp-for="Html"></textarea>
         </div>
     }
     else
     {
-        <textarea asp-for="Html" class="form-control"></textarea>
+        <textarea asp-for="Html"></textarea>
     }
 
     @if (!String.IsNullOrEmpty(settings.Hint))
@@ -57,7 +57,13 @@
         }
 
         var settings = { 
-            lang: '@culture.TwoLetterISOLanguageName'
+            lang: '@culture.TwoLetterISOLanguageName',
+            semantic: {
+                    'b': 'strong',
+                    'i': 'em',
+                    's': 'del',
+                    'strike': 'del'
+                }
         }
 
         $('#@Html.IdFor(m => m.Html)').trumbowyg(settings).on('tbwchange', function () {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
@@ -33,40 +33,35 @@
 </div>
 
 <script at="Foot">
-    $(function () {
-        @* set dir while keeping trumbowg translations dictionary intact *@
-        @if (culture.GetLanguageDirection() == LanguageDirection.RTL)
-        {
-            <text>
+    $(function() {
+    @* set dir while keeping trumbowg translations dictionary intact *@
+    @if (culture.GetLanguageDirection() == LanguageDirection.RTL)
+    {
+        <text>
             var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
 
             if (!langs) {
-                cloned = { 
+                cloned = {
                     ...jQuery.trumbowyg.langs['en'],
                     _dir: '@culture.GetLanguageDirection()'
                 };
                 jQuery.trumbowyg.langs['@culture.TwoLetterISOLanguageName'] = cloned;
             }
-            </text>
-        }
+        </text>
+    }
 
-        @* Extend trumbowyg default buttons. Only use for the wysiwyg editor which gets all buttons by default *@
+    @* Extend trumbowyg default buttons. Only use for the wysiwyg editor which gets all buttons by default *@
         var defaultButtons = jQuery.trumbowyg.defaultOptions.btns;
         if (defaultButtons[6] !== "insertShortcode") {
             defaultButtons.splice(6, 0, "insertShortcode");
         }
 
-        var settings = { 
+        var settings = {
             lang: '@culture.TwoLetterISOLanguageName',
-            semantic: {
-                    'b': 'strong',
-                    'i': 'em',
-                    's': 'del',
-                    'strike': 'del'
-                }
+            semantic: false
         }
 
-        $('#@Html.IdFor(m => m.Html)').trumbowyg(settings).on('tbwchange', function () {
+        $('#@Html.IdFor(m => m.Html)').trumbowyg(settings).on('tbwchange', function() {
             $(document).trigger('contentpreview:render');
         });
     });

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Trumbowyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Trumbowyg.Edit.cshtml
@@ -25,12 +25,12 @@ else
     @if (culture.IsRightToLeft())
     {
         <div style="text-align:right">
-            <textarea asp-for="Html" rows="5" class="form-control"></textarea>
+            <textarea asp-for="Html"></textarea>
         </div>
     }
     else
     {
-        <textarea asp-for="Html" rows="5" class="form-control"></textarea>
+        <textarea asp-for="Html"></textarea>
     }
     <span class="hint">@T["The body of the content item."]</span>
 </div>
@@ -57,13 +57,25 @@ else
             <text>
             var settings = @Html.Raw(trumbowygSettings.Options);
             settings['lang'] = '@culture.TwoLetterISOLanguageName';
+            settings['semantic'] = {
+                'b': 'strong',
+                'i': 'em',
+                's': 'del',
+                'strike': 'del'
+            };
             </text>
         }
         else
         {   
             <text>
             var settings = { 
-                lang: '@culture.TwoLetterISOLanguageName'
+                lang: '@culture.TwoLetterISOLanguageName',
+                semantic: {
+                    'b': 'strong',
+                    'i': 'em',
+                    's': 'del',
+                    'strike': 'del'
+                }
             }
             </text>
         }

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Trumbowyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Trumbowyg.Edit.cshtml
@@ -57,25 +57,13 @@ else
             <text>
             var settings = @Html.Raw(trumbowygSettings.Options);
             settings['lang'] = '@culture.TwoLetterISOLanguageName';
-            settings['semantic'] = {
-                'b': 'strong',
-                'i': 'em',
-                's': 'del',
-                'strike': 'del'
-            };
             </text>
         }
         else
         {   
             <text>
             var settings = { 
-                lang: '@culture.TwoLetterISOLanguageName',
-                semantic: {
-                    'b': 'strong',
-                    'i': 'em',
-                    's': 'del',
-                    'strike': 'del'
-                }
+                lang: '@culture.TwoLetterISOLanguageName'
             }
             </text>
         }

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
@@ -29,23 +29,23 @@
 
 <script at="Foot">
     $(function() {
-        @* set dir while keeping trumbowg translations dictionary intact *@
-        @if (culture.GetLanguageDirection() == LanguageDirection.RTL)
-        {
-            <text>
-                var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
+    @* set dir while keeping trumbowg translations dictionary intact *@
+    @if (culture.GetLanguageDirection() == LanguageDirection.RTL)
+    {
+        <text>
+            var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
 
-                if (!langs) {
-                    cloned = {
-                        ...jQuery.trumbowyg.langs['en'],
-                        _dir: '@culture.GetLanguageDirection()'
-                    };
-                    jQuery.trumbowyg.langs['@culture.TwoLetterISOLanguageName'] = cloned;
-                }
-            </text>
-        }
+            if (!langs) {
+                cloned = {
+                    ...jQuery.trumbowyg.langs['en'],
+                    _dir: '@culture.GetLanguageDirection()'
+                };
+                jQuery.trumbowyg.langs['@culture.TwoLetterISOLanguageName'] = cloned;
+            }
+        </text>
+    }
 
-        @* Extend trumbowyg default buttons. Only use for the wysiwyg editor which gets all buttons by default *@
+    @* Extend trumbowyg default buttons. Only use for the wysiwyg editor which gets all buttons by default *@
         var defaultButtons = jQuery.trumbowyg.defaultOptions.btns;
         if (defaultButtons[6] !== "insertShortcode") {
             defaultButtons.splice(6, 0, "insertShortcode");
@@ -53,12 +53,7 @@
 
         var settings = {
             lang: '@culture.TwoLetterISOLanguageName',
-            semantic: {
-                'b': 'strong',
-                'i': 'em',
-                's': 'del',
-                'strike': 'del'
-            }
+            semantic: false
         }
 
         $('#@Html.IdFor(m => m.Html)').trumbowyg(settings).on('tbwchange', function() {

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPart-Wysiwyg.Edit.cshtml
@@ -16,32 +16,32 @@
     @if (culture.IsRightToLeft())
     {
         <div style="text-align:right">
-            <textarea asp-for="Html" rows="5" class="form-control"></textarea>
+            <textarea asp-for="Html"></textarea>
         </div>
     }
     else
     {
-        <textarea asp-for="Html" rows="5" class="form-control"></textarea>
+        <textarea asp-for="Html"></textarea>
     }
     <span class="hint">@T["The body of the content item."]</span>
 </div>
 
 
 <script at="Foot">
-    $(function () {
+    $(function() {
         @* set dir while keeping trumbowg translations dictionary intact *@
         @if (culture.GetLanguageDirection() == LanguageDirection.RTL)
         {
             <text>
-            var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
+                var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
 
-            if (!langs) {
-                cloned = { 
-                    ...jQuery.trumbowyg.langs['en'],
-                    _dir: '@culture.GetLanguageDirection()'
-                };
-                jQuery.trumbowyg.langs['@culture.TwoLetterISOLanguageName'] = cloned;
-            }
+                if (!langs) {
+                    cloned = {
+                        ...jQuery.trumbowyg.langs['en'],
+                        _dir: '@culture.GetLanguageDirection()'
+                    };
+                    jQuery.trumbowyg.langs['@culture.TwoLetterISOLanguageName'] = cloned;
+                }
             </text>
         }
 
@@ -50,12 +50,18 @@
         if (defaultButtons[6] !== "insertShortcode") {
             defaultButtons.splice(6, 0, "insertShortcode");
         }
-                
-        var settings = { 
-            lang: '@culture.TwoLetterISOLanguageName'
+
+        var settings = {
+            lang: '@culture.TwoLetterISOLanguageName',
+            semantic: {
+                'b': 'strong',
+                'i': 'em',
+                's': 'del',
+                'strike': 'del'
+            }
         }
 
-        $('#@Html.IdFor(m => m.Html)').trumbowyg(settings).on('tbwchange', function () {
+        $('#@Html.IdFor(m => m.Html)').trumbowyg(settings).on('tbwchange', function() {
             $(document).trigger('contentpreview:render');
         });
     });


### PR DESCRIPTION
Fix #12049


From the semantic section in [Trumbowyg docx](https://alex-d.github.io/Trumbowyg/documentation/#semantic)

Since 2.12.0 you can also put an object to customize the semantic tag mapping for each one of these tags: `<b>, <i>, <s>, <strike>, <div>`.

The `semantic` option is set to `true` by default which is equivalent to:
```
$('.trumbowyg').trumbowyg({
    semantic: {
        'b': 'strong',
        'i': 'em',
        's': 'del',
        'strike': 'del',
        'div': 'p'
    }
});
```

To prevent the `div` from being converted into `p` we should set the semantic settings like this

```
$('.trumbowyg').trumbowyg({
    semantic: {
        'b': 'strong',
        'i': 'em',
        's': 'del',
        'strike': 'del'
    }
});
```

