### PR TITLE
Update NuGet.config (add <clear /> to the pacakgeSources)

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
     <!-- This feed should not be used when shipping on NuGet. It should just be used in the dev branch while dependencies are not available on NuGet.org -->
     <!--add key="OrchardCore" value="https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json" /-->


### PR DESCRIPTION
`clear` ensures no additional sources are inherited from another config file. If you are curious to learn more about how NuGet settings work, please refer to https://learn.microsoft.com/nuget/consume-packages/configuring-nuget-behavior#how-settings-are-applied