### PR TITLE
Use YesSql Named Options based on tenant names

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -88,7 +88,8 @@
     //"OrchardCore_Shells_Database": {
     //  "DatabaseProvider": "SqlConnection", // Set to a supported database provider.
     //  "ConnectionString": "", // Set to the database connection string.
-    //  "TablePrefix": "", // Optionally, configure a table prefix.
+    //  "TablePrefix": "", // Optionally, configure the database table prefix.
+    //  "Schema": "", // Optionally, configure the database schema.
     //  "MigrateFromFiles": true // Optionally, enable to migrate existing App_Data files to Database automatically.
     //},
     // By default background tasks are waiting for their shell to be lazily built on a first matching request.

--- a/src/OrchardCore.Modules/OrchardCore.AutoSetup/AutoSetupMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AutoSetup/AutoSetupMiddleware.cs
@@ -214,6 +214,7 @@ namespace OrchardCore.AutoSetup
 
             shellSettings["ConnectionString"] = setupOptions.DatabaseConnectionString;
             shellSettings["TablePrefix"] = setupOptions.DatabaseTablePrefix;
+            shellSettings["Schema"] = setupOptions.DatabaseSchema;
             shellSettings["DatabaseProvider"] = setupOptions.DatabaseProvider;
             shellSettings["Secret"] = Guid.NewGuid().ToString();
             shellSettings["RecipeName"] = setupOptions.RecipeName;
@@ -250,6 +251,7 @@ namespace OrchardCore.AutoSetup
             setupContext.Properties[SetupConstants.DatabaseConnectionString] = options.DatabaseConnectionString;
             setupContext.Properties[SetupConstants.DatabaseProvider] = options.DatabaseProvider;
             setupContext.Properties[SetupConstants.DatabaseTablePrefix] = options.DatabaseTablePrefix;
+            setupContext.Properties[SetupConstants.DatabaseSchema] = options.DatabaseSchema;
             setupContext.Properties[SetupConstants.SiteName] = options.SiteName;
             setupContext.Properties[SetupConstants.SiteTimeZone] = options.SiteTimeZone;
 

--- a/src/OrchardCore.Modules/OrchardCore.AutoSetup/Options/TenantSetupOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AutoSetup/Options/TenantSetupOptions.cs
@@ -56,6 +56,11 @@ namespace OrchardCore.AutoSetup.Options
         public string DatabaseTablePrefix { get; set; }
 
         /// <summary>
+        /// Gets or sets the database schema.
+        /// </summary>
+        public string DatabaseSchema { get; set; }
+
+        /// <summary>
         /// Gets or sets the recipe name.
         /// </summary>
         public string RecipeName { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -91,7 +91,7 @@ namespace OrchardCore.Tenants.Services
                     }
                 }
 
-                await AssertConnectionValidityAndApplyErrorsAsync(model.DatabaseProvider, model.ConnectionString, model.TablePrefix, errors, model.Name);
+                await AssertConnectionValidityAndApplyErrorsAsync(model.DatabaseProvider, model.ConnectionString, model.TablePrefix, schema: null, errors, model.Name);
             }
             else
             {
@@ -100,16 +100,16 @@ namespace OrchardCore.Tenants.Services
                     // While the tenant is in Uninitialized state, we still are able to change the database settings.
                     // Let's validate the database for assurance.
 
-                    await AssertConnectionValidityAndApplyErrorsAsync(model.DatabaseProvider, model.ConnectionString, model.TablePrefix, errors, model.Name);
+                    await AssertConnectionValidityAndApplyErrorsAsync(model.DatabaseProvider, model.ConnectionString, model.TablePrefix, schema: null, errors, model.Name);
                 }
             }
 
             return errors;
         }
 
