### PR TITLE
Fixes #12479: Set HttpContext before using ShellScope in Unit Tests

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Resources
         {
             _resourceOptions = resourceOptions.Value;
             _env = env;
-            _pathBase = httpContextAccessor.HttpContext?.Request.PathBase ?? "";
+            _pathBase = httpContextAccessor.HttpContext.Request.PathBase;
         }
 
         ResourceManifest BuildManifest()

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Resources
         {
             _resourceOptions = resourceOptions.Value;
             _env = env;
-            _pathBase = httpContextAccessor.HttpContext.Request.PathBase;
+            _pathBase = httpContextAccessor?.HttpContext?.Request?.PathBase ?? "";
         }
 
         ResourceManifest BuildManifest()

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Resources
         {
             _resourceOptions = resourceOptions.Value;
             _env = env;
-            _pathBase = httpContextAccessor?.HttpContext?.Request?.PathBase ?? "";
+            _pathBase = httpContextAccessor.HttpContext?.Request.PathBase ?? "";
         }
 
         ResourceManifest BuildManifest()

--- a/src/OrchardCore/OrchardCore.Abstractions/BackgroundTasks/ShellContextExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/BackgroundTasks/ShellContextExtensions.cs
@@ -7,7 +7,7 @@ using OrchardCore.Modules;
 
 namespace OrchardCore.BackgroundTasks;
 
