### PR TITLE
Fix the permission check logic in the DefaultContentsAdminListFilterProvider

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
@@ -127,7 +127,6 @@ namespace OrchardCore.Contents.Services
                         var context = (ContentQueryContext)ctx;
                         var httpContextAccessor = context.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
                         var authorizationService = context.ServiceProvider.GetRequiredService<IAuthorizationService>();
-                        var contentManager = context.ServiceProvider.GetRequiredService<IContentManager>();
                         var contentDefinitionManager = context.ServiceProvider.GetRequiredService<IContentDefinitionManager>();
                         var user = httpContextAccessor.HttpContext.User;
                         var userNameIdentifier = user?.FindFirstValue(ClaimTypes.NameIdentifier);

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
@@ -151,9 +151,11 @@ namespace OrchardCore.Contents.Services
                                 {
                                     query.With<ContentItemIndex>(x => x.ContentType == contentType && x.Owner == userNameIdentifier);
                                 }
+
+                                return query;
                             }
 
-                            return query;
+                            // At this point the given contentType is invalid. Ignore it.
                         }
 
                         var ListAnyContentTypes = new List<string>();

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
@@ -144,20 +144,15 @@ namespace OrchardCore.Contents.Services
                                 if (await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.EditContent, contentTypeDefinition.Name, owner: null)
                                 || await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.ViewContent, contentTypeDefinition.Name, owner: null))
                                 {
-                                    query.With<ContentItemIndex>(x => x.ContentType == contentType);
-                                }
-                                else
-                                {
-                                    query.With<ContentItemIndex>(x => x.ContentType == contentType && x.Owner == userNameIdentifier);
+                                    return query.With<ContentItemIndex>(x => x.ContentType == contentType);
                                 }
 
-                                return query;
+                                return query.With<ContentItemIndex>(x => x.ContentType == contentType && x.Owner == userNameIdentifier);
                             }
-
                             // At this point the given contentType is invalid. Ignore it.
                         }
 
-                        var ListAnyContentTypes = new List<string>();
+                        var listAnyContentTypes = new List<string>();
                         var listOwnContentTypes = new List<string>();
 
                         foreach (var ctd in contentDefinitionManager.ListTypeDefinitions())
@@ -171,7 +166,7 @@ namespace OrchardCore.Contents.Services
                             if (await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.EditContent, ctd.Name, owner: null)
                             || await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.ViewContent, ctd.Name, owner: null))
                             {
-                                ListAnyContentTypes.Add(ctd.Name);
+                                listAnyContentTypes.Add(ctd.Name);
 
                                 continue;
                             }
@@ -186,7 +181,7 @@ namespace OrchardCore.Contents.Services
                             }
                         }
 
-                        return query.With<ContentItemIndex>().Where(x => x.ContentType.IsIn(ListAnyContentTypes) || (x.ContentType.IsIn(listOwnContentTypes) && x.Owner == userNameIdentifier));
+                        return query.With<ContentItemIndex>().Where(x => x.ContentType.IsIn(listAnyContentTypes) || (x.ContentType.IsIn(listOwnContentTypes) && x.Owner == userNameIdentifier));
                     })
                     .MapTo<ContentOptionsViewModel>((val, model) =>
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
@@ -140,9 +140,8 @@ namespace OrchardCore.Contents.Services
                                 // We display a specific type even if it's not listable so that admin pages
                                 // can reuse the Content list page for specific types.
 
-                                // It is important to pass null to the owner parameter. This will check if the user can edit or view content that belongs to others.
-                                if (await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.EditContent, contentTypeDefinition.Name, owner: null)
-                                || await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.ViewContent, contentTypeDefinition.Name, owner: null))
+                                // It is important to pass null to the owner parameter. This will check if the user can view content that belongs to others.
+                                if (await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.ViewContent, contentTypeDefinition.Name, owner: null))
                                 {
                                     return query.With<ContentItemIndex>(x => x.ContentType == contentType);
                                 }
@@ -162,18 +161,16 @@ namespace OrchardCore.Contents.Services
                                 continue;
                             }
 
-                            // It is important to pass null to the owner parameter. This will check if the user can edit or view content that belongs to others.
-                            if (await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.EditContent, ctd.Name, owner: null)
-                            || await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.ViewContent, ctd.Name, owner: null))
+                            // It is important to pass null to the owner parameter. This will check if the user can view content that belongs to others.
+                            if (await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.ViewContent, ctd.Name, owner: null))
                             {
                                 listAnyContentTypes.Add(ctd.Name);
 
                                 continue;
                             }
 
-                            // It is important to pass the current user ID to the owner parameter. This will check if the user can edit or view their own content.
-                            if (await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.EditContent, ctd.Name, userNameIdentifier)
-                                || await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.ViewContent, ctd.Name, userNameIdentifier))
+                            // It is important to pass the current user ID to the owner parameter. This will check if the user can view their own content.
+                            if (await authorizationService.AuthorizeContentTypeAsync(user, CommonPermissions.ViewContent, ctd.Name, userNameIdentifier))
                             {
                                 listOwnContentTypes.Add(ctd.Name);
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsButtonEdit_SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsButtonEdit_SummaryAdmin.cshtml
@@ -5,6 +5,7 @@
 
 @{
     ContentItem contentItem = Model.ContentItem;
+    var hasPublished = await ContentManager.HasPublishedVersionAsync(contentItem);
 }
 
 @if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem))
@@ -12,7 +13,7 @@
     <a edit-for="@contentItem" asp-route-returnUrl="@FullRequestPath" class="btn btn-sm btn-primary edit"><span>@T["Edit"]</span></a>
 }
 
-@if (await ContentManager.HasPublishedVersionAsync(contentItem) && await AuthorizationService.AuthorizeAsync(User, CommonPermissions.ViewContent, contentItem))
+@if (hasPublished)
 {
     <a display-for="@contentItem" target="_blank" class="btn btn-sm btn-success view"><span>@T["View"]</span></a>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsButtonEdit_SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsButtonEdit_SummaryAdmin.cshtml
@@ -5,7 +5,6 @@
 
 @{
     ContentItem contentItem = Model.ContentItem;
-    var hasPublished = await ContentManager.HasPublishedVersionAsync(contentItem);
 }
 
 @if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem))
@@ -13,7 +12,7 @@
     <a edit-for="@contentItem" asp-route-returnUrl="@FullRequestPath" class="btn btn-sm btn-primary edit"><span>@T["Edit"]</span></a>
 }
 
-@if (hasPublished)
+@if (await ContentManager.HasPublishedVersionAsync(contentItem) && await AuthorizationService.AuthorizeAsync(User, CommonPermissions.ViewContent, contentItem))
 {
     <a display-for="@contentItem" target="_blank" class="btn btn-sm btn-success view"><span>@T["View"]</span></a>
 }


### PR DESCRIPTION
With the latest changes, a user with `ListContent` permission is needed to list content items. When the user call `DefaultContentsAdminListFilterProvider` they already have `ListContent` permission. That said, we need to fix the query logic to filter to restrict which content-types the user can actually see the listed content if they have `ViewContent` permission. Note. `ViewContent` permission is implied by `EditContent`.

Site with lots of content type, may notice a minor performance gain since we are no longer using `ContentManager.NewAsync()` to only check permission.

We had an issue where if the user provides invalid content type in the filter, ALL content items will be listed even if it is not listable.

@sebastienros I am adding this to the 1.6 milestone since it fixes an issue that is part of 1.6-previews.
