### PR TITLE
'IgnoreSystemSettings' culture option is not used.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Extensions/OrchardCoreRequestLocalizationOptionsExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Extensions/OrchardCoreRequestLocalizationOptionsExtensions.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Localization;
 
 internal static class OrchardCoreRequestLocalizationOptionsExtensions
 {
-    public static RequestLocalizationOptions WithRequestLocalizationOptions(
+    public static OrchardCoreRequestLocalizationOptions WithRequestLocalizationOptions(
         this OrchardCoreRequestLocalizationOptions orchardCoreRequestLocalization, RequestLocalizationOptions requestLocalizationOptions)
     {
         if (orchardCoreRequestLocalization is null)
@@ -24,6 +24,6 @@ internal static class OrchardCoreRequestLocalizationOptionsExtensions
         orchardCoreRequestLocalization.FallBackToParentCultures = requestLocalizationOptions.FallBackToParentCultures;
         orchardCoreRequestLocalization.FallBackToParentUICultures = requestLocalizationOptions.FallBackToParentUICultures;
 
-        return requestLocalizationOptions;
+        return orchardCoreRequestLocalization;
     }
 }

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCoreRequestLocalizationOptions.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/OrchardCoreRequestLocalizationOptions.cs
@@ -29,7 +29,7 @@ public class OrchardCoreRequestLocalizationOptions : RequestLocalizationOptions
     }
 
     /// <inheritdoc/>
-    public new RequestLocalizationOptions AddSupportedCultures(params string[] cultures)
+    public new OrchardCoreRequestLocalizationOptions AddSupportedCultures(params string[] cultures)
     {
         var supportedCultures = new List<CultureInfo>();
 
@@ -44,7 +44,7 @@ public class OrchardCoreRequestLocalizationOptions : RequestLocalizationOptions
     }
 
     /// <inheritdoc/>
-    public new RequestLocalizationOptions AddSupportedUICultures(params string[] uiCultures)
+    public new OrchardCoreRequestLocalizationOptions AddSupportedUICultures(params string[] uiCultures)
     {
         var supportedUICultures = new List<CultureInfo>();
         foreach (var culture in uiCultures)
@@ -58,7 +58,7 @@ public class OrchardCoreRequestLocalizationOptions : RequestLocalizationOptions
     }
 
     /// <inheritdoc/>
-    public new RequestLocalizationOptions SetDefaultCulture(string defaultCulture)
+    public new OrchardCoreRequestLocalizationOptions SetDefaultCulture(string defaultCulture)
     {
         DefaultRequestCulture = new RequestCulture(new CultureInfo(defaultCulture, _useUserOverride));
         


### PR DESCRIPTION
This currently as our our custom `SetDefaultCulture()` and `AddSupported[UI]Cultures()` are not called.

Repro: Enable Localization and put breakpoints in the methods intended to be executed.
