### PR TITLE
Form & Email attachments

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Email/OrchardCore.Email.csproj
@@ -18,6 +18,8 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Email.Core\OrchardCore.Email.Core.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.FileStorage.FileSystem\OrchardCore.FileStorage.FileSystem.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Media.Abstractions\OrchardCore.Media.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Email/Views/Items/EmailTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Views/Items/EmailTask.Fields.Edit.cshtml
@@ -52,6 +52,22 @@
 
 <div class="mb-3">
     <div class="form-check">
+        <input type="checkbox" class="form-check-input" asp-for="IncludeStoredAttachments" />
+        <label class="form-check-label" asp-for="IncludeStoredAttachments">@T["Include attachments from Save Form Attachments Task."]</label>
+        <span class="hint dashed">@T["If checked, attachments are included into email. They are also stored in predefined folder."]</span>
+    </div>
+</div>
+
+<div class="mb-3">
+    <div class="form-check">
+        <input type="checkbox" class="form-check-input" asp-for="RemoveStoredAttachments" />
+        <label class="form-check-label" asp-for="RemoveStoredAttachments">@T["Remove attachments from Save Form Attachments Task after sending email."]</label>
+        <span class="hint dashed">@T["If checked, attachments are removed from file storage after email is sent."]</span>
+    </div>
+</div>
+
+<div class="mb-3">
+    <div class="form-check">
         <input type="checkbox" class="form-check-input" asp-for="IsBodyHtml" />
         <label class="form-check-label" asp-for="IsBodyHtml">@T["Does the Body contain HTML?"]</label>
         <span class="hint dashed">@T["If checked, indicates the body of the email message will be sent as HTML."]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Activities/EmailTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Activities/EmailTask.cs
@@ -1,8 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.FileStorage;
+using OrchardCore.FileStorage.FileSystem;
+using OrchardCore.Media;
 using OrchardCore.Workflows.Abstractions.Models;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Models;
@@ -16,17 +22,26 @@ namespace OrchardCore.Email.Workflows.Activities
         private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
         private readonly IStringLocalizer S;
         private readonly HtmlEncoder _htmlEncoder;
+        private readonly IFileStore _fileStore;
+        private readonly IOptions<ShellOptions> _shellOptions;
+        readonly ShellSettings _shellSettings;
 
         public EmailTask(
             ISmtpService smtpService,
             IWorkflowExpressionEvaluator expressionEvaluator,
             IStringLocalizer<EmailTask> localizer,
+            IMediaFileStore mediaFileStore,
+            IOptions<ShellOptions> shellOptions,
+            ShellSettings shellSettings,
             HtmlEncoder htmlEncoder
         )
         {
             _smtpService = smtpService;
             _expressionEvaluator = expressionEvaluator;
             S = localizer;
+            _fileStore = mediaFileStore;
+            _shellOptions = shellOptions;
+            _shellSettings = shellSettings;
             _htmlEncoder = htmlEncoder;
         }
 
@@ -101,6 +116,18 @@ namespace OrchardCore.Email.Workflows.Activities
             set => SetProperty(value);
         }
 
+        public bool IncludeStoredAttachments
+        {
+            get => GetProperty(() => true);
+            set => SetProperty(value);
+        }
+
+        public bool RemoveStoredAttachments
+        {
+            get => GetProperty(() => true);
+            set => SetProperty(value);
+        }
+
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
             return Outcomes(S["Done"], S["Failed"]);
@@ -117,6 +144,7 @@ namespace OrchardCore.Email.Workflows.Activities
             var subject = await _expressionEvaluator.EvaluateAsync(Subject, workflowContext, null);
             var body = await _expressionEvaluator.EvaluateAsync(Body, workflowContext, _htmlEncoder);
             var bodyText = await _expressionEvaluator.EvaluateAsync(BodyText, workflowContext, null);
