### PR TITLE
Fix field wrappers

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField-Switch.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField-Switch.Edit.cshtml
@@ -2,10 +2,10 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<BooleanFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="form-check form-switch">
         <input asp-for="Value" type="checkbox" class="form-check-input content-preview-select" checked="@Model.Value" />
         <label asp-for="Value" class="form-check-label">@(String.IsNullOrEmpty(settings.Label) ? Model.PartFieldDefinition.DisplayName() : settings.Label)</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField-Switch.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField-Switch.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<BooleanFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField.Edit.cshtml
@@ -3,7 +3,7 @@
 
 @{
     var settings = Model.PartFieldDefinition.GetSettings<BooleanFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/BooleanField.Edit.cshtml
@@ -3,10 +3,10 @@
 
 @{
     var settings = Model.PartFieldDefinition.GetSettings<BooleanFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="form-check">
         <input asp-for="Value" type="checkbox" class="form-check-input content-preview-select" checked="@Model.Value" />
         <label class="form-check-label" asp-for="Value">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
@@ -6,7 +6,7 @@
     var settings = Model.PartFieldDefinition.GetSettings<ContentPickerFieldSettings>();
     var selectedItems = JsonConvert.SerializeObject(Model.SelectedItems, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
     var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "ContentPickerAdmin", action = "SearchContentItems", part = partName, field = fieldName });
     var vueElementId = $"ContentPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
     var multiple = settings.Multiple.ToString().ToLowerInvariant();

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
@@ -6,7 +6,8 @@
     var settings = Model.PartFieldDefinition.GetSettings<ContentPickerFieldSettings>();
     var selectedItems = JsonConvert.SerializeObject(Model.SelectedItems, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var fieldName = Model.PartFieldDefinition.Name;
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
     var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "ContentPickerAdmin", action = "SearchContentItems", part = partName, field = fieldName });
     var vueElementId = $"ContentPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
     var multiple = settings.Multiple.ToString().ToLowerInvariant();
@@ -15,7 +16,7 @@
 <script asp-name="vue-multiselect-wrapper" asp-src="~/OrchardCore.ContentFields/Scripts/vue-multiselect-wrapper.js" at="Foot" depends-on="vuejs, vue-multiselect, sortable, vuedraggable"></script>
 <style asp-name="vue-multiselect-wrapper" asp-src="~/OrchardCore.ContentFields/Styles/vue-multiselect-wrapper.min.css" debug-src="~/OrchardCore.ContentFields/Styles/vue-multiselect-wrapper.css" depends-on="vue-multiselect"></style>
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.ContentItemIds)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.ContentItemIds)_FieldWrapper">
     <label asp-for="ContentItemIds">@Model.PartFieldDefinition.DisplayName()</label>
 
     <div id="@vueElementId" class="vue-multiselect" data-part="@partName" data-field="@fieldName" data-editor-type="ContentPicker" data-selected-items="@selectedItems" data-search-url="@searchUrl" data-multiple="@multiple">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<DateFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <script asp-name="jQuery-ui-i18n" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateField.Edit.cshtml
@@ -2,11 +2,11 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<DateFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <script asp-name="jQuery-ui-i18n" at="Foot"></script>
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateTimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateTimeField.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<DateTimeFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 <script asp-name="jQuery-ui-i18n" at="Foot"></script>
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.LocalDateTime)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateTimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/DateTimeField.Edit.cshtml
@@ -2,10 +2,10 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<DateTimeFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 <script asp-name="jQuery-ui-i18n" at="Foot"></script>
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.LocalDateTime)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.LocalDateTime)_FieldWrapper">
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="LocalDateTime">@Model.PartFieldDefinition.DisplayName()</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Monaco.Edit.cshtml
@@ -4,10 +4,10 @@
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var monacoSettings = Model.PartFieldDefinition.GetSettings<HtmlFieldMonacoEditorSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
     @await DisplayAsync(await New.ShortcodeModal())
     <label asp-for="Html">@Model.PartFieldDefinition.DisplayName()</label>
     <div id="@Html.IdFor(x => x.Html)_editor" asp-for="Text" style="min-height: 400px;" class="form-control" dir="@culture.GetLanguageDirection()"></div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Monaco.Edit.cshtml
@@ -4,7 +4,7 @@
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var monacoSettings = Model.PartFieldDefinition.GetSettings<HtmlFieldMonacoEditorSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
@@ -20,8 +20,8 @@
 
 <script asp-name="monaco" depends-on="admin" at="Foot"></script>
 <script at="Foot" depends-on="monaco">
