### PR TITLE
Show AdminDashboard shape when "AccessAdminDashboard" is not granted

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Controllers/DashboardController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Controllers/DashboardController.cs
@@ -4,10 +4,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.Extensions.Localization;
-using Microsoft.Extensions.Logging;
 using OrchardCore.Admin;
 using OrchardCore.AdminDashboard.Models;
 using OrchardCore.AdminDashboard.Services;
@@ -17,9 +14,7 @@ using OrchardCore.ContentManagement.Display;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.Contents;
-using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.ModelBinding;
-using OrchardCore.DisplayManagement.Notify;
 
 namespace OrchardCore.AdminDashboard.Controllers
 {
@@ -32,12 +27,7 @@ namespace OrchardCore.AdminDashboard.Controllers
         private readonly IContentItemDisplayManager _contentItemDisplayManager;
         private readonly IContentDefinitionManager _contentDefinitionManager;
         private readonly IUpdateModelAccessor _updateModelAccessor;
-        private readonly INotifier _notifier;
-        private readonly IStringLocalizer S;
-        private readonly IHtmlLocalizer H;
-        private readonly dynamic New;
         private readonly YesSql.ISession _session;
-        private readonly ILogger _logger;
 
         public DashboardController(
             IAuthorizationService authorizationService,
@@ -46,12 +36,7 @@ namespace OrchardCore.AdminDashboard.Controllers
             IContentItemDisplayManager contentItemDisplayManager,
             IContentDefinitionManager contentDefinitionManager,
             IUpdateModelAccessor updateModelAccessor,
-            IShapeFactory shapeFactory,
-            INotifier notifier,
-            IStringLocalizer<DashboardController> stringLocalizer,
-            IHtmlLocalizer<DashboardController> htmlLocalizer,
-            YesSql.ISession session,
-            ILogger<DashboardController> logger)
+            YesSql.ISession session)
         {
             _authorizationService = authorizationService;
             _adminDashboardService = adminDashboardService;
@@ -59,36 +44,36 @@ namespace OrchardCore.AdminDashboard.Controllers
             _contentItemDisplayManager = contentItemDisplayManager;
             _contentDefinitionManager = contentDefinitionManager;
             _updateModelAccessor = updateModelAccessor;
-            New = shapeFactory;
-            _notifier = notifier;
-            S = stringLocalizer;
-            H = htmlLocalizer;
             _session = session;
-            _logger = logger;
         }
 
         public async Task<IActionResult> Index()
         {
-            if (!await _authorizationService.AuthorizeAsync(User, Permissions.AccessAdminDashboard))
+            var model = new AdminDashboardViewModel()
             {
-                return Forbid();
-            }
-
-            var widgets = await _adminDashboardService.GetWidgetsAsync(x => x.Published);
-            var wrappers = new List<DashboardWrapper>();
-            foreach (var item in widgets)
-            {
-                wrappers.Add(new DashboardWrapper
-                {
-                    Dashboard = item,
-                    Content = await _contentItemDisplayManager.BuildDisplayAsync(item, _updateModelAccessor.ModelUpdater, "DetailAdmin")
-                });
-            }
-
-            var model = new AdminDashboardViewModel
-            {
-                Dashboards = wrappers.ToArray()
+                CanManageDashboard = await _authorizationService.AuthorizeAsync(User, Permissions.ManageAdminDashboard),
             };
+
+            if (model.CanManageDashboard || await _authorizationService.AuthorizeAsync(User, Permissions.AccessAdminDashboard))
+            {
+                var wrappers = new List<DashboardWrapper>();
+                var widgets = await _adminDashboardService.GetWidgetsAsync(x => x.Published);
+                foreach (var widget in widgets)
+                {
+                    if (!model.CanManageDashboard && !await _authorizationService.AuthorizeAsync(User, CommonPermissions.ViewContent, widget))
+                    {
+                        continue;
+                    }
+
+                    wrappers.Add(new DashboardWrapper
+                    {
+                        Dashboard = widget,
+                        Content = await _contentItemDisplayManager.BuildDisplayAsync(widget, _updateModelAccessor.ModelUpdater, "DetailAdmin")
+                    });
+                }
+
+                model.Dashboards = wrappers.ToArray();
+            }
 
             return View(model);
         }
