### PR TITLE
Add a way to retrieve a UTC now datetime in Liquid

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/LocalTimeZoneFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/LocalTimeZoneFilter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Values;
+using OrchardCore.Modules;
+
+namespace OrchardCore.Liquid.Filters
+{
+    public class LocalTimeZoneFilter : ILiquidFilter
+    {
+        private readonly ILocalClock _localClock;
+
+        public LocalTimeZoneFilter(ILocalClock localClock)
+        {
+            _localClock = localClock;
+        }
+
+        public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext ctx)
+        {
+            DateTimeOffset value;
+
+            if (input.Type == FluidValues.String)
+            {
+                var stringValue = input.ToStringValue();
+
+                if (stringValue == "now" || stringValue == "today")
+                {
+                    value = await _localClock.LocalNowAsync;
+                }
+                else
+                {
+                    if (!DateTimeOffset.TryParse(stringValue, ctx.Options.CultureInfo, DateTimeStyles.AssumeUniversal, out value))
+                    {
+                        return NilValue.Instance;
+                    }
+                }
+            }
+            else
+            {
+                switch (input.ToObjectValue())
+                {
+                    case DateTime dateTime:
+                        value = dateTime;
+                        break;
+
+                    case DateTimeOffset dateTimeOffset:
+                        value = dateTimeOffset;
+                        break;
+
+                    default:
+                        return NilValue.Instance;
+                }
+            }
+
+            return new ObjectValue(await _localClock.ConvertToLocalAsync(value));
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/LocalTimeZoneFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/LocalTimeZoneFilter.cs
@@ -43,11 +43,9 @@ namespace OrchardCore.Liquid.Filters
                     case DateTime dateTime:
                         value = dateTime;
                         break;
-
                     case DateTimeOffset dateTimeOffset:
                         value = dateTimeOffset;
                         break;
-
                     default:
                         return NilValue.Instance;
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/TimeZoneFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/TimeZoneFilter.cs
@@ -28,6 +28,12 @@ namespace OrchardCore.Liquid.Filters
                 {
                     value = await _localClock.LocalNowAsync;
                 }
+                else if (stringValue == "utc_now" || stringValue == "utc_today")
+                {
+                    value = await _localClock.LocalNowAsync;
+
+                    return new ObjectValue(await _localClock.ConvertToUtcAsync(value.DateTime));
+                }
                 else
                 {
                     if (!DateTimeOffset.TryParse(stringValue, ctx.Options.CultureInfo, DateTimeStyles.AssumeUniversal, out value))

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/UtcTimeZoneFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/UtcTimeZoneFilter.cs
@@ -7,11 +7,11 @@ using OrchardCore.Modules;
 
 namespace OrchardCore.Liquid.Filters
 {
-    public class TimeZoneFilter : ILiquidFilter
+    internal class UtcTimeZoneFilter : ILiquidFilter
     {
         private readonly ILocalClock _localClock;
 
-        public TimeZoneFilter(ILocalClock localClock)
+        public UtcTimeZoneFilter(ILocalClock localClock)
         {
             _localClock = localClock;
         }
@@ -27,12 +27,6 @@ namespace OrchardCore.Liquid.Filters
                 if (stringValue == "now" || stringValue == "today")
                 {
                     value = await _localClock.LocalNowAsync;
-                }
-                else if (stringValue == "utc_now" || stringValue == "utc_today")
-                {
-                    value = await _localClock.LocalNowAsync;
-
-                    return new ObjectValue(await _localClock.ConvertToUtcAsync(value.DateTime));
                 }
                 else
                 {
@@ -59,7 +53,7 @@ namespace OrchardCore.Liquid.Filters
                 }
             }
 
-            return new ObjectValue(await _localClock.ConvertToLocalAsync(value));
+            return new ObjectValue(await _localClock.ConvertToUtcAsync(value.DateTime));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/UtcTimeZoneFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/UtcTimeZoneFilter.cs
@@ -7,7 +7,7 @@ using OrchardCore.Modules;
 
 namespace OrchardCore.Liquid.Filters
 {
-    internal class UtcTimeZoneFilter : ILiquidFilter
+    public class UtcTimeZoneFilter : ILiquidFilter
     {
         private readonly ILocalClock _localClock;
 
@@ -43,11 +43,9 @@ namespace OrchardCore.Liquid.Filters
                     case DateTime dateTime:
                         value = dateTime;
                         break;
-
                     case DateTimeOffset dateTimeOffset:
                         value = dateTimeOffset;
                         break;
-
                     default:
                         return NilValue.Instance;
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
@@ -65,7 +65,8 @@ namespace OrchardCore.Liquid
                 options.Filters.AddFilter("json", JsonFilter.Json);
                 options.Filters.AddFilter("jsonparse", JsonParseFilter.JsonParse);
             })
-            .AddLiquidFilter<TimeZoneFilter>("local")
+            .AddLiquidFilter<LocalTimeZoneFilter>("local")
+            .AddLiquidFilter<UtcTimeZoneFilter>("utc")
             .AddLiquidFilter<SlugifyFilter>("slugify")
             .AddLiquidFilter<LiquidFilter>("liquid")
             .AddLiquidFilter<ContentUrlFilter>("href")

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -107,6 +107,22 @@ Output
 Wednesday, 02 August 2017 11:54:48
 ```
 
+### `utc`
+
+Converts a local date and time to the UTC date and time based on the site settings.
+
+Input
+
+```liquid
+{{ "now" | utc | date: "%c" }}
+```
+
+Output
+
+```text
+Wednesday, 02 August 2017 11:54:48
+```
+
 ### `t`
 
 Localizes a string using the current culture.


### PR DESCRIPTION
utc: {{ "utc_now" | local | date: "%c" }}
local : {{ "now" | local | date: "%c" }}
local is the default : {{ "now" | date: "%c" }}

![image](https://user-images.githubusercontent.com/3228637/188486740-0e6e8430-2962-4683-b891-54834339e946.png)

At the same time I'm questioning the TimeZoneFilter name now. "local" doesn't make sense anymore if we do this. The idea of the TimeZoneFilter should be to allow returning a local DateTime or a DateTime affected by an offset. Here, we should probably consider creating a filter that allows passing a TimeZoneId or an Offset value simply. Need to think about the design. But at the same time `| local` here doesn't make sense to be required to retrieve a UTC DateTime value.

Else, a refactor of this filter might become a breaking change. Maybe better simply create a new one.