### PR TITLE
Contents should depend on ContentTypes, not the opposite

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Manifest.cs
@@ -6,6 +6,6 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "Allows to organize widgets in an Admin Dashboard.",
-    Dependencies = new[] { "OrchardCore.ContentTypes", "OrchardCore.Admin" },
+    Dependencies = new[] { "OrchardCore.Contents", "OrchardCore.Admin" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Manifest.cs
@@ -6,6 +6,6 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "The alias module enables content items to have custom logical identifier.",
-    Dependencies = new[] { "OrchardCore.ContentTypes" },
+    Dependencies = new[] { "OrchardCore.Contents" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Manifest.cs
@@ -5,6 +5,6 @@ using OrchardCore.Modules.Manifest;
     Author = ManifestConstants.OrchardCoreTeam,
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
-    Dependencies = new[] { "OrchardCore.ContentTypes" },
+    Dependencies = new[] { "OrchardCore.Contents" },
     Category = "Navigation"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Manifest.cs
@@ -13,7 +13,7 @@ using OrchardCore.Modules.Manifest;
     Name = "Content Fields",
     Category = "Content Management",
     Description = "Content Fields module adds common content fields to be used with your custom types.",
-    Dependencies = new[] { "OrchardCore.ContentTypes", "OrchardCore.Shortcodes" }
+    Dependencies = new[] { "OrchardCore.Contents", "OrchardCore.Shortcodes" }
 )]
 
 [assembly: Feature(

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Manifest.cs
@@ -13,7 +13,7 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.ContentLocalization",
     Name = "Content Localization",
     Description = "Provides a part that allows to localize content items.",
-    Dependencies = new[] { "OrchardCore.ContentTypes", "OrchardCore.Localization" },
+    Dependencies = new[] { "OrchardCore.Contents", "OrchardCore.Localization" },
     Category = "Internationalization"
 )]
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Manifest.cs
@@ -6,6 +6,5 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "Content Types modules enables the creation and alteration of content types not based on code.",
-    Dependencies = new[] { "OrchardCore.Contents" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Startup.cs
@@ -2,8 +2,11 @@ using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using OrchardCore.Admin;
+using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentTypes.Controllers;
 using OrchardCore.ContentTypes.Deployment;
 using OrchardCore.ContentTypes.Editors;
@@ -33,6 +36,8 @@ namespace OrchardCore.ContentTypes
         {
             services.AddScoped<IPermissionProvider, Permissions>();
             services.AddScoped<INavigationProvider, AdminMenu>();
+            services.TryAddScoped<IContentDefinitionManager, ContentDefinitionManager>();
+            services.TryAddScoped<IContentDefinitionStore, DatabaseContentDefinitionStore>();
             services.AddScoped<IContentDefinitionService, ContentDefinitionService>();
             services.AddScoped<IStereotypesProvider, DefaultStereotypesProvider>();
             services.AddScoped<IStereotypeService, StereotypeService>();

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Manifest.cs
@@ -13,6 +13,7 @@ using OrchardCore.Modules.Manifest;
     Description = "The contents module enables the edition and rendering of content items.",
     Dependencies = new[]
     {
+        "OrchardCore.ContentTypes",
         "OrchardCore.Settings",
         "OrchardCore.Liquid"
     },

--- a/src/OrchardCore.Modules/OrchardCore.Html/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Manifest.cs
@@ -6,6 +6,6 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "The Html module enables content items to have Html bodies.",
-    Dependencies = new[] { "OrchardCore.ContentTypes", "OrchardCore.Shortcodes" },
+    Dependencies = new[] { "OrchardCore.Contents", "OrchardCore.Shortcodes" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Manifest.cs
@@ -11,6 +11,6 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.Lists",
     Name = "Lists",
     Description = "Introduces a preconfigured container-enabled content type.",
-    Dependencies = new[] { "OrchardCore.ContentTypes" },
+    Dependencies = new[] { "OrchardCore.Contents" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Manifest.cs
@@ -6,6 +6,6 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "The markdown module enables content items to have markdown editors.",
-    Dependencies = new[] { "OrchardCore.ContentTypes", "OrchardCore.Shortcodes" },
+    Dependencies = new[] { "OrchardCore.Contents", "OrchardCore.Shortcodes" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Manifest.cs
@@ -11,7 +11,7 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.Media",
     Name = "Media",
     Description = "The media module adds media management support.",
-    Dependencies = new[] { "OrchardCore.ContentTypes" },
+    Dependencies = new[] { "OrchardCore.Contents" },
     Category = "Content Management"
 )]
 

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Manifest.cs
@@ -14,7 +14,7 @@ using OrchardCore.Modules.Manifest;
     Dependencies = new[]
     {
         "OrchardCore.Indexing",
-        "OrchardCore.ContentTypes"
+        "OrchardCore.Contents"
     },
     Category = "Search"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Manifest.cs
@@ -14,7 +14,7 @@ using OrchardCore.Modules.Manifest;
     Dependencies = new[]
     {
         "OrchardCore.Indexing",
-        "OrchardCore.ContentTypes"
+        "OrchardCore.Contents"
     },
     Category = "Search"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Spatial/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Spatial/Manifest.cs
@@ -6,6 +6,6 @@ using OrchardCore.Modules.Manifest;
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
     Description = "This feature provides the ability to provide spatial locations to content items.",
-    Dependencies = new[] { "OrchardCore.ContentTypes", "OrchardCore.Search.Lucene" },
+    Dependencies = new[] { "OrchardCore.Contents", "OrchardCore.Search.Lucene" },
     Category = "Content Management"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Manifest.cs
@@ -11,7 +11,7 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.Taxonomies",
     Name = "Taxonomies",
     Description = "The taxonomies module provides a way to categorize content items.",
-    Dependencies = new[] { "OrchardCore.ContentTypes" },
+    Dependencies = new[] { "OrchardCore.Contents" },
     Category = "Content Management"
 )]
 

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Manifest.cs
@@ -11,6 +11,6 @@ using OrchardCore.Modules.Manifest;
     Id = "OrchardCore.Widgets",
     Name = "Widgets",
     Description = "Provides a part allowing content items to render Widgets in theme zones.",
-    Dependencies = new[] { "OrchardCore.ContentTypes" },
+    Dependencies = new[] { "OrchardCore.Contents" },
     Category = "Content"
 )]