-        private async Task AssertConnectionValidityAndApplyErrorsAsync(string databaseProvider, string connectionString, string tablePrefix, List<ModelError> errors, string shellName)
+        private async Task AssertConnectionValidityAndApplyErrorsAsync(string databaseProvider, string connectionString, string tablePrefix, string schema, List<ModelError> errors, string shellName)
         {
-            switch (await _dbConnectionValidator.ValidateAsync(databaseProvider, connectionString, tablePrefix, shellName))
+            switch (await _dbConnectionValidator.ValidateAsync(databaseProvider, connectionString, tablePrefix, schema, shellName))
             {
                 case DbConnectionValidatorResult.UnsupportedProvider:
                     errors.Add(new ModelError(nameof(TenantViewModel.DatabaseProvider), S["The provided database provider is not supported."]));

--- a/src/OrchardCore/OrchardCore.Abstractions/Setup/SetupConstants.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Setup/SetupConstants.cs
@@ -10,6 +10,7 @@ namespace OrchardCore.Abstractions.Setup
         public const string DatabaseProvider = "DatabaseProvider";
         public const string DatabaseConnectionString = "DatabaseConnectionString";
         public const string DatabaseTablePrefix = "DatabaseTablePrefix";
+        public const string DatabaseSchema = "DatabaseSchema";
         public const string SiteTimeZone = "SiteTimeZone";
     }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/IDbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/IDbConnectionValidator.cs
@@ -4,5 +4,5 @@ namespace OrchardCore.Data;
 
 public interface IDbConnectionValidator
 {
-    Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, string shellName);
+    Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, string schema, string shellName);
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/YesSqlOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/YesSqlOptions.cs
@@ -19,4 +19,6 @@ public class YesSqlOptions
     public IContentSerializer ContentSerializer { get; set; }
 
     public string TablePrefixSeparator { get; set; } = "_";
+
+    public IdentityColumnSize IdentityColumnSize { get; set; } = IdentityColumnSize.Int32;
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -26,13 +26,13 @@ public class DbConnectionValidator : IDbConnectionValidator
     private static readonly string _shellDescriptorTypeColumnValue = new TypeService()[typeof(ShellDescriptor)];
 
     private readonly IEnumerable<DatabaseProvider> _databaseProviders;
-    private readonly IOptionsSnapshot<YesSqlOptions> _yesSqlOptions;
+    private readonly IOptionsMonitor<YesSqlOptions> _yesSqlOptions;
     private readonly SqliteOptions _sqliteOptions;
     private readonly ShellOptions _shellOptions;
 
     public DbConnectionValidator(
         IEnumerable<DatabaseProvider> databaseProviders,
-        IOptionsSnapshot<YesSqlOptions> yesSqlOptions,
+        IOptionsMonitor<YesSqlOptions> yesSqlOptions,
         IOptions<SqliteOptions> sqliteOptions,
         IOptions<ShellOptions> shellOptions)
     {

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -44,8 +44,6 @@ public class DbConnectionValidator : IDbConnectionValidator
 
     public async Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, string schema, string shellName)
     {
-        var yesSqlOptions = _yesSqlOptions.Get(shellName);
-
         if (String.IsNullOrWhiteSpace(databaseProvider))
         {
             return DbConnectionValidatorResult.NoProvider;
@@ -89,6 +87,8 @@ public class DbConnectionValidator : IDbConnectionValidator
 
             return DbConnectionValidatorResult.DocumentTableNotFound;
         }
+
+        var yesSqlOptions = _yesSqlOptions.Get(shellName);
 
         var selectBuilder = GetSelectBuilderForDocumentTable(tablePrefix, schema, databaseProvider, yesSqlOptions);
         try

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -42,7 +42,7 @@ public class DbConnectionValidator : IDbConnectionValidator
         _shellOptions = shellOptions.Value;
     }
 
-    public async Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, string shellName)
+    public async Task<DbConnectionValidatorResult> ValidateAsync(string databaseProvider, string connectionString, string tablePrefix, string schema, string shellName)
     {
         var yesSqlOptions = _yesSqlOptions.Get(shellName);
 
@@ -90,7 +90,7 @@ public class DbConnectionValidator : IDbConnectionValidator
             return DbConnectionValidatorResult.DocumentTableNotFound;
         }
 
