### PR TITLE
Don't localize custom errors returned by the userinfo endpoint

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/UserInfoController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/UserInfoController.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Localization;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
 using OrchardCore.Modules;
@@ -14,14 +13,11 @@ using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace OrchardCore.OpenId.Controllers
 {
+    // Note: the error descriptions used in this controller are deliberately not localized as
+    // the OAuth 2.0 specification only allows select US-ASCII characters in error_description.
     [Feature(OpenIdConstants.Features.Server), SkipStatusCodePages]
     public class UserInfoController : Controller
     {
-        private readonly IStringLocalizer S;
-
-        public UserInfoController(IStringLocalizer<UserInfoController> localizer)
-            => S = localizer;
-
         // GET/POST: /connect/userinfo
         [AcceptVerbs("GET", "POST")]
         [IgnoreAntiforgeryToken]
@@ -57,7 +53,7 @@ namespace OrchardCore.OpenId.Controllers
                 {
                     [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.InvalidRequest,
                     [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] =
-                        S["The userinfo endpoint can only be used with access tokens representing users."]
+                        "The userinfo endpoint can only be used with access tokens representing users."
                 }), OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
             }
 


### PR DESCRIPTION
The OAuth 2.0 specification explicitly requires that errors be composed exclusively of certain USCII characters, which basically prevents localizing them:

![image](https://user-images.githubusercontent.com/6998306/201483337-a951d94a-2f94-4a94-ac40-dd4c59bed987.png)

![image](https://user-images.githubusercontent.com/6998306/201483362-5c1c5ac4-14d5-4bcc-a053-123733974d6f.png)

It's an issue we identified and fixed some time ago for the errors returned by `AccessController`, but not by `UserInfoController`, that still returns a localized error. E.g in French:

![image](https://user-images.githubusercontent.com/6998306/201483202-cd20ba09-3f0c-4b4d-84d9-6a07f26cfa69.png)
