### PR TITLE
Remaining places unaware of virtual folder

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldMonacoEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldMonacoEditorSettings.Edit.cshtml
@@ -1,8 +1,7 @@
 @model OrchardCore.ContentFields.ViewModels.MonacoSettingsViewModel
-@inject OrchardCore.Environment.Shell.ShellSettings shellSettings;
+
 @{ 
-    var urlPrefix = String.IsNullOrWhiteSpace(shellSettings.RequestUrlPrefix) ? string.Empty : String.Concat(shellSettings.RequestUrlPrefix, '/');
-    var IStandaloneEditorConstructionOptionsSchemaPath = $"/{urlPrefix}OrchardCore.Resources/Scripts/monaco/IStandaloneEditorConstructionOptions.json";
+    var IStandaloneEditorConstructionOptionsSchemaPath = Url.Content("~/OrchardCore.Resources/Scripts/monaco/IStandaloneEditorConstructionOptions.json");
 }
 
 <div id="@Html.IdFor(m => m)" class="field-editor field-editor-monaco">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextFieldMonacoEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextFieldMonacoEditorSettings.Edit.cshtml
@@ -1,8 +1,7 @@
 @model OrchardCore.ContentFields.ViewModels.MonacoSettingsViewModel
-@inject OrchardCore.Environment.Shell.ShellSettings shellSettings;
+
 @{
-    var urlPrefix = String.IsNullOrWhiteSpace(shellSettings.RequestUrlPrefix) ? string.Empty : String.Concat(shellSettings.RequestUrlPrefix, '/');
-    var IStandaloneEditorConstructionOptionsSchemaPath = $"/{urlPrefix}OrchardCore.Resources/Scripts/monaco/IStandaloneEditorConstructionOptions.json";
+    var IStandaloneEditorConstructionOptionsSchemaPath = Url.Content("~/OrchardCore.Resources/Scripts/monaco/IStandaloneEditorConstructionOptions.json");
 }
 
 <div id="@Html.IdFor(m => m)" class="field-editor field-editor-monaco">

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/UrlMethodsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/UrlMethodsProvider.cs
@@ -15,30 +15,14 @@ namespace OrchardCore.Contents.Scripting
             _getUrlPrefix = new GlobalMethod
             {
                 Name = "getUrlPrefix",
-                Method = serviceProvider => (Func<string, string>)((string path) =>
-                 {
-                     string ret;
-
-                     var shellSettings = serviceProvider.GetRequiredService<ShellSettings>();
-
-                     if (!string.IsNullOrWhiteSpace(shellSettings.RequestUrlPrefix))
-                         ret = shellSettings.RequestUrlPrefix.Trim('/');
-                     else
-                         ret = string.Empty;
-
-                     if (!string.IsNullOrWhiteSpace(path))
-                     {
-                         ret = string.Concat(ret, '/', path.Trim('/')).Trim('/');
-                     }
-
-                     return string.Concat('/', ret);
-                 })
+                Method = serviceProvider => (string path) =>
+                {
+                    var shellSettings = serviceProvider.GetRequiredService<ShellSettings>();
+                    return String.Concat('/', $"{shellSettings.RequestUrlPrefix}/{path?.Trim('/')}".Trim('/'));
+                }
             };
         }
 
-        public IEnumerable<GlobalMethod> GetMethods()
-        {
-            return new[] { _getUrlPrefix };
-        }
+        public IEnumerable<GlobalMethod> GetMethods() => new[] { _getUrlPrefix };
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/UrlMethodsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/UrlMethodsProvider.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Contents.Scripting
             _getUrlPrefix = new GlobalMethod
             {
                 Name = "getUrlPrefix",
-                Method = serviceProvider => (string path) =>
+                Method = serviceProvider => (string path, bool? escaped) =>
                 {
                     var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
 
@@ -29,6 +29,11 @@ namespace OrchardCore.Contents.Scripting
                     if (path.Length > 0)
                     {
                         pathBase = pathBase.Add($"/{path}");
+                    }
+
+                    if (escaped.HasValue && escaped.Value)
+                    {
+                        return pathBase.ToString();
                     }
 
                     return pathBase.Value;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/UrlMethodsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/UrlMethodsProvider.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.Environment.Shell;
 using OrchardCore.Scripting;
 
 namespace OrchardCore.Contents.Scripting
@@ -17,8 +17,21 @@ namespace OrchardCore.Contents.Scripting
                 Name = "getUrlPrefix",
                 Method = serviceProvider => (string path) =>
                 {
-                    var shellSettings = serviceProvider.GetRequiredService<ShellSettings>();
-                    return String.Concat('/', $"{shellSettings.RequestUrlPrefix}/{path?.Trim('/')}".Trim('/'));
+                    var httpContextAccessor = serviceProvider.GetRequiredService<IHttpContextAccessor>();
+
+                    var pathBase = httpContextAccessor.HttpContext?.Request.PathBase ?? PathString.Empty;
+                    if (!pathBase.HasValue)
+                    {
+                        pathBase = "/";
+                    }
+
+                    path = path?.Trim(' ', '/') ?? String.Empty;
+                    if (path.Length > 0)
+                    {
+                        pathBase = pathBase.Add($"/{path}");
+                    }
+
+                    return pathBase.Value;
                 }
             };
         }

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartMonacoSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartMonacoSettings.Edit.cshtml
@@ -1,8 +1,7 @@
 @model OrchardCore.Html.ViewModels.MonacoSettingsViewModel
