### PR TITLE
Add Text and HTML body notification body

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Activities/NotifyContentOwnerTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Activities/NotifyContentOwnerTask.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentManagement;
-using OrchardCore.Notifications.Models;
 using OrchardCore.Users;
 using OrchardCore.Users.Indexes;
 using OrchardCore.Users.Models;
@@ -39,37 +39,27 @@ public class NotifyContentOwnerTask : NotifyUserTaskActivity
 
     public override LocalizedString DisplayText => S["Notify Content's Owner Task"];
 
-    protected override async Task<IUser> GetUserAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+    protected override async Task<IEnumerable<IUser>> GetUsersAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         if (workflowContext.Input.TryGetValue("ContentItem", out var obj)
             && obj is ContentItem contentItem
             && !String.IsNullOrEmpty(contentItem.Owner))
         {
-            if (workflowContext.Input.TryGetValue("Owner", out var ownerObject) && ownerObject is User user)
+            if (workflowContext.Input.TryGetValue("Owner", out var ownerObject) && ownerObject is User user && user.IsEnabled)
             {
-                return user;
+                return new[] { user };
             }
 
-            var owner = await _session.Query<User, UserIndex>(x => x.UserId == contentItem.Owner).FirstOrDefaultAsync();
+            var owner = await _session.Query<User, UserIndex>(x => x.UserId == contentItem.Owner && x.IsEnabled).FirstOrDefaultAsync();
 
-            workflowContext.Input.TryAdd("Owner", owner);
+            if (owner != null)
+            {
+                workflowContext.Input.TryAdd("Owner", owner);
 
-            return owner;
-
+                return new[] { owner };
+            }
         }
 
-        return null;
-    }
-
-    protected override async Task<INotificationMessage> GetMessageAsync(WorkflowExecutionContext workflowContext)
-    {
-        var message = new HtmlNotificationMessage()
-        {
-            Summary = await _expressionEvaluator.EvaluateAsync(Summary, workflowContext, _htmlEncoder),
-            Body = await _expressionEvaluator.EvaluateAsync(Body, workflowContext, _htmlEncoder),
-            IsHtmlBody = base.IsHtmlBody,
-        };
-
-        return message;
+        return Enumerable.Empty<IUser>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Activities/NotifyUserTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Activities/NotifyUserTask.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OrchardCore.Users;
+using OrchardCore.Users.Models;
 using OrchardCore.Workflows.Models;
 using OrchardCore.Workflows.Services;
 
@@ -28,13 +31,13 @@ public class NotifyUserTask : NotifyUserTaskActivity
 
     public override LocalizedString DisplayText => S["Notify User Task"];
 
-    protected override Task<IUser> GetUserAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+    protected override Task<IEnumerable<IUser>> GetUsersAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        if (workflowContext.Input.TryGetValue("User", out var userObject) && userObject is IUser user)
+        if (workflowContext.Input.TryGetValue("User", out var userObject) && userObject is User user && user.IsEnabled)
         {
-            return Task.FromResult(user);
+            return Task.FromResult<IEnumerable<IUser>>(new[] { user });
         }
 
-        return Task.FromResult<IUser>(null);
+        return Task.FromResult(Enumerable.Empty<IUser>());
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Drivers/NotifyUserTaskActivityDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Drivers/NotifyUserTaskActivityDisplayDriver.cs
@@ -50,9 +50,10 @@ public class NotifyUserTaskActivityDisplayDriver<TActivity, TEditViewModel> : Ac
     /// </summary>
     protected override void EditActivity(TActivity activity, TEditViewModel model)
     {
-        model.Summary = activity.Summary.Expression;
-        model.Body = activity.Body.Expression;
-        model.IsHtmlBody = activity.IsHtmlBody;
+        model.Subject = activity.Subject.Expression;
+        model.TextBody = activity.TextBody.Expression;
+        model.HtmlBody = activity.HtmlBody.Expression;
+        model.IsHtmlPreferred = activity.IsHtmlPreferred;
     }
 
     /// <summary>
@@ -70,9 +71,10 @@ public class NotifyUserTaskActivityDisplayDriver<TActivity, TEditViewModel> : Ac
     /// </summary>
     protected override void UpdateActivity(TEditViewModel model, TActivity activity)
     {
-        activity.Summary = new WorkflowExpression<string>(model.Summary);
-        activity.Body = new WorkflowExpression<string>(model.Body);
-        activity.IsHtmlBody = model.IsHtmlBody;
+        activity.Subject = new WorkflowExpression<string>(model.Subject);
+        activity.TextBody = new WorkflowExpression<string>(model.TextBody);
+        activity.HtmlBody = new WorkflowExpression<string>(model.HtmlBody);
+        activity.IsHtmlPreferred = model.IsHtmlPreferred;
     }
 
     public override IDisplayResult Display(TActivity activity)

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Handlers/CoreNotificationEventsHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Handlers/CoreNotificationEventsHandler.cs
@@ -17,15 +17,13 @@ public class CoreNotificationEventsHandler : NotificationEventsHandler
             context.Notification.UserId = user.UserId;
         }
 
