### PR TITLE
Use DateTime to sync the Default tenant while Uninitialized

### DIFF
--- a/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
@@ -95,9 +95,10 @@ namespace OrchardCore.Environment.Shell.Distributed
                     }
 
                     // Manage the 'DateTime' used to sync the default tenant while it is 'Uninitialized'.
-                    defaultTenantSyncingTime = defaultContext.Settings.State == TenantState.Uninitialized
-                        ? defaultTenantSyncingTime
-                        : DateTime.UtcNow;
+                    if (defaultContext.Settings.State != TenantState.Uninitialized)
+                    {
+                        defaultTenantSyncingTime = DateTime.UtcNow;
+                    }
 
                     // Check periodically if the default tenant is still 'Uninitialized'.
                     if (DateTime.UtcNow - defaultTenantSyncingTime > DefaultTenantSyncingPeriod)

--- a/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Environment.Shell.Distributed
         private static readonly TimeSpan MaxRetryTime = TimeSpan.FromMinutes(1);
         private static readonly TimeSpan MaxBusyTime = TimeSpan.FromSeconds(2);
 
-        // The syncing period in seconds of the default tenant while it is 'Uninitialized'.
+        // The syncing period of the default tenant while it is 'Uninitialized'.
         private static readonly TimeSpan DefaultTenantSyncingPeriod = TimeSpan.FromSeconds(20);
 
         private readonly IShellHost _shellHost;


### PR DESCRIPTION
After seeing the last meeting.

For info before it was only counting the execution iterations of the `DistributedShellHostedService` whose period is normally around one second, the min idle time between 2 executions.

    private static readonly TimeSpan MinIdleTime = TimeSpan.FromSeconds(1);

But yes not precise if some executions take relatively longer times, but here we don't need to be precise.

It only allows to sync the Default tenant while it is Uninitialized, knowing that the rest of the tenants syncing relies on the Default tenant being running. So here we check periodically if the Default tenant was setup by another instance, this by loading its settings from the tenants settings source.

**Updated**

@sebastienros Not sure it is worth to merge this PR? The advantage of the current code in the main branch is that it doesn't create a new `DateTime` (and all what the `UtcNow` getter does) on each iteration every second ;) Hmm, and the current code in the main branch is auto-regulated if it takes too much time to check the Default tenant state from the shared settings (e.g. before failing), this by forcing around 20 seconds **between** 2 retries, between the end of the previous retry and the start of a new one..
