### PR TITLE
Changing ViewContent to ViewOwnContent

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/ContentTypeQuery.cs
@@ -68,7 +68,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries
                 };
 
                 query.RequirePermission(CommonPermissions.ExecuteGraphQL);
-                query.RequirePermission(Contents.CommonPermissions.ViewContent, typeDefinition.Name);
+                query.RequirePermission(Contents.CommonPermissions.ViewOwnContent, typeDefinition.Name);
 
                 foreach (var builder in contentTypeBuilders)
                 {

--- a/test/OrchardCore.Tests/Apis/Context/AuthenticationContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/AuthenticationContext.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Principal;
@@ -52,10 +53,46 @@ namespace OrchardCore.Tests.Apis.Context
             }
             else
             {
-                context.Fail();
+                var grantingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                GetGrantingNamesInternal(requirement.Permission, grantingNames);
+
+                // SiteOwner permission grants them all
+                grantingNames.Add(StandardPermissions.SiteOwner.Name);
+
+                if (permissions.Any(p => grantingNames.Contains(p.Name)))
+                {
+                    context.Succeed(requirement);
+                }
+                else
+                {
+                    context.Fail();
+                }
             }
 
             return Task.CompletedTask;
+        }
+
+        private void GetGrantingNamesInternal(Permission permission, HashSet<string> stack)
+        {
+            // The given name is tested
+            stack.Add(permission.Name);
+
+            // Iterate implied permissions to grant, it present
+            if (permission.ImpliedBy != null && permission.ImpliedBy.Any())
+            {
+                foreach (var impliedBy in permission.ImpliedBy)
+                {
+                    // Avoid potential recursion
+                    if (impliedBy == null || stack.Contains(impliedBy.Name))
+                    {
+                        continue;
+                    }
+
+                    // Otherwise accumulate the implied permission names recursively
+                    GetGrantingNamesInternal(impliedBy, stack);
+                }
+            }
         }
     }
 

--- a/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
@@ -248,6 +248,31 @@ namespace OrchardCore.Tests.Apis.GraphQL
         }
 
         [Fact]
+        public async Task ShouldNotReturnBlogsWithViewOwnBlogContentPermission()
+        {
+            using var context = new SiteContext()
+                .WithPermissionsContext(new PermissionsContext
+                {
+                    UsePermissionsContext = true,
+                    AuthorizedPermissions = new[]
+                    {
+                        GraphQLApi.Permissions.ExecuteGraphQL,
+                        Contents.Permissions.ViewOwnContent
+                    }
+                });
+
+            await context.InitializeAsync();
+
+            var result = await context.GraphQLClient.Content
+                .Query("blog", builder =>
+                {
+                    builder.WithField("contentItemId");
+                });
+
+            Assert.Empty(result["data"]["blog"]);
+        }
+
+        [Fact]
         public async Task ShouldNotReturnBlogsWithoutViewBlogContentPermission()
         {
             using var context = new SiteContext()


### PR DESCRIPTION
Fix #12751

@jtkech we worked on the previous PR for GraphQL together. The permission change in this PR is correct since this will check a lower level permission that is implied by ViewContents.  But the `ShouldReturnBlogsWithViewBlogContentPermission` is failing. For some reason the authenticated user "in the test" has no claims which explain why the test will fail. Any idea on the fix? The change in this PR fixes the issue on hand but breaks the test.