### PR TITLE
Don't lose an empty option name on saving Predefined List settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Assets/js/OptionsEditor/optionsEditor.js
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Assets/js/OptionsEditor/optionsEditor.js
@@ -18,7 +18,7 @@ function initializeOptionsEditor(elem, data, defaultValue, modalBodyElement) {
         },
         getOptionsFormattedList: function () {
             if (this.debug) { console.log('getOptionsFormattedList triggered') };
-            return JSON.stringify(this.state.options.filter(function (x) { return !IsNullOrWhiteSpace(x.name) }));
+            return JSON.stringify(this.state.options);
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/wwwroot/Scripts/optionsEditor.js
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/wwwroot/Scripts/optionsEditor.js
@@ -36,9 +36,7 @@ function initializeOptionsEditor(elem, data, defaultValue, modalBodyElement) {
       }
 
       ;
-      return JSON.stringify(this.state.options.filter(function (x) {
-        return !IsNullOrWhiteSpace(x.name);
-      }));
+      return JSON.stringify(this.state.options);
     }
   };
   var optionsTable = {


### PR DESCRIPTION
Fixes #12592 

Because it is allowed to define an empty Option name in a Migration and it works well.
Just don't remove this empty Option name when saving the `PredefinedList` settings.
