### PR TITLE
Last try to fix deploy docker image for linux

### DIFF
--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -30,9 +30,7 @@ jobs:
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
     - name: Functional Tests
       if: matrix.os == 'ubuntu-latest'
-      shell: pwsh
       run: |
-        Get-ChildItem ./test | Select-Object -ExpandProperty Name
         cd test/OrchardCore.Tests.Functional
         npm install
         npm run cms:test

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -30,7 +30,9 @@ jobs:
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
     - name: Functional Tests
       if: matrix.os == 'ubuntu-latest'
+      shell: pwsh
       run: |
+        Get-ChildItem ./test | Select-Object -ExpandProperty Name
         cd test/OrchardCore.Tests.Functional
         npm install
         npm run cms:test

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -62,7 +62,7 @@ jobs:
       shell: pwsh
       run: |
         Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse -file | Remove-Item
-        Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data_Tests -Recurse | Remove-Item
+        Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data_Tests -Recurse -file | Remove-Item
         $output = [System.IO.Path]::GetFullPath("./.build/release")
         dotnet publish -c Release --property:PublishDir=$output --no-build --framework net7.0
         docker build -f Dockerfile-CI -t orchardproject/orchardcore-cms-linux:dev .

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -61,7 +61,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       shell: pwsh
       run: |
-        Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse | Remove-Item
+        Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse -file | Remove-Item
         Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data_Tests -Recurse | Remove-Item
         $output = [System.IO.Path]::GetFullPath("./.build/release")
         dotnet publish -c Release --property:PublishDir=$output --no-build --framework net7.0

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -72,7 +72,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       shell: pwsh
       run: |
-        Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse | Remove-Item
+        Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse -file | Remove-Item
         Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data_Tests -Recurse | Remove-Item
         $output = [System.IO.Path]::GetFullPath("./.build/release")
         dotnet publish -c Release --property:PublishDir=$output --no-build --framework net7.0

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -73,7 +73,7 @@ jobs:
       shell: pwsh
       run: |
         Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse -file | Remove-Item
-        Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data_Tests -Recurse | Remove-Item
+        Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data_Tests -Recurse -file | Remove-Item
         $output = [System.IO.Path]::GetFullPath("./.build/release")
         dotnet publish -c Release --property:PublishDir=$output --no-build --framework net7.0
         docker build -f Dockerfile-CI -t orchardproject/orchardcore-cms-linux:latest -t orchardproject/orchardcore-cms-linux:${{ steps.get_version.outputs.VERSION }} .


### PR DESCRIPTION
I'm trying to fix the github action to deploy docker for linux by using Powershell under Ubuntu.

But it seems that under Ubuntu the Powershell Pipeline doesn't work on the following

    Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse | Remove-Item

On `Remove-Item` it says `Object reference not set to an instance of an object.`

I will do some tests here around this.