### PR TITLE
SqlParser & SqlGrammar CTE support

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlGrammar.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlGrammar.cs
@@ -31,14 +31,18 @@ namespace OrchardCore.Queries.Sql
             var OVER = ToTerm("OVER");
             var UNION = ToTerm("UNION");
             var ALL = ToTerm("ALL");
+            var WITH = ToTerm("WITH");
+            var CTE = TerminalFactory.CreateSqlExtIdentifier(this, "CTE");
+            var ColumnAlias = TerminalFactory.CreateSqlExtIdentifier(this, "ColumnAlias");
+            var TableAlias = TerminalFactory.CreateSqlExtIdentifier(this, "TableAlias");
 
             //Non-terminals
             var Id = new NonTerminal("Id");
             var statement = new NonTerminal("stmt");
             var selectStatement = new NonTerminal("selectStatement");
             var idlist = new NonTerminal("idlist");
-            var aliaslist = new NonTerminal("aliaslist");
-            var aliasItem = new NonTerminal("aliasItem");
+            var tableAliasList = new NonTerminal("tableAliasList");
+            var tableAliasItem = new NonTerminal("tableAliasItem");
             var orderList = new NonTerminal("orderList");
             var orderMember = new NonTerminal("orderMember");
             var orderDirOptional = new NonTerminal("orderDirOpt");
@@ -57,7 +61,7 @@ namespace OrchardCore.Queries.Sql
             var columnItem = new NonTerminal("columnItem");
             var columnSource = new NonTerminal("columnSource");
             var asOpt = new NonTerminal("asOpt");
-            var aliasOpt = new NonTerminal("aliasOpt");
+            var tableAliasOpt = new NonTerminal("tableAliasOpt");
             var tuple = new NonTerminal("tuple");
             var joinChainOpt = new NonTerminal("joinChainOpt");
             var joinStatement = new NonTerminal("joinStatement");
@@ -88,6 +92,14 @@ namespace OrchardCore.Queries.Sql
             var unionStatementList = new NonTerminal("unionStmtList");
             var unionStatement = new NonTerminal("unionStmt");
             var unionClauseOpt = new NonTerminal("unionClauseOpt");
+            var withClauseOpt = new NonTerminal("withClauseOpt");
+            var cteList = new NonTerminal("cteList");
+            var cte = new NonTerminal("cte");
+            var cteColumnListOpt = new NonTerminal("cteColumnListOpt");
+            var columnNames = new NonTerminal("columnNames");
+            var IdColumn = new NonTerminal("IdColumn");
+            var columnAliasOpt = new NonTerminal("columnAliasOpt");
+            var IdTable = new NonTerminal("IdTable");
 
             //BNF Rules
             this.Root = statementList;
@@ -99,17 +111,27 @@ namespace OrchardCore.Queries.Sql
             optionalSemicolon.Rule = Empty | ";";
             statementList.Rule = MakePlusRule(statementList, statementLine);
 
-            statement.Rule = selectStatement;
+            columnNames.Rule = MakePlusRule(columnNames, comma, Id_simple);
+            cteColumnListOpt.Rule = Empty | "(" + columnNames + ")";
+            cte.Rule = CTE + cteColumnListOpt + AS + "(" + unionStatementList + ")";
+            cteList.Rule = MakePlusRule(cteList, comma, cte);
+            withClauseOpt.Rule = Empty | WITH + cteList;
+
+            statement.Rule = withClauseOpt + selectStatement;
 
             Id.Rule = MakePlusRule(Id, dot, Id_simple);
+            IdTable.Rule = MakePlusRule(IdTable, dot, TableAlias);
 
-            aliasOpt.Rule = Empty | asOpt + Id;
+            tableAliasOpt.Rule = Empty | asOpt + IdTable;
+            IdColumn.Rule = MakePlusRule(IdColumn, dot, ColumnAlias);
+            columnAliasOpt.Rule = Empty | asOpt + IdColumn;
+
             asOpt.Rule = Empty | AS;
 
             idlist.Rule = MakePlusRule(idlist, comma, columnSource);
 
-            aliaslist.Rule = MakePlusRule(aliaslist, comma, aliasItem);
-            aliasItem.Rule = Id + aliasOpt;
+            tableAliasList.Rule = MakePlusRule(tableAliasList, comma, tableAliasItem);
+            tableAliasItem.Rule = Id + tableAliasOpt;
 
             //Create Index
             orderList.Rule = MakePlusRule(orderList, comma, orderMember);
