### PR TITLE
Feature/graphql metrics

### DIFF
--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -31,6 +31,17 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Condition="'$(RazorRuntimeCompilation)' == 'true'" />
+    <PackageReference Include="AspNetCore.HealthChecks.AzureStorage" Version="6.1.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.Network" Version="6.0.4" />
+    <PackageReference Include="AspNetCore.HealthChecks.OpenIdConnectServer" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.Prometheus.Metrics" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
+    <PackageReference Include="AspNetCore.HealthChecks.System" Version="6.0.5" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI" Version="6.0.5" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.InMemory.Storage" Version="6.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore.Cms.Web/Program.cs
+++ b/src/OrchardCore.Cms.Web/Program.cs
@@ -1,3 +1,8 @@
+using HealthChecks.UI.Client;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using OrchardCore.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,6 +12,21 @@ builder.Host.UseNLogHost();
 builder.Services
     .AddOrchardCms()
     .AddSetupFeatures("OrchardCore.AutoSetup");
+
+builder.Services.AddHealthChecks().AddDiskStorageHealthCheck(setup => setup.CheckAllDrives = true);
+builder.Services.AddHealthChecksUI(setup =>
+{
+    setup.SetEvaluationTimeInSeconds(15); // time in seconds between check
+    setup.MaximumHistoryEntriesPerEndpoint(60); // maximum history of checks
+    setup.SetApiMaxActiveRequests(1);
+    setup.SetHeaderText("Health");
+    setup.AddHealthCheckEndpoint("diskstorage", "/health.json");
+    setup.AddHealthCheckEndpoint("test", "/health/live");
+
+    ////setup.AddWebhookNotification("webhook1", uri: "https://healthchecks.requestcatcher.com/",
+    ////                            payload: "{ message: \"Webhook report for [[LIVENESS]]: [[FAILURE]] - Description: [[DESCRIPTIONS]]\"}",
+    ////                            restorePayload: "{ message: \"[[LIVENESS]] is back to life\"}");
+}).AddInMemoryStorage();
 
 var app = builder.Build();
 
@@ -18,5 +38,18 @@ if (!app.Environment.IsDevelopment())
 app.UseStaticFiles();
 
 app.UseOrchardCore();
+
+app.MapHealthChecks("/health.json", new HealthCheckOptions
+{
+    AllowCachingResponses = false,
+    ResultStatusCodes =
+                {
+                    [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                    [HealthStatus.Degraded] = StatusCodes.Status500InternalServerError,
+                    [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+                },
+    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+});
+app.UseHealthChecksUI();
 
 app.Run();

--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -7,6 +7,11 @@
   },
   //"AllowedHosts": "example.com;localhost", // A semicolon-delimited list of host names without port numbers. Set it for public-facing edge servers or when the Host header is directly forwarded.
   "OrchardCore": {
+    "OrchardCore_Apis_GraphQL": {
+      "ExposeExceptions": true,
+      "EnableMetrics": true,
+      "EnableMetricsByHeader": false
+    }
     // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Admin/#custom-admin-prefix
     //"OrchardCore_Admin": {
     //   "AdminUrlPrefix": "Admin"

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using GraphQL;
 using GraphQL.DataLoader;
 using GraphQL.Execution;
+using GraphQL.Instrumentation;
 using GraphQL.SystemTextJson;
 using GraphQL.Validation;
 using Microsoft.AspNetCore.Builder;
@@ -78,6 +79,8 @@ namespace OrchardCore.Apis.GraphQL
                 c.MaxNumberOfResults = configuration.GetValue<int?>($"OrchardCore_Apis_GraphQL:{nameof(GraphQLSettings.MaxNumberOfResults)}") ?? 1000;
                 c.MaxNumberOfResultsValidationMode = maxNumberOfResultsValidationMode;
                 c.DefaultNumberOfResults = configuration.GetValue<int?>($"OrchardCore_Apis_GraphQL:{nameof(GraphQLSettings.DefaultNumberOfResults)}") ?? 100;
+                c.EnableMetrics = configuration.GetValue<bool?>($"OrchardCore_Apis_GraphQL:{nameof(GraphQLSettings.EnableMetrics)}") ?? false;
+                c.EnableMetricsByHeader = configuration.GetValue<bool?>($"OrchardCore_Apis_GraphQL:{nameof(GraphQLSettings.EnableMetricsByHeader)}") ?? false;
             });
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Views/TaxonomyField-Tags.Edit.cshtml
@@ -1,4 +1,6 @@
 @model OrchardCore.Taxonomies.ViewModels.EditTagTaxonomyFieldViewModel
