### PR TITLE
GitHub Actions pr_ci.yml improvements

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Restore
       if: steps.cache-nuget.outputs.cache-hit != 'true'
       run: |
-        dotnet restore --verbosity normal /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+        dotnet restore /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
 
     # for CI build we can use Deterministic = false to enable restore
     - name: Build

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -33,7 +33,7 @@ jobs:
            **/obj/project.assets.json
            **/obj/project.nuget.cache
            **/**/packages.lock.json
-         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.props') }}
+         key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dependencies*.props', '**/Directory.Packages.props') }}
          restore-keys: |
             ${{ runner.os }}-nuget-
     - name: Restore

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -15,10 +15,10 @@ jobs:
     name: Build & Test
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.0.x
+#    - name: Setup .NET 6.0
+#      uses: actions/setup-dotnet@v3
+#      with:
+#        dotnet-version: 6.0.x
     # https://github.com/actions/cache/blob/main/workarounds.md#improving-cache-restore-performance-on-windowsusing-cross-os-caching
     - if: ${{ runner.os == 'Windows' }}
       name: Use GNU tar

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -50,7 +50,7 @@ jobs:
            **/obj/project.nuget.cache
            **/*.csproj.nuget.g.targets
            **/packages.lock.json
-         key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dependencies*.props', '**/Directory.Packages.props') }}
+         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/Dependencies.props', '**/Dependencies.AspNetCore.props', '**/Directory.Packages.props') }}
          restore-keys: |
             ${{ runner.os }}-nuget-
 

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -43,10 +43,10 @@ jobs:
     - name: Restore
       if: steps.cache-nugets.outputs.cache-hit != 'true'
       run: |
-        dotnet restore --verbosity normal
+        dotnet restore --verbosity normal /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder
     - name: Build
       run: |
-        dotnet build -c Release --no-restore --framework net6.0 /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build -c Release --no-restore --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build  --framework net6.0 ./test/OrchardCore.Tests/OrchardCore.Tests.csproj

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -57,10 +57,9 @@ jobs:
       run: |
         dotnet restore /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder
 
-    # for CI build we can use Deterministic = false to enable restore
     - name: Build
       run: |
-        dotnet build -c Release --no-restore --framework net6.0 /p:IncludeSymbols=false /p:Deterministic=false /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build -c Release --no-restore --framework net6.0 /p:IncludeSymbols=false /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
 
     - name: Unit Tests
       run: |

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-nuget-
     - name: Restore
       run: |
-        dotnet restore --verbosity normal
+        dotnet restore
     - name: Build
       run: |
         dotnet build --no-restore --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -1,10 +1,13 @@
 name: PR - CI