@@ -122,13 +144,13 @@ namespace OrchardCore.Queries.Sql
             optionalSelectRestriction.Rule = Empty | "ALL" | "DISTINCT";
             selectorList.Rule = columnItemList | "*";
             columnItemList.Rule = MakePlusRule(columnItemList, comma, columnItem);
-            columnItem.Rule = columnSource + aliasOpt;
+            columnItem.Rule = columnSource + columnAliasOpt;
 
             columnSource.Rule = funCall + overClauseOpt | Id;
-            fromClauseOpt.Rule = Empty | FROM + aliaslist + joinChainOpt;
+            fromClauseOpt.Rule = Empty | FROM + tableAliasList + joinChainOpt;
 
             joinChainOpt.Rule = MakeStarRule(joinChainOpt, joinStatement);
-            joinStatement.Rule = joinKindOpt + JOIN + aliaslist + ON + joinConditions;
+            joinStatement.Rule = joinKindOpt + JOIN + tableAliasList + ON + joinConditions;
             joinConditions.Rule = MakePlusRule(joinConditions, AND, joinCondition);
             joinCondition.Rule = joinConditionArgument + "=" + joinConditionArgument;
             joinConditionArgument.Rule = Id | boolean | string_literal | number | parameter;
@@ -183,7 +205,7 @@ namespace OrchardCore.Queries.Sql
             // Transient non-terminals cannot have more than one non-punctuation child nodes.
             // Instead, we set flag InheritPrecedence on binOp , so that it inherits precedence value from it's children, and this precedence is used
             // in conflict resolution when binOp node is sitting on the stack
-            base.MarkTransient(statement, term, asOpt, aliasOpt, statementLine, expression, unOp, tuple);
+            base.MarkTransient(term, asOpt, tableAliasOpt, columnAliasOpt, statementLine, expression, unOp, tuple);
             binOp.SetFlag(TermFlags.InheritPrecedence);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlParser.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlParser.cs
@@ -808,55 +808,54 @@ namespace OrchardCore.Queries.Sql
 
         private string EvaluateCteStatement(ParseTreeNode cteStatement)
         {
-            var builder = new StringBuilder();
-            builder.Append("WITH ");
+            _builder.Append("WITH ");
             for (var i = 0; i < cteStatement.ChildNodes[1].ChildNodes.Count; i++)
             {
                 var cte = cteStatement.ChildNodes[1].ChildNodes[i];
                 if (i > 0)
                 {
-                    builder.Append(", ");
+                    _builder.Append(", ");
                 }
                 
                 var expressionName = cte.ChildNodes[0].Token.ValueString;
                 var optionalColumns = cte.ChildNodes[1];
-                builder.Append(expressionName);
+                _builder.Append(expressionName);
                 if (optionalColumns.ChildNodes.Count > 0)
                 {
                     var columns = optionalColumns.ChildNodes[0].ChildNodes;
-                    builder.Append("(");
+                    _builder.Append("(");
                     for (var j = 0; j < columns.Count; j++)
                     {
                         if (j > 0)
                         {
-                            builder.Append(", ");
+                            _builder.Append(", ");
                         }
-                        builder.Append(columns[j].Token.ValueString);
+                        _builder.Append(columns[j].Token.ValueString);
                     }
-                    builder.Append(")");
+                    _builder.Append(")");
                 }
-                builder.Append(" AS (");
+                _builder.Append(" AS (");
                 foreach (var unionStatement in cte.ChildNodes[3].ChildNodes)
                 {
                     var statement = unionStatement.ChildNodes[0];
                     var selectStatement = statement.ChildNodes[1];
                     var unionClauseOpt = unionStatement.ChildNodes[1];
-                    builder.Append(EvaluateSelectStatement(selectStatement));
+                    _builder.Append(EvaluateSelectStatement(selectStatement));
 
                     for (var k = 0; k < unionClauseOpt.ChildNodes.Count; k++)
                     {
                         if (k == 0)
                         {
-                            builder.Append(" ");
+                            _builder.Append(" ");
                         }
                         var term = unionClauseOpt.ChildNodes[k].Term;
-                        builder.Append(term).Append(" ");
+                        _builder.Append(term).Append(" ");
                     }
                 }
-                builder.Append(")");
+                _builder.Append(")");
             }
-            builder.Append(" ");
-            return builder.ToString();
+            _builder.Append(" ");
+            return _builder.ToString();
         }
 
         private enum FormattingModes

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlParser.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlParser.cs
@@ -15,7 +15,8 @@ namespace OrchardCore.Queries.Sql
         private IDictionary<string, object> _parameters;
         private ISqlDialect _dialect;
         private string _tablePrefix;
