### PR TITLE
Clear alternates before morphing Stereotypes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/DashboardWidget.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/DashboardWidget.Edit.cshtml
@@ -1,4 +1,5 @@
 @{
     Model.Metadata.Type = "Content_Edit";
-    @await DisplayAsync(Model)
+    Model.Metadata.Alternates.Clear();
 }
+@await DisplayAsync(Model)

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.Edit.cshtml
@@ -1,4 +1,5 @@
 @{
     Model.Metadata.Type = "Content_Edit";
-    @await DisplayAsync(Model)
+    Model.Metadata.Alternates.Clear();
 }
+@await DisplayAsync(Model)


### PR DESCRIPTION
Fix #12259

The same result could be achieved by removing `Widget.Edit.cshtml` and `DashboardWidget.Edit.cshtml` from the project and let `Stereotype.Edit.cshtml` handle the rendering "since that is what it's made for".

I would rather delete both `Widget.Edit.cshtml` and `DashboardWidget.Edit.cshtml` templates in this case, but not sure if the team want them kept.