### PR TITLE
Add permission Localizer

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Roles/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Permissions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using OrchardCore.Localization;
 using OrchardCore.Security;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Security.Services;
@@ -14,10 +15,12 @@ namespace OrchardCore.Roles
         public static readonly Permission AssignRoles = CommonPermissions.AssignRoles;
 
         private readonly IRoleService _roleService;
+        private readonly IPermissionLocalizer _permissionLocalizer;
 
-        public Permissions(IRoleService roleService)
+        public Permissions(IRoleService roleService, IPermissionLocalizer permissionLocalizer)
         {
             _roleService = roleService;
+            _permissionLocalizer = permissionLocalizer;
         }
 
         public async Task<IEnumerable<Permission>> GetPermissionsAsync()
@@ -37,7 +40,7 @@ namespace OrchardCore.Roles
                 list.Add(CommonPermissions.CreatePermissionForAssignRole(role));
             }
 
-            return list;
+            return list.Select(permission => _permissionLocalizer.Localizer(permission));
         }
 
         public IEnumerable<PermissionStereotype> GetDefaultStereotypes()

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/IPermissionLocalizer.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/IPermissionLocalizer.cs
@@ -1,0 +1,13 @@
+using OrchardCore.Security.Permissions;
+
+namespace OrchardCore.Localization;
+
+public interface IPermissionLocalizer
+{
+    /// <summary>
+    /// Localize the description of the given permission
+    /// </summary>
+    /// <param name="permission"></param>
+    /// <returns></returns>
+    Permission Localizer(Permission permission);
+}

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCore.Localization.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCore.Localization.Abstractions.csproj
@@ -1,18 +1,23 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>OrchardCore.Localization</RootNamespace>
     <!-- NuGet properties-->
     <Title>OrchardCore Localization Abstractions</Title>
-    <Description>$(OCFrameworkDescription)
+    <Description>
+      $(OCFrameworkDescription)
 
-    Abstractions for Localization
+      Abstractions for Localization
     </Description>
     <PackageTags>$(PackageTags) OrchardCoreFramework Localization</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OrchardCore.Infrastructure.Abstractions\OrchardCore.Infrastructure.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Localization.Core/Extensions/LocalizationServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/Extensions/LocalizationServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="setupAction">An action to configure the Microsoft.Extensions.Localization.LocalizationOptions.</param>
         public static IServiceCollection AddPortableObjectLocalization(this IServiceCollection services, Action<LocalizationOptions> setupAction)
         {
+            services.AddSingleton<IPermissionLocalizer, PermissionLocalizer>();
             services.AddSingleton<IPluralRuleProvider, DefaultPluralRuleProvider>();
             services.AddSingleton<ITranslationProvider, PoFilesTranslationsProvider>();
             services.AddSingleton<ILocalizationFileLocationProvider, ContentRootPoFileLocationProvider>();

--- a/src/OrchardCore/OrchardCore.Localization.Core/PermissionLocalizer.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PermissionLocalizer.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Security.Permissions;
+
+namespace OrchardCore.Localization;
+
+public class PermissionLocalizer : IPermissionLocalizer
+{
+    private readonly IStringLocalizer S;
+
+    public PermissionLocalizer(IStringLocalizer<PermissionLocalizer> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    public Permission Localizer(Permission permission)
+    {
+        if (permission == null)
+        {
+            throw new ArgumentNullException(nameof(permission));
+        }
+
+        if (String.IsNullOrEmpty(permission.Description))
+        {
+            return permission;
+        }
+
+        return new Permission(permission.Name, S[permission.Description], permission.ImpliedBy, permission.IsSecurityCritical);
+    }
+}


### PR DESCRIPTION
Add permission localizer to allow us to localize the description of permission. 

This PR suggest that the new `IPermissionLocalizer` is used in the implementation of `IPermissionProvider` alternatively, we can just use it in the Roles controller to only translate these permission when we are getting ready to render them to the UI instead. This may be a better approach. However, not sure if this would work for the team since one may decide to localize the permission in the `PermissionProvider`. Either way, this `IPermissionLocalizer` should give us what we need to localize the permissions.

Fix #10551 
