### PR TITLE
Ignore any explicit enable/disable 'EnabledByDependencyOnly' features

### DIFF
--- a/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
@@ -45,16 +45,16 @@ namespace OrchardCore.Environment.Shell
                 .ToHashSet();
 
             var installedFeatureIds = enabledFeatureIds
-                .Concat(shellDescriptor.Installed.Select(sf => sf.Id))
+                .Concat(shellDescriptor.Installed.Select(shellFeature => shellFeature.Id))
                 .ToHashSet();
 
-            var alwaysEnabledIds = _alwaysEnabledFeatures.Select(sf => sf.Id).ToArray();
+            var alwaysEnabledIds = _alwaysEnabledFeatures.Select(shellFeature => shellFeature.Id).ToArray();
 
             var byDependencyOnlyFeaturesToDisable = enabledFeatures
                 .Where(feature => feature.EnabledByDependencyOnly);
 
             var allFeaturesToDisable = featuresToDisable
-                .Where(feature => !feature.EnabledByDependencyOnly && !feature.IsAlwaysEnabled && !alwaysEnabledIds.Contains(feature.Id))
+                .Where(feature => !feature.EnabledByDependencyOnly && !alwaysEnabledIds.Contains(feature.Id))
                 .SelectMany(feature => GetFeaturesToDisable(feature, enabledFeatureIds, force))
                 // Always attempt to disable 'EnabledByDependencyOnly' features
                 // to ensure we auto disable any feature that is no longer needed.

--- a/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
@@ -37,11 +37,11 @@ namespace OrchardCore.Environment.Shell
             var featureEventHandlers = ShellScope.Services.GetServices<IFeatureEventHandler>();
 
             var enabledFeatures = _extensionManager.GetFeatures()
-                .Where(f => shellDescriptor.Features.Any(sf => sf.Id == f.Id))
-                .ToList();
+                .Where(feature => shellDescriptor.Features.Any(shellFeature => shellFeature.Id == feature.Id))
+                .ToArray();
 
             var enabledFeatureIds = enabledFeatures
-                .Select(f => f.Id)
+                .Select(feature => feature.Id)
                 .ToHashSet();
 
             var installedFeatureIds = enabledFeatureIds
@@ -51,10 +51,10 @@ namespace OrchardCore.Environment.Shell
             var alwaysEnabledIds = _alwaysEnabledFeatures.Select(sf => sf.Id).ToArray();
 
             var byDependencyOnlyFeaturesToDisable = enabledFeatures
-                .Where(f => f.EnabledByDependencyOnly);
+                .Where(feature => feature.EnabledByDependencyOnly);
 
             var allFeaturesToDisable = featuresToDisable
-                .Where(f => !f.EnabledByDependencyOnly && !alwaysEnabledIds.Contains(f.Id))
+                .Where(feature => !feature.EnabledByDependencyOnly && !feature.IsAlwaysEnabled && !alwaysEnabledIds.Contains(feature.Id))
                 .SelectMany(feature => GetFeaturesToDisable(feature, enabledFeatureIds, force))
                 // Always attempt to disable 'EnabledByDependencyOnly' features
                 // to ensure we auto disable any feature that is no longer needed.

--- a/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellDescriptorFeaturesManager.cs
@@ -38,7 +38,7 @@ namespace OrchardCore.Environment.Shell
 
             var enabledFeatures = _extensionManager.GetFeatures()
                 .Where(f => shellDescriptor.Features.Any(sf => sf.Id == f.Id))
-                .ToArray();
+                .ToList();
 
             var enabledFeatureIds = enabledFeatures
                 .Select(f => f.Id)
@@ -54,7 +54,7 @@ namespace OrchardCore.Environment.Shell
                 .Where(f => f.EnabledByDependencyOnly);
 
             var allFeaturesToDisable = featuresToDisable
-                .Where(f => !alwaysEnabledIds.Contains(f.Id))
+                .Where(f => !f.EnabledByDependencyOnly && !alwaysEnabledIds.Contains(f.Id))
                 .SelectMany(feature => GetFeaturesToDisable(feature, enabledFeatureIds, force))
                 // Always attempt to disable 'EnabledByDependencyOnly' features
                 // to ensure we auto disable any feature that is no longer needed.
@@ -76,6 +76,7 @@ namespace OrchardCore.Environment.Shell
             }
 
             var allFeaturesToEnable = featuresToEnable
+                .Where(feature => !feature.EnabledByDependencyOnly)
                 .SelectMany(feature => GetFeaturesToEnable(feature, enabledFeatureIds, force))
                 .Distinct()
                 .ToList();


### PR DESCRIPTION
@jtkech I think this change is needed to prevent someone from explicitly trying to enable or disable a feature that is enabled by dependency only