### PR TITLE
Only get definitions of provided contained types

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ContainedPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ContainedPartDisplayDriver.cs
@@ -164,16 +164,10 @@ namespace OrchardCore.Lists.Drivers
             }).Location("Content:1");
         }
 
-        private IEnumerable<ContentTypeDefinition> GetContainedContentTypes(ListPartSettings settings)
-        {
-            var contentTypes = settings.ContainedContentTypes ?? Enumerable.Empty<string>();
-
-            if (!contentTypes.Any())
-            {
-                return Enumerable.Empty<ContentTypeDefinition>();
-            }
-
-            return _contentDefinitionManager.ListTypeDefinitions().Where(x => contentTypes.Contains(x.Name));
-        }
+        private IEnumerable<ContentTypeDefinition> GetContainedContentTypes(ListPartSettings settings) =>
+            settings.ContainedContentTypes
+                ?.Where(contentType => !String.IsNullOrEmpty(contentType))
+                .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
+                ?? Enumerable.Empty<ContentTypeDefinition>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ContainedPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ContainedPartDisplayDriver.cs
@@ -166,8 +166,7 @@ namespace OrchardCore.Lists.Drivers
 
         private IEnumerable<ContentTypeDefinition> GetContainedContentTypes(ListPartSettings settings) =>
             settings.ContainedContentTypes
-                ?.Where(contentType => !String.IsNullOrEmpty(contentType))
-                .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
+                ?.Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
                 .Where(definition => definition is not null)
                 ?? Enumerable.Empty<ContentTypeDefinition>();
     }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ContainedPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ContainedPartDisplayDriver.cs
@@ -168,6 +168,7 @@ namespace OrchardCore.Lists.Drivers
             settings.ContainedContentTypes
                 ?.Where(contentType => !String.IsNullOrEmpty(contentType))
                 .Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType))
+                .Where(definition => definition is not null)
                 ?? Enumerable.Empty<ContentTypeDefinition>();
     }
 }


### PR DESCRIPTION
Fixes #13890 

Not really an issue but after seeing the last meeting I took a look at #13768 where in `ContainedPartDisplayDriver` we changed this.

    private IEnumerable<ContentTypeDefinition> GetContainedContentTypes(ListPartSettings settings)
    {
      var contentTypes = settings.ContainedContentTypes ?? Enumerable.Empty<string>();

      return contentTypes.Select(contentType => _contentDefinitionManager.GetTypeDefinition(contentType));
    }

By that.

    private IEnumerable<ContentTypeDefinition> GetContainedContentTypes(ListPartSettings settings)
    {
      var contentTypes = settings.ContainedContentTypes ?? Enumerable.Empty<string>();

      if (!contentTypes.Any())
      {
          return Enumerable.Empty<ContentTypeDefinition>();
      }

      return _contentDefinitionManager.ListTypeDefinitions().Where(x => contentTypes.Contains(x.Name));
    }

- Maybe not so important but before we were calling `GetTypeDefinition()` only for the provided types, but now we call `ListTypeDefinitions()` that calls `GetTypeDefinition()` for all existing content types.

- I also noticed that `GetTypeDefinition()` is case insentive which is no longer the case with `.Contains(x.Name)`. Note: the var name `x` of the delegate could also be changed.

- Reading at #13767 it was to fix an NRE when `GetTypeDefinition()` return null definitions, and that was fixed by retrieving all existing types in place of one by one with possible null definitions.

So here we only get the definitions of the provided types as before, but with a new null check.

**Edited**: Just tried, if the definition of a contained type is removed it still throws an NRE with a null definition when checking for dynamic content type permissions, even if I keep the existing code, so looks like that #13767 was not fixed, and to be able to edit the item having the list part we need to specify a contained type of an existing type, will see tomorrow.
