### PR TITLE
Fix zh cn

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -68,6 +69,7 @@ namespace OrchardCore.Localization.Drivers
             return Initialize<LocalizationSettingsViewModel>("LocalizationSettings_Edit", model =>
                 {
                     model.Cultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
+                    .Union(new[] { CultureInfo.GetCultureInfo("zh-CN") }).OrderBy(x => x.Name)
                         .Select(cultureInfo =>
                         {
                             return new CultureEntry

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
@@ -69,7 +69,7 @@ namespace OrchardCore.Localization.Drivers
             return Initialize<LocalizationSettingsViewModel>("LocalizationSettings_Edit", model =>
                 {
                     model.Cultures = CultureInfo.GetCultures(CultureTypes.AllCultures)
-                    .Union(new[] { CultureInfo.GetCultureInfo("zh-CN") }).OrderBy(x => x.Name)
+                    .Union(new[] { CultureInfo.GetCultureInfo("zh-CN") }).Distinct().OrderBy(x => x.Name)
                         .Select(cultureInfo =>
                         {
                             return new CultureEntry


### PR DESCRIPTION
fix : https://github.com/OrchardCMS/OrchardCore/issues/11672

In the recent update of System.Runtime, the `CultureInfo.GetCultures(CultureTypes.AllCultures)` 
command does not directly list zh-CN

In order to keep the browser consistent, a patch is made here to get the option of zh-CN, as it is only used for setting up the page, which should not cause performance problems

After fix:

![image](https://user-images.githubusercontent.com/15613121/210238774-1fd11255-1d89-42b0-83e0-6344faf1011c.png)

![image](https://user-images.githubusercontent.com/15613121/210238521-e31b2fdb-1562-4f07-bfa0-5fca3bb8484b.png)


