### PR TITLE
Fix content types fields dependency

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -604,7 +604,7 @@ namespace OrchardCore.ContentTypes.Controllers
             var viewModel = new AddFieldViewModel
             {
                 Part = partViewModel.PartDefinition,
-                Fields = fields.Select(x => x.Name).OrderBy(x => x).ToList()
+                Fields = fields.Select(field => field .Name).OrderBy(name  => name).ToList()
             };
 
             ViewData["ReturnUrl"] = returnUrl;

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -628,7 +628,7 @@ namespace OrchardCore.ContentTypes.Controllers
 
             var fields = _contentDefinitionService.GetFields().ToList();
 
-            if (!fields.Any(x => x.Name.Equals(viewModel.FieldTypeName, StringComparison.OrdinalIgnoreCase)))
+            if (!fields.Any(field => String.Equals(field.Name, viewModel.FieldTypeName, StringComparison.OrdinalIgnoreCase)))
             {
                 return NotFound();
             }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -710,7 +710,7 @@ namespace OrchardCore.ContentTypes.Controllers
             var partFieldDefinition = partViewModel.PartDefinition.Fields.FirstOrDefault(x => String.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
 
             if (partFieldDefinition?.FieldDefinition?.Name == null
-                || !_contentDefinitionService.GetFields().Any(x => x.Name.Equals(partFieldDefinition.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
+                || !_contentDefinitionService.GetFields().Any(field => String.Equals(field.Name, partFieldDefinition.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
             {
                 return NotFound();
             }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
@@ -16,12 +16,16 @@
         })
         .OrderBy(x => x.Order)
         .Select(x => x.Part);
-
-    var orderedFields = ((typePart?.PartDefinition?.Fields) ?? Enumerable.Empty<ContentPartFieldDefinition>())
-        .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
-        .OrderBy(x => x.Order)
-        .Select(x => x.Field)
-        .ToList();
+    var orderedFields = Enumerable.Empty<ContentPartFieldDefinition>();
+    
+    if(typePart?.PartDefinition?.Fields != null)
+    {
+        orderedFields = typePart.PartDefinition.Fields
+            .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
+            .OrderBy(x => x.Order)
+            .Select(x => x.Field)
+            .ToList();
+    }
 
     var fields = ContentDefinitionService.GetFields().ToList();
 }
@@ -53,7 +57,7 @@
                     <li class="list-group-item" style="cursor: move;">
                         <div class="w-100">
                             <div class="float-end">
-                                @if (fields.Any(field => String.Equals(field.Name, field.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
+                                @if (fields.Any(f => String.Equals(f.Name, field.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
                                 {
                                     <a asp-route-action="EditField" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@field.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
                                 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
@@ -1,12 +1,13 @@
 @model EditTypeViewModel
-@inject OrchardCore.ContentManagement.Metadata.IContentDefinitionManager ContentDefinitionManager
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
 @using OrchardCore.Mvc.Utilities
 
+@inject OrchardCore.ContentManagement.Metadata.IContentDefinitionManager ContentDefinitionManager
+@inject OrchardCore.ContentTypes.Services.IContentDefinitionService ContentDefinitionService
+
 @{
     var typePart = Model.TypeDefinition.Parts.FirstOrDefault(x => String.Equals(x.Name, Model.TypeDefinition.Name, StringComparison.OrdinalIgnoreCase));
-
     var orderedParts = Model.TypeDefinition.Parts
         .Select(part =>
         {
@@ -15,11 +16,6 @@
         })
         .OrderBy(x => x.Order)
         .Select(x => x.Part);
-
-    var orderedFields = typePart == null ? Enumerable.Empty<ContentPartFieldDefinition>() : typePart.PartDefinition.Fields
-        .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
-        .OrderBy(x => x.Order)
-        .Select(x => x.Field);
 }
 
 <zone Name="Title"><h1>@RenderTitleSegments(T["Edit Content Type - {0}", Model.TypeDefinition.DisplayName])</h1></zone>
@@ -38,12 +34,17 @@
 
     @await DisplayAsync(Model.Editor)
 
-    <div class="mb-3">
-        <h3>@T["Fields"]</h3>
+    @if (ContentDefinitionService.GetFields().Any())
+    {
+        var orderedFields = ((typePart?.PartDefinition?.Fields) ?? Enumerable.Empty<ContentPartFieldDefinition>())
+        .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
+        .OrderBy(x => x.Order)
+        .Select(x => x.Field);
 
-        <ul class="list-group sortable" id="fields">
-            @if (typePart != null)
-            {
+        <div class="mb-3">
+            <h3>@T["Fields"]</h3>
+
+            <ul class="list-group sortable" id="fields">
                 @foreach (var field in orderedFields)
                 {
                     <li class="list-group-item" style="cursor: move;">
@@ -54,11 +55,11 @@
                             </div>
                             @field.DisplayName() <span class="hint dashed">@field.FieldDefinition.Name.CamelFriendly()</span>
 
-                            @if (!string.IsNullOrEmpty(field.DisplayMode()))
+                            @if (!String.IsNullOrEmpty(field.DisplayMode()))
                             {
                                 <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fas fa-tv text-info" aria-hidden="true"></i> @field.DisplayMode()</span>
                             }
-                            @if (!string.IsNullOrEmpty(field.Editor()))
+                            @if (!String.IsNullOrEmpty(field.Editor()))
                             {
                                 <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa fa-edit text-info" aria-hidden="true"></i> @field.Editor()</span>
                             }
@@ -66,12 +67,12 @@
                         <input type="hidden" asp-for="OrderedFieldNames" value="@field.Name" />
                     </li>
                 }
-            }
-        </ul>
-    </div>
-    <div class="mb-3">
-        <a asp-route-action="AddFieldTo" asp-route-id="@Model.TypeDefinition.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-info btn-sm" role="button">@T["Add Field"]</a>
-    </div>
+            </ul>
+        </div>
+        <div class="mb-3">
+            <a asp-route-action="AddFieldTo" asp-route-id="@Model.TypeDefinition.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-info btn-sm" role="button">@T["Add Field"]</a>
+        </div>
+    }
     <div class="mb-3">
         <h3>@T["Parts"]</h3>
 
@@ -99,11 +100,11 @@
                             <span class="hint dashed">@T["Contains the fields for the current type"]</span>
                         }
 
-                        @if (!string.IsNullOrEmpty(part.DisplayMode()))
+                        @if (!String.IsNullOrEmpty(part.DisplayMode()))
                         {
                             <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fas fa-tv text-info" aria-hidden="true"></i> @part.DisplayMode()</span>
                         }
-                        @if (!string.IsNullOrEmpty(part.Editor()))
+                        @if (!String.IsNullOrEmpty(part.Editor()))
                         {
                             <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa fa-edit text-info" aria-hidden="true"></i> @part.Editor()</span>
                         }
@@ -126,10 +127,8 @@
 </form>
 
 <script at="Foot">
-    //<![CDATA[
     $(function () {
         Sortable.create(document.getElementById("fields"));
         Sortable.create(document.getElementById("parts"));
     })
-    //]]>
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
@@ -16,6 +16,14 @@
         })
         .OrderBy(x => x.Order)
         .Select(x => x.Part);
+
+    var orderedFields = ((typePart?.PartDefinition?.Fields) ?? Enumerable.Empty<ContentPartFieldDefinition>())
+        .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
+        .OrderBy(x => x.Order)
+        .Select(x => x.Field)
+        .ToList();
+
+    var fields = ContentDefinitionService.GetFields().ToList();
 }
 
 <zone Name="Title"><h1>@RenderTitleSegments(T["Edit Content Type - {0}", Model.TypeDefinition.DisplayName])</h1></zone>
@@ -34,13 +42,8 @@
 
     @await DisplayAsync(Model.Editor)
 
-    @if (ContentDefinitionService.GetFields().Any())
+    @if (orderedFields.Count > 0 || fields.Count > 0)
     {
-        var orderedFields = ((typePart?.PartDefinition?.Fields) ?? Enumerable.Empty<ContentPartFieldDefinition>())
-        .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
-        .OrderBy(x => x.Order)
-        .Select(x => x.Field);
-
         <div class="mb-3">
             <h3>@T["Fields"]</h3>
 
@@ -50,7 +53,10 @@
                     <li class="list-group-item" style="cursor: move;">
                         <div class="w-100">
                             <div class="float-end">
-                                <a asp-route-action="EditField" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@field.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
+                                @if (fields.Any(x => x.Name.Equals(field.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
+                                {
+                                    <a asp-route-action="EditField" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@field.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
+                                }
                                 <a asp-route-action="RemoveFieldFrom" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@field.Name" class="btn btn-danger btn-sm" role="button" data-url-af="UnsafeUrl RemoveUrl">@T["Remove"]</a>
                             </div>
                             @field.DisplayName() <span class="hint dashed">@field.FieldDefinition.Name.CamelFriendly()</span>
@@ -69,9 +75,13 @@
                 }
             </ul>
         </div>
-        <div class="mb-3">
-            <a asp-route-action="AddFieldTo" asp-route-id="@Model.TypeDefinition.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-info btn-sm" role="button">@T["Add Field"]</a>
-        </div>
+
+        @if (fields.Count > 0)
+        {
+            <div class="mb-3">
+                <a asp-route-action="AddFieldTo" asp-route-id="@Model.TypeDefinition.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-info btn-sm" role="button">@T["Add Field"]</a>
+            </div>
+        }
     }
     <div class="mb-3">
         <h3>@T["Parts"]</h3>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
@@ -8,7 +8,7 @@
 
 @{
     var typePart = Model.TypeDefinition.Parts.FirstOrDefault(x => String.Equals(x.Name, Model.TypeDefinition.Name, StringComparison.OrdinalIgnoreCase));
-    var orderedParts = Model.TypeDefinition.Parts
+    var partDefinitions = Model.TypeDefinition.Parts
         .Select(part =>
         {
             var defaultPosition = ContentDefinitionManager.GetPartDefinition(part.PartDefinition.Name)?.DefaultPosition() ?? "5";
@@ -16,15 +16,16 @@
         })
         .OrderBy(x => x.Order)
         .Select(x => x.Part);
-    var orderedFields = Enumerable.Empty<ContentPartFieldDefinition>();
-    
-    if(typePart?.PartDefinition?.Fields != null)
+
+    var fieldDefintions = new List<ContentPartFieldDefinition>();
+
+    if (typePart?.PartDefinition?.Fields != null)
     {
-        orderedFields = typePart.PartDefinition.Fields
-            .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
-            .OrderBy(x => x.Order)
-            .Select(x => x.Field)
-            .ToList();
+        fieldDefintions = typePart.PartDefinition.Fields
+        .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
+        .OrderBy(x => x.Order)
+        .Select(x => x.Field)
+        .ToList();
     }
 
     var fields = ContentDefinitionService.GetFields().ToList();
@@ -46,35 +47,35 @@
 
     @await DisplayAsync(Model.Editor)
 
-    @if (orderedFields.Count > 0 || fields.Count > 0)
+    @if (fieldDefintions.Count > 0 || fields.Count > 0)
     {
         <div class="mb-3">
             <h3>@T["Fields"]</h3>
 
             <ul class="list-group sortable" id="fields">
-                @foreach (var field in orderedFields)
+                @foreach (var fieldDefintion in fieldDefintions)
                 {
                     <li class="list-group-item" style="cursor: move;">
                         <div class="w-100">
                             <div class="float-end">
-                                @if (fields.Any(f => String.Equals(f.Name, field.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
+                                @if (fields.Any(field => String.Equals(field.Name, fieldDefintion.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
                                 {
-                                    <a asp-route-action="EditField" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@field.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
+                                    <a asp-route-action="EditField" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@fieldDefintion.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
                                 }
-                                <a asp-route-action="RemoveFieldFrom" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@field.Name" class="btn btn-danger btn-sm" role="button" data-url-af="UnsafeUrl RemoveUrl">@T["Remove"]</a>
+                                <a asp-route-action="RemoveFieldFrom" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@fieldDefintion.Name" class="btn btn-danger btn-sm" role="button" data-url-af="UnsafeUrl RemoveUrl">@T["Remove"]</a>
                             </div>
-                            @field.DisplayName() <span class="hint dashed">@field.FieldDefinition.Name.CamelFriendly()</span>
+                            @fieldDefintion.DisplayName() <span class="hint dashed">@fieldDefintion.FieldDefinition.Name.CamelFriendly()</span>
 
-                            @if (!String.IsNullOrEmpty(field.DisplayMode()))
+                            @if (!String.IsNullOrEmpty(fieldDefintion.DisplayMode()))
                             {
-                                <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fas fa-tv text-info" aria-hidden="true"></i> @field.DisplayMode()</span>
+                                <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fas fa-tv text-info" aria-hidden="true"></i> @fieldDefintion.DisplayMode()</span>
                             }
-                            @if (!String.IsNullOrEmpty(field.Editor()))
+                            @if (!String.IsNullOrEmpty(fieldDefintion.Editor()))
                             {
-                                <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa fa-edit text-info" aria-hidden="true"></i> @field.Editor()</span>
+                                <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa fa-edit text-info" aria-hidden="true"></i> @fieldDefintion.Editor()</span>
                             }
                         </div>
-                        <input type="hidden" asp-for="OrderedFieldNames" value="@field.Name" />
+                        <input type="hidden" asp-for="OrderedFieldNames" value="@fieldDefintion.Name" />
                     </li>
                 }
             </ul>
@@ -91,22 +92,22 @@
         <h3>@T["Parts"]</h3>
 
         <ul class="list-group sortable" id="parts">
-            @foreach (var part in orderedParts)
+            @foreach (var partDefinition in partDefinitions)
             {
-                <li class="list-group-item @(part == typePart ? " bg-faded" : null)" style="cursor: move;">
+                <li class="list-group-item @(partDefinition == typePart ? " bg-faded" : null)" style="cursor: move;">
                     <div class="w-100">
-                        @part.DisplayName()
+                        @partDefinition.DisplayName()
 
-                        @if (part != typePart)
+                        @if (partDefinition != typePart)
                         {
-                            @if (!String.IsNullOrEmpty(part.Description()))
+                            @if (!String.IsNullOrEmpty(partDefinition.Description()))
                             {
-                                <span class="hint dashed">@part.Description()</span>
+                                <span class="hint dashed">@partDefinition.Description()</span>
                             }
 
                             <div class="float-end">
-                                <a asp-route-action="EditTypePart" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@part.Name" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
-                                <a asp-route-action="RemovePart" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@part.Name" class="btn btn-danger btn-sm" role="button" data-url-af="UnsafeUrl RemoveUrl">@T["Remove"]</a>
+                                <a asp-route-action="EditTypePart" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@partDefinition.Name" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
+                                <a asp-route-action="RemovePart" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@partDefinition.Name" class="btn btn-danger btn-sm" role="button" data-url-af="UnsafeUrl RemoveUrl">@T["Remove"]</a>
                             </div>
                         }
                         else
@@ -114,16 +115,16 @@
                             <span class="hint dashed">@T["Contains the fields for the current type"]</span>
                         }
 
-                        @if (!String.IsNullOrEmpty(part.DisplayMode()))
+                        @if (!String.IsNullOrEmpty(partDefinition.DisplayMode()))
                         {
-                            <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fas fa-tv text-info" aria-hidden="true"></i> @part.DisplayMode()</span>
+                            <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fas fa-tv text-info" aria-hidden="true"></i> @partDefinition.DisplayMode()</span>
                         }
-                        @if (!String.IsNullOrEmpty(part.Editor()))
+                        @if (!String.IsNullOrEmpty(partDefinition.Editor()))
                         {
-                            <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa fa-edit text-info" aria-hidden="true"></i> @part.Editor()</span>
+                            <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa fa-edit text-info" aria-hidden="true"></i> @partDefinition.Editor()</span>
                         }
                     </div>
-                    <input type="hidden" asp-for="OrderedPartNames" value="@part.Name" />
+                    <input type="hidden" asp-for="OrderedPartNames" value="@partDefinition.Name" />
                 </li>
             }
         </ul>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
@@ -53,7 +53,7 @@
                     <li class="list-group-item" style="cursor: move;">
                         <div class="w-100">
                             <div class="float-end">
-                                @if (fields.Any(x => x.Name.Equals(field.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
+                                @if (fields.Any(field => String.Equals(field.Name, field.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
                                 {
                                     <a asp-route-action="EditField" asp-route-id="@Model.TypeDefinition.Name" asp-route-name="@field.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
                                 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/EditPart.cshtml
@@ -3,11 +3,16 @@
 @using OrchardCore.ContentManagement.Metadata.Settings
 @using OrchardCore.Mvc.Utilities
 
+@inject OrchardCore.ContentTypes.Services.IContentDefinitionService ContentDefinitionService
+
 @{
     var orderedFields = Model.PartDefinition.Fields
         .Select(field => new { Field = field, Order = int.Parse(field.GetSettings<ContentPartFieldSettings>().Position ?? "0") })
         .OrderBy(x => x.Order)
-        .Select(x => x.Field);
+        .Select(x => x.Field)
+        .ToList();
+
+    var fields = ContentDefinitionService.GetFields().ToList();
 }
 <zone Name="Title"><h1>@RenderTitleSegments(T["Edit Content Part - {0}", Model.DisplayName])</h1></zone>
 
@@ -23,32 +28,40 @@
 
     @await DisplayAsync(Model.Editor)
 
-    <div class="mb-3">
-        <h3>@T["Fields"]</h3>
+    @if (orderedFields.Count > 0 || fields.Count > 0)
+    {
+        <div class="mb-3">
+            <h3>@T["Fields"]</h3>
 
-        @if (Model.PartDefinition != null)
-        {
-            <ul class="list-group sortable" id="fields" style="cursor: move;">
-                @foreach (var field in orderedFields)
-                {
-                    <li class="list-group-item">
-                        <div class="w-100">
-                            <div class="float-end">
-                                <a asp-route-action="EditField" asp-route-id="@Model.PartDefinition.Name" asp-route-name="@field.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
-                                <a asp-route-action="RemoveFieldFrom" asp-route-id="@Model.PartDefinition.Name" asp-route-name="@field.Name" class="btn btn-danger btn-sm" role="button" data-url-af="UnsafeUrl RemoveUrl">@T["Remove"]</a>
+            @if (Model.PartDefinition != null)
+            {
+                <ul class="list-group sortable" id="fields" style="cursor: move;">
+                    @foreach (var field in orderedFields)
+                    {
+                        <li class="list-group-item">
+                            <div class="w-100">
+                                <div class="float-end">
+                                    @if (fields.Any(x => x.Name.Equals(field.FieldDefinition.Name, StringComparison.OrdinalIgnoreCase)))
+                                    {
+                                        <a asp-route-action="EditField" asp-route-id="@Model.PartDefinition.Name" asp-route-name="@field.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-primary btn-sm" role="button">@T["Edit"]</a>
+                                    }
+                                    <a asp-route-action="RemoveFieldFrom" asp-route-id="@Model.PartDefinition.Name" asp-route-name="@field.Name" class="btn btn-danger btn-sm" role="button" data-url-af="UnsafeUrl RemoveUrl">@T["Remove"]</a>
+                                </div>
+                                @field.DisplayName() <span class="hint dashed">@field.FieldDefinition.Name.CamelFriendly()</span>
                             </div>
-                            @field.DisplayName() <span class="hint dashed">@field.FieldDefinition.Name.CamelFriendly()</span>
-                        </div>
-                        <input type="hidden" name="OrderedFieldNames" value="@field.Name" />
-                    </li>
-                }
-            </ul>
+                            <input type="hidden" name="OrderedFieldNames" value="@field.Name" />
+                        </li>
+                    }
+                </ul>
+            }
+        </div>
+        @if (fields.Count > 0)
+        {
+            <div class="mb-3">
+                <a asp-route-action="AddFieldTo" asp-route-id="@Model.PartDefinition.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-info btn-sm" role="button">@T["Add Field"]</a>
+            </div>
         }
-    </div>
-    <div class="mb-3">
-        <a asp-route-action="AddFieldTo" asp-route-id="@Model.PartDefinition.Name" asp-route-returnUrl="@FullRequestPath" class="btn btn-info btn-sm" role="button">@T["Add Field"]</a>
-    </div>
-
+    }
     <div class="mb-3">
         <button class="btn btn-primary save" type="submit" name="submit.Save" value="Save">@T["Save"]</button>
         <button class="btn btn-danger delete" type="submit" name="submit.Delete" value="Delete" data-url-af="RemoveUrl">@T["Delete"]</button>
@@ -56,9 +69,7 @@
 </form>
 
 <script at="Foot">
-    //<![CDATA[
     $(function () {
         Sortable.create(document.getElementById("fields"));
     })
-    //]]>
 </script>


### PR DESCRIPTION
Fix #12488


The button shows up when at least 1 field definition is available. 
![image](https://user-images.githubusercontent.com/24724371/197052182-c400f622-a8dd-465a-882d-2bedda12e0e0.png)

A field was previously added to the content items. but there are no more field definition registred, so we allow removing previously attached fields but there is no Add Fields button

![image](https://user-images.githubusercontent.com/24724371/197052824-bb8db410-5d33-45e7-99dd-f83cbf3ffa61.png)

There is no content fields available, so we hide the button
![image](https://user-images.githubusercontent.com/24724371/197052932-afcf5796-0012-40bb-a5f9-fe2afafe4e2d.png)

