### PR TITLE
SqlParser & SqlGrammar subquery support

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlGrammar.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlGrammar.cs
@@ -100,6 +100,9 @@ namespace OrchardCore.Queries.Sql
             var IdColumn = new NonTerminal("IdColumn");
             var columnAliasOpt = new NonTerminal("columnAliasOpt");
             var IdTable = new NonTerminal("IdTable");
+            var subQuery = new NonTerminal("subQuery");
+            var tableAliasItemOrSubQuery = new NonTerminal("tableAliasItemOrSubQuery");
+            var tableAliasOrSubQueryList = new NonTerminal("tableAliasOrSubQueryList");
 
             //BNF Rules
             this.Root = statementList;
@@ -133,6 +136,10 @@ namespace OrchardCore.Queries.Sql
             tableAliasList.Rule = MakePlusRule(tableAliasList, comma, tableAliasItem);
             tableAliasItem.Rule = Id + tableAliasOpt;
 
+            subQuery.Rule = "(" + unionStatementList + ")" + AS + TableAlias;
+            tableAliasOrSubQueryList.Rule = MakePlusRule(tableAliasOrSubQueryList, comma, tableAliasItemOrSubQuery);
+            tableAliasItemOrSubQuery.Rule = tableAliasItem | subQuery;
+
             //Create Index
             orderList.Rule = MakePlusRule(orderList, comma, orderMember);
             orderMember.Rule = Id + orderDirOptional;
@@ -147,7 +154,7 @@ namespace OrchardCore.Queries.Sql
             columnItem.Rule = columnSource + columnAliasOpt;
 
             columnSource.Rule = funCall + overClauseOpt | Id;
-            fromClauseOpt.Rule = Empty | FROM + tableAliasList + joinChainOpt;
+            fromClauseOpt.Rule = Empty | FROM + tableAliasOrSubQueryList + joinChainOpt;
 
             joinChainOpt.Rule = MakeStarRule(joinChainOpt, joinStatement);
             joinStatement.Rule = joinKindOpt + JOIN + tableAliasList + ON + joinConditions;
@@ -205,7 +212,7 @@ namespace OrchardCore.Queries.Sql
             // Transient non-terminals cannot have more than one non-punctuation child nodes.
             // Instead, we set flag InheritPrecedence on binOp , so that it inherits precedence value from it's children, and this precedence is used
             // in conflict resolution when binOp node is sitting on the stack
-            base.MarkTransient(term, asOpt, tableAliasOpt, columnAliasOpt, statementLine, expression, unOp, tuple);
+            base.MarkTransient(tableAliasItemOrSubQuery, term, asOpt, tableAliasOpt, columnAliasOpt, statementLine, expression, unOp, tuple);
             binOp.SetFlag(TermFlags.InheritPrecedence);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlParser.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SqlParser.cs
@@ -808,55 +808,54 @@ namespace OrchardCore.Queries.Sql
 
         private string EvaluateCteStatement(ParseTreeNode cteStatement)
         {
-            var builder = new StringBuilder();
-            builder.Append("WITH ");
+            _builder.Append("WITH ");
             for (var i = 0; i < cteStatement.ChildNodes[1].ChildNodes.Count; i++)
             {
                 var cte = cteStatement.ChildNodes[1].ChildNodes[i];
                 if (i > 0)
                 {
-                    builder.Append(", ");
+                    _builder.Append(", ");
                 }
                 
                 var expressionName = cte.ChildNodes[0].Token.ValueString;
                 var optionalColumns = cte.ChildNodes[1];
-                builder.Append(expressionName);
+                _builder.Append(expressionName);
                 if (optionalColumns.ChildNodes.Count > 0)
                 {
                     var columns = optionalColumns.ChildNodes[0].ChildNodes;
-                    builder.Append("(");
+                    _builder.Append("(");
                     for (var j = 0; j < columns.Count; j++)
                     {
                         if (j > 0)
                         {
-                            builder.Append(", ");
+                            _builder.Append(", ");
                         }
-                        builder.Append(columns[j].Token.ValueString);
+                        _builder.Append(columns[j].Token.ValueString);
                     }
-                    builder.Append(")");
+                    _builder.Append(")");
                 }
-                builder.Append(" AS (");
+                _builder.Append(" AS (");
                 foreach (var unionStatement in cte.ChildNodes[3].ChildNodes)
                 {
                     var statement = unionStatement.ChildNodes[0];
                     var selectStatement = statement.ChildNodes[1];
                     var unionClauseOpt = unionStatement.ChildNodes[1];
-                    builder.Append(EvaluateSelectStatement(selectStatement));
+                    _builder.Append(EvaluateSelectStatement(selectStatement));
 
                     for (var k = 0; k < unionClauseOpt.ChildNodes.Count; k++)
                     {
                         if (k == 0)
                         {
-                            builder.Append(" ");
+                            _builder.Append(" ");
                         }
                         var term = unionClauseOpt.ChildNodes[k].Term;
-                        builder.Append(term).Append(" ");
+                        _builder.Append(term).Append(" ");
                     }
                 }
-                builder.Append(")");
+                _builder.Append(")");
             }
-            builder.Append(" ");
-            return builder.ToString();
+            _builder.Append(" ");
+            return _builder.ToString();
         }
 
         private enum FormattingModes

