### PR TITLE
Apply all filters before placing a shape

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/DefaultContentDefinitionDisplayManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Editors/DefaultContentDefinitionDisplayManager.cs
@@ -54,7 +54,7 @@ namespace OrchardCore.ContentTypes.Editors
                 contentTypeDefinitionShape,
                 groupId,
                 false,
-                "",
+                String.Empty,
                 _shapeFactory,
                 await _layoutAccessor.GetLayoutAsync(),
                 updater
@@ -112,7 +112,7 @@ namespace OrchardCore.ContentTypes.Editors
                 contentPartDefinitionShape,
                 groupId,
                 false,
-                "",
+                String.Empty,
                 _shapeFactory,
                 await _layoutAccessor.GetLayoutAsync(),
                 updater
@@ -171,7 +171,7 @@ namespace OrchardCore.ContentTypes.Editors
                 typePartDefinitionShape,
                 groupId,
                 false,
-                "",
+                String.Empty,
                 _shapeFactory,
                 await _layoutAccessor.GetLayoutAsync(),
                 updater
@@ -233,7 +233,7 @@ namespace OrchardCore.ContentTypes.Editors
                 partFieldDefinitionShape,
                 groupId,
                 false,
-                "",
+                String.Empty,
                 _shapeFactory,
                 await _layoutAccessor.GetLayoutAsync(),
                 updater

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementInfoResolver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementInfoResolver.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy;
+using OrchardCore.DisplayManagement.Shapes;
+
+namespace OrchardCore.Placements.Services
+{
+    public partial class PlacementProvider
+    {
+        public class PlacementInfoResolver : IPlacementInfoResolver
+        {
+            private readonly IReadOnlyDictionary<string, IEnumerable<PlacementNode>> _placements;
+            private readonly IEnumerable<IPlacementNodeFilterProvider> _placementNodeFilterProviders;
+
+            public PlacementInfoResolver(
+                IReadOnlyDictionary<string, IEnumerable<PlacementNode>> placements,
+                IEnumerable<IPlacementNodeFilterProvider> placementNodeFilterProviders)
+            {
+                _placements = placements;
+                _placementNodeFilterProviders = placementNodeFilterProviders;
+            }
+
+            public PlacementInfo ResolvePlacement(ShapePlacementContext placementContext)
+            {
+                PlacementInfo placement = null;
+
+                if (_placements.ContainsKey(placementContext.ShapeType))
+                {
+                    var shapePlacements = _placements[placementContext.ShapeType];
+
+                    foreach (var placementRule in shapePlacements)
+                    {
+                        if (!PlacementHelper.MatchesAllFilters(placementContext, placementRule, _placementNodeFilterProviders))
+                        {
+                            // Ignore rule.
+                            continue;
+                        }
+
+                        placement ??= new PlacementInfo
+                        {
+                            Source = "OrchardCore.Placements"
+                        };
+
+                        if (!String.IsNullOrEmpty(placementRule.Location))
+                        {
+                            placement.Location = placementRule.Location;
+                        }
+
+                        if (!String.IsNullOrEmpty(placementRule.ShapeType))
+                        {
+                            placement.ShapeType = placementRule.ShapeType;
+                        }
+
+                        if (placementRule.Alternates?.Length > 0)
+                        {
+                            placement.Alternates = placement.Alternates.Combine(new AlternatesCollection(placementRule.Alternates));
+                        }
+
+                        if (placementRule.Wrappers?.Length > 0)
+                        {
+                            placement.Wrappers = placement.Wrappers.Combine(new AlternatesCollection(placementRule.Wrappers));
+                        }
+                    }
+                }
+
+                return placement;
+            }
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementInfoResolver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementInfoResolver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy;
@@ -6,66 +6,63 @@ using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.Placements.Services
 {
-    public partial class PlacementProvider
+    public class PlacementInfoResolver : IPlacementInfoResolver
     {
-        public class PlacementInfoResolver : IPlacementInfoResolver
+        private readonly IReadOnlyDictionary<string, IEnumerable<PlacementNode>> _placements;
+        private readonly IEnumerable<IPlacementNodeFilterProvider> _placementNodeFilterProviders;
+
+        public PlacementInfoResolver(
+            IReadOnlyDictionary<string, IEnumerable<PlacementNode>> placements,
+            IEnumerable<IPlacementNodeFilterProvider> placementNodeFilterProviders)
         {
-            private readonly IReadOnlyDictionary<string, IEnumerable<PlacementNode>> _placements;
-            private readonly IEnumerable<IPlacementNodeFilterProvider> _placementNodeFilterProviders;
+            _placements = placements;
+            _placementNodeFilterProviders = placementNodeFilterProviders;
+        }
 
-            public PlacementInfoResolver(
-                IReadOnlyDictionary<string, IEnumerable<PlacementNode>> placements,
-                IEnumerable<IPlacementNodeFilterProvider> placementNodeFilterProviders)
+        public PlacementInfo ResolvePlacement(ShapePlacementContext placementContext)
+        {
+            PlacementInfo placement = null;
+
+            if (_placements.ContainsKey(placementContext.ShapeType))
             {
-                _placements = placements;
-                _placementNodeFilterProviders = placementNodeFilterProviders;
-            }
+                var shapePlacements = _placements[placementContext.ShapeType];
 
-            public PlacementInfo ResolvePlacement(ShapePlacementContext placementContext)
-            {
-                PlacementInfo placement = null;
-
-                if (_placements.ContainsKey(placementContext.ShapeType))
+                foreach (var placementRule in shapePlacements)
                 {
-                    var shapePlacements = _placements[placementContext.ShapeType];
-
-                    foreach (var placementRule in shapePlacements)
+                    if (!PlacementHelper.MatchesAllFilters(placementContext, placementRule, _placementNodeFilterProviders))
                     {
-                        if (!PlacementHelper.MatchesAllFilters(placementContext, placementRule, _placementNodeFilterProviders))
-                        {
-                            // Ignore rule.
-                            continue;
-                        }
+                        // Ignore rule.
+                        continue;
+                    }
 
-                        placement ??= new PlacementInfo
-                        {
-                            Source = "OrchardCore.Placements"
-                        };
+                    placement ??= new PlacementInfo
+                    {
+                        Source = "OrchardCore.Placements"
+                    };
 
-                        if (!String.IsNullOrEmpty(placementRule.Location))
-                        {
-                            placement.Location = placementRule.Location;
-                        }
+                    if (!String.IsNullOrEmpty(placementRule.Location))
+                    {
+                        placement.Location = placementRule.Location;
+                    }
 
-                        if (!String.IsNullOrEmpty(placementRule.ShapeType))
-                        {
-                            placement.ShapeType = placementRule.ShapeType;
-                        }
+                    if (!String.IsNullOrEmpty(placementRule.ShapeType))
+                    {
+                        placement.ShapeType = placementRule.ShapeType;
+                    }
 
-                        if (placementRule.Alternates?.Length > 0)
-                        {
-                            placement.Alternates = placement.Alternates.Combine(new AlternatesCollection(placementRule.Alternates));
-                        }
+                    if (placementRule.Alternates?.Length > 0)
+                    {
+                        placement.Alternates = placement.Alternates.Combine(new AlternatesCollection(placementRule.Alternates));
+                    }
 
-                        if (placementRule.Wrappers?.Length > 0)
-                        {
-                            placement.Wrappers = placement.Wrappers.Combine(new AlternatesCollection(placementRule.Wrappers));
-                        }
+                    if (placementRule.Wrappers?.Length > 0)
+                    {
+                        placement.Wrappers = placement.Wrappers.Combine(new AlternatesCollection(placementRule.Wrappers));
                     }
                 }
-
-                return placement;
             }
+
+            return placement;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementProvider.cs
@@ -6,7 +6,7 @@ using OrchardCore.DisplayManagement.Handlers;
 
 namespace OrchardCore.Placements.Services
 {
-    public partial class PlacementProvider : IShapePlacementProvider
+    public class PlacementProvider : IShapePlacementProvider
     {
         private readonly PlacementsManager _placementsManager;
         private readonly IEnumerable<IPlacementNodeFilterProvider> _placementNodeFilterProviders;

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementProvider.cs
@@ -1,16 +1,12 @@
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy;
 using OrchardCore.DisplayManagement.Handlers;
-using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.Placements.Services
 {
-    public class PlacementProvider : IShapePlacementProvider
+    public partial class PlacementProvider : IShapePlacementProvider
     {
         private readonly PlacementsManager _placementsManager;
         private readonly IEnumerable<IPlacementNodeFilterProvider> _placementNodeFilterProviders;
@@ -26,87 +22,8 @@ namespace OrchardCore.Placements.Services
         public async Task<IPlacementInfoResolver> BuildPlacementInfoResolverAsync(IBuildShapeContext context)
         {
             var placements = await _placementsManager.ListShapePlacementsAsync();
+
             return new PlacementInfoResolver(placements, _placementNodeFilterProviders);
-        }
-
-        public class PlacementInfoResolver : IPlacementInfoResolver
-        {
-            private readonly IReadOnlyDictionary<string, IEnumerable<PlacementNode>> _placements;
-            private readonly IEnumerable<IPlacementNodeFilterProvider> _placementNodeFilterProviders;
-
-            public PlacementInfoResolver(
-                IReadOnlyDictionary<string, IEnumerable<PlacementNode>> placements,
-                IEnumerable<IPlacementNodeFilterProvider> placementNodeFilterProviders)
-            {
-                _placements = placements;
-                _placementNodeFilterProviders = placementNodeFilterProviders;
-            }
-
-            public PlacementInfo ResolvePlacement(ShapePlacementContext placementContext)
-            {
-                PlacementInfo placement = null;
-
-                if (_placements.ContainsKey(placementContext.ShapeType))
-                {
-                    var shapePlacements = _placements[placementContext.ShapeType];
-
-                    foreach (var placementRule in shapePlacements)
-                    {
-                        var filters = placementRule.Filters.ToList();
-
-                        Func<ShapePlacementContext, bool> predicate = ctx => CheckFilter(ctx, placementRule);
-
-                        if (filters.Any())
-                        {
-                            predicate = filters.Aggregate(predicate, BuildPredicate);
-                        }
-
-                        if (!predicate(placementContext))
-                        {
-                            // Ignore rule
-                            continue;
-                        }
-
-                        if (placement == null)
-                        {
-                            placement = new PlacementInfo
-                            {
-                                Source = "OrchardCore.Placements"
-                            };
-                        }
-
-                        if (!string.IsNullOrEmpty(placementRule.Location))
-                        {
-                            placement.Location = placementRule.Location;
-                        }
-
-                        if (!string.IsNullOrEmpty(placementRule.ShapeType))
-                        {
-                            placement.ShapeType = placementRule.ShapeType;
-                        }
-
-                        if (placementRule.Alternates?.Length > 0)
-                        {
-                            placement.Alternates = placement.Alternates.Combine(new AlternatesCollection(placementRule.Alternates));
-                        }
-
-                        if (placementRule.Wrappers?.Length > 0)
-                        {
-                            placement.Wrappers = placement.Wrappers.Combine(new AlternatesCollection(placementRule.Wrappers));
-                        }
-                    }
-                }
-
-                return placement;
-            }
-
-            private static bool CheckFilter(ShapePlacementContext ctx, PlacementNode filter) => ShapePlacementParsingStrategy.CheckFilter(ctx, filter);
-
-            private Func<ShapePlacementContext, bool> BuildPredicate(Func<ShapePlacementContext, bool> predicate,
-                  KeyValuePair<string, JToken> term)
-            {
-                return ShapePlacementParsingStrategy.BuildPredicate(predicate, term, _placementNodeFilterProviders);
-            }
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
@@ -155,12 +155,12 @@ namespace OrchardCore.ContentManagement.Display
 
                     await shapeResult.ApplyAsync(context);
 
-                    var contentPartShape = shapeResult.Shape;
-
-                    // Make the ContentPart name property available on the shape
-                    contentPartShape.Properties[partTypeName] = part.Content;
-                    contentPartShape.Properties["ContentItem"] = part.ContentItem;
-
+                    if (shapeResult.Shape != null)
+                    {
+                        // Make the ContentPart name property available on the shape
+                        shapeResult.Shape.Properties[partTypeName] = part.Content;
+                        shapeResult.Shape.Properties["ContentItem"] = part.ContentItem;
+                    }
                     context = new BuildDisplayContext(shapeResult.Shape, context.DisplayType, context.GroupId, context.ShapeFactory, context.Layout, context.Updater)
                     {
                         // With a new display context we have the default FindPlacementDelegate that returns null, so we reuse the delegate from the temp context.

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/Placement/ContentPartPlacementNodeFilterProvider.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/Placement/ContentPartPlacementNodeFilterProvider.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy;
+
+namespace OrchardCore.ContentManagement.Display.Placement
+{
+    public class ContentPartPlacementNodeFilterProvider : ContentPlacementParseFilterProviderBase, IPlacementNodeFilterProvider
+    {
+        public string Key
+        {
+            get
+            {
+                return "contentPart";
+            }
+        }
+
+        public bool IsMatch(ShapePlacementContext context, JToken expression)
+        {
+            var contentItem = GetContent(context);
+
+            if (contentItem == null)
+            {
+                return false;
+            }
+
+            if (expression is JArray)
+            {
+                return expression.Any(p => contentItem.Has(p.Value<string>()));
+            }
+
+            return contentItem.Has(expression.Value<string>());
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/Placement/ContentPlacementParseFilterProviderBase.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/Placement/ContentPlacementParseFilterProviderBase.cs
@@ -1,0 +1,26 @@
+﻿using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.Descriptors;
+using OrchardCore.DisplayManagement.Shapes;
+
+namespace OrchardCore.ContentManagement.Display.Placement
+{
+    public class ContentPlacementParseFilterProviderBase
+    {
+        protected static bool HasContent(ShapePlacementContext context)
+        {
+            return context.ZoneShape is Shape shape
+                && shape.TryGetProperty("ContentItem", out object contentItem)
+                && contentItem != null;
+        }
+
+        protected static ContentItem GetContent(ShapePlacementContext context)
+        {
+            if (HasContent(context) && context.ZoneShape is Shape shape && shape.TryGetProperty("ContentItem", out ContentItem contentItem))
+            {
+                return contentItem;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/Placement/ContentTypePlacementNodeFilterProvider.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/Placement/ContentTypePlacementNodeFilterProvider.cs
@@ -2,40 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.Linq;
-using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy;
 using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.ContentManagement.Display.Placement
 {
-    public class ContentPartPlacementNodeFilterProvider : ContentPlacementParseFilterProviderBase, IPlacementNodeFilterProvider
-    {
-        public string Key
-        {
-            get
-            {
-                return "contentPart";
-            }
-        }
-
-        public bool IsMatch(ShapePlacementContext context, JToken expression)
-        {
-            var contentItem = GetContent(context);
-            if (contentItem == null)
-            {
-                return false;
-            }
-
-            if (expression is JArray)
-            {
-                return expression.Any(p => contentItem.Has(p.Value<string>()));
-            }
-
-            return contentItem.Has(expression.Value<string>());
-        }
-    }
-
     public class ContentTypePlacementNodeFilterProvider : ContentPlacementParseFilterProviderBase, IPlacementNodeFilterProvider
     {
         public string Key
@@ -49,6 +21,7 @@ namespace OrchardCore.ContentManagement.Display.Placement
         public bool IsMatch(ShapePlacementContext context, JToken expression)
         {
             var contentItem = GetContent(context);
+
             if (contentItem?.ContentType == null)
             {
                 return false;
@@ -85,26 +58,6 @@ namespace OrchardCore.ContentManagement.Display.Placement
             if (context.ZoneShape is Shape shape && shape.Properties.TryGetValue("Stereotype", out var stereotypeVal))
             {
                 return stereotypeVal?.ToString();
-            }
-
-            return null;
-        }
-    }
-
-    public class ContentPlacementParseFilterProviderBase
-    {
-        protected static bool HasContent(ShapePlacementContext context)
-        {
-            return context.ZoneShape is Shape shape
-                && shape.TryGetProperty("ContentItem", out object contentItem)
-                && contentItem != null;
-        }
-
-        protected static ContentItem GetContent(ShapePlacementContext context)
-        {
-            if (HasContent(context) && context.ZoneShape is Shape shape && shape.TryGetProperty("ContentItem", out ContentItem contentItem))
-            {
-                return contentItem;
             }
 
             return null;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementHelper.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy;
+
+namespace OrchardCore.DisplayManagement.Descriptors;
+
+public static class PlacementHelper
+{
+    public static bool MatchesAllFilters(ShapePlacementContext context, PlacementNode placementNode, IEnumerable<IPlacementNodeFilterProvider> placementNodeFilterProviders)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        if (placementNode == null)
+        {
+            throw new ArgumentNullException(nameof(placementNode));
+        }
+
+        if (!String.IsNullOrEmpty(placementNode.DisplayType) && placementNode.DisplayType != context.DisplayType)
+        {
+            return false;
+        }
+
+        if (!String.IsNullOrEmpty(placementNode.Differentiator) && placementNode.Differentiator != context.Differentiator)
+        {
+            return false;
+        }
+
+        if (placementNodeFilterProviders != null && placementNodeFilterProviders.Any())
+        {
+            foreach (var filter in placementNode.Filters)
+            {
+                var filterProviders = placementNodeFilterProviders.Where(x => x.Key == filter.Key).ToList();
+
+                foreach (var filterProvider in filterProviders)
+                {
+                    if (!filterProvider.IsMatch(context, filter.Value))
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementInfoExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementInfoExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.DisplayManagement.Descriptors
@@ -19,27 +20,29 @@ namespace OrchardCore.DisplayManagement.Descriptors
             {
                 return second;
             }
-            else if (second != null)
+
+            if (second != null)
             {
                 first.Alternates = first.Alternates.Combine(second.Alternates);
                 first.Wrappers = first.Wrappers.Combine(second.Wrappers);
-                if (!string.IsNullOrEmpty(second.ShapeType))
+                if (!String.IsNullOrEmpty(second.ShapeType))
                 {
                     first.ShapeType = second.ShapeType;
                 }
-                if (!string.IsNullOrEmpty(second.Location))
+                if (!String.IsNullOrEmpty(second.Location))
                 {
                     first.Location = second.Location;
                 }
-                if (!string.IsNullOrEmpty(second.DefaultPosition))
+                if (!String.IsNullOrEmpty(second.DefaultPosition))
                 {
                     first.DefaultPosition = second.DefaultPosition;
                 }
-                if (!string.IsNullOrEmpty(second.Source))
+                if (!String.IsNullOrEmpty(second.Source))
                 {
                     first.Source += "," + second.Source;
                 }
             }
+
             return first;
         }
 
@@ -58,10 +61,12 @@ namespace OrchardCore.DisplayManagement.Descriptors
             {
                 return second;
             }
-            else if (second != null)
+
+            if (second != null)
             {
                 first.AddRange(second);
             }
+
             return first;
         }
     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
@@ -77,7 +77,6 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy
                     {
                         Location = filter.Location,
                         ShapeType = filter.ShapeType,
-                        Source = featureDescriptor.Id,
                     };
 
                     if (filter.Alternates?.Length > 0)


### PR DESCRIPTION
Fix #13476

In summary, when multiple rules are set in placement, `ALL` of the rules must to be true. If one provides multiple `contentTypes` or `contentParts`, we still apply `ANY` logic to check if the array of `contentTypes` contains the content type being displayed and if the array of `contentParts` contains the content-part being displayed. 

```
{
  "TextField":[
    {
      "place":"-",
      "displayType":"Detail",
      "differentiator":null,
      "alternates":null,
      "wrappers":null,
      "shape":null,
      "contentType":[
        "Article",
        "Blog"
      ],
      "contentPart":[
        "ArticleSource",
        "BlogSource"
      ]
    }
  ]
}
```

In the above placement example, we hide the shape when **ALL** the following rules are met
- displayType is **Detail**
- contentType either **Article** or **Blog**
- contentPart is **ArticleSource** or **BlogSource**