-        var selectBuilder = GetSelectBuilderForDocumentTable(tablePrefix, databaseProvider, yesSqlOptions);
+        var selectBuilder = GetSelectBuilderForDocumentTable(tablePrefix, schema, databaseProvider, yesSqlOptions);
         try
         {
             var selectCommand = connection.CreateCommand();
@@ -120,7 +120,7 @@ public class DbConnectionValidator : IDbConnectionValidator
             return DbConnectionValidatorResult.DocumentTableNotFound;
         }
 
-        selectBuilder = GetSelectBuilderForShellDescriptorDocument(tablePrefix, databaseProvider, yesSqlOptions);
+        selectBuilder = GetSelectBuilderForShellDescriptorDocument(tablePrefix, schema, databaseProvider, yesSqlOptions);
         try
         {
             var selectCommand = connection.CreateCommand();
@@ -141,25 +141,25 @@ public class DbConnectionValidator : IDbConnectionValidator
         return DbConnectionValidatorResult.DocumentTableFound;
     }
 
-    private static ISqlBuilder GetSelectBuilderForDocumentTable(string tablePrefix, string databaseProvider, YesSqlOptions yesSqlOptions)
+    private static ISqlBuilder GetSelectBuilderForDocumentTable(string tablePrefix, string schema, string databaseProvider, YesSqlOptions yesSqlOptions)
     {
         var selectBuilder = GetSqlBuilder(databaseProvider, tablePrefix, yesSqlOptions);
 
         selectBuilder.Select();
         selectBuilder.Selector("*");
-        selectBuilder.Table(yesSqlOptions.TableNameConvention.GetDocumentTable(), alias: null, schema: null);
+        selectBuilder.Table(yesSqlOptions.TableNameConvention.GetDocumentTable(), alias: null, schema);
         selectBuilder.Take("1");
 
         return selectBuilder;
     }
 
-    private static ISqlBuilder GetSelectBuilderForShellDescriptorDocument(string tablePrefix, string databaseProvider, YesSqlOptions yesSqlOptions)
+    private static ISqlBuilder GetSelectBuilderForShellDescriptorDocument(string tablePrefix, string schema, string databaseProvider, YesSqlOptions yesSqlOptions)
     {
         var selectBuilder = GetSqlBuilder(databaseProvider, tablePrefix, yesSqlOptions);
 
         selectBuilder.Select();
         selectBuilder.Selector("*");
-        selectBuilder.Table(yesSqlOptions.TableNameConvention.GetDocumentTable(), alias: null, schema: null);
+        selectBuilder.Table(yesSqlOptions.TableNameConvention.GetDocumentTable(), alias: null, schema);
         selectBuilder.WhereAnd($"Type = '{_shellDescriptorTypeColumnValue}'");
         selectBuilder.Take("1");
 

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptions.cs
@@ -14,6 +14,6 @@ namespace OrchardCore.Data
         /// <para>There may be a performance penalty associated with disabling connection pooling.</para>
         /// <see href="https://docs.microsoft.com/en-us/dotnet/standard/data/sqlite/connection-strings#pooling" />
         /// </summary>
-        public bool UseConnectionPooling { get; set; }
+        public bool UseConnectionPooling { get; set; } = true;
     }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Options/YesSqlOptionsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Options/YesSqlOptionsConfiguration.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.Extensions.Options;
