### PR TITLE
Adding code for ability to set metadata address in openid validation …

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdValidationConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdValidationConfiguration.cs
@@ -105,6 +105,7 @@ namespace OrchardCore.OpenId.Configuration
             if (settings.Authority != null)
             {
                 options.Issuer = settings.Authority;
+                options.MetadataAddress = settings.MetadataAddress;
                 options.Audiences.Add(settings.Audience);
 
                 // Note: OpenIddict 3.0 only accepts tokens issued with a non-empty token type (e.g "at+jwt")

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
@@ -24,6 +24,7 @@ namespace OrchardCore.OpenId.Drivers
             => Task.FromResult<IDisplayResult>(Initialize<OpenIdValidationSettingsViewModel>("OpenIdValidationSettings_Edit", async model =>
             {
                 model.Authority = settings.Authority?.AbsoluteUri;
+                model.MetadataAddress = settings.MetadataAddress?.AbsoluteUri;
                 model.Audience = settings.Audience;
                 model.DisableTokenTypeValidation = settings.DisableTokenTypeValidation;
                 model.Tenant = settings.Tenant;
@@ -56,6 +57,7 @@ namespace OrchardCore.OpenId.Drivers
             await context.Updater.TryUpdateModelAsync(model, Prefix);
 
             settings.Authority = !string.IsNullOrEmpty(model.Authority) ? new Uri(model.Authority, UriKind.Absolute) : null;
+            settings.MetadataAddress = !string.IsNullOrEmpty(model.MetadataAddress) ? new Uri(model.MetadataAddress, UriKind.Absolute) : null;
             settings.Audience = model.Audience?.Trim();
             settings.DisableTokenTypeValidation = model.DisableTokenTypeValidation;
             settings.Tenant = model.Tenant;

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdValidationSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdValidationSettingsStep.cs
@@ -28,6 +28,7 @@ namespace OrchardCore.OpenId.Recipes
             var settings = await _validationService.LoadSettingsAsync();
 
             settings.Tenant = model.Tenant;
+            settings.MetadataAddress = !string.IsNullOrEmpty(model.MetadataAddress) ? new Uri(model.MetadataAddress, UriKind.Absolute) : null;
             settings.Authority = !string.IsNullOrEmpty(model.Authority) ? new Uri(model.Authority, UriKind.Absolute) : null;
             settings.Audience = model.Audience;
             settings.DisableTokenTypeValidation = model.DisableTokenTypeValidation;

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdValidationSettingsStepModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdValidationSettingsStepModel.cs
@@ -2,6 +2,8 @@ namespace OrchardCore.OpenId.Recipes
 {
     public class OpenIdValidationSettingsStepModel
     {
+
+        public string MetadataAddress { get; set; }
         public string Audience { get; set; }
 
         public string Authority { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdValidationService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdValidationService.cs
@@ -110,14 +110,6 @@ namespace OrchardCore.OpenId.Services
                     }));
                 }
 
-                if (settings.Authority.Scheme != Uri.UriSchemeHttps)
-                {
-                    results.Add(new ValidationResult(S["The specified authority requires the use of HTTPS."], new[]
-                    {
-                        nameof(settings.Authority)
-                    }));
-                }
-
                 if (!String.IsNullOrEmpty(settings.Authority.Query) || !string.IsNullOrEmpty(settings.Authority.Fragment))
                 {
                     results.Add(new ValidationResult(S["The authority cannot contain a query string or a fragment."], new[]
@@ -138,14 +130,6 @@ namespace OrchardCore.OpenId.Services
                     }));
                 }
 
-                if (settings.MetadataAddress.Scheme != Uri.UriSchemeHttps)
-                {
-                    results.Add(new ValidationResult(S["The specified metadata address requires the use of HTTPS."], new[]
-                    {
-                        nameof(settings.MetadataAddress)
-                    }));
-                }
-
                 if (!String.IsNullOrEmpty(settings.MetadataAddress.Query) || !string.IsNullOrEmpty(settings.MetadataAddress.Fragment))
                 {
                     results.Add(new ValidationResult(S["The metadata address cannot contain a query string or a fragment."], new[]
@@ -158,11 +142,10 @@ namespace OrchardCore.OpenId.Services
                 {
                     results.Add(new ValidationResult(S["No metatada address can be set when using another tenant."], new[]
                     {
-                    nameof(settings.MetadataAddress)
-                }));
+                        nameof(settings.MetadataAddress)
+                    }));
                 }
             }
-
 
             if (!String.IsNullOrEmpty(settings.Tenant) && !string.IsNullOrEmpty(settings.Audience))
             {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdValidationService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdValidationService.cs
@@ -110,6 +110,14 @@ namespace OrchardCore.OpenId.Services
                     }));
                 }
 