--- a/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using OrchardCore.ContentManagement.Cache;
 using OrchardCore.ContentManagement.Handlers;
-using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Records;
 using OrchardCore.Data.Migration;
 using OrchardCore.Environment.Cache;
@@ -15,8 +14,6 @@ namespace OrchardCore.ContentManagement
         public static IServiceCollection AddContentManagement(this IServiceCollection services)
         {
             services.AddScoped<ICacheContextProvider, ContentDefinitionCacheContextProvider>();
-            services.TryAddScoped<IContentDefinitionManager, ContentDefinitionManager>();
-            services.TryAddScoped<IContentDefinitionStore, DatabaseContentDefinitionStore>();
             services.TryAddScoped<IContentManager, DefaultContentManager>();
             services.TryAddScoped<IContentManagerSession, DefaultContentManagerSession>();
             services.AddSingleton<IIndexProvider, ContentItemIndexProvider>();


### PR DESCRIPTION
Fixes #12617.

First related to #12566 where we discussed about ordering recipe steps, I was suggesting to use as a 1st default the inner dependencies ordering, so the order in which recipe handlers are registered. But currently `OC.ContentTypes`depends on `OC.Contents` whereas whereas contents needs types definitions.

My 1st feeling was that `OC.Contents` should depend on `OC.ContentTypes`, not the opposite.

- Then I saw that this is `OC.Contents` that registers `ContentDefinitionManager` by calling `AddContentManagement()`, so I moved this registration in the `OC.ContentTypes` startup.

- Then in the manifest of `OC.ContentTypes` I removed the dependency on `OC.Contents`, and in the manifest of `OC.Contents` I added the dependency on `OC.ContentTypes`.

- Then I tried the Saas recipe to see if it still works by only enabling `OC.ContentTypes` that doesn't depend anymore on `OC.Contents`, then by only enabling `OC.Contents` which now depends on `OC.ContentTypes`.

- Finally I updated the other manifests having a dependency on `OC.ContentTypes` to now have a dependency on `OC.Contents` (that now depends on `OC.ContentTypes`).

- **Updated**: Then in the `OC.ContentTypes` project file I was able to remove the references to content management projects, unless `ContentManagement.GraphQL`, will see why tomorrow.