-    $(document).ready(function() {
-        require(['vs/editor/editor.main'], function() {
+    $(document).ready(function () {
+        require(['vs/editor/editor.main'], function () {
 
             var settings = @Html.Raw(monacoSettings.Options);
             if (settings.automaticLayout == undefined) {
@@ -55,8 +55,8 @@
             const shortcodesAction = {
                 id: "shortcodes",
                 label: "Add Shortcode",
-                run: function(editor) {
-                    shortcodesApp.init(function(value) {
+                run: function (editor) {
+                    shortcodesApp.init(function (value) {
                         if (value) {
                             var selection = editor.getSelection();
                             var text = value;
@@ -76,7 +76,7 @@
 
             editor.getModel().setValue(textArea.value);
 
-            window.addEventListener("submit", function() {
+            window.addEventListener("submit", function () {
                 textArea.value = editor.getValue();
             });
         });

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Multiline.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Multiline.Edit.cshtml
@@ -3,7 +3,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Multiline.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Multiline.Edit.cshtml
@@ -3,10 +3,10 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
     @await DisplayAsync(await New.ShortcodeModal())
     <label asp-for="Html">@Model.PartFieldDefinition.DisplayName()</label>
     <textarea asp-for="Html" rows="5" class="form-control content-preview-text shortcode-modal-input" dir="@culture.GetLanguageDirection()"></textarea>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
@@ -6,7 +6,7 @@
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var trumbowygSettings = Model.PartFieldDefinition.GetSettings<HtmlFieldTrumbowygEditorSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <script asp-name="trumbowyg-plugins" depends-on="admin" version="2" at="Foot"></script>
@@ -21,7 +21,7 @@ else
 <script asp-src="~/OrchardCore.ContentFields/Scripts/trumbowyg.media.tag.min.js" debug-src="~/OrchardCore.ContentFields/Scripts/trumbowyg.media.tag.js" depends-on="trumbowyg" at="Foot"></script>
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
     @await DisplayAsync(await New.ShortcodeModal())
     <label asp-for="Html">@Model.PartFieldDefinition.DisplayName()</label>
     @if (culture.IsRightToLeft())

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Trumbowyg.Edit.cshtml
@@ -6,7 +6,7 @@
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var trumbowygSettings = Model.PartFieldDefinition.GetSettings<HtmlFieldTrumbowygEditorSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <script asp-name="trumbowyg-plugins" depends-on="admin" version="2" at="Foot"></script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
@@ -5,7 +5,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <style asp-name="trumbowyg" version="2"></style>
@@ -34,12 +34,12 @@
 </div>
 
 <script at="Foot">
-    $(function() {
+    $(function () {
     @* set dir while keeping trumbowg translations dictionary intact *@
     @if (culture.GetLanguageDirection() == LanguageDirection.RTL)
     {
         <text>
-            var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
+                    var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
 
             if (!langs) {
                 cloned = {
@@ -52,7 +52,7 @@
     }
 
     @* Extend trumbowyg default buttons. Only use for the wysiwyg editor which gets all buttons by default *@
-        var defaultButtons = jQuery.trumbowyg.defaultOptions.btns;
+            var defaultButtons = jQuery.trumbowyg.defaultOptions.btns;
         if (defaultButtons[6] !== "insertShortcode") {
             defaultButtons.splice(6, 0, "insertShortcode");
         }
@@ -62,7 +62,7 @@
             semantic: false
         }
 
-        $('#@Html.IdFor(m => m.Html)').trumbowyg(settings).on('tbwchange', function() {
+        $('#@Html.IdFor(m => m.Html)').trumbowyg(settings).on('tbwchange', function () {
             $(document).trigger('contentpreview:render');
         });
     });

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
@@ -39,7 +39,7 @@
     @if (culture.GetLanguageDirection() == LanguageDirection.RTL)
     {
         <text>
-                    var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
+            var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
 
             if (!langs) {
                 cloned = {
@@ -52,7 +52,7 @@
     }
 
     @* Extend trumbowyg default buttons. Only use for the wysiwyg editor which gets all buttons by default *@
-            var defaultButtons = jQuery.trumbowyg.defaultOptions.btns;
+        var defaultButtons = jQuery.trumbowyg.defaultOptions.btns;
         if (defaultButtons[6] !== "insertShortcode") {
             defaultButtons.splice(6, 0, "insertShortcode");
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField-Wysiwyg.Edit.cshtml
@@ -5,7 +5,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <style asp-name="trumbowyg" version="2"></style>
@@ -13,7 +13,7 @@
 <script asp-name="trumbowyg-shortcodes" at="Foot"></script>
 
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
     @await DisplayAsync(await New.ShortcodeModal())
     <label asp-for="Html">@Model.PartFieldDefinition.DisplayName()</label>
     @if (culture.IsRightToLeft())
@@ -39,7 +39,7 @@
     @if (culture.GetLanguageDirection() == LanguageDirection.RTL)
     {
         <text>
-            var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
+                    var langs = jQuery.trumbowyg.langs.@culture.TwoLetterISOLanguageName;
 
             if (!langs) {
                 cloned = {
@@ -52,7 +52,7 @@
     }
 
     @* Extend trumbowyg default buttons. Only use for the wysiwyg editor which gets all buttons by default *@
-        var defaultButtons = jQuery.trumbowyg.defaultOptions.btns;
+            var defaultButtons = jQuery.trumbowyg.defaultOptions.btns;
         if (defaultButtons[6] !== "insertShortcode") {
             defaultButtons.splice(6, 0, "insertShortcode");
         }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
@@ -3,10 +3,10 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
     @await DisplayAsync(await New.ShortcodeModal())
 
     <label asp-for="Html">@Model.PartFieldDefinition.DisplayName()</label>
@@ -30,7 +30,7 @@
     $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
     @* When the field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
-            if (optionsTextArea) {
+                if (optionsTextArea) {
             var editor = CodeMirror.fromTextArea(optionsTextArea, {
                 autoCloseTags: true,
                 autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
@@ -3,7 +3,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<HtmlFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Html)_FieldWrapper">
@@ -27,10 +27,10 @@
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 <script at="Foot">
-    $(function() {
+    $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
     @* When the field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
-        if (optionsTextArea) {
+            if (optionsTextArea) {
             var editor = CodeMirror.fromTextArea(optionsTextArea, {
                 autoCloseTags: true,
                 autoRefresh: true,
@@ -43,7 +43,7 @@
 
             initializeCodeMirrorShortcodeWrapper(editor);
 
-            editor.on('change', function(cmEditor) {
+            editor.on('change', function (cmEditor) {
                 cmEditor.save();
                 $(document).trigger('contentpreview:render');
             });

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlField.Edit.cshtml
@@ -30,7 +30,7 @@
     $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Html)');
     @* When the field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
-                if (optionsTextArea) {
+        if (optionsTextArea) {
             var editor = CodeMirror.fromTextArea(optionsTextArea, {
                 autoCloseTags: true,
                 autoRefresh: true,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.Edit.cshtml
@@ -6,7 +6,7 @@
     var isTextRequired = settings.LinkTextMode == LinkTextMode.Required && String.IsNullOrWhiteSpace(settings.DefaultText);
     var urlClass = settings.Required ? "required" : null;
     var textClass = settings.LinkTextMode == LinkTextMode.Required ? "required" : null;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
     var useFormFloating = String.IsNullOrWhiteSpace(settings.UrlPlaceholder) || String.IsNullOrWhiteSpace(settings.TextPlaceholder);
 }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.Edit.cshtml
@@ -6,11 +6,11 @@
     var isTextRequired = settings.LinkTextMode == LinkTextMode.Required && String.IsNullOrWhiteSpace(settings.DefaultText);
     var urlClass = settings.Required ? "required" : null;
     var textClass = settings.LinkTextMode == LinkTextMode.Required ? "required" : null;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
     var useFormFloating = String.IsNullOrWhiteSpace(settings.UrlPlaceholder) || String.IsNullOrWhiteSpace(settings.TextPlaceholder);
 }
 
-<div class="row field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="row field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <div class="mb-1 col-md-12">
         <label asp-for="Url">@Model.PartFieldDefinition.DisplayName()</label>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
@@ -10,8 +10,8 @@
     var settings = Model.PartFieldDefinition.GetSettings<LocalizationSetContentPickerFieldSettings>();
     var selectedItems = JsonConvert.SerializeObject(Model.SelectedItems, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
-    var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "LocalizationSetContentPickerAdmin", action = "SearchLocalizationSets", part = partName, field = fieldName });
+    var fieldName = Model.PartFieldDefinition.Name;
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}"; var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "LocalizationSetContentPickerAdmin", action = "SearchLocalizationSets", part = partName, field = fieldName });
     var vueElementId = $"LocalizedContentPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
     var multiple = settings.Multiple.ToString().ToLowerInvariant();
 }
@@ -21,7 +21,7 @@
 
 <label asp-for="LocalizationSets">@Model.PartFieldDefinition.DisplayName()</label>
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.LocalizationSets)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.LocalizationSets)_FieldWrapper">
 
     <div id="@vueElementId" class="vue-multiselect" data-part="@partName" data-field="@fieldName" data-editor-type="LocalizationSetContentPicker" data-selected-items="@selectedItems" data-search-url="@searchUrl" data-multiple="@multiple">
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
@@ -11,7 +11,8 @@
     var selectedItems = JsonConvert.SerializeObject(Model.SelectedItems, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
     var fieldName = Model.PartFieldDefinition.Name;
-    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}"; var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "LocalizationSetContentPickerAdmin", action = "SearchLocalizationSets", part = partName, field = fieldName });
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "LocalizationSetContentPickerAdmin", action = "SearchLocalizationSets", part = partName, field = fieldName });
     var vueElementId = $"LocalizedContentPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
     var multiple = settings.Multiple.ToString().ToLowerInvariant();
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
@@ -10,7 +10,7 @@
     var settings = Model.PartFieldDefinition.GetSettings<LocalizationSetContentPickerFieldSettings>();
     var selectedItems = JsonConvert.SerializeObject(Model.SelectedItems, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
     var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "LocalizationSetContentPickerAdmin", action = "SearchLocalizationSets", part = partName, field = fieldName });
     var vueElementId = $"LocalizedContentPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
     var multiple = settings.Multiple.ToString().ToLowerInvariant();

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-CheckboxList.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-CheckboxList.Edit.cshtml
@@ -9,10 +9,10 @@
                     Value = option.Value,
                     Selected = Model.Values.Contains(option.Value)
                 }).ToList();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">
     <label>@Model.PartFieldDefinition.DisplayName()</label>
     @for (int i = 0; i < options.Count; i++)
     {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-CheckboxList.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-CheckboxList.Edit.cshtml
@@ -9,7 +9,7 @@
                     Value = option.Value,
                     Selected = Model.Values.Contains(option.Value)
                 }).ToList();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-Picker.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-Picker.Edit.cshtml
@@ -17,7 +17,7 @@
     var jOptions = JsonConvert.SerializeObject(settings.Options.Select(o => new { value = o.Value, name = o.Name }));
 
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 
     var vueElementId = $"MultiTextField-Picker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-Picker.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-Picker.Edit.cshtml
@@ -17,7 +17,8 @@
     var jOptions = JsonConvert.SerializeObject(settings.Options.Select(o => new { value = o.Value, name = o.Name }));
 
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var fieldName = Model.PartFieldDefinition.Name;
+    var uniqeName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 
     var vueElementId = $"MultiTextField-Picker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
 
@@ -27,7 +28,7 @@
 <script asp-src="~/OrchardCore.ContentFields/Scripts/vue-multiselect-multitextfieldpicker.min.js" debug-src="~/OrchardCore.ContentFields/Scripts/vue-multiselect-multitextfieldpicker.js" asp-name="multitextfieldpicker" at="Foot" depends-on="vuejs, vue-multiselect"></script>
 <style asp-src="~/OrchardCore.ContentFields/Styles/vue-multiselect-multitextfieldpicker.min.css" debug-src="~/OrchardCore.ContentFields/Styles/vue-multiselect-multitextfieldpicker.css" asp-name="multitextfieldpicker" depends-on="vue-multiselect"></style>
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqeName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">
     <label>@Model.PartFieldDefinition.DisplayName()</label>
     <div id="@vueElementId" class="multitextfieldpicker" data-selectedvalues="@jSelectedValues" data-options="@jOptions" data-valueskey="@valuesKey">
         <div class="w-xl-50">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField.Edit.cshtml
@@ -10,7 +10,7 @@
 
         options.Add(new SelectListItem { Text = option.Name, Value = option.Value, Selected = isSelected });
     }
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField.Edit.cshtml
@@ -10,10 +10,10 @@
 
         options.Add(new SelectListItem { Text = option.Name, Value = option.Value, Selected = isSelected });
     }
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">
     <label asp-for="Values">@Model.PartFieldDefinition.DisplayName()</label>
     <div class="row">
         <div class="col-md-6 col-lg-4">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
@@ -10,7 +10,7 @@
     string id = Html.IdFor(m => m.Value);
     string javascriptDecimalSeparator = CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
     string serverDecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
@@ -39,19 +39,19 @@
 
 <script asp-name="numericFieldRange" at="Foot">
     function numericFieldRange(id, value) {
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)'); </text>
-        }
+    }
             $('#' + id).val(value);
     }
 
     function numericFieldRangeSync(id, value) {
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)'); </text>
-        }
-        value = (Number(value) || 0);
+    }
+            value = (Number(value) || 0);
         $('#' + id).val(value);
     }
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
@@ -10,10 +10,10 @@
     string id = Html.IdFor(m => m.Value);
     string javascriptDecimalSeparator = CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
     string serverDecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@name</label>
@@ -39,19 +39,19 @@
 
 <script asp-name="numericFieldRange" at="Foot">
     function numericFieldRange(id, value) {
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)'); </text>
-        }
-        $('#' + id).val(value);
+    }
+            $('#' + id).val(value);
     }
 
     function numericFieldRangeSync(id, value) {
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)'); </text>
-        }
-        value = (Number(value) || 0);
+    }
+            value = (Number(value) || 0);
         $('#' + id).val(value);
     }
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Range.Edit.cshtml
@@ -39,19 +39,19 @@
 
 <script asp-name="numericFieldRange" at="Foot">
     function numericFieldRange(id, value) {
-    @if (javascriptDecimalSeparator != serverDecimalSeparator)
-    {
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
         <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)'); </text>
-    }
-            $('#' + id).val(value);
+        }
+        $('#' + id).val(value);
     }
 
     function numericFieldRangeSync(id, value) {
-    @if (javascriptDecimalSeparator != serverDecimalSeparator)
-    {
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
         <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)'); </text>
-    }
-            value = (Number(value) || 0);
+        }
+        value = (Number(value) || 0);
         $('#' + id).val(value);
     }
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Select.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Select.Edit.cshtml
@@ -6,7 +6,7 @@
     decimal step = (decimal)Math.Pow(10, 0 - settings.Scale);
     decimal from = settings.Minimum.HasValue ? settings.Minimum.Value : 0;
     decimal to = settings.Maximum.HasValue ? settings.Maximum.Value : 10;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Select.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Select.Edit.cshtml
@@ -6,10 +6,10 @@
     decimal step = (decimal)Math.Pow(10, 0 - settings.Scale);
     decimal from = settings.Minimum.HasValue ? settings.Minimum.Value : 0;
     decimal to = settings.Maximum.HasValue ? settings.Maximum.Value : 10;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@name</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -63,27 +63,27 @@
         range: {
             'min': @min,
             'max': @max
-                                            }
+        }
     });
 
     slider.noUiSlider.set("@Model.Value");
 
     slider.noUiSlider.on('change', function () {
         let value = slider.noUiSlider.get();
-    @if (javascriptDecimalSeparator != serverDecimalSeparator)
-    {
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
         <text>value = value.replace('@(javascriptDecimalSeparator)', serverDecimalSeparator); </text>
-    }
-            $('#@(id)').val(value);
+        }
+        $('#@(id)').val(value);
     });
 
     $('#@(id)').on('keyup', function () {
         let value = this.value;
-    @if (javascriptDecimalSeparator != serverDecimalSeparator)
-    {
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
         <text>value = value.replace(serverDecimalSeparator, '@(javascriptDecimalSeparator)'); </text>
-    }
-            slider.noUiSlider.set(Number(value) || 0);
+        }
+        slider.noUiSlider.set(Number(value) || 0);
     });
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -77,13 +77,13 @@
             $('#@(id)').val(value);
     });
 
-    $('#@(id)').on('keyup', function () {
+        $('#@(id)').on('keyup', function () {
         let value = this.value;
-    @if (javascriptDecimalSeparator != serverDecimalSeparator)
-    {
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
         <text>value = value.replace(serverDecimalSeparator, '@(javascriptDecimalSeparator)'); </text>
-    }
-            slider.noUiSlider.set(Number(value) || 0);
+        }
+        slider.noUiSlider.set(Number(value) || 0);
     });
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -77,7 +77,7 @@
             $('#@(id)').val(value);
     });
 
-        $('#@(id)').on('keyup', function () {
+    $('#@(id)').on('keyup', function () {
         let value = this.value;
         @if (javascriptDecimalSeparator != serverDecimalSeparator)
         {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -10,12 +10,12 @@
     string id = Html.IdFor(m => m.Value);
     string javascriptDecimalSeparator = CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
     string serverDecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <script asp-name="nouislider" at="Foot"></script>
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@name</label>
@@ -63,27 +63,27 @@
         range: {
             'min': @min,
             'max': @max
-        }
+            }
     });
 
     slider.noUiSlider.set("@Model.Value");
 
     slider.noUiSlider.on('change', function () {
         let value = slider.noUiSlider.get();
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace('@(javascriptDecimalSeparator)', serverDecimalSeparator); </text>
-        }
-        $('#@(id)').val(value);
+    }
+            $('#@(id)').val(value);
     });
 
     $('#@(id)').on('keyup', function () {
         let value = this.value;
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace(serverDecimalSeparator, '@(javascriptDecimalSeparator)'); </text>
-        }
-        slider.noUiSlider.set(Number(value) || 0);
+    }
+            slider.noUiSlider.set(Number(value) || 0);
     });
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Slider.Edit.cshtml
@@ -10,7 +10,7 @@
     string id = Html.IdFor(m => m.Value);
     string javascriptDecimalSeparator = CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
     string serverDecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <script asp-name="nouislider" at="Foot"></script>
