### PR TITLE
Fix bug report template label config (Lombiq Technologies: OCORE-107)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: 'bug :bug:'
 assignees: ''
 
 ---


### PR DESCRIPTION
When you open a bug with the template, it doesn't set the label because since then it has changed (to include an emoji at the end).