### PR TITLE
Added BlobFileStoreFactory to allow DefaultAzureCredential or Connectionstring authentication for Azure Blob storage

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Startup.cs
@@ -95,6 +95,9 @@ namespace OrchardCore.Media.Azure
                 services.AddSingleton<IMediaFileStoreCache>(serviceProvider =>
                     serviceProvider.GetRequiredService<IMediaFileStoreCacheFileProvider>());
 
+                // Register the BlobFileStorageFactory
+                services.AddAzureBlobFileStorage();
+
                 // Replace the default media file store with a blob file store.
                 services.Replace(ServiceDescriptor.Singleton<IMediaFileStore>(serviceProvider =>
                 {
@@ -102,15 +105,12 @@ namespace OrchardCore.Media.Azure
                     var shellOptions = serviceProvider.GetRequiredService<IOptions<ShellOptions>>();
                     var shellSettings = serviceProvider.GetRequiredService<ShellSettings>();
                     var mediaOptions = serviceProvider.GetRequiredService<IOptions<MediaOptions>>().Value;
-                    var clock = serviceProvider.GetRequiredService<IClock>();
-                    var contentTypeProvider = serviceProvider.GetRequiredService<IContentTypeProvider>();
                     var mediaEventHandlers = serviceProvider.GetServices<IMediaEventHandler>();
                     var mediaCreatingEventHandlers = serviceProvider.GetServices<IMediaCreatingEventHandler>();
                     var logger = serviceProvider.GetRequiredService<ILogger<DefaultMediaFileStore>>();
+                    var blobStoreFactory = serviceProvider.GetRequiredService<BlobFileStoreFactory>();
 
-                    var fileStore = new BlobFileStore(blobStorageOptions, clock, contentTypeProvider);
-
-                    var mediaPath = GetMediaPath(shellOptions.Value, shellSettings, mediaOptions.AssetsPath);
+                    var fileStore = blobStoreFactory.Create(blobStorageOptions);
 
                     var mediaUrlBase = "/" + fileStore.Combine(shellSettings.RequestUrlPrefix, mediaOptions.AssetsRequestPath);
 

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/AzureBlobFileStorageOrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/AzureBlobFileStorageOrchardCoreBuilderExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace OrchardCore.FileStorage.AzureBlob;
+public static class AzureBlobFileStorageOrchardCoreBuilderExtensions
+{
+    /// <summary>
+    /// This registers the AzureBlobFileStorage components.
+    /// Note: this method is safe to call more then once.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static OrchardCoreBuilder AddAzureBlobFileStorage(this OrchardCoreBuilder builder)
+    {
+        builder.ConfigureServices(services => services.AddAzureBlobFileStorage());
+
+        return builder;
+    }
+}

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/AzureBlobFileStorageOrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/AzureBlobFileStorageOrchardCoreBuilderExtensions.cs
@@ -11,8 +11,7 @@ public static class AzureBlobFileStorageOrchardCoreBuilderExtensions
     /// <returns></returns>
     public static OrchardCoreBuilder AddAzureBlobFileStorage(this OrchardCoreBuilder builder)
     {
-        builder.ConfigureServices(services => services.AddAzureBlobFileStorage());
-
+        builder.ApplicationServices.AddAzureBlobFileStorage();
         return builder;
     }
 }

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/AzureBlobFileStorageServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/AzureBlobFileStorageServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace OrchardCore.FileStorage.AzureBlob;
+
+public static class AzureBlobFileStorageServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the BlobFileStorage services in the ServiceCollection.
+    /// Note: this method can be called multiple times
+    /// </summary>
+    /// <param name="services"></param>
+    /// <returns></returns>
+    public static IServiceCollection AddAzureBlobFileStorage(this IServiceCollection services)
+    {
+        // always use TryXXX methods because this method can be called multiple times
+        // by different modules (currently: Azure Media and Azure Shells module)
+        services.TryAddSingleton<BlobFileStoreFactory>();
+        return services;
+    }
+}

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStoreFactory.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStoreFactory.cs
@@ -1,0 +1,50 @@
+using System;
+using Azure.Storage.Blobs;
+using Microsoft.AspNetCore.StaticFiles;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Modules;
+
+namespace OrchardCore.FileStorage.AzureBlob;
+public class BlobFileStoreFactory
+{
+    private readonly IAzureClientFactory<BlobServiceClient> _clientFactory;
+    private readonly IServiceProvider _serviceProvider;
+
+    public BlobFileStoreFactory(IAzureClientFactory<BlobServiceClient> clientFactory, IServiceProvider serviceProvider)
+    {
+        _clientFactory = clientFactory;
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="BlobFileStore"/> from <see cref="BlobStorageOptions"/>
+    /// If a connectionstring is specified, it will use the connectionstring
+    /// otherwise it will try to get the BlobServiceClient configured with the specified name in the BlobServiceName property
+    /// </summary>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    public virtual BlobFileStore Create(BlobStorageOptions options)
+    {
+        var containerClient = CreateContainerClientFromOptions(options);
+
+        return new BlobFileStore(
+            containerClient,
+            options.BasePath,
+            _serviceProvider.GetRequiredService<IClock>(),
+            _serviceProvider.GetRequiredService<IContentTypeProvider>());
+    }
+
+
+    private BlobContainerClient CreateContainerClientFromOptions(BlobStorageOptions options)
+    {
+        if (!String.IsNullOrEmpty(options.ConnectionString))
+        {
+            return new BlobContainerClient(options.ConnectionString, options.ContainerName);
+        }
+
+        var serviceClient = _clientFactory.CreateClient(options.BlobServiceName);
+        return serviceClient.GetBlobContainerClient(options.ContainerName);
+    }
+
+}

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobStorageOptions.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobStorageOptions.cs
@@ -1,3 +1,5 @@
+using Azure.Core;
+
 namespace OrchardCore.FileStorage.AzureBlob
 {
     public abstract class BlobStorageOptions
@@ -6,6 +8,13 @@ namespace OrchardCore.FileStorage.AzureBlob
         /// The Azure Blob connection string.
         /// </summary>
         public string ConnectionString { get; set; }
+
+        /// <summary>
+        /// The reference to a named AzureClient.
+        /// The client needs to be registered using the AddAzureClients extension method.
+        /// more info: https://learn.microsoft.com/en-us/dotnet/azure/sdk/dependency-injection#configure-multiple-service-clients-with-different-names
+        /// </summary>
+        public string BlobServiceName { get; set; }
 
         /// <summary>
         /// The Azure Blob container name.

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/OrchardCore.FileStorage.AzureBlob.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Shells.Azure/Extensions/BlobShellsOrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Shells.Azure/Extensions/BlobShellsOrchardCoreBuilderExtensions.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.TryAddSingleton<IContentTypeProvider, FileExtensionContentTypeProvider>();
 
+            // register the azure blob file storage services
+            builder.AddAzureBlobFileStorage();
+
             services.AddSingleton<IShellsFileStore>(sp =>
             {
                 var configuration = sp.GetRequiredService<IConfiguration>();
@@ -34,10 +37,9 @@ namespace Microsoft.Extensions.DependencyInjection
                         "The 'OrchardCore.Shells.Azure' configuration section must be defined");
                 }
 
-                var clock = sp.GetRequiredService<IClock>();
-                var contentTypeProvider = sp.GetRequiredService<IContentTypeProvider>();
+                var blobFileStoreFactory = sp.GetRequiredService<BlobFileStoreFactory>();
 
-                var fileStore = new BlobFileStore(blobOptions, clock, contentTypeProvider);
+                var fileStore = blobFileStoreFactory.Create(blobOptions);
 
                 return new BlobShellsFileStore(fileStore);
             });


### PR DESCRIPTION
Fixes #12639

This PR introduces a `BlobFileStoreFactory` which is used by the `OrchardCore.Shells.Azure` and `OrchardCore.Media.Azure` module.

It allows to specify a reference to a configured `BlobServiceClient`  through the [Microsoft.Extensions.Azure](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/extensions/Microsoft.Extensions.Azure/README.md) nuget package.

see https://learn.microsoft.com/en-us/dotnet/azure/sdk/dependency-injection#configure-multiple-service-clients-with-different-names about configuring multiple blob clients and also: https://devblogs.microsoft.com/azure-sdk/best-practices-for-using-azure-sdk-with-asp-net-core/ for best-practices

for example:

`program.cs`

```csharp
builder.Services.AddAzureClients(clientBuilder =>
{
    clientBuilder.AddBlobServiceClient(builder.Configuration.GetSection("PublicStorage"));
    clientBuilder.AddBlobServiceClient(builder.Configuration.GetSection("PrivateStorage"))
        .WithName("PrivateStorage");
});
```

`appsettings.json`
```json
{
  "OrchardCore": {
    "OrchardCore_Shells_Azure": {
      "BlobServiceName": "PrivateStorage", //<<< ! this is where the magic happens
      "ContainerName": "a-container-name", 
      "BasePath": "shells"
    }
  }
}
```

