### PR TITLE
Append quality parameter after format parameter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -57,6 +57,8 @@ namespace OrchardCore.Media.Processing
                 queryStringParams["rmode"] = resizeMode.ToString().ToLower();
             }
 
+            // The format is set before quality such that the quality is not 
+            // invalidated when the url is generated.
             if (format != Format.Undefined)
             {
                 queryStringParams["format"] = format.ToString().ToLower();

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -57,14 +57,14 @@ namespace OrchardCore.Media.Processing
                 queryStringParams["rmode"] = resizeMode.ToString().ToLower();
             }
 
-            if (quality.HasValue)
-            {
-                queryStringParams["quality"] = quality.ToString();
-            }
-
             if (format != Format.Undefined)
             {
                 queryStringParams["format"] = format.ToString().ToLower();
+            }
+
+            if (quality.HasValue)
+            {
+                queryStringParams["quality"] = quality.ToString();
             }
 
             if (anchor != null)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaProfileService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaProfileService.cs
@@ -36,14 +36,15 @@ namespace OrchardCore.Media.Services
                 {
                     commands["rmode"] = mediaProfile.Mode.ToString().ToLower();
                 }
-                if (mediaProfile.Quality > 0 && mediaProfile.Quality < 100)
-                {
-                    commands["quality"] = mediaProfile.Quality.ToString();
-                }
 
                 if (mediaProfile.Format != Format.Undefined)
                 {
                     commands["format"] = mediaProfile.Format.ToString().ToLower();
+                }
+
+                if (mediaProfile.Quality > 0 && mediaProfile.Quality < 100)
+                {
+                    commands["quality"] = mediaProfile.Quality.ToString();
                 }
 
                 if (!String.IsNullOrEmpty(mediaProfile.BackgroundColor))


### PR DESCRIPTION
Fix #13079

A quick fix to make the quality parameter work.  
Because with `Dictionary` the order of items is not guaranteed the fix is not regression proof.
`OrderedDictionary` could be used as an alternative, but this would require a reference to `System.Collections.Specialized` in addition.