+using OrchardCore.Data.YesSql;
+using YesSql.Services;
+
+namespace OrchardCore.Data
+{
+    public class YesSqlOptionsConfiguration : IConfigureNamedOptions<YesSqlOptions>
+    {
+        public void Configure(YesSqlOptions options) => Configure(String.Empty, options);
+
+        public void Configure(string name, YesSqlOptions options)
+        {
+            options.TableNameConvention ??= new DefaultTableNameConvention();
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 QueryGatingEnabled = yesSqlOptions.QueryGatingEnabled,
                 ContentSerializer = new PoolingJsonContentSerializer(sp.GetService<ArrayPool<char>>()),
                 TableNameConvention = yesSqlOptions.TableNameConvention,
+                IdentityColumnSize = yesSqlOptions.IdentityColumnSize,
             };
 
             if (yesSqlOptions.IdGenerator != null)

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.AddScoped<IModularTenantEvents, AutomaticDataMigrations>();
 
                 services.AddTransient<IConfigureOptions<SqliteOptions>, SqliteOptionsConfiguration>();
-                services.AddTransient<IConfigureNamedOptions<YesSqlOptions>, YesSqlOptionsConfiguration>();
+                services.AddTransient<IConfigureOptions<YesSqlOptions>, YesSqlOptionsConfiguration>();
 
                 // Adding supported databases
                 services.TryAddDataProvider(name: "Sql Server", value: DatabaseProviderValue.SqlConnection, hasConnectionString: true, sampleConnectionString: "Server=localhost;Database=Orchard;User Id=username;Password=password", hasTablePrefix: true, isDefault: false);
@@ -58,7 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         return null;
                     }
 
-                    var yesSqlOptions = sp.GetService<IOptionsSnapshot<YesSqlOptions>>().Get(shellSettings.Name);
+                    var yesSqlOptions = sp.GetService<IOptionsMonitor<YesSqlOptions>>().Get(shellSettings.Name);
                     var storeConfiguration = GetStoreConfiguration(sp, yesSqlOptions);
 
                     switch (shellSettings["DatabaseProvider"])

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -100,6 +100,11 @@ namespace Microsoft.Extensions.DependencyInjection
                         storeConfiguration = storeConfiguration.SetTablePrefix(tablePrefix);
                     }
 
+                    if (!String.IsNullOrWhiteSpace(shellSettings["Schema"]))
+                    {
+                        storeConfiguration.Schema = shellSettings["Schema"].Trim();
+                    }
+
                     var store = StoreFactory.CreateAndInitializeAsync(storeConfiguration).GetAwaiter().GetResult();
                     var options = sp.GetService<IOptions<StoreCollectionOptions>>().Value;
                     foreach (var collection in options.Collections)

