### PR TITLE
Default Shell State Consistency

### DIFF
--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -60,8 +60,15 @@ namespace OrchardCore.Modules
 
             if (_options.ShellWarmup)
             {
-                // Ensure all ShellContext are loaded and available.
-                await _shellHost.InitializeAsync();
+                try
+                {
+                    // Ensure all tenants are pre-loaded.
+                    await _shellHost.InitializeAsync();
+                }
+                catch (Exception ex) when (!ex.IsFatal())
+                {
+                    _logger.LogError(ex, "Failed to warm up the tenants from '{ServiceName}'.", nameof(ModularBackgroundService));
+                }
             }
 
             while (GetRunningShells().Count() < 1)
@@ -93,7 +100,7 @@ namespace OrchardCore.Modules
                 }
                 catch (Exception ex) when (!ex.IsFatal())
                 {
-                    _logger.LogError(ex, "Error while executing '{ServiceName}'", nameof(ModularBackgroundService));
+                    _logger.LogError(ex, "Error while executing '{ServiceName}'.", nameof(ModularBackgroundService));
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
@@ -104,7 +104,7 @@ namespace OrchardCore.Environment.Shell.Distributed
                         var defaultSettings = await _shellSettingsManager.LoadSettingsAsync(ShellHelper.DefaultShellName);
                         if (defaultSettings.State == TenantState.Running)
                         {
-                            // If the default tenant is running, keep it in sync by reloading it locally.
+                            // If the default tenant has been setup, keep it in sync locally by reloading it.
                             await _shellHost.ReloadShellContextAsync(defaultContext.Settings, eventSource: false);
                         }
 

--- a/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
@@ -65,7 +65,7 @@ namespace OrchardCore.Environment.Shell.Distributed
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             // The syncing period in seconds of the default tenant while it is 'Uninitialized'.
-            const int DefaultTenantSyncingPeriod = 25;
+            const int DefaultTenantSyncingPeriod = 20;
 
             stoppingToken.Register(() =>
             {
@@ -99,16 +99,16 @@ namespace OrchardCore.Environment.Shell.Distributed
                         ? defaultTenantSyncingPeriod++
                         : 0;
 
-                    // Check periodically if the default tenant is no more 'Uninitialized'.
+                    // Check periodically if the default tenant is still 'Uninitialized'.
                     if (defaultTenantSyncingPeriod++ > DefaultTenantSyncingPeriod)
                     {
                         defaultTenantSyncingPeriod = 0;
 
-                        // Load the shared state of the default tenant that may have been setup by another instance.
+                        // Load the settings of the default tenant that may have been setup by another instance.
                         var defaultSettings = await _shellSettingsManager.LoadSettingsAsync(ShellHelper.DefaultShellName);
-                        if (defaultSettings.State == TenantState.Running || defaultSettings.State == TenantState.Disabled)
+                        if (defaultSettings.State == TenantState.Running)
                         {
-                            // If the default tenant has been setup, keep it in sync locally by reloading it.
+                            // If the default tenant has been setup by another instance, reload it locally.
                             await _shellHost.ReloadShellContextAsync(defaultContext.Settings, eventSource: false);
                         }
 

--- a/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
@@ -22,6 +22,9 @@ namespace OrchardCore.Environment.Shell.Distributed
         private const string ReleaseIdKeySuffix = "_RELEASE_ID";
         private const string ReloadIdKeySuffix = "_RELOAD_ID";
 
+        // The syncing period in seconds of the default tenant while it is uninitialized.
+        private const int DefaultTenantSyncingPeriod = 25;
+
         private static readonly TimeSpan MinIdleTime = TimeSpan.FromSeconds(1);
         private static readonly TimeSpan MaxRetryTime = TimeSpan.FromMinutes(1);
         private static readonly TimeSpan MaxBusyTime = TimeSpan.FromSeconds(2);
@@ -72,6 +75,9 @@ namespace OrchardCore.Environment.Shell.Distributed
             // Init the idle time.
             var idleTime = MinIdleTime;
 
+            // Init the syncing period of the default tenant while it is uninitialized.
+            var defaultTenantSyncingPeriod = 0;
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 try
@@ -82,12 +88,36 @@ namespace OrchardCore.Environment.Shell.Distributed
                         break;
                     }
 
-                    // If there is no default tenant or it is not running, nothing to do.
-                    if (!_shellHost.TryGetShellContext(ShellHelper.DefaultShellName, out var defaultContext) ||
-                        defaultContext.Settings.State != TenantState.Running)
+                    // If there is no default tenant, nothing to do.
+                    if (!_shellHost.TryGetShellContext(ShellHelper.DefaultShellName, out var defaultContext))
                     {
                         continue;
                     }
+
+                    // If the default tenant is uninitialized, check its shared state periodically.
+                    if (defaultContext.Settings.State == TenantState.Uninitialized &&
+                        defaultTenantSyncingPeriod++ > DefaultTenantSyncingPeriod)
+                    {
+                        defaultTenantSyncingPeriod = 0;
+
+                        // Load the shared state of the default tenant that may have been setup by another instance.
+                        var defaultSettings = await _shellSettingsManager.LoadSettingsAsync(ShellHelper.DefaultShellName);
+                        if (defaultSettings.State == TenantState.Running)
+                        {
+                            // If the default tenant is running, keep it in sync by reloading it locally.
+                            await _shellHost.ReloadShellContextAsync(defaultContext.Settings, eventSource: false);
+                        }
+
+                        continue;
+                    }
+
+                    // If the default tenant is not running, nothing to do.
+                    if (defaultContext.Settings.State != TenantState.Running)
+                    {
+                        continue;
+                    }
+
+                    defaultTenantSyncingPeriod = 0;
 
                     // Get or create a new distributed context if the default tenant has changed.
                     var context = await GetOrCreateDistributedContextAsync(defaultContext);

--- a/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
@@ -75,8 +75,8 @@ namespace OrchardCore.Environment.Shell.Distributed
             // Init the idle time.
             var idleTime = MinIdleTime;
 
-            // Init the syncing period of the default tenant while it is 'Uninitialized'.
-            var defaultTenantSyncingPeriod = 0;
+            // Init the second counter used to sync the default tenant while it is 'Uninitialized'.
+            var defaultTenantSyncingSeconds = 0;
 
             while (!stoppingToken.IsCancellationRequested)
             {
@@ -94,15 +94,15 @@ namespace OrchardCore.Environment.Shell.Distributed
                         continue;
                     }
 
-                    // Manage the syncing period of the default tenant while it is 'Uninitialized'.
-                    defaultTenantSyncingPeriod = defaultContext.Settings.State == TenantState.Uninitialized
-                        ? defaultTenantSyncingPeriod++
+                    // Manage the second counter used to sync the default tenant while it is 'Uninitialized'.
+                    defaultTenantSyncingSeconds = defaultContext.Settings.State == TenantState.Uninitialized
+                        ? defaultTenantSyncingSeconds++
                         : 0;
 
                     // Check periodically if the default tenant is still 'Uninitialized'.
-                    if (defaultTenantSyncingPeriod++ > DefaultTenantSyncingPeriod)
+                    if (defaultTenantSyncingSeconds++ > DefaultTenantSyncingPeriod)
                     {
-                        defaultTenantSyncingPeriod = 0;
+                        defaultTenantSyncingSeconds = 0;
 
                         // Load the settings of the default tenant that may have been setup by another instance.
                         var defaultSettings = await _shellSettingsManager.LoadSettingsAsync(ShellHelper.DefaultShellName);

--- a/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellHost.cs
@@ -67,11 +67,11 @@ namespace OrchardCore.Environment.Shell
                 if (!_initialized)
                 {
                     await PreCreateAndRegisterShellsAsync();
+                    _initialized = true;
                 }
             }
             finally
             {
-                _initialized = true;
                 _initializingSemaphore.Release();
             }
         }


### PR DESCRIPTION
In a multi instances env with tenant settings coming from a shared source as the database, if it fails due to a bad connection or the absence of the needed table, the `Default` tenant is in an inconsistent state.

Not a big issue when we work with only one OC instance (just needs to be restarted), and this is what we recommend before having setup the `Default` tenant on which we rely e.g. to keep in sync tenants.

But while testing the Tenant Removal with a local K8S deployment allowing multiple OC replicas, when I forget to specify only one OC replica before a fresh setup, it is less easy to find the OC pods to restart.

So here the main point is when `_shellSettingsManager.LoadSettingsAsync()` fails from different places.

- When it fails from `ShellHost.InitializeAsync()`, here we still let the exception be thrown but we don't mark the `ShellHost` as `_initialized`, so that when the database connection/table are okay, on a new request we can create a setup context and render the setup form in place of a blank page.

- We also call `_shellHost.InitializeAsync()` In `ModularBackgroundService` if the `.ShellWarmup` option is true, here we use a try/catch block to log an error but without interrupting the background service, so that when the Default tenant is finally setup the background service will start its periodic loop.

- TODO: In a multi instances env, the `Default` setup form may be rendered by one instance, but the setup executed by another one. In that case the `Default` tenant of the first instance will always be `Uninitialized` because tenant syncing rely on the `Default` tenant being running.

    Here the solution, in `DistributedShellHostedService`, would be to periodically check directly from the shared tenants settings source if the `Default` tenant was setup by another instance.

    Maybe here or in a separate PR. **Updated**: Okay done here.