### PR TITLE
Tenant names checking tweaks

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/AdminController.cs
@@ -86,7 +86,7 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
@@ -105,7 +105,7 @@ namespace OrchardCore.Tenants.Controllers
                         Description = x["Description"],
                         Name = x.Name,
                         ShellSettings = x,
-                        IsDefaultTenant = String.Equals(x.Name, ShellHelper.DefaultShellName, StringComparison.OrdinalIgnoreCase)
+                        IsDefaultTenant = x.Name == ShellHelper.DefaultShellName,
                     };
 
                     if (x.State == TenantState.Uninitialized && !String.IsNullOrEmpty(x["Secret"]))
@@ -230,7 +230,7 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
@@ -239,11 +239,7 @@ namespace OrchardCore.Tenants.Controllers
 
             foreach (var tenantName in model.TenantNames ?? Enumerable.Empty<string>())
             {
-                var shellSettings = allSettings
-                    .Where(x => String.Equals(x.Name, tenantName, StringComparison.OrdinalIgnoreCase))
-                    .FirstOrDefault();
-
-                if (shellSettings == null)
+                if (!_shellHost.TryGetSettings(tenantName, out var shellSettings))
                 {
                     break;
                 }
@@ -251,7 +247,7 @@ namespace OrchardCore.Tenants.Controllers
                 switch (model.BulkAction.ToString())
                 {
                     case "Disable":
-                        if (String.Equals(shellSettings.Name, ShellHelper.DefaultShellName, StringComparison.OrdinalIgnoreCase))
+                        if (shellSettings.Name == ShellHelper.DefaultShellName)
                         {
                             await _notifier.WarningAsync(H["You cannot disable the default tenant."]);
                         }
@@ -295,7 +291,7 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
@@ -336,7 +332,7 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
@@ -387,16 +383,12 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
 
-            var shellSettings = _shellHost.GetAllSettings()
-                .Where(x => String.Equals(x.Name, id, StringComparison.OrdinalIgnoreCase))
-                .FirstOrDefault();
-
-            if (shellSettings == null)
+            if (!_shellHost.TryGetSettings(id, out var shellSettings))
             {
                 return NotFound();
             }
@@ -443,7 +435,7 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
@@ -453,11 +445,7 @@ namespace OrchardCore.Tenants.Controllers
                 await ValidateViewModelAsync(model, false);
             }
 
-            var shellSettings = _shellHost.GetAllSettings()
-                .Where(x => String.Equals(x.Name, model.Name, StringComparison.OrdinalIgnoreCase))
-                .FirstOrDefault();
-
-            if (shellSettings == null)
+            if (!_shellHost.TryGetSettings(model.Name, out var shellSettings))
             {
                 return NotFound();
             }
@@ -516,21 +504,17 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
 
-            var shellSettings = _shellHost.GetAllSettings()
-                .Where(s => String.Equals(s.Name, id, StringComparison.OrdinalIgnoreCase))
-                .FirstOrDefault();
-
-            if (shellSettings == null)
+            if (!_shellHost.TryGetSettings(id, out var shellSettings))
             {
                 return NotFound();
             }
 
-            if (String.Equals(shellSettings.Name, ShellHelper.DefaultShellName, StringComparison.OrdinalIgnoreCase))
+            if (shellSettings.Name == ShellHelper.DefaultShellName)
             {
                 await _notifier.ErrorAsync(H["You cannot disable the default tenant."]);
                 return RedirectToAction(nameof(Index));
@@ -556,16 +540,12 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
 
-            var shellSettings = _shellHost.GetAllSettings()
-                .Where(x => String.Equals(x.Name, id, StringComparison.OrdinalIgnoreCase))
-                .FirstOrDefault();
-
-            if (shellSettings == null)
+            if (!_shellHost.TryGetSettings(id, out var shellSettings))
             {
                 return NotFound();
             }
@@ -589,16 +569,12 @@ namespace OrchardCore.Tenants.Controllers
                 return Forbid();
             }
 
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
 
-            var shellSettings = _shellHost.GetAllSettings()
-                .Where(x => String.Equals(x.Name, id, StringComparison.OrdinalIgnoreCase))
-                .FirstOrDefault();
-
-            if (shellSettings == null)
+            if (!_shellHost.TryGetSettings(id, out var shellSettings))
             {
                 return NotFound();
             }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -76,7 +76,7 @@ namespace OrchardCore.Tenants.Controllers
         [Route("create")]
         public async Task<IActionResult> Create(CreateApiViewModel model)
         {
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return Forbid();
             }
@@ -132,7 +132,7 @@ namespace OrchardCore.Tenants.Controllers
         [Route("setup")]
         public async Task<ActionResult> Setup(SetupApiViewModel model)
         {
-            if (!_currentShellSettings.IsDefaultShell())
+            if (_currentShellSettings.Name != ShellHelper.DefaultShellName)
             {
                 return this.ChallengeOrForbid("Api");
             }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -18,20 +18,17 @@ namespace OrchardCore.Tenants.Services
         private readonly IShellHost _shellHost;
         private readonly IFeatureProfilesService _featureProfilesService;
         private readonly IEnumerable<DatabaseProvider> _databaseProviders;
-        private readonly ShellSettings _shellSettings;
         private readonly IStringLocalizer<TenantValidator> S;
 
         public TenantValidator(
             IShellHost shellHost,
             IFeatureProfilesService featureProfilesService,
             IEnumerable<DatabaseProvider> databaseProviders,
-            ShellSettings shellSettings,
             IStringLocalizer<TenantValidator> stringLocalizer)
         {
             _shellHost = shellHost;
             _featureProfilesService = featureProfilesService;
             _databaseProviders = databaseProviders;
-            _shellSettings = shellSettings;
             S = stringLocalizer;
         }
 
@@ -64,7 +61,7 @@ namespace OrchardCore.Tenants.Services
                 errors.Add(new ModelError(nameof(model.Name), S["Invalid tenant name. Must contain characters only and no spaces."]));
             }
 
-            if (!_shellSettings.IsDefaultShell() && String.IsNullOrWhiteSpace(model.RequestUrlHost) && String.IsNullOrWhiteSpace(model.RequestUrlPrefix))
+            if (String.IsNullOrWhiteSpace(model.RequestUrlHost) && String.IsNullOrWhiteSpace(model.RequestUrlPrefix))
             {
                 errors.Add(new ModelError(nameof(model.RequestUrlPrefix), S["Host and url prefix can not be empty at the same time."]));
             }
@@ -77,16 +74,14 @@ namespace OrchardCore.Tenants.Services
                 }
             }
 
