### PR TITLE
Fixes #12596: Sitemap Home Page Url

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -83,7 +83,7 @@ namespace OrchardCore.Autoroute.Handlers
                 await SetHomeRouteAsync(part, homeRoute =>
                 {
                     homeRoute[_options.ContentItemIdKey] = context.ContentItem.ContentItemId;
-                    homeRoute[_options.JsonPathKey] = "";
+                    homeRoute.Remove(_options.JsonPathKey);
                 });
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutorouteValuesAddressScheme.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Routing/AutorouteValuesAddressScheme.cs
@@ -28,7 +28,6 @@ namespace OrchardCore.Autoroute.Routing
                 return Enumerable.Empty<Endpoint>();
             }
 
-
             // Try to get the contained item first, then the container content item
             string contentItemId = address.ExplicitValues[_options.ContainedContentItemIdKey]?.ToString();
             if (string.IsNullOrEmpty(contentItemId))


### PR DESCRIPTION
Fixes #12596
Fixes #12167

It was already intended to work through the `HomeRouteValuesAddressScheme` when generating a link, but at some point we allowed contained items to be routable (also the Home Page) by introducing a new route value whose key is `JsonPathKey`.

The problem was that when the Home Page is not a contained item, the `HomeRoute` was still containing a `JsonPathKey` value, an empty string but not null. So in that case, when genarating the url the `ExplicitValues` was not matching the `HomeRoute`.

So in that case the solution was to set this entry to null or just remove this entry as done here, this when we publish an item to be the new Home, and then persist the new `HomeRoute` to Site Settings.

