### PR TITLE
Remove IValidatableObject from RegisterExternalLoginViewModel

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/ViewModels/RegisterExternalLoginViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/ViewModels/RegisterExternalLoginViewModel.cs
@@ -1,12 +1,8 @@
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Localization;
-using OrchardCore.Email;
 
 namespace OrchardCore.Users.ViewModels
 {
-    public class RegisterExternalLoginViewModel : IValidatableObject
+    public class RegisterExternalLoginViewModel
     {
         public bool NoUsername { get; set; }
 
@@ -14,52 +10,20 @@ namespace OrchardCore.Users.ViewModels
 
         public bool NoPassword { get; set; }
 
+        [Required(ErrorMessage = "Username is required.")]
         public string UserName { get; set; }
 
+        [Required(ErrorMessage = "Email is required.")]
+        [Email.EmailAddress(ErrorMessage = "Invalid Email.")]
         public string Email { get; set; }
 
+        [Required(ErrorMessage = "Passowrd is required.")]
         [DataType(DataType.Password)]
+        [StringLength(100, ErrorMessage = "Password must be between 6 and 100 characters.", MinimumLength = 6)]
         public string Password { get; set; }
 
+        [Compare(nameof(Password), ErrorMessage = "Confirm Password do not match.")]
         [DataType(DataType.Password)]
         public string ConfirmPassword { get; set; }
-
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-        {
-            var emailAddressValidator = validationContext.GetService<IEmailAddressValidator>();
-            var S = validationContext.GetService<IStringLocalizer<RegisterExternalLoginViewModel>>();
-
-            if (string.IsNullOrWhiteSpace(Email))
-            {
-                if (!NoEmail)
-                {
-                    yield return new ValidationResult(S["Email is required!"], new[] { "Email" });
-                }
-            }
-            else if (!emailAddressValidator.Validate(Email))
-            {
-                yield return new ValidationResult(S["Invalid Email."], new[] { "Email" });
-            }
-
-            if (string.IsNullOrWhiteSpace(UserName) && !NoUsername)
-            {
-                yield return new ValidationResult(S["Username is required!"], new[] { "UserName" });
-            }
-
-            if (string.IsNullOrWhiteSpace(Password) && !NoPassword)
-            {
-                yield return new ValidationResult(S["Password is required!"], new[] { "Password" });
-            }
-
-            if (Password != ConfirmPassword)
-            {
-                yield return new ValidationResult(S["Confirm Password do not match"], new[] { "ConfirmPassword" });
-            }
-
-            if (Password != null && (Password.Length < 6 || Password.Length > 100))
-            {
-                yield return new ValidationResult(string.Format(S["Password must be between {0} and {1} characters"], 6, 100), new[] { "Password" });
-            }
-        }
     }
 }


### PR DESCRIPTION
No need for `IValidatableObject` here while we already supported data annotations localization