--- a/src/OrchardCore/OrchardCore.Infrastructure/Shells.Database/Configuration/DatabaseShellsStorageOptions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shells.Database/Configuration/DatabaseShellsStorageOptions.cs
@@ -1,5 +1,3 @@
-using OrchardCore.Data;
-
 namespace OrchardCore.Shells.Database.Configuration
 {
     public class DatabaseShellsStorageOptions
@@ -8,5 +6,6 @@ namespace OrchardCore.Shells.Database.Configuration
         public string DatabaseProvider { get; set; }
         public string ConnectionString { get; set; }
         public string TablePrefix { get; set; }
+        public string Schema { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Shells.Database/Extensions/DatabaseShellContextFactoryExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shells.Database/Extensions/DatabaseShellContextFactoryExtensions.cs
@@ -27,6 +27,7 @@ namespace OrchardCore.Shells.Database.Extensions
             settings["DatabaseProvider"] = options.DatabaseProvider;
             settings["ConnectionString"] = options.ConnectionString;
             settings["TablePrefix"] = options.TablePrefix;
+            settings["Schema"] = options.Schema;
 
             return shellContextFactory.CreateDescribedContextAsync(settings, new ShellDescriptor());
         }

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -38,7 +38,6 @@ namespace OrchardCore.Setup.Services
         private readonly IHostApplicationLifetime _applicationLifetime;
         private readonly IHttpContextAccessor _httpContextAccessor;
         private readonly IDbConnectionValidator _dbConnectionValidator;
-        private readonly YesSqlOptions _yesSqlOptions;
         private readonly string _applicationName;
         private IEnumerable<RecipeDescriptor> _recipes;
 
@@ -55,7 +54,6 @@ namespace OrchardCore.Setup.Services
         /// <param name="applicationLifetime">The <see cref="IHostApplicationLifetime"/>.</param>
         /// <param name="httpContextAccessor">The <see cref="IHttpContextAccessor"/>.</param>
         /// <param name="dbConnectionValidator">The <see cref="IDbConnectionValidator"/>.</param>
-        /// <param name="yesSqlOptions">The <see cref="YesSqlOptions"/>.</param>
         public SetupService(
             IShellHost shellHost,
             IHostEnvironment hostingEnvironment,
@@ -66,8 +64,7 @@ namespace OrchardCore.Setup.Services
             IStringLocalizer<SetupService> stringLocalizer,
             IHostApplicationLifetime applicationLifetime,
             IHttpContextAccessor httpContextAccessor,
-            IDbConnectionValidator dbConnectionValidator,
-            IOptions<YesSqlOptions> yesSqlOptions)
+            IDbConnectionValidator dbConnectionValidator)
         {
             _shellHost = shellHost;
             _applicationName = hostingEnvironment.ApplicationName;
@@ -79,7 +76,6 @@ namespace OrchardCore.Setup.Services
             _applicationLifetime = applicationLifetime;
             _httpContextAccessor = httpContextAccessor;
             _dbConnectionValidator = dbConnectionValidator;
-            _yesSqlOptions = yesSqlOptions.Value;
         }
 
         /// <inheritdoc />

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -167,7 +167,7 @@ namespace OrchardCore.Setup.Services
                 shellSettings["TablePrefix"] = context.Properties.TryGetValue(SetupConstants.DatabaseTablePrefix, out var databaseTablePrefix) ? databaseTablePrefix?.ToString() : String.Empty;
             }
 
-            switch (await _dbConnectionValidator.ValidateAsync(shellSettings["DatabaseProvider"], shellSettings["ConnectionString"], shellSettings["TablePrefix"], shellSettings.Name))
+            switch (await _dbConnectionValidator.ValidateAsync(shellSettings["DatabaseProvider"], shellSettings["ConnectionString"], shellSettings["TablePrefix"], shellSettings["Schema"], shellSettings.Name))
             {
                 case DbConnectionValidatorResult.NoProvider:
                     context.Errors.Add(String.Empty, S["DatabaseProvider setting is required."]);

--- a/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
+++ b/src/OrchardCore/OrchardCore.Setup.Core/SetupService.cs
@@ -165,6 +165,7 @@ namespace OrchardCore.Setup.Services
                 shellSettings["DatabaseProvider"] = context.Properties.TryGetValue(SetupConstants.DatabaseProvider, out var databaseProvider) ? databaseProvider?.ToString() : String.Empty;
                 shellSettings["ConnectionString"] = context.Properties.TryGetValue(SetupConstants.DatabaseConnectionString, out var databaseConnectionString) ? databaseConnectionString?.ToString() : String.Empty;
                 shellSettings["TablePrefix"] = context.Properties.TryGetValue(SetupConstants.DatabaseTablePrefix, out var databaseTablePrefix) ? databaseTablePrefix?.ToString() : String.Empty;
+                shellSettings["Schema"] = context.Properties.TryGetValue(SetupConstants.DatabaseTablePrefix, out var databaseSchema) ? databaseSchema?.ToString() : null;
             }
 
             switch (await _dbConnectionValidator.ValidateAsync(shellSettings["DatabaseProvider"], shellSettings["ConnectionString"], shellSettings["TablePrefix"], shellSettings["Schema"], shellSettings.Name))

--- a/src/docs/reference/core/Data/README.md
+++ b/src/docs/reference/core/Data/README.md
@@ -31,21 +31,22 @@ OrchardCore uses the `YesSql` library to interact with the configured database p
 | Setting | Description |
 | --- | --- |
 | `CommandsPageSize` | Gets or sets the command page size. If you have to many queries in one command, `YesSql` will split the large command into multiple commands. |
