### PR TITLE
Fix the admin UI Sort

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
@@ -83,23 +83,23 @@ namespace OrchardCore.Contents.Services
                             switch (contentsOrder)
                             {
                                 case ContentsOrder.Modified:
-                                    query.With<ContentItemIndex>().OrderByDescending(x => x.ModifiedUtc);
+                                    query.With<ContentItemIndex>().OrderByDescending(cr => cr.ModifiedUtc).ThenBy(cr => cr.Id);
                                     break;
                                 case ContentsOrder.Published:
-                                    query.With<ContentItemIndex>().OrderByDescending(cr => cr.PublishedUtc);
+                                    query.With<ContentItemIndex>().OrderByDescending(cr => cr.PublishedUtc).ThenBy(cr => cr.Id);
                                     break;
                                 case ContentsOrder.Created:
-                                    query.With<ContentItemIndex>().OrderByDescending(cr => cr.CreatedUtc);
+                                    query.With<ContentItemIndex>().OrderByDescending(cr => cr.CreatedUtc).ThenBy(cr => cr.Id);
                                     break;
                                 case ContentsOrder.Title:
-                                    query.With<ContentItemIndex>().OrderBy(cr => cr.DisplayText);
+                                    query.With<ContentItemIndex>().OrderBy(cr => cr.DisplayText).ThenBy(cr => cr.Id);
                                     break;
                             };
                         }
                         else
                         {
                             // Modified is a default value and applied when there is no filter.
-                            query.With<ContentItemIndex>().OrderByDescending(x => x.ModifiedUtc);
+                            query.With<ContentItemIndex>().OrderByDescending(cr => cr.ModifiedUtc).ThenBy(cr => cr.Id);
                         }
 
                         return query;


### PR DESCRIPTION
When you import many contents with the same `ModifiedUtc`, the pager logic will not work correctly and some items will be skipped why trying to paginate. With this fix, we add a sort by ID after the sorted value to ensure no records are skipped do the identical value. 