### PR TITLE
Update MultiTextField-CheckboxList editor

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-CheckboxList.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/MultiTextField-CheckboxList.Edit.cshtml
@@ -1,4 +1,5 @@
 @model OrchardCore.ContentFields.ViewModels.EditMultiTextFieldViewModel
+@using OrchardCore
 @using OrchardCore.Mvc.Utilities
 @{
     var settings = Model.PartFieldDefinition.GetSettings<MultiTextFieldSettings>();
@@ -12,19 +13,21 @@
     var uniqueName = $"{Model.PartFieldDefinition.PartDefinition.Name}-{Model.PartFieldDefinition.Name}";
 }
 
-<div class="mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">
-    <label>@Model.PartFieldDefinition.DisplayName()</label>
-    @for (int i = 0; i < options.Count; i++)
-    {
-        var option = options[i];
-        <div class="form-check">
-            <input type="checkbox" id="@(Html.IdFor(m => m.Values) + "_" + i)" name="@(Html.NameFor(m => m.Values))" class="form-check-input" value="@option.Value" @(option.Selected ? "checked='checked'" : "") />
-            <label class="form-check-label" for="@(Html.IdFor(m => m.Values) + "_" + i)">@option.Text</label>
-        </div>
-    }
+<div class="row mb-3 field-wrapper field-wrapper-@uniqueName.HtmlClassify()" id="@Html.IdFor(x => x.Values)_FieldWrapper">
+    <label class="@Orchard.GetLabelCssClasses()">@Model.PartFieldDefinition.DisplayName()</label>
+    <div class="@Orchard.GetEndCssClasses()">
+        @for (int i = 0; i < options.Count; i++)
+        {
+            var option = options[i];
+            <div class="form-check">
+                <input type="checkbox" id="@(Html.IdFor(m => m.Values) + "_" + i)" name="@(Html.NameFor(m => m.Values))" class="form-check-input" value="@option.Value" @(option.Selected ? "checked='checked'" : String.Empty) />
+                <label class="form-check-label" for="@(Html.IdFor(m => m.Values) + "_" + i)">@option.Text</label>
+            </div>
+        }
 
-    @if (!String.IsNullOrEmpty(settings.Hint))
-    {
-        <span class="hint">@settings.Hint</span>
-    }
+        @if (!String.IsNullOrEmpty(settings.Hint))
+        {
+            <span class="hint">@settings.Hint</span>
+        }
+    </div>
 </div>


### PR DESCRIPTION
MultiTextField is not using the new `Orchard.GetLabelCssClasses()` and`Orchard.GetEndCssClasses()` helpers