### PR TITLE
Prevent AutoroutePartIndex from throwing exception when content definition is not found

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Indexes/AutoroutePartIndex.cs
@@ -54,8 +54,8 @@ namespace OrchardCore.ContentManagement.Records
     public class AutoroutePartIndexProvider : ContentHandlerBase, IIndexProvider, IScopedIndexProvider
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly HashSet<ContentItem> _itemRemoved = new HashSet<ContentItem>();
-        private readonly HashSet<string> _partRemoved = new HashSet<string>();
+        private readonly HashSet<ContentItem> _itemRemoved = new();
+        private readonly HashSet<string> _partRemoved = new();
         private IContentDefinitionManager _contentDefinitionManager;
         private IContentManager _contentManager;
 
@@ -92,7 +92,7 @@ namespace OrchardCore.ContentManagement.Records
 
                 // Search for this part.
                 var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-                if (!contentTypeDefinition.Parts.Any(ctpd => ctpd.Name == nameof(AutoroutePart)))
+                if (contentTypeDefinition != null && !contentTypeDefinition.Parts.Any(ctpd => ctpd.Name == nameof(AutoroutePart)))
                 {
                     context.ContentItem.Remove<AutoroutePart>();
                     _partRemoved.Add(context.ContentItem.ContentItemId);
@@ -125,7 +125,7 @@ namespace OrchardCore.ContentManagement.Records
                     var partRemoved = _partRemoved.Contains(contentItem.ContentItemId);
 
                     var part = contentItem.As<AutoroutePart>();
-                    if (!partRemoved && (part == null || String.IsNullOrEmpty(part.Path)))
+                    if (!partRemoved && String.IsNullOrEmpty(part?.Path))
                     {
                         return null;
                     }


### PR DESCRIPTION
Fix #12575