### PR TITLE
Fixing NRE when publishing item with LocalizationPart removed (Lombiq Technologies: OCORE-102)

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/Records/LocalizedContentItemIndex.cs
+++ b/src/OrchardCore/OrchardCore.ContentLocalization.Abstractions/Records/LocalizedContentItemIndex.cs
@@ -101,7 +101,7 @@ namespace OrchardCore.ContentLocalization.Records
                     return new LocalizedContentItemIndex
                     {
                         Culture = !partRemoved ? part.Culture.ToLowerInvariant() : null,
-                        LocalizationSet = part.LocalizationSet,
+                        LocalizationSet = !partRemoved ? part.LocalizationSet : null,
                         ContentItemId = contentItem.ContentItemId,
                         Published = contentItem.Published,
                         Latest = contentItem.Latest


### PR DESCRIPTION
Looks like an oversight since line 103 handles this in the same `LocalizedContentItemIndexProvider`.