### PR TITLE
 Move role creation into the recipe instead of feature activation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
@@ -214,10 +214,7 @@ namespace OrchardCore.Roles.Controllers
             var rolesDocument = await _rolesDocumentManager.GetOrCreateMutableAsync();
             var updateRolesDocument = false;
 
-            if (!rolesDocument.PermissionGroups.ContainsKey(role.RoleName))
-            {
-                rolesDocument.PermissionGroups.TryAdd(role.RoleName, new List<string>());
-            }
+            rolesDocument.PermissionGroups.TryAdd(role.RoleName, new List<string>());
 
             var permissionNames = _permissionProviders.SelectMany(x => x.GetDefaultStereotypes())
                 .SelectMany(y => y.Permissions ?? Enumerable.Empty<Permission>())

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
@@ -10,8 +10,10 @@ using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Data.Documents;
 using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Documents;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Environment.Extensions.Features;
+using OrchardCore.Roles.Models;
 using OrchardCore.Roles.ViewModels;
 using OrchardCore.Security;
 using OrchardCore.Security.Permissions;
@@ -25,6 +27,7 @@ namespace OrchardCore.Roles.Controllers
         private readonly IAuthorizationService _authorizationService;
         private readonly IStringLocalizer S;
         private readonly RoleManager<IRole> _roleManager;
+        private readonly IDocumentManager<RolesDocument> _rolesDocumentManager;
         private readonly IEnumerable<IPermissionProvider> _permissionProviders;
         private readonly ITypeFeatureProvider _typeFeatureProvider;
         private readonly IRoleService _roleService;
@@ -38,6 +41,7 @@ namespace OrchardCore.Roles.Controllers
             IStringLocalizer<AdminController> stringLocalizer,
             IHtmlLocalizer<AdminController> htmlLocalizer,
             RoleManager<IRole> roleManager,
+            IDocumentManager<RolesDocument> rolesDocumentManager,
             IRoleService roleService,
             INotifier notifier,
             IEnumerable<IPermissionProvider> permissionProviders
@@ -49,6 +53,7 @@ namespace OrchardCore.Roles.Controllers
             _typeFeatureProvider = typeFeatureProvider;
             _permissionProviders = permissionProviders;
             _roleManager = roleManager;
+            _rolesDocumentManager = rolesDocumentManager;
             S = stringLocalizer;
             _authorizationService = authorizationService;
             _documentStore = documentStore;
@@ -97,12 +102,12 @@ namespace OrchardCore.Roles.Controllers
 
                 if (model.RoleName.Contains('/'))
                 {
-                    ModelState.AddModelError(string.Empty, S["Invalid role name."]);
+                    ModelState.AddModelError(String.Empty, S["Invalid role name."]);
                 }
 
                 if (await _roleManager.FindByNameAsync(_roleManager.NormalizeKey(model.RoleName)) != null)
                 {
-                    ModelState.AddModelError(string.Empty, S["The role is already used."]);
+                    ModelState.AddModelError(String.Empty, S["The role is already used."]);
                 }
             }
 
@@ -120,7 +125,7 @@ namespace OrchardCore.Roles.Controllers
 
                 foreach (var error in result.Errors)
                 {
-                    ModelState.AddModelError(string.Empty, error.Description);
+                    ModelState.AddModelError(String.Empty, error.Description);
                 }
             }
 
@@ -171,8 +176,7 @@ namespace OrchardCore.Roles.Controllers
                 return Forbid();
             }
 
-            var role = (Role)await _roleManager.FindByNameAsync(_roleManager.NormalizeKey(id));
-            if (role == null)
+            if (await _roleManager.FindByNameAsync(_roleManager.NormalizeKey(id)) is not Role role)
             {
                 return NotFound();
             }
@@ -200,22 +204,52 @@ namespace OrchardCore.Roles.Controllers
                 return Forbid();
             }
 
-            var role = (Role)await _roleManager.FindByNameAsync(_roleManager.NormalizeKey(id));
-
-            if (role == null)
+            if (await _roleManager.FindByNameAsync(_roleManager.NormalizeKey(id)) is not Role role)
             {
                 return NotFound();
             }
 
             role.RoleDescription = roleDescription;
 