-| `ContentTypeOptions` | Gets or sets the `QueryGatingEnabled` option in `YesSql`. |
-| `TableNameConvention` | You can provide your own implementation for generating ids. |
+| `QueryGatingEnabled` | Gets or sets the `QueryGatingEnabled` option in `YesSql`. |
+| `TableNameConvention` | You can provide your own implementation for generating table names. |
 | `IdentifierAccessorFactory` | You can provide your own value accessor factory. |
 | `VersionAccessorFactory` | You can provide your own version accessor factory. |
 | `ContentSerializer` | You can provide your own content serializer. |
 | `TablePrefixSeparator` | Gets or sets the prefix used to seperate database prefix and the table name. |
+| `IdentityColumnSize` | Gets or sets the identity column size, `Int32` or `Int64` size, by default `Int32` size. |
 
-Custom settings should be provided by named options and not rely on a module feature, this to be able to check a database connection before a tenant is built.
+!!! warning
+    Custom settings should be provided by named options and not rely on a module feature, this to be able to check a database connection before a tenant is built.
 
-For example, if you know by advance the tenant names, you can change their default table prefix seperator from `_` to `__` by adding the following code to your startup code.
+If you know by advance the tenant names, you can change their default table prefix seperator from `_` to `__` by adding the following code to your startup code.
 
 ```C#
 builder.Services
     .AddOrchardCms()
-    .AddSetupFeatures("OrchardCore.AutoSetup")
     .ConfigureServices(tenantServices =>
     {
         tenantServices.Configure<YesSqlOptions>("Default", options =>
@@ -59,15 +60,28 @@ builder.Services
     });
 ```
 
-For example, if you don't know by advance the tenant names, you can register a global configuration implementing `IConfigureNamedOptions<YesSqlOptions>` to provide options based on tenant names.
+To apply the same customization indifferently to all tenants, you can do the following.
 
 ```C#
 builder.Services
     .AddOrchardCms()
-    .AddSetupFeatures("OrchardCore.AutoSetup")
     .ConfigureServices(tenantServices =>
     {
-        services.AddTransient<IConfigureOptions<YesSqlOptions>, CustomYesSqlOptionsConfiguration>();
+        tenantServices.ConfigureAll<YesSqlOptions>(options =>
+        {
+            options.TablePrefixSeparator = "__";
+        });
+    });
+```
+
+If you don't know by advance the tenant names, you can register a custom configuration that should implement `IConfigureNamedOptions<YesSqlOptions>` to provide options based on tenant names.
+
+```C#
+builder.Services
+    .AddOrchardCms()
+    .ConfigureServices(tenantServices =>
+    {
+        services.AddTransient<IConfigureOptions<YesSqlOptions>, CustomYesSqlNamedOptionsConfiguration>();
     });
 ```
 

--- a/src/docs/reference/core/Data/README.md
+++ b/src/docs/reference/core/Data/README.md
@@ -38,13 +38,37 @@ OrchardCore uses the `YesSql` library to interact with the configured database p
 | `ContentSerializer` | You can provide your own content serializer. |
 | `TablePrefixSeparator` | Gets or sets the prefix used to seperate database prefix and the table name. |
 