--- a/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
@@ -233,5 +233,20 @@ namespace OrchardCore.Tests.OrchardCore.Queries
             Assert.True(result);
             Assert.Equal(expectedSql, FormatSql(rawQuery));
         }
+
+        [Theory]
+        [InlineData("select * from (select * from t) as b", "SELECT * FROM (SELECT * FROM [tp_t]) AS b;")]
+        [InlineData("select b.a from (select a from t) as b where b.a = b.a", "SELECT b.[a] FROM (SELECT [a] FROM [tp_t]) AS b WHERE b.[a] = b.[a];")]
+        [InlineData("select c.b from (select a as b from t) as c", "SELECT c.[b] FROM (SELECT [a] AS b FROM [tp_t]) AS c;")]
+        [InlineData("select b.a from (select a from t where [a] = 1) as b where b.a = 1", "SELECT b.[a] FROM (SELECT [a] FROM [tp_t] WHERE [a] = 1) AS b WHERE b.[a] = 1;")]
+        [InlineData("select b.a from (select a from t where [a] = 1 union all select a from t where [a] = 2) as b", "SELECT b.[a] FROM (SELECT [a] FROM [tp_t] WHERE [a] = 1 UNION ALL SELECT [a] FROM [tp_t] WHERE [a] = 2) AS b;")]
+        [InlineData("select d.b, g.b from (select a as b from c) as d, (select e as b from f) as g", "SELECT d.[b], g.[b] FROM (SELECT [a] AS b FROM [tp_c]) AS d, (SELECT [e] AS b FROM [tp_f]) AS g;")]
+        [InlineData("select * from (select d as e from (select c as d from (select b as c from (select a as b from t) as l4) as l3) as l2) as l1", "SELECT * FROM (SELECT [d] AS e FROM (SELECT [c] AS d FROM (SELECT [b] AS c FROM (SELECT [a] AS b FROM [tp_t]) AS l4) AS l3) AS l2) AS l1;")]
+        public void ShouldParseSubquery(string sql, string expectedSql)
+        {
+            var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
+            Assert.True(result);
+            Assert.Equal(expectedSql, FormatSql(rawQuery));
+        }
     }
 }

--- a/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
+++ b/test/OrchardCore.Tests/Orchard.Queries/SqlParserTests.cs
@@ -229,7 +229,7 @@ namespace OrchardCore.Tests.OrchardCore.Queries
         [InlineData("with test(test) as (select a as test from t) select test from test", "WITH test(test) AS (SELECT [a] AS test FROM [tp_t]) SELECT [test] FROM [test];")]
         public void ShouldParseCte(string sql, string expectedSql)
         {
-            var result = SqlParser.TryParse(sql, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
+            var result = SqlParser.TryParse(sql, _schema, _defaultDialect, _defaultTablePrefix, null, out var rawQuery, out var messages);
             Assert.True(result);
             Assert.Equal(expectedSql, FormatSql(rawQuery));
         }


### PR DESCRIPTION
fixes #11785

example query:

```
select * from (
    select d as e from (
        select c as d from (
            select b as c from (
                select a as b from t
            ) as l4
        ) as l3
    ) as l2
) as l1;
```

(this PR also includes changes from #12637 CTE support)

/cc @sebastienros 