+            var rolesDocument = await _rolesDocumentManager.GetOrCreateMutableAsync();
+            var updateRolesDocument = false;
+
+            if (!rolesDocument.PermissionGroups.ContainsKey(role.RoleName))
+            {
+                rolesDocument.PermissionGroups.TryAdd(role.RoleName, new List<string>());
+            }
+
+            var permissionNames = _permissionProviders.SelectMany(x => x.GetDefaultStereotypes())
+                .SelectMany(y => y.Permissions ?? Enumerable.Empty<Permission>())
+                .Select(x => x.Name)
+                .ToList();
+
             // Save
             var rolePermissions = new List<RoleClaim>();
-            foreach (string key in Request.Form.Keys)
+            foreach (var key in Request.Form.Keys)
             {
-                if (key.StartsWith("Checkbox.", StringComparison.Ordinal) && Request.Form[key] == "true")
+                var permissionName = key;
+
+                if (key.StartsWith("Checkbox.", StringComparison.Ordinal))
                 {
-                    string permissionName = key.Substring("Checkbox.".Length);
+                    permissionName = key.Substring("Checkbox.".Length);
+                }
+
+                if (!permissionNames.Contains(permissionName, StringComparer.OrdinalIgnoreCase))
+                {
+                    // The request contains an invalid permission, let's ignore it
+                    continue;
+                }
+
+                if (!rolesDocument.PermissionGroups[role.RoleName].Contains(permissionName, StringComparer.OrdinalIgnoreCase))
+                {
+                    // Save the permission in the permissions history so it never gets auto assigned to this role.
+                    rolesDocument.PermissionGroups[role.RoleName].Add(permissionName);
+                    updateRolesDocument = true;
+                }
+
+                if (String.Equals(Request.Form[key], "true", StringComparison.OrdinalIgnoreCase))
+                {
                     rolePermissions.Add(new RoleClaim { ClaimType = Permission.ClaimType, ClaimValue = permissionName });
                 }
             }
@@ -224,6 +258,11 @@ namespace OrchardCore.Roles.Controllers
             role.RoleClaims.AddRange(rolePermissions);
 
             await _roleManager.UpdateAsync(role);
+
+            if (updateRolesDocument)
+            {
+                await _rolesDocumentManager.UpdateAsync(rolesDocument);
+            }
 
             await _notifier.SuccessAsync(H["Role updated successfully."]);
 

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Models/RolesDocument.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Models/RolesDocument.cs
@@ -1,11 +1,19 @@
+using System;
 using System.Collections.Generic;
 using OrchardCore.Data.Documents;
 using OrchardCore.Security;
