### PR TITLE
Introduce EnabledByDependencyOnly flag for features to allow the feature's state to be auto (enabled or disabled)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Manifest.cs
@@ -6,5 +6,6 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "The admin menu module enables user custom admin menus.",
-    Category = "Content Management"
+    Category = "Content Management",
+    Listable = false
 )]

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Manifest.cs
@@ -6,6 +6,5 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "The admin menu module enables user custom admin menus.",
-    Category = "Content Management",
-    Listable = false
+    Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -57,7 +57,7 @@ namespace OrchardCore.Features.Controllers
 
             var moduleFeatures = new List<ModuleFeature>();
 
-            var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync()).Where(f => !f.IsTheme());
+            var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync()).Where(f => !f.IsTheme() && f.Listable);
 
             foreach (var moduleFeatureInfo in features)
             {
@@ -101,7 +101,7 @@ namespace OrchardCore.Features.Controllers
             if (ModelState.IsValid)
             {
                 var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                    .Where(f => !f.IsTheme() && model.FeatureIds.Contains(f.Id));
+                    .Where(f => !f.IsTheme() && !f.Listable && model.FeatureIds.Contains(f.Id));
 
                 await EnableOrDisableFeaturesAsync(features, model.BulkAction, force);
             }
@@ -118,7 +118,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && f.Id == id);
+                .FirstOrDefault(f => !f.IsTheme() && !f.Listable && f.Id == id);
 
             if (feature == null)
             {
@@ -145,7 +145,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && f.Id == id);
+                .FirstOrDefault(f => !f.IsTheme() && !f.Listable && f.Id == id);
 
             if (feature == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -57,7 +57,7 @@ namespace OrchardCore.Features.Controllers
 
             var moduleFeatures = new List<ModuleFeature>();
 
-            var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync()).Where(f => !f.IsTheme() && f.Listable);
+            var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync()).Where(f => !f.IsTheme());
 
             foreach (var moduleFeatureInfo in features)
             {
@@ -69,6 +69,7 @@ namespace OrchardCore.Features.Controllers
                     Descriptor = moduleFeatureInfo,
                     IsEnabled = enabledFeatures.Contains(moduleFeatureInfo),
                     IsAlwaysEnabled = alwaysEnabledFeatures.Contains(moduleFeatureInfo),
+                    Listable = moduleFeatureInfo.Listable,
                     //IsRecentlyInstalled = _moduleService.IsRecentlyInstalled(f.Extension),
                     //NeedsUpdate = featuresThatNeedUpdate.Contains(f.Id),
                     EnabledDependentFeatures = dependentFeatures.Where(x => x.Id != moduleFeatureInfo.Id && enabledFeatures.Contains(x)).ToList(),

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -101,7 +101,7 @@ namespace OrchardCore.Features.Controllers
             if (ModelState.IsValid)
             {
                 var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                    .Where(f => !f.IsTheme() && !f.Listable && model.FeatureIds.Contains(f.Id));
+                    .Where(f => !f.IsTheme() && f.Listable && model.FeatureIds.Contains(f.Id));
 
                 await EnableOrDisableFeaturesAsync(features, model.BulkAction, force);
             }
@@ -118,7 +118,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && !f.Listable && f.Id == id);
+                .FirstOrDefault(f => !f.IsTheme() && f.Listable && f.Id == id);
 
             if (feature == null)
             {
@@ -145,7 +145,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && !f.Listable && f.Id == id);
+                .FirstOrDefault(f => !f.IsTheme() && f.Listable && f.Id == id);
 
             if (feature == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -102,7 +102,7 @@ namespace OrchardCore.Features.Controllers
             if (ModelState.IsValid)
             {
                 var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                    .Where(f => !f.IsTheme() && f.EnabledByDependencyOnly && model.FeatureIds.Contains(f.Id));
+                    .Where(f => !f.IsTheme() && !f.EnabledByDependencyOnly && model.FeatureIds.Contains(f.Id));
 
                 await EnableOrDisableFeaturesAsync(features, model.BulkAction, force);
             }
@@ -119,7 +119,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && f.EnabledByDependencyOnly && f.Id == id);
+                .FirstOrDefault(f => !f.IsTheme() && !f.EnabledByDependencyOnly && f.Id == id);
 
             if (feature == null)
             {
@@ -146,7 +146,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && f.EnabledByDependencyOnly && f.Id == id);
+                .FirstOrDefault(f => !f.IsTheme() && !f.EnabledByDependencyOnly && f.Id == id);
 
             if (feature == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -69,7 +69,7 @@ namespace OrchardCore.Features.Controllers
                     Descriptor = moduleFeatureInfo,
                     IsEnabled = enabledFeatures.Contains(moduleFeatureInfo),
                     IsAlwaysEnabled = alwaysEnabledFeatures.Contains(moduleFeatureInfo),
-                    Listable = moduleFeatureInfo.Listable,
+                    EnabledByDependencyOnly = moduleFeatureInfo.EnabledByDependencyOnly,
                     //IsRecentlyInstalled = _moduleService.IsRecentlyInstalled(f.Extension),
                     //NeedsUpdate = featuresThatNeedUpdate.Contains(f.Id),
                     EnabledDependentFeatures = dependentFeatures.Where(x => x.Id != moduleFeatureInfo.Id && enabledFeatures.Contains(x)).ToList(),
@@ -102,7 +102,7 @@ namespace OrchardCore.Features.Controllers
             if (ModelState.IsValid)
             {
                 var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                    .Where(f => !f.IsTheme() && f.Listable && model.FeatureIds.Contains(f.Id));
+                    .Where(f => !f.IsTheme() && f.EnabledByDependencyOnly && model.FeatureIds.Contains(f.Id));
 
                 await EnableOrDisableFeaturesAsync(features, model.BulkAction, force);
             }
@@ -119,7 +119,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && f.Listable && f.Id == id);
+                .FirstOrDefault(f => !f.IsTheme() && f.EnabledByDependencyOnly && f.Id == id);
 
             if (feature == null)
             {
@@ -146,7 +146,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && f.Listable && f.Id == id);
+                .FirstOrDefault(f => !f.IsTheme() && f.EnabledByDependencyOnly && f.Id == id);
 
             if (feature == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -119,7 +119,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && !f.EnabledByDependencyOnly && f.Id == id);