+            IFileStore fileStore = null;
 
             var message = new MailMessage
             {
@@ -131,7 +159,7 @@ namespace OrchardCore.Email.Workflows.Activities
                 Body = body?.Trim(),
                 BodyText = bodyText?.Trim(),
                 IsBodyHtml = IsBodyHtml,
-                IsBodyText = IsBodyText
+                IsBodyText = IsBodyText,
             };
 
             if (!String.IsNullOrWhiteSpace(sender))
@@ -139,7 +167,10 @@ namespace OrchardCore.Email.Workflows.Activities
                 message.Sender = sender.Trim();
             }
 
+            fileStore = await AddMailAttachments(workflowContext, fileStore, message);
             var result = await _smtpService.SendAsync(message);
+            await DeleteStoredAttachments(workflowContext, fileStore, result, message);
+
             workflowContext.LastResult = result;
 
             if (!result.Succeeded)
@@ -148,6 +179,47 @@ namespace OrchardCore.Email.Workflows.Activities
             }
 
             return Outcomes("Done");
+        }
+
+        private async Task DeleteStoredAttachments(WorkflowExecutionContext workflowContext, IFileStore fileStore, SmtpResult result, MailMessage message)
+        {
+            if (RemoveStoredAttachments && result.Succeeded && fileStore != null && workflowContext.Properties.ContainsKey("FormAttachments"))
+            {
+                // close open file streams
+                message.Attachments.ForEach(p => p.Stream.Dispose());
+
+                foreach (var filePath in (List<string>)workflowContext.Properties["FormAttachments"])
+                {
+                    var success = await fileStore?.TryDeleteFileAsync(filePath);
+                }
+            }
+        }
+
+        private async Task<IFileStore> AddMailAttachments(WorkflowExecutionContext workflowContext, IFileStore fileStore, MailMessage message)
+        {
+            if (IncludeStoredAttachments
+                            && workflowContext.Properties.ContainsKey("FormAttachmentsUseMediaFileStore")
+                            && workflowContext.Properties.ContainsKey("FormAttachments"))
+            {
+                bool useMediaFileStore = (bool)workflowContext.Properties["FormAttachmentsUseMediaFileStore"];
+                fileStore = useMediaFileStore ? _fileStore : CreateDefaultFileStore();
+                foreach (var filePath in (List<string>)workflowContext.Properties["FormAttachments"])
+                {
+                    var fileInfo = await fileStore.GetFileInfoAsync(filePath);
+                    var fileStream = await fileStore.GetFileStreamAsync(fileInfo);
+                    message.Attachments.Add(new MailMessageAttachment() { Filename = fileInfo.Name, Stream = fileStream });
+                }
+            }
+
+            return fileStore;
+        }
+
+        private IFileStore CreateDefaultFileStore()
+        {
+            var shell = _shellOptions.Value;
+            var innerPath = PathExtensions.Combine(shell.ShellsContainerName, _shellSettings.Name);
+            var directory = PathExtensions.Combine(shell.ShellsApplicationDataPath, innerPath);
+            return new FileSystemStore(directory);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Drivers/EmailTaskDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Workflows/Drivers/EmailTaskDisplayDriver.cs
@@ -20,6 +20,8 @@ namespace OrchardCore.Email.Workflows.Drivers
             model.IsBodyText = activity.IsBodyText;
             model.BccExpression = activity.Bcc.Expression;
             model.CcExpression = activity.Cc.Expression;
+            model.IncludeStoredAttachments = activity.IncludeStoredAttachments;
+            model.RemoveStoredAttachments = activity.RemoveStoredAttachments;
         }
 
         protected override void UpdateActivity(EmailTaskViewModel model, EmailTask activity)
@@ -35,6 +37,8 @@ namespace OrchardCore.Email.Workflows.Drivers
             activity.IsBodyText = model.IsBodyText;
             activity.Bcc = new WorkflowExpression<string>(model.BccExpression);
             activity.Cc = new WorkflowExpression<string>(model.CcExpression);
