### PR TITLE
Add a script to cleanup the `lib`/`bin` and/or `node_modules` folders

### DIFF
--- a/.scripts/cleanup.js
+++ b/.scripts/cleanup.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const glob = require("glob"),
+      exec = require('child_process').exec,
+      fs = require('fs'),
+      nodePath = require('path');
+
+const deleteFolderRecursive = function (directoryPath) {
+    if (!fs.existsSync(directoryPath)) {
+        return;
+    }
+
+    fs.readdirSync(directoryPath).forEach((file, index) => {
+      const curPath = nodePath.join(directoryPath, file);
+      if (fs.lstatSync(curPath).isDirectory()) {
+       // recurse
+        deleteFolderRecursive(curPath);
+      } else {
+        // delete file
+        fs.unlinkSync(curPath);
+      }
+    });
+
+    fs.rmdirSync(directoryPath);
+};
+
+const paths = [];
+let target = '';
+
+if(process.argv.length == 3) {
+    target = process.argv[2].toLowerCase();
+}
+
+if(target == 'all' || target == ''){
+
+    let libPaths = glob.sync("./src/**/{bin,obj}/", {});
+
+    paths.push(...libPaths);
+}
+
+if(target == 'all' || target == 'node_modules'){
+
+    let modulesPaths = glob.sync("./**/node_modules/", {});
+
+    paths.push(...modulesPaths);
+}
+
+paths.sort().forEach(function (path) {
+    console.log(`Deleting: '${path}'`);  
+    deleteFolderRecursive(path);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "postinstall": "node .scripts/install.js",
     "update-projects": "node .scripts/update.js",
     "install-project": "node .scripts/project.js install",
-    "update-project": "node .scripts/project.js update"
+    "update-project": "node .scripts/project.js update",
+    "cleanup": "node .scripts/cleanup.js"
   },
   "devDependencies": {
     "@babel/core": "^7.20.5",


### PR DESCRIPTION
Fix #13737

if you want to remove `bin` and `lib` folder from all the projects you can run
```
npm run cleanup
```

If you want to remove all `node_modules` folder from all the project, you can run

```
npm run cleanup node_modules
```

if you want to cleanup  `bin` , `lib` and `node_modules` you can run 

```
npm run cleanup all
```