### PR TITLE
fix error condition for custom fields

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
@@ -53,7 +53,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                     continue;
                 }
 
-                if (!(part.PartDefinition.Fields.Any(field=> contentFieldProviders.Any(fieldProvider=>fieldProvider.GetField(field)!=null))))
+                if (!(part.PartDefinition.Fields.Any(field => contentFieldProviders.Any(fieldProvider => fieldProvider.GetField(field)!=null))))
                 {
                     continue;
                 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
@@ -53,6 +53,11 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                     continue;
                 }
 
+                if (!(part.PartDefinition.Fields.Any(field=> contentFieldProviders.Any(fieldProvider=>fieldProvider.GetField(field)!=null))))
+                {
+                    continue;
+                }
+
                 if (_contentOptions.ShouldCollapse(part))
                 {
                     foreach (var field in part.PartDefinition.Fields)

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/DynamicContentTypeBuilder.cs
@@ -53,7 +53,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                     continue;
                 }
 
-                if (!(part.PartDefinition.Fields.Any(field => contentFieldProviders.Any(fieldProvider => fieldProvider.GetField(field)!=null))))
+                if (!(part.PartDefinition.Fields.Any(field => contentFieldProviders.Any(fieldProvider => fieldProvider.GetField(field) != null))))
                 {
                     continue;
                 }


### PR DESCRIPTION
#13144 
#13136 
When a ContentPart only contains custom fields, that GraphQL doesn't know how to use, the ContentPart is excluded.