-            var allSettings = _shellHost.GetAllSettings();
-
-            if (model.IsNewTenant && allSettings.Any(tenant => String.Equals(tenant.Name, model.Name, StringComparison.OrdinalIgnoreCase)))
+            if (_shellHost.TryGetSettings(model.Name, out var settings) && model.IsNewTenant)
             {
                 errors.Add(new ModelError(nameof(model.Name), S["A tenant with the same name already exists."]));
             }
 
-            var allOtherShells = allSettings.Where(t => !String.Equals(t.Name, model.Name, StringComparison.OrdinalIgnoreCase));
+            var allOtherSettings = _shellHost.GetAllSettings().Where(s => s != settings);
 
-            if (allOtherShells.Any(tenant => String.Equals(tenant.RequestUrlPrefix, model.RequestUrlPrefix?.Trim(), StringComparison.OrdinalIgnoreCase) && DoesUrlHostExist(tenant.RequestUrlHost, model.RequestUrlHost)))
+            if (allOtherSettings.Any(tenant => String.Equals(tenant.RequestUrlPrefix, model.RequestUrlPrefix?.Trim(), StringComparison.OrdinalIgnoreCase) && DoesUrlHostExist(tenant.RequestUrlHost, model.RequestUrlHost)))
             {
                 errors.Add(new ModelError(nameof(model.RequestUrlPrefix), S["A tenant with the same host and prefix already exists."]));
             }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellSettings.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/ShellSettings.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
@@ -75,8 +74,5 @@ namespace OrchardCore.Environment.Shell
         }
 
         public Task EnsureConfigurationAsync() => _configuration.EnsureConfigurationAsync();