+            activity.IncludeStoredAttachments = model.IncludeStoredAttachments;
+            activity.RemoveStoredAttachments = model.RemoveStoredAttachments;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Email/Workflows/ViewModels/EmailTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Workflows/ViewModels/EmailTaskViewModel.cs
@@ -23,5 +23,7 @@ namespace OrchardCore.Email.Workflows.ViewModels
         public bool IsBodyHtml { get; set; }
 
         public bool IsBodyText { get; set; }
+        public bool IncludeStoredAttachments { get; set; }
+        public bool RemoveStoredAttachments { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SaveFormAttachmentsTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SaveFormAttachmentsTask.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
+using OrchardCore.Environment.Shell;
+using OrchardCore.FileStorage;
+using OrchardCore.FileStorage.FileSystem;
+using OrchardCore.Media;
+using OrchardCore.Workflows.Abstractions.Models;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Services;
+
+namespace OrchardCore.Workflows.Activities
+{
+    public class SaveFormAttachmentsTask : TaskActivity
+    {
+        readonly IOptions<ShellOptions> _shellOptions;
+        protected readonly IStringLocalizer S;
+        readonly ShellSettings _shellSettings;
+        private readonly IFileStore _fileStore;
+        private readonly IHttpContextAccessor _http;
+        private readonly IWorkflowExpressionEvaluator _expressionEvaluator;
+
+        public SaveFormAttachmentsTask(
+            IWorkflowExpressionEvaluator expressionEvaluator,
+            IStringLocalizer<SaveFormAttachmentsTask> localizer,
+            IOptions<ShellOptions> shellOptions,
+            ShellSettings shellSettings,
+            IMediaFileStore mediaFileStore,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _shellOptions = shellOptions;
+            _shellSettings = shellSettings;
+            _fileStore = mediaFileStore;
+            _http = httpContextAccessor;
+            S = localizer;
+            _expressionEvaluator = expressionEvaluator;
+        }
+
+        public override string Name => nameof(SaveFormAttachmentsTask);
+
+        public override LocalizedString DisplayText => S["Save Form Attachments Task"];
+
+        public override LocalizedString Category => S["UI"];
+
+        public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            return Outcomes(S["Done"]);
+        }
+
+        public override bool CanExecute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            return _http.HttpContext?.Request?.Form != null;
+        }
+
+        public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+        {
+            // use either configured mediaFileStore or create new FileSystemStore --> TODO: mediaFileStore does not resolve permissions, everything is in public folders and can be accessible.
+            // to put files in different folder, we would need either to register some private MediaFileStore, or allow to specify folder outside base path (?)
+            var fileStore = UseMediaFileStore ? _fileStore : CreateDefaultFileStore();
+            var filePaths = new List<string>();
+            foreach (var file in _http.HttpContext.Request.Form.Files)
+            {
+                var filePath = PathExtensions.Combine(Folder, $"{workflowContext.WorkflowId}-{file.FileName}");
+                filePaths.Add(await fileStore.CreateFileFromStreamAsync(filePath, file.OpenReadStream()));
+            }
+
+            workflowContext.Properties["FormAttachments"] = filePaths;
+            workflowContext.Properties["FormAttachmentsUseMediaFileStore"] = UseMediaFileStore;
+            return Outcomes("Done");
+        }
+
+        public string Folder
+        {
+            get => GetProperty<string>(() => string.Empty);
+            set => SetProperty(value);
+        }
+
+        public bool UseMediaFileStore
+        {
+            get => GetProperty<bool>();
+            set => SetProperty(value);
+        }
+
+        private IFileStore CreateDefaultFileStore()
+        {
+            var shell = _shellOptions.Value;
+            var innerPath = PathExtensions.Combine(shell.ShellsContainerName, _shellSettings.Name);
+            var directory = PathExtensions.Combine(shell.ShellsApplicationDataPath, innerPath);
+
+            // do not include Folder in FileSystemStore path, it is included in file path.
+            var destPath = PathExtensions.Combine(directory, Folder);
+            Directory.CreateDirectory(destPath);
+            return new FileSystemStore(directory);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SaveFormAttachmentsTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/SaveFormAttachmentsTask.cs
@@ -43,7 +43,7 @@ namespace OrchardCore.Workflows.Activities
 
         public override LocalizedString DisplayText => S["Save Form Attachments Task"];
 
-        public override LocalizedString Category => S["UI"];
+        public override LocalizedString Category => S["Media"];
 
         public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
         {
@@ -63,7 +63,7 @@ namespace OrchardCore.Workflows.Activities
             var filePaths = new List<string>();
             foreach (var file in _http.HttpContext.Request.Form.Files)
             {
-                var filePath = PathExtensions.Combine(Folder, $"{workflowContext.WorkflowId}-{file.FileName}");
+                var filePath = fileStore.Combine(Folder, $"{workflowContext.WorkflowId}-{file.FileName}");
                 filePaths.Add(await fileStore.CreateFileFromStreamAsync(filePath, file.OpenReadStream()));
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/SaveFormAttachmentsTaskDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/SaveFormAttachmentsTaskDisplayDriver.cs
@@ -1,0 +1,22 @@
+using OrchardCore.Workflows.Activities;
+using OrchardCore.Workflows.Display;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.ViewModels;
+
+namespace OrchardCore.Workflows.Drivers
+{
+    public class SaveFormAttachmentsTaskDisplayDriver : ActivityDisplayDriver<SaveFormAttachmentsTask, SaveFormAttachmentsTaskViewModel>
+    {
+        protected override void EditActivity(SaveFormAttachmentsTask activity, SaveFormAttachmentsTaskViewModel model)
+        {
+            model.Folder = activity.Folder;
+            model.UseMediaFileStore = activity.UseMediaFileStore;
+        }
+
+        protected override void UpdateActivity(SaveFormAttachmentsTaskViewModel model, SaveFormAttachmentsTask activity)
+        {
+            activity.Folder = model.Folder;
+            activity.UseMediaFileStore = model.UseMediaFileStore;
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Manifest.cs
@@ -40,3 +40,11 @@ using OrchardCore.Modules.Manifest;
     Dependencies = new[] { "OrchardCore.Workflows" },
     Category = "Workflows"
 )]
+
+[assembly: Feature(
+    Id = "OrchardCore.Workflows.SaveFormAttachments",
+    Name = "Save Form Attachments Activities",
+    Description = "Provides Save Form Attachments activity.",
+    Dependencies = new[] { "OrchardCore.Workflows", "OrchardCore.Media", "OrchardCore.FileStorage" },
+    Category = "Workflows"
+)]

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/OrchardCore.Workflows.csproj
@@ -28,6 +28,8 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Deployment.Abstractions\OrchardCore.Deployment.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement.Liquid\OrchardCore.DisplayManagement.Liquid.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.FileStorage.FileSystem\OrchardCore.FileStorage.FileSystem.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Media.Abstractions\OrchardCore.Media.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Liquid.Abstractions\OrchardCore.Liquid.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Localization.Abstractions\OrchardCore.Localization.Abstractions.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
@@ -143,4 +143,13 @@ namespace OrchardCore.Workflows
             services.AddActivity<CommitTransactionTask, CommitTransactionTaskDisplayDriver>();
         }
     }
+
+    [Feature("OrchardCore.Workflows.SaveFormAttachments")]
+    public class SaveFormAttachmentsStartup : StartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.AddActivity<SaveFormAttachmentsTask, SaveFormAttachmentsTaskDisplayDriver>();
+        }
+    }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/ViewModels/SaveFormAttachmentsTaskViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/ViewModels/SaveFormAttachmentsTaskViewModel.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace OrchardCore.Workflows.ViewModels
+{
+    public class SaveFormAttachmentsTaskViewModel
+    {
+        [Required]
+        public string Folder { get; set; }
+
+        [Required]
+        public bool UseMediaFileStore { get; set; }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/SaveFormAttachmentsTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/SaveFormAttachmentsTask.Fields.Design.cshtml
@@ -1,0 +1,9 @@
+@model OrchardCore.Workflows.ViewModels.ActivityViewModel<SaveFormAttachmentsTask>
+
+
+<header>
+    <h4><i class="fa fa-floppy-o"></i>@Model.Activity.GetTitleOrDefault(() => T["Save form attachments"])</h4>
+</header>
+
+
+@Model.Activity.Folder

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/SaveFormAttachmentsTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/SaveFormAttachmentsTask.Fields.Edit.cshtml
@@ -1,0 +1,14 @@
+@model OrchardCore.Workflows.ViewModels.SaveFormAttachmentsTaskViewModel
+
+<div class="form-group" asp-validation-class-for="Folder">
+    <label asp-for="Folder">@T["Folder name"]</label>
+    <input type="text" asp-for="Folder" class="form-control code" />
+    <span asp-validation-for="Folder"></span>
+    <span class="hint">@T["The folder name. In case of not using media file storage, folder is created under tenant folder."]</span>
+</div>
+
+<div class="mb-3">
+    <input type="checkbox" asp-for="UseMediaFileStore" />
+    <label asp-for="UseMediaFileStore">@T["Use Media File Store"]</label>
+    <span class="hint">@T["If checked, configured media file storage is used. Beware, currently not secured, so your files would be visible."]</span>
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/SaveFormAttachmentsTask.Fields.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/SaveFormAttachmentsTask.Fields.Thumbnail.cshtml
@@ -1,0 +1,2 @@
+<h4 class="card-title"><i class="fa fa-floppy-o"></i>@T["Save form attachments"]</h4>
+<p>@T["Stores attachments from POST request into file system or predefined media file storage. Request has to be of multipart/form-data enctype. Attachments can be consumed by Send Email Task."]</p>

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email/Workflows/EmailTaskTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email/Workflows/EmailTaskTests.cs
@@ -10,6 +10,8 @@ using Moq;
 using OrchardCore.Email;
 using OrchardCore.Email.Services;
 using OrchardCore.Email.Workflows.Activities;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Media;
 using OrchardCore.Workflows.Models;
 using OrchardCore.Workflows.Services;
 using Xunit;
@@ -28,6 +30,9 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Email.Workflows
                 smtpService,
                 new SimpleWorkflowExpressionEvaluator(),
                 Mock.Of<IStringLocalizer<EmailTask>>(),
+                Mock.Of<IMediaFileStore>(),
+                Mock.Of<IOptions<ShellOptions>>(),
+                Mock.Of<ShellSettings>(),
                 HtmlEncoder.Default)
             {
                 Subject = new WorkflowExpression<string>("Test"),


### PR DESCRIPTION
Fixes #5108, fixes #6027. Related to some other tasks. 

I have created task to store attachments from OrchardCore Forms (or POST requests using multipart/form-data). It is based on code from #6027 and enhanced, still it is more like a POC, but completely working & tested. Feel free to merge or finish what is needed, I might have some time to do customizations also.

Can be used in workflows for sending mails, or just to store files without sending.
![image](https://user-images.githubusercontent.com/52829889/185352276-3dbb3f6b-4a1f-46d0-8c08-90a0570d755a.png)

Inside task, you can configure if you want files to be stored in configured media storage or custom path in App_Data/Tenant/Folder

![image](https://user-images.githubusercontent.com/52829889/185352440-27c41e96-052c-4ea9-8bc7-3297eae20a91.png)

In existing Email task there are two new checkboxes to configure this functionality. You can enable/disable sending attachments and choose if you want to remove files after sending (you may want to keep them, if you log your emails somewhere).

![image](https://user-images.githubusercontent.com/52829889/185352550-d156ae43-f21b-4028-8b4e-fa2c815aba8b.png)


What I think could be added:

- [ ] Secure folder in default media file storage from public access (currently they are secured in app_data folder when not using media file storage)
- [ ] Attachment size and type limitation
- [ ] Error notifications / output
- [ ] Maybe choose source fields, so we can send multiple mails with different attachments.
- [ ] automatic tests? 
- [ ] strip workflowid prefix from file when sending?