@@ -63,12 +63,12 @@
         range: {
             'min': @min,
             'max': @max
-                                        }
+                                            }
     });
 
     slider.noUiSlider.set("@Model.Value");
 
-    slider.noUiSlider.on('change', function() {
+    slider.noUiSlider.on('change', function () {
         let value = slider.noUiSlider.get();
     @if (javascriptDecimalSeparator != serverDecimalSeparator)
     {
@@ -77,13 +77,13 @@
             $('#@(id)').val(value);
     });
 
-    $('#@(id)').on('keyup', function() {
+    $('#@(id)').on('keyup', function () {
         let value = this.value;
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace(serverDecimalSeparator, '@(javascriptDecimalSeparator)'); </text>
-        }
-        slider.noUiSlider.set(Number(value) || 0);
+    }
+            slider.noUiSlider.set(Number(value) || 0);
     });
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
@@ -45,19 +45,19 @@
 
     function numericFieldSpinner(id, scale, step, min, max) {
         let value = $('#' + id).val();
-    @if (javascriptDecimalSeparator != serverDecimalSeparator)
-    {
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
         <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)'); </text>
-    }
-            value = (Number(value) || 0) + step;
+        }
+        value = (Number(value) || 0) + step;
         value = Math.min(value, max); // Never go above max
         value = Math.max(value, min); // or below min
         value = Number(value.toFixed(scale)).toString(); // Drop insignificant trailing zeros
-    @if (javascriptDecimalSeparator != serverDecimalSeparator)
-    {
+        @if (javascriptDecimalSeparator != serverDecimalSeparator)
+        {
         <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)'); </text>
-    }
-            $('#' + id).val(value);
+        }
+        $('#' + id).val(value);
     }
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
@@ -13,7 +13,7 @@
     string id = Html.IdFor(m => m.Value);
     string javascriptDecimalSeparator = CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
     string serverDecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
