### PR TITLE
Add Content Field handlers, and update Api Contents to return group keys

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
@@ -39,7 +39,7 @@ namespace OrchardCore.Alias.Handlers
             S = stringLocalizer;
         }
 
-        public override async Task ValidatingAsync(ValidateContentContext context, AliasPart part)
+        public override async Task ValidatingAsync(ValidatePartContentContext context, AliasPart part)
         {
             // Only validate the alias if it's not empty.
             if (String.IsNullOrWhiteSpace(part.Alias))

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -16,7 +16,6 @@ using OrchardCore.ContentLocalization;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
-using OrchardCore.ContentManagement.Records;
 using OrchardCore.ContentManagement.Routing;
 using OrchardCore.Environment.Cache;
 using OrchardCore.Liquid;
@@ -115,7 +114,7 @@ namespace OrchardCore.Autoroute.Handlers
             }
         }
 
-        public override async Task ValidatingAsync(ValidateContentContext context, AutoroutePart part)
+        public override async Task ValidatingAsync(ValidatePartContentContext context, AutoroutePart part)
         {
             // Only validate the path if it's not empty.
             if (String.IsNullOrWhiteSpace(part.Path))

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Handlers/TextFieldHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Handlers/TextFieldHandler.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using OrchardCore.ContentFields.Fields;
+using OrchardCore.ContentFields.Settings;
+using OrchardCore.ContentManagement.Handlers;
+using OrchardCore.ContentManagement.Metadata.Models;
+
+namespace OrchardCore.ContentFields.Handlers;
+
+public class TextFieldHandler : ContentFieldHandler<TextField>
+{
+    private readonly IStringLocalizer<TextFieldHandler> S;
+
+    public TextFieldHandler(IStringLocalizer<TextFieldHandler> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    public override Task ValidatingAsync(ValidateFieldContentContext context, TextField field)
+    {
+        var settings = context.ContentPartFieldDefinition.GetSettings<TextFieldSettings>();
+
+        if (settings.Required && String.IsNullOrEmpty(field.Text))
+        {
+            context.Fail(S["A value is required for {0}.", context.ContentPartFieldDefinition.DisplayName()], nameof(field.Text));
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
@@ -8,6 +8,7 @@ using OrchardCore.Admin;
 using OrchardCore.ContentFields.Controllers;
 using OrchardCore.ContentFields.Drivers;
 using OrchardCore.ContentFields.Fields;
+using OrchardCore.ContentFields.Handlers;
 using OrchardCore.ContentFields.Indexing;
 using OrchardCore.ContentFields.Indexing.SQL;
 using OrchardCore.ContentFields.Services;
@@ -69,7 +70,8 @@ namespace OrchardCore.ContentFields
 
             // Text Field
             services.AddContentField<TextField>()
-                .UseDisplayDriver<TextFieldDisplayDriver>();
+                .UseDisplayDriver<TextFieldDisplayDriver>()
+                .AddHandler<TextFieldHandler>();
             services.AddScoped<IContentPartFieldDefinitionDisplayDriver, TextFieldSettingsDriver>();
             services.AddScoped<IContentFieldIndexHandler, TextFieldIndexHandler>();
             services.AddScoped<IContentPartFieldDefinitionDisplayDriver, TextFieldPredefinedListEditorSettingsDriver>();

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ApiController.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Linq;
 using System.Net;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
 using Newtonsoft.Json.Linq;
 using OrchardCore.ContentManagement;
+using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 
 namespace OrchardCore.Contents.Controllers
@@ -109,29 +111,30 @@ namespace OrchardCore.Contents.Controllers
                     return BadRequest();
                 }
 
-                var newContentItem = await _contentManager.NewAsync(model.ContentType);
-                newContentItem.Merge(model);
+                contentItem = await _contentManager.NewAsync(model.ContentType);
+                contentItem.Owner = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
-                var result = await _contentManager.UpdateValidateAndCreateAsync(newContentItem, VersionOptions.Draft);
+                contentItem.Merge(model);
+
+                var result = await _contentManager.UpdateValidateAndCreateAsync(contentItem, VersionOptions.Draft);
 
                 if (!result.Succeeded)
                 {
-                    return Problem(
-                        title: S["One or more validation errors occurred."],
-                        detail: string.Join(',', result.Errors),
-                        statusCode: (int)HttpStatusCode.BadRequest);
-                }
-                // We check the model state after calling all handlers because they trigger WF content events so, even they are not
-                // intended to add model errors (only drivers), a WF content task may be executed inline and add some model errors.
-                else if (!ModelState.IsValid)
-                {
-                    return Problem(
-                        title: S["One or more validation errors occurred."],
-                        detail: String.Join(", ", ModelState.Values.SelectMany(x => x.Errors.Select(x => x.ErrorMessage))),
-                        statusCode: (int)HttpStatusCode.BadRequest);
+                    // Add the validation results to the ModelState to present the errors as part of the response.
+                    AddValidationErrorsToModelState(result);
                 }
 
-                contentItem = newContentItem;
+                // We check the model state after calling all handlers because they trigger WF content events so, even they are not
+                // intended to add model errors (only drivers), a WF content task may be executed inline and add some model errors.
+                if (!ModelState.IsValid)
+                {
+                    return ValidationProblem(new ValidationProblemDetails(ModelState)
+                    {
+                        Title = S["One or more validation errors occurred."],
+                        Detail = String.Join(", ", ModelState.Values.SelectMany(x => x.Errors.Select(x => x.ErrorMessage))),
+                        Status = (int)HttpStatusCode.BadRequest,
+                    });
+                }
             }
             else
             {
@@ -147,19 +150,19 @@ namespace OrchardCore.Contents.Controllers
 
                 if (!result.Succeeded)
                 {
-                    return Problem(
-                        title: S["One or more validation errors occurred."],
-                        detail: string.Join(',', result.Errors),
-                        statusCode: (int)HttpStatusCode.BadRequest);
+                    AddValidationErrorsToModelState(result);
                 }
+
                 // We check the model state after calling all handlers because they trigger WF content events so, even they are not
                 // intended to add model errors (only drivers), a WF content task may be executed inline and add some model errors.
-                else if (!ModelState.IsValid)
+                if (!ModelState.IsValid)
                 {
-                    return Problem(
-                        title: S["One or more validation errors occurred."],
-                        detail: String.Join(", ", ModelState.Values.SelectMany(x => x.Errors.Select(x => x.ErrorMessage))),
-                        statusCode: (int)HttpStatusCode.BadRequest);
+                    return ValidationProblem(new ValidationProblemDetails(ModelState)
+                    {
+                        Title = S["One or more validation errors occurred."],
+                        Detail = String.Join(", ", ModelState.Values.SelectMany(x => x.Errors.Select(x => x.ErrorMessage))),
+                        Status = (int)HttpStatusCode.BadRequest,
+                    });
                 }
             }
 
@@ -173,6 +176,24 @@ namespace OrchardCore.Contents.Controllers
             }
 
             return Ok(contentItem);
+        }
+
+        private void AddValidationErrorsToModelState(ContentValidateResult result)
+        {
+            foreach (var error in result.Errors)
+            {
+                if (error.MemberNames != null && error.MemberNames.Any())
+                {
+                    foreach (var memberName in error.MemberNames)
+                    {
+                        ModelState.AddModelError(memberName, error.ErrorMessage);
+                    }
+                }
+                else
+                {
+                    ModelState.AddModelError(String.Empty, error.ErrorMessage);
+                }
+            }
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Fluid;
 using Fluid.Values;
+using Microsoft.Extensions.Localization;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
@@ -17,21 +18,26 @@ namespace OrchardCore.Title.Handlers
     {
         private readonly ILiquidTemplateManager _liquidTemplateManager;
         private readonly IContentDefinitionManager _contentDefinitionManager;
+        private readonly IStringLocalizer<TitlePartHandler> S;
 
         public TitlePartHandler(
             ILiquidTemplateManager liquidTemplateManager,
-            IContentDefinitionManager contentDefinitionManager)
+            IContentDefinitionManager contentDefinitionManager,
+            IStringLocalizer<TitlePartHandler> stringLocalizer)
         {
             _liquidTemplateManager = liquidTemplateManager;
             _contentDefinitionManager = contentDefinitionManager;
+            S = stringLocalizer;
         }
 
         public override async Task UpdatedAsync(UpdateContentContext context, TitlePart part)
         {
             var settings = GetSettings(part);
-            // Do not compute the title if the user can modify it and the text is already set.
-            if (settings.Options == TitlePartOptions.Editable && !String.IsNullOrWhiteSpace(part.ContentItem.DisplayText))
+            // Do not compute the title if the user can modify it.
+            if (settings.Options == TitlePartOptions.Editable || settings.Options == TitlePartOptions.EditableRequired)
             {
+                part.ContentItem.DisplayText = part.Title;
+
                 return;
             }
 
@@ -53,6 +59,18 @@ namespace OrchardCore.Title.Handlers
                 part.ContentItem.DisplayText = title;
                 part.Apply();
             }
+        }
+
+        public override Task ValidatingAsync(ValidatePartContentContext context, TitlePart part)
+        {
+            var settings = context.ContentTypePartDefinition.GetSettings<TitlePartSettings>();
+
+            if (settings.Options == TitlePartOptions.EditableRequired && String.IsNullOrEmpty(part.Title))
+            {
+                context.Fail(S["A value is required for Title."], nameof(part.Title));
+            }
+
+            return Task.CompletedTask;
         }
 
         private TitlePartSettings GetSettings(TitlePart part)

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentFieldOption.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentFieldOption.cs
@@ -1,11 +1,26 @@
 using System;
+using System.Collections.Generic;
 
 namespace OrchardCore.ContentManagement
 {
     public class ContentFieldOption : ContentFieldOptionBase
     {
+        private readonly List<Type> _handlers = new List<Type>();
+
         public ContentFieldOption(Type contentFieldType) : base(contentFieldType)
         {
+        }
+
+        public IReadOnlyList<Type> Handlers => _handlers;
+
+        internal void AddHandler(Type type)
+        {
+            _handlers.Add(type);
+        }
+
+        internal void RemoveHandler(Type type)
+        {
+            _handlers.Remove(type);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentOptions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentOptions.cs
@@ -9,22 +9,25 @@ namespace OrchardCore.ContentManagement
     /// </summary>
     public class ContentOptions
     {
-        private readonly List<ContentPartOption> _contentParts = new List<ContentPartOption>();
-        private readonly List<ContentFieldOption> _contentFields = new List<ContentFieldOption>();
+        private readonly List<ContentPartOption> _contentParts = new();
+        private readonly List<ContentFieldOption> _contentFields = new();
 
         private IReadOnlyDictionary<string, ContentPartOption> _contentPartOptionsLookup;
         public IReadOnlyDictionary<string, ContentPartOption> ContentPartOptionsLookup => _contentPartOptionsLookup ??= ContentPartOptions.ToDictionary(k => k.Type.Name);
 
+        private IReadOnlyDictionary<string, ContentFieldOption> _contentFieldOptionsLookup;
+        public IReadOnlyDictionary<string, ContentFieldOption> ContentFieldOptionsLookup => _contentFieldOptionsLookup ??= ContentFieldOptions.ToDictionary(k => k.Type.Name);
+
         public IReadOnlyList<ContentPartOption> ContentPartOptions => _contentParts;
         public IReadOnlyList<ContentFieldOption> ContentFieldOptions => _contentFields;
 
-        internal void AddHandler(Type contentPartType, Type handlerType)
+        internal void AddPartHandler(Type contentPartType, Type handlerType)
         {
             var option = GetOrAddContentPart(contentPartType);
             option.AddHandler(handlerType);
         }
 
-        internal void RemoveHandler(Type contentPartType, Type handlerType)
+        internal void RemovePartHandler(Type contentPartType, Type handlerType)
         {
             var option = GetOrAddContentPart(contentPartType);
             option.RemoveHandler(handlerType);
@@ -47,17 +50,30 @@ namespace OrchardCore.ContentManagement
             return option;
         }
 
-        internal ContentFieldOption GetOrAddContentField(Type contentFieldType)
+
+        internal void AddFieldHandler(Type contentPartType, Type handlerType)
         {
-            if (!contentFieldType.IsSubclassOf(typeof(ContentField)))
+            var option = GetOrAddContentField(contentPartType);
+            option.AddHandler(handlerType);
+        }
+
+        internal void RemoveFieldHandler(Type contentPartType, Type handlerType)
+        {
+            var option = GetOrAddContentField(contentPartType);
+            option.RemoveHandler(handlerType);
+        }
+
+        internal ContentFieldOption GetOrAddContentField(Type contentPartType)
+        {
+            if (!contentPartType.IsSubclassOf(typeof(ContentField)))
             {
                 throw new ArgumentException("The type must inherit from " + nameof(ContentField));
             }
 
-            var option = _contentFields.FirstOrDefault(o => o.Type == contentFieldType);
+            var option = _contentFields.FirstOrDefault(x => x.Type == contentPartType);
             if (option == null)
             {
-                option = new ContentFieldOption(contentFieldType);
+                option = new ContentFieldOption(contentPartType);
                 _contentFields.Add(option);
             }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ActivatingContentContext.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ActivatingContentContext.cs
@@ -2,10 +2,13 @@ using OrchardCore.ContentManagement.Metadata.Models;
 
 namespace OrchardCore.ContentManagement.Handlers
 {
-    public class ActivatingContentContext
+    public class ActivatingContentContext : ContentContextBase
     {
+        public ActivatingContentContext(ContentItem contentItem) : base(contentItem)
+        {
+        }
+
         public string ContentType { get; set; }
         public ContentTypeDefinition Definition { get; set; }
-        public ContentItem ContentItem { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentFieldHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentFieldHandler.cs
@@ -1,0 +1,223 @@
+using System.Threading.Tasks;
+
+namespace OrchardCore.ContentManagement.Handlers;
+
+public abstract class ContentFieldHandler<TField> : IContentFieldHandler where TField : ContentField, new()
+{
+    Task IContentFieldHandler.ActivatedAsync(ActivatedContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? ActivatedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.ActivatingAsync(ActivatingContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? ActivatingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.InitializingAsync(InitializingContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? InitializingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.InitializedAsync(InitializingContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? InitializedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.CreatingAsync(CreateContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? CreatingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.CreatedAsync(CreateContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? CreatedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.LoadingAsync(LoadContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? LoadingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.LoadedAsync(LoadContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? LoadedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.ImportingAsync(ImportContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? ImportingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.ImportedAsync(ImportContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? ImportedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+    Task IContentFieldHandler.UpdatingAsync(UpdateContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? UpdatingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.UpdatedAsync(UpdateContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? UpdatedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.ValidatingAsync(ValidateFieldContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? ValidatingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.ValidatedAsync(ValidateFieldContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? ValidatedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.VersioningAsync(VersionContentContext context, ContentField existing, ContentField building)
+    {
+        return existing is TField texisting && building is TField tbuilding
+            ? VersioningAsync(context, texisting, tbuilding)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.VersionedAsync(VersionContentContext context, ContentField existing, ContentField building)
+    {
+        return existing is TField texisting && building is TField tbuilding
+            ? VersionedAsync(context, texisting, tbuilding)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.DraftSavingAsync(SaveDraftContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? DraftSavingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.DraftSavedAsync(SaveDraftContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? DraftSavedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.PublishingAsync(PublishContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? PublishingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.PublishedAsync(PublishContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? PublishedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.UnpublishingAsync(PublishContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? UnpublishingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.UnpublishedAsync(PublishContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? UnpublishedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.RemovingAsync(RemoveContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? RemovingAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.RemovedAsync(RemoveContentContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? RemovedAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+
+    Task IContentFieldHandler.GetContentItemAspectAsync(ContentItemAspectContext context, ContentField field)
+    {
+        return field is TField tfield
+            ? GetContentItemAspectAsync(context, tfield)
+            : Task.CompletedTask;
+    }
+    async Task IContentFieldHandler.CloningAsync(CloneContentContext context, ContentField field)
+    {
+        if (field is TField tfield)
+        {
+            await CloningAsync(context, tfield);
+        }
+    }
+
+    async Task IContentFieldHandler.ClonedAsync(CloneContentContext context, ContentField field)
+    {
+        if (field is TField tfield)
+        {
+            await ClonedAsync(context, tfield);
+        }
+    }
+
+    public virtual Task ActivatedAsync(ActivatedContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task ActivatingAsync(ActivatingContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task InitializingAsync(InitializingContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task InitializedAsync(InitializingContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task CreatingAsync(CreateContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task CreatedAsync(CreateContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task LoadingAsync(LoadContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task LoadedAsync(LoadContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task ImportingAsync(ImportContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task ImportedAsync(ImportContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task UpdatingAsync(UpdateContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task UpdatedAsync(UpdateContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task ValidatingAsync(ValidateFieldContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task ValidatedAsync(ValidateFieldContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task VersioningAsync(VersionContentContext context, TField existing, TField building) => Task.CompletedTask;
+    public virtual Task VersionedAsync(VersionContentContext context, TField existing, TField building) => Task.CompletedTask;
+    public virtual Task DraftSavingAsync(SaveDraftContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task DraftSavedAsync(SaveDraftContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task PublishingAsync(PublishContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task PublishedAsync(PublishContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task UnpublishingAsync(PublishContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task UnpublishedAsync(PublishContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task RemovingAsync(RemoveContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task RemovedAsync(RemoveContentContext context, TField instance) => Task.CompletedTask;
+    public virtual Task GetContentItemAspectAsync(ContentItemAspectContext context, TField part) => Task.CompletedTask;
+    public virtual Task CloningAsync(CloneContentContext context, TField part) => Task.CompletedTask;
+    public virtual Task ClonedAsync(CloneContentContext context, TField part) => Task.CompletedTask;
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentPartHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ContentPartHandler.cs
@@ -87,14 +87,14 @@ namespace OrchardCore.ContentManagement.Handlers
                 : Task.CompletedTask;
         }
 
-        Task IContentPartHandler.ValidatingAsync(ValidateContentContext context, ContentPart part)
+        Task IContentPartHandler.ValidatingAsync(ValidatePartContentContext context, ContentPart part)
         {
             return part is TPart tpart
                 ? ValidatingAsync(context, tpart)
                 : Task.CompletedTask;
         }
 
-        Task IContentPartHandler.ValidatedAsync(ValidateContentContext context, ContentPart part)
+        Task IContentPartHandler.ValidatedAsync(ValidatePartContentContext context, ContentPart part)
         {
             return part is TPart tpart
                 ? ValidatedAsync(context, tpart)
@@ -205,8 +205,8 @@ namespace OrchardCore.ContentManagement.Handlers
         public virtual Task ImportedAsync(ImportContentContext context, TPart instance) => Task.CompletedTask;
         public virtual Task UpdatingAsync(UpdateContentContext context, TPart instance) => Task.CompletedTask;
         public virtual Task UpdatedAsync(UpdateContentContext context, TPart instance) => Task.CompletedTask;
-        public virtual Task ValidatingAsync(ValidateContentContext context, TPart instance) => Task.CompletedTask;
-        public virtual Task ValidatedAsync(ValidateContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task ValidatingAsync(ValidatePartContentContext context, TPart instance) => Task.CompletedTask;
+        public virtual Task ValidatedAsync(ValidatePartContentContext context, TPart instance) => Task.CompletedTask;
         public virtual Task VersioningAsync(VersionContentContext context, TPart existing, TPart building) => Task.CompletedTask;
         public virtual Task VersionedAsync(VersionContentContext context, TPart existing, TPart building) => Task.CompletedTask;
         public virtual Task DraftSavingAsync(SaveDraftContentContext context, TPart instance) => Task.CompletedTask;

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentFieldHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentFieldHandler.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+
+namespace OrchardCore.ContentManagement.Handlers
+{
+    /// <summary>
+    /// An implementation of this class is called for all the fields of a content item.
+    /// </summary>
+    public interface IContentFieldHandler
+    {
+        Task ActivatedAsync(ActivatedContentContext context, ContentField field);
+        Task ActivatingAsync(ActivatingContentContext context, ContentField field);
+        Task InitializingAsync(InitializingContentContext context, ContentField field);
+        Task InitializedAsync(InitializingContentContext context, ContentField field);
+        Task CreatingAsync(CreateContentContext context, ContentField field);
+        Task CreatedAsync(CreateContentContext context, ContentField field);
+        Task LoadingAsync(LoadContentContext context, ContentField field);
+        Task LoadedAsync(LoadContentContext context, ContentField field);
+        Task ImportingAsync(ImportContentContext context, ContentField field);
+        Task ImportedAsync(ImportContentContext context, ContentField field);
+        Task UpdatingAsync(UpdateContentContext context, ContentField field);
+        Task UpdatedAsync(UpdateContentContext context, ContentField field);
+        Task ValidatingAsync(ValidateFieldContentContext context, ContentField field);
+        Task ValidatedAsync(ValidateFieldContentContext context, ContentField field);
+        Task VersioningAsync(VersionContentContext context, ContentField existing, ContentField building);
+        Task VersionedAsync(VersionContentContext context, ContentField existing, ContentField building);
+        Task DraftSavingAsync(SaveDraftContentContext context, ContentField field);
+        Task DraftSavedAsync(SaveDraftContentContext context, ContentField field);
+        Task PublishingAsync(PublishContentContext context, ContentField field);
+        Task PublishedAsync(PublishContentContext context, ContentField field);
+        Task UnpublishingAsync(PublishContentContext context, ContentField field);
+        Task UnpublishedAsync(PublishContentContext context, ContentField field);
+        Task RemovingAsync(RemoveContentContext context, ContentField field);
+        Task RemovedAsync(RemoveContentContext context, ContentField field);
+        Task GetContentItemAspectAsync(ContentItemAspectContext context, ContentField field);
+        Task CloningAsync(CloneContentContext context, ContentField field);
+        Task ClonedAsync(CloneContentContext context, ContentField field);
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentFieldHandlerResolver.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentFieldHandlerResolver.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace OrchardCore.ContentManagement.Handlers
+{
+    public interface IContentFieldHandlerResolver
+    {
+        IList<IContentFieldHandler> GetHandlers(string fieldName);
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentPartHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/IContentPartHandler.cs
@@ -19,8 +19,8 @@ namespace OrchardCore.ContentManagement.Handlers
         Task ImportedAsync(ImportContentContext context, ContentPart part);
         Task UpdatingAsync(UpdateContentContext context, ContentPart part);
         Task UpdatedAsync(UpdateContentContext context, ContentPart part);
-        Task ValidatingAsync(ValidateContentContext context, ContentPart part);
-        Task ValidatedAsync(ValidateContentContext context, ContentPart part);
+        Task ValidatingAsync(ValidatePartContentContext context, ContentPart part);
+        Task ValidatedAsync(ValidatePartContentContext context, ContentPart part);
         Task VersioningAsync(VersionContentContext context, ContentPart existing, ContentPart building);
         Task VersionedAsync(VersionContentContext context, ContentPart existing, ContentPart building);
         Task DraftSavingAsync(SaveDraftContentContext context, ContentPart part);

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ValidateContentContext.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ValidateContentContext.cs
@@ -3,6 +3,7 @@ using System.Linq;
 
 namespace OrchardCore.ContentManagement.Handlers
 {
+
     public class ValidateContentContext : ContentContextBase
     {
         public ValidateContentContext(ContentItem contentItem) : base(contentItem)

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ValidateFieldContentContext.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ValidateFieldContentContext.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel.DataAnnotations;
+using OrchardCore.ContentManagement.Metadata.Models;
+
+namespace OrchardCore.ContentManagement.Handlers
+{
+    public class ValidateFieldContentContext : ValidateContentContext
+    {
+        public ValidateFieldContentContext(
+            ContentItem contentItem,
+            ContentPartFieldDefinition contentPartFieldDefinition,
+            string partName) : base(contentItem)
+        {
+            ContentPartFieldDefinition = contentPartFieldDefinition;
+            PartName = partName;
+        }
+
+        public ContentPartFieldDefinition ContentPartFieldDefinition { get; set; }
+
+        public string PartName { get; set; }
+    }
+
+    public static class ValidateFieldContentContextExtensions
+    {
+
+        public static void Fail(this ValidateFieldContentContext context, ValidationResult error)
+        {
+            context.ContentValidateResult.Fail(error);
+        }
+
+        public static void Fail(this ValidateFieldContentContext context, string errorMessage, string propertyName)
+        {
+            if (propertyName == null)
+            {
+                context.ContentValidateResult.Fail(new ValidationResult(errorMessage));
+            }
+            else
+            {
+                var memberName = $"{context.PartName}.{context.ContentPartFieldDefinition.Name}.{propertyName}";
+
+                context.ContentValidateResult.Fail(new ValidationResult(errorMessage, new[] { memberName }));
+            }
+        }
+
+        public static void Fail(this ValidatePartContentContext context, string errorMessage, string propertyName)
+        {
+            if (propertyName == null)
+            {
+                context.ContentValidateResult.Fail(new ValidationResult(errorMessage));
+            }
+            else
+            {
+                var memberName = $"{context.ContentTypePartDefinition.Name}.{propertyName}";
+
+                context.ContentValidateResult.Fail(new ValidationResult(errorMessage, new[] { memberName }));
+            }
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ValidatePartContentContext.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/ValidatePartContentContext.cs
@@ -1,0 +1,14 @@
+using OrchardCore.ContentManagement.Metadata.Models;
+
+namespace OrchardCore.ContentManagement.Handlers
+{
+    public class ValidatePartContentContext : ValidateContentContext
+    {
+        public ValidatePartContentContext(ContentItem contentItem, ContentTypePartDefinition contentTypePartDefinition) : base(contentItem)
+        {
+            ContentTypePartDefinition = contentTypePartDefinition;
+        }
+
+        public ContentTypePartDefinition ContentTypePartDefinition { get; set; }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ServiceCollectionExtensions.cs
@@ -65,7 +65,7 @@ namespace OrchardCore.ContentManagement
             builder.Services.TryAddScoped(handlerType);
             builder.Services.Configure<ContentOptions>(o =>
             {
-                o.AddHandler(builder.ContentPartType, handlerType);
+                o.AddPartHandler(builder.ContentPartType, handlerType);
             });
 
             return builder;
@@ -89,7 +89,55 @@ namespace OrchardCore.ContentManagement
             builder.Services.RemoveAll(handlerType);
             builder.Services.Configure<ContentOptions>(o =>
             {
-                o.RemoveHandler(builder.ContentPartType, handlerType);
+                o.RemovePartHandler(builder.ContentPartType, handlerType);
+            });
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Register a handler for use with a content field.
+        /// </summary>
+        /// <typeparam name="TContentFieldHandler"></typeparam>
+        public static ContentFieldOptionBuilder AddHandler<TContentFieldHandler>(this ContentFieldOptionBuilder builder)
+            where TContentFieldHandler : class, IContentFieldHandler
+        {
+            return builder.AddHandler(typeof(TContentFieldHandler));
+        }
+
+        /// <summary>
+        /// Register a handler for use with a content part.
+        /// </summary>
+        public static ContentFieldOptionBuilder AddHandler(this ContentFieldOptionBuilder builder, Type handlerType)
+        {
+            builder.Services.TryAddScoped(handlerType);
+            builder.Services.Configure<ContentOptions>(o =>
+            {
+                o.AddFieldHandler(builder.ContentFieldType, handlerType);
+            });
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Remove a handler registration from a content part.
+        /// </summary>
+        /// <typeparam name="TContentFieldHandler"></typeparam>
+        public static ContentFieldOptionBuilder RemoveHandler<TContentFieldHandler>(this ContentFieldOptionBuilder builder)
+            where TContentFieldHandler : class, IContentFieldHandler
+        {
+            return builder.RemoveHandler(typeof(TContentFieldHandler));
+        }
+
+        /// <summary>
+        /// Remove a handler registration from a content part.
+        /// </summary>
+        public static ContentFieldOptionBuilder RemoveHandler(this ContentFieldOptionBuilder builder, Type handlerType)
+        {
+            builder.Services.RemoveAll(handlerType);
+            builder.Services.Configure<ContentOptions>(o =>
+            {
+                o.RemoveFieldHandler(builder.ContentFieldType, handlerType);
             });
 
             return builder;

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -61,11 +61,10 @@ namespace OrchardCore.ContentManagement
             }
 
             // create a new kernel for the model instance
-            var context = new ActivatingContentContext
+            var context = new ActivatingContentContext(new ContentItem() { ContentType = contentTypeDefinition.Name })
             {
                 ContentType = contentTypeDefinition.Name,
                 Definition = contentTypeDefinition,
-                ContentItem = new ContentItem() { ContentType = contentTypeDefinition.Name }
             };
 
             // invoke handlers to weld aspects onto kernel

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentFieldHandlerResolver.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentFieldHandlerResolver.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace OrchardCore.ContentManagement.Handlers
+{
+    public class ContentFieldHandlerResolver : IContentFieldHandlerResolver
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ContentOptions _contentOptions;
+
+        public ContentFieldHandlerResolver(
+            IServiceProvider serviceProvider,
+            IOptions<ContentOptions> contentDisplayOptions
+            )
+        {
+            _serviceProvider = serviceProvider;
+            _contentOptions = contentDisplayOptions.Value;
+        }
+
+        public IList<IContentFieldHandler> GetHandlers(string fieldName)
+        {
+            var services = new List<IContentFieldHandler>();
+
+            if (_contentOptions.ContentFieldOptionsLookup.TryGetValue(fieldName, out var contentFieldOption))
+            {
+                foreach (var handlerOption in contentFieldOption.Handlers)
+                {
+                    services.Add((IContentFieldHandler)_serviceProvider.GetRequiredService(handlerOption));
+                }
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/ContentPartHandlerCoordinator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentManagement.Metadata;
@@ -11,6 +12,7 @@ namespace OrchardCore.ContentManagement.Handlers
     public class ContentPartHandlerCoordinator : ContentHandlerBase
     {
         private readonly IContentPartHandlerResolver _contentPartHandlerResolver;
+        private readonly IContentFieldHandlerResolver _contentFieldHandlerResolver;
         private readonly ITypeActivatorFactory<ContentPart> _contentPartFactory;
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly ITypeActivatorFactory<ContentField> _contentFieldFactory;
@@ -18,498 +20,184 @@ namespace OrchardCore.ContentManagement.Handlers
 
         public ContentPartHandlerCoordinator(
             IContentPartHandlerResolver contentPartHandlerResolver,
+            IContentFieldHandlerResolver contentFieldHandlerResolver,
             ITypeActivatorFactory<ContentPart> contentPartFactory,
             ITypeActivatorFactory<ContentField> contentFieldFactory,
             IContentDefinitionManager contentDefinitionManager,
             ILogger<ContentPartHandlerCoordinator> logger)
         {
             _contentPartHandlerResolver = contentPartHandlerResolver;
+            _contentFieldHandlerResolver = contentFieldHandlerResolver;
             _contentPartFactory = contentPartFactory;
             _contentFieldFactory = contentFieldFactory;
             _contentDefinitionManager = contentDefinitionManager;
             _logger = logger;
         }
 
-        public override async Task ActivatingAsync(ActivatingContentContext context)
+        public override Task ActivatingAsync(ActivatingContentContext context)
         {
             // This method is called on New()
             // Adds all the parts to a content item based on the content type definition.
-
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-
-                // We create the part from it's known type or from a generic one
-                var part = _contentPartFactory.GetTypeActivator(partName).CreateInstance();
-                var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                await partHandlers.InvokeAsync((handler, context, part) => handler.ActivatingAsync(context, part), context, part, _logger);
-                context.ContentItem.Weld(typePartDefinition.Name, part);
-
-                foreach (var partFieldDefinition in typePartDefinition.PartDefinition.Fields)
-                {
-                    var fieldName = partFieldDefinition.Name;
-
-                    if (!part.Has(fieldName))
-                    {
-                        var fieldActivator = _contentFieldFactory.GetTypeActivator(partFieldDefinition.FieldDefinition.Name);
-                        part.Weld(fieldName, fieldActivator.CreateInstance());
-                    }
-                }
-            }
+            // When a part/field does not exists, we create the part from it's known type or from a generic one
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.ActivatingAsync(context, part),
+                (handler, context, field) => handler.ActivatingAsync(context, field),
+                createPartIfNotExists: true,
+                createFieldIfNotExists: true);
         }
 
-        public override async Task ActivatedAsync(ActivatedContentContext context)
+        public override Task ActivatedAsync(ActivatedContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, partName) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.ActivatedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.ActivatedAsync(context, part),
+                (handler, context, field) => handler.ActivatedAsync(context, field));
         }
 
-        public override async Task CreatingAsync(CreateContentContext context)
+        public override Task CreatingAsync(CreateContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.CreatingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.CreatingAsync(context, part),
+                (handler, context, field) => handler.CreatingAsync(context, field));
         }
 
-        public override async Task CreatedAsync(CreateContentContext context)
+        public override Task CreatedAsync(CreateContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.CreatedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.CreatedAsync(context, part),
+                (handler, context, field) => handler.CreatedAsync(context, field));
         }
 
-        public override async Task ImportingAsync(ImportContentContext context)
+        public override Task ImportingAsync(ImportContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.ImportingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.ImportingAsync(context, part),
+                (handler, context, field) => handler.ImportingAsync(context, field));
         }
 
-        public override async Task ImportedAsync(ImportContentContext context)
+        public override Task ImportedAsync(ImportContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.ImportedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.ImportedAsync(context, part),
+                (handler, context, field) => handler.ImportedAsync(context, field));
         }
 
-        public override async Task InitializingAsync(InitializingContentContext context)
+        public override Task InitializingAsync(InitializingContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.InitializingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.InitializingAsync(context, part),
+                (handler, context, field) => handler.InitializingAsync(context, field));
         }
 
-        public override async Task InitializedAsync(InitializingContentContext context)
+        public override Task InitializedAsync(InitializingContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.InitializedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.InitializedAsync(context, part),
+                (handler, context, field) => handler.InitializedAsync(context, field));
         }
 
-        public override async Task LoadingAsync(LoadContentContext context)
+        public override Task LoadingAsync(LoadContentContext context)
         {
             // This method is called on Get()
             // Adds all the missing parts to a content item based on the content type definition.
             // A part is missing if the content type is changed and an old content item is loaded,
             // like edited.
 
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-            {
-                return;
-            }
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                // If no existing part was not found in the content item, create a new one
-                if (part == null)
-                {
-                    part = activator.CreateInstance();
-                    context.ContentItem.Weld(typePartDefinition.Name, part);
-                }
-
-                var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                await partHandlers.InvokeAsync((handler, context, part) => handler.LoadingAsync(context, part), context, part, _logger);
-                foreach (var partFieldDefinition in typePartDefinition.PartDefinition.Fields)
-                {
-                    var fieldName = partFieldDefinition.Name;
-
-                    if (!part.Has(fieldName))
-                    {
-                        var fieldActivator = _contentFieldFactory.GetTypeActivator(partFieldDefinition.FieldDefinition.Name);
-                        part.Weld(fieldName, fieldActivator.CreateInstance());
-                    }
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.LoadingAsync(context, part),
+                (handler, context, field) => handler.LoadingAsync(context, field),
+                createPartIfNotExists: true,
+                createFieldIfNotExists: true);
         }
 
-        public override async Task LoadedAsync(LoadContentContext context)
+        public override Task LoadedAsync(LoadContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.LoadedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.LoadedAsync(context, part),
+                (handler, context, field) => handler.LoadedAsync(context, field));
         }
 
-        public override async Task ValidatingAsync(ValidateContentContext context)
+        public override Task ValidatingAsync(ValidateContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.ValidatingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeValidationHandlers(context,
+                (handler, context, part) => handler.ValidatingAsync(context, part),
+                (handler, context, field) => handler.ValidatingAsync(context, field));
         }
 
-        public override async Task ValidatedAsync(ValidateContentContext context)
+        public override Task ValidatedAsync(ValidateContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.ValidatedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeValidationHandlers(context,
+                (handler, context, part) => handler.ValidatedAsync(context, part),
+                (handler, context, field) => handler.ValidatedAsync(context, field));
         }
 
-        public override async Task DraftSavingAsync(SaveDraftContentContext context)
+        public override Task DraftSavingAsync(SaveDraftContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.DraftSavingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.DraftSavingAsync(context, part),
+                (handler, context, field) => handler.DraftSavingAsync(context, field));
         }
 
-        public override async Task DraftSavedAsync(SaveDraftContentContext context)
+        public override Task DraftSavedAsync(SaveDraftContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.DraftSavedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.DraftSavedAsync(context, part),
+                (handler, context, field) => handler.DraftSavedAsync(context, field));
         }
 
-        public override async Task PublishingAsync(PublishContentContext context)
+        public override Task PublishingAsync(PublishContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.PublishingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.PublishingAsync(context, part),
+                (handler, context, field) => handler.PublishingAsync(context, field));
         }
 
-        public override async Task PublishedAsync(PublishContentContext context)
+        public override Task PublishedAsync(PublishContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.PublishedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.PublishedAsync(context, part),
+                (handler, context, field) => handler.PublishedAsync(context, field));
         }
 
-        public override async Task RemovingAsync(RemoveContentContext context)
+        public override Task RemovingAsync(RemoveContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.RemovingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.RemovingAsync(context, part),
+                (handler, context, field) => handler.RemovingAsync(context, field));
         }
 
-        public override async Task RemovedAsync(RemoveContentContext context)
+        public override Task RemovedAsync(RemoveContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.RemovedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.RemovedAsync(context, part),
+                (handler, context, field) => handler.RemovedAsync(context, field));
         }
 
-        public override async Task UnpublishingAsync(PublishContentContext context)
+        public override Task UnpublishingAsync(PublishContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.UnpublishingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.UnpublishingAsync(context, part),
+                (handler, context, field) => handler.UnpublishingAsync(context, field));
         }
 
-        public override async Task UnpublishedAsync(PublishContentContext context)
+        public override Task UnpublishedAsync(PublishContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.UnpublishedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.UnpublishedAsync(context, part),
+                (handler, context, field) => handler.UnpublishedAsync(context, field));
         }
 
-        public override async Task UpdatingAsync(UpdateContentContext context)
+        public override Task UpdatingAsync(UpdateContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.UpdatingAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.UpdatingAsync(context, part),
+                (handler, context, field) => handler.UpdatingAsync(context, field));
         }
 
-        public override async Task UpdatedAsync(UpdateContentContext context)
+        public override Task UpdatedAsync(UpdateContentContext context)
         {
-            var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
-            if (contentTypeDefinition == null)
-                return;
-
-            foreach (var typePartDefinition in contentTypeDefinition.Parts)
-            {
-                var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart; ;
-
-                if (part != null)
-                {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.UpdatedAsync(context, part), context, part, _logger);
-                }
-            }
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.UpdatedAsync(context, part),
+                (handler, context, field) => handler.UpdatedAsync(context, field));
         }
 
         public override async Task VersioningAsync(VersionContentContext context)
@@ -538,20 +226,62 @@ namespace OrchardCore.ContentManagement.Handlers
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
+            {
                 return;
+            }
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
                 var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
 
-                var buildingPart = (ContentPart)context.BuildingContentItem.Get(activator.Type, partName);
-                var existingPart = (ContentPart)context.ContentItem.Get(activator.Type, typePartDefinition.Name);
-
-                if (buildingPart != null && existingPart != null)
+                if (String.IsNullOrEmpty(partName))
                 {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, existingPart, buildingPart) => handler.VersionedAsync(context, existingPart, buildingPart), context, existingPart, buildingPart, _logger);
+                    _logger.LogError("The content type '{contentType}' contains part '{contentPart}' that does not exists.", contentTypeDefinition.Name, partName);
+
+                    continue;
+                }
+
+                var partActivator = _contentPartFactory.GetTypeActivator(partName);
+
+                var buildingPart = (ContentPart)context.BuildingContentItem.Get(partActivator.Type, partName);
+                var existingPart = (ContentPart)context.ContentItem.Get(partActivator.Type, typePartDefinition.Name);
+
+                if (buildingPart == null || existingPart == null)
+                {
+                    continue;
+                }
+
+                var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
+                await partHandlers.InvokeAsync((handler, context, existingPart, buildingPart) => handler.VersionedAsync(context, existingPart, buildingPart), context, existingPart, buildingPart, _logger);
+
+                if (typePartDefinition.PartDefinition?.Fields == null)
+                {
+                    continue;
+                }
+
+                foreach (var partFieldDefinition in typePartDefinition.PartDefinition.Fields)
+                {
+                    var fieldName = partFieldDefinition.FieldDefinition.Name;
+
+                    if (String.IsNullOrEmpty(partName))
+                    {
+                        _logger.LogError("The content part '{contentPert}' contains field '{contentField}' that does not exists.", partName, fieldName);
+                        continue;
+                    }
+
+                    var fieldActivator = _contentFieldFactory.GetTypeActivator(fieldName);
+
+
+                    var buildingField = (ContentField)buildingPart.Get(fieldActivator.Type, fieldName);
+                    var existingField = (ContentField)existingPart.Get(fieldActivator.Type, partFieldDefinition.Name);
+
+                    if (buildingField == null || existingField == null)
+                    {
+                        continue;
+                    }
+
+                    var fieldHandlers = _contentFieldHandlerResolver.GetHandlers(fieldName);
+                    await fieldHandlers.InvokeAsync((handler, context, existingField, buildingField) => handler.VersionedAsync(context, existingField, buildingField), context, existingField, buildingField, _logger);
                 }
             }
         }
@@ -560,56 +290,205 @@ namespace OrchardCore.ContentManagement.Handlers
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
+            {
                 return;
+            }
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
                 var partName = typePartDefinition.PartDefinition.Name;
+
+                if (String.IsNullOrEmpty(partName))
+                {
+                    _logger.LogError("The content type '{contentType}' contains part '{contentPart}' that does not exists.", contentTypeDefinition.Name, partName);
+
+                    continue;
+                }
+
                 var activator = _contentPartFactory.GetTypeActivator(partName);
                 var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
 
-                if (part != null)
+                if (part == null)
                 {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.GetContentItemAspectAsync(context, part), context, part, _logger);
+                    continue;
+                }
+
+                var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
+                await partHandlers.InvokeAsync((handler, context, part) => handler.GetContentItemAspectAsync(context, part), context, part, _logger);
+
+                if (typePartDefinition.PartDefinition?.Fields == null)
+                {
+                    continue;
+                }
+
+                foreach (var partFieldDefinition in typePartDefinition.PartDefinition.Fields)
+                {
+                    var fieldName = partFieldDefinition.FieldDefinition.Name;
+
+                    if (String.IsNullOrEmpty(partName))
+                    {
+                        _logger.LogError("The content part '{contentPert}' contains field '{contentField}' that does not exists.", partName, fieldName);
+                        continue;
+                    }
+
+                    var fieldActivator = _contentFieldFactory.GetTypeActivator(fieldName);
+                    var field = context.ContentItem.Get(fieldActivator.Type, partFieldDefinition.Name) as ContentField;
+
+                    if (field == null)
+                    {
+                        continue;
+                    }
+
+                    var fieldHandlers = _contentFieldHandlerResolver.GetHandlers(fieldName);
+                    await fieldHandlers.InvokeAsync((handler, context, field) => handler.GetContentItemAspectAsync(context, field), context, field, _logger);
                 }
             }
         }
-        public override async Task ClonedAsync(CloneContentContext context)
+
+        public override Task ClonedAsync(CloneContentContext context)
+        {
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.ClonedAsync(context, part),
+                (handler, context, field) => handler.ClonedAsync(context, field));
+        }
+        public override Task CloningAsync(CloneContentContext context)
+        {
+            return InvokeHandlers(context,
+                (handler, context, part) => handler.CloningAsync(context, part),
+                (handler, context, field) => handler.CloningAsync(context, field));
+        }
+
+        private async Task InvokeHandlers<TContext>(
+            TContext context,
+            Func<IContentPartHandler, TContext, ContentPart, Task> partHandlerAction,
+            Func<IContentFieldHandler, TContext, ContentField, Task> fieldHandlerAction,
+            bool createPartIfNotExists = false,
+            bool createFieldIfNotExists = false)
+            where TContext : ContentContextBase
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
+            {
                 return;
+            }
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
                 var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
+                var partActivator = _contentPartFactory.GetTypeActivator(partName);
+                var part = context.ContentItem.Get(partActivator.Type, typePartDefinition.Name) as ContentPart;
 
-                if (part != null)
+                if (part == null && createPartIfNotExists)
                 {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.ClonedAsync(context, part), context, part, _logger);
+                    part = partActivator.CreateInstance();
+                    context.ContentItem.Weld(typePartDefinition.Name, part);
+                }
+
+                if (part == null)
+                {
+                    continue;
+                }
+
+                var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
+                await partHandlers.InvokeAsync(partHandlerAction, context, part, _logger);
+
+                if (typePartDefinition.PartDefinition?.Fields == null)
+                {
+                    continue;
+                }
+
+                foreach (var partFieldDefinition in typePartDefinition.PartDefinition.Fields)
+                {
+                    var fieldName = partFieldDefinition.FieldDefinition.Name;
+                    var fieldActivator = _contentFieldFactory.GetTypeActivator(fieldName);
+
+                    // Attempt to get the field from the part.
+                    var field = part.Get(fieldActivator.Type, partFieldDefinition.Name) as ContentField;
+
+                    if (field == null && createFieldIfNotExists)
+                    {
+                        field = fieldActivator.CreateInstance();
+
+                        part.Weld(partFieldDefinition.Name, field);
+                    }
+
+                    if (field == null)
+                    {
+                        continue;
+                    }
+
+                    var fieldHandlers = _contentFieldHandlerResolver.GetHandlers(fieldName);
+                    await fieldHandlers.InvokeAsync(fieldHandlerAction, context, field, _logger);
                 }
             }
         }
-        public override async Task CloningAsync(CloneContentContext context)
+
+        private async Task InvokeValidationHandlers<TContext>(
+            TContext context,
+            Func<IContentPartHandler, ValidatePartContentContext, ContentPart, Task> partHandlerAction,
+            Func<IContentFieldHandler, ValidateFieldContentContext, ContentField, Task> fieldHandlerAction)
+            where TContext : ValidateContentContext
         {
             var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(context.ContentItem.ContentType);
             if (contentTypeDefinition == null)
+            {
                 return;
+            }
 
             foreach (var typePartDefinition in contentTypeDefinition.Parts)
             {
                 var partName = typePartDefinition.PartDefinition.Name;
-                var activator = _contentPartFactory.GetTypeActivator(partName);
-                var part = context.ContentItem.Get(activator.Type, typePartDefinition.Name) as ContentPart;
+                var partActivator = _contentPartFactory.GetTypeActivator(partName);
+                var part = context.ContentItem.Get(partActivator.Type, typePartDefinition.Name) as ContentPart;
 
-                if (part != null)
+                if (part == null)
                 {
-                    var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
-                    await partHandlers.InvokeAsync((handler, context, part) => handler.CloningAsync(context, part), context, part, _logger);
+                    continue;
+                }
+
+                var partHandlers = _contentPartHandlerResolver.GetHandlers(partName);
+
+                var validatePartContentContext = new ValidatePartContentContext(context.ContentItem, typePartDefinition);
+
+                await partHandlers.InvokeAsync(partHandlerAction, validatePartContentContext, part, _logger);
+
+                if (typePartDefinition.PartDefinition?.Fields == null)
+                {
+                    continue;
+                }
+
+                foreach (var partFieldDefinition in typePartDefinition.PartDefinition.Fields)
+                {
+                    var fieldName = partFieldDefinition.FieldDefinition.Name;
+
+                    var fieldActivator = _contentFieldFactory.GetTypeActivator(fieldName);
+
+                    var field = part.Get(fieldActivator.Type, partFieldDefinition.Name) as ContentField;
+
+                    if (field == null)
+                    {
+                        continue;
+                    }
+
+                    var validateFieldContentContext = new ValidateFieldContentContext(
+                        validatePartContentContext.ContentItem,
+                        partFieldDefinition,
+                        typePartDefinition.Name ?? partName);
+
+                    var fieldHandlers = _contentFieldHandlerResolver.GetHandlers(fieldName);
+                    await fieldHandlers.InvokeAsync(fieldHandlerAction, validateFieldContentContext, field, _logger);
+
+                    // Add any field errors to the context errors.
+                    foreach (var error in validateFieldContentContext.ContentValidateResult.Errors)
+                    {
+                        context.ContentValidateResult.Fail(error);
+                    }
+                }
+
+                // Add any part errors to the context errors.
+                foreach (var error in validatePartContentContext.ContentValidateResult.Errors)
+                {
+                    context.ContentValidateResult.Fail(error);
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ namespace OrchardCore.ContentManagement
 
             services.AddOptions<ContentOptions>();
             services.AddScoped<IContentPartHandlerResolver, ContentPartHandlerResolver>();
+            services.AddScoped<IContentFieldHandlerResolver, ContentFieldHandlerResolver>();
 
             return services;
         }


### PR DESCRIPTION
Fix #12696 

- Add a way to attach handlers for fields. For example, `services.AddContentField<TextField>().UseDisplayDriver<TextFieldDisplayDriver>().AddHandler<TextFieldHandler>();`
- *(Breaking Change)* In the interface `IContentPartHandler` the signature `Task ValidatingAsync(ValidateContentContext context, ContentPart part);` was changed to `Task ValidatingAsync(ValidatePartContentContext context, ContentPart part);`. Also, the signature `Task ValidatedAsync(ValidateContentContext context, ContentPart part);` was changed to `Task ValidatedAsync(ValidatePartContentContext context, ContentPart part);`
- `TitlePartHandler` was modified to validate the part against the `TitlePartSettings`
- Now that validation takes place, the post request to `/api/contents` return validation error with key.
- New Handlers were added
  - `TextFieldHandler` to validate a text field
  - One handler for each part/field will be added "if it does not exists" that would implement that `ValidatingAsync(...)` event. This would be part of a follow up PR ensure team is on agreement with the approach and to reduce the code change.
