### PR TITLE
Fixes Stereotype Filter Binding and Thumbnail

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/ContentOptionsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/ContentOptionsDisplayDriver.cs
@@ -20,8 +20,9 @@ namespace OrchardCore.Contents.Drivers
                 Initialize<ContentOptionsViewModel>("ContentsAdminListBulkActions", m => BuildContentOptionsViewModel(m, model)).Location("BulkActions", "Content:10"),
                 View("ContentsAdminFilters_Thumbnail__DisplayText", model).Location("Thumbnail", "Content:10"),
                 View("ContentsAdminFilters_Thumbnail__ContentType", model).Location("Thumbnail", "Content:20"),
-                View("ContentsAdminFilters_Thumbnail__Status", model).Location("Thumbnail", "Content:30"),
-                View("ContentsAdminFilters_Thumbnail__Sort", model).Location("Thumbnail", "Content:40")
+                View("ContentsAdminFilters_Thumbnail__Stereotype", model).Location("Thumbnail", "Content:30"),
+                View("ContentsAdminFilters_Thumbnail__Status", model).Location("Thumbnail", "Content:40"),
+                View("ContentsAdminFilters_Thumbnail__Sort", model).Location("Thumbnail", "Content:50")
             );
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/DefaultContentsAdminListFilterProvider.cs
@@ -149,6 +149,7 @@ namespace OrchardCore.Contents.Services
 
                                 return query.With<ContentItemIndex>(x => x.ContentType == contentType && x.Owner == userNameIdentifier);
                             }
+
                             // At this point, the given contentType is invalid. Ignore it.
                         }
 
@@ -211,9 +212,9 @@ namespace OrchardCore.Contents.Services
                         if (!String.IsNullOrEmpty(stereotype))
                         {
                             var contentTypeDefinitionNames = contentDefinitionManager.ListTypeDefinitions()
-                            .Where(definition => definition.StereotypeEquals(stereotype, StringComparison.OrdinalIgnoreCase))
-                            .Select(definition => definition.Name)
-                            .ToList();
+                                .Where(definition => definition.StereotypeEquals(stereotype, StringComparison.OrdinalIgnoreCase))
+                                .Select(definition => definition.Name)
+                                .ToList();
 
                             // We display a specific type even if it's not listable so that admin pages
                             // can reuse the content list page for specific types.
@@ -246,22 +247,6 @@ namespace OrchardCore.Contents.Services
                         }
 
                         return query;
-                    })
-                    .MapTo<ContentOptionsViewModel>((val, model) =>
-                    {
-                        if (!String.IsNullOrEmpty(val))
-                        {
-                            model.SelectedContentType = val;
-                        }
-                    })
-                    .MapFrom<ContentOptionsViewModel>((model) =>
-                    {
-                        if (!String.IsNullOrEmpty(model.SelectedContentType))
-                        {
-                            return (true, model.SelectedContentType);
-                        }
-
-                        return (false, String.Empty);
                     })
                 )
                 .WithDefaultTerm(ContentsAdminListFilterOptions.DefaultTermName, builder => builder

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Stereotype.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Stereotype.Thumbnail.cshtml
@@ -4,7 +4,7 @@
 }
 
 <h4 class="card-title">Content Type Stereotype</h4>
-<pre class="mb-3">@(@term != null ? @term.ToString() : "stereotype:...")</pre>
+<pre class="mb-3">@(term?.ToString() ?? "stereotype:...")</pre>
 <p>@T["Filters on a specified content type stereotype."]</p>
 <div class="d-block text-end">
     <span>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Stereotype.Thumbnail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentsAdminFilters-Stereotype.Thumbnail.cshtml
@@ -1,0 +1,13 @@
+@model ShapeViewModel<ContentOptionsViewModel>
+@{
+    var term = Model.Value.FilterResult.FirstOrDefault(x => x.TermName == "stereotype");
+}
+
+<h4 class="card-title">Content Type Stereotype</h4>
+<pre class="mb-3">@(@term != null ? @term.ToString() : "stereotype:...")</pre>
+<p>@T["Filters on a specified content type stereotype."]</p>
+<div class="d-block text-end">
+    <span>
+        <i class="fa-solid fa-sm fa-minus text-primary" aria-hidden="true"></i>
+    </span>
+</div>


### PR DESCRIPTION
Fixes #13932 

The new `stereotype:...` filter is a standalone admin list filter with no related drop down.

- It should not be mapped to and from the `SelectedContentType` as it is currently.

- Clicking on `Filter Syntax`, it is missing in the description of all available filters.
