### PR TITLE
Allows nested migration recipes

### DIFF
--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -125,6 +125,7 @@ namespace OrchardCore.Recipes.Services
                                         foreach (var descriptor in recipeStep.InnerRecipes)
                                         {
                                             var innerExecutionId = Guid.NewGuid().ToString();
+                                            descriptor.RequireNewScope = recipeDescriptor.RequireNewScope;
                                             await ExecuteAsync(innerExecutionId, descriptor, environment, cancellationToken);
                                         }
                                     }


### PR DESCRIPTION
Fixes #13914 

Related discussion #13155 

So, when executing a migration recipe we set `.RequireNewScope` to false so that we don't create a new shell scope that would try to activate the shell while we already are activating it.

Here, we now flow up the `.RequireNewScope` value to child recipes so that we don't create shell scopes for them either, preventing from being blocked on recursive shell activations.

Note: A migration recipe still can't use any kind of step, for example enabling features still need to be run in its own scope so that the next sibling scope will run the feature migrations by re-activating the shell.