### PR TITLE
Elasticsearch regression: Add Lucene deployment plan migration

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Startup.cs
@@ -229,21 +229,24 @@ namespace OrchardCore.Search.Elasticsearch
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddTransient<IDeploymentSource, ElasticIndexDeploymentSource>();
-            services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<ElasticIndexDeploymentStep>());
-            services.AddScoped<IDisplayDriver<DeploymentStep>, ElasticIndexDeploymentStepDriver>();
+            if (services.Any(d => d.ImplementationType == typeof(ElasticSearchProvider)))
+            {
+                services.AddTransient<IDeploymentSource, ElasticIndexDeploymentSource>();
+                services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<ElasticIndexDeploymentStep>());
+                services.AddScoped<IDisplayDriver<DeploymentStep>, ElasticIndexDeploymentStepDriver>();
 
-            services.AddTransient<IDeploymentSource, ElasticSettingsDeploymentSource>();
-            services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<ElasticSettingsDeploymentStep>());
-            services.AddScoped<IDisplayDriver<DeploymentStep>, ElasticSettingsDeploymentStepDriver>();
+                services.AddTransient<IDeploymentSource, ElasticSettingsDeploymentSource>();
+                services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<ElasticSettingsDeploymentStep>());
+                services.AddScoped<IDisplayDriver<DeploymentStep>, ElasticSettingsDeploymentStepDriver>();
 
-            services.AddTransient<IDeploymentSource, ElasticIndexRebuildDeploymentSource>();
-            services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<ElasticIndexRebuildDeploymentStep>());
-            services.AddScoped<IDisplayDriver<DeploymentStep>, ElasticIndexRebuildDeploymentStepDriver>();
+                services.AddTransient<IDeploymentSource, ElasticIndexRebuildDeploymentSource>();
+                services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<ElasticIndexRebuildDeploymentStep>());
+                services.AddScoped<IDisplayDriver<DeploymentStep>, ElasticIndexRebuildDeploymentStepDriver>();
 
-            services.AddTransient<IDeploymentSource, ElasticIndexResetDeploymentSource>();
-            services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<ElasticIndexResetDeploymentStep>());
-            services.AddScoped<IDisplayDriver<DeploymentStep>, ElasticIndexResetDeploymentStepDriver>();
+                services.AddTransient<IDeploymentSource, ElasticIndexResetDeploymentSource>();
+                services.AddSingleton<IDeploymentStepFactory>(new DeploymentStepFactory<ElasticIndexResetDeploymentStep>());
+                services.AddScoped<IDisplayDriver<DeploymentStep>, ElasticIndexResetDeploymentStepDriver>();
+            }
         }
     }
 
@@ -252,7 +255,10 @@ namespace OrchardCore.Search.Elasticsearch
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<IBackgroundTask, IndexingBackgroundTask>();
+            if (services.Any(d => d.ImplementationType == typeof(ElasticSearchProvider)))
+            { 
+                services.AddSingleton<IBackgroundTask, IndexingBackgroundTask>();
+            }
         }
     }
 
@@ -261,9 +267,12 @@ namespace OrchardCore.Search.Elasticsearch
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddScoped<IContentPickerResultProvider, ElasticContentPickerResultProvider>();
-            services.AddScoped<IContentPartFieldDefinitionDisplayDriver, ContentPickerFieldElasticEditorSettingsDriver>();
-            services.AddShapeAttributes<ElasticContentPickerShapeProvider>();
+            if (services.Any(d => d.ImplementationType == typeof(ElasticSearchProvider)))
+            {
+                services.AddScoped<IContentPickerResultProvider, ElasticContentPickerResultProvider>();
+                services.AddScoped<IContentPartFieldDefinitionDisplayDriver, ContentPickerFieldElasticEditorSettingsDriver>();
+                services.AddShapeAttributes<ElasticContentPickerShapeProvider>();
+            }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Controllers/SearchController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Controllers/SearchController.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.Search.Lucene.Controllers
         private readonly LuceneIndexingService _luceneIndexingService;
         private readonly LuceneIndexSettingsService _luceneIndexSettingsService;
         private readonly LuceneAnalyzerManager _luceneAnalyzerManager;
