### PR TITLE
Data Provider Values, YesSql Options and Db Validator tweaks.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AutoSetup/AutoSetupMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AutoSetup/AutoSetupMiddleware.cs
@@ -214,7 +214,7 @@ namespace OrchardCore.AutoSetup
 
             shellSettings["ConnectionString"] = setupOptions.DatabaseConnectionString;
             shellSettings["TablePrefix"] = setupOptions.DatabaseTablePrefix;
-            shellSettings["DatabaseProvider"] = setupOptions.DatabaseProvider.ToString();
+            shellSettings["DatabaseProvider"] = setupOptions.DatabaseProvider;
             shellSettings["Secret"] = Guid.NewGuid().ToString();
             shellSettings["RecipeName"] = setupOptions.RecipeName;
 

--- a/src/OrchardCore.Modules/OrchardCore.AutoSetup/Options/TenantSetupOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AutoSetup/Options/TenantSetupOptions.cs
@@ -43,7 +43,7 @@ namespace OrchardCore.AutoSetup.Options
         /// <summary>
         /// Gets or sets the database provider.
         /// </summary>
-        public DatabaseProviderName DatabaseProvider { get; set; }
+        public string DatabaseProvider { get; set; }
 
         /// <summary>
         /// Gets or sets the database connection string.

--- a/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Controllers/SetupController.cs
@@ -198,13 +198,9 @@ namespace OrchardCore.Setup.Controllers
             if (!String.IsNullOrEmpty(_shellSettings["DatabaseProvider"]))
             {
                 model.DatabaseConfigurationPreset = true;
-                if (Enum.TryParse(_shellSettings["DatabaseProvider"], out DatabaseProviderName providerName))
-                {
-                    model.DatabaseProvider = providerName;
-                }
+                model.DatabaseProvider = _shellSettings["DatabaseProvider"];
             }
-
-            if (!model.DatabaseProvider.HasValue)
+            else
             {
                 model.DatabaseProvider = model.DatabaseProviders.FirstOrDefault(p => p.IsDefault)?.Value;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Setup/ViewModels/SetupViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/ViewModels/SetupViewModel.cs
@@ -16,7 +16,7 @@ namespace OrchardCore.Setup.ViewModels
 
         public string Description { get; set; }
 
-        public DatabaseProviderName? DatabaseProvider { get; set; }
+        public string DatabaseProvider { get; set; }
 
         public string ConnectionString { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -180,9 +180,8 @@ namespace OrchardCore.Tenants.Controllers
                 databaseProvider = model.DatabaseProvider;
             }
 
-            Enum.TryParse(databaseProvider, out DatabaseProviderName providerName);
-
-            var selectedProvider = _databaseProviders.FirstOrDefault(x => x.Value == providerName);
+            var selectedProvider = _databaseProviders.FirstOrDefault(provider =>
+                String.Equals(provider.Value, databaseProvider, StringComparison.OrdinalIgnoreCase));
 
             if (selectedProvider == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -180,12 +180,17 @@ namespace OrchardCore.Tenants.Controllers
                 databaseProvider = model.DatabaseProvider;
             }
 
+            if (String.IsNullOrEmpty(databaseProvider))
+            {
+                return BadRequest(S["The database provider is not defined."]);
+            }
+
             var selectedProvider = _databaseProviders.FirstOrDefault(provider =>
                 String.Equals(provider.Value, databaseProvider, StringComparison.OrdinalIgnoreCase));
 
             if (selectedProvider == null)
             {
-                return BadRequest(S["The database provider is not defined."]);
+                return BadRequest(S["The database provider is not supported."]);
             }
 
             var tablePrefix = shellSettings["TablePrefix"];

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -118,7 +118,7 @@ namespace OrchardCore.Tenants.Services
                     errors.Add(new ModelError(nameof(TenantViewModel.ConnectionString), S["The provided connection string is invalid or server is unreachable."]));
                     break;
                 case DbConnectionValidatorResult.DocumentTableFound:
-                    if (databaseProvider == DatabaseProviderName.Sqlite)
+                    if (databaseProvider == DatabaseProviderValue.Sqlite)
                     {
                         errors.Add(new ModelError(String.Empty, S["The related database file is already in use."]));
                     }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -91,7 +91,7 @@ namespace OrchardCore.Tenants.Services
                     }
                 }
 
