### PR TITLE
DbConnectionValidator fails if Shell Settings from database

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -117,7 +117,7 @@ namespace OrchardCore.Tenants.Services
                 case DbConnectionValidatorResult.InvalidConnection:
                     errors.Add(new ModelError(nameof(TenantViewModel.ConnectionString), S["The provided connection string is invalid or server is unreachable."]));
                     break;
-                case DbConnectionValidatorResult.DocumentFound:
+                case DbConnectionValidatorResult.DatabaseAndPrefixInUse:
                     errors.Add(new ModelError(nameof(TenantViewModel.TablePrefix), S["The provided database and prefix are already in use."]));
                     break;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -117,8 +117,8 @@ namespace OrchardCore.Tenants.Services
                 case DbConnectionValidatorResult.InvalidConnection:
                     errors.Add(new ModelError(nameof(TenantViewModel.ConnectionString), S["The provided connection string is invalid or server is unreachable."]));
                     break;
-                case DbConnectionValidatorResult.DatabaseAndPrefixInUse:
-                    errors.Add(new ModelError(nameof(TenantViewModel.TablePrefix), S["The provided database and prefix are already in use."]));
+                case DbConnectionValidatorResult.DatabaseAndTablePrefixInUse:
+                    errors.Add(new ModelError(nameof(TenantViewModel.TablePrefix), S["The provided database and table prefix are already in use."]));
                     break;
             }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -118,7 +118,7 @@ namespace OrchardCore.Tenants.Services
                     errors.Add(new ModelError(nameof(TenantViewModel.ConnectionString), S["The provided connection string is invalid or server is unreachable."]));
                     break;
                 case DbConnectionValidatorResult.DocumentFound:
-                    errors.Add(new ModelError(nameof(TenantViewModel.TablePrefix), S["The provided table prefix already exists."]));
+                    errors.Add(new ModelError(nameof(TenantViewModel.TablePrefix), S["The provided database and prefix are already in use."]));
                     break;
             }
         }

--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/DbConnectionValidatorResult.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/DbConnectionValidatorResult.cs
@@ -6,6 +6,6 @@ public enum DbConnectionValidatorResult
     NoProvider,
     UnsupportedProvider,
     InvalidConnection,
-    DatabaseAndPrefixInUse,
+    DatabaseAndTablePrefixInUse,
     Success,
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/DbConnectionValidatorResult.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/DbConnectionValidatorResult.cs
@@ -2,21 +2,10 @@ namespace OrchardCore.Data;
 
 public enum DbConnectionValidatorResult
 {
-    // Unknown indicates that the connection string status is unknown or was not yet validated
     Unknown,
-
-    // NoProvider indicated that the provider is missing
     NoProvider,
-
-    // DocumentNotFound indicates that the connection string was valid, yet the Document table does not exist 
-    DocumentNotFound,
-
-    // DocumentFound indicates that the connection string was valid, yet the Document table exist
-    DocumentFound,
-
-    // InvalidConnection unable to open a connection to the given connection string
+    UnsupportedProvider,
     InvalidConnection,
-
-    // UnsupportedProvider indicated invalid or unsupported database provider
-    UnsupportedProvider
+    DatabaseAndPrefixInUse,
+    Success,
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -85,7 +85,7 @@ public class DbConnectionValidator : IDbConnectionValidator
             if (result.HasRows)
             {
                 // The database and prefix are already in use.
-                return DbConnectionValidatorResult.DatabaseAndPrefixInUse;
+                return DbConnectionValidatorResult.DatabaseAndTablePrefixInUse;
             }
         }
         catch

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -51,7 +51,7 @@ public class DbConnectionValidator : IDbConnectionValidator
 
         if (provider != null && !provider.HasConnectionString)
         {
-            return DbConnectionValidatorResult.DocumentNotFound;
+            return DbConnectionValidatorResult.Success;
         }
 
         if (String.IsNullOrWhiteSpace(connectionString))
@@ -80,20 +80,19 @@ public class DbConnectionValidator : IDbConnectionValidator
             sqlCommand.CommandText = sqlBuilder.ToSqlString();
 
             using var result = await sqlCommand.ExecuteReaderAsync();
