### PR TITLE
Normalize user "Administrator" role on setup.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/SetupEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/SetupEventHandler.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity;
 using OrchardCore.Abstractions.Setup;
 using OrchardCore.Setup.Events;
 using OrchardCore.Users.Models;
@@ -14,12 +13,10 @@ namespace OrchardCore.Users.Services
     public class SetupEventHandler : ISetupEventHandler
     {
         private readonly IUserService _userService;
-        private readonly ILookupNormalizer _keyNormalizer;
 
-        public SetupEventHandler(IUserService userService, ILookupNormalizer keyNormalizer)
+        public SetupEventHandler(IUserService userService)
         {
             _userService = userService;
-            _keyNormalizer = keyNormalizer;
         }
 
         public async Task Setup(
@@ -35,7 +32,7 @@ namespace OrchardCore.Users.Services
                 EmailConfirmed = true
             };
 
-            user.RoleNames.Add(_keyNormalizer.NormalizeName("Administrator"));
+            user.RoleNames.Add("Administrator");
 
             await _userService.CreateUserAsync(user, properties[SetupConstants.AdminPassword]?.ToString(), reportError);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/SetupEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/SetupEventHandler.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using OrchardCore.Abstractions.Setup;
-using OrchardCore.Security;
 using OrchardCore.Setup.Events;
 using OrchardCore.Users.Models;
 
@@ -15,15 +14,15 @@ namespace OrchardCore.Users.Services
     public class SetupEventHandler : ISetupEventHandler
     {
         private readonly IUserService _userService;
-        private readonly RoleManager<IRole> _roleManager;
+        private readonly ILookupNormalizer _keyNormalizer;
 
-        public SetupEventHandler(IUserService userService, RoleManager<IRole> roleManager)
+        public SetupEventHandler(IUserService userService, ILookupNormalizer keyNormalizer)
         {
             _userService = userService;
-            _roleManager = roleManager;
+            _keyNormalizer = keyNormalizer;
         }
 
-        public Task Setup(
+        public async Task Setup(
             IDictionary<string, object> properties,
             Action<string, string> reportError
             )
@@ -36,9 +35,9 @@ namespace OrchardCore.Users.Services
                 EmailConfirmed = true
             };
 
-            user.RoleNames.Add(_roleManager.NormalizeKey("Administrator"));
+            user.RoleNames.Add(_keyNormalizer.NormalizeName("Administrator"));
 
-            return _userService.CreateUserAsync(user, properties[SetupConstants.AdminPassword]?.ToString(), reportError);
+            await _userService.CreateUserAsync(user, properties[SetupConstants.AdminPassword]?.ToString(), reportError);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/SetupEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/SetupEventHandler.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
 using OrchardCore.Abstractions.Setup;
+using OrchardCore.Security;
 using OrchardCore.Setup.Events;
 using OrchardCore.Users.Models;
 
@@ -13,10 +15,12 @@ namespace OrchardCore.Users.Services
     public class SetupEventHandler : ISetupEventHandler
     {
         private readonly IUserService _userService;
+        private readonly RoleManager<IRole> _roleManager;
 
-        public SetupEventHandler(IUserService userService)
+        public SetupEventHandler(IUserService userService, RoleManager<IRole> roleManager)
         {
             _userService = userService;
+            _roleManager = roleManager;
         }
 
         public Task Setup(
@@ -29,9 +33,10 @@ namespace OrchardCore.Users.Services
                 UserName = properties.TryGetValue(SetupConstants.AdminUsername, out var adminUserName) ? adminUserName?.ToString() : String.Empty,
                 UserId = properties.TryGetValue(SetupConstants.AdminUserId, out var adminUserId) ? adminUserId?.ToString() : String.Empty,
                 Email = properties.TryGetValue(SetupConstants.AdminEmail, out var adminEmail) ? adminEmail?.ToString() : String.Empty,
-                RoleNames = new string[] { "Administrator" },
                 EmailConfirmed = true
             };
+
+            user.RoleNames.Add(_roleManager.NormalizeKey("Administrator"));
 
             return _userService.CreateUserAsync(user, properties[SetupConstants.AdminPassword]?.ToString(), reportError);
         }

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserStore.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserStore.cs
@@ -462,13 +462,14 @@ namespace OrchardCore.Users.Services
             if (user is User u)
             {
                 var roleNames = await _roleService.GetRoleNamesAsync();
+                var roleName = roleNames?.FirstOrDefault(r => NormalizeKey(r) == normalizedRoleName);
 
                 if (!roleNames.Any(r => NormalizeKey(r) == normalizedRoleName))
                 {
                     throw new InvalidOperationException($"Role {normalizedRoleName} does not exist.");
                 }
 
-                u.RoleNames.Add(normalizedRoleName);
+                u.RoleNames.Add(roleName);
             }
         }
 
@@ -482,13 +483,14 @@ namespace OrchardCore.Users.Services
             if (user is User u)
             {
                 var roleNames = await _roleService.GetRoleNamesAsync();
+                var roleName = roleNames?.FirstOrDefault(r => NormalizeKey(r) == normalizedRoleName);
 
                 if (!roleNames.Any(r => NormalizeKey(r) == normalizedRoleName))
                 {
                     throw new InvalidOperationException($"Role {normalizedRoleName} does not exist.");
                 }
 
-                u.RoleNames.Remove(normalizedRoleName);
+                u.RoleNames.Remove(roleName);
             }
         }
 


### PR DESCRIPTION
On setup in the `SetupEventHandler` we set the `user.RoleNames` to a string array in place of a list, and with the `Administrator` role name in place of the normalized `ADMINISTRATOR`. 

So, when saved in the database document we have.

    "RoleNames":{"$type":"System.String[], System.Private.CoreLib","$values":["Administrator"]}

If we save again, we no longer see the string array type, but the role is still not normalized.

    "RoleNames":["Administrator"]

If we add a role, only the new role is normalized.

    "RoleNames":["Administrator","AUTHOR"]

---

After the fix, the role is normalized from the beginning, on setup.

    "RoleNames":["ADMINISTRATOR"]

It may explain in some places the need to be case insensitive when comparing normalized role names to user roles, and/or in other places maybe some unexpected behaviors.
