### PR TITLE
Fixes #12544: Make UpdateAtomic Delegates distinct

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
@@ -92,6 +92,11 @@ namespace OrchardCore.Documents
                     document = await ((UpdateDelegate)d)();
                 }
 
+                if (document == null)
+                {
+                    return;
+                }
+
                 document.Identifier ??= IdGenerator.GenerateId();
 
                 await SetInternalAsync(document);

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
@@ -15,7 +15,8 @@ namespace OrchardCore.Documents
     /// <summary>
     /// A <see cref="DocumentManager{TDocument}"/> using a multi level cache but without any persistent storage.
     /// </summary>
-    public class VolatileDocumentManager<TDocument> : DocumentManager<TDocument>, IVolatileDocumentManager<TDocument> where TDocument : class, IDocument, new()
+    public class VolatileDocumentManager<TDocument> : DocumentManager<TDocument>, IVolatileDocumentManager<TDocument>
+        where TDocument : class, IDocument, new()
     {
         private readonly IDistributedLock _distributedLock;
         private readonly ILogger _logger;
@@ -49,7 +50,7 @@ namespace OrchardCore.Documents
                     await DocumentStore.CancelAsync();
 
                     _logger.LogError("Can't update the '{DocumentName}' if not able to access the distributed cache", typeof(TDocument).Name);
-                    
+
                     throw;
                 }
             }
@@ -105,11 +106,11 @@ namespace OrchardCore.Documents
             });
         }
 
-        private class UpdateDelegates
+        private sealed class UpdateDelegates
         {
             public UpdateDelegate UpdateDelegateAsync;
             public AfterUpdateDelegate AfterUpdateDelegateAsync;
-            public HashSet<object> Targets = new HashSet<object>();
+            public HashSet<object> Targets = new();
         }
     }
 }


### PR DESCRIPTION
Fixes #12544 

Here the comment of the related issue

> Maybe I'm alone to use `IVolatileDocumentManager.UpdateAtomicAsync()`, see #10673 where we fixed a first problem but the 2nd concern is still there, otherwise it works well.

> So, when enlisting multiple update delegates (not allowed with the regular UpdateAsync()) in bulk actions, we can still enlist multiple times the same delegate, we wanted to make the results of the delegate invocation list distincts, but they are wrapped objects for which the equality operator overload is not sufficient.

> I fixed it locally by checking the `Target` directly on the the delegates passed as parameters, this in place of checking the delegates retrieved from the invocation list of the combined delegate.

Note: Currently as a workaround I overrided the implementation which doesn't have a lot of code as it is a derived class.
