### PR TITLE
Reject grant_type=client_credentials token requests containing scope=offline_access

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -442,6 +442,16 @@ namespace OrchardCore.OpenId.Controllers
 
         private async Task<IActionResult> ExchangeClientCredentialsGrantType(OpenIddictRequest request)
         {
+            if (request.HasScope(Scopes.OfflineAccess))
+            {
+                return Forbid(new AuthenticationProperties(new Dictionary<string, string>
+                {
+                    [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.InvalidScope,
+                    [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] =
+                        "The 'offline_access' scope is not allowed when using the client credentials grant."
+                }), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+            }
+
             // Note: client authentication is always enforced by OpenIddict before this action is invoked.
             var application = await _applicationManager.FindByClientIdAsync(request.ClientId) ??
                 throw new InvalidOperationException("The application details cannot be found.");


### PR DESCRIPTION
We recently added the ability to automatically grant the requested scopes for `grant_type=client_credentials` (which requires that the client be granted the corresponding scope permissions, of course) but we forgot to add a check to prevent a refresh token from being requested via `scope=offline_access`, which is a scenario we deliberately don't allow. We have a check preventing blocking `grant_type=refresh_token` requests in this case:

https://github.com/OrchardCMS/OrchardCore/blob/18938aa517fa151f5ac582d03cb80c93ca2f7b27/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs#L588-L600

Since there's no point returning a refresh token that won't be usable, we should add a check to prevent the `offline_access` scope from being requested in the first place. That's exactly what this PR does 😄 