### PR TITLE
NotificationIndex Content Column Size is too high

### DIFF
--- a/src/OrchardCore/OrchardCore.Notifications.Core/NotificationConstants.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/NotificationConstants.cs
@@ -4,8 +4,11 @@ public class NotificationConstants
 {
     public const string NotificationCollection = "Notification";
 
-    /// <summary>
-    /// If this number is increased after the site is setup, you must alter the <see cref="Notification" /> using migration
-    /// </summary>
-    public const int NotificationIndexContentLength = 2500;
+    // Maximum length that MySql can support in an inner index under utf8mb4 collation is 768,
+    // minus 2 for the 'DocumentId' integer (bigint size = 8 bytes = 2 character size),
+    // minus 2 for the 'CreatedAtUtc' (date time size = 8 bytes = 2 character size),
+    // minus 26 for 'NotificationId', 26 for 'UserId' and 1 for the 'IsRead' bool,
+    // minus 4 to allow a new integer column, for example the 'Id' column,
+    // minus 2 to allow a new date time, for example 'ReadAtUtc'.
+    public const int NotificationIndexContentLength = 705;
 }


### PR DESCRIPTION
Fixes #13934 

With `MySql` in a given `inner index` the total of the included columns sizes should not be greater than `3072` bytes, so with the `utf8mb4_general_ci` not greater than 3072 / 4 = `768 chars`. We already fixed the same issue for the `Alias` column size that was a little too high, see https://github.com/OrchardCMS/OrchardCore/pull/13585#issuecomment-1553457322.

So at least for `MySql`, `NotificationIndexContentLength` which is equal to `2500` is too high.

---

For info when using directly `.QueryIndex<SomeIndex>()` it is useful that the related inner index include all columns, being a full inner index, this because `.QueryIndex<SomeIndex>()` selects all columns. Most of our inner indexes are missing the `Id` column but we began to include it, see below.
 https://github.com/OrchardCMS/OrchardCore/blob/4aadfbf6132dd827b195e0f7df48dce4a79ec5c4/src/OrchardCore.Modules/OrchardCore.PublishLater/Migrations.cs#L34-L42

About the `NotificationIndex` table, its inner index is missing the `Id` column too and also the `ReadAtUtc` column, but because no direct `.QueryIndex<NotificationIndex>()` is done, for now I let it as is.