-        if (context.NotificationMessage is INotificationBodyMessage message)
-        {
-            var bodyPart = context.Notification.As<NotificationBodyInfo>();
+        var bodyPart = context.Notification.As<NotificationBodyInfo>();
 
-            bodyPart.IsHtmlBody = message.IsHtmlBody;
-            bodyPart.Body = message.Body;
+        bodyPart.Summary = context.NotificationMessage.Summary;
+        bodyPart.TextBody = context.NotificationMessage.TextBody;
+        bodyPart.HtmlBody = context.NotificationMessage.HtmlBody;
 
-            context.Notification.Put(bodyPart);
-        }
+        context.Notification.Put(bodyPart);
 
         return Task.CompletedTask;
     }

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Startup.cs
@@ -77,13 +77,11 @@ public class Startup : StartupBase
 
     public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
     {
-        var adminControllerName = typeof(AdminController).ControllerName();
-
         routes.MapAreaControllerRoute(
             name: "ListNotifications",
             areaName: "OrchardCore.Notifications",
             pattern: _adminOptions.AdminUrlPrefix + "/notifications",
-            defaults: new { controller = adminControllerName, action = nameof(AdminController.List) }
+            defaults: new { controller = typeof(AdminController).ControllerName(), action = nameof(AdminController.List) }
         );
     }
 }
@@ -107,7 +105,7 @@ public class UsersWorkflowStartup : StartupBase
 }
 
 [Feature("OrchardCore.Notifications.Email")]