-For example, you can change the default table prefix seperator from `_` to `__` by adding the following code to your startup code.
+Custom settings should be provided by named options and not rely on a module feature, this to be able to check a database connection before a tenant is built.
+
+For example, if you know by advance the tenant names, you can change their default table prefix seperator from `_` to `__` by adding the following code to your startup code.
 
 ```C#
-services.Configure<YesSqlOptions>(options =>
-{
-    options.TablePrefixSeparator = "__";
-});
+builder.Services
+    .AddOrchardCms()
+    .AddSetupFeatures("OrchardCore.AutoSetup")
+    .ConfigureServices(tenantServices =>
+    {
+        tenantServices.Configure<YesSqlOptions>("Default", options =>
+        {
+            options.TablePrefixSeparator = "__";
+        });
+        tenantServices.Configure<YesSqlOptions>("MyTenant1", options =>
+        {
+            options.TablePrefixSeparator = "__";
+        });
+    });
+```
+
+For example, if you don't know by advance the tenant names, you can register a global options configuration using custom rules based on tenant names.
+
+```C#
+builder.Services
+    .AddOrchardCms()
+    .AddSetupFeatures("OrchardCore.AutoSetup")
+    .ConfigureServices(tenantServices =>
+    {
+        services.AddTransient<IConfigureNamedOptions<YesSqlOptions>, CustomYesSqlOptionsConfiguration>();
+    });
 ```
 
 ## Running SQL queries

--- a/src/docs/reference/core/Data/README.md
+++ b/src/docs/reference/core/Data/README.md
@@ -59,7 +59,7 @@ builder.Services
     });
 ```
 
-For example, if you don't know by advance the tenant names, you can register a global options configuration using custom rules based on tenant names.
+For example, if you don't know by advance the tenant names, you can register a global configuration implementing `IConfigureNamedOptions<YesSqlOptions>` to provide options based on tenant names.
 
 ```C#
 builder.Services
@@ -67,7 +67,7 @@ builder.Services
     .AddSetupFeatures("OrchardCore.AutoSetup")
     .ConfigureServices(tenantServices =>
     {
-        services.AddTransient<IConfigureNamedOptions<YesSqlOptions>, CustomYesSqlOptionsConfiguration>();
+        services.AddTransient<IConfigureOptions<YesSqlOptions>, CustomYesSqlOptionsConfiguration>();
     });
 ```
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
@@ -118,7 +118,7 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
                 : new ShellSettings();
 
             var connectionFactory = new Mock<IDbConnectionValidator>();
-            connectionFactory.Setup(l => l.ValidateAsync(shellSettings["ProviderName"], shellSettings["ConnectionName"], shellSettings["TablePrefix"], shellSettings.Name));
+            connectionFactory.Setup(l => l.ValidateAsync(shellSettings["ProviderName"], shellSettings["ConnectionName"], shellSettings["Schema"], shellSettings["TablePrefix"], shellSettings.Name));
 
             return new TenantValidator(
                 ShellHost,


### PR DESCRIPTION
Fixes #12646 

- If `YesSqlOptions` may have different values per tenant, we can't use `DbConnectionValidator` on a shell that is not yet built. I thought about only using configuration so that we could stack a tenant config section.

        var tenantConfigurationOnly = new ConfigurationBuilder()
            .AddConfiguration(_configuration)
            .AddConfiguration(_configuration.GetSection(shellName))
            .Build();

        var yesSqlOptions = tenantConfigurationOnly.Get<YesSqlOptions>();

    But `YesSqlOptions` not only contains simple fields but also implementations as `TableNameConvention`.

- So I'm thinking about an `IConfigureNamedOptions<YesSqlOptions>` returning options by tenant name, the default would always return the same values, and people could register a custom one to collaborate by applying their rules, or if they know by advance some tenant names just use.

      s.Configure<YesSqlOptions>("Default", options => options.TablePrefixSeparator = "_");
      s.Configure<YesSqlOptions>("MyTenant1", options => options.TablePrefixSeparator = "__");
      s.Configure<YesSqlOptions>("MyTenant2", options => options.TablePrefixSeparator = "___");

    People would have to register their config from the application e.g. by using `OCBuilder.ConfigureServices()`, as we do in `OCBuilder.AddDataAccess()`. This to have the same registrations for all tenants, to not rely on any module feature and to be able to retrieve options for a given tenant name before the tenant itself is built.

- Maybe we should do the same for `SqliteOptions` but it is there since a longer time I think.