-
-        public bool IsDefaultShell()
-            => String.Equals(Name, ShellHelper.DefaultShellName, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
@@ -21,6 +21,8 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
 
         [Theory]
         [InlineData("Tenant1", "tenant1", "", "Feature Profile", new[] { "A tenant with the same name already exists." })]
+        [InlineData("tEnAnT1", "tenant1", "", "Feature Profile", new[] { "A tenant with the same name already exists." })]
+        [InlineData("dEfAuLt", "", "", "Feature Profile", new[] { "The tenant name is in conflict with the 'Default' tenant." })]
         [InlineData("Tenant5", "tenant3", "", "Feature Profile", new[] { "A tenant with the same host and prefix already exists." })]
         [InlineData("Tenant5", "tenant3", null, "Feature Profile", new[] { "A tenant with the same host and prefix already exists." })]
         [InlineData("Tenant5", "", "example2.com", "Feature Profile", new[] { "A tenant with the same host and prefix already exists." })]

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
 {
     public class TenantValidatorTests
     {
-        private readonly IList<ShellSettings> _shellSettings = new List<ShellSettings>();
+        private readonly Dictionary<string, ShellSettings> _shellSettings = new(StringComparer.OrdinalIgnoreCase);
 
         public TenantValidatorTests() => SeedTenants();
 
@@ -39,7 +39,7 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
         public async Task TenantValidationFailsIfInvalidConfigurationsWasProvided(string name, string urlPrefix, string hostName, string featureProfile, string[] errorMessages)
         {
             // Arrange
-            var tenantValidator = CreateTenantValidator(defaultTenant: false);
+            var tenantValidator = CreateTenantValidator();
 
             // Act & Assert
             var viewModel = new EditTenantViewModel
@@ -87,10 +87,16 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
             Assert.Equal("A tenant with the same host and prefix already exists.", errors.Single().Message);
         }
 
-        private TenantValidator CreateTenantValidator(bool defaultTenant = true)
+        private delegate bool MockShellHostTryGetSettings(string name, out ShellSettings settings);
+
+        private TenantValidator CreateTenantValidator()
         {
             var shellHostMock = new Mock<IShellHost>();
-            shellHostMock.Setup(h => h.GetAllSettings()).Returns(_shellSettings);
+            shellHostMock.Setup(h => h.GetAllSettings()).Returns(_shellSettings.Values.ToArray());
+
+            shellHostMock.Setup(h => h.TryGetSettings(It.IsAny<string>(), out It.Ref<ShellSettings>.IsAny))
+                .Returns(new MockShellHostTryGetSettings((string name, out ShellSettings shellSettings) =>
+                    _shellSettings.TryGetValue(name, out shellSettings)));
 
             var featureProfilesServiceMock = new Mock<IFeatureProfilesService>();
             featureProfilesServiceMock.Setup(fp => fp.GetFeatureProfilesAsync())
@@ -107,25 +113,20 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
                 .Setup(l => l[It.IsAny<string>(), It.IsAny<object[]>()])
                 .Returns<string, object[]>((n, a) => new LocalizedString(n, n));
 
-            var shellSettings = defaultTenant
-                ? _shellSettings.First()
-                : new ShellSettings();
-
             return new TenantValidator(
                 shellHostMock.Object,
                 featureProfilesServiceMock.Object,
                 Enumerable.Empty<DatabaseProvider>(),
-                shellSettings,
                 stringLocalizerMock.Object);
         }
 
         private void SeedTenants()
         {
-            _shellSettings.Add(new ShellSettings{ Name = ShellHelper.DefaultShellName });
-            _shellSettings.Add(new ShellSettings { Name = "Tenant1" });
-            _shellSettings.Add(new ShellSettings { Name = "Tenant2", RequestUrlPrefix = String.Empty, RequestUrlHost = "example2.com" });
-            _shellSettings.Add(new ShellSettings { Name = "Tenant3", RequestUrlPrefix = "tenant3", RequestUrlHost = String.Empty });
-            _shellSettings.Add(new ShellSettings { Name = "Tenant4", RequestUrlPrefix = "tenant4", RequestUrlHost = "example4.com,example5.com" });
+            _shellSettings.Add(ShellHelper.DefaultShellName, new ShellSettings { Name = ShellHelper.DefaultShellName });
+            _shellSettings.Add("Tenant1", new ShellSettings { Name = "Tenant1" });
+            _shellSettings.Add("Tenant2", new ShellSettings { Name = "Tenant2", RequestUrlPrefix = String.Empty, RequestUrlHost = "example2.com" });
+            _shellSettings.Add("Tenant3", new ShellSettings { Name = "Tenant3", RequestUrlPrefix = "tenant3", RequestUrlHost = String.Empty });
+            _shellSettings.Add("Tenant4", new ShellSettings { Name = "Tenant4", RequestUrlPrefix = "tenant4", RequestUrlHost = "example4.com,example5.com" });
         }
     }
 }


### PR DESCRIPTION
Related to the following PRs #11435 #11822 #12114 (closed) #12120 (merged).

@hishamco @CrestApps 

Here a summary of what we already discussed in the above related PRs.

And knowing for example that the shellHost inner dictionaries now are case insensitive.

Quickly done and not tried yet, for now just to show what I meant.

Will comment it more as needed.