-@inject OrchardCore.Environment.Shell.ShellSettings shellSettings;
+
 @{
-    var urlPrefix = String.IsNullOrWhiteSpace(shellSettings.RequestUrlPrefix) ? string.Empty : String.Concat(shellSettings.RequestUrlPrefix, '/');
-    var IStandaloneEditorConstructionOptionsSchemaPath = $"/{urlPrefix}OrchardCore.Resources/Scripts/monaco/IStandaloneEditorConstructionOptions.json";
+    var IStandaloneEditorConstructionOptionsSchemaPath = Url.Content("~/OrchardCore.Resources/Scripts/monaco/IStandaloneEditorConstructionOptions.json");
 }
 
 <div id="@Html.IdFor(m => m)" class="type-part-editor type-part-editor-monaco">

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/CookieOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/CookieOptionsConfiguration.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
-using OrchardCore.Environment.Shell;
 using MicrosoftIdentityDefaults = Microsoft.Identity.Web.Constants;
 
 namespace OrchardCore.Microsoft.Authentication.Configuration
@@ -10,9 +10,15 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
     {
         private readonly string _tenantPrefix;
 
-        public CookieOptionsConfiguration(ShellSettings shellSettings)
+        public CookieOptionsConfiguration(IHttpContextAccessor httpContextAccessor)
         {
-            _tenantPrefix = "/" + shellSettings.RequestUrlPrefix;
+            var pathBase = httpContextAccessor.HttpContext?.Request.PathBase ?? PathString.Empty;
+            if (!pathBase.HasValue)
+            {
+                pathBase = "/";
+            }
+
+            _tenantPrefix = pathBase;
         }
 
         public void Configure(string name, CookieAuthenticationOptions options)

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.ContentPreview;
 using OrchardCore.DisplayManagement.ModelBinding;
-using OrchardCore.Environment.Shell;
 using OrchardCore.Settings;
 using OrchardCore.Templates.ViewModels;
 
@@ -28,8 +28,8 @@ namespace OrchardCore.Templates.Controllers
             IContentItemDisplayManager contentItemDisplayManager,
             IAuthorizationService authorizationService,
             ISiteService siteService,
-            ShellSettings shellSettings,
-            IUpdateModelAccessor updateModelAccessor)
+            IUpdateModelAccessor updateModelAccessor,
+            IHttpContextAccessor httpContextAccessor)
         {
             _contentManager = contentManager;
             _contentHandleManager = contentHandleManager;
@@ -37,7 +37,7 @@ namespace OrchardCore.Templates.Controllers
             _authorizationService = authorizationService;
             _siteService = siteService;
             _updateModelAccessor = updateModelAccessor;
-            _homeUrl = ('/' + (shellSettings.RequestUrlPrefix ?? string.Empty)).TrimEnd('/') + '/';
+            _homeUrl = httpContextAccessor.HttpContext.Request.PathBase.Add("/");
         }
 
         public IActionResult Index()
@@ -59,7 +59,7 @@ namespace OrchardCore.Templates.Controllers
             var name = Request.Form["Name"];
             var content = Request.Form["Content"];
 
-            if (!string.IsNullOrEmpty(name) && !string.IsNullOrEmpty(content))
+            if (!String.IsNullOrEmpty(name) && !string.IsNullOrEmpty(content))
             {
                 HttpContext.Items["OrchardCore.PreviewTemplate"] = new TemplateViewModel { Name = name, Content = content };
             }
@@ -68,7 +68,7 @@ namespace OrchardCore.Templates.Controllers
 
             string contentItemId;
 
