### PR TITLE
Fixes #13723 Tenant Validator

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -66,7 +66,7 @@ namespace OrchardCore.Tenants.Services
 
             _ = _shellHost.TryGetSettings(model.Name, out var existingShellSettings);
 
-            // Check first if the existing shell settings are not related to the 'Default' tenant.
+            // First check that existing settings are not those of the 'Default' tenant.
             if ((existingShellSettings == null ||
                 !existingShellSettings.IsDefaultShell()) &&
                 String.IsNullOrWhiteSpace(model.RequestUrlHost) &&
@@ -86,7 +86,7 @@ namespace OrchardCore.Tenants.Services
                 ?.Split(_hostSeparators, StringSplitOptions.RemoveEmptyEntries)
                 ?? Array.Empty<string>();
 
-            // Check first if the existing shell settings are not related to the 'Default' tenant.
+            // First check that existing settings are not those of the 'Default' tenant.
             if ((existingShellSettings == null ||
                 !existingShellSettings.IsDefaultShell()) &&
                 _shellHost.GetAllSettings().Any(settings =>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -66,7 +66,8 @@ namespace OrchardCore.Tenants.Services
 
             _ = _shellHost.TryGetSettings(model.Name, out var existingShellSettings);
 
-            if ((existingShellSettings == null || !existingShellSettings.IsDefaultShell()) &&
+            if ((existingShellSettings == null ||
+                !existingShellSettings.IsDefaultShell()) &&
                 String.IsNullOrWhiteSpace(model.RequestUrlHost) &&
                 String.IsNullOrWhiteSpace(model.RequestUrlPrefix))
             {
@@ -84,10 +85,12 @@ namespace OrchardCore.Tenants.Services
                 ?.Split(_hostSeparators, StringSplitOptions.RemoveEmptyEntries)
                 ?? Array.Empty<string>();
 
-            if (_shellHost.GetAllSettings().Any(settings =>
-                settings != existingShellSettings &&
-                String.Equals(settings.RequestUrlPrefix ?? String.Empty, modelUrlPrefix, StringComparison.OrdinalIgnoreCase) &&
-                DoesUrlHostExist(settings.RequestUrlHosts, modelUrlHosts)))
+            if ((existingShellSettings == null ||
+                !existingShellSettings.IsDefaultShell()) &&
+                _shellHost.GetAllSettings().Any(settings =>
+                    settings != existingShellSettings &&
+                    String.Equals(settings.RequestUrlPrefix ?? String.Empty, modelUrlPrefix, StringComparison.OrdinalIgnoreCase) &&
+                    DoesUrlHostExist(settings.RequestUrlHosts, modelUrlHosts)))
             {
                 errors.Add(new ModelError(nameof(model.RequestUrlPrefix), S["A tenant with the same host and prefix already exists."]));
             }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -66,6 +66,7 @@ namespace OrchardCore.Tenants.Services
 
             _ = _shellHost.TryGetSettings(model.Name, out var existingShellSettings);
 
+            // Check first if the existing shell settings are not related to the 'Default' tenant.
             if ((existingShellSettings == null ||
                 !existingShellSettings.IsDefaultShell()) &&
                 String.IsNullOrWhiteSpace(model.RequestUrlHost) &&
@@ -85,6 +86,7 @@ namespace OrchardCore.Tenants.Services
                 ?.Split(_hostSeparators, StringSplitOptions.RemoveEmptyEntries)
                 ?? Array.Empty<string>();
 
+            // Check first if the existing shell settings are not related to the 'Default' tenant.
             if ((existingShellSettings == null ||
                 !existingShellSettings.IsDefaultShell()) &&
                 _shellHost.GetAllSettings().Any(settings =>


### PR DESCRIPTION
Fixes #13723 

Sometimes the Tenant Validator Test fails because another new test registers a `Tenant1` tenant with no url prefix and host, so depending on the execution order of tests, when trying to validate an invalid `dEfAuLt` tenant (also with no prefix and host), we may not only have the error stating that it is in conflict with the `Default` tenant, but also an error stating that a tenant with the same host and prefix already exists (here empty ones), which makes the test fail as it is intended to only have one error message.

I could repro by mixing the 2 tests.

But the 2nd error message should not be added if the retrieved existing shell is the `Default` shell, which is the case when looking up for the `dEfAuLt` tenant (the lookup is case insensitive).

Can be fixed in the other test that registers a `Tenant1` tenant by also specifying e.g. a non empty prefix, but anyway an additional check should be added in `TenantValidator`, which is done here.

So in `TenantValidator`, before adding the 2nd error we now check that the retrieved settings are not those of the `Default` tenant, as we already do to check that a tenant should have a prefix or host.