+                if (settings.Authority.Scheme != Uri.UriSchemeHttps)
+                {
+                    results.Add(new ValidationResult(S["The specified authority requires the use of HTTPS."], new[]
+                    {
+                        nameof(settings.Authority)
+                    }));
+                }
+
                 if (!String.IsNullOrEmpty(settings.Authority.Query) || !string.IsNullOrEmpty(settings.Authority.Fragment))
                 {
                     results.Add(new ValidationResult(S["The authority cannot contain a query string or a fragment."], new[]
@@ -117,7 +125,44 @@ namespace OrchardCore.OpenId.Services
                         nameof(settings.Authority)
                     }));
                 }
+
             }
+
+            if (settings.MetadataAddress != null)
+            {
+                if (!settings.MetadataAddress.IsAbsoluteUri || !settings.MetadataAddress.IsWellFormedOriginalString())
+                {
+                    results.Add(new ValidationResult(S["The specified metadata address is not valid."], new[]
+                    {
+                        nameof(settings.MetadataAddress)
+                    }));
+                }
+
+                if (settings.MetadataAddress.Scheme != Uri.UriSchemeHttps)
+                {
+                    results.Add(new ValidationResult(S["The specified metadata address requires the use of HTTPS."], new[]
+                    {
+                        nameof(settings.MetadataAddress)
+                    }));
+                }
+
+                if (!String.IsNullOrEmpty(settings.MetadataAddress.Query) || !string.IsNullOrEmpty(settings.MetadataAddress.Fragment))
+                {
+                    results.Add(new ValidationResult(S["The metadata address cannot contain a query string or a fragment."], new[]
+                    {
+                        nameof(settings.MetadataAddress)
+                    }));
+                }
+
+                if (!String.IsNullOrEmpty(settings.Tenant))
+                {
+                    results.Add(new ValidationResult(S["No metatada address can be set when using another tenant."], new[]
+                    {
+                    nameof(settings.MetadataAddress)
+                }));
+                }
+            }
+
 
             if (!String.IsNullOrEmpty(settings.Tenant) && !string.IsNullOrEmpty(settings.Audience))
             {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdValidationSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdValidationSettings.cs
@@ -8,5 +8,8 @@ namespace OrchardCore.OpenId.Settings
         public Uri Authority { get; set; }
         public bool DisableTokenTypeValidation { get; set; }
         public string Tenant { get; set; }
+#nullable enable
+        public Uri? MetadataAddress { get; set; }
+#nullable disable
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdValidationSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdValidationSettings.cs
@@ -8,8 +8,7 @@ namespace OrchardCore.OpenId.Settings
         public Uri Authority { get; set; }
         public bool DisableTokenTypeValidation { get; set; }
         public string Tenant { get; set; }
-#nullable enable
-        public Uri? MetadataAddress { get; set; }
-#nullable disable
+        public Uri MetadataAddress { get; set; }
+
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdValidationSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdValidationSettingsViewModel.cs
@@ -6,6 +6,9 @@ namespace OrchardCore.OpenId.ViewModels
     public class OpenIdValidationSettingsViewModel
     {
         [Url]
+        public string MetadataAddress { get; set; }
+
+        [Url]
         public string Authority { get; set; }
 
         public string Audience { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
@@ -25,14 +25,14 @@
     <label asp-for="Authority">@T["Authority"]</label>
     <input asp-for="Authority" class="form-control" />
     <span asp-validation-for="Authority"></span>
-    <span class="hint">@T["The address of the remote OpenID Connect server. Using a HTTPS address is strongly recommended."]</span>
+    <span class="hint">@T["The address of the remote OpenID Connect server. An HTTPS address is required."]</span>
 </div>
 
 <div class="mb-3" asp-validation-class-for="MetadataAddress">
-    <label asp-for="MetadataAddress">@T["Well Known Metadata Address"]</label>
+    <label asp-for="MetadataAddress">@T["OpenID Connect Metadata Address"]</label>
     <input asp-for="MetadataAddress" class="form-control" />
     <span asp-validation-for="MetadataAddress"></span>
-    <span class="hint">@T["The address of the metatdata endpoint. Optional. (https://{your base url}/.well-known/openid-configuration)"]</span>
+    <span class="hint">@T["The well-formed URI of the OpenID Connect Metadata Address endpoint. This is only for advanced scenarios when metadata is not available from the standard authority endpoint. It cannot be used when using a Tenant and a HTTPS address is required."]</span>
 </div>
 
 <div class="mb-3" asp-validation-class-for="Audience">

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
@@ -28,6 +28,13 @@
     <span class="hint">@T["The address of the remote OpenID Connect server. Using a HTTPS address is strongly recommended."]</span>
 </div>
 
+<div class="mb-3" asp-validation-class-for="MetadataAddress">
+    <label asp-for="MetadataAddress">@T["Well Known Metadata Address"]</label>
+    <input asp-for="MetadataAddress" class="form-control" />
+    <span asp-validation-for="MetadataAddress"></span>
+    <span class="hint">@T["The address of the metatdata endpoint. Optional. (https://{your base url}/.well-known/openid-configuration)"]</span>
+</div>
+
 <div class="mb-3" asp-validation-class-for="Audience">
     <label asp-for="Audience">@T["Audience"]</label>
     <input asp-for="Audience" class="form-control" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdValidationSettings.Edit.cshtml
@@ -25,14 +25,14 @@
     <label asp-for="Authority">@T["Authority"]</label>
     <input asp-for="Authority" class="form-control" />
     <span asp-validation-for="Authority"></span>
-    <span class="hint">@T["The address of the remote OpenID Connect server. An HTTPS address is required."]</span>
+    <span class="hint">@T["The address of the remote OpenID Connect server. Using a HTTPS address is strongly recommended."]</span>
 </div>
 
 <div class="mb-3" asp-validation-class-for="MetadataAddress">
     <label asp-for="MetadataAddress">@T["OpenID Connect Metadata Address"]</label>
     <input asp-for="MetadataAddress" class="form-control" />
     <span asp-validation-for="MetadataAddress"></span>
-    <span class="hint">@T["The well-formed URI of the OpenID Connect Metadata Address endpoint. This is only for advanced scenarios when metadata is not available from the standard authority endpoint. It cannot be used when using a Tenant and a HTTPS address is required."]</span>
+    <span class="hint">@T["The well-formed URI of the OpenID Connect Metadata Address endpoint. This is only for advanced scenarios when metadata is not available from the standard authority endpoint. It cannot be used when using a Tenant and using a HTTPS address is strongly recommended."]</span>
 </div>
 
 <div class="mb-3" asp-validation-class-for="Audience">


### PR DESCRIPTION
…options. Helpful for Azure B2C scenarios. This PR contains code for making Metadata (well known) address set via the token validation module. This will force a download of the information for there instead of trying to use the issuer/authority. Helpful in scenarios such as Azure B2C.