### PR TITLE
Removed popperjs because it was removed from package.json

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Setup/Assets.json
+++ b/src/OrchardCore.Modules/OrchardCore.Setup/Assets.json
@@ -10,7 +10,6 @@
   {
     "inputs": [
       "node_modules/jquery/dist/jquery.js",
-      "node_modules/@popperjs/core/dist/umd/popper.js",
       "node_modules/bootstrap/dist/js/bootstrap.js",
       "Assets/js/setup.js",
       "Assets/js/strength.js"


### PR DESCRIPTION
popperjs was removed from package.json but it was still used in Assets.json. This throws an exception when building assets on a clean install.