+@using Newtonsoft.Json;
+@using Newtonsoft.Json.Serialization;
 @using OrchardCore.Taxonomies.Settings
 @using OrchardCore.ContentManagement.Metadata.Models
 @using Microsoft.AspNetCore.Authorization
@@ -44,6 +46,28 @@
         }
         else
         {
+            var termEntries = new List<TermEntry>();
+            OrchardCore.Taxonomies.Drivers.TaxonomyFieldDriverHelper.PopulateTermEntries(termEntries, Model.Field, Model.Taxonomy.As<TaxonomyPart>().Terms, 0);
+            for (int i = 0; i < termEntries.Count; i++)
+            {
+                if (termEntries[i].Level > 0)
+                {
+                    termEntries[i].Term.DisplayText = $"{termEntries[i - 1].Term.DisplayText} - {termEntries[i].Term.DisplayText}";
+                }
+            }
+
+            var tagTermEntries = termEntries.Select(te => new TagTermEntry
+                {
+                    ContentItemId = te.ContentItemId,
+                    Selected = te.Selected,
+                    DisplayText = te.Term.DisplayText,
+                    IsLeaf = te.IsLeaf
+                });
+
+
+            Model.TagTermEntries = JsonConvert.SerializeObject(tagTermEntries, new JsonSerializerSettings() { ContractResolver = new CamelCasePropertyNamesContractResolver() });
+
+
             <div id="@vueElementId" class="tags" data-taxonomy-content-item-id="@Model.Taxonomy.ContentItemId" data-open="@open.ToString().ToLower()" data-leaves-only="@taxonomySettings.LeavesOnly.ToString().ToLower()" data-create-tag-error-message="@T["Error creating tag"]" data-all-tag-terms="@Model.TagTermEntries" data-create-tag-url="@createTagUrl">
 
                 <div class="w-100">

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/GraphQLSettings.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/GraphQLSettings.cs
@@ -16,6 +16,8 @@ namespace OrchardCore.Apis.GraphQL
         public double? FieldImpact { get; set; }
         public int DefaultNumberOfResults { get; set; }
         public int MaxNumberOfResults { get; set; }
+        public bool EnableMetrics { get; set; }
+        public bool EnableMetricsByHeader { get; set; }
         public MaxNumberOfResultsValidationMode MaxNumberOfResultsValidationMode { get; set; }
     }
 

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ICustomFieldMiddleware.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ICustomFieldMiddleware.cs
@@ -1,0 +1,6 @@
+namespace GraphQL.Instrumentation
+{
+    public interface ICustomFieldMiddleware : IFieldMiddleware
+    {
+    }
+}

--- a/src/docs/reference/modules/Apis.GraphQL/README.md
+++ b/src/docs/reference/modules/Apis.GraphQL/README.md
@@ -87,7 +87,9 @@ Configuration is done via the standard shell configuration, as follows.
       "FieldImpact": 2.0,
       "DefaultNumberOfResults": 100,
       "MaxNumberOfResults": 1000,
-      "MaxNumberOfResultsValidationMode": "Default"
+      "MaxNumberOfResultsValidationMode": "Default",
+      "EnableMetrics": true,
+      "EnableMetricsByHeader": false
     }
   }
 }
@@ -117,5 +119,13 @@ Enforces the total maximum nesting across all queries in a request.
 *MaxComplexity (int?, Default: null)*
 
 *FieldImpact (double?, Default: null)*
+
+*EnableMetrics (bool?, Default: false)*
+
+Enables metrics in GraphQl, enriches results with Apollo tracing and applies InstrumentFieldsMiddleware on results. Allows to add custom field middleware by registering implementations of ICustomFieldMiddleware interface.
+
+*EnableMetricsByHeader (bool?, Default: false)*
+
+Same as EnableMetrics but metrics are allowed only when request is made with X-GRAPHQL-METRICS header present.
 
 For more information on MaxDepth, MaxComplexity, FieldImpact & protecting against malicious queries view the graphql-dot-net documentation at <https://graphql-dotnet.github.io/docs/getting-started/malicious-queries/>


### PR DESCRIPTION
Add graphql metrics support as suggested in #4257.

* added conditional enabling of metrics from settings
* added header activated metrics as in https://graphql-dotnet.github.io/docs/getting-started/metrics/
* added apollo tracing & InstrumentFieldsMiddleware activation
* added possibility to add custom field middleware to graphql schema by registering implementation of ICustomfieldmiddleware