### PR TITLE
Don't use Feature Step in Migration Recipe

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Manifest.cs
@@ -8,8 +8,9 @@ using OrchardCore.Modules.Manifest;
     Description = "Allows to organize widgets in an Admin Dashboard.",
     Dependencies = new[]
     {
-        "OrchardCore.ContentTypes",
         "OrchardCore.Admin",
+        "OrchardCore.Html",
+        "OrchardCore.Title",
         "OrchardCore.Recipes.Core",
     },
     Category = "Content Management"

--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Migrations/dashboard-widgets.recipe.json
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Migrations/dashboard-widgets.recipe.json
@@ -1,13 +1,6 @@
 {
   "steps": [
     {
-      "name": "Feature",
-      "enable": [
-        "OrchardCore.Html",
-        "OrchardCore.Title"
-      ]
-    },
-    {
       "name": "ContentDefinition",
       "ContentTypes": [
         {


### PR DESCRIPTION
Fixes #13225 

After enabling features, the first shell scope activates the shell in a child scope that doesn't activate the shell again to prevent recursions, and where migrations are run, so if a migration executes a migration recipe, this is not good that this recipe enables features that may need their own migrations to be run.

Better to just add these features in the related module Manifest.