+                .FirstOrDefault(f => f.Id == id && !f.IsTheme() && !f.EnabledByDependencyOnly);
 
             if (feature == null)
             {
@@ -146,7 +146,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => !f.IsTheme() && !f.EnabledByDependencyOnly && f.Id == id);
+                .FirstOrDefault(f => f.Id == id && !f.IsTheme() && !f.EnabledByDependencyOnly);
 
             if (feature == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -102,7 +102,7 @@ namespace OrchardCore.Features.Controllers
             if (ModelState.IsValid)
             {
                 var features = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                    .Where(f => !f.IsTheme() && !f.EnabledByDependencyOnly && model.FeatureIds.Contains(f.Id));
+                    .Where(f => !f.EnabledByDependencyOnly && !f.IsTheme() && model.FeatureIds.Contains(f.Id));
 
                 await EnableOrDisableFeaturesAsync(features, model.BulkAction, force);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -119,7 +119,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => f.Id == id && !f.IsTheme() && !f.EnabledByDependencyOnly);
+                .FirstOrDefault(f => f.Id == id && !f.EnabledByDependencyOnly && !f.IsTheme());
 
             if (feature == null)
             {
@@ -146,7 +146,7 @@ namespace OrchardCore.Features.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => f.Id == id && !f.IsTheme() && !f.EnabledByDependencyOnly);
+                .FirstOrDefault(f => f.Id == id && !f.EnabledByDependencyOnly && !f.IsTheme());
 
             if (feature == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Models/ModuleFeature.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Models/ModuleFeature.cs
@@ -39,9 +39,9 @@ namespace OrchardCore.Features.Models
         public bool IsRecentlyInstalled { get; set; }
 
         /// <summary>
-        /// Boolean value indicating if the feature is listable.
+        /// Boolean value indicating if the feature is enabled by dependency only.
         /// </summary>
-        public bool Listable { get; set; }
+        public bool EnabledByDependencyOnly { get; set; }
 
         /// <summary>
         /// List of enabled features that depend on this feature.

--- a/src/OrchardCore.Modules/OrchardCore.Features/Models/ModuleFeature.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Models/ModuleFeature.cs
@@ -39,6 +39,11 @@ namespace OrchardCore.Features.Models
         public bool IsRecentlyInstalled { get; set; }
 
         /// <summary>
+        /// Boolean value indicating if the feature is listable.
+        /// </summary>
+        public bool Listable { get; set; }
+
+        /// <summary>
         /// List of enabled features that depend on this feature.
         /// </summary>
         public IEnumerable<IFeatureInfo> EnabledDependentFeatures { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -103,7 +103,7 @@
                                             }
                                             @if (feature.EnabledByDependencyOnly || feature.IsAlwaysEnabled)
                                             {
-                                                <span class="badge bg-info" title="@T["Current Status"]">
+                                                <span class="badge bg-info" title="@T["Current State"]">
                                                     @if (feature.IsEnabled)
                                                     {
                                                         <strong>@T["Enabled"]</strong>

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -101,35 +101,46 @@
                                                     </span>
                                                 }
                                             }
-                                            @if (feature.EnabledByDependencyOnly || feature.IsAlwaysEnabled)
-                                            {
-                                                <span class="badge bg-info" title="@T["Current State"]">
-                                                    @if (feature.IsEnabled)
-                                                    {
-                                                        <strong>@T["Enabled"]</strong>
-                                                    }
-                                                    else
-                                                    {
-                                                        @T["Disabled"]
-                                                    }
-                                                </span>
-                                            }
                                         </div>
                                     </div>
                                     <div class="col-md-2 text-end">
-                                        @if (showEnable && !feature.IsEnabled)
+                                        @if (feature.EnabledByDependencyOnly)
                                         {
-                                            <a id="btn-enable-@Html.GenerateIdFromName(feature.Descriptor.Id)" asp-action="Enable" asp-route-id="@feature.Descriptor.Id" class="btn btn-primary btn-sm" data-url-af="UnsafeUrl">@T["Enable"]</a>
-                                        }
-                                        @if (showDisable && feature.IsEnabled)
-                                        {
-                                            var confirmationMessage = T["Are you sure you want to disable the {0} feature? Continue?", feature.Descriptor.Name];
-                                            if (feature.EnabledDependentFeatures.Any())
+                                            @if (feature.IsEnabled)
                                             {
-                                                var enabledDependentFeatures = new HtmlString($"<ul>{String.Join("", feature.EnabledDependentFeatures.Select(f => $"<li>{f.Name}</li>"))}</ul>");
-                                                confirmationMessage = T["Disabling the {0} feature will also disable the following dependent features:{1}Continue?", feature.Descriptor.Name, enabledDependentFeatures];
+                                                <div data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is automaticlly enabled based on dependency and cannot be manually disabled."]">
+                                                    <button class="btn btn-danger btn-sm" disabled>@T["Disable"]</button>
+                                                </div>
                                             }
-                                            <a id="btn-disable-@Html.GenerateIdFromName(feature.Descriptor.Id)" asp-action="Disable" asp-route-id="@feature.Descriptor.Id" class="btn btn-danger btn-sm" data-title="@T["Disable Feature"]" data-message="@confirmationMessage" data-ok-text="@T["Yes"]" data-cancel-text="@T["No"]" data-url-af="UnsafeUrl RemoveUrl">@T["Disable"]</a>
+                                            else
+                                            {
+                                                <div data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is automaticlly disabled based on dependency and cannot be manually enabled."]">
+                                                    <button class="btn btn-primary btn-sm" disabled>@T["Enable"]</button>
+                                                </div>
+                                            }
+                                        }
+                                        else if (feature.IsAlwaysEnabled && feature.IsEnabled)
+                                        {
+                                            <div data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is always enabled and cannot be manually disabled."]">
+                                                <button class="btn btn-danger btn-sm" disabled>@T["Disable"]</button>
+                                            </div>
+                                        }
+                                        else
+                                        {
+                                            if (showEnable && !feature.IsEnabled)
+                                            {
+                                                <a id="btn-enable-@Html.GenerateIdFromName(feature.Descriptor.Id)" asp-action="Enable" asp-route-id="@feature.Descriptor.Id" class="btn btn-primary btn-sm" data-url-af="UnsafeUrl">@T["Enable"]</a>
+                                            }
+                                            @if (showDisable && feature.IsEnabled)
+                                            {
+                                                var confirmationMessage = T["Are you sure you want to disable the {0} feature? Continue?", feature.Descriptor.Name];
+                                                if (feature.EnabledDependentFeatures.Any())
+                                                {
+                                                    var enabledDependentFeatures = new HtmlString($"<ul>{String.Join("", feature.EnabledDependentFeatures.Select(f => $"<li>{f.Name}</li>"))}</ul>");
+                                                    confirmationMessage = T["Disabling the {0} feature will also disable the following dependent features:{1}Continue?", feature.Descriptor.Name, enabledDependentFeatures];
+                                                }
+                                                <a id="btn-disable-@Html.GenerateIdFromName(feature.Descriptor.Id)" asp-action="Disable" asp-route-id="@feature.Descriptor.Id" class="btn btn-danger btn-sm" data-title="@T["Disable Feature"]" data-message="@confirmationMessage" data-ok-text="@T["Yes"]" data-cancel-text="@T["No"]" data-url-af="UnsafeUrl RemoveUrl">@T["Disable"]</a>
+                                            }
                                         }
                                     </div>
                                 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -56,6 +56,10 @@
                     @{
                         foreach (var feature in features)
                         {
+                            if (!feature.Listable)
+                            {
+                                continue;
+                            }
                             //var lifecycleStatus = feature.Descriptor.Extension.LifecycleStatus;
                             var featureId = feature.Descriptor.Id;
                             var featureName = feature.Descriptor.Name;
@@ -133,11 +137,11 @@
     }
 </form>
 <script at="Foot">
-    $(function () {
+    $(function() {
         var searchBox = $('#search-box');
 
         // On each keypress filter the list of features
-        searchBox.keyup(function (e) {
+        searchBox.keyup(function(e) {
             var search = $(this).val().toLowerCase();
             var elementsToFilter = $("[data-filter-value]");
 
@@ -146,21 +150,19 @@
                 searchBox.val('');
                 elementsToFilter.removeClass("d-none first-child-visible last-child-visible");
             } else {
-                elementsToFilter.each(function () {
+                elementsToFilter.each(function() {
                     var text = $(this).data('filter-value').toLowerCase();
                     var found = text.indexOf(search) > -1;
 
-                    if (found)
-                    {
+                    if (found) {
                         $(this).removeClass("d-none first-child-visible last-child-visible");
                     }
-                    else
-                    {
+                    else {
                         $(this).addClass("d-none");
                     }
                 });
 
-                $('ul.list-group').each(function () {
+                $('ul.list-group').each(function() {
                     $(this).find('li').filter(":not(.d-none)").first().addClass("first-child-visible");
                     $(this).find('li').filter(":not(.d-none)").last().addClass("last-child-visible");
                 });
@@ -176,7 +178,7 @@
         });
 
         //prevent posting form on pressing enter key
-        searchBox.keypress(function (e) {
+        searchBox.keypress(function(e) {
             var key = e.charCode || e.keyCode || 0;
             if (key == 13) {
                 return false;
@@ -185,7 +187,7 @@
 
         $(".dropdown-menu a").filter(function() {
             return $(this).data("action");
-        }).on('click', function () {
+        }).on('click', function() {
             $("[name='BulkAction']").val($(this).data('action'));
             $("[name='submit.BulkAction']").click();
         });

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -59,15 +59,14 @@
                             //var lifecycleStatus = feature.Descriptor.Extension.LifecycleStatus;
                             var featureId = feature.Descriptor.Id;
                             var featureName = feature.Descriptor.Name;
-                            var featureState = feature.IsEnabled ? "enabled" : "disabled";
 
                             var dependencies = (from d in feature.FeatureDependencies
                                                 select (from f in Model.Features where f.Descriptor.Id == d.Id select f).SingleOrDefault()).Where(f => f != null).OrderBy(f => f.Descriptor.Name);
                             var dependenciesNames = String.Join(" ", dependencies.Select(d => d.Descriptor.Name));
                             var missingDependencies = feature.FeatureDependencies
                             .Where(d => !Model.Features.Any(f => f.Descriptor.Id == d.Id));
-                            var showDisable = feature.EnabledByDependencyOnly && !feature.IsAlwaysEnabled && categoryName != "Core" && feature.Descriptor.Name != Application.ModuleName;
-                            var showEnable = feature.EnabledByDependencyOnly && !missingDependencies.Any() && feature.Descriptor.Id != "OrchardCore.Setup" && feature.Descriptor.Id != "OrchardCore.AutoSetup";
+                            var showDisable = !feature.EnabledByDependencyOnly && !feature.IsAlwaysEnabled && categoryName != "Core" && feature.Descriptor.Name != Application.ModuleName;
+                            var showEnable = !feature.EnabledByDependencyOnly && !missingDependencies.Any() && feature.Descriptor.Id != "OrchardCore.Setup" && feature.Descriptor.Id != "OrchardCore.AutoSetup";
 
                             <li class="list-group-item" data-filter-value="@categoryName @dependenciesNames @featureName">
                                 <div class="row">
@@ -102,20 +101,18 @@
                                                     </span>
                                                 }
                                             }
-                                            @if (!showEnable && !showDisable)
+                                            @if (feature.EnabledByDependencyOnly || feature.IsAlwaysEnabled)
                                             {
-                                                if (feature.IsEnabled)
-                                                {
-                                                    <span class="badge bg-info">
-                                                        @T["Enabled"]
-                                                    </span>
-                                                }
-                                                else
-                                                {
-                                                    <span class="badge bg-info">
+                                                <span class="badge bg-info" title="@T["Current Status"]">
+                                                    @if (feature.IsEnabled)
+                                                    {
+                                                        <strong>@T["Enabled"]</strong>
+                                                    }
+                                                    else
+                                                    {
                                                         @T["Disabled"]
-                                                    </span>
-                                                }
+                                                    }
+                                                </span>
                                             }
                                         </div>
                                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -56,10 +56,6 @@
                     @{
                         foreach (var feature in features)
                         {
-                            if (!feature.Listable)
-                            {
-                                continue;
-                            }
                             //var lifecycleStatus = feature.Descriptor.Extension.LifecycleStatus;
                             var featureId = feature.Descriptor.Id;
                             var featureName = feature.Descriptor.Name;
@@ -70,8 +66,8 @@
                             var dependenciesNames = String.Join(" ", dependencies.Select(d => d.Descriptor.Name));
                             var missingDependencies = feature.FeatureDependencies
                             .Where(d => !Model.Features.Any(f => f.Descriptor.Id == d.Id));
-                            var showDisable = !feature.IsAlwaysEnabled && categoryName != "Core" && feature.Descriptor.Name != Application.ModuleName;
-                            var showEnable = !missingDependencies.Any() && feature.Descriptor.Id != "OrchardCore.Setup" && feature.Descriptor.Id != "OrchardCore.AutoSetup";
+                            var showDisable = feature.Listable && !feature.IsAlwaysEnabled && categoryName != "Core" && feature.Descriptor.Name != Application.ModuleName;
+                            var showEnable = feature.Listable && !missingDependencies.Any() && feature.Descriptor.Id != "OrchardCore.Setup" && feature.Descriptor.Id != "OrchardCore.AutoSetup";
 
                             <li class="list-group-item" data-filter-value="@categoryName @dependenciesNames @featureName">
                                 <div class="row">
@@ -103,6 +99,21 @@
                                                 {
                                                     <span class="badge bg-warning">
                                                         @d
+                                                    </span>
+                                                }
+                                            }
+                                            @if (!showEnable && !showDisable)
+                                            {
+                                                if (feature.IsEnabled)
+                                                {
+                                                    <span class="badge bg-info">
+                                                        @T["Enabled"]
+                                                    </span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="badge bg-info">
+                                                        @T["Disabled"]
                                                     </span>
                                                 }
                                             }

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -66,8 +66,8 @@
                             var dependenciesNames = String.Join(" ", dependencies.Select(d => d.Descriptor.Name));
                             var missingDependencies = feature.FeatureDependencies
                             .Where(d => !Model.Features.Any(f => f.Descriptor.Id == d.Id));
-                            var showDisable = feature.Listable && !feature.IsAlwaysEnabled && categoryName != "Core" && feature.Descriptor.Name != Application.ModuleName;
-                            var showEnable = feature.Listable && !missingDependencies.Any() && feature.Descriptor.Id != "OrchardCore.Setup" && feature.Descriptor.Id != "OrchardCore.AutoSetup";
+                            var showDisable = feature.EnabledByDependencyOnly && !feature.IsAlwaysEnabled && categoryName != "Core" && feature.Descriptor.Name != Application.ModuleName;
+                            var showEnable = feature.EnabledByDependencyOnly && !missingDependencies.Any() && feature.Descriptor.Id != "OrchardCore.Setup" && feature.Descriptor.Id != "OrchardCore.AutoSetup";
 
                             <li class="list-group-item" data-filter-value="@categoryName @dependenciesNames @featureName">
                                 <div class="row">

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.Themes.Controllers
             var themes = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
                 .Where(f =>
                 {
-                    if (!f.IsTheme() || f.IsAlwaysEnabled || f.EnabledByDependencyOnly)
+                    if (f.IsAlwaysEnabled || f.EnabledByDependencyOnly || !f.IsTheme())
                     {
                         return false;
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -117,7 +117,7 @@ namespace OrchardCore.Themes.Controllers
             else
             {
                 var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                    .FirstOrDefault(f => f.Id == id && f.IsTheme() && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly);
+                    .FirstOrDefault(f => f.Id == id && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly && f.IsTheme());
 
                 if (feature == null)
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -192,7 +192,7 @@ namespace OrchardCore.Themes.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => f.Id == id && f.IsTheme() && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly);
+                .FirstOrDefault(f => f.Id == id && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly && f.IsTheme());
 
             if (feature == null)
             {
@@ -215,7 +215,7 @@ namespace OrchardCore.Themes.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => f.Id == id && f.IsTheme() && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly);
+                .FirstOrDefault(f => f.Id == id && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly && f.IsTheme());
 
             if (feature == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.Themes.Controllers
             var themes = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
                 .Where(f =>
                 {
-                    if (!f.IsTheme())
+                    if (!f.IsTheme() || f.IsAlwaysEnabled || f.EnabledByDependencyOnly)
                     {
                         return false;
                     }
@@ -117,7 +117,7 @@ namespace OrchardCore.Themes.Controllers
             else
             {
                 var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                    .FirstOrDefault(f => f.IsTheme() && f.Id == id);
+                    .FirstOrDefault(f => f.Id == id && f.IsTheme() && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly);
 
                 if (feature == null)
                 {
@@ -192,7 +192,7 @@ namespace OrchardCore.Themes.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => f.IsTheme() && f.Id == id);
+                .FirstOrDefault(f => f.Id == id && f.IsTheme() && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly);
 
             if (feature == null)
             {
@@ -215,7 +215,7 @@ namespace OrchardCore.Themes.Controllers
             }
 
             var feature = (await _shellFeaturesManager.GetAvailableFeaturesAsync())
-                .FirstOrDefault(f => f.IsTheme() && f.Id == id);
+                .FirstOrDefault(f => f.Id == id && f.IsTheme() && !f.IsAlwaysEnabled && !f.EnabledByDependencyOnly);
 
             if (feature == null)
             {

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
@@ -20,7 +20,7 @@ namespace OrchardCore.Environment.Extensions.Features
         public string[] FeatureDependencyIds { get; set; }
         public bool DefaultTenantOnly { get; set; }
         public bool IsAlwaysEnabled { get; set; }
-        public bool Listable { get; set; }
+        public bool EnabledByDependencyOnly { get; set; }
     }
 
     public abstract class FeatureBuilderEvents : IFeatureBuilderEvents

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
@@ -21,7 +21,6 @@ namespace OrchardCore.Environment.Extensions.Features
         public bool DefaultTenantOnly { get; set; }
         public bool IsAlwaysEnabled { get; set; }
         public bool Listable { get; set; }
-
     }
 
     public abstract class FeatureBuilderEvents : IFeatureBuilderEvents

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
@@ -20,6 +20,8 @@ namespace OrchardCore.Environment.Extensions.Features
         public string[] FeatureDependencyIds { get; set; }
         public bool DefaultTenantOnly { get; set; }
         public bool IsAlwaysEnabled { get; set; }
+        public bool Listable { get; set; }
+
     }
 
     public abstract class FeatureBuilderEvents : IFeatureBuilderEvents

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureInfo.cs
@@ -11,6 +11,6 @@ namespace OrchardCore.Environment.Extensions.Features
         IExtensionInfo Extension { get; }
         string[] Dependencies { get; }
         bool IsAlwaysEnabled { get; }
-        bool Listable { get; }
+        bool EnabledByDependencyOnly { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureInfo.cs
@@ -11,5 +11,6 @@ namespace OrchardCore.Environment.Extensions.Features
         IExtensionInfo Extension { get; }
         string[] Dependencies { get; }
         bool IsAlwaysEnabled { get; }
+        bool Listable { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
@@ -68,8 +68,7 @@ namespace OrchardCore.Modules.Manifest
         /// corresponding to each of the feature <see cref="Name"/> properties.</param>
         /// <param name="defaultTenant">Whether considered default tenant only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.</param>
-        /// <param name="listable">Whether feature is listable on the Features UI
-        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
+        /// <param name="listable">Whether feature is listable on the Features UI.</param>
         public FeatureAttribute(
             string id
             , string description
@@ -160,7 +159,7 @@ namespace OrchardCore.Modules.Manifest
             Id = id;
             Name = name;
             Category = category ?? DefaultCategory;
-            Priority = priority ?? string.Empty;
+            Priority = priority ?? String.Empty;
             Description = description ?? DefaultDescription;
             DelimitedDependencies = featureDependencies ?? DefaultFeatureDependencies;
 
@@ -175,7 +174,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Whether the feature exists based on the <see cref="Id"/>.
         /// </summary>
-        public virtual bool Exists => !string.IsNullOrEmpty(Id);
+        public virtual bool Exists => !String.IsNullOrEmpty(Id);
 
         private string _id;
 
@@ -188,7 +187,7 @@ namespace OrchardCore.Modules.Manifest
             set
             {
                 // Guards setting Id with strictly invalid values.
-                if (string.IsNullOrEmpty(value))
+                if (String.IsNullOrEmpty(value))
                 {
                     throw new InvalidOperationException($"When '{nameof(Id)}' has been provided it should not be null or empty.")
                     {
@@ -204,12 +203,12 @@ namespace OrchardCore.Modules.Manifest
 
         /// <summary>
         /// Returns the <see cref="string"/> <paramref name="s"/> as is, or <c>null</c> when that
-        /// or <see cref="string.Empty"/>.
+        /// or <see cref="String.Empty"/>.
         /// </summary>
         /// <param name="s">The string value to consider.</param>
         /// <returns>The <paramref name="s"/> value as is, or Null when either that or Empty.</returns>
-        /// <see cref="string.IsNullOrEmpty(string?)"/>
-        internal static string StringOrNull(string s) => string.IsNullOrEmpty(s) ? null : s;
+        /// <see cref="String.IsNullOrEmpty(string?)"/>
+        internal static string StringOrNull(string s) => String.IsNullOrEmpty(s) ? null : s;
 
         /// <summary>
         /// Gets or sets the human readable or canonical feature name. <see cref="Id"/> will be
@@ -248,7 +247,7 @@ namespace OrchardCore.Modules.Manifest
         /// <returns>The first or default Description with optional back stop features.</returns>
         internal virtual string Describe(params FeatureAttribute[] additionalFeatures)
         {
-            static bool IsNotNullOrEmpty(string s) => !string.IsNullOrEmpty(s);
+            static bool IsNotNullOrEmpty(string s) => !String.IsNullOrEmpty(s);
             var firstOrDefaultResult = GetValues(this).Concat(additionalFeatures)
                 .Select(feature => feature.Description)
                 .FirstOrDefault(IsNotNullOrEmpty);
@@ -267,7 +266,7 @@ namespace OrchardCore.Modules.Manifest
         /// perspective. Also common are comma (&apos;,&apos;) and space (&apos; &apos;)
         /// delimiters.
         /// </summary>
-        /// <see cref="string.Split(char[], StringSplitOptions)"/>
+        /// <see cref="String.Split(char[], StringSplitOptions)"/>
         internal protected static char[] ListDelims { get; } = GetValues(';', ',', ' ').ToArray();
 
         /// <summary>
@@ -346,7 +345,7 @@ namespace OrchardCore.Modules.Manifest
         /// <returns>The Category normalized across This instance and optional Module.</returns>
         internal virtual string Categorize(params FeatureAttribute[] additionalFeatures)
         {
-            static bool IsNotNullOrEmpty(string s) => !string.IsNullOrEmpty(s);
+            static bool IsNotNullOrEmpty(string s) => !String.IsNullOrEmpty(s);
             var categories = GetValues(this).Concat(additionalFeatures).Select(feature => feature.Category);
             var category = categories.FirstOrDefault(IsNotNullOrEmpty);
             // TODO: MWP: 'Uncategorized'? or is empty acceptable here?

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
@@ -68,7 +68,8 @@ namespace OrchardCore.Modules.Manifest
         /// corresponding to each of the feature <see cref="Name"/> properties.</param>
         /// <param name="defaultTenant">Whether considered default tenant only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.</param>
-        /// <param name="listable">Whether feature is listable on the Features UI</param>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public FeatureAttribute(
             string id
             , string description
@@ -103,7 +104,8 @@ namespace OrchardCore.Modules.Manifest
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
-        /// <param name="listable">Whether feature is listable on the Features UI</param>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public FeatureAttribute(
             string id
             , string name
@@ -141,7 +143,8 @@ namespace OrchardCore.Modules.Manifest
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
-        /// <param name="listable">Whether feature is listable on the Features UI</param>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public FeatureAttribute(
             string id
             , string name

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
@@ -68,12 +68,14 @@ namespace OrchardCore.Modules.Manifest
         /// corresponding to each of the feature <see cref="Name"/> properties.</param>
         /// <param name="defaultTenant">Whether considered default tenant only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.</param>
+        /// <param name="listable">Whether feature is listable on the Features UI</param>
         public FeatureAttribute(
             string id
             , string description
             , string featureDependencies
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : this(
             id
             , default
@@ -83,6 +85,7 @@ namespace OrchardCore.Modules.Manifest
             , featureDependencies
             , defaultTenant
             , alwaysEnabled
+            , listable
         )
         {
         }
@@ -100,6 +103,7 @@ namespace OrchardCore.Modules.Manifest
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
+        /// <param name="listable">Whether feature is listable on the Features UI</param>
         public FeatureAttribute(
             string id
             , string name
@@ -107,6 +111,7 @@ namespace OrchardCore.Modules.Manifest
             , string featureDependencies
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : this(
             id
             , name
@@ -116,6 +121,7 @@ namespace OrchardCore.Modules.Manifest
             , featureDependencies
             , defaultTenant
             , alwaysEnabled
+            , listable
         )
         {
         }
@@ -135,6 +141,7 @@ namespace OrchardCore.Modules.Manifest
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
+        /// <param name="listable">Whether feature is listable on the Features UI</param>
         public FeatureAttribute(
             string id
             , string name
@@ -144,6 +151,7 @@ namespace OrchardCore.Modules.Manifest
             , string featureDependencies
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         )
         {
             Id = id;
@@ -158,6 +166,7 @@ namespace OrchardCore.Modules.Manifest
 
             DefaultTenantOnly = ToBoolean(defaultTenant);
             IsAlwaysEnabled = ToBoolean(alwaysEnabled);
+            Listable = ToBoolean(listable ?? true);
         }
 
         /// <summary>
@@ -180,7 +189,7 @@ namespace OrchardCore.Modules.Manifest
                 {
                     throw new InvalidOperationException($"When '{nameof(Id)}' has been provided it should not be null or empty.")
                     {
-                        Data = {{nameof(value), value}}
+                        Data = { { nameof(value), value } }
                     };
                 }
 
@@ -350,5 +359,10 @@ namespace OrchardCore.Modules.Manifest
         /// Once enabled, check whether the feature cannot be disabled. Defaults to <c>false</c>.
         /// </summary>
         public virtual bool IsAlwaysEnabled { get; set; } = false;
+
+        /// <summary>
+        /// Set to <c>false</c> to not list the feature on the Features UI.
+        /// </summary>
+        public virtual bool Listable { get; set; } = true;
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
@@ -68,14 +68,15 @@ namespace OrchardCore.Modules.Manifest
         /// corresponding to each of the feature <see cref="Name"/> properties.</param>
         /// <param name="defaultTenant">Whether considered default tenant only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.</param>
-        /// <param name="listable">Whether feature is listable on the Features UI.</param>
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public FeatureAttribute(
             string id
             , string description
             , string featureDependencies
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : this(
             id
             , default
@@ -85,7 +86,7 @@ namespace OrchardCore.Modules.Manifest
             , featureDependencies
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
         }
@@ -103,7 +104,7 @@ namespace OrchardCore.Modules.Manifest
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public FeatureAttribute(
             string id
@@ -112,7 +113,7 @@ namespace OrchardCore.Modules.Manifest
             , string featureDependencies
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : this(
             id
             , name
@@ -122,7 +123,7 @@ namespace OrchardCore.Modules.Manifest
             , featureDependencies
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
         }
@@ -142,7 +143,7 @@ namespace OrchardCore.Modules.Manifest
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         /// <param name="alwaysEnabled">Whether feature is always enabled.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public FeatureAttribute(
             string id
@@ -153,7 +154,7 @@ namespace OrchardCore.Modules.Manifest
             , string featureDependencies
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         )
         {
             Id = id;
@@ -168,7 +169,7 @@ namespace OrchardCore.Modules.Manifest
 
             DefaultTenantOnly = ToBoolean(defaultTenant);
             IsAlwaysEnabled = ToBoolean(alwaysEnabled);
-            Listable = ToBoolean(listable ?? true);
+            EnabledByDependencyOnly = ToBoolean(enabledByDependencyOnly);
         }
 
         /// <summary>
@@ -363,8 +364,8 @@ namespace OrchardCore.Modules.Manifest
         public virtual bool IsAlwaysEnabled { get; set; } = false;
 
         /// <summary>
-        /// Set to <c>false</c> to not list the feature on the Features UI.
+        /// Set to <c>true</c> to make the feature available by dependency only.
         /// </summary>
-        public virtual bool Listable { get; set; } = true;
+        public virtual bool EnabledByDependencyOnly { get; set; };
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/FeatureAttribute.cs
@@ -366,6 +366,6 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Set to <c>true</c> to make the feature available by dependency only.
         /// </summary>
-        public virtual bool EnabledByDependencyOnly { get; set; };
+        public virtual bool EnabledByDependencyOnly { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ModuleAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ModuleAttribute.cs
@@ -259,8 +259,8 @@ namespace OrchardCore.Modules.Manifest
             , listable
         )
         {
-            type = (type ?? string.Empty).Trim();
-            _type = string.IsNullOrEmpty(type) ? null : type;
+            type = (type ?? String.Empty).Trim();
+            _type = String.IsNullOrEmpty(type) ? null : type;
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ModuleAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ModuleAttribute.cs
@@ -58,7 +58,8 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI</param>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ModuleAttribute(
             string id
             , string description
@@ -110,7 +111,8 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI</param>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ModuleAttribute(
             string id
             , string name
@@ -165,7 +167,8 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI</param>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ModuleAttribute(
             string id
             , string name
@@ -223,7 +226,8 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI</param>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ModuleAttribute(
             string id
             , string name

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ModuleAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ModuleAttribute.cs
@@ -58,6 +58,7 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
+        /// <param name="listable">Whether feature is listable on the Features UI</param>
         public ModuleAttribute(
             string id
             , string description
@@ -68,6 +69,7 @@ namespace OrchardCore.Modules.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : this(
             id
             , default
@@ -81,6 +83,7 @@ namespace OrchardCore.Modules.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
+            , listable
         )
         {
         }
@@ -107,6 +110,7 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
+        /// <param name="listable">Whether feature is listable on the Features UI</param>
         public ModuleAttribute(
             string id
             , string name
@@ -118,6 +122,7 @@ namespace OrchardCore.Modules.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : this(
             id
             , name
@@ -131,6 +136,7 @@ namespace OrchardCore.Modules.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
+            , listable
         )
         {
         }
@@ -159,6 +165,7 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
+        /// <param name="listable">Whether feature is listable on the Features UI</param>
         public ModuleAttribute(
             string id
             , string name
@@ -172,6 +179,7 @@ namespace OrchardCore.Modules.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : base(
             id
             , name
@@ -181,6 +189,7 @@ namespace OrchardCore.Modules.Manifest
             , featureDependencies
             , defaultTenant
             , alwaysEnabled
+            , listable
         )
         {
             Author = author;
@@ -214,6 +223,7 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
+        /// <param name="listable">Whether feature is listable on the Features UI</param>
         public ModuleAttribute(
             string id
             , string name
@@ -228,6 +238,7 @@ namespace OrchardCore.Modules.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : this(
             id
             , name
@@ -241,6 +252,7 @@ namespace OrchardCore.Modules.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
+            , listable
         )
         {
             type = (type ?? string.Empty).Trim();

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ModuleAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ModuleAttribute.cs
@@ -58,7 +58,7 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ModuleAttribute(
             string id
@@ -70,7 +70,7 @@ namespace OrchardCore.Modules.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : this(
             id
             , default
@@ -84,7 +84,7 @@ namespace OrchardCore.Modules.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
         }
@@ -111,7 +111,7 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ModuleAttribute(
             string id
@@ -124,7 +124,7 @@ namespace OrchardCore.Modules.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : this(
             id
             , name
@@ -138,7 +138,7 @@ namespace OrchardCore.Modules.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
         }
@@ -167,7 +167,7 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ModuleAttribute(
             string id
@@ -182,7 +182,7 @@ namespace OrchardCore.Modules.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : base(
             id
             , name
@@ -192,7 +192,7 @@ namespace OrchardCore.Modules.Manifest
             , featureDependencies
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
             Author = author;
@@ -226,7 +226,7 @@ namespace OrchardCore.Modules.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ModuleAttribute(
             string id
@@ -242,7 +242,7 @@ namespace OrchardCore.Modules.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : this(
             id
             , name
@@ -256,7 +256,7 @@ namespace OrchardCore.Modules.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
             type = (type ?? String.Empty).Trim();

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Module.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Module.cs
@@ -68,6 +68,7 @@ namespace OrchardCore.Modules
                         , null
                         , true
                         , default
+                        , true
                     ));
 
                     // Adds the application default feature.
@@ -80,6 +81,7 @@ namespace OrchardCore.Modules
                         , null
                         , true
                         , default
+                        , true
                     ));
                 }
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Module.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Module.cs
@@ -68,7 +68,7 @@ namespace OrchardCore.Modules
                         , null
                         , true
                         , default
-                        , true
+                        , default
                     ));
 
                     // Adds the application default feature.
@@ -81,7 +81,7 @@ namespace OrchardCore.Modules
                         , null
                         , true
                         , default
-                        , true
+                        , default
                     ));
                 }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Manifest/ThemeAttribute.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Manifest/ThemeAttribute.cs
@@ -179,6 +179,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
+            , listable: true
         )
         {
             BaseTheme = baseTheme;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Manifest/ThemeAttribute.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Manifest/ThemeAttribute.cs
@@ -44,6 +44,8 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ThemeAttribute(
             string id
             , string baseTheme
@@ -55,6 +57,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : this(
             id
             , default
@@ -69,6 +72,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
+            , listable
         )
         {
         }
@@ -96,6 +100,8 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ThemeAttribute(
             string id
             , string name
@@ -108,6 +114,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : this(
             id
             , name
@@ -122,6 +129,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
+            , listable
         )
         {
         }
@@ -152,6 +160,8 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
+        /// <param name="listable">Whether feature is listable on the Features UI
+        /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ThemeAttribute(
             string id
             , string name
@@ -166,6 +176,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
+            , object listable
         ) : base(
             id
             , name
@@ -179,7 +190,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
-            , listable: true
+            , listable
         )
         {
             BaseTheme = baseTheme;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Manifest/ThemeAttribute.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Manifest/ThemeAttribute.cs
@@ -44,7 +44,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ThemeAttribute(
             string id
@@ -57,7 +57,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : this(
             id
             , default
@@ -72,7 +72,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
         }
@@ -100,7 +100,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ThemeAttribute(
             string id
@@ -114,7 +114,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : this(
             id
             , name
@@ -129,7 +129,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
         }
@@ -160,7 +160,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <see cref="!:https://semver.org">Semantic Versioning</see>
         /// <remarks>At least <paramref name="author" /> expected herein to differentiate with
         /// parameterless ctor.</remarks>
-        /// <param name="listable">Whether feature is listable on the Features UI
+        /// <param name="enabledByDependencyOnly">Whether feature is enabled by dependency only.
         /// Supported types are <see cref="string"/> and <see cref="bool"/> only.</param>
         public ThemeAttribute(
             string id
@@ -176,7 +176,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , string tags
             , object defaultTenant
             , object alwaysEnabled
-            , object listable
+            , object enabledByDependencyOnly
         ) : base(
             id
             , name
@@ -190,7 +190,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             , tags
             , defaultTenant
             , alwaysEnabled
-            , listable
+            , enabledByDependencyOnly
         )
         {
             BaseTheme = baseTheme;

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
@@ -137,6 +137,7 @@
     6: , string featureDependencies
     7: , object defaultTenant
     8: , object alwaysEnabled
+    9: , object listable
     -->
   <Target Name="OrchardCoreEmbedFeatures"
           DependsOnTargets="OrchardCoreErrorsFeatureNoErrors"
@@ -146,7 +147,7 @@
     <Message
       Importance="high"
       Condition="'$(OrchardCoreDebugTargets)' == 'true'"
-      Text="Embedding '@(OrchardCoreFeatures)' feature: {'id': '%(OrchardCoreFeatures.Identity)', 'name': '%(OrchardCoreFeatures.Name)', 'category': '%(OrchardCoreFeatures.Category)', 'priority': '%(OrchardCoreFeatures.Priority)', 'description': '%(OrchardCoreFeatures.Description)', 'dependencies': '%(OrchardCoreFeatures.Dependencies)', 'defaultTenant': '%(OrchardCoreFeatures.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreFeatures.AlwaysEnabled)')}" />
+      Text="Embedding '@(OrchardCoreFeatures)' feature: {'id': '%(OrchardCoreFeatures.Identity)', 'name': '%(OrchardCoreFeatures.Name)', 'category': '%(OrchardCoreFeatures.Category)', 'priority': '%(OrchardCoreFeatures.Priority)', 'description': '%(OrchardCoreFeatures.Description)', 'dependencies': '%(OrchardCoreFeatures.Dependencies)', 'defaultTenant': '%(OrchardCoreFeatures.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreFeatures.AlwaysEnabled)', 'listable': '%(OrchardCoreFeatures.Listable)')}" />
     <ItemGroup>
       <AssemblyAttribute Include="OrchardCore.Modules.Manifest.FeatureAttribute">
         <_Parameter1>@(OrchardCoreFeatures)</_Parameter1>
@@ -157,6 +158,7 @@
         <_Parameter6>%(OrchardCoreFeatures.Dependencies)</_Parameter6>
         <_Parameter7>%(OrchardCoreFeatures.DefaultTenant)</_Parameter7>
         <_Parameter8>%(OrchardCoreFeatures.AlwaysEnabled)</_Parameter8>
+        <_Parameter9>%(OrchardCoreFeatures.Listable)</_Parameter9>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
@@ -185,6 +187,7 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
+    14: , object listable
     -->
   <Target Name="OrchardCoreEmbedModules"
           DependsOnTargets="OrchardCoreErrorsModuleAtMostOne"
@@ -194,7 +197,7 @@
     <!-- 'ModuleType' property consistent with other usage, i.e. 'ModuleMarkerAttribute' -->
     <Message Importance="high"
              Condition="'$(OrchardCoreDebugTargets)' == 'true'"
-             Text="Embedding '@(OrchardCoreModules)' module: {'id': '%(OrchardCoreModules.Identity)', 'name': '%(OrchardCoreModules.Name)', 'type': '%(OrchardCoreModules.ModuleType)', 'category': '%(OrchardCoreModules.Category)', 'priority': '%(OrchardCoreModules.Priority)', 'description': '%(OrchardCoreModules.Description)', 'author': '%(OrchardCoreModules.Author)', 'version': '%(OrchardCoreModules.Version)', 'website': '%(OrchardCoreModules.Website)', 'dependencies': '%(OrchardCoreModules.Dependencies)', 'tags': '%(OrchardCoreModules.Tags)', 'defaultTenant': '%(OrchardCoreModules.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreModules.AlwaysEnabled)')}" />
+             Text="Embedding '@(OrchardCoreModules)' module: {'id': '%(OrchardCoreModules.Identity)', 'name': '%(OrchardCoreModules.Name)', 'type': '%(OrchardCoreModules.ModuleType)', 'category': '%(OrchardCoreModules.Category)', 'priority': '%(OrchardCoreModules.Priority)', 'description': '%(OrchardCoreModules.Description)', 'author': '%(OrchardCoreModules.Author)', 'version': '%(OrchardCoreModules.Version)', 'website': '%(OrchardCoreModules.Website)', 'dependencies': '%(OrchardCoreModules.Dependencies)', 'tags': '%(OrchardCoreModules.Tags)', 'defaultTenant': '%(OrchardCoreModules.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreModules.AlwaysEnabled)', 'listable': '%(OrchardCoreModules.Listable)')}" />
     <ItemGroup>
       <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAttribute">
         <_Parameter1>@(OrchardCoreModules)</_Parameter1>
@@ -210,6 +213,7 @@
         <_Parameter11>%(OrchardCoreModules.Tags)</_Parameter11>
         <_Parameter12>%(OrchardCoreModules.DefaultTenant)</_Parameter12>
         <_Parameter13>%(OrchardCoreModules.AlwaysEnabled)</_Parameter13>
+        <_Parameter13>%(OrchardCoreModules.Listable)</_Parameter13>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Module.Targets/OrchardCore.Module.Targets.targets
@@ -137,7 +137,7 @@
     6: , string featureDependencies
     7: , object defaultTenant
     8: , object alwaysEnabled
-    9: , object listable
+    9: , object enabledByDependencyOnly
     -->
   <Target Name="OrchardCoreEmbedFeatures"
           DependsOnTargets="OrchardCoreErrorsFeatureNoErrors"
@@ -147,7 +147,7 @@
     <Message
       Importance="high"
       Condition="'$(OrchardCoreDebugTargets)' == 'true'"
-      Text="Embedding '@(OrchardCoreFeatures)' feature: {'id': '%(OrchardCoreFeatures.Identity)', 'name': '%(OrchardCoreFeatures.Name)', 'category': '%(OrchardCoreFeatures.Category)', 'priority': '%(OrchardCoreFeatures.Priority)', 'description': '%(OrchardCoreFeatures.Description)', 'dependencies': '%(OrchardCoreFeatures.Dependencies)', 'defaultTenant': '%(OrchardCoreFeatures.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreFeatures.AlwaysEnabled)', 'listable': '%(OrchardCoreFeatures.Listable)')}" />
+      Text="Embedding '@(OrchardCoreFeatures)' feature: {'id': '%(OrchardCoreFeatures.Identity)', 'name': '%(OrchardCoreFeatures.Name)', 'category': '%(OrchardCoreFeatures.Category)', 'priority': '%(OrchardCoreFeatures.Priority)', 'description': '%(OrchardCoreFeatures.Description)', 'dependencies': '%(OrchardCoreFeatures.Dependencies)', 'defaultTenant': '%(OrchardCoreFeatures.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreFeatures.AlwaysEnabled)')}" />
     <ItemGroup>
       <AssemblyAttribute Include="OrchardCore.Modules.Manifest.FeatureAttribute">
         <_Parameter1>@(OrchardCoreFeatures)</_Parameter1>
@@ -158,7 +158,7 @@
         <_Parameter6>%(OrchardCoreFeatures.Dependencies)</_Parameter6>
         <_Parameter7>%(OrchardCoreFeatures.DefaultTenant)</_Parameter7>
         <_Parameter8>%(OrchardCoreFeatures.AlwaysEnabled)</_Parameter8>
-        <_Parameter9>%(OrchardCoreFeatures.Listable)</_Parameter9>
+        <_Parameter9>%(OrchardCoreFeatures.EnabledByDependencyOnly)</_Parameter9>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>
@@ -187,7 +187,7 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
-    14: , object listable
+    14: , object enabledByDependencyOnly
     -->
   <Target Name="OrchardCoreEmbedModules"
           DependsOnTargets="OrchardCoreErrorsModuleAtMostOne"
@@ -197,7 +197,7 @@
     <!-- 'ModuleType' property consistent with other usage, i.e. 'ModuleMarkerAttribute' -->
     <Message Importance="high"
              Condition="'$(OrchardCoreDebugTargets)' == 'true'"
-             Text="Embedding '@(OrchardCoreModules)' module: {'id': '%(OrchardCoreModules.Identity)', 'name': '%(OrchardCoreModules.Name)', 'type': '%(OrchardCoreModules.ModuleType)', 'category': '%(OrchardCoreModules.Category)', 'priority': '%(OrchardCoreModules.Priority)', 'description': '%(OrchardCoreModules.Description)', 'author': '%(OrchardCoreModules.Author)', 'version': '%(OrchardCoreModules.Version)', 'website': '%(OrchardCoreModules.Website)', 'dependencies': '%(OrchardCoreModules.Dependencies)', 'tags': '%(OrchardCoreModules.Tags)', 'defaultTenant': '%(OrchardCoreModules.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreModules.AlwaysEnabled)', 'listable': '%(OrchardCoreModules.Listable)')}" />
+             Text="Embedding '@(OrchardCoreModules)' module: {'id': '%(OrchardCoreModules.Identity)', 'name': '%(OrchardCoreModules.Name)', 'type': '%(OrchardCoreModules.ModuleType)', 'category': '%(OrchardCoreModules.Category)', 'priority': '%(OrchardCoreModules.Priority)', 'description': '%(OrchardCoreModules.Description)', 'author': '%(OrchardCoreModules.Author)', 'version': '%(OrchardCoreModules.Version)', 'website': '%(OrchardCoreModules.Website)', 'dependencies': '%(OrchardCoreModules.Dependencies)', 'tags': '%(OrchardCoreModules.Tags)', 'defaultTenant': '%(OrchardCoreModules.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreModules.AlwaysEnabled)')}" />
     <ItemGroup>
       <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAttribute">
         <_Parameter1>@(OrchardCoreModules)</_Parameter1>
@@ -213,7 +213,7 @@
         <_Parameter11>%(OrchardCoreModules.Tags)</_Parameter11>
         <_Parameter12>%(OrchardCoreModules.DefaultTenant)</_Parameter12>
         <_Parameter13>%(OrchardCoreModules.AlwaysEnabled)</_Parameter13>
-        <_Parameter13>%(OrchardCoreModules.Listable)</_Parameter13>
+        <_Parameter14>%(OrchardCoreModules.EnabledByDependencyOnly)</_Parameter14>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.targets
@@ -49,7 +49,7 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
-    14: , object listable
+    14: , object enabledByDependencyOnly
     -->
   <!-- OrchardCoreEmbeddingAfter/BeforeTargets declared in the 'OrchardCore.Modules.Targets.targets' file;
     may be appended by consuming developer discretionary requirements. -->
@@ -61,7 +61,7 @@
     <Message
       Importance="high"
       Condition="'$(OrchardCoreDebugTargets)' == 'true'"
-      Text="Embedding '@(OrchardCoreThemes)' theme: {'id': '%(OrchardCoreThemes.Identity)', 'name': '%(OrchardCoreThemes.Name)', 'base': '%(OrchardCoreThemes.Base)', 'category': '%(OrchardCoreThemes.Category)', 'priority': '%(OrchardCoreThemes.Priority)', 'description': '%(OrchardCoreThemes.Description)', 'author': '%(OrchardCoreThemes.Author)', 'version': '%(OrchardCoreThemes.Version)', 'website': '%(OrchardCoreThemes.Website)', 'dependencies': '%(OrchardCoreThemes.Dependencies)', 'tags': '%(OrchardCoreThemes.Tags)', 'defaultTenant': '%(OrchardCoreThemes.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreThemes.AlwaysEnabled')}" />
+      Text="Embedding '@(OrchardCoreThemes)' theme: {'id': '%(OrchardCoreThemes.Identity)', 'name': '%(OrchardCoreThemes.Name)', 'base': '%(OrchardCoreThemes.Base)', 'category': '%(OrchardCoreThemes.Category)', 'priority': '%(OrchardCoreThemes.Priority)', 'description': '%(OrchardCoreThemes.Description)', 'author': '%(OrchardCoreThemes.Author)', 'version': '%(OrchardCoreThemes.Version)', 'website': '%(OrchardCoreThemes.Website)', 'dependencies': '%(OrchardCoreThemes.Dependencies)', 'tags': '%(OrchardCoreThemes.Tags)', 'defaultTenant': '%(OrchardCoreThemes.DefaultTenant)', 'alwaysEnabled': '%(OrchardCoreThemes.AlwaysEnabled'), 'enabledByDependencyOnly': '%(OrchardCoreThemes.EnabledByDependencyOnly')}" />
     <ItemGroup>
       <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
         <_Parameter1>@(OrchardCoreThemes)</_Parameter1>
@@ -77,7 +77,7 @@
         <_Parameter11>%(OrchardCoreThemes.Tags)</_Parameter11>
         <_Parameter12>%(OrchardCoreThemes.DefaultTenant)</_Parameter12>
         <_Parameter13>%(OrchardCoreThemes.AlwaysEnabled)</_Parameter13>
-        <_Parameter14>%(OrchardCoreThemes.Listable)</_Parameter14>
+        <_Parameter14>%(OrchardCoreThemes.EnabledByDependencyOnly)</_Parameter14>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Theme.Targets/OrchardCore.Theme.Targets.targets
@@ -49,6 +49,7 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
+    14: , object listable
     -->
   <!-- OrchardCoreEmbeddingAfter/BeforeTargets declared in the 'OrchardCore.Modules.Targets.targets' file;
     may be appended by consuming developer discretionary requirements. -->
@@ -76,6 +77,7 @@
         <_Parameter11>%(OrchardCoreThemes.Tags)</_Parameter11>
         <_Parameter12>%(OrchardCoreThemes.DefaultTenant)</_Parameter12>
         <_Parameter13>%(OrchardCoreThemes.AlwaysEnabled)</_Parameter13>
+        <_Parameter14>%(OrchardCoreThemes.Listable)</_Parameter14>
       </AssemblyAttribute>
     </ItemGroup>
   </Target>

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
@@ -9,7 +9,6 @@ namespace OrchardCore.Environment.Extensions.Features
             Id = Name = id;
             Extension = extensionInfo;
             Dependencies = Array.Empty<string>();
-            Listable = true;
         }
 
         public FeatureInfo(
@@ -22,7 +21,7 @@ namespace OrchardCore.Environment.Extensions.Features
             string[] dependencies,
             bool defaultTenantOnly,
             bool isAlwaysEnabled,
-            bool listable)
+            bool enabledByDependencyOnly)
         {
             Id = id;
             Name = name;
@@ -33,7 +32,7 @@ namespace OrchardCore.Environment.Extensions.Features
             Dependencies = dependencies;
             DefaultTenantOnly = defaultTenantOnly;
             IsAlwaysEnabled = isAlwaysEnabled;
-            Listable = listable;
+            EnabledByDependencyOnly = enabledByDependencyOnly;
         }
 
         public string Id { get; }
@@ -45,6 +44,6 @@ namespace OrchardCore.Environment.Extensions.Features
         public IExtensionInfo Extension { get; }
         public string[] Dependencies { get; }
         public bool IsAlwaysEnabled { get; }
-        public bool Listable { get; }
+        public bool EnabledByDependencyOnly { get; }
     }
 }

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
@@ -9,6 +9,7 @@ namespace OrchardCore.Environment.Extensions.Features
             Id = Name = id;
             Extension = extensionInfo;
             Dependencies = Array.Empty<string>();
+            Listable = true;
         }
 
         public FeatureInfo(
@@ -20,7 +21,8 @@ namespace OrchardCore.Environment.Extensions.Features
             IExtensionInfo extension,
             string[] dependencies,
             bool defaultTenantOnly,
-            bool isAlwaysEnabled)
+            bool isAlwaysEnabled,
+            bool listable)
         {
             Id = id;
             Name = name;
@@ -31,6 +33,7 @@ namespace OrchardCore.Environment.Extensions.Features
             Dependencies = dependencies;
             DefaultTenantOnly = defaultTenantOnly;
             IsAlwaysEnabled = isAlwaysEnabled;
+            Listable = listable;
         }
 
         public string Id { get; }
@@ -42,5 +45,7 @@ namespace OrchardCore.Environment.Extensions.Features
         public IExtensionInfo Extension { get; }
         public string[] Dependencies { get; }
         public bool IsAlwaysEnabled { get; }
+        public bool Listable { get; }
+
     }
 }

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeatureInfo.cs
@@ -46,6 +46,5 @@ namespace OrchardCore.Environment.Extensions.Features
         public string[] Dependencies { get; }
         public bool IsAlwaysEnabled { get; }
         public bool Listable { get; }
-
     }
 }

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
@@ -4,8 +4,6 @@ using System.Linq;
 
 namespace OrchardCore.Environment.Extensions.Features
 {
-    using Modules.Manifest;
-
     /// <inheritdoc/>
     public class FeaturesProvider : IFeaturesProvider
     {
@@ -48,8 +46,6 @@ namespace OrchardCore.Environment.Extensions.Features
                     var featureCategory = feature.Categorize(manifestInfo.ModuleInfo);
                     var featurePriority = feature.Prioritize(manifestInfo.ModuleInfo);
                     var featureDescription = feature.Describe(manifestInfo.ModuleInfo);
-                    var featureDefaultTenantOnly = feature.DefaultTenantOnly;
-                    var featureIsAlwaysEnabled = feature.IsAlwaysEnabled;
 
                     var context = new FeatureBuildingContext
                     {
@@ -61,8 +57,9 @@ namespace OrchardCore.Environment.Extensions.Features
                         ManifestInfo = manifestInfo,
                         Priority = featurePriority,
                         FeatureDependencyIds = featureDependencyIds,
-                        DefaultTenantOnly = featureDefaultTenantOnly,
-                        IsAlwaysEnabled = featureIsAlwaysEnabled
+                        DefaultTenantOnly = feature.DefaultTenantOnly,
+                        IsAlwaysEnabled = feature.IsAlwaysEnabled,
+                        Listable = feature.Listable
                     };
 
                     foreach (var builder in _featureBuilderEvents)
@@ -79,7 +76,8 @@ namespace OrchardCore.Environment.Extensions.Features
                         context.ExtensionInfo,
                         context.FeatureDependencyIds,
                         context.DefaultTenantOnly,
-                        context.IsAlwaysEnabled);
+                        context.IsAlwaysEnabled,
+                        context.Listable);
 
                     foreach (var builder in _featureBuilderEvents)
                     {
@@ -101,8 +99,6 @@ namespace OrchardCore.Environment.Extensions.Features
                 var featureCategory = manifestInfo.ModuleInfo.Categorize();
                 var featurePriority = manifestInfo.ModuleInfo.Prioritize();
                 var featureDescription = manifestInfo.ModuleInfo.Describe();
-                var featureDefaultTenantOnly = manifestInfo.ModuleInfo.DefaultTenantOnly;
-                var featureIsAlwaysEnabled = manifestInfo.ModuleInfo.IsAlwaysEnabled;
 
                 var context = new FeatureBuildingContext
                 {
@@ -114,8 +110,9 @@ namespace OrchardCore.Environment.Extensions.Features
                     ManifestInfo = manifestInfo,
                     Priority = featurePriority,
                     FeatureDependencyIds = featureDependencyIds,
-                    DefaultTenantOnly = featureDefaultTenantOnly,
-                    IsAlwaysEnabled = featureIsAlwaysEnabled
+                    DefaultTenantOnly = manifestInfo.ModuleInfo.DefaultTenantOnly,
+                    IsAlwaysEnabled = manifestInfo.ModuleInfo.IsAlwaysEnabled,
+                    Listable = manifestInfo.ModuleInfo.Listable,
                 };
 
                 foreach (var builder in _featureBuilderEvents)
@@ -132,7 +129,8 @@ namespace OrchardCore.Environment.Extensions.Features
                     context.ExtensionInfo,
                     context.FeatureDependencyIds,
                     context.DefaultTenantOnly,
-                    context.IsAlwaysEnabled);
+                    context.IsAlwaysEnabled,
+                    context.Listable);
 
                 foreach (var builder in _featureBuilderEvents)
                 {

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
@@ -46,6 +46,9 @@ namespace OrchardCore.Environment.Extensions.Features
                     var featureCategory = feature.Categorize(manifestInfo.ModuleInfo);
                     var featurePriority = feature.Prioritize(manifestInfo.ModuleInfo);
                     var featureDescription = feature.Describe(manifestInfo.ModuleInfo);
+                    var featureDefaultTenantOnly = feature.DefaultTenantOnly;
+                    var featureIsAlwaysEnabled = feature.IsAlwaysEnabled;
+                    var featureIsListable = feature.Listable;
 
                     var context = new FeatureBuildingContext
                     {
@@ -57,9 +60,9 @@ namespace OrchardCore.Environment.Extensions.Features
                         ManifestInfo = manifestInfo,
                         Priority = featurePriority,
                         FeatureDependencyIds = featureDependencyIds,
-                        DefaultTenantOnly = feature.DefaultTenantOnly,
-                        IsAlwaysEnabled = feature.IsAlwaysEnabled,
-                        Listable = feature.Listable
+                        DefaultTenantOnly = featureDefaultTenantOnly,
+                        IsAlwaysEnabled = featureIsAlwaysEnabled,
+                        Listable = featureIsListable
                     };
 
                     foreach (var builder in _featureBuilderEvents)
@@ -99,6 +102,9 @@ namespace OrchardCore.Environment.Extensions.Features
                 var featureCategory = manifestInfo.ModuleInfo.Categorize();
                 var featurePriority = manifestInfo.ModuleInfo.Prioritize();
                 var featureDescription = manifestInfo.ModuleInfo.Describe();
+                var featureDefaultTenantOnly = manifestInfo.ModuleInfo.DefaultTenantOnly;
+                var featureIsAlwaysEnabled = manifestInfo.ModuleInfo.IsAlwaysEnabled;
+                var featureIsListable = manifestInfo.ModuleInfo.Listable;
 
                 var context = new FeatureBuildingContext
                 {
@@ -110,9 +116,9 @@ namespace OrchardCore.Environment.Extensions.Features
                     ManifestInfo = manifestInfo,
                     Priority = featurePriority,
                     FeatureDependencyIds = featureDependencyIds,
-                    DefaultTenantOnly = manifestInfo.ModuleInfo.DefaultTenantOnly,
-                    IsAlwaysEnabled = manifestInfo.ModuleInfo.IsAlwaysEnabled,
-                    Listable = manifestInfo.ModuleInfo.Listable,
+                    DefaultTenantOnly = featureDefaultTenantOnly,
+                    IsAlwaysEnabled = featureIsAlwaysEnabled,
+                    Listable = featureIsListable,
                 };
 
                 foreach (var builder in _featureBuilderEvents)

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
@@ -48,7 +48,7 @@ namespace OrchardCore.Environment.Extensions.Features
                     var featureDescription = feature.Describe(manifestInfo.ModuleInfo);
                     var featureDefaultTenantOnly = feature.DefaultTenantOnly;
                     var featureIsAlwaysEnabled = feature.IsAlwaysEnabled;
-                    var featureIsListable = feature.Listable;
+                    var featureEnabledByDependencyOnly = feature.EnabledByDependencyOnly;
 
                     var context = new FeatureBuildingContext
                     {
@@ -62,7 +62,7 @@ namespace OrchardCore.Environment.Extensions.Features
                         FeatureDependencyIds = featureDependencyIds,
                         DefaultTenantOnly = featureDefaultTenantOnly,
                         IsAlwaysEnabled = featureIsAlwaysEnabled,
-                        Listable = featureIsListable
+                        EnabledByDependencyOnly = featureEnabledByDependencyOnly
                     };
 
                     foreach (var builder in _featureBuilderEvents)
@@ -80,7 +80,7 @@ namespace OrchardCore.Environment.Extensions.Features
                         context.FeatureDependencyIds,
                         context.DefaultTenantOnly,
                         context.IsAlwaysEnabled,
-                        context.Listable);
+                        context.EnabledByDependencyOnly);
 
                     foreach (var builder in _featureBuilderEvents)
                     {
@@ -104,7 +104,7 @@ namespace OrchardCore.Environment.Extensions.Features
                 var featureDescription = manifestInfo.ModuleInfo.Describe();
                 var featureDefaultTenantOnly = manifestInfo.ModuleInfo.DefaultTenantOnly;
                 var featureIsAlwaysEnabled = manifestInfo.ModuleInfo.IsAlwaysEnabled;
-                var featureIsListable = manifestInfo.ModuleInfo.Listable;
+                var featureEnabledByDependencyOnly = manifestInfo.ModuleInfo.EnabledByDependencyOnly;
 
                 var context = new FeatureBuildingContext
                 {
@@ -118,7 +118,7 @@ namespace OrchardCore.Environment.Extensions.Features
                     FeatureDependencyIds = featureDependencyIds,
                     DefaultTenantOnly = featureDefaultTenantOnly,
                     IsAlwaysEnabled = featureIsAlwaysEnabled,
-                    Listable = featureIsListable,
+                    EnabledByDependencyOnly = featureEnabledByDependencyOnly,
                 };
 
                 foreach (var builder in _featureBuilderEvents)
@@ -136,7 +136,7 @@ namespace OrchardCore.Environment.Extensions.Features
                     context.FeatureDependencyIds,
                     context.DefaultTenantOnly,
                     context.IsAlwaysEnabled,
-                    context.Listable);
+                    context.EnabledByDependencyOnly);
 
                 foreach (var builder in _featureBuilderEvents)
                 {

--- a/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
@@ -32,17 +32,13 @@ namespace OrchardCore.Environment.Shell
         }
 
         public async Task<(IEnumerable<IFeatureInfo>, IEnumerable<IFeatureInfo>)> UpdateFeaturesAsync(ShellDescriptor shellDescriptor,
-            IEnumerable<IFeatureInfo> featuresToDisable,
-            IEnumerable<IFeatureInfo> featuresToEnable,
-            bool force)
+            IEnumerable<IFeatureInfo> featuresToDisable, IEnumerable<IFeatureInfo> featuresToEnable, bool force)
         {
             var featureEventHandlers = ShellScope.Services.GetServices<IFeatureEventHandler>();
-
-            var enabledFeatures = _extensionManager.GetFeatures()
+            var allFeatures = _extensionManager.GetFeatures().ToHashSet();
+            var enabledFeatureIds = allFeatures
                 .Where(f => shellDescriptor.Features.Any(sf => sf.Id == f.Id))
-                .ToHashSet();
-
-            var enabledFeatureIds = enabledFeatures.Select(f => f.Id)
+                .Select(f => f.Id)
                 .ToHashSet();
 
             var installedFeatureIds = enabledFeatureIds
@@ -51,70 +47,14 @@ namespace OrchardCore.Environment.Shell
 
             var alwaysEnabledIds = _alwaysEnabledFeatures.Select(sf => sf.Id).ToArray();
 
-            var safeToEnableFeatures = new List<IFeatureInfo>();
-
-            // Look for features that can be enabled automatically.
-            foreach (var featureToEnable in featuresToEnable)
-            {
-                if (featureToEnable.EnabledByDependencyOnly)
-                {
-                    // EnabledByDependencyOnly features are managed internally and can't be explicitly enabled.
-                    continue;
-                }
-
-                // its safe to enable this feature
-                safeToEnableFeatures.AddRange(GetFeaturesToEnable(featureToEnable, enabledFeatureIds, force));
-
-                // Find any dependency that has EnabledByDependencyOnly, and manually enable it.
-                var autoEnable = _extensionManager.GetFeatureDependencies(featureToEnable.Id)
-                    .Where(feature => feature.EnabledByDependencyOnly);
-
-                safeToEnableFeatures.AddRange(autoEnable);
-            }
-
-            var safeToDisableFeatures = new List<IFeatureInfo>();
-
-            // Look for features that can be disabled automatically.
-            foreach (var featureToDisable in featuresToDisable)
-            {
-                if (featureToDisable.IsAlwaysEnabled || featureToDisable.EnabledByDependencyOnly)
-                {
-                    // IsAlwaysEnabled cannot be disabled
-                    // EnabledByDependencyOnly features are managed internally and can't be explicitly disabled
-                    continue;
-                }
-
-                // It's safe to disable this feature
-                safeToDisableFeatures.AddRange(GetFeaturesToDisable(featureToDisable, enabledFeatureIds, force));
-
-                // If any of the dependencies has EnabledByDependencyOnly, we'll need to manually disable it.
-                // Get any features that are selectable and could be disabled automatically.
-                var canBeDisabled = _extensionManager.GetFeatureDependencies(featureToDisable.Id)
-                    .Where(feature => feature.EnabledByDependencyOnly && !safeToEnableFeatures.Any(safeToEnableFeature => safeToEnableFeature.Id == feature.Id));
-
-                safeToDisableFeatures.AddRange(canBeDisabled);
-            }
-
-            var allFeaturesToDisable = safeToDisableFeatures.Distinct().Reverse().ToList();
-
-            var willAutoDisable = safeToDisableFeatures.Where(safeToDisableFeature => safeToDisableFeature.EnabledByDependencyOnly).ToArray();
-
-            if (willAutoDisable.Length > 0)
-            {
-                // At this point, we know there are at least one feature that will be automatically disabled.
-
-                // Let's check all the enabled features recursively to make sure it's truely safe to disable them
-                foreach (var enabledFeature in enabledFeatures)
-                {
-                    if (safeToDisableFeatures.Any(feature => feature.Id == enabledFeature.Id && !enabledFeature.EnabledByDependencyOnly))
-                    {
-                        // This feature will be disabled, we don't need to evaluate it
-                        continue;
-                    }
-
-                    EvaluateDependenciesAndKeepWhatIsNeeded(enabledFeature.Id, safeToDisableFeatures, willAutoDisable);
-                }
-            }
+            var allFeaturesToDisable = featuresToDisable
+                .Where(f => !alwaysEnabledIds.Contains(f.Id))
+                .SelectMany(feature => GetFeaturesToDisable(feature, enabledFeatureIds, force))
+                // Always attempt to disable EnabledByDependencyOnly features to ensure we auto disable any feature that is no longer needed
+                .Union(allFeatures.Where(f => f.EnabledByDependencyOnly))
+                .Distinct()
+                .Reverse()
+                .ToList();
 
             foreach (var feature in allFeaturesToDisable)
             {
@@ -128,7 +68,10 @@ namespace OrchardCore.Environment.Shell
                 await featureEventHandlers.InvokeAsync((handler, featureInfo) => handler.DisablingAsync(featureInfo), feature, _logger);
             }
 
-            var allFeaturesToEnable = safeToEnableFeatures.Distinct().ToList();
+            var allFeaturesToEnable = featuresToEnable
+                .SelectMany(feature => GetFeaturesToEnable(feature, enabledFeatureIds, force))
+                .Distinct()
+                .ToList();
 
             foreach (var feature in allFeaturesToEnable)
             {
@@ -206,31 +149,6 @@ namespace OrchardCore.Environment.Shell
         }
 
         /// <summary>
-        /// Evaluate dependencies and removes it necessary from toDisable
-        /// </summary>
-        private void EvaluateDependenciesAndKeepWhatIsNeeded(string id, List<IFeatureInfo> safeToDisableFeatures, IFeatureInfo[] willAutoDisable)
-        {
-            var features = _extensionManager.GetFeatureDependencies(id)
-                .Union(_extensionManager.GetDependentFeatures(id));
-
-            foreach (var feature in features)
-            {
-                if (feature.Id == id || !feature.EnabledByDependencyOnly)
-                {
-                    continue;
-                }
-
-                var cannotDisable = willAutoDisable.FirstOrDefault(feature => feature.Id == feature.Id);
-
-                if (cannotDisable != null)
-                {
-                    // This dependency is needed by other features, let's not disable it.
-                    safeToDisableFeatures.Remove(cannotDisable);
-                }
-            }
-        }
-
-        /// <summary>
         /// Enables a feature.
         /// </summary>
         /// <param name="featureInfo">The info of the feature to be enabled.</param>
@@ -241,7 +159,7 @@ namespace OrchardCore.Environment.Shell
         {
             var featuresToEnable = _extensionManager
                 .GetFeatureDependencies(featureInfo.Id)
-                .Where(f => !f.EnabledByDependencyOnly && !enabledFeatureIds.Contains(f.Id))
+                .Where(f => !enabledFeatureIds.Contains(f.Id))
                 .ToList();
 
             if (featuresToEnable.Count > 1 && !force)
@@ -268,7 +186,7 @@ namespace OrchardCore.Environment.Shell
         {
             var featuresToDisable = _extensionManager
                 .GetDependentFeatures(featureInfo.Id)
-                .Where(f => !f.EnabledByDependencyOnly && enabledFeatureIds.Contains(f.Id))
+                .Where(f => enabledFeatureIds.Contains(f.Id))
                 .ToList();
 
             if (featuresToDisable.Count > 1 && !force)

--- a/src/OrchardCore/OrchardCore/Shell/ShellFeaturesManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellFeaturesManager.cs
@@ -75,15 +75,15 @@ namespace OrchardCore.Environment.Shell
             // Look for features that can be enabled automatically.
             foreach (var featureToEnable in featuresToEnable)
             {
-                if (!featureToEnable.Listable)
+                if (!featureToEnable.EnabledByDependencyOnly)
                 {
-                    // Not listable features are managed internally and can't be explicitly enabled.
+                    // EnabledByDependencyOnly features are managed internally and can't be explicitly enabled.
                     continue;
                 }
 
-                // When any of the dependencies are not listable, we'll need to manually enable them.
+                // When any of the dependencies are EnabledByDependencyOnly, we'll need to manually enable them.
                 var autoEnable = _extensionManager.GetFeatureDependencies(featureToEnable.Id)
-                    .Where(feature => !feature.Listable).ToArray();
+                    .Where(feature => !feature.EnabledByDependencyOnly).ToArray();
 
                 toEnable.AddRange(autoEnable);
                 toEnable.Add(featureToEnable);
@@ -92,22 +92,22 @@ namespace OrchardCore.Environment.Shell
             // Look for features that can be disabled automatically.
             foreach (var featureToDisable in featuresToDisable)
             {
-                if (!featureToDisable.Listable)
+                if (!featureToDisable.EnabledByDependencyOnly)
                 {
-                    // Not listable features are managed internally and can't be explicitly disabled
+                    // EnabledByDependencyOnly features are managed internally and can't be explicitly disabled
                     continue;
                 }
-                // If any of the dependencies are not listable, we'll need to manually disable them.
+                // If any of the dependencies are EnabledByDependencyOnly, we'll need to manually disable them.
                 // Get any features that are selectable and could be disabled automatically.
                 var canBeDisabled = _extensionManager.GetFeatureDependencies(featureToDisable.Id)
-                    .Where(feature => !feature.Listable && !toEnable.Any(willEnableFeature => willEnableFeature.Id == feature.Id))
+                    .Where(feature => !feature.EnabledByDependencyOnly && !toEnable.Any(willEnableFeature => willEnableFeature.Id == feature.Id))
                     .ToArray();
 
                 toDisable.AddRange(canBeDisabled);
                 toDisable.Add(featureToDisable);
             }
 
-            var willAutoDisable = toDisable.Where(f => !f.Listable).ToArray();
+            var willAutoDisable = toDisable.Where(f => !f.EnabledByDependencyOnly).ToArray();
 
             if (willAutoDisable.Length > 0)
             {
@@ -118,7 +118,7 @@ namespace OrchardCore.Environment.Shell
                 // At this point, we know there are at least one feature that will be automatically disabled.
                 foreach (var enabledFeature in enabledFeatures)
                 {
-                    if (toDisable.Any(feature => feature.Id == enabledFeature.Id && enabledFeature.Listable))
+                    if (toDisable.Any(feature => feature.Id == enabledFeature.Id && enabledFeature.EnabledByDependencyOnly))
                     {
                         // This feature will be disabled, we don't need to evaluate it
                         continue;
@@ -150,7 +150,7 @@ namespace OrchardCore.Environment.Shell
 
             foreach (var dependency in dependencies)
             {
-                if (dependency.Id == id || dependency.Listable)
+                if (dependency.Id == id || dependency.EnabledByDependencyOnly)
                 {
                     continue;
                 }

--- a/src/OrchardCore/OrchardCore/Shell/ShellFeaturesManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellFeaturesManager.cs
@@ -67,9 +67,9 @@ namespace OrchardCore.Environment.Shell
             return Task.FromResult(_extensionManager.GetFeatures().Where(f => _shellDescriptor.Features.All(sf => sf.Id != f.Id)));
         }
 
-        public async Task<(IEnumerable<IFeatureInfo>, IEnumerable<IFeatureInfo>)> UpdateFeaturesAsync(IEnumerable<IFeatureInfo> featuresToDisable, IEnumerable<IFeatureInfo> featuresToEnable, bool force)
+        public Task<(IEnumerable<IFeatureInfo>, IEnumerable<IFeatureInfo>)> UpdateFeaturesAsync(IEnumerable<IFeatureInfo> featuresToDisable, IEnumerable<IFeatureInfo> featuresToEnable, bool force)
         {
-            return await _shellDescriptorFeaturesManager.UpdateFeaturesAsync(_shellDescriptor, featuresToDisable, featuresToEnable, force);
+            return _shellDescriptorFeaturesManager.UpdateFeaturesAsync(_shellDescriptor, featuresToDisable, featuresToEnable, force);
         }
 
         public Task<IEnumerable<IExtensionInfo>> GetEnabledExtensionsAsync()
@@ -80,34 +80,6 @@ namespace OrchardCore.Environment.Shell
 
             // Extensions are still ordered according to the weight of their first features.
             return Task.FromResult(_extensionManager.GetExtensions().Where(e => enabledIds.Contains(e.Id)));
-        }
-
-        /// <summary>
-        /// Recursively evaluate dependencies and removes it necessary from toDisable
-        /// </summary>
-        private void EvaluateDependenciesAndKeepWhatIsNeeded(string id, List<IFeatureInfo> safeToDisableFeatures, IFeatureInfo[] willAutoDisable)
-        {
-            var dependencies = _extensionManager.GetFeatureDependencies(id);
-
-            foreach (var dependency in dependencies)
-            {
-                if (dependency.Id == id || !dependency.EnabledByDependencyOnly)
-                {
-                    continue;
-                }
-
-                var cannotDisable = willAutoDisable.FirstOrDefault(feature => feature.Id == dependency.Id);
-
-                if (cannotDisable != null)
-                {
-                    // This dependency is needed by other features, let's not disable it.
-                    safeToDisableFeatures.Remove(cannotDisable);
-                }
-                else
-                {
-                    EvaluateDependenciesAndKeepWhatIsNeeded(dependency.Id, safeToDisableFeatures, willAutoDisable);
-                }
-            }
         }
     }
 }

--- a/src/docs/guides/leverage-csproj-meta-info/README.md
+++ b/src/docs/guides/leverage-csproj-meta-info/README.md
@@ -31,7 +31,7 @@ There are several items you may be interested in, depending on your projects, i.
                      Dependencies="..."
                      DefaultTenant="..."
                      AlwaysEnabled="..."
-                     IsOnDemand="..." />
+                     EnabledByDependencyOnly="..." />
 ```
 
 ```xml
@@ -48,7 +48,7 @@ There are several items you may be interested in, depending on your projects, i.
                     Tags="..."
                     DefaultTenant="..."
                     AlwaysEnabled="..."
-                    IsOnDemand="..." />
+                    EnabledByDependencyOnly="..." />
 ```
 
 ```xml
@@ -65,7 +65,7 @@ There are several items you may be interested in, depending on your projects, i.
                    Tags="..."
                    DefaultTenant="..."
                    AlwaysEnabled="..."
-                   IsOnDemand="..."/>
+                   EnabledByDependencyOnly="..."/>
 ```
 
 With all _properties_ described as follows.
@@ -85,7 +85,7 @@ With all _properties_ described as follows.
 |`Tags`|`list`|Optional, semi-colon delimited list of tags. <sup>3</sup>|
 |`DefaultTenant`|`bool` <sup>1</sup>|Optional, Boolean, `true|false`, defaults to `false`.|
 |`AlwaysEnabled`|`bool` <sup>1</sup>|Optional, Boolean, `true|false`, defaults to `false`.|
-|`IsOnDemand`|`bool` <sup>1</sup>|Optional, Boolean, `true|false`, defaults to `false`.|
+|`EnabledByDependencyOnly`|`bool` <sup>1</sup>|Optional, Boolean, `true|false`, defaults to `false`.|
 
 <sup>[1] `MSBuild` relays all meta data as `string`, leaving authors to contend with either `string` or `object` type conversions i.e. either `int` or `bool`, which is fine for our purposes.</sup>
 <br/><sup>[2] Depending on the `Attribute` context, `ModuleAttribute` yields `"Module"`, `ThemeAttribute` yields `"Theme"` by default.</sup>

--- a/src/docs/guides/leverage-csproj-meta-info/README.md
+++ b/src/docs/guides/leverage-csproj-meta-info/README.md
@@ -30,7 +30,8 @@ There are several items you may be interested in, depending on your projects, i.
                      Description="..."
                      Dependencies="..."
                      DefaultTenant="..."
-                     AlwaysEnabled="..." />
+                     AlwaysEnabled="..."
+                     IsOnDemand="..." />
 ```
 
 ```xml
@@ -46,7 +47,8 @@ There are several items you may be interested in, depending on your projects, i.
                     Dependencies="..."
                     Tags="..."
                     DefaultTenant="..."
-                    AlwaysEnabled="..." />
+                    AlwaysEnabled="..."
+                    IsOnDemand="..." />
 ```
 
 ```xml
@@ -62,7 +64,8 @@ There are several items you may be interested in, depending on your projects, i.
                    Dependencies="..."
                    Tags="..."
                    DefaultTenant="..."
-                   AlwaysEnabled="..." />
+                   AlwaysEnabled="..."
+                   IsOnDemand="..."/>
 ```
 
 With all _properties_ described as follows.
@@ -82,6 +85,7 @@ With all _properties_ described as follows.
 |`Tags`|`list`|Optional, semi-colon delimited list of tags. <sup>3</sup>|
 |`DefaultTenant`|`bool` <sup>1</sup>|Optional, Boolean, `true|false`, defaults to `false`.|
 |`AlwaysEnabled`|`bool` <sup>1</sup>|Optional, Boolean, `true|false`, defaults to `false`.|
+|`IsOnDemand`|`bool` <sup>1</sup>|Optional, Boolean, `true|false`, defaults to `false`.|
 
 <sup>[1] `MSBuild` relays all meta data as `string`, leaving authors to contend with either `string` or `object` type conversions i.e. either `int` or `bool`, which is fine for our purposes.</sup>
 <br/><sup>[2] Depending on the `Attribute` context, `ModuleAttribute` yields `"Module"`, `ThemeAttribute` yields `"Theme"` by default.</sup>

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.Attribute.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.Attribute.cs
@@ -128,7 +128,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Classifier supporting
         /// <see cref="FeatureAttribute(string, string, string, bool, bool, bool)"/>, arguments in
-        /// order, <c>id, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
+        /// order, <c>id, description, featureDependencies, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -143,7 +143,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Classifier supporting
         /// <see cref="FeatureAttribute(string, string, string, string, bool, bool, bool)"/>, arguments in
-        /// order, <c>id, name, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
+        /// order, <c>id, name, description, featureDependencies, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -158,7 +158,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Classifier supporting
         /// <see cref="FeatureAttribute(string, string, string, string, string, string, bool, bool, bool)"/>, arguments in
-        /// order, <c>id, name, category, priority, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
+        /// order, <c>id, name, category, priority, description, featureDependencies, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.Attribute.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.Attribute.cs
@@ -109,7 +109,8 @@ namespace OrchardCore.Modules.Manifest
             var allAttributeCtorWithParameterTypes = allAttributeCtors.Select(ctor => new
             {
                 Callback = ctor
-                , Types = ctor.GetParameters().Select(_ => _.ParameterType).ToArray()
+                ,
+                Types = ctor.GetParameters().Select(_ => _.ParameterType).ToArray()
             }).ToArray();
 
             var attributeCtor = allAttributeCtorWithParameterTypes.SingleOrDefault(_ => _.Types.SequenceEqual(types))?.Callback;
@@ -126,8 +127,8 @@ namespace OrchardCore.Modules.Manifest
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="FeatureAttribute(string, string, string, bool, bool)"/>, arguments in
-        /// order, <c>id, description, featureDependencies, defaultTenant, alwaysEnabled</c>.
+        /// <see cref="FeatureAttribute(string, string, string, bool, bool, bool)"/>, arguments in
+        /// order, <c>id, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -135,14 +136,14 @@ namespace OrchardCore.Modules.Manifest
         protected virtual Type FeatureString3Object2CtorClassifier(int index, object arg) =>
             index switch
             {
-                3 or 4 => typeof(object),
+                3 or 4 or 5 => typeof(object),
                 _ => typeof(string),
             };
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="FeatureAttribute(string, string, string, string, bool, bool)"/>, arguments in
-        /// order, <c>id, name, description, featureDependencies, defaultTenant, alwaysEnabled</c>.
+        /// <see cref="FeatureAttribute(string, string, string, string, bool, bool, bool)"/>, arguments in
+        /// order, <c>id, name, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -150,14 +151,14 @@ namespace OrchardCore.Modules.Manifest
         protected virtual Type FeatureString4Object2CtorClassifier(int index, object arg) =>
             index switch
             {
-                4 or 5 => typeof(object),
+                4 or 5 or 6 => typeof(object),
                 _ => typeof(string),
             };
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="FeatureAttribute(string, string, string, string, string, string, bool, bool)"/>, arguments in
-        /// order, <c>id, name, category, priority, description, featureDependencies, defaultTenant, alwaysEnabled</c>.
+        /// <see cref="FeatureAttribute(string, string, string, string, string, string, bool, bool, bool)"/>, arguments in
+        /// order, <c>id, name, category, priority, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -165,7 +166,7 @@ namespace OrchardCore.Modules.Manifest
         protected virtual Type FeatureString6Object2CtorClassifier(int index, object arg) =>
             index switch
             {
-                6 or 7 => typeof(object),
+                6 or 7 or 8 => typeof(object),
                 _ => typeof(string),
             };
 
@@ -318,7 +319,7 @@ namespace OrchardCore.Modules.Manifest
             }
 
             /// <inheritdoc/>
-            public override string ToString() => string.Join(": ", $"\"{Key}\"", Render.Invoke(Value));
+            public override string ToString() => String.Join(": ", $"\"{Key}\"", Render.Invoke(Value));
         }
 
         /// <summary>
@@ -327,8 +328,8 @@ namespace OrchardCore.Modules.Manifest
         /// <param name="pairs"></param>
         /// <returns></returns>
         protected virtual string RenderKeyValuePairs(params RenderKeyValuePair[] pairs) =>
-            string.Join(
-                string.Join(", ", pairs.Select(_ => $"{_}")), "{}".ToCharArray().Select(_ => $"{_}")
+            String.Join(
+                String.Join(", ", pairs.Select(_ => $"{_}")), "{}".ToCharArray().Select(_ => $"{_}")
             );
 
         /// <summary>
@@ -372,6 +373,7 @@ namespace OrchardCore.Modules.Manifest
             where T : Attribute
         {
             predicate ??= DefaultAssemblyAttribPredicate;
+
             var attribs = rootType.Assembly.GetCustomAttributes<T>().Where(predicate).ToArray();
             return attribs;
         }

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.Attribute.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.Attribute.cs
@@ -133,7 +133,7 @@ namespace OrchardCore.Modules.Manifest
         /// <param name="index"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        protected virtual Type FeatureString3Object2CtorClassifier(int index, object arg) =>
+        protected virtual Type FeatureString3Object3CtorClassifier(int index, object arg) =>
             index switch
             {
                 3 or 4 or 5 => typeof(object),
@@ -148,7 +148,7 @@ namespace OrchardCore.Modules.Manifest
         /// <param name="index"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        protected virtual Type FeatureString4Object2CtorClassifier(int index, object arg) =>
+        protected virtual Type FeatureString4Object3CtorClassifier(int index, object arg) =>
             index switch
             {
                 4 or 5 or 6 => typeof(object),
@@ -163,7 +163,7 @@ namespace OrchardCore.Modules.Manifest
         /// <param name="index"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        protected virtual Type FeatureString6Object2CtorClassifier(int index, object arg) =>
+        protected virtual Type FeatureString6Object3CtorClassifier(int index, object arg) =>
             index switch
             {
                 6 or 7 or 8 => typeof(object),
@@ -373,7 +373,6 @@ namespace OrchardCore.Modules.Manifest
             where T : Attribute
         {
             predicate ??= DefaultAssemblyAttribPredicate;
-
             var attribs = rootType.Assembly.GetCustomAttributes<T>().Where(predicate).ToArray();
             return attribs;
         }

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
@@ -62,7 +62,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var feature = CreateFromArgs(FeatureString3Object2CtorClassifier, id, description, depString, defaultTenant, alwaysEnabled, listable);
+            var feature = CreateFromArgs(FeatureString3Object3CtorClassifier, id, description, depString, defaultTenant, alwaysEnabled, listable);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -109,7 +109,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var feature = CreateFromArgs(FeatureString4Object2CtorClassifier, id, name, description, depString, defaultTenant, alwaysEnabled, listable);
+            var feature = CreateFromArgs(FeatureString4Object3CtorClassifier, id, name, description, depString, defaultTenant, alwaysEnabled, listable);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -161,7 +161,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var feature = CreateFromArgs(FeatureString6Object2CtorClassifier, id, name, category, priString, description, depString, defaultTenant, alwaysEnabled, listable);
+            var feature = CreateFromArgs(FeatureString6Object3CtorClassifier, id, name, category, priString, description, depString, defaultTenant, alwaysEnabled, listable);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -280,7 +280,7 @@ namespace OrchardCore.Modules.Manifest
 
             // TODO: TBD: also for attributes created using property initializers
             FeatureAttribute CreateForPriority(string priString = null) => CreateFromArgs(
-                FeatureString6Object2CtorClassifier
+                FeatureString6Object3CtorClassifier
                 , LoremWords(1)
                 , name
                 , category
@@ -321,7 +321,7 @@ namespace OrchardCore.Modules.Manifest
 
             // TODO: TBD: also for attributes created using property initializers
             FeatureAttribute CreateForDescription(string description = null) => CreateFromArgs(
-                FeatureString6Object2CtorClassifier
+                FeatureString6Object3CtorClassifier
                 , LoremWords(1)
                 , name
                 , category
@@ -362,7 +362,7 @@ namespace OrchardCore.Modules.Manifest
 
             // TODO: TBD: also for attributes created using property initializers
             FeatureAttribute CreateForCategory(string category = null) => CreateFromArgs(
-                FeatureString6Object2CtorClassifier
+                FeatureString6Object3CtorClassifier
                 , LoremWords(1)
                 , name
                 , category
@@ -403,7 +403,7 @@ namespace OrchardCore.Modules.Manifest
             var listDelims = FeatureAttribute.ListDelims;
 
             FeatureAttribute CreateForDeps(params string[] deps) => CreateFromArgs(
-                FeatureString6Object2CtorClassifier
+                FeatureString6Object3CtorClassifier
                 , LoremWords(1)
                 , null
                 , null

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
@@ -39,7 +39,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Verify the <see cref="FeatureAttribute(string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, description, featureDependencies, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id()
@@ -49,7 +49,7 @@ namespace OrchardCore.Modules.Manifest
             var deps = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var depString = String.Join(';', deps);
 
@@ -59,10 +59,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(deps), depString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var feature = CreateFromArgs(FeatureString3Object3CtorClassifier, id, description, depString, defaultTenant, alwaysEnabled, listable);
+            var feature = CreateFromArgs(FeatureString3Object3CtorClassifier, id, description, depString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -84,7 +84,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Verify the <see cref="FeatureAttribute(string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, description, featureDependencies, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name()
@@ -95,7 +95,7 @@ namespace OrchardCore.Modules.Manifest
             var deps = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var depString = String.Join(';', deps);
 
@@ -106,10 +106,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(deps), depString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var feature = CreateFromArgs(FeatureString4Object3CtorClassifier, id, name, description, depString, defaultTenant, alwaysEnabled, listable);
+            var feature = CreateFromArgs(FeatureString4Object3CtorClassifier, id, name, description, depString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -131,7 +131,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Verify the <see cref="FeatureAttribute(string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, category, priority, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, category, priority, description, featureDependencies, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name_Cat_Pri()
@@ -144,7 +144,7 @@ namespace OrchardCore.Modules.Manifest
             var deps = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var depString = String.Join(';', deps);
             var priString = $"{priority}";
@@ -158,10 +158,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(deps), depString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var feature = CreateFromArgs(FeatureString6Object3CtorClassifier, id, name, category, priString, description, depString, defaultTenant, alwaysEnabled, listable);
+            var feature = CreateFromArgs(FeatureString6Object3CtorClassifier, id, name, category, priString, description, depString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -273,7 +273,7 @@ namespace OrchardCore.Modules.Manifest
             const string depString = null;
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priority = DefaultPriority;
             var expected = priority + 1;
@@ -289,7 +289,7 @@ namespace OrchardCore.Modules.Manifest
                 , depString
                 , defaultTenant
                 , alwaysEnabled
-                , listable
+                , enabledByDependencyOnly
             );
 
             var alpha = CreateForPriority();
@@ -315,7 +315,7 @@ namespace OrchardCore.Modules.Manifest
             const string depString = null;
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var expected = LoremWords(7);
 
@@ -330,7 +330,7 @@ namespace OrchardCore.Modules.Manifest
                 , depString
                 , defaultTenant
                 , alwaysEnabled
-                , listable
+                , enabledByDependencyOnly
             );
 
             var alpha = CreateForDescription();
@@ -356,7 +356,7 @@ namespace OrchardCore.Modules.Manifest
             const string depString = null;
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var expected = LoremWords(1);
 
@@ -371,7 +371,7 @@ namespace OrchardCore.Modules.Manifest
                 , depString
                 , defaultTenant
                 , alwaysEnabled
-                , listable
+                , enabledByDependencyOnly
             );
 
             var alpha = CreateForCategory();
@@ -412,7 +412,7 @@ namespace OrchardCore.Modules.Manifest
                 , depString
                 , default(bool)
                 , default(bool)
-                , true
+                , default(bool)
             );
 
             var feature = CreateForDeps(deps);

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
@@ -37,9 +37,9 @@ namespace OrchardCore.Modules.Manifest
         }
 
         /// <summary>
-        /// Verify the <see cref="FeatureAttribute(string, string, string, bool, bool)"/>
+        /// Verify the <see cref="FeatureAttribute(string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, description, featureDependencies, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id()
@@ -49,8 +49,10 @@ namespace OrchardCore.Modules.Manifest
             var deps = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
-            var depString = string.Join(';', deps);
+
+            var depString = String.Join(';', deps);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -58,9 +60,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(deps), depString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var feature = CreateFromArgs(FeatureString3Object2CtorClassifier, id, description, depString, defaultTenant, alwaysEnabled);
+            var feature = CreateFromArgs(FeatureString3Object2CtorClassifier, id, description, depString, defaultTenant, alwaysEnabled, listable);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -70,7 +73,7 @@ namespace OrchardCore.Modules.Manifest
             Assert.Equal(description, feature.Description);
 
             Assert.Null(feature.InternalPriority);
-            Assert.Equal(string.Empty, feature.Priority);
+            Assert.Equal(String.Empty, feature.Priority);
 
             Assert.NotNull(feature.Dependencies);
             Assert.Equal(deps, feature.Dependencies);
@@ -80,9 +83,9 @@ namespace OrchardCore.Modules.Manifest
         }
 
         /// <summary>
-        /// Verify the <see cref="FeatureAttribute(string, string, string, string, bool, bool)"/>
+        /// Verify the <see cref="FeatureAttribute(string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, description, featureDependencies, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name()
@@ -93,8 +96,9 @@ namespace OrchardCore.Modules.Manifest
             var deps = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
-            var depString = string.Join(';', deps);
+            var depString = String.Join(';', deps);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -103,9 +107,11 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(deps), depString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var feature = CreateFromArgs(FeatureString4Object2CtorClassifier, id, name, description, depString, defaultTenant, alwaysEnabled);
+            var feature = CreateFromArgs(FeatureString4Object2CtorClassifier, id, name, description, depString, defaultTenant, alwaysEnabled, listable);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -115,7 +121,7 @@ namespace OrchardCore.Modules.Manifest
             Assert.Equal(description, feature.Description);
 
             Assert.Null(feature.InternalPriority);
-            Assert.Equal(string.Empty, feature.Priority);
+            Assert.Equal(String.Empty, feature.Priority);
 
             Assert.NotNull(feature.Dependencies);
             Assert.Equal(deps, feature.Dependencies);
@@ -125,9 +131,9 @@ namespace OrchardCore.Modules.Manifest
         }
 
         /// <summary>
-        /// Verify the <see cref="FeatureAttribute(string, string, string, string, string, string, bool, bool)"/>
+        /// Verify the <see cref="FeatureAttribute(string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, category, priority, description, featureDependencies, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, category, priority, description, featureDependencies, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name_Cat_Pri()
@@ -140,8 +146,9 @@ namespace OrchardCore.Modules.Manifest
             var deps = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
-            var depString = string.Join(';', deps);
+            var depString = String.Join(';', deps);
             var priString = $"{priority}";
 
             ReportKeyValuePairs(
@@ -153,9 +160,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(deps), depString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var feature = CreateFromArgs(FeatureString6Object2CtorClassifier, id, name, category, priString, description, depString, defaultTenant, alwaysEnabled);
+            var feature = CreateFromArgs(FeatureString6Object2CtorClassifier, id, name, category, priString, description, depString, defaultTenant, alwaysEnabled, listable);
 
             Assert.True(feature.Exists);
             Assert.Equal(id, feature.Id);
@@ -267,6 +275,7 @@ namespace OrchardCore.Modules.Manifest
             const string depString = null;
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
             var priority = DefaultPriority;
             var expected = priority + 1;
@@ -277,11 +286,12 @@ namespace OrchardCore.Modules.Manifest
                 , LoremWords(1)
                 , name
                 , category
-                , priString ?? string.Empty
+                , priString ?? String.Empty
                 , description
                 , depString
                 , defaultTenant
                 , alwaysEnabled
+                , listable
             );
 
             var alpha = CreateForPriority();
@@ -307,6 +317,8 @@ namespace OrchardCore.Modules.Manifest
             const string depString = null;
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
+
 
             var expected = LoremWords(7);
 
@@ -321,6 +333,7 @@ namespace OrchardCore.Modules.Manifest
                 , depString
                 , defaultTenant
                 , alwaysEnabled
+                , listable
             );
 
             var alpha = CreateForDescription();
@@ -346,6 +359,7 @@ namespace OrchardCore.Modules.Manifest
             const string depString = null;
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
             var expected = LoremWords(1);
 
@@ -360,6 +374,7 @@ namespace OrchardCore.Modules.Manifest
                 , depString
                 , defaultTenant
                 , alwaysEnabled
+                , listable
             );
 
             var alpha = CreateForCategory();
@@ -386,7 +401,7 @@ namespace OrchardCore.Modules.Manifest
         public virtual void Dependencies(char delim)
         {
             var deps = LoremWords(5).Split(' ');
-            var depString = string.Join(delim, deps);
+            var depString = String.Join(delim, deps);
 
             var listDelims = FeatureAttribute.ListDelims;
 
@@ -400,6 +415,7 @@ namespace OrchardCore.Modules.Manifest
                 , depString
                 , default(bool)
                 , default(bool)
+                , true
             );
 
             var feature = CreateForDeps(deps);

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/FeatureAttributeTests.cs
@@ -51,7 +51,6 @@ namespace OrchardCore.Modules.Manifest
             const bool alwaysEnabled = default;
             const bool listable = true;
 
-
             var depString = String.Join(';', deps);
 
             ReportKeyValuePairs(
@@ -107,7 +106,6 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(deps), depString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
                 , new RenderKeyValuePair(nameof(listable), listable)
             );
 
@@ -318,7 +316,6 @@ namespace OrchardCore.Modules.Manifest
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
             const bool listable = true;
-
 
             var expected = LoremWords(7);
 

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.Attribute.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.Attribute.cs
@@ -125,7 +125,7 @@ namespace OrchardCore.Modules.Manifest
         /// Classifier supporting
         /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -141,7 +141,7 @@ namespace OrchardCore.Modules.Manifest
         /// Classifier supporting
         /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -157,7 +157,7 @@ namespace OrchardCore.Modules.Manifest
         /// Classifier supporting
         /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -173,7 +173,7 @@ namespace OrchardCore.Modules.Manifest
         /// Classifier supporting
         /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, type, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, type, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.Attribute.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.Attribute.cs
@@ -130,7 +130,7 @@ namespace OrchardCore.Modules.Manifest
         /// <param name="index"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        protected virtual Type ModuleString7Object2CtorClassifier(int index, object arg) =>
+        protected virtual Type ModuleString7Object3CtorClassifier(int index, object arg) =>
             index switch
             {
                 7 or 8 or 9 => typeof(object),
@@ -146,7 +146,7 @@ namespace OrchardCore.Modules.Manifest
         /// <param name="index"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        protected virtual Type ModuleString8Object2CtorClassifier(int index, object arg) =>
+        protected virtual Type ModuleString8Object3CtorClassifier(int index, object arg) =>
             index switch
             {
                 8 or 9 or 10 => typeof(object),
@@ -162,7 +162,7 @@ namespace OrchardCore.Modules.Manifest
         /// <param name="index"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        protected virtual Type ModuleString10Object2CtorClassifier(int index, object arg) =>
+        protected virtual Type ModuleString10Object3CtorClassifier(int index, object arg) =>
             index switch
             {
                 10 or 11 or 12 => typeof(object),
@@ -178,7 +178,7 @@ namespace OrchardCore.Modules.Manifest
         /// <param name="index"></param>
         /// <param name="arg"></param>
         /// <returns></returns>
-        protected virtual Type ModuleString11Object2CtorClassifier(int index, object arg) =>
+        protected virtual Type ModuleString11Object3CtorClassifier(int index, object arg) =>
             index switch
             {
                 11 or 12 or 13 => typeof(object),

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.Attribute.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.Attribute.cs
@@ -123,9 +123,9 @@ namespace OrchardCore.Modules.Manifest
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, bool, bool)"/>,
+        /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -139,9 +139,9 @@ namespace OrchardCore.Modules.Manifest
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, bool, bool)"/>,
+        /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -155,9 +155,9 @@ namespace OrchardCore.Modules.Manifest
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, bool, bool)"/>,
+        /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>
@@ -171,9 +171,9 @@ namespace OrchardCore.Modules.Manifest
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool)"/>,
+        /// <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, type, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, type, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index"></param>
         /// <param name="arg"></param>

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.Attribute.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.Attribute.cs
@@ -133,7 +133,7 @@ namespace OrchardCore.Modules.Manifest
         protected virtual Type ModuleString7Object2CtorClassifier(int index, object arg) =>
             index switch
             {
-                7 or 8 => typeof(object),
+                7 or 8 or 9 => typeof(object),
                 _ => typeof(string),
             };
 
@@ -149,7 +149,7 @@ namespace OrchardCore.Modules.Manifest
         protected virtual Type ModuleString8Object2CtorClassifier(int index, object arg) =>
             index switch
             {
-                8 or 9 => typeof(object),
+                8 or 9 or 10 => typeof(object),
                 _ => typeof(string),
             };
 
@@ -165,7 +165,7 @@ namespace OrchardCore.Modules.Manifest
         protected virtual Type ModuleString10Object2CtorClassifier(int index, object arg) =>
             index switch
             {
-                10 or 11 => typeof(object),
+                10 or 11 or 12 => typeof(object),
                 _ => typeof(string),
             };
 
@@ -181,7 +181,7 @@ namespace OrchardCore.Modules.Manifest
         protected virtual Type ModuleString11Object2CtorClassifier(int index, object arg) =>
             index switch
             {
-                11 or 12 => typeof(object),
+                11 or 12 or 13 => typeof(object),
                 _ => typeof(string),
             };
     }

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.cs
@@ -56,9 +56,9 @@ namespace OrchardCore.Modules.Manifest
         }
 
         /// <summary>
-        /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, bool, bool)"/>
+        /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id()
@@ -66,16 +66,17 @@ namespace OrchardCore.Modules.Manifest
             var id = LoremWords(1);
             var description = LoremWords(7);
             var author = LoremWords(2);
-            var semVer = string.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
+            var semVer = String.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
             var website = LoremWebsiteUrl();
             var deps = LoremWords(5).Split(' ');
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
-            var priString = string.Empty;
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var priString = String.Empty;
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -87,9 +88,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var module = CreateFromArgs(ModuleString7Object2CtorClassifier, id, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled);
+            var module = CreateFromArgs(ModuleString7Object2CtorClassifier, id, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(id, module.Name);
@@ -121,9 +123,9 @@ namespace OrchardCore.Modules.Manifest
 
         // TODO: TBD: add the ArgumentException path for the bool (object) variations...
         /// <summary>
-        /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, bool, bool)"/>
+        /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name()
@@ -132,16 +134,17 @@ namespace OrchardCore.Modules.Manifest
             var name = LoremWords(1);
             var description = LoremWords(7);
             var author = LoremWords(2);
-            var semVer = string.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
+            var semVer = String.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
             var website = LoremWebsiteUrl();
             var deps = LoremWords(5).Split(' ');
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
-            var priString = string.Empty;
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var priString = String.Empty;
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -154,9 +157,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var module = CreateFromArgs(ModuleString8Object2CtorClassifier, id, name, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled);
+            var module = CreateFromArgs(ModuleString8Object2CtorClassifier, id, name, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);
@@ -187,9 +191,9 @@ namespace OrchardCore.Modules.Manifest
         }
 
         /// <summary>
-        /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, bool, bool)"/>
+        /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name_Cat_Pri()
@@ -200,16 +204,17 @@ namespace OrchardCore.Modules.Manifest
             var priority = DefaultPriority + 1;
             var description = LoremWords(7);
             var author = LoremWords(2);
-            var semVer = string.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
+            var semVer = String.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
             var website = LoremWebsiteUrl();
             var deps = LoremWords(5).Split(' ');
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
             var priString = $"{priority}";
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -224,9 +229,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var module = CreateFromArgs(ModuleString10Object2CtorClassifier, id, name, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled);
+            var module = CreateFromArgs(ModuleString10Object2CtorClassifier, id, name, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);
@@ -255,9 +261,9 @@ namespace OrchardCore.Modules.Manifest
         }
 
         /// <summary>
-        /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool)"/>
+        /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, type, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, type, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name_Type_Cat_Pri()
@@ -269,16 +275,17 @@ namespace OrchardCore.Modules.Manifest
             var priority = DefaultPriority + 1;
             var description = LoremWords(7);
             var author = LoremWords(2);
-            var semVer = string.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
+            var semVer = String.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
             var website = LoremWebsiteUrl();
             var deps = LoremWords(5).Split(' ');
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
             var priString = $"{priority}";
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -294,9 +301,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var module = CreateFromArgs(ModuleString11Object2CtorClassifier, id, name, type, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled);
+            var module = CreateFromArgs(ModuleString11Object2CtorClassifier, id, name, type, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);
@@ -356,10 +364,11 @@ namespace OrchardCore.Modules.Manifest
             var tags = GetArray("seven", "eight", "nine");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
+            const bool listable = true;
 
-            var priString = string.Empty;
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var priString = String.Empty;
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -371,6 +380,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
             // We are looking for one instance of ModuleAttribute in particular in this case
@@ -425,10 +435,11 @@ namespace OrchardCore.Modules.Manifest
             var tags = GetArray("eight", "nine", "ten");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
+            const bool listable = true;
 
-            var priString = string.Empty;
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var priString = String.Empty;
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -441,6 +452,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
             // We are looking for one instance of ModuleAttribute in particular in this case
@@ -496,10 +508,11 @@ namespace OrchardCore.Modules.Manifest
             var tags = GetArray("ten", "eleven", "twelve");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
+            const bool listable = true;
 
             var priString = $"{priority}";
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -514,6 +527,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
             // We are looking for one instance of ModuleAttribute in particular in this case
@@ -626,7 +640,7 @@ namespace OrchardCore.Modules.Manifest
              * should contain 'two' in the following shapes:
              */
             Assert.Contains(features, _ =>
-                _.Id == string.Join(".", baseId, One)
+                _.Id == String.Join(".", baseId, One)
                 && _.Name == _.Id
                 && _.Category == Two.ToLower()
                 && _.InternalPriority == _3
@@ -637,7 +651,7 @@ namespace OrchardCore.Modules.Manifest
             );
 
             Assert.Contains(features, _ =>
-                _.Id == string.Join(".", baseId, Two)
+                _.Id == String.Join(".", baseId, Two)
                 && _.Name == _.Id
                 && _.Category == three
                 && _.InternalPriority == _4

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.cs
@@ -58,7 +58,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id()
@@ -72,7 +72,7 @@ namespace OrchardCore.Modules.Manifest
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = String.Empty;
             var depString = String.Join(';', deps);
@@ -88,10 +88,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var module = CreateFromArgs(ModuleString7Object3CtorClassifier, id, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var module = CreateFromArgs(ModuleString7Object3CtorClassifier, id, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(id, module.Name);
@@ -125,7 +125,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name()
@@ -140,7 +140,7 @@ namespace OrchardCore.Modules.Manifest
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = String.Empty;
             var depString = String.Join(';', deps);
@@ -157,10 +157,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var module = CreateFromArgs(ModuleString8Object3CtorClassifier, id, name, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var module = CreateFromArgs(ModuleString8Object3CtorClassifier, id, name, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);
@@ -193,7 +193,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name_Cat_Pri()
@@ -210,7 +210,7 @@ namespace OrchardCore.Modules.Manifest
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = $"{priority}";
             var depString = String.Join(';', deps);
@@ -229,10 +229,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var module = CreateFromArgs(ModuleString10Object3CtorClassifier, id, name, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var module = CreateFromArgs(ModuleString10Object3CtorClassifier, id, name, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);
@@ -263,7 +263,7 @@ namespace OrchardCore.Modules.Manifest
         /// <summary>
         /// Verify the <see cref="ModuleAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, type, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, type, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name_Type_Cat_Pri()
@@ -281,7 +281,7 @@ namespace OrchardCore.Modules.Manifest
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = $"{priority}";
             var depString = String.Join(';', deps);
@@ -301,10 +301,10 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var module = CreateFromArgs(ModuleString11Object3CtorClassifier, id, name, type, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var module = CreateFromArgs(ModuleString11Object3CtorClassifier, id, name, type, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);
@@ -364,7 +364,7 @@ namespace OrchardCore.Modules.Manifest
             var tags = GetArray("seven", "eight", "nine");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = String.Empty;
             var depString = String.Join(';', deps);
@@ -380,7 +380,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
             // We are looking for one instance of ModuleAttribute in particular in this case
@@ -435,7 +435,7 @@ namespace OrchardCore.Modules.Manifest
             var tags = GetArray("eight", "nine", "ten");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = String.Empty;
             var depString = String.Join(';', deps);
@@ -452,7 +452,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
             // We are looking for one instance of ModuleAttribute in particular in this case
@@ -508,7 +508,7 @@ namespace OrchardCore.Modules.Manifest
             var tags = GetArray("ten", "eleven", "twelve");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = $"{priority}";
             var depString = String.Join(';', deps);
@@ -527,7 +527,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
             // We are looking for one instance of ModuleAttribute in particular in this case

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.cs
@@ -91,7 +91,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var module = CreateFromArgs(ModuleString7Object2CtorClassifier, id, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var module = CreateFromArgs(ModuleString7Object3CtorClassifier, id, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(id, module.Name);
@@ -160,7 +160,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var module = CreateFromArgs(ModuleString8Object2CtorClassifier, id, name, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var module = CreateFromArgs(ModuleString8Object3CtorClassifier, id, name, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);
@@ -232,7 +232,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var module = CreateFromArgs(ModuleString10Object2CtorClassifier, id, name, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var module = CreateFromArgs(ModuleString10Object3CtorClassifier, id, name, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);
@@ -304,7 +304,7 @@ namespace OrchardCore.Modules.Manifest
                 , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var module = CreateFromArgs(ModuleString11Object2CtorClassifier, id, name, type, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var module = CreateFromArgs(ModuleString11Object3CtorClassifier, id, name, type, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, module.Id);
             Assert.Equal(name, module.Name);

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ThemeAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ThemeAttributeTests.cs
@@ -22,17 +22,17 @@ namespace OrchardCore.DisplayManagement.Manifest
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, bool, bool)"/>,
+        /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index">The parameter index.</param>
         /// <param name="_">The argument, unused.</param>
         /// <returns></returns>
-        private static Type ThemeString8Bool2CtorClassifier(int index, object _) =>
+        private static Type ThemeString8Bool3CtorClassifier(int index, object _) =>
             index switch
             {
-                8 or 9 => typeof(object),
+                8 or 9 or 10 => typeof(object),
                 _ => typeof(string),
             };
 
@@ -48,40 +48,40 @@ namespace OrchardCore.DisplayManagement.Manifest
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, bool, bool)"/>,
+        /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index">The parameter index.</param>
         /// <param name="_">The argument, unused.</param>
         /// <returns></returns>
-        private static Type ThemeString9Bool2CtorClassifier(int index, object _) =>
+        private static Type ThemeString9Bool3CtorClassifier(int index, object _) =>
             index switch
             {
-                9 or 10 => typeof(object),
+                9 or 10 or 11 => typeof(object),
                 _ => typeof(string),
             };
 
         /// <summary>
         /// Classifier supporting
-        /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool)"/>,
+        /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, baseTheme, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, baseTheme, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         /// <param name="index">The parameter index.</param>
         /// <param name="_">The argument, unused.</param>
         /// <returns></returns>
-        private static Type ThemeString11Bool2CtorClassifier(int index, object _) =>
+        private static Type ThemeString11Bool3CtorClassifier(int index, object _) =>
             index switch
             {
-                11 or 12 => typeof(object),
+                11 or 12 or 13 => typeof(object),
                 _ => typeof(string),
             };
 
         /// <summary>
-        /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string ,string, bool, bool)"/>
+        /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string ,string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id()
@@ -90,15 +90,16 @@ namespace OrchardCore.DisplayManagement.Manifest
             var baseTheme = LoremWords(1);
             var description = LoremWords(7);
             var author = LoremWords(2);
-            var semVer = string.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
+            var semVer = String.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
             var deps = LoremWords(5).Split(' ');
             var website = LoremWebsiteUrl();
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -111,17 +112,18 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var theme = CreateFromArgs(ThemeString8Bool2CtorClassifier, id, baseTheme, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled);
+            var theme = CreateFromArgs(ThemeString8Bool3CtorClassifier, id, baseTheme, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, theme.Id);
             Assert.Equal(id, theme.Name);
             Assert.Equal(baseTheme, theme.BaseTheme);
 
-            Assert.Equal(string.Empty, theme.Category);
+            Assert.Equal(String.Empty, theme.Category);
             Assert.Null(theme.InternalPriority);
-            Assert.Equal(string.Empty, theme.Priority);
+            Assert.Equal(String.Empty, theme.Priority);
 
             Assert.Equal(description, theme.Description);
 
@@ -143,9 +145,9 @@ namespace OrchardCore.DisplayManagement.Manifest
         }
 
         /// <summary>
-        /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string, string ,string, bool, bool)"/>
+        /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string, string ,string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name()
@@ -155,15 +157,16 @@ namespace OrchardCore.DisplayManagement.Manifest
             var baseTheme = LoremWords(1);
             var description = LoremWords(7);
             var author = LoremWords(2);
-            var semVer = string.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
+            var semVer = String.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
             var deps = LoremWords(5).Split(' ');
             var website = LoremWebsiteUrl();
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             ReportKeyValuePairs(
                 new RenderKeyValuePair(nameof(id), id)
@@ -177,17 +180,18 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var theme = CreateFromArgs(ThemeString9Bool2CtorClassifier, id, name, baseTheme, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled);
+            var theme = CreateFromArgs(ThemeString9Bool3CtorClassifier, id, name, baseTheme, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, theme.Id);
             Assert.Equal(name, theme.Name);
             Assert.Equal(baseTheme, theme.BaseTheme);
 
-            Assert.Equal(string.Empty, theme.Category);
+            Assert.Equal(String.Empty, theme.Category);
             Assert.Null(theme.InternalPriority);
-            Assert.Equal(string.Empty, theme.Priority);
+            Assert.Equal(String.Empty, theme.Priority);
 
             Assert.Equal(description, theme.Description);
 
@@ -209,9 +213,9 @@ namespace OrchardCore.DisplayManagement.Manifest
         }
 
         /// <summary>
-        /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, string ,string, bool, bool)"/>
+        /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, string ,string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, baseTheme, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled</c>.
+        /// <c>id, name, baseTheme, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name_Cat_Pri()
@@ -223,15 +227,16 @@ namespace OrchardCore.DisplayManagement.Manifest
             var priority = DefaultPriority + 1;
             var description = LoremWords(7);
             var author = LoremWords(2);
-            var semVer = string.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
+            var semVer = String.Join('.', GetValues(1, 2, 3, 4).Select(_ => $"{_}"));
             var deps = LoremWords(5).Split(' ');
             var website = LoremWebsiteUrl();
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
+            const bool listable = true;
 
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
             var priString = $"{priority}";
 
             ReportKeyValuePairs(
@@ -248,9 +253,10 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
-            var theme = CreateFromArgs(ThemeString11Bool2CtorClassifier, id, name, baseTheme, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled);
+            var theme = CreateFromArgs(ThemeString11Bool3CtorClassifier, id, name, baseTheme, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
 
             Assert.Equal(id, theme.Id);
             Assert.Equal(name, theme.Name);
@@ -287,7 +293,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         {
             var id = "one";
             var baseTheme = "two";
-            var category = string.Empty;
+            var category = String.Empty;
             var description = "three";
             var author = "four";
             var semVer = "5.6.7";
@@ -296,10 +302,11 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = GetArray("eight", "nine", "ten");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
+            const bool listable = true;
 
-            var priString = string.Empty;
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var priString = String.Empty;
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             // Would inject via Theory but for issues xUnit failing to discover the cases
             var rootType = typeof(Examples.Themes.AssyAttrib.Charlie.Root);
@@ -315,6 +322,7 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
             // We are looking for one instance of ThemeAttribute in particular in this case
@@ -362,7 +370,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             var id = "one";
             var name = "two";
             var baseTheme = "three";
-            var category = string.Empty;
+            var category = String.Empty;
             var description = "four";
             var author = "five";
             var semVer = "6.7.8";
@@ -371,10 +379,11 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = GetArray("nine", "ten", "eleven");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
+            const bool listable = true;
 
-            var priString = string.Empty;
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var priString = String.Empty;
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             // Would inject via Theory but for issues xUnit failing to discover the cases
             var rootType = typeof(Examples.Themes.AssyAttrib.Bravo.Root);
@@ -391,6 +400,7 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
             // We are looking for one instance of ThemeAttribute in particular in this case
@@ -448,10 +458,11 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = GetArray("eleven", "twelve", "thirteen");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
+            const bool listable = true;
 
             var priString = $"{priority}";
-            var depString = string.Join(';', deps);
-            var tagString = string.Join(';', tags);
+            var depString = String.Join(';', deps);
+            var tagString = String.Join(';', tags);
 
             // Would inject via Theory but for issues xUnit failing to discover the cases
             var rootType = typeof(Examples.Themes.AssyAttrib.Alpha.Root);
@@ -470,6 +481,7 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
+                , new RenderKeyValuePair(nameof(listable), listable)
             );
 
             // We are looking for one instance of ThemeAttribute in particular in this case

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ThemeAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ThemeAttributeTests.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// Classifier supporting
         /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index">The parameter index.</param>
         /// <param name="_">The argument, unused.</param>
@@ -50,7 +50,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// Classifier supporting
         /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index">The parameter index.</param>
         /// <param name="_">The argument, unused.</param>
@@ -66,7 +66,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// Classifier supporting
         /// <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, string, string, bool, bool, bool)"/>,
         /// arguments in order,
-        /// <c>id, name, baseTheme, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, baseTheme, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         /// <param name="index">The parameter index.</param>
         /// <param name="_">The argument, unused.</param>
@@ -81,7 +81,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <summary>
         /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string ,string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id()
@@ -96,7 +96,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var depString = String.Join(';', deps);
             var tagString = String.Join(';', tags);
@@ -112,10 +112,10 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var theme = CreateFromArgs(ThemeString8Bool3CtorClassifier, id, baseTheme, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var theme = CreateFromArgs(ThemeString8Bool3CtorClassifier, id, baseTheme, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.Equal(id, theme.Id);
             Assert.Equal(id, theme.Name);
@@ -147,7 +147,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <summary>
         /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string, string ,string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, baseTheme, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name()
@@ -163,7 +163,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var depString = String.Join(';', deps);
             var tagString = String.Join(';', tags);
@@ -180,10 +180,10 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var theme = CreateFromArgs(ThemeString9Bool3CtorClassifier, id, name, baseTheme, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var theme = CreateFromArgs(ThemeString9Bool3CtorClassifier, id, name, baseTheme, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.Equal(id, theme.Id);
             Assert.Equal(name, theme.Name);
@@ -215,7 +215,7 @@ namespace OrchardCore.DisplayManagement.Manifest
         /// <summary>
         /// Verify the <see cref="ThemeAttribute(string, string, string, string, string, string, string, string, string, string ,string, bool, bool, bool)"/>
         /// ctor, arguments
-        /// <c>id, name, baseTheme, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, listable</c>.
+        /// <c>id, name, baseTheme, category, priority, description, author, semVer, featureDependencies, websiteUrl, tags, defaultTenant, alwaysEnabled, enabledByDependencyOnly</c>.
         /// </summary>
         [Fact]
         public virtual void Ipsum_Ctor_Id_Name_Cat_Pri()
@@ -233,7 +233,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = LoremWords(5).Split(' ');
             const bool defaultTenant = default;
             const bool alwaysEnabled = default;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var depString = String.Join(';', deps);
             var tagString = String.Join(';', tags);
@@ -253,10 +253,10 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
-            var theme = CreateFromArgs(ThemeString11Bool3CtorClassifier, id, name, baseTheme, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, listable);
+            var theme = CreateFromArgs(ThemeString11Bool3CtorClassifier, id, name, baseTheme, category, priString, description, author, semVer, website, depString, tagString, defaultTenant, alwaysEnabled, enabledByDependencyOnly);
 
             Assert.Equal(id, theme.Id);
             Assert.Equal(name, theme.Name);
@@ -302,7 +302,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = GetArray("eight", "nine", "ten");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = String.Empty;
             var depString = String.Join(';', deps);
@@ -322,7 +322,7 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
             // We are looking for one instance of ThemeAttribute in particular in this case
@@ -379,7 +379,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = GetArray("nine", "ten", "eleven");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = String.Empty;
             var depString = String.Join(';', deps);
@@ -400,7 +400,7 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
             // We are looking for one instance of ThemeAttribute in particular in this case
@@ -458,7 +458,7 @@ namespace OrchardCore.DisplayManagement.Manifest
             var tags = GetArray("eleven", "twelve", "thirteen");
             const bool defaultTenant = true;
             const bool alwaysEnabled = true;
-            const bool listable = true;
+            const bool enabledByDependencyOnly = default;
 
             var priString = $"{priority}";
             var depString = String.Join(';', deps);
@@ -481,7 +481,7 @@ namespace OrchardCore.DisplayManagement.Manifest
                 , new RenderKeyValuePair(nameof(tags), tagString)
                 , new RenderKeyValuePair(nameof(defaultTenant), defaultTenant)
                 , new RenderKeyValuePair(nameof(alwaysEnabled), alwaysEnabled)
-                , new RenderKeyValuePair(nameof(listable), listable)
+                , new RenderKeyValuePair(nameof(enabledByDependencyOnly), enabledByDependencyOnly)
             );
 
             // We are looking for one instance of ThemeAttribute in particular in this case

--- a/test/OrchardCore.Tests.Features/Examples.Features.AssyAttrib/Examples.Features.AssyAttrib.csproj
+++ b/test/OrchardCore.Tests.Features/Examples.Features.AssyAttrib/Examples.Features.AssyAttrib.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\..\src\OrchardCore.Build\OrchardCore.Commons.props" />
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
@@ -29,7 +29,7 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
-    14: , object listable
+    14: , object enabledByDependencyOnly
     -->
     <!-- TODO: TBD: possible to switch after a sort using MSBuild? -->
     <!-- TODO: TBD: with of course 'Include' being the 'Id' -->
@@ -43,7 +43,7 @@
                            Dependencies="six;seven;eight"
                            DefaultTenant="true"
                            AlwaysEnabled="true"
-                           Listable="true" />
+                           EnabledByDependencyOnly="false" />
     <OrchardCoreAttributes Include="OrchardCore.FeatureSet.Bravo"
                            Type="feature"
                            Name="Bravo"
@@ -53,7 +53,7 @@
                            Dependencies="seven;eight;nine"
                            DefaultTenant="true"
                            AlwaysEnabled="true"
-                           Listable="true" />
+                           EnabledByDependencyOnly="false" />
     <OrchardCoreAttributes Include="OrchardCore.FeatureSet.Charlie"
                            Type="feature"
                            Name="Charlie"
@@ -63,7 +63,7 @@
                            Dependencies="eight;nine;ten"
                            DefaultTenant="true"
                            AlwaysEnabled="true"
-                           Listable="true" />
+                           EnabledByDependencyOnly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Features/Examples.Features.AssyAttrib/Examples.Features.AssyAttrib.csproj
+++ b/test/OrchardCore.Tests.Features/Examples.Features.AssyAttrib/Examples.Features.AssyAttrib.csproj
@@ -29,6 +29,7 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
+    14: , object listable
     -->
     <!-- TODO: TBD: possible to switch after a sort using MSBuild? -->
     <!-- TODO: TBD: with of course 'Include' being the 'Id' -->
@@ -41,7 +42,8 @@
                            Description="five"
                            Dependencies="six;seven;eight"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" />
+                           AlwaysEnabled="true"
+                           Listable="true" />
     <OrchardCoreAttributes Include="OrchardCore.FeatureSet.Bravo"
                            Type="feature"
                            Name="Bravo"
@@ -50,7 +52,8 @@
                            Description="six"
                            Dependencies="seven;eight;nine"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" />
+                           AlwaysEnabled="true"
+                           Listable="true" />
     <OrchardCoreAttributes Include="OrchardCore.FeatureSet.Charlie"
                            Type="feature"
                            Name="Charlie"
@@ -59,7 +62,8 @@
                            Description="seven"
                            Dependencies="eight;nine;ten"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" />
+                           AlwaysEnabled="true"
+                           Listable="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Alpha/Examples.Modules.AssyAttrib.Alpha.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Alpha/Examples.Modules.AssyAttrib.Alpha.csproj
@@ -32,6 +32,7 @@
     , 10: string tagString
     , 11: bool defaultTenant
     , 12: bool alwaysEnabled
+    , 13: bool listable
     -->
     <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAttribute">
       <_Parameter1>one</_Parameter1>
@@ -46,6 +47,7 @@
       <_Parameter10>ten;eleven;twelve</_Parameter10>
       <_Parameter11>true</_Parameter11>
       <_Parameter12>true</_Parameter12>
+      <_Parameter13>true</_Parameter13>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Alpha/Examples.Modules.AssyAttrib.Alpha.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Alpha/Examples.Modules.AssyAttrib.Alpha.csproj
@@ -32,7 +32,7 @@
     , 10: string tagString
     , 11: bool defaultTenant
     , 12: bool alwaysEnabled
-    , 13: bool listable
+    , 13: bool enabledByDependencyOnly
     -->
     <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAttribute">
       <_Parameter1>one</_Parameter1>
@@ -47,7 +47,7 @@
       <_Parameter10>ten;eleven;twelve</_Parameter10>
       <_Parameter11>true</_Parameter11>
       <_Parameter12>true</_Parameter12>
-      <_Parameter13>true</_Parameter13>
+      <_Parameter13>false</_Parameter13>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Bravo/Examples.Modules.AssyAttrib.Bravo.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Bravo/Examples.Modules.AssyAttrib.Bravo.csproj
@@ -31,7 +31,7 @@
     , 8: string tagString
     , 9: bool defaultTenant
     , 10: bool alwaysEnabled
-    , 11: bool listable
+    , 11: bool enabledByDependencyOnly
     -->
     <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAttribute">
       <_Parameter1>one</_Parameter1>
@@ -44,7 +44,7 @@
       <_Parameter8>eight;nine;ten</_Parameter8>
       <_Parameter9>true</_Parameter9>
       <_Parameter10>true</_Parameter10>
-      <_Parameter11>true</_Parameter11>
+      <_Parameter11>false</_Parameter11>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Bravo/Examples.Modules.AssyAttrib.Bravo.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Bravo/Examples.Modules.AssyAttrib.Bravo.csproj
@@ -31,6 +31,7 @@
     , 8: string tagString
     , 9: bool defaultTenant
     , 10: bool alwaysEnabled
+    , 11: bool listable
     -->
     <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAttribute">
       <_Parameter1>one</_Parameter1>
@@ -43,6 +44,7 @@
       <_Parameter8>eight;nine;ten</_Parameter8>
       <_Parameter9>true</_Parameter9>
       <_Parameter10>true</_Parameter10>
+      <_Parameter11>true</_Parameter11>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Charlie/Examples.Modules.AssyAttrib.Charlie.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Charlie/Examples.Modules.AssyAttrib.Charlie.csproj
@@ -30,7 +30,7 @@
     , 7: string tagString
     , 8: bool defaultTenant
     , 9: bool alwaysEnabled
-    , 10: bool listable
+    , 10: bool enabledByDependencyOnly
     -->
     <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAttribute">
       <_Parameter1>one</_Parameter1>
@@ -42,7 +42,7 @@
       <_Parameter7>seven;eight;nine</_Parameter7>
       <_Parameter8>true</_Parameter8>
       <_Parameter9>true</_Parameter9>
-      <_Parameter10>true</_Parameter10>
+      <_Parameter10>false</_Parameter10>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Charlie/Examples.Modules.AssyAttrib.Charlie.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Charlie/Examples.Modules.AssyAttrib.Charlie.csproj
@@ -30,6 +30,7 @@
     , 7: string tagString
     , 8: bool defaultTenant
     , 9: bool alwaysEnabled
+    , 10: bool listable
     -->
     <AssemblyAttribute Include="OrchardCore.Modules.Manifest.ModuleAttribute">
       <_Parameter1>one</_Parameter1>
@@ -41,6 +42,7 @@
       <_Parameter7>seven;eight;nine</_Parameter7>
       <_Parameter8>true</_Parameter8>
       <_Parameter9>true</_Parameter9>
+      <_Parameter10>true</_Parameter10>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Modules/Examples.OrchardCoreModules.Alpha/Examples.OrchardCoreModules.Alpha.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.OrchardCoreModules.Alpha/Examples.OrchardCoreModules.Alpha.csproj
@@ -23,7 +23,8 @@
                            Description="four"
                            Dependencies="five;six;seven"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" />
+                           AlwaysEnabled="true"
+                           Listable="true" />
 
     <OrchardCoreAttributes Include="$(MSBuildProjectName).Two"
                            Type="feature"
@@ -32,7 +33,8 @@
                            Description="five"
                            Dependencies="six;seven;eight"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" />
+                           AlwaysEnabled="true" 
+                           Listable="true" />
 
     <OrchardCoreAttributes Include="$(MSBuildProjectName)"
                            Category="three"
@@ -44,7 +46,8 @@
                            Dependencies="nine;ten;eleven"
                            Tags="ten;eleven;twelve"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" />
+                           AlwaysEnabled="true" 
+                           Listable="true" />
   </ItemGroup>
 
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.targets" />

--- a/test/OrchardCore.Tests.Modules/Examples.OrchardCoreModules.Alpha/Examples.OrchardCoreModules.Alpha.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.OrchardCoreModules.Alpha/Examples.OrchardCoreModules.Alpha.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\..\..\src\OrchardCore.Build\OrchardCore.Commons.props" />
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.props" />
@@ -24,7 +24,7 @@
                            Dependencies="five;six;seven"
                            DefaultTenant="true"
                            AlwaysEnabled="true"
-                           Listable="true" />
+                           EnabledByDependencyOnly="false" />
 
     <OrchardCoreAttributes Include="$(MSBuildProjectName).Two"
                            Type="feature"
@@ -34,7 +34,7 @@
                            Dependencies="six;seven;eight"
                            DefaultTenant="true"
                            AlwaysEnabled="true"
-                           Listable="true" />
+                           EnabledByDependencyOnly="false" />
 
     <OrchardCoreAttributes Include="$(MSBuildProjectName)"
                            Category="three"
@@ -47,7 +47,7 @@
                            Tags="ten;eleven;twelve"
                            DefaultTenant="true"
                            AlwaysEnabled="true"
-                           Listable="true" />
+                           EnabledByDependencyOnly="false" />
   </ItemGroup>
 
   <Import Project="..\..\..\src\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.targets" />

--- a/test/OrchardCore.Tests.Modules/Examples.OrchardCoreModules.Alpha/Examples.OrchardCoreModules.Alpha.csproj
+++ b/test/OrchardCore.Tests.Modules/Examples.OrchardCoreModules.Alpha/Examples.OrchardCoreModules.Alpha.csproj
@@ -33,7 +33,7 @@
                            Description="five"
                            Dependencies="six;seven;eight"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" 
+                           AlwaysEnabled="true"
                            Listable="true" />
 
     <OrchardCoreAttributes Include="$(MSBuildProjectName)"
@@ -46,7 +46,7 @@
                            Dependencies="nine;ten;eleven"
                            Tags="ten;eleven;twelve"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" 
+                           AlwaysEnabled="true"
                            Listable="true" />
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.OrchardCoreThemes.Alpha/Examples.OrchardCoreThemes.Alpha.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.OrchardCoreThemes.Alpha/Examples.OrchardCoreThemes.Alpha.csproj
@@ -32,7 +32,8 @@
                            Dependencies="ten;eleven;twelve"
                            Tags="eleven;twelve;thirteen"
                            DefaultTenant="true"
-                           AlwaysEnabled="true" />
+                           AlwaysEnabled="true"
+                           Listable="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Themes/Examples.OrchardCoreThemes.Alpha/Examples.OrchardCoreThemes.Alpha.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.OrchardCoreThemes.Alpha/Examples.OrchardCoreThemes.Alpha.csproj
@@ -33,7 +33,7 @@
                            Tags="eleven;twelve;thirteen"
                            DefaultTenant="true"
                            AlwaysEnabled="true"
-                           Listable="true" />
+                           EnabledByDependencyOnly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Alpha/Examples.Themes.AssyAttrib.Alpha.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Alpha/Examples.Themes.AssyAttrib.Alpha.csproj
@@ -37,7 +37,6 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
-    14: , object listable
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -53,7 +52,6 @@
       <_Parameter11>eleven;twelve;thirteen</_Parameter11>
       <_Parameter12>true</_Parameter12>
       <_Parameter13>true</_Parameter13>
-      <_Parameter14>true</_Parameter14>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Alpha/Examples.Themes.AssyAttrib.Alpha.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Alpha/Examples.Themes.AssyAttrib.Alpha.csproj
@@ -37,6 +37,7 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
+    14: , object listable
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -52,6 +53,7 @@
       <_Parameter11>eleven;twelve;thirteen</_Parameter11>
       <_Parameter12>true</_Parameter12>
       <_Parameter13>true</_Parameter13>
+      <_Parameter14>true</_Parameter14>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Alpha/Examples.Themes.AssyAttrib.Alpha.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Alpha/Examples.Themes.AssyAttrib.Alpha.csproj
@@ -37,7 +37,7 @@
     11: , string tags
     12: , object defaultTenant
     13: , object alwaysEnabled
-    14: , object listable
+    14: , object enabledByDependencyOnly
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -53,7 +53,7 @@
       <_Parameter11>eleven;twelve;thirteen</_Parameter11>
       <_Parameter12>true</_Parameter12>
       <_Parameter13>true</_Parameter13>
-      <_Parameter14>true</_Parameter14>
+      <_Parameter14>false</_Parameter14>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Bravo/Examples.Themes.AssyAttrib.Bravo.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Bravo/Examples.Themes.AssyAttrib.Bravo.csproj
@@ -35,7 +35,6 @@
     9: , string tags
     10: , object defaultTenant
     11: , object alwaysEnabled
-    12: , object listable
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -49,7 +48,6 @@
       <_Parameter9>nine;ten;eleven</_Parameter9>
       <_Parameter10>true</_Parameter10>
       <_Parameter11>true</_Parameter11>
-      <_Parameter12>true</_Parameter12>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Bravo/Examples.Themes.AssyAttrib.Bravo.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Bravo/Examples.Themes.AssyAttrib.Bravo.csproj
@@ -35,7 +35,7 @@
     9: , string tags
     10: , object defaultTenant
     11: , object alwaysEnabled
-    12: , object listable
+    12: , object enabledByDependencyOnly
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -49,7 +49,7 @@
       <_Parameter9>nine;ten;eleven</_Parameter9>
       <_Parameter10>true</_Parameter10>
       <_Parameter11>true</_Parameter11>
-      <_Parameter12>true</_Parameter12>
+      <_Parameter12>false</_Parameter12>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Bravo/Examples.Themes.AssyAttrib.Bravo.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Bravo/Examples.Themes.AssyAttrib.Bravo.csproj
@@ -35,6 +35,7 @@
     9: , string tags
     10: , object defaultTenant
     11: , object alwaysEnabled
+    12: , object listable
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -48,6 +49,7 @@
       <_Parameter9>nine;ten;eleven</_Parameter9>
       <_Parameter10>true</_Parameter10>
       <_Parameter11>true</_Parameter11>
+      <_Parameter12>true</_Parameter12>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Charlie/Examples.Themes.AssyAttrib.Charlie.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Charlie/Examples.Themes.AssyAttrib.Charlie.csproj
@@ -34,6 +34,7 @@
     8: , string tags
     9: , object defaultTenant
     10: , object alwaysEnabled
+    11: , object listable
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -46,6 +47,7 @@
       <_Parameter8>eight;nine;ten</_Parameter8>
       <_Parameter9>true</_Parameter9>
       <_Parameter10>true</_Parameter10>
+      <_Parameter11>true</_Parameter11>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Charlie/Examples.Themes.AssyAttrib.Charlie.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Charlie/Examples.Themes.AssyAttrib.Charlie.csproj
@@ -34,7 +34,7 @@
     8: , string tags
     9: , object defaultTenant
     10: , object alwaysEnabled
-    11: , object listable
+    11: , object enabledByDependencyOnly
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -47,7 +47,7 @@
       <_Parameter8>eight;nine;ten</_Parameter8>
       <_Parameter9>true</_Parameter9>
       <_Parameter10>true</_Parameter10>
-      <_Parameter11>true</_Parameter11>
+      <_Parameter11>false</_Parameter11>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Charlie/Examples.Themes.AssyAttrib.Charlie.csproj
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Charlie/Examples.Themes.AssyAttrib.Charlie.csproj
@@ -34,7 +34,6 @@
     8: , string tags
     9: , object defaultTenant
     10: , object alwaysEnabled
-    11: , object listable
     -->
     <AssemblyAttribute Include="OrchardCore.DisplayManagement.Manifest.ThemeAttribute">
       <_Parameter1>one</_Parameter1>
@@ -47,7 +46,6 @@
       <_Parameter8>eight;nine;ten</_Parameter8>
       <_Parameter9>true</_Parameter9>
       <_Parameter10>true</_Parameter10>
-      <_Parameter11>true</_Parameter11>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -106,7 +106,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 Features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[] { baseTheme.Id }, false, false, true) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[] { baseTheme.Id }, false, false, false) }
                     };
 
                 Id = name;

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
 {
     public class DefaultShapeTableManagerTests : IDisposable
     {
-        private IServiceProvider _serviceProvider;
+        private readonly IServiceProvider _serviceProvider;
 
         private class TestModuleExtensionInfo : IExtensionInfo
         {
@@ -45,7 +45,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, Array.Empty<string>(), false, false) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, Array.Empty<string>(), false, false, true) }
                     };
 
                 Features = features;
@@ -79,7 +79,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, Array.Empty<string>(), false, false) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, Array.Empty<string>(), false, false, true) }
                     };
 
                 Features = features;
@@ -106,7 +106,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 Features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[] { baseTheme.Id }, false, false) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, new string[] { baseTheme.Id }, false, false, true) }
                     };
 
                 Id = name;
@@ -213,7 +213,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
 
         public class TestExtensionManager : IExtensionManager
         {
-            private IEnumerable<IFeatureInfo> _features;
+            private readonly IEnumerable<IFeatureInfo> _features;
             public TestExtensionManager(IEnumerable<IFeatureInfo> features)
             {
                 _features = features;

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -45,7 +45,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, Array.Empty<string>(), false, false, true) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, Array.Empty<string>(), false, false, false) }
                     };
 
                 Features = features;
@@ -79,7 +79,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
                 var features =
                     new List<IFeatureInfo>()
                     {
-                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, Array.Empty<string>(), false, false, true) }
+                        { new FeatureInfo(name, name, 0, String.Empty, String.Empty, this, Array.Empty<string>(), false, false, false) }
                     };
 
                 Features = features;
@@ -314,7 +314,7 @@ namespace OrchardCore.Tests.DisplayManagement.Decriptors
         {
             var manager = _serviceProvider.GetService<IShapeTableManager>();
             var shapeTable1 = manager.GetShapeTable(null);
-            var shapeTable2 = manager.GetShapeTable(string.Empty);
+            var shapeTable2 = manager.GetShapeTable(String.Empty);
             Assert.NotNull(shapeTable1.Descriptors["Hello"]);
             Assert.NotNull(shapeTable2.Descriptors["Hello"]);
         }

--- a/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
@@ -143,7 +143,7 @@ namespace OrchardCore.Tests.Shell
 
         public static IFeatureInfo AddStartup(ShellBlueprint shellBlueprint, Type startupType)
         {
-            var featureInfo = new FeatureInfo(startupType.Name, startupType.Name, 1, "Tests", null, null, null, false, false);
+            var featureInfo = new FeatureInfo(startupType.Name, startupType.Name, 1, "Tests", null, null, null, false, false, true);
             shellBlueprint.Dependencies.Add(startupType, new FeatureEntry(featureInfo));
 
             return featureInfo;

--- a/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
@@ -143,7 +143,7 @@ namespace OrchardCore.Tests.Shell
 
         public static IFeatureInfo AddStartup(ShellBlueprint shellBlueprint, Type startupType)
         {
-            var featureInfo = new FeatureInfo(startupType.Name, startupType.Name, 1, "Tests", null, null, null, false, false, true);
+            var featureInfo = new FeatureInfo(startupType.Name, startupType.Name, 1, "Tests", null, null, null, false, false, false);
             shellBlueprint.Dependencies.Add(startupType, new FeatureEntry(featureInfo));
 
             return featureInfo;


### PR DESCRIPTION
Fix #12279 

A feature with `EnabledByDependencyOnly`, will automatically get enabled/disabled as needed by other features.

Let's say we have the following features

```
[assembly: Feature(
    Id = "OC.Notification",
    EnabledByDependencyOnly = true
)]

[assembly: Feature(
    Id = "OC.Notification.Email",
    Dependencies = new[]
    {
        "OC.Notification"
    }
)]

[assembly: Feature(
    Id = "OC.Notification.Push",
    Dependencies = new[]
    {
        "OC.Notification"
    }
)]

[assembly: Feature(
    Id = "OC.Notification.Web",
    Dependencies = new[]
    {
        "OC.Notification"
    }
)]
```

The feature `OC.Notification` will automatically get **enabled** when **any** of `OC.Notification.Email`, `OC.Notification.Push`, or `OC.Notification.Web` are enabled by the user.

At the same time, `OC.Notification` will automatically get **disabled** when **all** of `OC.Notification.Email`, `OC.Notification.Push`, and `OC.Notification.Web` are disabled.

The key difference between `EnabledByDependencyOnly` and `IsAlwaysEnabled` is that the latter will always be enabled regardless whether it's needed or not.

Checkout this screen-cast to the end to see the full behavior in action.

![EnabledByDependencyOnly](https://user-images.githubusercontent.com/24724371/187082566-b2f49a31-977a-4f91-9ea3-ad1f0e178943.gif)