### PR TITLE
Allow to display icon for CustomSettings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
@@ -33,6 +33,8 @@ namespace OrchardCore.CustomSettings
                         .Add(S["Settings"], settings => settings
                             .Add(new LocalizedString(type.DisplayName, type.DisplayName), type.DisplayName.PrefixPosition(), layers => layers
                                 .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = type.Name })
+                                .AddClass(type.Name)
+                                .Id(type.Name)
                                 .Permission(Permissions.CreatePermissionForType(type))
                                 .Resource(type.Name)
                                 .LocalNav()

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.CustomSettings.Services;
+using OrchardCore.Mvc.Utilities;
 using OrchardCore.Navigation;
 
 namespace OrchardCore.CustomSettings
@@ -33,8 +34,8 @@ namespace OrchardCore.CustomSettings
                         .Add(S["Settings"], settings => settings
                             .Add(new LocalizedString(type.DisplayName, type.DisplayName), type.DisplayName.PrefixPosition(), layers => layers
                                 .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = type.Name })
-                                .AddClass(type.Name)
-                                .Id(type.Name)
+                                .AddClass(type.Name.HtmlClassify())
+                                .Id(type.Name.HtmlClassify())
                                 .Permission(Permissions.CreatePermissionForType(type))
                                 .Resource(type.Name)
                                 .LocalNav()

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Utilities/StringExtensions.cs
@@ -69,39 +69,6 @@ namespace OrchardCore.ContentManagement.Utilities
             return trimmed + ellipsis;
         }
 
-        public static string HtmlClassify(this string text)
-        {
-            if (string.IsNullOrWhiteSpace(text))
-                return "";
-
-            var friendlier = text.CamelFriendly();
-
-            var result = new char[friendlier.Length];
-
-            var cursor = 0;
-            var previousIsNotLetter = false;
-            for (var i = 0; i < friendlier.Length; i++)
-            {
-                char current = friendlier[i];
-                if (IsLetter(current) || (char.IsDigit(current) && cursor > 0))
-                {
-                    if (previousIsNotLetter && i != 0 && cursor > 0)
-                    {
-                        result[cursor++] = '-';
-                    }
-
-                    result[cursor++] = char.ToLowerInvariant(current);
-                    previousIsNotLetter = false;
-                }
-                else
-                {
-                    previousIsNotLetter = true;
-                }
-            }
-
-            return new string(result, 0, cursor);
-        }
-
         public static LocalizedString OrDefault(this string text, LocalizedString defaultValue)
         {
             return string.IsNullOrEmpty(text)


### PR DESCRIPTION
While I'm working on a website, I notice that the `CustomSettings` don't allow us to set the icon on the newly added menu item.

Fixes #10367.