-        private readonly ILuceneSearchQueryService _searchQueryService;
+        private readonly Abstractions.ILuceneSearchQueryService _searchQueryService;
         private readonly ISession _session;
         private readonly IStringLocalizer S;
         private readonly IEnumerable<IPermissionProvider> _permissionProviders;
@@ -44,7 +44,7 @@ namespace OrchardCore.Search.Lucene.Controllers
             LuceneIndexingService luceneIndexingService,
             LuceneIndexSettingsService luceneIndexSettingsService,
             LuceneAnalyzerManager luceneAnalyzerManager,
-            ILuceneSearchQueryService searchQueryService,
+            Abstractions.ILuceneSearchQueryService searchQueryService,
             ISession session,
             IStringLocalizer<SearchController> stringLocalizer,
             IEnumerable<IPermissionProvider> permissionProviders,

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Migrations.cs
@@ -178,6 +178,10 @@ namespace OrchardCore.Search.Lucene
                             var updateCmd = $"UPDATE {dialect.QuoteForTableName(table)} SET Content = REPLACE(content, '\"$type\":\"OrchardCore.Lucene.LuceneQuery, OrchardCore.Lucene\"', '\"$type\":\"OrchardCore.Search.Lucene.LuceneQuery, OrchardCore.Search.Lucene\"') WHERE [Type] = 'OrchardCore.Queries.Services.QueriesDocument, OrchardCore.Queries'";
 
                             await transaction.Connection.ExecuteAsync(updateCmd, null, transaction);
+                            
+                            updateCmd = $"UPDATE {dialect.QuoteForTableName(table)} SET Content = REPLACE(content, '\"$type\":\"OrchardCore.Lucene.Deployment.LuceneIndexDeploymentStep, OrchardCore.Lucene\"', '\"$type\":\"OrchardCore.Search.Lucene.Deployment.LuceneIndexDeploymentStep, OrchardCore.Search.Lucene\"') WHERE [Type] = 'OrchardCore.Deployment.DeploymentPlan, OrchardCore.Deployment.Abstractions'";
+
+                            await transaction.Connection.ExecuteAsync(updateCmd, null, transaction);
 
                             updateCmd = $"UPDATE {dialect.QuoteForTableName(table)} SET [Type] = 'OrchardCore.Search.Lucene.Model.LuceneIndexSettingsDocument, OrchardCore.Search.Lucene' WHERE [Type] = 'OrchardCore.Lucene.Model.LuceneIndexSettingsDocument, OrchardCore.Lucene'";
 

--- a/src/docs/releases/1.5.0.md
+++ b/src/docs/releases/1.5.0.md
@@ -8,9 +8,12 @@
 
 ## Lucene Migration
 
-Manual migration to get back Lucene Indices Settings and Queries. (Reference only)
+Manual migration to get back Lucene Indices Settings, Deployment plans, and Queries. (Reference only)
 
 ```sql
+  UPDATE Document SET Content = REPLACE(content, '\"$type\":\"OrchardCore.Lucene.Deployment.LuceneIndexDeploymentStep, OrchardCore.Lucene\"', '\"$type\":\"OrchardCore.Search.Lucene.Deployment.LuceneIndexDeploymentStep, OrchardCore.Search.Lucene\"')
+  WHERE [Type] = 'OrchardCore.Deployment.DeploymentPlan, OrchardCore.Deployment.Abstractions'
+
   UPDATE Document SET Content = REPLACE(content, '"$type":"OrchardCore.Lucene.LuceneQuery, OrchardCore.Lucene"', '"$type":"OrchardCore.Search.Lucene.LuceneQuery, OrchardCore.Search.Lucene"')
   WHERE  [Type] = 'OrchardCore.Queries.Services.QueriesDocument, OrchardCore.Queries'
 


### PR DESCRIPTION
Fixes #12590

Also adds verification on the ElasticsearchProvider registration before allowing to register other dependent services.
Fixes also the usage of the proper ILuceneSearchQueryService in the Lucene module SearchController.