### PR TITLE
GraphQL: Fix null exception on resolving GraphQLSettings

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
@@ -78,7 +78,8 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                                         Arguments = context.Arguments,
                                         Source = resolvedPart,
                                         FieldDefinition = field,
-                                        UserContext = context.UserContext
+                                        UserContext = context.UserContext,
+                                        RequestServices = context.RequestServices
                                     });
                                 })
                             };


### PR DESCRIPTION
When GraphQL is trying to resolve a content type with a NamedBagPart and without arguments is get a null exception which is reported in reported in: #13168

The `Page<T, TSource>(this IResolveFieldContext<T> context, IEnumerable<TSource> source)` its trying to resolve the GraphQLSettings from the `context.RequestServices`, However the requested service is not set.

This PR will fix the null exception that can be thrown on this line:
https://github.com/OrchardCMS/OrchardCore/blob/6a69e253609984679ed2080453aecddf42371643/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Extensions/ResolveFieldContextExtensions.cs#L54