-                await AssertConnectionValidityAndApplyErrorsAsync(model.DatabaseProvider, model.ConnectionString, model.TablePrefix, errors, shellSettings?.IsDefaultShell() == true);
+                await AssertConnectionValidityAndApplyErrorsAsync(model.DatabaseProvider, model.ConnectionString, model.TablePrefix, errors, model.Name);
             }
             else
             {
@@ -100,16 +100,16 @@ namespace OrchardCore.Tenants.Services
                     // While the tenant is in Uninitialized state, we still are able to change the database settings.
                     // Let's validate the database for assurance.
 
-                    await AssertConnectionValidityAndApplyErrorsAsync(model.DatabaseProvider, model.ConnectionString, model.TablePrefix, errors, shellSettings?.IsDefaultShell() == true);
+                    await AssertConnectionValidityAndApplyErrorsAsync(model.DatabaseProvider, model.ConnectionString, model.TablePrefix, errors, model.Name);
                 }
             }
 
             return errors;
         }
 
-        private async Task AssertConnectionValidityAndApplyErrorsAsync(string databaseProvider, string connectionString, string tablePrefix, List<ModelError> errors, bool isDefaultShell)
+        private async Task AssertConnectionValidityAndApplyErrorsAsync(string databaseProvider, string connectionString, string tablePrefix, List<ModelError> errors, string shellName)
         {
-            switch (await _dbConnectionValidator.ValidateAsync(databaseProvider, connectionString, tablePrefix, isDefaultShell))
+            switch (await _dbConnectionValidator.ValidateAsync(databaseProvider, connectionString, tablePrefix, shellName))
             {
                 case DbConnectionValidatorResult.UnsupportedProvider:
                     errors.Add(new ModelError(nameof(TenantViewModel.DatabaseProvider), S["The provided database provider is not supported."]));
@@ -118,7 +118,15 @@ namespace OrchardCore.Tenants.Services
                     errors.Add(new ModelError(nameof(TenantViewModel.ConnectionString), S["The provided connection string is invalid or server is unreachable."]));
                     break;
                 case DbConnectionValidatorResult.DocumentTableFound:
-                    errors.Add(new ModelError(nameof(TenantViewModel.TablePrefix), S["The provided database and table prefix are already in use."]));
+                    if (databaseProvider == DatabaseProviderName.Sqlite)
+                    {
+                        errors.Add(new ModelError(String.Empty, S["The related database file is already in use."]));
+                    }
+                    else
+                    {
+                        errors.Add(new ModelError(nameof(TenantViewModel.TablePrefix), S["The provided database and table prefix are already in use."]));
+                    }
+
                     break;
             }
         }

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/DatabaseProvider.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/DatabaseProvider.cs
@@ -3,7 +3,7 @@ namespace OrchardCore.Data
     public class DatabaseProvider
     {
         public string Name { get; set; }
-        public DatabaseProviderName Value { get; set; }
+        public string Value { get; set; }
         public bool HasConnectionString { get; set; }
         public bool HasTablePrefix { get; set; }
         public bool IsDefault { get; set; }

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/DatabaseProviderName.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/DatabaseProviderName.cs
@@ -1,10 +1,9 @@
-﻿namespace OrchardCore.Data;
+namespace OrchardCore.Data;
 
-public enum DatabaseProviderName
+public static class DatabaseProviderName
 {
-    None,
-    SqlConnection,
-    Sqlite,
-    MySql,
-    Postgres,
+    public const string MySql = nameof(MySql);
+    public const string Postgres = nameof(Postgres);
+    public const string SqlConnection = nameof(SqlConnection);
+    public const string Sqlite = nameof(Sqlite);
 }

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/DatabaseProviderValue.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/DatabaseProviderValue.cs
@@ -1,6 +1,6 @@
 namespace OrchardCore.Data;
 
-public static class DatabaseProviderName
+public static class DatabaseProviderValue
 {
     public const string MySql = nameof(MySql);
     public const string Postgres = nameof(Postgres);

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace OrchardCore.Data
         /// <param name="isDefault">Whether the data provider is the default one.</param>
         /// <param name="sampleConnectionString">A sample connection string, e.g. Server={Server Name};Database={Database Name};IntegratedSecurity=true</param>
         /// <returns></returns>
-        public static IServiceCollection TryAddDataProvider(this IServiceCollection services, string name, DatabaseProviderName value, bool hasConnectionString, bool hasTablePrefix, bool isDefault, string sampleConnectionString = "")
+        public static IServiceCollection TryAddDataProvider(this IServiceCollection services, string name, string value, bool hasConnectionString, bool hasTablePrefix, bool isDefault, string sampleConnectionString = "")
         {
             for (var i = services.Count - 1; i >= 0; i--)
             {

--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/IDbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/IDbConnectionValidator.cs
@@ -4,5 +4,5 @@ namespace OrchardCore.Data;
 
 public interface IDbConnectionValidator
 {
-    Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, bool isDefaultShell);
+    Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, string shellName);
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/YesSqlOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/YesSqlOptions.cs
@@ -1,6 +1,6 @@
 using YesSql;
 
-namespace OrchardCore.Data.YesSql.Abstractions;
+namespace OrchardCore.Data.YesSql;
 
 public class YesSqlOptions
 {

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -59,7 +59,7 @@ public class DbConnectionValidator : IDbConnectionValidator
 
         if (!provider.HasConnectionString)
         {
-            if (provider.Value != DatabaseProviderName.Sqlite)
+            if (provider.Value != DatabaseProviderValue.Sqlite)
             {
                 return DbConnectionValidatorResult.DocumentTableNotFound;
             }
@@ -92,7 +92,7 @@ public class DbConnectionValidator : IDbConnectionValidator
         }
         catch
         {
-            if (provider.Value != DatabaseProviderName.Sqlite)
+            if (provider.Value != DatabaseProviderValue.Sqlite)
             {
                 return DbConnectionValidatorResult.InvalidConnection;
             }
@@ -180,10 +180,10 @@ public class DbConnectionValidator : IDbConnectionValidator
     {
         return databaseProvider switch
         {
-            DatabaseProviderName.SqlConnection => new DbConnectionFactory<SqlConnection>(connectionString),
-            DatabaseProviderName.MySql => new DbConnectionFactory<MySqlConnection>(connectionString),
-            DatabaseProviderName.Sqlite => new DbConnectionFactory<SqliteConnection>(connectionString),
-            DatabaseProviderName.Postgres => new DbConnectionFactory<NpgsqlConnection>(connectionString),
+            DatabaseProviderValue.SqlConnection => new DbConnectionFactory<SqlConnection>(connectionString),
+            DatabaseProviderValue.MySql => new DbConnectionFactory<MySqlConnection>(connectionString),
+            DatabaseProviderValue.Sqlite => new DbConnectionFactory<SqliteConnection>(connectionString),
+            DatabaseProviderValue.Postgres => new DbConnectionFactory<NpgsqlConnection>(connectionString),
             _ => throw new ArgumentOutOfRangeException(nameof(databaseProvider), "Unsupported database provider"),
         };
     }
@@ -192,10 +192,10 @@ public class DbConnectionValidator : IDbConnectionValidator
     {
         ISqlDialect dialect = databaseProvider switch
         {
-            DatabaseProviderName.SqlConnection => new SqlServerDialect(),
-            DatabaseProviderName.MySql => new MySqlDialect(),
-            DatabaseProviderName.Sqlite => new SqliteDialect(),
-            DatabaseProviderName.Postgres => new PostgreSqlDialect(),
+            DatabaseProviderValue.SqlConnection => new SqlServerDialect(),
+            DatabaseProviderValue.MySql => new MySqlDialect(),
+            DatabaseProviderValue.Sqlite => new SqliteDialect(),
+            DatabaseProviderValue.Postgres => new PostgreSqlDialect(),
             _ => throw new ArgumentOutOfRangeException(nameof(databaseProvider), "Unsupported database provider"),
         };
 

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -34,8 +34,7 @@ public class DbConnectionValidator : IDbConnectionValidator
         IEnumerable<DatabaseProvider> databaseProviders,
         IOptions<YesSqlOptions> yesSqlOptions,
         IOptions<SqliteOptions> sqliteOptions,
-        IOptions<ShellOptions> shellOptions
-        )
+        IOptions<ShellOptions> shellOptions)
     {
         _databaseProviders = databaseProviders;
         _yesSqlOptions = yesSqlOptions.Value;

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -7,7 +8,8 @@ using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Options;
 using MySqlConnector;
 using Npgsql;
-using OrchardCore.Data.YesSql.Abstractions;
+using OrchardCore.Data.YesSql;
+using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Descriptor.Models;
 using YesSql;
 using YesSql.Provider.MySql;
@@ -25,37 +27,54 @@ public class DbConnectionValidator : IDbConnectionValidator
     private static readonly string _shellDescriptorTypeColumnValue = new TypeService()[typeof(ShellDescriptor)];
 
     private readonly IEnumerable<DatabaseProvider> _databaseProviders;
-    private readonly ITableNameConvention _tableNameConvention;
     private readonly YesSqlOptions _yesSqlOptions;
+    private readonly SqliteOptions _sqliteOptions;
+    private readonly ShellOptions _shellOptions;
 
     public DbConnectionValidator(
         IEnumerable<DatabaseProvider> databaseProviders,
-        ITableNameConvention tableNameConvention,
-        IOptions<YesSqlOptions> yesSqlOptions
+        IOptions<YesSqlOptions> yesSqlOptions,
+        IOptions<SqliteOptions> sqliteOptions,
+        IOptions<ShellOptions> shellOptions
         )
     {
         _databaseProviders = databaseProviders;
-        _tableNameConvention = tableNameConvention;
         _yesSqlOptions = yesSqlOptions.Value;
+        _sqliteOptions = sqliteOptions.Value;
+        _shellOptions = shellOptions.Value;
     }
 
-    public async Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, bool isDefaultShell)
+    public async Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, string shellName)
     {
         if (String.IsNullOrWhiteSpace(databaseProvider))
         {
             return DbConnectionValidatorResult.NoProvider;
         }
 
-        if (!Enum.TryParse(databaseProvider, out DatabaseProviderName providerName) || providerName == DatabaseProviderName.None)
+        var provider = _databaseProviders.FirstOrDefault(x => x.Value == databaseProvider);
+        if (provider == null)
         {
             return DbConnectionValidatorResult.UnsupportedProvider;
         }
 
-        var provider = _databaseProviders.FirstOrDefault(x => x.Value == providerName);
-
-        if (provider != null && !provider.HasConnectionString)
+        if (!provider.HasConnectionString)
         {
-            return DbConnectionValidatorResult.DocumentTableNotFound;
+            if (provider.Value != DatabaseProviderName.Sqlite)
+            {
+                return DbConnectionValidatorResult.DocumentTableNotFound;
+            }
+
+            var databaseFolder = Path.Combine(_shellOptions.ShellsApplicationDataPath, _shellOptions.ShellsContainerName, shellName);
+            var databaseFile = Path.Combine(databaseFolder, "yessql.db");
+
+            var connectionStringBuilder = new SqliteConnectionStringBuilder
+            {
+                DataSource = databaseFile,
+                Cache = SqliteCacheMode.Shared,
+                Pooling = _sqliteOptions.UseConnectionPooling
+            };
+
+            connectionString = connectionStringBuilder.ToString();
         }
 
         if (String.IsNullOrWhiteSpace(connectionString))
@@ -63,7 +82,7 @@ public class DbConnectionValidator : IDbConnectionValidator
             return DbConnectionValidatorResult.InvalidConnection;
         }
 
-        var factory = GetFactory(providerName, connectionString);
+        var factory = GetFactory(databaseProvider, connectionString);
 
         using var connection = factory.CreateConnection();
 
@@ -73,17 +92,22 @@ public class DbConnectionValidator : IDbConnectionValidator
         }
         catch
         {
-            return DbConnectionValidatorResult.InvalidConnection;
+            if (provider.Value != DatabaseProviderName.Sqlite)
+            {
+                return DbConnectionValidatorResult.InvalidConnection;
+            }
+
+            return DbConnectionValidatorResult.DocumentTableNotFound;
         }
 
-        var selectBuilder = GetSelectBuilderForDocumentTable(tablePrefix, providerName);
+        var selectBuilder = GetSelectBuilderForDocumentTable(tablePrefix, databaseProvider);
         try
         {
             var selectCommand = connection.CreateCommand();
             selectCommand.CommandText = selectBuilder.ToSqlString();
 
             using var result = await selectCommand.ExecuteReaderAsync();
-            if (!isDefaultShell)
+            if (shellName != ShellHelper.DefaultShellName)
             {
                 // The 'Document' table exists.
                 return DbConnectionValidatorResult.DocumentTableFound;
@@ -106,7 +130,7 @@ public class DbConnectionValidator : IDbConnectionValidator
             return DbConnectionValidatorResult.DocumentTableNotFound;
         }
 
-        selectBuilder = GetSelectBuilderForShellDescriptorDocument(tablePrefix, providerName);
+        selectBuilder = GetSelectBuilderForShellDescriptorDocument(tablePrefix, databaseProvider);
         try
         {
             var selectCommand = connection.CreateCommand();
@@ -127,59 +151,59 @@ public class DbConnectionValidator : IDbConnectionValidator
         return DbConnectionValidatorResult.DocumentTableFound;
     }
 
-    private ISqlBuilder GetSelectBuilderForDocumentTable(string tablePrefix, DatabaseProviderName providerName)
+    private ISqlBuilder GetSelectBuilderForDocumentTable(string tablePrefix, string databaseProvider)
     {
-        var selectBuilder = GetSqlBuilder(providerName, tablePrefix);
+        var selectBuilder = GetSqlBuilder(databaseProvider, tablePrefix);
 
         selectBuilder.Select();
         selectBuilder.Selector("*");
-        selectBuilder.Table(_tableNameConvention.GetDocumentTable());
+        selectBuilder.Table(_yesSqlOptions.TableNameConvention.GetDocumentTable());
         selectBuilder.Take("1");
 
         return selectBuilder;
     }
 
-    private ISqlBuilder GetSelectBuilderForShellDescriptorDocument(string tablePrefix, DatabaseProviderName providerName)
+    private ISqlBuilder GetSelectBuilderForShellDescriptorDocument(string tablePrefix, string databaseProvider)
     {
-        var selectBuilder = GetSqlBuilder(providerName, tablePrefix);
+        var selectBuilder = GetSqlBuilder(databaseProvider, tablePrefix);
 
         selectBuilder.Select();
         selectBuilder.Selector("*");
-        selectBuilder.Table(_tableNameConvention.GetDocumentTable());
+        selectBuilder.Table(_yesSqlOptions.TableNameConvention.GetDocumentTable());
         selectBuilder.WhereAnd($"Type = '{_shellDescriptorTypeColumnValue}'");
         selectBuilder.Take("1");
 
         return selectBuilder;
     }
 
-    private static IConnectionFactory GetFactory(DatabaseProviderName providerName, string connectionString)
+    private static IConnectionFactory GetFactory(string databaseProvider, string connectionString)
     {
-        return providerName switch
+        return databaseProvider switch
         {
             DatabaseProviderName.SqlConnection => new DbConnectionFactory<SqlConnection>(connectionString),
             DatabaseProviderName.MySql => new DbConnectionFactory<MySqlConnection>(connectionString),
             DatabaseProviderName.Sqlite => new DbConnectionFactory<SqliteConnection>(connectionString),
             DatabaseProviderName.Postgres => new DbConnectionFactory<NpgsqlConnection>(connectionString),
-            _ => throw new ArgumentOutOfRangeException(nameof(providerName), "Unsupported database provider"),
+            _ => throw new ArgumentOutOfRangeException(nameof(databaseProvider), "Unsupported database provider"),
         };
     }
 
-    private ISqlBuilder GetSqlBuilder(DatabaseProviderName providerName, string tablePrefix)
+    private ISqlBuilder GetSqlBuilder(string databaseProvider, string tablePrefix)
     {
-        ISqlDialect dialect = providerName switch
+        ISqlDialect dialect = databaseProvider switch
         {
             DatabaseProviderName.SqlConnection => new SqlServerDialect(),
             DatabaseProviderName.MySql => new MySqlDialect(),
             DatabaseProviderName.Sqlite => new SqliteDialect(),
             DatabaseProviderName.Postgres => new PostgreSqlDialect(),
-            _ => throw new ArgumentOutOfRangeException(nameof(providerName), "Unsupported database provider"),
+            _ => throw new ArgumentOutOfRangeException(nameof(databaseProvider), "Unsupported database provider"),
         };
 
         var prefix = String.Empty;
 
         if (!String.IsNullOrEmpty(tablePrefix))
         {
-            prefix = tablePrefix.Trim() + (_yesSqlOptions.TablePrefixSeparator ?? String.Empty);
+            prefix = tablePrefix.Trim() + _yesSqlOptions.TablePrefixSeparator;
         }
 
         return new SqlBuilder(prefix, dialect);

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.SqlClient;
@@ -64,17 +63,7 @@ public class DbConnectionValidator : IDbConnectionValidator
                 return DbConnectionValidatorResult.DocumentTableNotFound;
             }
 
-            var databaseFolder = Path.Combine(_shellOptions.ShellsApplicationDataPath, _shellOptions.ShellsContainerName, shellName);
-            var databaseFile = Path.Combine(databaseFolder, "yessql.db");
-
-            var connectionStringBuilder = new SqliteConnectionStringBuilder
-            {
-                DataSource = databaseFile,
-                Cache = SqliteCacheMode.Shared,
-                Pooling = _sqliteOptions.UseConnectionPooling
-            };
-
-            connectionString = connectionStringBuilder.ToString();
+            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, shellName);
         }
 
         if (String.IsNullOrWhiteSpace(connectionString))

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -188,8 +188,7 @@ public class DbConnectionValidator : IDbConnectionValidator
         };
 
         var prefix = String.Empty;
