### PR TITLE
Add scope to client credentials token

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -479,6 +479,7 @@ namespace OrchardCore.OpenId.Controllers
             }
 
             var principal = new ClaimsPrincipal(identity);
+            principal.SetScopes(request.GetScopes());
             principal.SetResources(await GetResourcesAsync(request.GetScopes()));
 
             return SignIn(principal, OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);


### PR DESCRIPTION
Added scope field to token. The field is required for validation access policy on the server side