+using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Roles.Models
 {
     public class RolesDocument : Document
     {
         public List<Role> Roles { get; set; } = new List<Role>();
+
+
+        /// <summary>
+        /// Keeps track of all permission that were automaticly assigned to a role using <see cref="IPermissionProvider"></see>/>
+        /// </summary>
+        public Dictionary<string, List<string>> PermissionGroups { get; set; } = new(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
@@ -117,10 +117,7 @@ namespace OrchardCore.Roles.Services
                     .Distinct()
                     .ToList();
 
-                if (!rolesDocument.PermissionGroups.ContainsKey(group.RoleName))
-                {
-                    rolesDocument.PermissionGroups.TryAdd(group.RoleName, new List<string>());
-                }
+                rolesDocument.PermissionGroups.TryAdd(group.RoleName, new List<string>());
 
                 // Get all available permission names that isn't already assigned to the role.
                 var additionalPermissionNames = distinctPermissionNames.Except(currentPermissionNames);

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
@@ -1,41 +1,50 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
-using OrchardCore.Environment.Extensions;
+using OrchardCore.Documents;
 using OrchardCore.Environment.Extensions.Features;
 using OrchardCore.Environment.Shell;
+using OrchardCore.Modules;
+using OrchardCore.Roles.Models;
 using OrchardCore.Security;
 using OrchardCore.Security.Permissions;
+using OrchardCore.Security.Services;
 
 namespace OrchardCore.Roles.Services
 {
-    public class RoleUpdater : IFeatureEventHandler
+    public class RoleUpdater : ModularTenantEvents, IFeatureEventHandler
     {
         private readonly RoleManager<IRole> _roleManager;
         private readonly IEnumerable<IPermissionProvider> _permissionProviders;
-        private readonly ITypeFeatureProvider _typeFeatureProvider;
         private readonly ILogger _logger;
+        private readonly IRoleService _roleService;
+        private readonly IDocumentManager<RolesDocument> _rolesDocumentManager;
+
+        private bool _updateInProgress;
 
         public RoleUpdater(
             RoleManager<IRole> roleManager,
             IEnumerable<IPermissionProvider> permissionProviders,
-            ITypeFeatureProvider typeFeatureProvider,
-            ILogger<RoleUpdater> logger)
+            ILogger<RoleUpdater> logger,
+            IRoleService roleService,
+            IDocumentManager<RolesDocument> rolesDocumentManager)
         {
-            _typeFeatureProvider = typeFeatureProvider;
             _roleManager = roleManager;
             _permissionProviders = permissionProviders;
             _logger = logger;
+            _roleService = roleService;
+            _rolesDocumentManager = rolesDocumentManager;
         }
 
         Task IFeatureEventHandler.InstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
 
-        Task IFeatureEventHandler.InstalledAsync(IFeatureInfo feature) => AddDefaultRolesForFeatureAsync(feature);
+        Task IFeatureEventHandler.InstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
 
-        Task IFeatureEventHandler.EnablingAsync(IFeatureInfo feature) => Task.CompletedTask;
+        Task IFeatureEventHandler.EnablingAsync(IFeatureInfo feature) => AssignPermissionsToRolesAsync();
 
         Task IFeatureEventHandler.EnabledAsync(IFeatureInfo feature) => Task.CompletedTask;
 
@@ -47,68 +56,109 @@ namespace OrchardCore.Roles.Services
 
         Task IFeatureEventHandler.UninstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
 
-        public async Task AddDefaultRolesForFeatureAsync(IFeatureInfo feature)
+        /// <summary>
+        /// This event is called of the very first request to the tenant after a tenant is built/rebuilt.
+        /// Using this event will ensure that any new permission were added are auto assigned to a role.
+        /// </summary>
+        /// <returns></returns>
+        public override Task ActivatedAsync() => AssignPermissionsToRolesAsync();
+
+        /// <summary>
+        /// Checks all available permissions to role mapping from any available <see cref="IPermissionProvider"/>.
+        /// When a new permission is found, auto assign it to the mapped role. If the permission was previously assigned,
+        /// do not assign the permission. This method could get called multiple time from the same request,
+        /// so it should not be executed again if the parameter "_updateInProgress" is set to true.
+        /// </summary>
+        /// <returns></returns>
+        private async Task AssignPermissionsToRolesAsync()
         {
-            // when another module is being enabled, locate matching permission providers
-            var providersForEnabledModule = _permissionProviders
-                .Where(x => _typeFeatureProvider.GetFeatureForDependency(x.GetType()).Id == feature.Id);
-
-            if (_logger.IsEnabled(LogLevel.Debug))
+            if (_updateInProgress)
             {
-                if (providersForEnabledModule.Any())
+                return;
+            }
+
+            _updateInProgress = true;
+
+            var roleNames = await _roleService.GetRoleNamesAsync();
+
+            if (!roleNames.Any())
+            {
+                // Site roles are initially added using the "RolesStep" handler, while no role names are availble. This means
+                // that RoleUpdater handler was called before the "RolesStep".
+                // Its likley to be coming from a tenant setup request. Nothing to do.
+                return;
+            }
+
+            var rolesDocument = await _rolesDocumentManager.GetOrCreateMutableAsync();
+            var updateRolesDocument = false;
+
+            // Get all the available permissions grouped by role name as defined by IPermissionProvider.
+            var groups = _permissionProviders.SelectMany(x => x.GetDefaultStereotypes())
+                .GroupBy(stereotype => stereotype.Name)
+                .Select(x => new
                 {
-                    _logger.LogDebug("Configuring default roles for feature '{FeatureName}'", feature.Id);
+                    RoleName = x.Key,
+                    PermissionNames = x.SelectMany(y => y.Permissions ?? Enumerable.Empty<Permission>()).Select(x => x.Name)
+                });
+
+            foreach (var group in groups)
+            {
+                if (!roleNames.Any(roleName => roleName.Equals(group.RoleName, StringComparison.OrdinalIgnoreCase))
+                    || await _roleManager.FindByNameAsync(group.RoleName) is not Role role)
+                {
+                    // A role is mapped in IPermissionProvider, yet it isn't available for the tenant, ignore it.
+                    continue;
                 }
-                else
+
+                var currentPermissionNames = role.RoleClaims.Where(x => x.ClaimType == Permission.ClaimType).Select(x => x.ClaimValue);
+
+                var distinctPermissionNames = currentPermissionNames
+                    .Union(group.PermissionNames)
+                    .Distinct()
+                    .ToList();
+
+                if (!rolesDocument.PermissionGroups.ContainsKey(group.RoleName))
                 {
-                    _logger.LogDebug("No default roles for feature '{FeatureName}'", feature.Id);
+                    rolesDocument.PermissionGroups.TryAdd(group.RoleName, new List<string>());
+                }
+
+                // Get all available permission names that isn't already assigned to the role.
+                var additionalPermissionNames = distinctPermissionNames.Except(currentPermissionNames);
+
+                foreach (var permissionName in additionalPermissionNames)
+                {
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Default role '{Role}' granted permission '{Permission}'", group.RoleName, permissionName);
+                    }
+
+                    if (rolesDocument.PermissionGroups[group.RoleName].Contains(permissionName, StringComparer.OrdinalIgnoreCase))
+                    {
+                        // The permission was previously assigned to the role, we can't assign it again.
+                        continue;
+                    }
+
+                    await _roleManager.AddClaimAsync(role, new Claim(Permission.ClaimType, permissionName));
+                }
+
+                foreach (var distinctPermissionName in distinctPermissionNames)
+                {
+                    if (rolesDocument.PermissionGroups[group.RoleName].Contains(distinctPermissionName, StringComparer.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    rolesDocument.PermissionGroups[group.RoleName].Add(distinctPermissionName);
+                    updateRolesDocument = true;
                 }
             }
 
-            foreach (var permissionProvider in providersForEnabledModule)
+            if (updateRolesDocument)
             {
-                // get and iterate stereotypical groups of permissions
-                var stereotypes = permissionProvider.GetDefaultStereotypes();
-                foreach (var stereotype in stereotypes)
-                {
-                    // turn those stereotypes into roles
-                    var role = await _roleManager.FindByNameAsync(stereotype.Name);
-                    if (role == null)
-                    {
-                        if (_logger.IsEnabled(LogLevel.Information))
-                        {
-                            _logger.LogInformation("Defining new role '{RoleName}' for permission stereotype", stereotype.Name);
-                        }
-
-                        role = new Role { RoleName = stereotype.Name, RoleDescription = stereotype.Name + " role" };
-                        await _roleManager.CreateAsync(role);
-                    }
-
-                    // and merge the stereotypical permissions into that role
-                    var stereotypePermissionNames = (stereotype.Permissions ?? Enumerable.Empty<Permission>()).Select(x => x.Name);
-                    var currentPermissionNames = ((Role)role).RoleClaims.Where(x => x.ClaimType == Permission.ClaimType).Select(x => x.ClaimValue);
-
-                    var distinctPermissionNames = currentPermissionNames
-                        .Union(stereotypePermissionNames)
-                        .Distinct();
-
-                    // update role if set of permissions has increased
-                    var additionalPermissionNames = distinctPermissionNames.Except(currentPermissionNames);
-
-                    if (additionalPermissionNames.Any())
-                    {
-                        foreach (var permissionName in additionalPermissionNames)
-                        {
-                            if (_logger.IsEnabled(LogLevel.Debug))
-                            {
-                                _logger.LogDebug("Default role '{Role}' granted permission '{Permission}'", stereotype.Name, permissionName);
-                            }
-
-                            await _roleManager.AddClaimAsync(role, new Claim(Permission.ClaimType, permissionName));
-                        }
-                    }
-                }
+                await _rolesDocumentManager.UpdateAsync(rolesDocument);
             }
+
+            _updateInProgress = false;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Startup.cs
@@ -41,8 +41,9 @@ namespace OrchardCore.Roles
             services.TryAddScoped<IRoleClaimStore<IRole>, RoleStore>();
             services.AddRecipeExecutionStep<RolesStep>();
 
-            services.AddScoped<IFeatureEventHandler, RoleUpdater>();
-            services.AddScoped<IModularTenantEvents, RoleUpdater>();
+            services.AddScoped<RoleUpdater>();
+            services.AddScoped<IFeatureEventHandler>(sp => sp.GetRequiredService<RoleUpdater>());
+            services.AddScoped<IModularTenantEvents>(sp => sp.GetRequiredService<RoleUpdater>());
             services.AddScoped<IAuthorizationHandler, RolesPermissionsHandler>();
             services.AddScoped<INavigationProvider, AdminMenu>();
             services.AddScoped<IPermissionProvider, Permissions>();

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Startup.cs
@@ -42,6 +42,7 @@ namespace OrchardCore.Roles
             services.AddRecipeExecutionStep<RolesStep>();
 
             services.AddScoped<IFeatureEventHandler, RoleUpdater>();
+            services.AddScoped<IModularTenantEvents, RoleUpdater>();
             services.AddScoped<IAuthorizationHandler, RolesPermissionsHandler>();
             services.AddScoped<INavigationProvider, AdminMenu>();
             services.AddScoped<IPermissionProvider, Permissions>();

--- a/src/OrchardCore.Themes/TheAdmin/Recipes/blank.recipe.json
+++ b/src/OrchardCore.Themes/TheAdmin/Recipes/blank.recipe.json
@@ -65,6 +65,46 @@
       "name": "themes",
       "admin": "TheAdmin",
       "site": ""
+    },
+    {
+      "name": "Roles",
+      "Roles": [
+        {
+          "Name": "Administrator",
+          "Description": "Administrator",
+          "Permissions": []
+        },
+        {
+          "Name": "Moderator",
+          "Description": "Moderator",
+          "Permissions": []
+        },
+        {
+          "Name": "Editor",
+          "Description": "Editor",
+          "Permissions": []
+        },
+        {
+          "Name": "Author",
+          "Description": "Author",
+          "Permissions": []
+        },
+        {
+          "Name": "Contributor",
+          "Description": "Contributor",
+          "Permissions": []
+        },
+        {
+          "Name": "Authenticated",
+          "Description": "Authenticated",
+          "Permissions": []
+        },
+        {
+          "Name": "Anonymous",
+          "Description": "Anonymous",
+          "Permissions": []
+        }
+      ]
     }
   ]
 }

--- a/src/OrchardCore.Themes/TheAdmin/Recipes/headless.recipe.json
+++ b/src/OrchardCore.Themes/TheAdmin/Recipes/headless.recipe.json
@@ -65,8 +65,33 @@
       "name": "Roles",
       "Roles": [
         {
+          "Name": "Administrator",
+          "Description": "Administrator",
+          "Permissions": []
+        },
+        {
+          "Name": "Moderator",
+          "Description": "Moderator",
+          "Permissions": []
+        },
+        {
+          "Name": "Editor",
+          "Description": "Editor",
+          "Permissions": []
+        },
+        {
+          "Name": "Author",
+          "Description": "Author",
+          "Permissions": []
+        },
+        {
+          "Name": "Contributor",
+          "Description": "Contributor",
+          "Permissions": []
+        },
+        {
           "Name": "AUTHENTICATED",
-          "Description": null,
+          "Description": "Authenticated",
           "Permissions": [
             "ViewContent",
             "ExecuteGraphQL",
@@ -75,7 +100,7 @@
         },
         {
           "Name": "ANONYMOUS",
-          "Description": null,
+          "Description": "Anonymous",
           "Permissions": []
         }
       ]

--- a/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Recipes/agency.recipe.json
@@ -71,6 +71,46 @@
       "site": "TheAgencyTheme"
     },
     {
+      "name": "Roles",
+      "Roles": [
+        {
+          "Name": "Administrator",
+          "Description": "Administrator",
+          "Permissions": []
+        },
+        {
+          "Name": "Moderator",
+          "Description": "Moderator",
+          "Permissions": []
+        },
+        {
+          "Name": "Editor",
+          "Description": "Editor",
+          "Permissions": []
+        },
+        {
+          "Name": "Author",
+          "Description": "Author",
+          "Permissions": []
+        },
+        {
+          "Name": "Contributor",
+          "Description": "Contributor",
+          "Permissions": []
+        },
+        {
+          "Name": "Authenticated",
+          "Description": "Authenticated",
+          "Permissions": []
+        },
+        {
+          "Name": "Anonymous",
+          "Description": "Anonymous",
+          "Permissions": []
+        }
+      ]
+    },
+    {
       "name": "settings",
       "HomeRoute": {
         "Action": "Display",
@@ -419,7 +459,7 @@
           "Name": "RawHtml",
           "DisplayName": "Html",
           "Settings": {
-            "ContentTypeSettings": {           
+            "ContentTypeSettings": {
               "Draftable": true,
               "Versionable": true,
               "Securable": true,
@@ -583,7 +623,7 @@
                 },
                 "MediaFieldSettings": {
                   "Required": true,
-                  "Multiple":  false
+                  "Multiple": false
                 }
               }
             },
@@ -861,7 +901,7 @@
                 "ConditionId": "[js: uuid()]"
               }
             ]
-          },          
+          },
           "Description": "The widgets in this layer are displayed on any page of this site."
         },
         {
@@ -876,7 +916,7 @@
                 "ConditionId": "[js: uuid()]"
               }
             ]