-            if (string.IsNullOrEmpty(handle) || handle == _homeUrl)
+            if (String.IsNullOrEmpty(handle) || handle == _homeUrl)
             {
                 var homeRoute = (await _siteService.GetSiteSettingsAsync()).HomeRoute;
                 contentItemId = homeRoute["contentItemId"]?.ToString();
@@ -76,18 +76,17 @@ namespace OrchardCore.Templates.Controllers
             else
             {
                 var index = handle.IndexOf(_homeUrl, StringComparison.Ordinal);
-                handle = (index < 0) ? handle : handle.Substring(_homeUrl.Length);
+                handle = ((index < 0) ? handle : handle.Substring(_homeUrl.Length)).ToUriComponents(UriFormat.SafeUnescaped);
                 contentItemId = await _contentHandleManager.GetContentItemIdAsync("slug:" + handle);
             }
 
-            if (string.IsNullOrEmpty(contentItemId))
+            if (String.IsNullOrEmpty(contentItemId))
             {
                 return NotFound();
             }
 
             var contentItem = await _contentManager.GetAsync(contentItemId, VersionOptions.Published);
-
-            if (contentItem == null)
+            if (contentItem is null)
             {
                 return NotFound();
             }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/PreviewController.cs
@@ -76,7 +76,10 @@ namespace OrchardCore.Templates.Controllers
             else
             {
                 var index = handle.IndexOf(_homeUrl, StringComparison.Ordinal);
-                handle = ((index < 0) ? handle : handle.Substring(_homeUrl.Length)).ToUriComponents(UriFormat.SafeUnescaped);
+
+                handle = (index < 0 ? handle : handle[_homeUrl.Length..])
+                    .ToUriComponents(UriFormat.SafeUnescaped);
+
                 contentItemId = await _contentHandleManager.GetContentItemIdAsync("slug:" + handle);
             }
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Preview/Index.cshtml
@@ -22,7 +22,7 @@
 
 <div id="indexPreviewUrl" style="display:none" data-value="@Url.Action("Index", "Preview" , new { area="OrchardCore.Templates" })"></div>
 <div id="renderPreviewUrl" style="display:none" data-value="@Url.Action("Render", "Preview" , new { area="OrchardCore.Templates" })"></div>
-<div id="contentPreviewUrl" style="display:none" data-value="@Url.Content("~/")"></div>
+<div id="contentPreviewUrl" style="display:none" data-value="@Url.Content("~/").ToUriComponents()"></div>
 
 <resources type="Footer" />
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/HttpContextExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/HttpContextExtensions.cs
@@ -13,7 +13,7 @@ public static class HttpContextExtensions
         var host = shellSettings.RequestUrlHosts.FirstOrDefault();
 
         var hostString = httpContext.Request.Host;
-        if (host != null)
+        if (host is not null)
         {
             hostString = new HostString(host);
             if (httpContext.Request.Host.Port.HasValue)
@@ -22,7 +22,7 @@ public static class HttpContextExtensions
             }
         }
 
-        var pathString = httpContext.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? new PathString();
+        var pathString = httpContext.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? PathString.Empty;
         if (!String.IsNullOrEmpty(shellSettings.RequestUrlPrefix))
         {
             pathString = pathString.Add('/' + shellSettings.RequestUrlPrefix);

--- a/src/OrchardCore/OrchardCore.Abstractions/StringUriExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/StringUriExtensions.cs
@@ -2,7 +2,7 @@ namespace System
 {
     public static class StringUriExtensions
     {
-        public static string ToUriComponents(this string url)
+        public static string ToUriComponents(this string url, UriFormat uriFormat = UriFormat.UriEscaped)
         {
             if (String.IsNullOrEmpty(url))
             {
@@ -11,7 +11,7 @@ namespace System
 
             var uri = new Uri(url, UriKind.RelativeOrAbsolute);
 
-            return uri.GetComponents(UriComponents.SerializationInfoString, UriFormat.UriEscaped);
+            return uri.GetComponents(UriComponents.SerializationInfoString, uriFormat);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
@@ -209,7 +209,7 @@ namespace OrchardCore.DisplayManagement.Notify
                 HttpOnly = true
             };
 
-            if (!httpContext.Request.PathBase.Equals(PathString.Empty))
+            if (httpContext.Request.PathBase.HasValue)
             {
                 cookieOptions.Path = httpContext.Request.PathBase;
             }


### PR DESCRIPTION
Fixes #13874 

There are some remaining places where the tenant PathBase (that may include a virtual folder) is not taken into account, for example OC.Templates preview doesn't work if under a virtual folder.

In OC.Templates preview there is also an encoding issue when the virtual folder or the tenant prefix contains a special char, or if we navigate to a content item whose path contains a special char.

This because in the view we use `@Url.Action()` that escapes the url, so in the `PreviewController` we need to compare with escaped strings. Then we also use `@Url.Content()` but this one doesn't escape the url, most of the time that's okay but not when retrieved and used by a script, so here we also need to escape the result of `@Url.Content()`, and in the Controller unescape the slug part to retrieve a given item.