-internal static class ShellContextExtensions
+public static class ShellContextExtensions
 {
     private const string Localhost = "localhost";
 

--- a/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Autoroute.Models;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Records;
-using OrchardCore.Environment.Shell;
 using OrchardCore.Lists.Models;
 using OrchardCore.Taxonomies.Fields;
 using OrchardCore.Tests.Apis.Context;
@@ -73,7 +72,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.ContentApiController
                 await context.Client.PostAsJsonAsync("api/content", context.BlogPost);
 
                 // Test
-                var shellScope = await BlogPostApiControllerContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -251,7 +250,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.ContentApiController
                 // Test
                 Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
                 Assert.Contains("Your permalink is already in use.", problemDetails.Detail);
-                var shellScope = await BlogPostApiControllerContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -306,7 +305,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.ContentApiController
                 var publishedContentItem = await content.Content.ReadAsAsync<ContentItem>();
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 var blogPostContentItemIds = new List<string>
                     {
                         context.BlogPost.ContentItemId,

--- a/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
@@ -72,8 +72,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.ContentApiController
                 await context.Client.PostAsJsonAsync("api/content", context.BlogPost);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -250,8 +249,8 @@ namespace OrchardCore.Tests.Apis.ContentManagement.ContentApiController
                 // Test
                 Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
                 Assert.Contains("Your permalink is already in use.", problemDetails.Detail);
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -305,14 +304,13 @@ namespace OrchardCore.Tests.Apis.ContentManagement.ContentApiController
                 var publishedContentItem = await content.Content.ReadAsAsync<ContentItem>();
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
                 var blogPostContentItemIds = new List<string>
                     {
                         context.BlogPost.ContentItemId,
                         publishedContentItem.ContentItemId
                     };
 
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var newAutoroutePartIndex = await session

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
@@ -31,8 +31,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                     await context.PostRecipeAsync(recipe);
 
                     // Test
-                    var shellScope = await context.GetTenantScopeAsync();
-                    await shellScope.UsingAsync(async scope =>
+                    await context.UsingTenantScopeAsync(async scope =>
                     {
                         var session = scope.ServiceProvider.GetRequiredService<ISession>();
                         var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -72,8 +71,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                     await context.PostRecipeAsync(recipe);
 
                     // Test
-                    var shellScope = await context.GetTenantScopeAsync();
-                    await shellScope.UsingAsync(async scope =>
+                    await context.UsingTenantScopeAsync(async scope =>
                     {
                         var session = scope.ServiceProvider.GetRequiredService<ISession>();
                         var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Records;
-using OrchardCore.Environment.Shell;
 using OrchardCore.Tests.Apis.Context;
 using Xunit;
 using YesSql;
@@ -32,7 +31,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                     await context.PostRecipeAsync(recipe);
 
                     // Test
-                    var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                    var shellScope = await context.GetTenantScopeAsync();
                     await shellScope.UsingAsync(async scope =>
                     {
                         var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -73,7 +72,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                     await context.PostRecipeAsync(recipe);
 
                     // Test
-                    var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                    var shellScope = await context.GetTenantScopeAsync();
                     await shellScope.UsingAsync(async scope =>
                     {
                         var session = scope.ServiceProvider.GetRequiredService<ISession>();

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
@@ -5,7 +5,6 @@ using Newtonsoft.Json.Linq;
 using OrchardCore.Autoroute.Models;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Records;
-using OrchardCore.Environment.Shell;
 using OrchardCore.Tests.Apis.Context;
 using Xunit;
 using YesSql;
@@ -32,7 +31,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -74,7 +73,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -120,7 +119,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -165,7 +164,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -211,7 +210,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(firstRecipe);
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
@@ -31,8 +31,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -73,8 +72,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -119,8 +117,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -164,8 +161,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPostsCount = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -210,8 +206,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(firstRecipe);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPostsCount = await session.Query<ContentItem, ContentItemIndex>(x =>

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
@@ -28,8 +28,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -62,8 +61,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>
@@ -104,8 +102,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await context.GetTenantScopeAsync();
-                await shellScope.UsingAsync(async scope =>
+                await context.UsingTenantScopeAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
                     var blogPosts = await session.Query<ContentItem, ContentItemIndex>(x =>

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Records;
-using OrchardCore.Environment.Shell;
 using OrchardCore.Tests.Apis.Context;
 using Xunit;
 using YesSql;
@@ -29,7 +28,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -63,7 +62,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();
@@ -105,7 +104,7 @@ namespace OrchardCore.Tests.Apis.ContentManagement.DeploymentPlans
                 await context.PostRecipeAsync(recipe);
 
                 // Test
-                var shellScope = await BlogPostDeploymentContext.ShellHost.GetScopeAsync(context.TenantName);
+                var shellScope = await context.GetTenantScopeAsync();
                 await shellScope.UsingAsync(async scope =>
                 {
                     var session = scope.ServiceProvider.GetRequiredService<ISession>();

--- a/test/OrchardCore.Tests/Apis/Context/AgencyContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/AgencyContext.cs
@@ -1,15 +1,9 @@
-using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.Environment.Shell;
-
 namespace OrchardCore.Tests.Apis.Context
 {
     public class AgencyContext : SiteContext
     {
-        public static IShellHost ShellHost { get; }
-
         static AgencyContext()
         {
-            ShellHost = Site.Services.GetRequiredService<IShellHost>();
         }
 
         public AgencyContext()

--- a/test/OrchardCore.Tests/Apis/Context/BlogContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogContext.cs
@@ -12,11 +12,8 @@ namespace OrchardCore.Tests.Apis.Context
 
         public string BlogContentItemId { get; private set; }
 
-        public static IShellHost ShellHost { get; }
-
         static BlogContext()
         {
-            ShellHost = Site.Services.GetRequiredService<IShellHost>();
         }
 
         public override async Task InitializeAsync()

--- a/test/OrchardCore.Tests/Apis/Context/BlogContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogContext.cs
@@ -1,6 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.Tests.Apis.Context
 {
@@ -19,8 +17,8 @@ namespace OrchardCore.Tests.Apis.Context
         public override async Task InitializeAsync()
         {
             await base.InitializeAsync();
-            await RunRecipeAsync(ShellHost, luceneRecipeName, luceneRecipePath);
-            await ResetLuceneIndiciesAsync(ShellHost, luceneIndexName);
+            await RunRecipeAsync(luceneRecipeName, luceneRecipePath);
+            await ResetLuceneIndiciesAsync(luceneIndexName);
 
             var result = await GraphQLClient
                 .Content

--- a/test/OrchardCore.Tests/Apis/Context/BlogPostApiControllerContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogPostApiControllerContext.cs
@@ -1,15 +1,11 @@
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Apis.GraphQL.Client;
 using OrchardCore.ContentManagement;
-using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.Tests.Apis.Context
 {
     public class BlogPostApiControllerContext : SiteContext
     {
-        public static IShellHost ShellHost { get; private set; }
-
         public string BlogContentItemId { get; private set; }
         public ContentItem BlogPost { get; private set; }
         public string CategoriesTaxonomyContentItemId { get; private set; }
@@ -17,7 +13,6 @@ namespace OrchardCore.Tests.Apis.Context
 
         static BlogPostApiControllerContext()
         {
-            ShellHost = Site.Services.GetRequiredService<IShellHost>();
         }
 
         public override async Task InitializeAsync()

--- a/test/OrchardCore.Tests/Apis/Context/BlogPostDeploymentContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogPostDeploymentContext.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.Tests.Apis.Context
         public override async Task InitializeAsync()
         {
             await base.InitializeAsync();
-            await RunRecipeAsync(ShellHost, BlogContext.luceneRecipeName, BlogContext.luceneRecipePath);
+            await RunRecipeAsync(BlogContext.luceneRecipeName, BlogContext.luceneRecipePath);
 
             var result = await GraphQLClient
                 .Content
@@ -43,8 +43,7 @@ namespace OrchardCore.Tests.Apis.Context
             OriginalBlogPost = await content.Content.ReadAsAsync<ContentItem>();
             OriginalBlogPostVersionId = OriginalBlogPost.ContentItemVersionId;
 
-            var shellScope = await GetTenantScopeAsync();
-            await shellScope.UsingAsync(async scope =>
+            await UsingTenantScopeAsync(async scope =>
             {
                 var remoteClientService = scope.ServiceProvider.GetRequiredService<RemoteClientService>();
 

--- a/test/OrchardCore.Tests/Apis/Context/BlogPostDeploymentContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogPostDeploymentContext.cs
@@ -9,7 +9,6 @@ using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
 using OrchardCore.Deployment.Remote.Services;
 using OrchardCore.Deployment.Remote.ViewModels;
-using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.Tests.Apis.Context
 {
@@ -17,15 +16,12 @@ namespace OrchardCore.Tests.Apis.Context
     {
         public const string RemoteDeploymentClientName = "testserver";
         public const string RemoteDeploymentApiKey = "testkey";
-        public static IShellHost ShellHost { get; }
-
         public string BlogPostContentItemId { get; private set; }
         public ContentItem OriginalBlogPost { get; private set; }
         public string OriginalBlogPostVersionId { get; private set; }
 
         static BlogPostDeploymentContext()
         {
-            ShellHost = Site.Services.GetRequiredService<IShellHost>();
         }
 
         public override async Task InitializeAsync()
@@ -47,7 +43,7 @@ namespace OrchardCore.Tests.Apis.Context
             OriginalBlogPost = await content.Content.ReadAsAsync<ContentItem>();
             OriginalBlogPostVersionId = OriginalBlogPost.ContentItemVersionId;
 
-            var shellScope = await ShellHost.GetScopeAsync(TenantName);
+            var shellScope = await GetTenantScopeAsync();
             await shellScope.UsingAsync(async scope =>
             {
                 var remoteClientService = scope.ServiceProvider.GetRequiredService<RemoteClientService>();

--- a/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Apis.GraphQL.Client;
+using OrchardCore.BackgroundTasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Recipes.Services;
@@ -118,6 +120,9 @@ namespace OrchardCore.Tests.Apis.Context
         public async Task ResetLuceneIndiciesAsync(IShellHost shellHost, string indexName)
         {
             var shellScope = await shellHost.GetScopeAsync(TenantName);
+            var httpContextAccessor = shellScope.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
+            httpContextAccessor.HttpContext = shellScope.ShellContext.CreateHttpContext();
+
             await shellScope.UsingAsync(async scope =>
             {
                 var luceneIndexSettingsService = scope.ServiceProvider.GetRequiredService<LuceneIndexSettingsService>();

--- a/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
@@ -96,8 +96,9 @@ namespace OrchardCore.Tests.Apis.Context
 
         public async Task UsingTenantScopeAsync(Func<ShellScope, Task> execute, bool activateShell = true)
         {
-            // Ensure 'HttpContext' is not null as in a backgroun task.
             var shellScope = await ShellHost.GetScopeAsync(TenantName);
+
+            // Ensure that 'HttpContext' is not null, as done in a background task.
             var httpContextAccessor = shellScope.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
             httpContextAccessor.HttpContext = shellScope.ShellContext.CreateHttpContext();
 

--- a/test/OrchardCore.Tests/Apis/Lucene/LuceneContext.cs
+++ b/test/OrchardCore.Tests/Apis/Lucene/LuceneContext.cs
@@ -1,16 +1,11 @@
-using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.Environment.Shell;
 using OrchardCore.Tests.Apis.Context;
 
 namespace OrchardCore.Tests.Apis.Lucene
 {
     public class LuceneContext : SiteContext
     {
-        public static IShellHost ShellHost { get; }
-
         static LuceneContext()
         {
-            ShellHost = Site.Services.GetRequiredService<IShellHost>();
         }
 
         public LuceneContext()

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Moq;
 using OrchardCore.Data;
@@ -17,11 +16,8 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
 {
     public class TenantValidatorTests : SiteContext
     {
-        public static IShellHost ShellHost { get; }
-
         static TenantValidatorTests()
         {
-            ShellHost = Site.Services.GetRequiredService<IShellHost>();
         }
 
         [Theory]

--- a/test/OrchardCore.Tests/Shell/ShellHostTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellHostTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Models;
 using OrchardCore.Tests.Apis.Context;
@@ -9,11 +8,8 @@ namespace OrchardCore.Tests.Shell;
 
 public class ShellHostTests : SiteContext
 {
-    public static IShellHost ShellHost { get; }
-
     static ShellHostTests()
     {
-        ShellHost = Site.Services.GetRequiredService<IShellHost>();
     }
 
     [Theory]


### PR DESCRIPTION
Fixes #12479 

The failing report is there for a while, it doesn't break the unit tests as the exception is catched in our invoke extension, the error is only logged. For now what I saw from the trace is on a content manager loading an item.

    Content item loading...
    ...
    HtmlBodyPartHandler => IShortcodeService =>
    IShortcodeProvider => AssetUrlShortcodeProvider  =>
    IOptions<ResourceManagementOptions> =>
    ResourceManagementOptionsConfiguration =>
    NRE  on _pathBase = httpContextAccessor.HttpContext.Request.PathBase;

So I'm adding null operators step by step for testing
