### PR TITLE
Adding permission check when querying content using GraphQL

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Permissions.cs
@@ -6,8 +6,8 @@ namespace OrchardCore.Apis.GraphQL
 {
     public class Permissions : IPermissionProvider
     {
-        public static readonly Permission ExecuteGraphQLMutations = new Permission("ExecuteGraphQLMutations", "Execute GraphQL Mutations.");
-        public static readonly Permission ExecuteGraphQL = new Permission("ExecuteGraphQL", "Execute GraphQL.", new[] { ExecuteGraphQLMutations });
+        public static readonly Permission ExecuteGraphQLMutations = CommonPermissions.ExecuteGraphQLMutations;
+        public static readonly Permission ExecuteGraphQL = CommonPermissions.ExecuteGraphQL;
 
         public Task<IEnumerable<Permission>> GetPermissionsAsync()
         {

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/RequiresPermissionValidationRule.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/RequiresPermissionValidationRule.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -7,7 +6,6 @@ using GraphQL.Language.AST;
 using GraphQL.Types;
 using GraphQL.Validation;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 
 namespace OrchardCore.Apis.GraphQL.ValidationRules
@@ -71,34 +69,34 @@ namespace OrchardCore.Apis.GraphQL.ValidationRules
 
         private async Task AuthorizeNodePermissionAsync(INode node, IFieldType fieldType, ValidationContext validationContext, GraphQLUserContext userContext)
         {
-            if (!fieldType.HasPermissions())
+            var permissions = fieldType?.GetPermissions();
+
+            if (permissions == null)
             {
                 return;
             }
-
-            var permissions = fieldType?.GetPermissions() ?? Enumerable.Empty<GraphQLPermissionContext>();
 
             if (permissions.Count() == 1)
             {
                 var permission = permissions.First();
                 // small optimization for the single policy - no 'new List<>()', no 'await Task.WhenAll()'
-                var authorizationResult = await _authorizationService.AuthorizeAsync(userContext.User, permission.Permission, permission.Resource);
-                if (!authorizationResult)
+                if (!await _authorizationService.AuthorizeAsync(userContext.User, permission.Permission, permission.Resource))
+                {
                     AddPermissionValidationError(validationContext, node, fieldType.Name);
+                }
             }
             else
             {
-                var tasks = new List<Task<bool>>(permissions.Count());
+                var tasks = new List<Task<bool>>();
 
                 foreach (var permission in permissions)
                 {
-                    var task = _authorizationService.AuthorizeAsync(userContext.User, permission.Permission, permission.Resource);
-                    tasks.Add(task);
+                    tasks.Add(_authorizationService.AuthorizeAsync(userContext.User, permission.Permission, permission.Resource));
                 }
 
                 var authorizationResults = await Task.WhenAll(tasks);
 
-                if (authorizationResults.Any(x => !true))
+                if (authorizationResults.Any(isAuthorized => !isAuthorized))
                 {
                     AddPermissionValidationError(validationContext, node, fieldType.Name);
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/RequiresPermissionValidationRule.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/ValidationRules/RequiresPermissionValidationRule.cs
@@ -76,7 +76,14 @@ namespace OrchardCore.Apis.GraphQL.ValidationRules
                 return;
             }
 
-            if (permissions.Count() == 1)
+            var totalPermissions = permissions.Count();
+
+            if (totalPermissions == 0)
+            {
+                return;
+            }
+
+            if (totalPermissions == 1)
             {
                 var permission = permissions.First();
                 // small optimization for the single policy - no 'new List<>()', no 'await Task.WhenAll()'

--- a/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/SiteLayersQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/GraphQL/SiteLayersQuery.cs
@@ -5,8 +5,10 @@ using GraphQL;
 using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.Apis.GraphQL.Resolvers;
+using OrchardCore.ContentManagement.GraphQL.Options;
 using OrchardCore.Layers.Models;
 using OrchardCore.Layers.Services;
 
@@ -15,16 +17,25 @@ namespace OrchardCore.Layers.GraphQL
     public class SiteLayersQuery : ISchemaBuilder
     {
         private readonly IStringLocalizer S;
+        private readonly GraphQLContentOptions _graphQLContentOptions;
 
-        public SiteLayersQuery(IStringLocalizer<SiteLayersQuery> localizer)
+        public SiteLayersQuery(
+            IStringLocalizer<SiteLayersQuery> localizer,
+            IOptions<GraphQLContentOptions> graphQLContentOptions)
         {
             S = localizer;
+            _graphQLContentOptions = graphQLContentOptions.Value;
         }
 
         public Task<string> GetIdentifierAsync() => Task.FromResult(String.Empty);
 
         public Task BuildAsync(ISchema schema)
         {
+            if (_graphQLContentOptions.ShouldSkipContentType("SiteLayers"))
+            {
+                return Task.CompletedTask;
+            }
+
             var field = new FieldType
             {
                 Name = "SiteLayers",

--- a/src/OrchardCore.Modules/OrchardCore.Localization/GraphQL/SiteCulturesQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/GraphQL/SiteCulturesQuery.cs
@@ -6,8 +6,10 @@ using GraphQL;
 using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.Apis.GraphQL.Resolvers;
+using OrchardCore.ContentManagement.GraphQL.Options;
 
 namespace OrchardCore.Localization.GraphQL
 {
@@ -17,14 +19,20 @@ namespace OrchardCore.Localization.GraphQL
     public class SiteCulturesQuery : ISchemaBuilder
     {
         private readonly IStringLocalizer S;
+        private readonly GraphQLContentOptions _graphQLContentOptions;
 
         /// <summary>
         /// Creates a new instance of the <see cref="SiteCulturesQuery"/>.
         /// </summary>
         /// <param name="localizer">The <see cref="IStringLocalizer"/>.</param>
-        public SiteCulturesQuery(IStringLocalizer<SiteCulturesQuery> localizer)
+        /// <param name="graphQLContentOptions">The <see cref="GraphQLContentOptions"/>.</param>
+        /// 
+        public SiteCulturesQuery(
+            IStringLocalizer<SiteCulturesQuery> localizer,
+            IOptions<GraphQLContentOptions> graphQLContentOptions)
         {
             S = localizer;
+            _graphQLContentOptions = graphQLContentOptions.Value;
         }
 
         public Task<string> GetIdentifierAsync() => Task.FromResult(String.Empty);
@@ -32,6 +40,11 @@ namespace OrchardCore.Localization.GraphQL
         /// <inheritdocs/>
         public Task BuildAsync(ISchema schema)
         {
+            if (_graphQLContentOptions.ShouldSkipContentType("SiteCultures"))
+            {
+                return Task.CompletedTask;
+            }
+
             var field = new FieldType
             {
                 Name = "SiteCultures",

--- a/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/OrchardCore.Localization.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Apis.GraphQL.Abstractions\OrchardCore.Apis.GraphQL.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Localization.Abstractions\OrchardCore.Localization.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Localization.Core\OrchardCore.Localization.Core.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/GraphQL/MediaAssetQuery.cs
@@ -6,8 +6,10 @@ using GraphQL;
 using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.Apis.GraphQL.Resolvers;
+using OrchardCore.ContentManagement.GraphQL.Options;
 using OrchardCore.FileStorage;
 
 namespace OrchardCore.Media.GraphQL
@@ -15,16 +17,25 @@ namespace OrchardCore.Media.GraphQL
     public class MediaAssetQuery : ISchemaBuilder
     {
         private readonly IStringLocalizer S;
+        private readonly GraphQLContentOptions _graphQLContentOptions;
 
-        public MediaAssetQuery(IStringLocalizer<MediaAssetQuery> localizer)
+        public MediaAssetQuery(
+            IStringLocalizer<MediaAssetQuery> localizer,
+            IOptions<GraphQLContentOptions> graphQLContentOptions)
         {
             S = localizer;
+            _graphQLContentOptions = graphQLContentOptions.Value;
         }
 
         public Task<string> GetIdentifierAsync() => Task.FromResult(String.Empty);
 
         public Task BuildAsync(ISchema schema)
         {
+            if (_graphQLContentOptions.ShouldSkipContentType("MediaAssets"))
+            {
+                return Task.CompletedTask;
+            }
+
             var field = new FieldType
             {
                 Name = "MediaAssets",

--- a/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Apis.GraphQL.Abstractions\OrchardCore.Apis.GraphQL.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Abstractions\OrchardCore.ContentManagement.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.Display\OrchardCore.ContentManagement.Display.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentPreview.Abstractions\OrchardCore.ContentPreview.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentTypes.Abstractions\OrchardCore.ContentTypes.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/CommonPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/CommonPermissions.cs
@@ -1,0 +1,9 @@
+using OrchardCore.Security.Permissions;
+
+namespace OrchardCore.Apis.GraphQL;
+
+public class CommonPermissions
+{
+    public static readonly Permission ExecuteGraphQLMutations = new("ExecuteGraphQLMutations", "Execute GraphQL Mutations.");
+    public static readonly Permission ExecuteGraphQL = new("ExecuteGraphQL", "Execute GraphQL.", new[] { ExecuteGraphQLMutations });
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLContentOptions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLContentOptions.cs
@@ -106,7 +106,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                 return true;
             }
 
-            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => ctp.ContentType == contentType);
+            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => String.Equals(ctp.ContentType, contentType, StringComparison.OrdinalIgnoreCase));
 
             if (contentTypeOption != null)
             {
@@ -115,7 +115,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                     return true;
                 }
 
-                var contentTypePartOption = contentTypeOption.PartOptions.FirstOrDefault(p => p.Name == partName);
+                var contentTypePartOption = contentTypeOption.PartOptions.FirstOrDefault(p => String.Equals(p.Name, partName, StringComparison.OrdinalIgnoreCase));
 
                 if (contentTypePartOption != null)
                 {
@@ -126,7 +126,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                 }
             }
 
-            var contentPartOption = PartOptions.FirstOrDefault(p => p.Name == partName);
+            var contentPartOption = PartOptions.FirstOrDefault(p => String.Equals(p.Name, partName, StringComparison.OrdinalIgnoreCase));
 
             if (contentPartOption != null)
             {
@@ -156,6 +156,18 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
             return false;
         }
 
+        public bool ShouldSkipContentType(string contentType)
+        {
+            if (String.IsNullOrEmpty(contentType))
+            {
+                throw new ArgumentNullException(nameof(contentType));
+            }
+
+            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => String.Equals(ctp.ContentType, contentType, StringComparison.OrdinalIgnoreCase));
+
+            return contentTypeOption?.Hidden ?? false;
+        }
+
         internal bool ShouldSkip(Type fieldType, string fieldName)
         {
             return HiddenFields
@@ -167,7 +179,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
             var contentType = definition.ContentTypeDefinition.Name;
             var partName = definition.PartDefinition.Name;
 
-            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => ctp.ContentType == contentType);
+            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => String.Equals(ctp.ContentType, contentType, StringComparison.OrdinalIgnoreCase));
 
             if (contentTypeOption != null)
             {
@@ -176,7 +188,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                     return true;
                 }
 
-                var contentTypePartOption = contentTypeOption.PartOptions.FirstOrDefault(p => p.Name == partName);
+                var contentTypePartOption = contentTypeOption.PartOptions.FirstOrDefault(p => String.Equals(p.Name, partName, StringComparison.OrdinalIgnoreCase));
 
                 if (contentTypePartOption != null)
                 {
@@ -187,7 +199,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                 }
             }
 
-            var contentPartOption = PartOptions.FirstOrDefault(p => p.Name == partName);
+            var contentPartOption = PartOptions.FirstOrDefault(p => String.Equals(p.Name, partName, StringComparison.OrdinalIgnoreCase));
 
             if (contentPartOption != null)
             {

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLContentOptions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Options/GraphQLContentOptions.cs
@@ -106,7 +106,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                 return true;
             }
 
-            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => String.Equals(ctp.ContentType, contentType, StringComparison.OrdinalIgnoreCase));
+            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => ctp.ContentType == contentType);
 
             if (contentTypeOption != null)
             {
@@ -115,7 +115,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                     return true;
                 }
 
-                var contentTypePartOption = contentTypeOption.PartOptions.FirstOrDefault(p => String.Equals(p.Name, partName, StringComparison.OrdinalIgnoreCase));
+                var contentTypePartOption = contentTypeOption.PartOptions.FirstOrDefault(p => p.Name == partName);
 
                 if (contentTypePartOption != null)
                 {
@@ -126,7 +126,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                 }
             }
 
-            var contentPartOption = PartOptions.FirstOrDefault(p => String.Equals(p.Name, partName, StringComparison.OrdinalIgnoreCase));
+            var contentPartOption = PartOptions.FirstOrDefault(p => p.Name == partName);
 
             if (contentPartOption != null)
             {
@@ -163,7 +163,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                 throw new ArgumentNullException(nameof(contentType));
             }
 
-            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => String.Equals(ctp.ContentType, contentType, StringComparison.OrdinalIgnoreCase));
+            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => ctp.ContentType == contentType);
 
             return contentTypeOption?.Hidden ?? false;
         }
@@ -179,7 +179,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
             var contentType = definition.ContentTypeDefinition.Name;
             var partName = definition.PartDefinition.Name;
 
-            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => String.Equals(ctp.ContentType, contentType, StringComparison.OrdinalIgnoreCase));
+            var contentTypeOption = ContentTypeOptions.FirstOrDefault(ctp => ctp.ContentType == contentType);
 
             if (contentTypeOption != null)
             {
@@ -188,7 +188,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                     return true;
                 }
 
-                var contentTypePartOption = contentTypeOption.PartOptions.FirstOrDefault(p => String.Equals(p.Name, partName, StringComparison.OrdinalIgnoreCase));
+                var contentTypePartOption = contentTypeOption.PartOptions.FirstOrDefault(p => p.Name == partName);
 
                 if (contentTypePartOption != null)
                 {
@@ -199,7 +199,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Options
                 }
             }
 
-            var contentPartOption = PartOptions.FirstOrDefault(p => String.Equals(p.Name, partName, StringComparison.OrdinalIgnoreCase));
+            var contentPartOption = PartOptions.FirstOrDefault(p => p.Name == partName);
 
             if (contentPartOption != null)
             {

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemFilters.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentItemFilters.cs
@@ -1,0 +1,60 @@
+using System.Security.Claims;
+using System.Threading.Tasks;
+using GraphQL;
+using GraphQL.Types;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Records;
+using OrchardCore.Contents;
+using OrchardCore.Contents.Security;
+using YesSql;
+
+namespace OrchardCore.ContentManagement.GraphQL.Queries;
+
+public class ContentItemFilters : GraphQLFilter<ContentItem>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IContentDefinitionManager _contentDefinitionManager;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IContentManager _contentManager;
+
+    public ContentItemFilters(IHttpContextAccessor httpContextAccessor,
+        IContentDefinitionManager contentDefinitionManager,
+        IAuthorizationService authorizationService,
+        IContentManager contentManager)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _contentDefinitionManager = contentDefinitionManager;
+        _authorizationService = authorizationService;
+        _contentManager = contentManager;
+    }
+
+    public override async Task<IQuery<ContentItem>> PreQueryAsync(IQuery<ContentItem> query, IResolveFieldContext context)
+    {
+        var contentType = ((ListGraphType)(context.FieldDefinition).ResolvedType).ResolvedType.Name;
+
+        var contentTypeDefinition = _contentDefinitionManager.GetTypeDefinition(contentType);
+        var contentTypePermission = ContentTypePermissionsHelper.ConvertToDynamicPermission(CommonPermissions.ViewContent);
+        var dynamicPermission = ContentTypePermissionsHelper.CreateDynamicPermission(contentTypePermission, contentTypeDefinition);
+
+        var dummy = await _contentManager.NewAsync(contentTypeDefinition.Name);
+
+        if (await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, dynamicPermission, dummy))
+        {
+            return await base.PreQueryAsync(query, context);
+        }
+
+        var userId = _httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+        dummy.Owner = userId;
+
+        var contentTypeOwnPermission = ContentTypePermissionsHelper.ConvertToDynamicPermission(CommonPermissions.ViewOwnContent);
+
+        if (await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, contentTypeOwnPermission, dummy))
+        {
+            return query.With<ContentItemIndex>(x => x.Owner == userId);
+        }
+
+        return query.With<ContentItemIndex>(x => x.ContentType != contentType);
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
@@ -10,8 +10,6 @@ using OrchardCore.ContentManagement.GraphQL.Options;
 using OrchardCore.ContentManagement.GraphQL.Queries.Types;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
-using OrchardCore.Contents;
-using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.ContentManagement.GraphQL.Queries
 {
@@ -69,8 +67,8 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
                     ResolvedType = new ListGraphType(typeType)
                 };
 
-                query.RequirePermission(new Permission("ExecuteGraphQL"));
-                query.RequirePermission(CommonPermissions.ViewContent, typeDefinition.Name);
+                query.RequirePermission(CommonPermissions.ExecuteGraphQL);
+                query.RequirePermission(Contents.CommonPermissions.ViewContent, typeDefinition.Name);
 
                 foreach (var builder in contentTypeBuilders)
                 {

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
@@ -11,6 +11,7 @@ using OrchardCore.ContentManagement.GraphQL.Queries.Types;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.Contents;
+using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.ContentManagement.GraphQL.Queries
 {
@@ -68,7 +69,8 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
                     ResolvedType = new ListGraphType(typeType)
                 };
 
-                query.RequirePermission(CommonPermissions.ViewOwnContent, typeDefinition.Name);
+                query.RequirePermission(new Permission("ExecuteGraphQL"));
+                query.RequirePermission(CommonPermissions.ViewContent, typeDefinition.Name);
 
                 foreach (var builder in contentTypeBuilders)
                 {

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
@@ -50,6 +50,11 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
 
             foreach (var typeDefinition in contentDefinitionManager.ListTypeDefinitions())
             {
+                if (_contentOptionsAccessor.Value.ShouldSkipContentType(typeDefinition.Name))
+                {
+                    continue;
+                }
+
                 var typeType = new ContentItemType(_contentOptionsAccessor)
                 {
                     Name = typeDefinition.Name,
@@ -63,7 +68,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
                     ResolvedType = new ListGraphType(typeType)
                 };
 
-                query.RequirePermission(CommonPermissions.ViewContent, typeDefinition.Name);
+                query.RequirePermission(CommonPermissions.ViewOwnContent, typeDefinition.Name);
 
                 foreach (var builder in contentTypeBuilders)
                 {

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
@@ -33,6 +33,11 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
             var serviceProvider = _httpContextAccessor.HttpContext.RequestServices;
             var contentFieldProviders = serviceProvider.GetServices<IContentFieldProvider>().ToList();
 
+            if (_contentOptions.ShouldSkipContentType(contentTypeDefinition.Name))
+            {
+                return;
+            }
+
             foreach (var part in contentTypeDefinition.Parts)
             {
                 var partName = part.Name;

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
@@ -27,14 +27,25 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
             var serviceProvider = _httpContextAccessor.HttpContext.RequestServices;
             var typeActivator = serviceProvider.GetService<ITypeActivatorFactory<ContentPart>>();
 
+            if (_contentOptions.ShouldSkipContentType(contentTypeDefinition.Name))
+            {
+                return;
+            }
+
             foreach (var part in contentTypeDefinition.Parts)
             {
-                if (_contentOptions.ShouldSkip(part)) continue;
+                if (_contentOptions.ShouldSkip(part))
+                {
+                    continue;
+                }
 
                 var partName = part.Name;
 
                 // Check if another builder has already added a field for this part.
-                if (contentItemType.HasField(partName)) continue;
+                if (contentItemType.HasField(partName))
+                {
+                    continue;
+                }
 
                 var activator = typeActivator.GetTypeActivator(part.PartDefinition.Name);
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/ServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.ContentManagement.GraphQL
             services.AddScoped<IContentTypeBuilder, DynamicContentTypeBuilder>();
 
             services.AddOptions<GraphQLContentOptions>();
-
+            services.AddGraphQLFilterType<ContentItem, ContentItemFilters>();
             services.AddWhereInputIndexPropertyProvider<ContentItemIndex>();
 
             return services;

--- a/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.Autoroute.Models;
@@ -233,7 +232,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                     AuthorizedPermissions = new[]
                     {
                         GraphQLApi.Permissions.ExecuteGraphQL,
-                        Contents.Permissions.ViewContent
+                        Contents.Permissions.ViewContent,
                     }
                 });
 

--- a/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
@@ -232,7 +232,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
                     AuthorizedPermissions = new[]
                     {
                         GraphQLApi.Permissions.ExecuteGraphQL,
-                        Contents.Permissions.ViewContent,
+                        Contents.Permissions.ViewContent
                     }
                 });
 


### PR DESCRIPTION
Fix #12693 

Prior this PR, a user with permission to GraphQL can see all content regardless of their permissions. With the new added filter, we honor their permissions.

Also, `GraphQLContentOptions.ConfigureContentType(...)` had no effect. Like if the user configure contentType as hidden, we still show it anyway. This was also fixed.