@@ -100,7 +85,7 @@ namespace OrchardCore.AdminDashboard.Controllers
                 return Forbid();
             }
 
-            // Set Manage Dashboard Feature
+            // Set Manage Dashboard Feature.
             Request.HttpContext.Features.Set(new DashboardFeature()
             {
                 IsManageRequest = true
@@ -111,15 +96,17 @@ namespace OrchardCore.AdminDashboard.Controllers
             var widgetContentTypes = _contentDefinitionManager.ListTypeDefinitions()
                     .Where(t => t.TryGetStereotype(out var stereotype) && stereotype.Contains("DashboardWidget"))
                     .OrderBy(x => x.DisplayName);
+
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
             foreach (var ctd in widgetContentTypes)
             {
-                var contentItem = await _contentManager.NewAsync(ctd.Name);
-                contentItem.Owner = User.FindFirstValue(ClaimTypes.NameIdentifier);
-                var authorized = await _authorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem);
-                if (authorized)
+                if (!await _authorizationService.AuthorizeContentTypeAsync(User, CommonPermissions.EditContent, ctd.Name, userId))
                 {
-                    dashboardCreatable.Add(new SelectListItem(ctd.DisplayName, ctd.Name));
+                    continue;
                 }
+
+                dashboardCreatable.Add(new SelectListItem(ctd.DisplayName, ctd.Name));
             }
 
             var widgets = await _adminDashboardService.GetWidgetsAsync(x => x.Latest);
@@ -131,6 +118,7 @@ namespace OrchardCore.AdminDashboard.Controllers
                     Dashboard = item,
                     Content = await _contentItemDisplayManager.BuildDisplayAsync(item, _updateModelAccessor.ModelUpdater, "DetailAdmin")
                 };
+
                 wrappers.Add(wrapper);
             }
 
@@ -142,6 +130,7 @@ namespace OrchardCore.AdminDashboard.Controllers
 
             return View(model);
         }
+
         [HttpPost]
         public async Task<IActionResult> Update([FromForm] DashboardPartViewModel[] parts)
         {
@@ -152,15 +141,15 @@ namespace OrchardCore.AdminDashboard.Controllers
 
             var contentItemIds = parts.Select(i => i.ContentItemId).ToArray();
 
-            // Load the latest version first if any
+            // Load the latest version first if any.
             var latestItems = await _contentManager.GetAsync(contentItemIds, true);
-
-            var publishedItems = await _contentManager.GetAsync(contentItemIds, false);
 
             if (latestItems == null)
             {
                 return NotFound();
             }
+
+            var publishedItems = await _contentManager.GetAsync(contentItemIds, false);
 
             foreach (var contentItem in latestItems)
             {
@@ -170,7 +159,7 @@ namespace OrchardCore.AdminDashboard.Controllers
                     return Forbid();
                 }
 
-                var partViewModel = parts.Where(m => m.ContentItemId == contentItem.ContentItemId).FirstOrDefault();
+                var partViewModel = parts.FirstOrDefault(m => m.ContentItemId == contentItem.ContentItemId);
 
                 dashboardPart.Position = partViewModel?.Position ?? 0;
                 dashboardPart.Width = partViewModel?.Width ?? 1;
@@ -182,7 +171,7 @@ namespace OrchardCore.AdminDashboard.Controllers
 
                 if (contentItem.IsPublished() == false)
                 {
-                    var publishedVersion = publishedItems.Where(p => p.ContentItemId == contentItem.ContentItemId).FirstOrDefault();
+                    var publishedVersion = publishedItems.FirstOrDefault(p => p.ContentItemId == contentItem.ContentItemId);
                     var publishedMetaData = publishedVersion?.As<DashboardPart>();
                     if (publishedVersion != null && publishedMetaData != null)
                     {
@@ -193,18 +182,14 @@ namespace OrchardCore.AdminDashboard.Controllers
                         _session.Save(publishedVersion);
                     }
                 }
-
             }
 
             if (Request.Headers != null && Request.Headers["X-Requested-With"] == "XMLHttpRequest")
             {
                 return Ok();
             }
