### PR TITLE
FeatureEventHandler base class

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenSettingsUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/MediaTokenSettingsUpdater.cs
@@ -4,6 +4,7 @@ using OrchardCore.Entities;
 using OrchardCore.Environment.Extensions.Features;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Environment.Shell.Models;
+using OrchardCore.Environment.Shell.Removing;
 using OrchardCore.Modules;
 using OrchardCore.Settings;
 
@@ -13,7 +14,7 @@ namespace OrchardCore.Media.Processing
     /// Generates a random key for media token hashing.
     /// To regenerate the key disabled and enable the feature.
     /// </summary>
-    public class MediaTokenSettingsUpdater : ModularTenantEvents, IFeatureEventHandler
+    public class MediaTokenSettingsUpdater : FeatureEventHandler, IModularTenantEvents
     {
         private readonly ISiteService _siteService;
         private readonly ShellSettings _shellSettings;
@@ -24,9 +25,8 @@ namespace OrchardCore.Media.Processing
             _shellSettings = shellSettings;
         }
 
-        public override async Task ActivatedAsync()
+        public async Task ActivatedAsync()
         {
-
             if (_shellSettings.State == TenantState.Uninitialized)
             {
                 // If the tenant is 'Uninitialized' there is no registered 'ISession' and then 'ISiteService' can't be used.
@@ -49,21 +49,12 @@ namespace OrchardCore.Media.Processing
             }
         }
 
-        Task IFeatureEventHandler.InstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
+        public Task ActivatingAsync() => Task.CompletedTask;
+        public Task RemovingAsync(ShellRemovingContext context) => Task.CompletedTask;
+        public Task TerminatedAsync() => Task.CompletedTask;
+        public Task TerminatingAsync() => Task.CompletedTask;
 
-        Task IFeatureEventHandler.InstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        Task IFeatureEventHandler.EnablingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        Task IFeatureEventHandler.EnabledAsync(IFeatureInfo feature) => SetMediaTokenSettingsAsync(feature);
-
-        Task IFeatureEventHandler.DisablingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        Task IFeatureEventHandler.DisabledAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        Task IFeatureEventHandler.UninstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        Task IFeatureEventHandler.UninstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
+        public override Task EnabledAsync(IFeatureInfo feature) => SetMediaTokenSettingsAsync(feature);
 
         private async Task SetMediaTokenSettingsAsync(IFeatureInfo feature)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
@@ -13,7 +13,7 @@ using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Roles.Services
 {
-    public class RoleUpdater : IFeatureEventHandler, IRoleCreatedEventHandler, IRoleRemovedEventHandler
+    public class RoleUpdater : FeatureEventHandler, IRoleCreatedEventHandler, IRoleRemovedEventHandler
     {
         private readonly ShellDescriptor _shellDescriptor;
         private readonly IExtensionManager _extensionManager;
@@ -40,21 +40,9 @@ namespace OrchardCore.Roles.Services
             _logger = logger;
         }
 
-        public Task InstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
+        public override Task InstalledAsync(IFeatureInfo feature) => UpdateRolesForInstalledFeatureAsync(feature);
 
-        public Task InstalledAsync(IFeatureInfo feature) => UpdateRolesForInstalledFeatureAsync(feature);
-
-        public Task EnablingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        public Task EnabledAsync(IFeatureInfo feature) => UpdateRolesForEnabledFeatureAsync(feature);
-
-        public Task DisablingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        public Task DisabledAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        public Task UninstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-        public Task UninstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
+        public override Task EnabledAsync(IFeatureInfo feature) => UpdateRolesForEnabledFeatureAsync(feature);
 
         public Task RoleCreatedAsync(string roleName) => UpdateRoleForInstalledFeaturesAsync(roleName);
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/FeatureEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/FeatureEventHandler.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using OrchardCore.Environment.Extensions.Features;
+
+namespace OrchardCore.Environment.Shell;
+
+public class FeatureEventHandler : IFeatureEventHandler
+{
+    public virtual Task DisabledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task DisablingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task EnabledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task EnablingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task InstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task InstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task UninstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task UninstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/IFeatureEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/IFeatureEventHandler.cs
@@ -14,22 +14,3 @@ public interface IFeatureEventHandler
     Task UninstallingAsync(IFeatureInfo feature);
     Task UninstalledAsync(IFeatureInfo feature);
 }
-
-public class FeatureEventHandler : IFeatureEventHandler
-{
-    public virtual Task DisabledAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-    public virtual Task DisablingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-    public virtual Task EnabledAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-    public virtual Task EnablingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-    public virtual Task InstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-    public virtual Task InstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-    public virtual Task UninstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
-
-    public virtual Task UninstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
-}

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/IFeatureEventHandler.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/IFeatureEventHandler.cs
@@ -1,17 +1,35 @@
 using System.Threading.Tasks;
 using OrchardCore.Environment.Extensions.Features;
 
-namespace OrchardCore.Environment.Shell
+namespace OrchardCore.Environment.Shell;
+
+public interface IFeatureEventHandler
 {
-    public interface IFeatureEventHandler
-    {
-        Task InstallingAsync(IFeatureInfo feature);
-        Task InstalledAsync(IFeatureInfo feature);
-        Task EnablingAsync(IFeatureInfo feature);
-        Task EnabledAsync(IFeatureInfo feature);
-        Task DisablingAsync(IFeatureInfo feature);
-        Task DisabledAsync(IFeatureInfo feature);
-        Task UninstallingAsync(IFeatureInfo feature);
-        Task UninstalledAsync(IFeatureInfo feature);
-    }
+    Task InstallingAsync(IFeatureInfo feature);
+    Task InstalledAsync(IFeatureInfo feature);
+    Task EnablingAsync(IFeatureInfo feature);
+    Task EnabledAsync(IFeatureInfo feature);
+    Task DisablingAsync(IFeatureInfo feature);
+    Task DisabledAsync(IFeatureInfo feature);
+    Task UninstallingAsync(IFeatureInfo feature);
+    Task UninstalledAsync(IFeatureInfo feature);
+}
+
+public class FeatureEventHandler : IFeatureEventHandler
+{
+    public virtual Task DisabledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task DisablingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task EnabledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task EnablingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task InstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task InstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task UninstalledAsync(IFeatureInfo feature) => Task.CompletedTask;
+
+    public virtual Task UninstallingAsync(IFeatureInfo feature) => Task.CompletedTask;
 }


### PR DESCRIPTION
To not have to define all methods when implementing `IFeatureEventHandler`.

As we already have with `ModularTenantEvents` and `IModularTenantEvents`.

And apply it to the current implementations.