-
-        if (!String.IsNullOrEmpty(tablePrefix))
+        if (!String.IsNullOrWhiteSpace(tablePrefix))
         {
             prefix = tablePrefix.Trim() + _yesSqlOptions.TablePrefixSeparator;
         }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.TryAddDataProvider(name: "MySql", value: DatabaseProviderValue.MySql, hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;Uid=username;Pwd=password", hasTablePrefix: true, isDefault: false);
                 services.TryAddDataProvider(name: "Postgres", value: DatabaseProviderValue.Postgres, hasConnectionString: true, sampleConnectionString: "Server=localhost;Port=5432;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
 
+                // Ensure a non null 'TableNameConvention' to be always used for `YesSql.Configuration`.
                 services.PostConfigure<YesSqlOptions>(o => o.TableNameConvention ??= new YesSql.Configuration().TableNameConvention);
 
                 // Configuring data access

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Extensions.DependencyInjection
                             throw new ArgumentException("Unknown database provider: " + shellSettings["DatabaseProvider"]);
                     }
 
-                    if (!String.IsNullOrEmpty(shellSettings["TablePrefix"]))
+                    if (!String.IsNullOrWhiteSpace(shellSettings["TablePrefix"]))
                     {
                         var tablePrefix = shellSettings["TablePrefix"].Trim() + yesSqlOptions.TablePrefixSeparator;
                         storeConfiguration = storeConfiguration.SetTablePrefix(tablePrefix);

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddScoped<IDataMigrationManager, DataMigrationManager>();
                 services.AddScoped<IModularTenantEvents, AutomaticDataMigrations>();
 
-                //services.AddOptions<StoreCollectionOptions>();
                 services.AddTransient<IConfigureOptions<SqliteOptions>, SqliteOptionsConfiguration>();
 
                 // Adding supported databases
@@ -48,7 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.TryAddDataProvider(name: "MySql", value: DatabaseProviderValue.MySql, hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;Uid=username;Pwd=password", hasTablePrefix: true, isDefault: false);
                 services.TryAddDataProvider(name: "Postgres", value: DatabaseProviderValue.Postgres, hasConnectionString: true, sampleConnectionString: "Server=localhost;Port=5432;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
 
-                services.PostConfigure<YesSqlOptions>(options => options.TableNameConvention ??= new YesSql.Configuration().TableNameConvention);
+                services.PostConfigure<YesSqlOptions>(o => o.TableNameConvention ??= new YesSql.Configuration().TableNameConvention);
 
                 // Configuring data access
                 services.AddSingleton(sp =>

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.TryAddDataProvider(name: "MySql", value: DatabaseProviderValue.MySql, hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;Uid=username;Pwd=password", hasTablePrefix: true, isDefault: false);
                 services.TryAddDataProvider(name: "Postgres", value: DatabaseProviderValue.Postgres, hasConnectionString: true, sampleConnectionString: "Server=localhost;Port=5432;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
 
-                // Ensure a non null 'TableNameConvention' to be always used for `YesSql.Configuration`.
+                // Ensure a non null 'TableNameConvention' to be always used for `YesSql.Configuration` and then in sync with it.
                 services.PostConfigure<YesSqlOptions>(o => o.TableNameConvention ??= new YesSql.Configuration().TableNameConvention);
 
                 // Configuring data access

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -44,10 +44,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddTransient<IConfigureOptions<SqliteOptions>, SqliteOptionsConfiguration>();
 
                 // Adding supported databases
-                services.TryAddDataProvider(name: "Sql Server", value: DatabaseProviderName.SqlConnection, hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
-                services.TryAddDataProvider(name: "Sqlite", value: DatabaseProviderName.Sqlite, hasConnectionString: false, hasTablePrefix: false, isDefault: true);
-                services.TryAddDataProvider(name: "MySql", value: DatabaseProviderName.MySql, hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;Uid=username;Pwd=password", hasTablePrefix: true, isDefault: false);
-                services.TryAddDataProvider(name: "Postgres", value: DatabaseProviderName.Postgres, hasConnectionString: true, sampleConnectionString: "Server=localhost;Port=5432;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
+                services.TryAddDataProvider(name: "Sql Server", value: DatabaseProviderValue.SqlConnection, hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
+                services.TryAddDataProvider(name: "Sqlite", value: DatabaseProviderValue.Sqlite, hasConnectionString: false, hasTablePrefix: false, isDefault: true);
+                services.TryAddDataProvider(name: "MySql", value: DatabaseProviderValue.MySql, hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;Uid=username;Pwd=password", hasTablePrefix: true, isDefault: false);
+                services.TryAddDataProvider(name: "Postgres", value: DatabaseProviderValue.Postgres, hasConnectionString: true, sampleConnectionString: "Server=localhost;Port=5432;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
 
                 services.Configure<YesSqlOptions>(options => options.TableNameConvention = new YesSql.Configuration().TableNameConvention);
 
@@ -67,12 +67,12 @@ namespace Microsoft.Extensions.DependencyInjection
 
                     switch (shellSettings["DatabaseProvider"])
                     {
-                        case DatabaseProviderName.SqlConnection:
+                        case DatabaseProviderValue.SqlConnection:
                             storeConfiguration
                                 .UseSqlServer(shellSettings["ConnectionString"], IsolationLevel.ReadUncommitted)
                                 .UseBlockIdGenerator();
                             break;
-                        case DatabaseProviderName.Sqlite:
+                        case DatabaseProviderValue.Sqlite:
                             var shellOptions = sp.GetService<IOptions<ShellOptions>>();
                             var sqliteOptions = sp.GetService<IOptions<SqliteOptions>>()?.Value ?? new SqliteOptions();
                             var option = shellOptions.Value;
@@ -90,12 +90,12 @@ namespace Microsoft.Extensions.DependencyInjection
                                 .UseSqLite(connectionStringBuilder.ToString(), IsolationLevel.ReadUncommitted)
                                 .UseDefaultIdGenerator();
                             break;
-                        case DatabaseProviderName.MySql:
+                        case DatabaseProviderValue.MySql:
                             storeConfiguration
                                 .UseMySql(shellSettings["ConnectionString"], IsolationLevel.ReadUncommitted)
                                 .UseBlockIdGenerator();
                             break;
-                        case DatabaseProviderName.Postgres:
+                        case DatabaseProviderValue.Postgres:
                             storeConfiguration
                                 .UsePostgreSql(shellSettings["ConnectionString"], IsolationLevel.ReadUncommitted)
                                 .UseBlockIdGenerator();

--- a/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using Microsoft.Data.Sqlite;
+using OrchardCore.Environment.Shell;
+
+namespace OrchardCore.Data;
+
+public static class SqliteHelper
+{
+    public static string GetConnectionString(SqliteOptions sqliteOptions, ShellOptions shellOptions, string shellName) =>
+        GetConnectionString(sqliteOptions, GetDatabaseFolder(shellOptions, shellName));
+
+    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder) =>
+        new SqliteConnectionStringBuilder
+        {
+            DataSource = Path.Combine(databaseFolder, "yessql.db"),
+            Cache = SqliteCacheMode.Shared,
+            Pooling = sqliteOptions.UseConnectionPooling
+        }
+        .ToString();
+
+    public static string GetDatabaseFolder(ShellOptions shellOptions, string shellName) =>
+        Path.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellName);
+}

--- a/src/OrchardCore/OrchardCore.Infrastructure/Shells.Database/Configuration/DatabaseShellsStorageOptions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shells.Database/Configuration/DatabaseShellsStorageOptions.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Shells.Database.Configuration
     public class DatabaseShellsStorageOptions
     {
         public bool MigrateFromFiles { get; set; }
-        public DatabaseProviderName DatabaseProvider { get; set; }
+        public string DatabaseProvider { get; set; }
         public string ConnectionString { get; set; }
         public string TablePrefix { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Shells.Database/Extensions/DatabaseShellContextFactoryExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shells.Database/Extensions/DatabaseShellContextFactoryExtensions.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using OrchardCore.Data;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Descriptor.Models;
@@ -13,7 +12,7 @@ namespace OrchardCore.Shells.Database.Extensions
     {
         internal static Task<ShellContext> GetDatabaseContextAsync(this IShellContextFactory shellContextFactory, DatabaseShellsStorageOptions options)
         {
-            if (options.DatabaseProvider == DatabaseProviderName.None)
+            if (options.DatabaseProvider == null)
             {
                 throw new ArgumentNullException(nameof(options.DatabaseProvider),
                     "The 'OrchardCore.Shells.Database' configuration section should define a 'DatabaseProvider'");
@@ -25,7 +24,7 @@ namespace OrchardCore.Shells.Database.Extensions
                 State = TenantState.Running
             };
 
-            settings["DatabaseProvider"] = options.DatabaseProvider.ToString();
+            settings["DatabaseProvider"] = options.DatabaseProvider;
             settings["ConnectionString"] = options.ConnectionString;
             settings["TablePrefix"] = options.TablePrefix;
 

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Abstractions.Setup;
 using OrchardCore.Data;
-using OrchardCore.Data.YesSql.Abstractions;
+using OrchardCore.Data.YesSql;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Descriptor;
@@ -170,7 +170,7 @@ namespace OrchardCore.Setup.Services
                 shellSettings["TablePrefix"] = context.Properties.TryGetValue(SetupConstants.DatabaseTablePrefix, out var databaseTablePrefix) ? databaseTablePrefix?.ToString() : String.Empty;
             }
 
-            switch (await _dbConnectionValidator.ValidateAsync(shellSettings["DatabaseProvider"], shellSettings["ConnectionString"], shellSettings["TablePrefix"], shellSettings.IsDefaultShell()))
+            switch (await _dbConnectionValidator.ValidateAsync(shellSettings["DatabaseProvider"], shellSettings["ConnectionString"], shellSettings["TablePrefix"], shellSettings.Name))
             {
                 case DbConnectionValidatorResult.NoProvider:
                     context.Errors.Add(String.Empty, S["DatabaseProvider setting is required."]);

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -161,8 +161,6 @@ namespace OrchardCore.Setup.Services
 
             var shellSettings = new ShellSettings(context.ShellSettings);
 
-            shellSettings["TablePrefixSeparator"] = _yesSqlOptions.TablePrefixSeparator ?? String.Empty;
-
             if (String.IsNullOrWhiteSpace(shellSettings["DatabaseProvider"]))
             {
                 shellSettings["DatabaseProvider"] = context.Properties.TryGetValue(SetupConstants.DatabaseProvider, out var databaseProvider) ? databaseProvider?.ToString() : String.Empty;

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
@@ -122,7 +122,7 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
                 : new ShellSettings();
 
             var connectionFactory = new Mock<IDbConnectionValidator>();
-            connectionFactory.Setup(l => l.ValidateAsync(shellSettings["ProviderName"], shellSettings["ConnectionName"], shellSettings["TablePrefix"], shellSettings.IsDefaultShell()));
+            connectionFactory.Setup(l => l.ValidateAsync(shellSettings["ProviderName"], shellSettings["ConnectionName"], shellSettings["TablePrefix"], shellSettings.Name));
 
             return new TenantValidator(
                 ShellHost,


### PR DESCRIPTION
- Reuse strings for data provider values in place of an Enum so that we don't have to do `Enum.TryParse()` in one direction and an explicitly `.ToString()` in the other direction.

- Don't rely on defined Enum values for supported providers but on the registered providers.

- Ensure that `YesSqlOptions` has a non null `ITableNameConvention` and in sync with yesSql configuration, also allow to not have to register `ITableNameConvention` in the DI.

- We can define any `ShellSettings` value from the config stack, so in the setup better to not mutate `shellSettings["TablePrefixSeparator"]` from `_yesSqlOptions`, just use the options elsewhere. 

- In `DbConnectionValidator`also covers the case of `Sqlite` to check if the Document table exists.

- Update `IndexingTaskManager` to not use an hard coded `_` table prefix separator.