+
 on: 
   pull_request:
     branches: [ main, release/** ]
+
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+
 jobs:
   build_test:
     runs-on: ${{ matrix.os }}
@@ -18,10 +21,14 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout source code
 
-#    - name: Setup .NET 6.0
-#      uses: actions/setup-dotnet@v3
-#      with:
-#        dotnet-version: 6.0.x
+   - name: Setup .NET 6.0
+     uses: actions/setup-dotnet@v3
+     with:
+       dotnet-version: 6.0.x
+	   
+    - uses: actions/setup-node@v3
+      with:
+        node-version: "16"
 
     # https://github.com/actions/cache/blob/main/workarounds.md#improving-cache-restore-performance-on-windowsusing-cross-os-caching
     - if: ${{ runner.os == 'Windows' }}
@@ -55,7 +62,7 @@ jobs:
     # for CI build we can use Deterministic = false to enable restore
     - name: Build
       run: |
-        dotnet build -c Release --no-restore --framework net6.0 /p:Deterministic=false /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build -c Release --no-restore --framework net6.0 /IncludeSymbols=false / /p:Deterministic=false /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
 
     - name: Unit Tests
       run: |

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -32,7 +32,8 @@ jobs:
            ~/.nuget/packages
            **/obj/project.assets.json
            **/obj/project.nuget.cache
-         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.props') }}
+           **/packages.lock.json
+         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
          restore-keys: |
             ${{ runner.os }}-nuget-
     - name: Restore
@@ -40,7 +41,7 @@ jobs:
         dotnet restore --verbosity normal
     - name: Build
       run: |
-        dotnet build -c Release --no-restore --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build -c Release --no-restore --framework net6.0 /p:RestorePackagesWithLockFile /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build  --framework net6.0 ./test/OrchardCore.Tests/OrchardCore.Tests.csproj

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -28,8 +28,11 @@ jobs:
         echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
     - uses: actions/cache@v3
       with:
-         path: ~/.nuget/packages
-         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+         path: |
+           ~/.nuget/packages
+           **/obj/project.assets.json
+           **/obj/project.nuget.cache
+         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.props') }}
          restore-keys: |
             ${{ runner.os }}-nuget-
     - name: Restore

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
-      uses: actions/cache@v3
+    - uses: actions/cache@v3
       with:
          path: ~/.nuget/packages
          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-nuget-
     - name: Restore
       run: |
-        dotnet restore --configuration Release --framework net6.0 --verbosity normal
+        dotnet restore --configuration Release --verbosity normal
     - name: Build
       run: |
         dotnet build --no-restore --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true /p:CreateHardLinksForAdditionalFilesIfPossible=true /p:CreateHardLinksForCopyAdditionalFilesIfPossible=true
@@ -48,3 +48,4 @@ jobs:
         path: |
           test/OrchardCore.Tests.Functional/cms-tests/cypress/screenshots
           src/OrchardCore.Cms.Web/App_Data/logs
+

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -19,6 +19,13 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
+    # https://github.com/actions/cache/blob/main/workarounds.md#improving-cache-restore-performance-on-windowsusing-cross-os-caching
+    - if: ${{ runner.os == 'Windows' }}
+      name: Use GNU tar
+      shell: cmd
+      run: |
+        echo "Adding GNU tar to PATH"
+        echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
     - uses: actions/cache@v3
       with:
          path: ~/.nuget/packages
@@ -27,7 +34,7 @@ jobs:
             ${{ runner.os }}-nuget-
     - name: Restore
       run: |
-        dotnet restore --configuration Release --verbosity normal
+        dotnet restore --verbosity normal
     - name: Build
       run: |
         dotnet build --no-restore --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true /p:CreateHardLinksForAdditionalFilesIfPossible=true /p:CreateHardLinksForCopyAdditionalFilesIfPossible=true

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -63,7 +63,7 @@ jobs:
     # for CI build we can use Deterministic = false to enable restore
     - name: Build
       run: |
-        dotnet build -c Release --no-restore --framework net6.0 /IncludeSymbols=false / /p:Deterministic=false /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build -c Release --no-restore --framework net6.0 /p:IncludeSymbols=false /p:Deterministic=false /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
 
     - name: Unit Tests
       run: |

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -59,3 +59,4 @@ jobs:
         path: |
           test/OrchardCore.Tests.Functional/cms-tests/cypress/screenshots
           src/OrchardCore.Cms.Web/App_Data/logs
+

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Restore
       if: steps.cache-nuget.outputs.cache-hit != 'true'
       run: |
-        dotnet restore /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+        dotnet restore --force-evaluate /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
 
     # for CI build we can use Deterministic = false to enable restore
     - name: Build

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -54,11 +54,10 @@ jobs:
          restore-keys: |
             ${{ runner.os }}-nuget-
 
-    # we can restore just OrchardCore.Cms.Web.csproj because it links to full dependency file, with Directory.Packages.props should use solution
     - name: Restore
       if: steps.cache-nuget.outputs.cache-hit != 'true'
       run: |
-        dotnet restore --force-evaluate /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+        dotnet restore /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder
 
     # for CI build we can use Deterministic = false to enable restore
     - name: Build

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -46,10 +46,8 @@ jobs:
       with:
          path: |
            ~/.nuget/packages
-           **/obj/project.assets.json
-           **/obj/project.nuget.cache
-           **/*.csproj.nuget.g.targets
-           **/packages.lock.json
+           **/obj/project.*
+           **/obj/*.csproj.nuget.*
          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json', '**/Dependencies.props', '**/Dependencies.AspNetCore.props', '**/Directory.Packages.props') }}
          restore-keys: |
             ${{ runner.os }}-nuget-

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -32,7 +32,8 @@ jobs:
            ~/.nuget/packages
            **/obj/project.assets.json
            **/obj/project.nuget.cache
-           **/**/packages.lock.json
+           **/*.csproj.nuget.g.targets.
+           **/packages.lock.json
          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dependencies*.props', '**/Directory.Packages.props') }}
          restore-keys: |
             ${{ runner.os }}-nuget-

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -14,14 +14,21 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     name: Build & Test
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
       with:
         node-version: "15"
     - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 6.0.x
+        include-prerelease: true
+    - uses: actions/cache@v3
+      with:
+         path: ~/.nuget/packages
+         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+         restore-keys: |
+            ${{ runner.os }}-nuget-
     - name: Build
       run: |
         dotnet build --configuration Release --framework net6.0

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -15,6 +15,7 @@ jobs:
     name: Build & Test
     steps:
     - uses: actions/checkout@v3
+      name: Checkout source code
 #    - name: Setup .NET 6.0
 #      uses: actions/setup-dotnet@v3
 #      with:
@@ -28,6 +29,7 @@ jobs:
         echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
     - uses: actions/cache@v3
       id: cache-nuget
+      name: Cache NuGet packages and generated restore targets
       with:
          path: |
            ~/.nuget/packages

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches: [ main, release/** ]
 env:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   build_test:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-nuget-
     - name: Restore
       run: |
-        dotnet restore
+        dotnet restore --verbosity normal
     - name: Build
       run: |
         dotnet build --no-restore --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -32,8 +32,8 @@ jobs:
            ~/.nuget/packages
            **/obj/project.assets.json
            **/obj/project.nuget.cache
-           **/packages.lock.json
-         key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+           **/**/packages.lock.json
+         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.props') }}
          restore-keys: |
             ${{ runner.os }}-nuget-
     - name: Restore
@@ -41,7 +41,7 @@ jobs:
         dotnet restore --verbosity normal
     - name: Build
       run: |
-        dotnet build -c Release --no-restore --framework net6.0 /p:RestorePackagesWithLockFile /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build -c Release --no-restore --framework net6.0 /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build  --framework net6.0 ./test/OrchardCore.Tests/OrchardCore.Tests.csproj

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -15,14 +15,16 @@ jobs:
     name: Build & Test
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: "15"
-    - name: Setup .NET 6.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-        include-prerelease: true
+# Node.JS 16 is included by default
+#    - uses: actions/setup-node@v2
+#      with:
+#        node-version: "15"
+# NET 6 is included by default
+#    - name: Setup .NET 6.0
+#      uses: actions/setup-dotnet@v1
+#      with:
+#        dotnet-version: 6.0.x
+#        include-prerelease: true
     - uses: actions/cache@v3
       with:
          path: ~/.nuget/packages

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -21,12 +21,12 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout source code
 
-    - name: Setup .NET 6.0
+    - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.0.x
 
-    - name: Setup Node
+    - name: Setup Node.js
       uses: actions/setup-node@v3
       with:
         node-version: "16"

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -27,17 +27,19 @@ jobs:
         echo "Adding GNU tar to PATH"
         echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
     - uses: actions/cache@v3
+      id: cache-nuget
       with:
          path: |
            ~/.nuget/packages
            **/obj/project.assets.json
            **/obj/project.nuget.cache
-           **/*.csproj.nuget.g.targets.
+           **/*.csproj.nuget.g.targets
            **/packages.lock.json
          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dependencies*.props', '**/Directory.Packages.props') }}
          restore-keys: |
             ${{ runner.os }}-nuget-
     - name: Restore
+      if: steps.cache-nugets.outputs.cache-hit != 'true'
       run: |
         dotnet restore --verbosity normal
     - name: Build

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -14,16 +14,23 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     name: Build & Test
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v3
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+      uses: actions/cache@v3
       with:
          path: ~/.nuget/packages
          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
          restore-keys: |
             ${{ runner.os }}-nuget-
+    - name: Restore
+      run: |
+        dotnet restore --configuration Release --framework net6.0 --verbosity normal
     - name: Build
       run: |
-        dotnet build --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build --no-restore --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true /p:CreateHardLinksForAdditionalFilesIfPossible=true /p:CreateHardLinksForCopyAdditionalFilesIfPossible=true
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -34,7 +41,7 @@ jobs:
         npm install
         npm run cms:test
         npm run mvc:test
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: matrix.os == 'ubuntu-latest' && failure()
       with:
         name: functional-test-failure

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-nuget-
     - name: Build
       run: |
-        dotnet build --configuration Release --framework net6.0
+        dotnet build --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -14,12 +14,15 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     name: Build & Test
     steps:
+
     - uses: actions/checkout@v3
       name: Checkout source code
+
 #    - name: Setup .NET 6.0
 #      uses: actions/setup-dotnet@v3
 #      with:
 #        dotnet-version: 6.0.x
+
     # https://github.com/actions/cache/blob/main/workarounds.md#improving-cache-restore-performance-on-windowsusing-cross-os-caching
     - if: ${{ runner.os == 'Windows' }}
       name: Use GNU tar
@@ -27,9 +30,11 @@ jobs:
       run: |
         echo "Adding GNU tar to PATH"
         echo C:\Program Files\Git\usr\bin>>"%GITHUB_PATH%"
+
+    # caching all generated nuget items so we don't need to call restore
     - uses: actions/cache@v3
       id: cache-nuget
-      name: Cache NuGet packages and generated restore targets
+      name: Cached NuGet artifacts
       with:
          path: |
            ~/.nuget/packages
@@ -40,16 +45,21 @@ jobs:
          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Dependencies*.props', '**/Directory.Packages.props') }}
          restore-keys: |
             ${{ runner.os }}-nuget-
+
+    # we can restore just OrchardCore.Cms.Web.csproj because it links to full dependency file, with Directory.Packages.props should use solution
     - name: Restore
-      if: steps.cache-nugets.outputs.cache-hit != 'true'
+      if: steps.cache-nuget.outputs.cache-hit != 'true'
       run: |
-        dotnet restore --verbosity normal /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder
+        dotnet restore --verbosity normal /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+
     - name: Build
       run: |
         dotnet build -c Release --no-restore --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build  --framework net6.0 ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
+
     - name: Functional Tests
       if: matrix.os == 'ubuntu-latest'
       run: |
@@ -57,6 +67,7 @@ jobs:
         npm install
         npm run cms:test
         npm run mvc:test
+
     - uses: actions/upload-artifact@v3
       if: matrix.os == 'ubuntu-latest' && failure()
       with:

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -37,7 +37,7 @@ jobs:
         dotnet restore --verbosity normal
     - name: Build
       run: |
-        dotnet build --no-restore --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true /p:CreateHardLinksForAdditionalFilesIfPossible=true /p:CreateHardLinksForCopyAdditionalFilesIfPossible=true
+        dotnet build --no-restore --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -55,4 +55,3 @@ jobs:
         path: |
           test/OrchardCore.Tests.Functional/cms-tests/cypress/screenshots
           src/OrchardCore.Cms.Web/App_Data/logs
-

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -51,4 +51,3 @@ jobs:
         path: |
           test/OrchardCore.Tests.Functional/cms-tests/cypress/screenshots
           src/OrchardCore.Cms.Web/App_Data/logs
-  

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -1,6 +1,6 @@
 name: PR - CI
 
-on: 
+on:
   pull_request:
     branches: [ main, release/** ]
 
@@ -21,12 +21,13 @@ jobs:
     - uses: actions/checkout@v3
       name: Checkout source code
 
-   - name: Setup .NET 6.0
-     uses: actions/setup-dotnet@v3
-     with:
-       dotnet-version: 6.0.x
-	   
-    - uses: actions/setup-node@v3
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
       with:
         node-version: "16"
 

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -37,10 +37,10 @@ jobs:
         dotnet restore --verbosity normal
     - name: Build
       run: |
-        dotnet build --no-restore --configuration Release --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build -c Release --no-restore --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
     - name: Unit Tests
       run: |
-        dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
+        dotnet test -c Release --no-restore --no-build  --framework net6.0 ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
     - name: Functional Tests
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -15,16 +15,6 @@ jobs:
     name: Build & Test
     steps:
     - uses: actions/checkout@v2
-# Node.JS 16 is included by default
-#    - uses: actions/setup-node@v2
-#      with:
-#        node-version: "15"
-# NET 6 is included by default
-#    - name: Setup .NET 6.0
-#      uses: actions/setup-dotnet@v1
-#      with:
-#        dotnet-version: 6.0.x
-#        include-prerelease: true
     - uses: actions/cache@v3
       with:
          path: ~/.nuget/packages

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -52,9 +52,10 @@ jobs:
       run: |
         dotnet restore --verbosity normal /p:DisableImplicitNuGetFallbackFolder=true /p:DisableImplicitLibraryPacksFolder src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
 
+    # for CI build we can use Deterministic = false to enable restore
     - name: Build
       run: |
-        dotnet build -c Release --no-restore --framework net6.0 /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
+        dotnet build -c Release --no-restore --framework net6.0 /p:Deterministic=false /p:CreateHardLinksForCopyLocalIfPossible=true /p:CreateHardLinksForCopyFilesToOutputDirectoryIfPossible=true /p:CreateHardLinksForPublishFilesIfPossible=true
 
     - name: Unit Tests
       run: |

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -63,5 +63,4 @@
     <PackageManagement Include="YesSql.Filters.Query" Version="3.2.0" />
     <PackageManagement Include="ZString" Version="2.4.4" />
   </ItemGroup>
-  
 </Project>

--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -63,4 +63,5 @@
     <PackageManagement Include="YesSql.Filters.Query" Version="3.2.0" />
     <PackageManagement Include="ZString" Version="2.4.4" />
   </ItemGroup>
+  
 </Project>

--- a/src/OrchardCore.Build/OrchardCore.Commons.targets
+++ b/src/OrchardCore.Build/OrchardCore.Commons.targets
@@ -35,4 +35,18 @@
              File="$(MSBuildProjectFullPath)" />
   </Target>
 
+  <Target Name="SetAllProjectReferenceAsPublic"
+          AfterTargets="AssignProjectConfiguration"
+          BeforeTargets="ResolveProjectReferences"
+          Condition="'$(OutputType)' == 'Library' and '$(CopyLocalLockFileAssemblies)' != 'true' and $(MSBuildProjectDirectory.Contains('.Tests.')) == 'false' ">
+    <ItemGroup>
+      <ProjectReferenceWithConfiguration Update="@(ProjectReferenceWithConfiguration)">
+        <Private>false</Private>
+      </ProjectReferenceWithConfiguration>
+      <ProjectReference Update="@(ProjectReference)">
+        <Private>false</Private>
+      </ProjectReference>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\OrchardCore.Build\Dependencies.props" />
 

--- a/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
+++ b/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\OrchardCore.Build\Dependencies.props" />
 

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/OrchardCore.Application.Pages.csproj
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Application.Pages/OrchardCore.Application.Pages.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <Import Project="..\..\..\src\OrchardCore.Build\Dependencies.props" />
 


### PR DESCRIPTION
Relates to https://github.com/OrchardCMS/OrchardCore/issues/12583 , checking how to make PR CI build faster on GH actions side.

* NuGet packages probably come faster from local data center than public download interface
* Don't install .NET 6 (comes OOB), don't install Node.JS 15 (v16 comes OOB)
* Add hard-linking to improve build speeds on Windows, [some discussion about the feature](https://github.com/dotnet/msbuild/issues/3788) (not working inside VS but for CI build seems like a good choice)

Probably not a common thing to see Windows build completing faster than the Linux one?

![image](https://user-images.githubusercontent.com/171892/194700347-4cf66cbd-b53f-40c1-8b6b-a74438b87426.png)

I'd so much love to have NUKE used in this project, but I guess that's way too far-fetched...