-          },          
+          },
           "Description": "The widgets in this layer are only displayed on the homepage."
         }
       ]
@@ -1593,7 +1633,7 @@
           "Mode": 0,
           "Format": 0,
           "Quality": 100
-        },        
+        },
         "small": {
           "Hint": "A small image (240px x 240px)",
           "Width": 240,
@@ -1601,7 +1641,7 @@
           "Mode": 0,
           "Format": 0,
           "Quality": 100
-        },        
+        },
         "extrasmall": {
           "Hint": "A extra small image (160px x 160px)",
           "Width": 160,
@@ -1611,6 +1651,6 @@
           "Quality": 100
         }
       }
-    }  
+    }
   ]
 }

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.recipe.json
@@ -85,6 +85,46 @@
       "site": "TheBlogTheme"
     },
     {
+      "name": "Roles",
+      "Roles": [
+        {
+          "Name": "Administrator",
+          "Description": "Administrator",
+          "Permissions": []
+        },
+        {
+          "Name": "Moderator",
+          "Description": "Moderator",
+          "Permissions": []
+        },
+        {
+          "Name": "Editor",
+          "Description": "Editor",
+          "Permissions": []
+        },
+        {
+          "Name": "Author",
+          "Description": "Author",
+          "Permissions": []
+        },
+        {
+          "Name": "Contributor",
+          "Description": "Contributor",
+          "Permissions": []
+        },
+        {
+          "Name": "Authenticated",
+          "Description": "Authenticated",
+          "Permissions": []
+        },
+        {
+          "Name": "Anonymous",
+          "Description": "Anonymous",
+          "Permissions": []
+        }
+      ]
+    },
+    {
       "name": "settings",
       "HomeRoute": {
         "Action": "Display",
@@ -324,7 +364,7 @@
           "Name": "Blockquote",
           "DisplayName": "Blockquote",
           "Settings": {
-            "ContentTypeSettings": {           
+            "ContentTypeSettings": {
               "Draftable": true,
               "Versionable": true,
               "Securable": true,
@@ -393,7 +433,7 @@
           "Name": "RawHtml",
           "DisplayName": "Raw Html",
           "Settings": {
-            "ContentTypeSettings": {           
+            "ContentTypeSettings": {
               "Draftable": true,
               "Versionable": true,
               "Securable": true,
@@ -507,7 +547,7 @@
                   "ManageContainedItemRoutes": true
                 }
               }
-            }           
+            }
           ]
         },
         {
@@ -610,8 +650,8 @@
                   "Multiple": false,
                   "AllowAnchors": true
                 }
-              }  
-            },              
+              }
+            },
             {
               "FieldName": "TaxonomyField",
               "Name": "Tags",
@@ -956,7 +996,7 @@
               "Paths": [
                 "home-bg.jpg"
               ],
-              "MediaTexts":[
+              "MediaTexts": [
                 ""
               ],
               "Anchors": [
@@ -997,7 +1037,7 @@
               "Paths": [
                 "post-bg.jpg"
               ],
-              "MediaTexts":[
+              "MediaTexts": [
                 ""
               ],
               "Anchors": [
@@ -1014,7 +1054,7 @@
                 "[js: variables('spaceTagContentItemId')]"
               ],
               "TaxonomyContentItemId": "[js: variables('tagsContentItemId')]",
-              "TagNames": [ 
+              "TagNames": [
                 "Earth",
                 "Exploration",
                 "Space"
@@ -1102,7 +1142,7 @@
         {
           "Name": "Always",
           "LayerRule": {
-            "ConditionId":"[js: uuid()]",
+            "ConditionId": "[js: uuid()]",
             "Conditions": [
               {
                 "$type": "OrchardCore.Rules.Models.BooleanCondition, OrchardCore.Rules",
@@ -1111,7 +1151,7 @@
                 "ConditionId": "[js: uuid()]"
               }
             ]
-          },          
+          },
           "Description": "The widgets in this layer are displayed on any page of this site."
         },
         {
@@ -1126,7 +1166,7 @@
                 "ConditionId": "[js: uuid()]"
               }
             ]
-          },          
+          },
           "Description": "The widgets in this layer are only displayed on the homepage."
         }
       ]