-public class EmailNotificationStartup : StartupBase
+public class EmailNotificationsStartup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/ViewModels/NotifyUserTaskActivityViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/ViewModels/NotifyUserTaskActivityViewModel.cs
@@ -5,9 +5,11 @@ namespace OrchardCore.Notifications.ViewModels;
 public class NotifyUserTaskActivityViewModel
 {
     [Required]
-    public string Summary { get; set; }
+    public string Subject { get; set; }
 
-    public string Body { get; set; }
+    public string TextBody { get; set; }
 
-    public bool IsHtmlBody { get; set; }
+    public string HtmlBody { get; set; }
+
+    public bool IsHtmlPreferred { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Items/NotifyContentOwnerTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Items/NotifyContentOwnerTask.Fields.Design.cshtml
@@ -7,4 +7,4 @@
 <header>
     <h4><i class="fa fa-envelope" aria-hidden="true"></i>@Model.Activity.GetTitleOrDefault(() => T["Notify user"])</h4>
 </header>
-<em>&quot;@Model.Activity.Summary&quot;</em>
+<em>&quot;@Model.Activity.Subject&quot;</em>

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Items/NotifyContentOwnerTask.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Items/NotifyContentOwnerTask.Fields.Edit.cshtml
@@ -1,19 +1,28 @@
 @model NotifyUserTaskActivityViewModel
 
-<div class="mb-3" asp-validation-class-for="Summary">
-    <label asp-for="Summary">@T["Summary"]</label>
-    <input type="text" asp-for="Summary" class="form-control" />
-    <span asp-validation-for="Summary"></span>
+<div class="mb-3" asp-validation-class-for="Subject">
+    <label asp-for="Subject">@T["Subject"]</label>
+    <input type="text" asp-for="Subject" class="form-control" />
+    <span asp-validation-for="Subject"></span>
+    <span class="hint">@T["You may use Liquid syntax."]</span>
 </div>
 
-<div class="mb-3" asp-validation-class-for="Body">
-    <label asp-for="Body">@T["Body"]</label>
-    <textarea asp-for="Body" rows="10" class="form-control"></textarea>
+<div class="mb-3" asp-validation-class-for="TextBody">
+    <label asp-for="TextBody">@T["Text Body"]</label>
+    <textarea asp-for="TextBody" rows="10" class="form-control"></textarea>
+    <span class="hint">@T["This optional text body does not support HTML. You may use Liquid syntax."]</span>
+</div>
+
+<div class="mb-3" asp-validation-class-for="TextBody">
+    <label asp-for="HtmlBody">@T["HTML Body"]</label>
+    <textarea asp-for="HtmlBody" rows="10" class="form-control"></textarea>
+    <span class="hint">@T["HTML message will only be sent if the notification provider supports it. You may use Liquid syntax."]</span>
 </div>
 
 <div class="mb-3">
     <div class="form-check">
-        <input asp-for="IsHtmlBody" type="checkbox" class="form-check-input" />
-        <label class="form-check-label" asp-for="IsHtmlBody">@T["The Body contains HTML"]</label>
+        <input asp-for="IsHtmlPreferred" type="checkbox" class="form-check-input" />
+        <label class="form-check-label" asp-for="IsHtmlPreferred">@T["Use HTML Body when possible"]</label>
     </div>
+    <span class="hint">@T["When checked, the notification provider will use the HTML body if it supports HTML."]</span>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Items/NotifyUserTask.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Items/NotifyUserTask.Fields.Design.cshtml
@@ -7,4 +7,4 @@
 <header>
     <h4><i class="fa fa-envelope" aria-hidden="true"></i>@Model.Activity.GetTitleOrDefault(() => T["Notify user"])</h4>
 </header>
-<em>&quot;@Model.Activity.Summary&quot;</em>
+<em>&quot;@Model.Activity.Subject&quot;</em>

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Items/NotifyUserTaskActivity.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Items/NotifyUserTaskActivity.Fields.Edit.cshtml
@@ -1,19 +1,28 @@
 @model NotifyUserTaskActivityViewModel
 
-<div class="mb-3" asp-validation-class-for="Summary">
-    <label asp-for="Summary">@T["Summary"]</label>
-    <input type="text" asp-for="Summary" class="form-control" />
-    <span asp-validation-for="Summary"></span>
+<div class="mb-3" asp-validation-class-for="Subject">
+    <label asp-for="Subject">@T["Subject"]</label>
+    <input type="text" asp-for="Subject" class="form-control" />
+    <span asp-validation-for="Subject"></span>
+    <span class="hint">@T["You may use Liquid syntax."]</span>
 </div>
 
-<div class="mb-3" asp-validation-class-for="Body">
-    <label asp-for="Body">@T["Body"]</label>
-    <textarea asp-for="Body" rows="10" class="form-control"></textarea>
+<div class="mb-3" asp-validation-class-for="TextBody">
+    <label asp-for="TextBody">@T["Text Body"]</label>
+    <textarea asp-for="TextBody" rows="10" class="form-control"></textarea>
+    <span class="hint">@T["This optional text body does not support HTML. You may use Liquid syntax."]</span>
+</div>
+
+<div class="mb-3" asp-validation-class-for="TextBody">
+    <label asp-for="HtmlBody">@T["HTML Body"]</label>
+    <textarea asp-for="HtmlBody" rows="10" class="form-control"></textarea>
+    <span class="hint">@T["HTML message will only be sent if the notification provider supports it. You may use Liquid syntax."]</span>
 </div>
 
 <div class="mb-3">
     <div class="form-check">
-        <input asp-for="IsHtmlBody" type="checkbox" class="form-check-input" />
-        <label class="form-check-label" asp-for="IsHtmlBody">@T["The Body contains HTML"]</label>
+        <input asp-for="IsHtmlPreferred" type="checkbox" class="form-check-input" />
+        <label class="form-check-label" asp-for="IsHtmlPreferred">@T["Use HTML Body when possible"]</label>
     </div>
+    <span class="hint">@T["When checked, the notification provider will use the HTML body if it supports HTML."]</span>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Notification.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/Notification.SummaryAdmin.cshtml
@@ -36,17 +36,10 @@
 
                     <h5 class="mb-0">@notification.Summary</h5>
 
-                    @if (!String.IsNullOrWhiteSpace(bodyInfo.Body))
+                    @if (!String.IsNullOrWhiteSpace(bodyInfo.TextBody))
                     {
                         <p class="mb-0 mt-2">
-                            @if (bodyInfo.IsHtmlBody)
-                            {
-                                @Html.Raw(bodyInfo.Body)
-                            }
-                            else
-                            {
-                                @bodyInfo.Body
-                            }
+                            @bodyInfo.TextBody
                         </p>
                     }
 

--- a/src/OrchardCore/OrchardCore.Notifications.Abstractions/INotificationMessage.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Abstractions/INotificationMessage.cs
@@ -3,11 +3,10 @@ namespace OrchardCore.Notifications;
 public interface INotificationMessage
 {
     string Summary { get; }
-}
 
-public interface INotificationBodyMessage
-{
-    string Body { get; }
+    string TextBody { get; }
 
-    bool IsHtmlBody { get; }
+    string HtmlBody { get; }
+
+    bool IsHtmlPreferred { get; }
 }

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Indexes/NotificationIndex.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Indexes/NotificationIndex.cs
@@ -40,9 +40,9 @@ public class NotificationIndexProvider : IndexProvider<Notification>
 
                 var bodyInfo = notification.As<NotificationBodyInfo>();
 
-                if (!String.IsNullOrEmpty(bodyInfo?.Body))
+                if (!String.IsNullOrEmpty(bodyInfo?.TextBody))
                 {
-                    content += $" {bodyInfo.Body}";
+                    content += $" {bodyInfo.TextBody}";
                 }
 
                 content = StripHTML(content);

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Models/HtmlNotificationMessage.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Models/HtmlNotificationMessage.cs
@@ -1,8 +1,0 @@
-namespace OrchardCore.Notifications.Models;
-
-public class HtmlNotificationMessage : NotificationMessage, INotificationBodyMessage
-{
-    public string Body { get; set; }
-
-    public bool IsHtmlBody { get; set; }
-}

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Models/NotificationBodyInfo.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Models/NotificationBodyInfo.cs
@@ -3,7 +3,7 @@ namespace OrchardCore.Notifications.Models;
 public class NotificationBodyInfo
 {
     /// <summary>
-    /// The Summary or subject of the notification.
+    /// The summary or subject of the notification.
     /// </summary>
     public string Summary { get; set; }
 

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Models/NotificationBodyInfo.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Models/NotificationBodyInfo.cs
@@ -1,14 +1,19 @@
-﻿namespace OrchardCore.Notifications.Models;
+namespace OrchardCore.Notifications.Models;
 
 public class NotificationBodyInfo
 {
     /// <summary>
-    /// The body of the notification.
+    /// The Summary or subject of the notification.
     /// </summary>
-    public string Body { get; set; }
+    public string Summary { get; set; }
 
     /// <summary>
-    /// Whether or not the body is an HTML.
+    /// The text body of the notification.
     /// </summary>
-    public bool IsHtmlBody { get; set; }
+    public string TextBody { get; set; }
+
+    /// <summary>
+    /// The html body of the notification.
+    /// </summary>
+    public string HtmlBody { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Models/NotificationMessage.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Models/NotificationMessage.cs
@@ -3,4 +3,10 @@ namespace OrchardCore.Notifications.Models;
 public class NotificationMessage : INotificationMessage
 {
     public string Summary { get; set; }
+
+    public string TextBody { get; set; }
+
+    public string HtmlBody { get; set; }
+
+    public bool IsHtmlPreferred { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Services/EmailNotificationProvider.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Services/EmailNotificationProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Email;
@@ -35,24 +36,17 @@ public class EmailNotificationProvider : INotificationMethodProvider
         {
             To = user.Email,
             Subject = message.Summary,
-            BodyText = message.Summary,
+            BodyText = message.TextBody,
             IsBodyHtml = false,
             IsBodyText = true,
         };
 
-        if (message is INotificationBodyMessage emailNotificationMessage)
+        if (message.IsHtmlPreferred && !String.IsNullOrWhiteSpace(message.HtmlBody))
         {
-            if (emailNotificationMessage.IsHtmlBody)
-            {
-                emailMessage.Body = emailNotificationMessage.Body;
-                emailMessage.BodyText = null;
-                emailMessage.IsBodyHtml = true;
-                emailMessage.IsBodyText = false;
-            }
-            else
-            {
-                emailMessage.BodyText = emailNotificationMessage.Body;
-            }
+            emailMessage.Body = message.HtmlBody;
+            emailMessage.BodyText = null;
+            emailMessage.IsBodyHtml = true;
+            emailMessage.IsBodyText = false;
         }
 
         var result = await _smtpService.SendAsync(emailMessage);

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Services/EmailNotificationProvider.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Services/EmailNotificationProvider.cs
@@ -27,29 +27,29 @@ public class EmailNotificationProvider : INotificationMethodProvider
     {
         var user = notify as User;
 
-        if (user == null)
+        if (String.IsNullOrEmpty(user?.Email))
         {
             return false;
         }
 
-        var emailMessage = new MailMessage()
+        var mailMessage = new MailMessage()
         {
             To = user.Email,
             Subject = message.Summary,
-            BodyText = message.TextBody,
-            IsBodyHtml = false,
-            IsBodyText = true,
         };
 
         if (message.IsHtmlPreferred && !String.IsNullOrWhiteSpace(message.HtmlBody))
         {
-            emailMessage.Body = message.HtmlBody;
-            emailMessage.BodyText = null;
-            emailMessage.IsBodyHtml = true;
-            emailMessage.IsBodyText = false;
+            mailMessage.Body = message.HtmlBody;
+            mailMessage.IsBodyHtml = true;
+        }
+        else
+        {
+            mailMessage.BodyText = message.TextBody;
+            mailMessage.IsBodyText = true;
         }
 
-        var result = await _smtpService.SendAsync(emailMessage);
+        var result = await _smtpService.SendAsync(mailMessage);
 
         return result.Succeeded;
     }

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Services/NotificationService.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Services/NotificationService.cs
@@ -66,7 +66,7 @@ public class NotificationService : INotificationService
         {
             NotificationId = IdGenerator.GenerateId(),
             CreatedUtc = _clock.UtcNow,
-            Summary = context.NotificationMessage.TextBody,
+            Summary = context.NotificationMessage.Summary,
         };
 
         context.Notification = notification;

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Services/NotificationService.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Services/NotificationService.cs
@@ -66,7 +66,7 @@ public class NotificationService : INotificationService
         {
             NotificationId = IdGenerator.GenerateId(),
             CreatedUtc = _clock.UtcNow,
-            Summary = context.NotificationMessage.Summary,
+            Summary = context.NotificationMessage.TextBody,
         };
 
         context.Notification = notification;

--- a/src/docs/reference/modules/Notifications/README.md
+++ b/src/docs/reference/modules/Notifications/README.md
@@ -4,18 +4,18 @@ The `Notifications` module provides the infrastructure necessary to send notific
 
 ## Notification Methods
 
-There are many methods to send notifications to a user (e.x., Web, Email, Push, SMS, etc.). In addition to web notification, OrchardCore is shipped with Email based notifications. To allow users to receive Email notification, enable the `Email Notifications` feature. 
+There are many methods to send notifications to a user (e.x., Email, Web Push, Mobile Push, SMS, etc.). In addition to the notification center, OrchardCore is shipped with Email based notification feature. To allow users to receive notification via email, enable the `Email Notifications` feature. 
 
 !!! note
-When using `Email Notifications` feature, you must also configure the [SMTP Settings](../Email/README.md). When multiple notification methods are enabled, the user can opt-in or opt-out any method they wishes to receive by editing their profile.
+When using `Email Notifications` feature, you must also configure the [SMTP Service](../Email/README.md). When multiple notification methods are enabled, the user can opt-in/out any method they wishes to receive by editing their profile.
 
 
 ## Adding Custom Notification Provider
-To add a new notification method like `Push` or `SMS`, you can simply implement the `INotificationMethodProvider` interface and then register it as we do in `OrchardCore.Notifications.Email` feature
+To add a new notification method like `Web Push`, `Mobile Push` or `SMS`, you can simply implement the `INotificationMethodProvider` interface. Then, register your new implementation. For example, in the `Email Notifications` feature we register the email notification provider like this 
 
 ```C#
 [Feature("OrchardCore.Notifications.Email")]
-public class EmailNotificationStartup : StartupBase
+public class EmailNotificationsStartup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {

--- a/src/docs/releases/1.6.0.md
+++ b/src/docs/releases/1.6.0.md
@@ -36,6 +36,10 @@ If your are using setup recipes and want to enable `Features`, be sure to explic
 
 ## Change Logs
 
+### New `OrchardCore.Notifications` Module
+New feature was added to provide a way to send notification messages to the users. [Click here](../reference/modules/Notifications/README.md) for more info about notifications.
+
+### `OrchardCore.Contents` Feature
 Prior this release, a user with `ViewContent` permission and has access to the dashboard, automatically gets access to "Content Items". Now, to be able to list contents on the dashboard, a user needs `ListContent` permission instead. 
 
 ### Setting for `TheAdmin` theme


### PR DESCRIPTION
With this PR, notification allows you to defined a Text notification and HTML notification along with a way to set if HTML is preferred. Each Notification provider will decide which message body to send based on it's support. For example, the HTML notification provider supports HTML, if the user prefers HTML, we'll send the HTML message. However, in other notification providers like SMS, HTML is not supported so the TEXT body will be sent.