### PR TITLE
Reduce memory when reloading settings of a given tenant from database.

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Configuration/IShellsSettingsSources.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Configuration/IShellsSettingsSources.cs
@@ -7,6 +7,7 @@ namespace OrchardCore.Environment.Shell.Configuration
     public interface IShellsSettingsSources
     {
         Task AddSourcesAsync(IConfigurationBuilder builder);
+        Task AddSourcesAsync(string tenant, IConfigurationBuilder builder);
         Task SaveAsync(string tenant, IDictionary<string, string> data);
     }
 
@@ -15,6 +16,12 @@ namespace OrchardCore.Environment.Shell.Configuration
         public static async Task<IConfigurationBuilder> AddSourcesAsync(this IConfigurationBuilder builder, IShellsSettingsSources sources)
         {
             await sources.AddSourcesAsync(builder);
+            return builder;
+        }
+
+        public static async Task<IConfigurationBuilder> AddSourcesAsync(this IConfigurationBuilder builder, string tenant, IShellsSettingsSources sources)
+        {
+            await sources.AddSourcesAsync(tenant, builder);
             return builder;
         }
     }

--- a/src/OrchardCore/OrchardCore.Shells.Azure/Configuration/BlobShellsSettingsSources.cs
+++ b/src/OrchardCore/OrchardCore.Shells.Azure/Configuration/BlobShellsSettingsSources.cs
@@ -51,6 +51,8 @@ namespace OrchardCore.Shells.Azure.Configuration
             }
         }
 
+        public Task AddSourcesAsync(string tenant, IConfigurationBuilder builder) => AddSourcesAsync(builder);
+
         public async Task SaveAsync(string tenant, IDictionary<string, string> data)
         {
             JObject tenantsSettings;

--- a/src/OrchardCore/OrchardCore/Shell/Configuration/ShellsSettingsSources.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Configuration/ShellsSettingsSources.cs
@@ -23,6 +23,8 @@ namespace OrchardCore.Environment.Shell.Configuration
             return Task.CompletedTask;
         }
 
+        public Task AddSourcesAsync(string tenant, IConfigurationBuilder builder) => AddSourcesAsync(builder);
+
         public async Task SaveAsync(string tenant, IDictionary<string, string> data)
         {
             JObject tenantsSettings;

--- a/src/OrchardCore/OrchardCore/Shell/ShellSettingsManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellSettingsManager.cs
@@ -118,7 +118,7 @@ namespace OrchardCore.Environment.Shell
                 await EnsureConfigurationAsync();
 
                 var tenantsSettings = (await new ConfigurationBuilder()
-                    .AddSourcesAsync(_settingsSources))
+                    .AddSourcesAsync(tenant, _settingsSources))
                     .Build();
 
                 var tenantSettings = new ConfigurationBuilder()


### PR DESCRIPTION
Fixes #11965 

Among our tenant config/settings sources, one of them is by default the `tenants.json` file. In fact **when we reload a given tenant** we don't need all data from this source but only those related to this tenant.

When we add this source to the config stack of a given tenant, if we still use `builder.AddJsonFile()` we have no choice, we can't split this file in smaller parts per tenant.

But when this source comes from the database, we do a `builder.AddJsonStream()` on a `MemoryStream` that holds all data of this source, so here **the idea is to only hold in memory the data related to this tenant**.

To do so I added a method to the interface of this source allowing to pass a tenant name.

So that when the source comes from the database, each time we reload a specified tenant we still create a `MemoryStream` but that only holds the data related to this tenant (not all tenants).

When calling this new method on the other implementations of this source, they just ignore the provided tenant name by calling the existing method without this parameter.

---

Note: Maybe something to do in `BlobShellsSettingsSources` when we do `builder.AddJsonStream()`.

---

@ShaneCourtrille Can you give it a try if you have time?