--- a/src/OrchardCore.Themes/TheComingSoonTheme/Recipes/comingsoon.recipe.json
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/Recipes/comingsoon.recipe.json
@@ -68,6 +68,46 @@
       "site": "TheComingSoonTheme"
     },
     {
+      "name": "Roles",
+      "Roles": [
+        {
+          "Name": "Administrator",
+          "Description": "Administrator",
+          "Permissions": []
+        },
+        {
+          "Name": "Moderator",
+          "Description": "Moderator",
+          "Permissions": []
+        },
+        {
+          "Name": "Editor",
+          "Description": "Editor",
+          "Permissions": []
+        },
+        {
+          "Name": "Author",
+          "Description": "Author",
+          "Permissions": []
+        },
+        {
+          "Name": "Contributor",
+          "Description": "Contributor",
+          "Permissions": []
+        },
+        {
+          "Name": "Authenticated",
+          "Description": "Authenticated",
+          "Permissions": []
+        },
+        {
+          "Name": "Anonymous",
+          "Description": "Anonymous",
+          "Permissions": []
+        }
+      ]
+    },
+    {
       "name": "settings",
       "HomeRoute": {
         "Action": "Display",

--- a/src/OrchardCore.Themes/TheTheme/Recipes/saas.recipe.json
+++ b/src/OrchardCore.Themes/TheTheme/Recipes/saas.recipe.json
@@ -41,6 +41,26 @@
       "site": "TheTheme"
     },
     {
+      "name": "Roles",
+      "Roles": [
+        {
+          "Name": "Administrator",
+          "Description": "Administrator",
+          "Permissions": []
+        },
+        {
+          "Name": "Authenticated",
+          "Description": "Authenticated",
+          "Permissions": []
+        },
+        {
+          "Name": "Anonymous",
+          "Description": "Anonymous",
+          "Permissions": []
+        }
+      ]
+    },
+    {
       "name": "settings",
       "HomeRoute": {
         "Action": "Index",

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/Recipes/pages.recipe.json
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/Recipes/pages.recipe.json
@@ -70,6 +70,46 @@
       "name": "themes",
       "admin": "TheAdmin",
       "site": "Theme.Pages"
+    },
+    {
+      "name": "Roles",
+      "Roles": [
+        {
+          "Name": "Administrator",
+          "Description": "Administrator",
+          "Permissions": []
+        },
+        {
+          "Name": "Moderator",
+          "Description": "Moderator",
+          "Permissions": []
+        },
+        {
+          "Name": "Editor",
+          "Description": "Editor",
+          "Permissions": []
+        },
+        {
+          "Name": "Author",
+          "Description": "Author",
+          "Permissions": []
+        },
+        {
+          "Name": "Contributor",
+          "Description": "Contributor",
+          "Permissions": []
+        },
+        {
+          "Name": "Authenticated",
+          "Description": "Authenticated",
+          "Permissions": []
+        },
+        {
+          "Name": "Anonymous",
+          "Description": "Anonymous",
+          "Permissions": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Fix #12425 

@jtkech please check this out when your time permits since we chatted about this in the issue.

Here is a summary of the enhancements this PR brings
1. We can now use recipe step to explicitly list the roles we want to use for the site. We are no longer forced to use the default roles.
2. If a role is deleted, it wont come back at some point after installing new features. Currently, even if we delete a role, it could come back after installing more features.
3. If the Roles feature is disabled, and re-enabled later, we keep track of permissions history to automatically assign any permission that would not have been assigned previously while the Roles feature is disabled.
4. If an enabled feature introduces new permissions, it'll now get assigned to the proper roles by default "if these roles exists".
