### PR TITLE
Allows multi-process logging

### DIFF
--- a/src/OrchardCore.Cms.Web/NLog.config
+++ b/src/OrchardCore.Cms.Web/NLog.config
@@ -15,6 +15,7 @@
         <target xsi:type="File" name="file"
                 fileName="${var:configDir}/App_Data/logs/orchard-log-${shortdate}.log"
                 layout="${longdate}|${orchard-tenant-name}|${aspnet-traceidentifier}|${event-properties:item=EventId}|${logger}|${uppercase:${level}}|${message} ${exception:format=ToString,StackTrace}"
+                concurrentWrites = "true"
         />
 
         <!-- console target -->


### PR DESCRIPTION
Fixes #13634 

Not sure we want it but if multiple instances run on the same file system, adding `concurrentWrites = "true"` in `NLog.config` prevents from having a bunch of  `NLog Failed to create file appender`.