### PR TITLE
Fix notifier cookie path

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using OrchardCore.DisplayManagement.Layout;
-using OrchardCore.Environment.Shell;
 
 namespace OrchardCore.DisplayManagement.Notify
 {
@@ -25,7 +24,6 @@ namespace OrchardCore.DisplayManagement.Notify
 
         private NotifyEntry[] _existingEntries = Array.Empty<NotifyEntry>();
         private bool _shouldDeleteCookie;
-        private string _tenantPath;
         private readonly HtmlEncoder _htmlEncoder;
         private readonly ILogger _logger;
 
@@ -33,7 +31,6 @@ namespace OrchardCore.DisplayManagement.Notify
             INotifier notifier,
             ILayoutAccessor layoutAccessor,
             IShapeFactory shapeFactory,
-            ShellSettings shellSettings,
             IDataProtectionProvider dataProtectionProvider,
             HtmlEncoder htmlEncoder,
             ILogger<NotifyFilter> logger)
@@ -45,8 +42,6 @@ namespace OrchardCore.DisplayManagement.Notify
             _layoutAccessor = layoutAccessor;
             _notifier = notifier;
             _shapeFactory = shapeFactory;
-
-            _tenantPath = "/" + shellSettings.RequestUrlPrefix;
         }
 
         private void OnHandlerExecuting(FilterContext filterContext)
@@ -94,7 +89,7 @@ namespace OrchardCore.DisplayManagement.Notify
             // String data type used instead of complex array to be session-friendly.
             if (result is not ViewResult && result is not PageResult && _existingEntries.Length > 0)
             {
-                filterContext.HttpContext.Response.Cookies.Append(CookiePrefix, SerializeNotifyEntry(_existingEntries), new CookieOptions { HttpOnly = true, Path = _tenantPath });
+                filterContext.HttpContext.Response.Cookies.Append(CookiePrefix, SerializeNotifyEntry(_existingEntries), new CookieOptions { HttpOnly = true, Path = filterContext.HttpContext.Request.PathBase });
             }
         }
 
@@ -168,7 +163,7 @@ namespace OrchardCore.DisplayManagement.Notify
 
         private void DeleteCookies(ResultExecutingContext filterContext)
         {
-            filterContext.HttpContext.Response.Cookies.Delete(CookiePrefix, new CookieOptions { Path = _tenantPath });
+            filterContext.HttpContext.Response.Cookies.Delete(CookiePrefix, new CookieOptions { Path = filterContext.HttpContext.Request.PathBase });
         }
 
         private string SerializeNotifyEntry(NotifyEntry[] notifyEntries)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
@@ -89,7 +89,7 @@ namespace OrchardCore.DisplayManagement.Notify
             // String data type used instead of complex array to be session-friendly.
             if (result is not ViewResult && result is not PageResult && _existingEntries.Length > 0)
             {
-                filterContext.HttpContext.Response.Cookies.Append(CookiePrefix, SerializeNotifyEntry(_existingEntries), new CookieOptions { HttpOnly = true, Path = filterContext.HttpContext.Request.PathBase });
+                filterContext.HttpContext.Response.Cookies.Append(CookiePrefix, SerializeNotifyEntry(_existingEntries), GetCookieOptions(filterContext.HttpContext));
             }
         }
 
@@ -163,7 +163,7 @@ namespace OrchardCore.DisplayManagement.Notify
 
         private void DeleteCookies(ResultExecutingContext filterContext)
         {
-            filterContext.HttpContext.Response.Cookies.Delete(CookiePrefix, new CookieOptions { Path = filterContext.HttpContext.Request.PathBase });
+            filterContext.HttpContext.Response.Cookies.Delete(CookiePrefix, GetCookieOptions(filterContext.HttpContext));
         }
 
         private string SerializeNotifyEntry(NotifyEntry[] notifyEntries)
@@ -200,6 +200,21 @@ namespace OrchardCore.DisplayManagement.Notify
 
                 _logger.LogWarning("The notification entries could not be decrypted");
             }
+        }
+
+        private static CookieOptions GetCookieOptions(HttpContext httpContext)
+        {
+            var cookieOptions = new CookieOptions
+            {
+                HttpOnly = true
+            };
+
+            if (!httpContext.Request.PathBase.Equals(PathString.Empty))
+            {
+                cookieOptions.Path = httpContext.Request.PathBase;
+            }
+
+            return cookieOptions;
         }
     }
 }


### PR DESCRIPTION
Fixes #13653 

### Notification works for default tenant using /orchard
![default_works](https://user-images.githubusercontent.com/68876423/236483746-79a4b18e-ae61-4649-baca-94d2bb3b57b9.gif)

### Notification works for tenant A using /orchard/tenantA
![tenantA_works](https://user-images.githubusercontent.com/68876423/236483838-517cb1d3-a6ea-4cde-bf54-d7ea0c30d580.gif)

### Making sure the standard case still works when there is no prefix at all
![nopath_works](https://user-images.githubusercontent.com/68876423/236484134-80da0a4e-6d15-451d-aa35-127182edc859.gif)