-        private HashSet<string> _aliases;
+        private HashSet<string> _tableAliases;
+        private HashSet<string> _ctes;
         private ParseTree _tree;
         private static LanguageData language = new LanguageData(new SqlGrammar());
         private Stack<FormattingModes> _modes;
@@ -87,6 +88,7 @@ namespace OrchardCore.Queries.Sql
         private string Evaluate()
         {
             PopulateAliases(_tree);
+            PopulateCteNames(_tree);
             var statementList = _tree.Root;
 
             var statementsBuilder = new StringBuilder();
@@ -95,8 +97,14 @@ namespace OrchardCore.Queries.Sql
             {
                 foreach (var unionStatement in unionStatementList.ChildNodes)
                 {
-                    var selectStatement = unionStatement.ChildNodes[0];
+                    var statement = unionStatement.ChildNodes[0];
+                    var cte = statement.ChildNodes[0];
+                    var selectStatement = statement.ChildNodes[1];
                     var unionClauseOpt = unionStatement.ChildNodes[1];
+                    if (cte.ChildNodes.Count > 0)
+                    {
+                        statementsBuilder.Append(EvaluateCteStatement(cte));
+                    }
                     statementsBuilder.Append(EvaluateSelectStatement(selectStatement));
 
                     for (var i = 0; i < unionClauseOpt.ChildNodes.Count; i++)
@@ -109,8 +117,8 @@ namespace OrchardCore.Queries.Sql
                         statementsBuilder.Append(term).Append(" ");
                     }
                 }
-                statementsBuilder.Append(';');
             }
+            statementsBuilder.Append(';');
 
             return statementsBuilder.ToString();
         }
@@ -120,13 +128,26 @@ namespace OrchardCore.Queries.Sql
             // In order to determine if an Id is a table name or an alias, we
             // analyze every Alias and store the value.
 
-            _aliases = new HashSet<string>();
+            _tableAliases = new HashSet<string>();
 
             for (var i = 0; i < tree.Tokens.Count; i++)
             {
-                if (tree.Tokens[i].Terminal.Name == "AS")
+                if (tree.Tokens[i].Terminal.Name == "TableAlias")
                 {
-                    _aliases.Add(tree.Tokens[i + 1].ValueString);
+                    _tableAliases.Add(tree.Tokens[i].ValueString);
+                }
+            }
+        }
+
+        private void PopulateCteNames(ParseTree tree)
+        {
+            _ctes = new HashSet<string>();
+
+            for (var i = 0; i < tree.Tokens.Count; i++)
+            {
+                if (tree.Tokens[i].Terminal.Name == "CTE")
+                {
+                    _ctes.Add(tree.Tokens[i].ValueString);
                 }
             }
         }
