### PR TITLE
Fix OC version used in templates

### DIFF
--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 15471 ))" >> $GITHUB_ENV
     - name: Build
       run: |
-        dotnet build --configuration Release --framework net6.0
+        dotnet build --configuration Release --framework net6.0 -p:Version=${{ steps.get_version.outputs.VERSION }}
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 


### PR DESCRIPTION
The template default settings are generated on build. These templates have an `OrchardVersion` argument that has a default value defined in an msbuild script to be replaced with the `Version` property. In the release pipeline this value will have the `VersionSuffix` applied to it, like `preview`. 

This PR forces the value of the version property to be the one in the tag which will prevent `preview` from being added. This will also fix the templates' default value for `OrchardVersion`.

The `pack` command uses the `Version` property only for the packages, and at that point the templates json files are already built with the wrong version.