@@ -45,19 +45,19 @@
 
     function numericFieldSpinner(id, scale, step, min, max) {
         let value = $('#' + id).val();
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace('@(serverDecimalSeparator)', '@(javascriptDecimalSeparator)'); </text>
-        }
+    }
             value = (Number(value) || 0) + step;
         value = Math.min(value, max); // Never go above max
         value = Math.max(value, min); // or below min
         value = Number(value.toFixed(scale)).toString(); // Drop insignificant trailing zeros
-        @if (javascriptDecimalSeparator != serverDecimalSeparator)
-        {
+    @if (javascriptDecimalSeparator != serverDecimalSeparator)
+    {
         <text>value = value.replace('@(javascriptDecimalSeparator)', '@(serverDecimalSeparator)'); </text>
-        }
-        $('#' + id).val(value);
+    }
+            $('#' + id).val(value);
     }
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField-Spinner.Edit.cshtml
@@ -13,10 +13,10 @@
     string id = Html.IdFor(m => m.Value);
     string javascriptDecimalSeparator = CultureInfo.InvariantCulture.NumberFormat.NumberDecimalSeparator;
     string serverDecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@name</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.Edit.cshtml
@@ -5,10 +5,10 @@
     string name = Model.PartFieldDefinition.DisplayName();
     decimal min = settings.Minimum.HasValue ? settings.Minimum.Value : 0;
     decimal max = settings.Maximum.HasValue ? settings.Maximum.Value : 10000;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@name</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/NumericField.Edit.cshtml
