### PR TITLE
Indexing Latest not working as intended

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
@@ -199,14 +199,17 @@ namespace OrchardCore.Search.Lucene
             var doc = new Document
             {
                 // Always store the content item id and version id
-                new StoredField("ContentItemId", documentIndex.ContentItemId.ToString()),
-                new StoredField("ContentItemVersionId", documentIndex.ContentItemVersionId.ToString())
+                // These fields need to be indexed as a StringField because it needs to be searchable for the writer.DeleteDocuments method.
+                // Else it won't be able to prune oldest draft from the indexes.
+                // Maybe eventually find a way to remove a document from a StoredDocument.
+                new StringField("ContentItemId", documentIndex.ContentItemId.ToString(), Field.Store.YES),
+                new StringField("ContentItemVersionId", documentIndex.ContentItemVersionId.ToString(), Field.Store.YES)
             };
 
             if (indexSettings.StoreSourceData)
             {
-                doc.Add(new StoredField(IndexingConstants.SourceKey + "ContentItemId", documentIndex.ContentItemId.ToString()));
-                doc.Add(new StoredField(IndexingConstants.SourceKey + "ContentItemVersionId", documentIndex.ContentItemVersionId.ToString()));
+                doc.Add(new StringField(IndexingConstants.SourceKey + "ContentItemId", documentIndex.ContentItemId.ToString(), Field.Store.YES));
+                doc.Add(new StringField(IndexingConstants.SourceKey + "ContentItemVersionId", documentIndex.ContentItemVersionId.ToString(), Field.Store.YES));
             }
 
             foreach (var entry in documentIndex.Entries)

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
@@ -208,8 +208,8 @@ namespace OrchardCore.Search.Lucene
 
             if (indexSettings.StoreSourceData)
             {
-                doc.Add(new StringField(IndexingConstants.SourceKey + "ContentItemId", documentIndex.ContentItemId.ToString(), Field.Store.YES));
-                doc.Add(new StringField(IndexingConstants.SourceKey + "ContentItemVersionId", documentIndex.ContentItemVersionId.ToString(), Field.Store.YES));
+                doc.Add(new StoredField(IndexingConstants.SourceKey + "ContentItemId", documentIndex.ContentItemId.ToString()));
+                doc.Add(new StoredField(IndexingConstants.SourceKey + "ContentItemVersionId", documentIndex.ContentItemVersionId.ToString()));
             }
 
             foreach (var entry in documentIndex.Entries)

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexingService.cs
@@ -129,7 +129,7 @@ namespace OrchardCore.Search.Lucene
                     var allPublishedContentItems = await contentManager.GetAsync(updatedContentItemIds);
                     allPublished = allPublishedContentItems.DistinctBy(x => x.ContentItemId).ToDictionary(k => k.ContentItemId, v => v);
                     var allLatestContentItems = await contentManager.GetAsync(updatedContentItemIds, latest: true);
-                    allLatest = allLatestContentItems.DistinctBy(x => x.ContentItemId).ToDictionary(k => k.ContentItemVersionId, v => v);
+                    allLatest = allLatestContentItems.DistinctBy(x => x.ContentItemId).ToDictionary(k => k.ContentItemId, v => v);
 
                     // Group all DocumentIndex by index to batch update them
                     var updatedDocumentsByIndex = new Dictionary<string, List<DocumentIndex>>();


### PR DESCRIPTION
Fixes #12690

This should do it. I thought a StoredField would be enough to find these documents in the indices but seems like it is not.
The other issue is that I refactored the LuceneIndexManager to make it a little faster and made a mistake on the value that should be stored in the dictionary to retrieve a Draft. Seems like we never really use the ContentItemVersionId when indexing. We just take the latest one or the published one and we prune any document indexed related to a ContentItemId before updating with new documents.