### PR TITLE
Fix media URL base

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/Startup.cs
@@ -106,7 +106,7 @@ public class Startup : Modules.StartupBase
 
                 var originalPathBase = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext
                     ?.Features.Get<ShellContextFeature>()
-                    ?.OriginalPathBase;
+                    ?.OriginalPathBase ?? PathString.Empty;
 
                 if (originalPathBase.HasValue)
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/Startup.cs
@@ -114,7 +114,7 @@ namespace OrchardCore.Media.Azure
 
                     var originalPathBase = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext
                         ?.Features.Get<ShellContextFeature>()
-                        ?.OriginalPathBase;
+                        ?.OriginalPathBase ?? PathString.Empty;
 
                     if (originalPathBase.HasValue)
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -117,8 +117,9 @@ namespace OrchardCore.Media
 
                 var mediaUrlBase = "/" + fileStore.Combine(shellSettings.RequestUrlPrefix, mediaOptions.AssetsRequestPath);
 
-                var originalPathBase = serviceProvider.GetRequiredService<IHttpContextAccessor>()
-                    .HttpContext?.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? PathString.Empty;
+                var originalPathBase = serviceProvider.GetRequiredService<IHttpContextAccessor>().HttpContext
+                    ?.Features.Get<ShellContextFeature>()
+                    ?.OriginalPathBase ?? PathString.Empty;
 
                 if (originalPathBase.HasValue)
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -118,7 +118,7 @@ namespace OrchardCore.Media
                 var mediaUrlBase = "/" + fileStore.Combine(shellSettings.RequestUrlPrefix, mediaOptions.AssetsRequestPath);
 
                 var originalPathBase = serviceProvider.GetRequiredService<IHttpContextAccessor>()
-                    .HttpContext?.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? null;
+                    .HttpContext?.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? PathString.Empty;
 
                 if (originalPathBase.HasValue)
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/ApiController.cs
@@ -466,7 +466,7 @@ namespace OrchardCore.Tenants.Controllers
             var host = shellSettings.RequestUrlHosts.FirstOrDefault();
             var hostString = host != null ? new HostString(host) : Request.Host;
 
-            var pathString = HttpContext.Features.Get<ShellContextFeature>().OriginalPathBase;
+            var pathString = HttpContext.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? PathString.Empty;
             if (!String.IsNullOrEmpty(shellSettings.RequestUrlPrefix))
             {
                 pathString = pathString.Add('/' + shellSettings.RequestUrlPrefix);

--- a/src/OrchardCore/OrchardCore.Abstractions/BackgroundTasks/ShellContextExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/BackgroundTasks/ShellContextExtensions.cs
@@ -17,7 +17,7 @@ public static class ShellContextExtensions
         context.Features.Set(new ShellContextFeature
         {
             ShellContext = shell,
-            OriginalPathBase = String.Empty,
+            OriginalPathBase = PathString.Empty,
             OriginalPath = "/"
         });
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ApiControllerTests.cs
@@ -190,7 +190,7 @@ public class ApiControllerTests
 
         httpContext.Features.Set(new ShellContextFeature
         {
-            OriginalPathBase = new PathString()
+            OriginalPathBase = PathString.Empty
         });
 
         httpContext.User.AddIdentity(new ClaimsIdentity());


### PR DESCRIPTION
Fix #13199 

@jtkech this fixes the issue I mentioned to you about broken media links.

Prior this PR, the media URL base looked like this `media/...`. With this PR it is now `/media/...` which fixed the broken links.

Media URL base should always start with `/`