@@ -663,7 +684,7 @@ namespace OrchardCore.Queries.Sql
         {
             for (var i = 0; i < id.ChildNodes.Count; i++)
             {
-                if (i == 0 && id.ChildNodes.Count > 1 && !_aliases.Contains(id.ChildNodes[i].Token.ValueString))
+                if (i == 0 && id.ChildNodes.Count > 1 && !_tableAliases.Contains(id.ChildNodes[i].Token.ValueString))
                 {
                     _builder.Append(_dialect.QuoteForTableName(_tablePrefix + id.ChildNodes[i].Token.ValueString, _schema));
                 }
@@ -674,7 +695,7 @@ namespace OrchardCore.Queries.Sql
                         _builder.Append(".");
                     }
 
-                    if (_aliases.Contains(id.ChildNodes[i].Token.ValueString))
+                    if (_tableAliases.Contains(id.ChildNodes[i].Token.ValueString))
                     {
                         _builder.Append(id.ChildNodes[i].Token.ValueString);
                     }
@@ -690,7 +711,7 @@ namespace OrchardCore.Queries.Sql
         {
             for (var i = 0; i < id.ChildNodes.Count; i++)
             {
-                if (i == 0 && !_aliases.Contains(id.ChildNodes[i].Token.ValueString))
+                if (i == 0 && !_tableAliases.Contains(id.ChildNodes[i].Token.ValueString) && !_ctes.Contains(id.ChildNodes[i].Token.ValueString))
                 {
                     _builder.Append(_dialect.QuoteForTableName(_tablePrefix + id.ChildNodes[i].Token.ValueString, _schema));
                 }
@@ -783,6 +804,59 @@ namespace OrchardCore.Queries.Sql
             }
 
             _builder.Append(")");
+        }
+
+        private string EvaluateCteStatement(ParseTreeNode cteStatement)
+        {
+            var builder = new StringBuilder();
+            builder.Append("WITH ");
+            for (var i = 0; i < cteStatement.ChildNodes[1].ChildNodes.Count; i++)
+            {
+                var cte = cteStatement.ChildNodes[1].ChildNodes[i];
+                if (i > 0)
+                {
+                    builder.Append(", ");
+                }
+                
+                var expressionName = cte.ChildNodes[0].Token.ValueString;
+                var optionalColumns = cte.ChildNodes[1];
+                builder.Append(expressionName);
+                if (optionalColumns.ChildNodes.Count > 0)
+                {
+                    var columns = optionalColumns.ChildNodes[0].ChildNodes;
+                    builder.Append("(");
+                    for (var j = 0; j < columns.Count; j++)
+                    {
+                        if (j > 0)
+                        {
+                            builder.Append(", ");
+                        }
+                        builder.Append(columns[j].Token.ValueString);
+                    }
+                    builder.Append(")");
+                }
+                builder.Append(" AS (");
+                foreach (var unionStatement in cte.ChildNodes[3].ChildNodes)
+                {
+                    var statement = unionStatement.ChildNodes[0];
+                    var selectStatement = statement.ChildNodes[1];
+                    var unionClauseOpt = unionStatement.ChildNodes[1];
+                    builder.Append(EvaluateSelectStatement(selectStatement));
+
+                    for (var k = 0; k < unionClauseOpt.ChildNodes.Count; k++)
+                    {
+                        if (k == 0)
+                        {
+                            builder.Append(" ");
+                        }
+                        var term = unionClauseOpt.ChildNodes[k].Term;
+                        builder.Append(term).Append(" ");
+                    }
+                }
+                builder.Append(")");
+            }
+            builder.Append(" ");
+            return builder.ToString();
         }
 
         private enum FormattingModes

--- a/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
@@ -220,5 +220,18 @@ namespace OrchardCore.Tests.OrchardCore.Queries
             Assert.True(result);
             Assert.Equal(expectedSql, FormatSql(rawQuery));
         }
+
+        [Theory]
+        [InlineData("with cte as (select a from t) select * from cte", "WITH cte AS (SELECT [a] FROM [tp_t]) SELECT * FROM [cte];")]
+        [InlineData("with cte as (select a from t), cte2 as (select b from t) select * from cte2", "WITH cte AS (SELECT [a] FROM [tp_t]), cte2 AS (SELECT [b] FROM [tp_t]) SELECT * FROM [cte2];")]
+        [InlineData("with cte as (select a from t union all select b from t) select * from cte", "WITH cte AS (SELECT [a] FROM [tp_t] UNION ALL SELECT [b] FROM [tp_t]) SELECT * FROM [cte];")]
+        [InlineData("with cte1(abc, def) as (select id as abc, id as def from t), cte2(ghi,jkl) as (select abc as ghi, def as jkl from cte1) select ghi, jkl from cte2", "WITH cte1(abc, def) AS (SELECT [id] AS abc, [id] AS def FROM [tp_t]), cte2(ghi, jkl) AS (SELECT [abc] AS ghi, [def] AS jkl FROM [cte1]) SELECT [ghi], [jkl] FROM [cte2];")]
+        [InlineData("with test(test) as (select a as test from t) select test from test", "WITH test(test) AS (SELECT [a] AS test FROM [tp_t]) SELECT [test] FROM [test];")]
+        public void ShouldParseCte(string sql, string expectedSql)
+        {
+            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
     }
 }

--- a/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
@@ -229,7 +229,7 @@ namespace OrchardCore.Tests.OrchardCore.Queries
         [InlineData("with test(test) as (select a as test from t) select test from test", "WITH test(test) AS (SELECT [a] AS test FROM [tp_t]) SELECT [test] FROM [test];")]
         public void ShouldParseCte(string sql, string expectedSql)
         {
-            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
+            var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
             Assert.True(result);
             Assert.Equal(expectedSql, FormatSql(rawQuery));
         }


### PR DESCRIPTION
fixes #12446

example sql query, which is now valid:
```
with 
  cte1(abc, def) as (
    select id as abc, id as def from s
    union all
    select id as abc, id as def from t
  ), 
  cte2(ghi,jkl) as (
    select abc as ghi, def as jkl from cte1
  )
select ghi, jkl from cte2;
```

/cc @sebastienros 