### PR TITLE
Move SQLQueryResults to OrchardCore.Queries

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SQLQueryResults.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/SQLQueryResults.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
-using OrchardCore.Queries;
 
-namespace OrchardCore.Data
+namespace OrchardCore.Queries.Sql
 {
     public class SQLQueryResults : IQueryResults
     {

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Abstractions\OrchardCore.Abstractions.csproj" />
-    <ProjectReference Include="..\OrchardCore.Queries.Abstractions\OrchardCore.Queries.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/OrchardCore.Data.Abstractions.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Abstractions\OrchardCore.Abstractions.csproj" />
+    <ProjectReference Include="..\OrchardCore.Queries.Abstractions\OrchardCore.Queries.Abstractions.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.Data.Abstractions/SQLQueryResults.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/SQLQueryResults.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using OrchardCore.Queries;
+
+namespace OrchardCore.Data
+{
+    [Obsolete("This class has been deprecated and will be removed on the upcoming major release.", error: true)]
+    public class SQLQueryResults : IQueryResults
+    {
+        public IEnumerable<object> Items { get; set; }
+    }
+}


### PR DESCRIPTION
I'm not sure if the refactor of queries & searching was done before or after `1.5`, here `SQLQueryResults` doesn't make sense to live in `OC.Data.Abstractions`, if you remember both `LuceneQueryResults` & `ElasticQueryResults` are living on their own `OC.XXX.Abstractions`, while there's no `OC.Queries.Core` for providing the default SQL implementation, I see `OC.Queries` is the suited places for this type

@Skrypt @MikeAlhayek if you remember when this moved into the current namespace it will help us to move the type safely or deprecate the current on