### PR TITLE
Change the namespace of SearchSettings in the search module

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search/Controllers/SearchController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Controllers/SearchController.cs
@@ -15,7 +15,7 @@ using OrchardCore.Entities;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Search.Abstractions;
-using OrchardCore.Search.Model;
+using OrchardCore.Search.Models;
 using OrchardCore.Search.ViewModels;
 using OrchardCore.Settings;
 using YesSql;

--- a/src/OrchardCore.Modules/OrchardCore.Search/Deployment/SearchSettingsDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Deployment/SearchSettingsDeploymentSource.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using OrchardCore.Deployment;
 using OrchardCore.Entities;
-using OrchardCore.Search.Model;
+using OrchardCore.Search.Models;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Search.Deployment

--- a/src/OrchardCore.Modules/OrchardCore.Search/Drivers/SearchFormPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Drivers/SearchFormPartDisplayDriver.cs
@@ -4,7 +4,7 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.Search.Model;
+using OrchardCore.Search.Models;
 using OrchardCore.Search.ViewModels;
 
 namespace OrchardCore.Search.Drivers;

--- a/src/OrchardCore.Modules/OrchardCore.Search/Drivers/SearchSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Drivers/SearchSettingsDisplayDriver.cs
@@ -9,7 +9,7 @@ using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Search.Abstractions;
-using OrchardCore.Search.Model;
+using OrchardCore.Search.Models;
 using OrchardCore.Search.ViewModels;
 using OrchardCore.Settings;
 

--- a/src/OrchardCore.Modules/OrchardCore.Search/Model/SearchSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Model/SearchSettings.cs
@@ -1,4 +1,4 @@
-namespace OrchardCore.Search.Model
+namespace OrchardCore.Search.Models
 {
     public class SearchSettings
     {

--- a/src/OrchardCore.Modules/OrchardCore.Search/Services/SearchSettingsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Services/SearchSettingsConfiguration.cs
@@ -1,6 +1,6 @@
 using Microsoft.Extensions.Options;
 using OrchardCore.Entities;
-using OrchardCore.Search.Model;
+using OrchardCore.Search.Models;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Search.Configuration

--- a/src/OrchardCore.Modules/OrchardCore.Search/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Startup.cs
@@ -16,7 +16,7 @@ using OrchardCore.Search.Configuration;
 using OrchardCore.Search.Deployment;
 using OrchardCore.Search.Drivers;
 using OrchardCore.Search.Migrations;
-using OrchardCore.Search.Model;
+using OrchardCore.Search.Models;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Settings;
 

--- a/src/OrchardCore.Modules/OrchardCore.Search/Views/SearchFormPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Views/SearchFormPart.cshtml
@@ -1,5 +1,5 @@
 @using OrchardCore.DisplayManagement.Views
-@using OrchardCore.Search.Model
+@using OrchardCore.Search.Models
 
 @model ShapeViewModel<SearchFormPart>
 

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/Models/SearchFormPart.cs
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/Models/SearchFormPart.cs
@@ -1,6 +1,6 @@
 using OrchardCore.ContentManagement;
 
-namespace OrchardCore.Search.Model;
+namespace OrchardCore.Search.Models;
 
 public class SearchFormPart : ContentPart
 {

--- a/src/docs/releases/1.6.0.md
+++ b/src/docs/releases/1.6.0.md
@@ -36,7 +36,6 @@ Additionally, the namespace of the `SearchFormViewModel`, `SearchIndexViewModel`
 
 The namespace of `SearchSettings` class changed from `OrchardCore.Search.Model` to `OrchardCore.Search.Models`.
 
-
 ### Features and Recipes
 
 `OrchardCore.Features` is no longer auto enabled by `OrchardCore.Recipes` as it doesn't depend on it anymore. If you find yourself using recipes services like `IRecipeMigrator` in your module, be sure to add a dependency on `OrchardCore.Recipes.Core` feature in your module's Manifest file to ensures that the recipe services are available before using them.

--- a/src/docs/releases/1.6.0.md
+++ b/src/docs/releases/1.6.0.md
@@ -34,6 +34,9 @@ The property `SearchProviderAreaName` in the `SearchSettings` class was renamed 
 
 Additionally, the namespace of the `SearchFormViewModel`, `SearchIndexViewModel`, and `SearchResultViewModel` was changed from `OrchardCore.Search.Abstractions.ViewModels` to `OrchardCore.Search.ViewModels`.
 
+The namespace of `SearchSettings` class changed from `OrchardCore.Search.Model` to `OrchardCore.Search.Models`.
+
+
 ### Features and Recipes
 
 `OrchardCore.Features` is no longer auto enabled by `OrchardCore.Recipes` as it doesn't depend on it anymore. If you find yourself using recipes services like `IRecipeMigrator` in your module, be sure to add a dependency on `OrchardCore.Recipes.Core` feature in your module's Manifest file to ensures that the recipe services are available before using them.


### PR DESCRIPTION
We recently added a namespace change in the search module. I am changing the namespace of the `SearchSettings` from `OrchardCore.Search.Model` to `OrchardCore.Search.Models`.