+
+            // If the 'ShellDescriptor' document already exists.
             if (result.HasRows)
             {
-                // At this point we know that the 'ShellDescriptor' document exists.
-                return DbConnectionValidatorResult.DocumentFound;
+                // The database and prefix are already in use.
+                return DbConnectionValidatorResult.DatabaseAndPrefixInUse;
             }
-
-            // The 'Document' table exists but not the 'ShellDescriptor' document.
-            return DbConnectionValidatorResult.DocumentNotFound;
         }
         catch
         {
-            // At this point we know that the document table does not exist.
-            return DbConnectionValidatorResult.DocumentNotFound;
         }
+
+        return DbConnectionValidatorResult.Success;
     }
 
     private ISqlBuilder GetSqlBuilderForShellDescriptorDocument(string tablePrefix, DatabaseProviderName providerName)

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -78,7 +78,7 @@ public class DbConnectionValidator : IDbConnectionValidator
         // If the shell settings come from the same database, the document table may already exist.
         if (_shellsSettingsSources.GetType().Name == "DatabaseShellsSettingsSources")
         {
-            // 'DocumentNotFound' is returned to not break the validation.
+            // In that case return 'DocumentNotFound' to not break the validation.
             return DbConnectionValidatorResult.DocumentNotFound;
         }
 
@@ -91,12 +91,12 @@ public class DbConnectionValidator : IDbConnectionValidator
 
             using var result = await selectCommand.ExecuteReaderAsync();
 
-            // at this point the query succeeded and the table exists
+            // At this point the query succeeded and the table exists.
             return DbConnectionValidatorResult.DocumentFound;
         }
         catch
         {
-            // at this point we know that the document table does not exist
+            // At this point we know that the document table does not exist.
 
             return DbConnectionValidatorResult.DocumentNotFound;
         }

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -181,8 +181,8 @@ namespace OrchardCore.Setup.Services
                 case DbConnectionValidatorResult.InvalidConnection:
                     context.Errors.Add(String.Empty, S["The provided connection string is invalid or server is unreachable."]);
                     break;
-                case DbConnectionValidatorResult.DatabaseAndPrefixInUse:
-                    context.Errors.Add(String.Empty, S["The provided database and prefix are already in use."]);
+                case DbConnectionValidatorResult.DatabaseAndTablePrefixInUse:
+                    context.Errors.Add(String.Empty, S["The provided database and table prefix are already in use."]);
                     break;
             }
 

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -181,7 +181,7 @@ namespace OrchardCore.Setup.Services
                 case DbConnectionValidatorResult.InvalidConnection:
                     context.Errors.Add(String.Empty, S["The provided connection string is invalid or server is unreachable."]);
                     break;
-                case DbConnectionValidatorResult.DocumentFound:
+                case DbConnectionValidatorResult.DatabaseAndPrefixInUse:
                     context.Errors.Add(String.Empty, S["The provided database and prefix are already in use."]);
                     break;
             }

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -182,7 +182,7 @@ namespace OrchardCore.Setup.Services
                     context.Errors.Add(String.Empty, S["The provided connection string is invalid or server is unreachable."]);
                     break;
                 case DbConnectionValidatorResult.DocumentFound:
-                    context.Errors.Add(String.Empty, S["The provided database is already in use."]);
+                    context.Errors.Add(String.Empty, S["The provided database and prefix are already in use."]);
                     break;
             }
 

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -182,7 +182,7 @@ namespace OrchardCore.Setup.Services
                     context.Errors.Add(String.Empty, S["The provided connection string is invalid or server is unreachable."]);
                     break;
                 case DbConnectionValidatorResult.DocumentFound:
-                    context.Errors.Add(String.Empty, S["The provided database table is already in use."]);
+                    context.Errors.Add(String.Empty, S["The provided database is already in use."]);
                     break;
             }
 


### PR DESCRIPTION
Fixes #12334 

If shell settings come from the same database, the document table may already exist before the setup, in that case during the setup the DbConnectionValidator fails because the document table already exits.

**Updated**: So here, in case the Document table exists, we check if the `ShellDescriptor` document exists.