-            else
-            {
-                return RedirectToAction(nameof(Manage));
-            }
 
+            return RedirectToAction(nameof(Manage));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/ViewModels/AdminDashboardViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/ViewModels/AdminDashboardViewModel.cs
@@ -7,7 +7,11 @@ namespace OrchardCore.AdminDashboard.ViewModels
     public class AdminDashboardViewModel
     {
         [BindNever]
+        public bool CanManageDashboard { get; set; }
+
+        [BindNever]
         public DashboardWrapper[] Dashboards { get; set; }
+
         [BindNever]
         public List<SelectListItem> Creatable { get; set; }
     }

--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/Dashboard/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/Dashboard/Index.cshtml
@@ -1,26 +1,27 @@
-@model AdminDashboardViewModel
 @using OrchardCore.ContentManagement
+
+@model AdminDashboardViewModel
+
 @inject IAuthorizationService AuthorizationService
 @inject IContentManager ContentManager
 @inject OrchardCore.ContentManagement.Metadata.IContentDefinitionManager ContentDefinitionManager
 @inject OrchardCore.ContentManagement.Display.IContentItemDisplayManager ContentItemDisplayManager
 
 @{
-    var hasManageDashboardPermission = await AuthorizationService.AuthorizeAsync(User, Permissions.ManageAdminDashboard);
+    Model.Dashboards ??= Array.Empty<DashboardWrapper>();
 
-    // Todo Create Settings for Dashboard
+    // Todo Create Settings for Dashboard.
     var settings = new
     {
-        // Default is 1, i.e. 6 columns in large screen, 3 for tablets and 1 for phones. 
-        // Changing Scale 2 will increase the # columns to 12 for large screen, 6 for tablets and 2 for phones. 
-        ColumnScale = 1 
+        // Default is 1, i.e. 6 columns in large screen, 3 for tablets and 1 for phones.
+        // Changing Scale 2 will increase the # columns to 12 for large screen, 6 for tablets and 2 for phones.
+        ColumnScale = 1
     };
-
 }
 
 <style asp-src="~/OrchardCore.AdminDashboard/Styles/dashboard.min.css" debug-src="~/OrchardCore.AdminDashboard/Styles/dashboard.css" at="Head"></style>
 
-@if (hasManageDashboardPermission)
+@if (Model.CanManageDashboard)
 {
     <div class="btn-group float-end mb-3">
         <a class="btn btn-primary btn-sm" asp-action="Manage">
@@ -29,12 +30,28 @@
     </div>
 }
 
-<zone Name="Title"><h1 class="float-start">@RenderTitleSegments(T["Dashboard"])</h1></zone>
-<div class="clearfix"></div>
+@if (Model.CanManageDashboard || Model.Dashboards.Length > 0)
+{
+    <zone Name="Title"><h1 class="float-start">@RenderTitleSegments(T["Dashboard"])</h1></zone>
+    <div class="clearfix"></div>
 
-<div class="dashboard-container" style="--dashboard-columns: calc( @(settings.ColumnScale) * var(--dashboard-columns-default));">
-    @foreach (var dashboard in Model.Dashboards)
+    @if (Model.Dashboards.Length > 0)
     {
-        @await DisplayAsync(dashboard);
+        <div class="dashboard-container" style="--dashboard-columns: calc( @(settings.ColumnScale) * var(--dashboard-columns-default));">
+            @foreach (var dashboard in Model.Dashboards)
+            {
+                @await DisplayAsync(dashboard)
+            }
+        </div>
     }
-</div>
+    else
+    {
+        <div class="alert alert-warning" role="alert">
+            @T["Click on Manage Dashboard button to add dashboard widget."]
+        </div>
+    }
+}
+else
+{
+    @await DisplayAsync(await New.AdminDashboard())
+}


### PR DESCRIPTION
Fix #13548

Summary,
1. If the does not have `AccessAdminDashboard` permission, instead of showing 401, we now render `AdminDashboard` shape.
2. When a DashboardWidget is secured, we check the permission to ensure the user is able to view it before rendering it. This will give us the ability to control who get to see which widget.
3. Some cleanup int he controller.