@@ -5,7 +5,7 @@
     string name = Model.PartFieldDefinition.DisplayName();
     decimal min = settings.Minimum.HasValue ? settings.Minimum.Value : 0;
     decimal max = settings.Maximum.HasValue ? settings.Maximum.Value : 10000;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
@@ -3,10 +3,10 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <textarea asp-for="Text" rows="5" class="form-control content-preview-text" dir="@culture.GetLanguageDirection()"></textarea>
     @if (!String.IsNullOrEmpty(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-CodeMirror.Edit.cshtml
@@ -3,7 +3,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
@@ -25,7 +25,7 @@
 <script asp-name="codemirror-mode-javascript" at="Foot"></script>
 <script asp-name="codemirror-mode-xml" at="Foot"></script>
 <script at="Foot">
-    $(function() {
+    $(function () {
         var optionsTextArea = document.getElementById('@Html.IdFor(x => x.Text)');
         // When part rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (optionsTextArea) {
@@ -39,7 +39,7 @@
                 mode: { name: "htmlmixed" }
             });
 
-            editor.on('change', function(cmEditor) {
+            editor.on('change', function (cmEditor) {
                 cmEditor.save();
                 $(document).trigger('contentpreview:render');
             });

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Color.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Color.Edit.cshtml
@@ -2,10 +2,10 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <input asp-for="Text" class="form-control content-preview-text" type="color" />
     @if (!String.IsNullOrEmpty(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Color.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Color.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Email.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Email.Edit.cshtml
@@ -2,10 +2,10 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <div class="input-group mb-2">
         <span class="input-group-text">@@</span>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Email.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Email.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-IconPicker.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-IconPicker.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <style asp-name="fontpickerStyle" at="Head" asp-src="~/OrchardCore.ContentFields/Styles/fontawesome-iconpicker.min.css" debug-src="~/OrchardCore.ContentFields/Styles/fontawesome-iconpicker.css"></style>
@@ -33,7 +33,7 @@
 </div>
 
 <script at="Foot">
-    $(function() {
+    $(function () {
 
         $('#@Html.IdForModel()').iconpicker();
 
@@ -43,7 +43,7 @@
             $('#@Html.IdForModel()').data('iconpicker').update(storedIcon);
         }
 
-        $('#@Html.IdForModel()').on('iconpickerSelected', function(e) {
+        $('#@Html.IdForModel()').on('iconpickerSelected', function (e) {
             $('#@Html.IdFor(m=>m.Text)').val(e.iconpickerInstance.options.fullClassFormatter(e.iconpickerValue));
         });
     });

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-IconPicker.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-IconPicker.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <style asp-name="fontpickerStyle" at="Head" asp-src="~/OrchardCore.ContentFields/Styles/fontawesome-iconpicker.min.css" debug-src="~/OrchardCore.ContentFields/Styles/fontawesome-iconpicker.css"></style>
@@ -10,7 +10,7 @@
 <script asp-name="fontpickerScript" asp-src="~/OrchardCore.ContentFields/Scripts/fontawesome-iconpicker.min.js" debug-src="~/OrchardCore.ContentFields/Scripts/fontawesome-iconpicker.js" at="Foot" depends-on="jquery"></script>
 <script asp-name="iconpickerCustomScript" asp-src="~/OrchardCore.ContentFields/Scripts/iconpicker-custom.js" at="Foot"></script>
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <input type="hidden" asp-for="Text" id="@Html.IdFor(m=>m.Text)" />
     <div class="btn-toolbar" role="toolbar" aria-label="Icon Selector Toolbar">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Monaco.Edit.cshtml
@@ -4,7 +4,7 @@
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
     var monacoSettings = Model.PartFieldDefinition.GetSettings<TextFieldMonacoEditorSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
@@ -19,8 +19,8 @@
 
 <script asp-name="monaco" depends-on="admin" at="Foot"></script>
 <script at="Foot" depends-on="monaco">
-    $(document).ready(function() {
-        require(['vs/editor/editor.main'], function() {
+    $(document).ready(function () {
+        require(['vs/editor/editor.main'], function () {
 
             var settings = @Html.Raw(monacoSettings.Options);
             if (settings.automaticLayout == undefined) {
@@ -47,7 +47,7 @@
 
             editor.getModel().setValue(textArea.value);
 
-            window.addEventListener("submit", function() {
+            window.addEventListener("submit", function () {
                 textArea.value = editor.getValue();
             });
             editor.getModel().onDidChangeContent((event) => {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Monaco.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Monaco.Edit.cshtml
@@ -4,10 +4,10 @@
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
     var monacoSettings = Model.PartFieldDefinition.GetSettings<TextFieldMonacoEditorSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <div id="@Html.IdFor(x => x.Text)_editor" asp-for="Text" style="min-height: 400px;" class="form-control" dir="@culture.GetLanguageDirection()"></div>
     <textarea asp-for="Text" hidden>@Html.Raw(Model.Text)</textarea>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-PredefinedList.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-PredefinedList.Edit.cshtml
@@ -14,10 +14,10 @@
 
         options.Add(new SelectListItem { Text = option.Name, Value = option.Value, Selected = isSelected });
     }
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
 
     @if (listSettings.Editor == EditorOption.Radio)
     {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-PredefinedList.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-PredefinedList.Edit.cshtml
@@ -14,7 +14,7 @@
 
         options.Add(new SelectListItem { Text = option.Name, Value = option.Value, Selected = isSelected });
     }
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Tel.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Tel.Edit.cshtml
@@ -2,10 +2,10 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <input asp-for="Text" class="form-control content-preview-text" type="tel" />
     @if (!String.IsNullOrEmpty(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Tel.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Tel.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-TextArea.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-TextArea.Edit.cshtml
@@ -3,7 +3,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-TextArea.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-TextArea.Edit.cshtml
@@ -3,10 +3,10 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <textarea asp-for="Text" class="form-control content-preview-text" dir="@culture.GetLanguageDirection()"></textarea>
     <span class="hint">@settings.Hint</span>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Url.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Url.Edit.cshtml
@@ -2,10 +2,10 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <input asp-for="Text" class="form-control content-preview-text" type="url" />
     @if (!String.IsNullOrEmpty(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Url.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField-Url.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField.Edit.cshtml
@@ -3,10 +3,10 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">
     <label asp-for="Text">@Model.PartFieldDefinition.DisplayName()</label>
     <input asp-for="Text" class="form-control content-preview-text" dir="@culture.GetLanguageDirection()" />
     @if (!String.IsNullOrEmpty(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextField.Edit.cshtml
@@ -3,7 +3,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TextFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Text)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TimeFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TimeField.Edit.cshtml
@@ -2,10 +2,10 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<TimeFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Value)_FieldWrapper">
     <div class="row">
         <div class="col-md-6 col-lg-4">
             <label asp-for="Value">@Model.PartFieldDefinition.DisplayName()</label>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField.Edit.cshtml
@@ -6,7 +6,8 @@
     var settings = Model.PartFieldDefinition.GetSettings<UserPickerFieldSettings>();
     var selectedUsers = JsonConvert.SerializeObject(Model.SelectedUsers, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var fieldName = Model.PartFieldDefinition.Name;
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
     var contentTypeName = Model.TypePartDefinition.Name;
     var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "UserPickerAdmin", action = "SearchUsers", part = partName, field = fieldName, contentType = contentTypeName });
     var vueElementId = $"UserPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";
@@ -16,7 +17,7 @@
 <script asp-name="vue-multiselect-userpicker" asp-src="~/OrchardCore.ContentFields/Scripts/vue-multiselect-userpicker.js" at="Foot" depends-on="vuejs, vue-multiselect, sortable, vuedraggable"></script>
 <style asp-name="vue-multiselect-userpicker" asp-src="~/OrchardCore.ContentFields/Styles/vue-multiselect-userpicker.min.css" debug-src="~/OrchardCore.ContentFields/Styles/vue-multiselect-userpicker.css" depends-on="vue-multiselect"></style>
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.UserIds)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.UserIds)_FieldWrapper">
     <label asp-for="UserIds">@Model.PartFieldDefinition.DisplayName()</label>
     <div id="@vueElementId" class="vue-multiselect" data-part="@partName" data-field="@fieldName" data-content-type="@contentTypeName" data-editor-type="UserPicker" data-selected-users="@selectedUsers" data-search-url="@searchUrl" data-multiple="@multiple">
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/UserPickerField.Edit.cshtml
@@ -6,7 +6,7 @@
     var settings = Model.PartFieldDefinition.GetSettings<UserPickerFieldSettings>();
     var selectedUsers = JsonConvert.SerializeObject(Model.SelectedUsers, new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() });
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
     var contentTypeName = Model.TypePartDefinition.Name;
     var searchUrl = Url.RouteUrl(new { area = "OrchardCore.ContentFields", controller = "UserPickerAdmin", action = "SearchUsers", part = partName, field = fieldName, contentType = contentTypeName });
     var vueElementId = $"UserPicker_{partName}_{fieldName}_{Guid.NewGuid().ToString("n")}";

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/YoutubeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/YoutubeField.Edit.cshtml
@@ -2,10 +2,10 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<YoutubeFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.RawAddress)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.RawAddress)_FieldWrapper">
     <label asp-for="RawAddress">@Model.PartFieldDefinition.DisplayName()</label>
     <input asp-for="RawAddress" class="form-control content-preview-text" required="@settings.Required" />
     @if (!String.IsNullOrEmpty(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/YoutubeField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/YoutubeField.Edit.cshtml
@@ -2,7 +2,7 @@
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<YoutubeFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.RawAddress)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-TextArea.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-TextArea.Edit.cshtml
@@ -6,10 +6,10 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MarkdownFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Markdown)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Markdown)_FieldWrapper">
     @await DisplayAsync(await New.ShortcodeModal())
     <label asp-for="Markdown">@Model.PartFieldDefinition.DisplayName()</label>
     <textarea asp-for="Markdown" rows="5" class="form-control content-preview-text shortcode-modal-input" dir="@culture.GetLanguageDirection()"></textarea>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-TextArea.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-TextArea.Edit.cshtml
@@ -6,7 +6,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MarkdownFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Markdown)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -6,13 +6,13 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MarkdownFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <style asp-name="codemirror"></style>
 <style asp-name="mdecss" asp-src="~/OrchardCore.Markdown/Styles/mde.min.css" debug-src="~/OrchardCore.Markdown/Styles/mde.css"></style>
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Markdown)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Markdown)_FieldWrapper">
     @await DisplayAsync(await New.ShortcodeModal())
     <label asp-for="Markdown">@Model.PartFieldDefinition.DisplayName()</label>
     <textarea asp-for="Markdown" rows="5" class="form-control content-preview-text"></textarea>
@@ -24,8 +24,8 @@
 <script at="Foot">
     $(function () {
         var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
-            @* When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
-        if (markdownElement) {
+    @* When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
+            if (markdownElement) {
             var mde = new EasyMDE({
                 element: markdownElement,
                 forceSync: true,
@@ -39,11 +39,11 @@
                 $(document).trigger('contentpreview:render');
             });
 
-            @if (culture.IsRightToLeft())
-            {
-            <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
-                    $('.CodeMirror').attr('style', 'text-align:right'); </text>
+    @if (culture.IsRightToLeft())
+    {
+        <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
+                $('.CodeMirror').attr('style', 'text-align:right'); </text>
+    }
             }
-        }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -6,7 +6,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MarkdownFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <style asp-name="codemirror"></style>
@@ -22,10 +22,10 @@
     }
 </div>
 <script at="Foot">
-    $(function() {
+    $(function () {
         var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
-        @* When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
-        if (markdownElement) {
+    @* When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
+            if (markdownElement) {
             var mde = new EasyMDE({
                 element: markdownElement,
                 forceSync: true,
@@ -35,15 +35,15 @@
 
             initializeMdeShortcodeWrapper(mde);
 
-            mde.codemirror.on('change', function() {
+            mde.codemirror.on('change', function () {
                 $(document).trigger('contentpreview:render');
             });
 
-        @if (culture.IsRightToLeft())
-        {
+    @if (culture.IsRightToLeft())
+    {
         <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
-        $('.CodeMirror').attr('style', 'text-align:right'); </text>
-        }
-                                                        }
+                $('.CodeMirror').attr('style', 'text-align:right'); </text>
+    }
+                                                            }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -24,8 +24,8 @@
 <script at="Foot">
     $(function () {
         var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
-    @* When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
-            if (markdownElement) {
+        @* When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
+        if (markdownElement) {
             var mde = new EasyMDE({
                 element: markdownElement,
                 forceSync: true,
@@ -39,11 +39,11 @@
                 $(document).trigger('contentpreview:render');
             });
 
-    @if (culture.IsRightToLeft())
-    {
+        @if (culture.IsRightToLeft())
+        {
         <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
-                $('.CodeMirror').attr('style', 'text-align:right'); </text>
-    }
-            }
+        $('.CodeMirror').attr('style', 'text-align:right'); </text>
+        }
+        }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -24,8 +24,8 @@
 <script at="Foot">
     $(function () {
         var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
-    @* When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
-            if (markdownElement) {
+            @* When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist. *@
+        if (markdownElement) {
             var mde = new EasyMDE({
                 element: markdownElement,
                 forceSync: true,
@@ -39,11 +39,11 @@
                 $(document).trigger('contentpreview:render');
             });
 
-    @if (culture.IsRightToLeft())
-    {
-        <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
-                $('.CodeMirror').attr('style', 'text-align:right'); </text>
-    }
-                                                            }
+            @if (culture.IsRightToLeft())
+            {
+            <text>$('.editor-toolbar').attr('style', 'direction:rtl;text-align:right');
+                    $('.CodeMirror').attr('style', 'text-align:right'); </text>
+            }
+        }
     });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField.Edit.cshtml
@@ -6,10 +6,10 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MarkdownFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Markdown)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Markdown)_FieldWrapper">
     @await DisplayAsync(await New.ShortcodeModal())
     <label asp-for="Markdown">@Model.PartFieldDefinition.DisplayName()</label>
     <input asp-for="Markdown" class="form-control content-preview-text shortcode-modal-input" dir="@culture.GetLanguageDirection()" />

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField.Edit.cshtml
@@ -6,7 +6,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MarkdownFieldSettings>();
     var culture = await Orchard.GetContentCultureAsync(Model.Field.ContentItem);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Markdown)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
@@ -5,7 +5,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MediaFieldSettings>();
     var mediaFieldId = Html.IdFor(m => m);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable, jQuery-ui"></script>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
@@ -5,13 +5,13 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MediaFieldSettings>();
     var mediaFieldId = Html.IdFor(m => m);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable, jQuery-ui"></script>
 <style asp-src="~/OrchardCore.Media/Styles/media.min.css" debug-src="~/OrchardCore.Media/Styles/media.css"></style>
 
-<div class="field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Paths)_FieldWrapper">
+<div class="field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Paths)_FieldWrapper">
     <div class="mb-3" id="@mediaFieldId" data-for="@Html.IdFor(m => m.Paths)">
         <label asp-for="Paths">@Model.PartFieldDefinition.DisplayName()</label>
         @if (!string.IsNullOrWhiteSpace(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
@@ -6,7 +6,7 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MediaFieldSettings>();
     var modalMediaId = "Modal" + Html.IdFor(m => m);
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 <script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable, jQuery-ui"></script>
 <style asp-src="~/OrchardCore.Media/Styles/media.min.css" debug-src="~/OrchardCore.Media/Styles/media.css"></style>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
@@ -6,12 +6,12 @@
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MediaFieldSettings>();
     var modalMediaId = "Modal" + Html.IdFor(m => m);
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 <script asp-src="~/OrchardCore.Media/Scripts/media.js" asp-name="media" at="Foot" depends-on="admin, vuejs, sortable, vuedraggable, jQuery-ui"></script>
 <style asp-src="~/OrchardCore.Media/Styles/media.min.css" debug-src="~/OrchardCore.Media/Styles/media.css"></style>
 
-<div class="field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.Paths)_FieldWrapper">
+<div class="field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Paths)_FieldWrapper">
     <div class="mb-3" id="@Html.IdFor(m => m)" data-for="@Html.IdFor(m => m.Paths)">
         <label asp-for="Paths">@Model.PartFieldDefinition.DisplayName()</label>
         @if (!String.IsNullOrWhiteSpace(settings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.Spatial/Views/GeoPointField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Spatial/Views/GeoPointField.Edit.cshtml
@@ -4,7 +4,7 @@
 @model EditGeoPointFieldViewModel
 @{
     var settings = Model.PartFieldDefinition.Settings.ToObject<GeoPointFieldSettings>();
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="form-row field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x)_FieldWrapper">

--- a/src/OrchardCore.Modules/OrchardCore.Spatial/Views/GeoPointField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Spatial/Views/GeoPointField.Edit.cshtml
@@ -4,10 +4,10 @@
 @model EditGeoPointFieldViewModel
 @{
     var settings = Model.PartFieldDefinition.Settings.ToObject<GeoPointFieldSettings>();
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="form-row field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x)_FieldWrapper">
+<div class="form-row field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x)_FieldWrapper">
     <div class="mb-3 col-md-4">
         <label asp-for="Latitude">@T["Latitude"]</label>
         <input asp-for="Latitude" type="number" min="-90.000000" max="90.000000" step=".000001" placeholder="00.000000" class="form-control content-preview-text" required="@settings.Required" />

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
@@ -10,7 +10,7 @@
     var tagsSettings = Model.PartFieldDefinition.GetSettings<TaxonomyFieldTagsEditorSettings>();
 
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 
     var createTagUrl = Url.Action("Create", "Tag", new { area = "OrchardCore.Taxonomies" });
 

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
@@ -10,7 +10,8 @@
     var tagsSettings = Model.PartFieldDefinition.GetSettings<TaxonomyFieldTagsEditorSettings>();
 
     var partName = Model.PartFieldDefinition.PartDefinition.Name;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var fieldName = Model.PartFieldDefinition.Name;
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 
     var createTagUrl = Url.Action("Create", "Tag", new { area = "OrchardCore.Taxonomies" });
 
@@ -26,7 +27,7 @@
 <script asp-src="~/OrchardCore.Taxonomies/Scripts/tags-editor.min.js" debug-src="~/OrchardCore.Taxonomies/Scripts/tags-editor.js" asp-name="tags-editor" at="Foot" depends-on="vuejs, vue-multiselect"></script>
 <style asp-src="~/OrchardCore.Taxonomies/Styles/tags-editor.min.css" debug-src="~/OrchardCore.Taxonomies/Styles/tags-editor.css" asp-name="tags-editor" depends-on="vue-multiselect"></style>
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.TermContentItemIds)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.TermContentItemIds)_FieldWrapper">
     <label>@Model.PartFieldDefinition.DisplayName()</label>
 
     @if (!String.IsNullOrEmpty(taxonomySettings.Hint))

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
@@ -6,10 +6,10 @@
     var settings = Model.PartFieldDefinition.GetSettings<TaxonomyFieldSettings>();
     int previousLevel = 0;
     int closingDivs = 0;
-    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
+    var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.TermEntries)_FieldWrapper">
+<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.TermEntries)_FieldWrapper">
 
     <label>@Model.PartFieldDefinition.DisplayName()</label>
 

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField.Edit.cshtml
@@ -6,7 +6,7 @@
     var settings = Model.PartFieldDefinition.GetSettings<TaxonomyFieldSettings>();
     int previousLevel = 0;
     int closingDivs = 0;
-    var fieldName = Model.PartFieldDefinition.Name;
+    var fieldName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
 <div class="mb-3 field-wrapper field-wrapper-@fieldName.HtmlClassify()" id="@Html.IdFor(x => x.TermEntries)_FieldWrapper">


### PR DESCRIPTION
In PR #12347 I added css class wrapper to content fields to allow us to use JS to hide/show fields. However, the class name we used for the wrapper is not unique since the same name can be used on multiple parts. To make it unique, I am adding part name to make it unique. This PR makes the class name as `field-wrapper-partname-fieldname` instead of `field-wrapper-fieldname`

