### PR TITLE
Allows any tenant to be at the root

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -146,35 +146,35 @@
     //  "Tenants": [
     //    {
     //      "ShellName": "Default",
-    //      "SiteName": "Test",
+    //      "SiteName": "AutoSetup Example",
     //      "SiteTimeZone": "Europe/Amsterdam",
     //      "AdminUsername": "admin",
     //      "AdminEmail": "info@orchardproject.net",
-    //      "AdminPassword": "Admin123!",
+    //      "AdminPassword": "OrchardCoreRules1!",
     //      "DatabaseProvider": "Sqlite",
     //      "DatabaseConnectionString": "",
     //      "DatabaseTablePrefix": "",
     //      "DatabaseSchema": "",
-    //      "RecipeName": "Blog",
-    //      "RequestUrlPrefix": ""
+    //      "RecipeName": "SaaS",
+    //      "RequestUrlPrefix": "default"
     //    },
     //    {
-    //      "ShellName": "Tenant1",
-    //      "SiteName": "Tenant 1",
+    //      "ShellName": "AutoSetupTenant",
+    //      "SiteName": "AutoSetup Tenant",
     //      "SiteTimeZone": "Europe/Amsterdam",
     //      "AdminUsername": "tenantadmin",
     //      "AdminEmail": "tenant@orchardproject.net",
-    //      "AdminPassword": "Admin123!",
+    //      "AdminPassword": "OrchardCoreRules1!",
     //      "DatabaseProvider": "Sqlite",
     //      "DatabaseConnectionString": "",
-    //      "DatabaseTablePrefix": "",
+    //      "DatabaseTablePrefix": "tenant",
     //      "DatabaseSchema": "",
     //      "RecipeName": "Agency",
     //      "RequestUrlHost": "",
-    //      "RequestUrlPrefix": "tenant1"
+    //      "RequestUrlPrefix": ""
     //    }
     //  ]
-    //}
+    //},
     //"OrchardCore_HealthChecks": {
     //  "Url": "/health/live"
     //},

--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -146,34 +146,35 @@
     //  "Tenants": [
     //    {
     //      "ShellName": "Default",
-    //      "SiteName": "AutoSetup Example",
+    //      "SiteName": "Test",
     //      "SiteTimeZone": "Europe/Amsterdam",
     //      "AdminUsername": "admin",
     //      "AdminEmail": "info@orchardproject.net",
-    //      "AdminPassword": "OrchardCoreRules1!",
+    //      "AdminPassword": "Admin123!",
     //      "DatabaseProvider": "Sqlite",
     //      "DatabaseConnectionString": "",
     //      "DatabaseTablePrefix": "",
     //      "DatabaseSchema": "",
-    //      "RecipeName": "SaaS"
+    //      "RecipeName": "Blog",
+    //      "RequestUrlPrefix": ""
     //    },
     //    {
-    //      "ShellName": "AutoSetupTenant",
-    //      "SiteName": "AutoSetup Tenant",
+    //      "ShellName": "Tenant1",
+    //      "SiteName": "Tenant 1",
     //      "SiteTimeZone": "Europe/Amsterdam",
     //      "AdminUsername": "tenantadmin",
     //      "AdminEmail": "tenant@orchardproject.net",
-    //      "AdminPassword": "OrchardCoreRules1!",
+    //      "AdminPassword": "Admin123!",
     //      "DatabaseProvider": "Sqlite",
     //      "DatabaseConnectionString": "",
-    //      "DatabaseTablePrefix": "tenant",
+    //      "DatabaseTablePrefix": "",
     //      "DatabaseSchema": "",
     //      "RecipeName": "Agency",
     //      "RequestUrlHost": "",
-    //      "RequestUrlPrefix": "tenant"
+    //      "RequestUrlPrefix": "tenant1"
     //    }
     //  ]
-    //},
+    //}
     //"OrchardCore_HealthChecks": {
     //  "Url": "/health/live"
     //},

--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -155,8 +155,7 @@
     //      "DatabaseConnectionString": "",
     //      "DatabaseTablePrefix": "",
     //      "DatabaseSchema": "",
-    //      "RecipeName": "SaaS",
-    //      "RequestUrlPrefix": "default"
+    //      "RecipeName": "SaaS"
     //    },
     //    {
     //      "ShellName": "AutoSetupTenant",
@@ -171,7 +170,7 @@
     //      "DatabaseSchema": "",
     //      "RecipeName": "Agency",
     //      "RequestUrlHost": "",
-    //      "RequestUrlPrefix": ""
+    //      "RequestUrlPrefix": "tenant"
     //    }
     //  ]
     //},

--- a/src/OrchardCore.Modules/OrchardCore.AutoSetup/AutoSetupMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AutoSetup/AutoSetupMiddleware.cs
@@ -245,6 +245,9 @@ namespace OrchardCore.AutoSetup
                 Errors = new Dictionary<string, string>()
             };
 
+            shellSettings.RequestUrlHost = options.RequestUrlHost;
+            shellSettings.RequestUrlPrefix = options.RequestUrlPrefix;
+
             setupContext.Properties[SetupConstants.AdminEmail] = options.AdminEmail;
             setupContext.Properties[SetupConstants.AdminPassword] = options.AdminPassword;
             setupContext.Properties[SetupConstants.AdminUsername] = options.AdminUsername;

--- a/src/OrchardCore.Modules/OrchardCore.AutoSetup/AutoSetupMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AutoSetup/AutoSetupMiddleware.cs
@@ -245,8 +245,13 @@ namespace OrchardCore.AutoSetup
                 Errors = new Dictionary<string, string>()
             };
 
-            shellSettings.RequestUrlHost = options.RequestUrlHost;
-            shellSettings.RequestUrlPrefix = options.RequestUrlPrefix;
+            if (shellSettings.IsDefaultShell())
+            {
+                // The 'Default' shell is first created by the infrastructure,
+                // so the following 'Autosetup' options need to be passed.
+                shellSettings.RequestUrlHost = options.RequestUrlHost;
+                shellSettings.RequestUrlPrefix = options.RequestUrlPrefix;
+            }
 
             setupContext.Properties[SetupConstants.AdminEmail] = options.AdminEmail;
             setupContext.Properties[SetupConstants.AdminPassword] = options.AdminPassword;

--- a/src/OrchardCore.Modules/OrchardCore.AutoSetup/Options/TenantSetupOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AutoSetup/Options/TenantSetupOptions.cs
@@ -111,11 +111,6 @@ namespace OrchardCore.AutoSetup.Options
                 yield return new ValidationResult("The tenant name is in conflict with the 'Default' tenant name.");
             }
 
-            //if (!IsDefault && String.IsNullOrWhiteSpace(RequestUrlPrefix) && String.IsNullOrWhiteSpace(RequestUrlHost))
-            //{
-            //    yield return new ValidationResult("RequestUrlPrefix or RequestUrlHost should be provided for a non 'Default' Tenant.");
-            //}
-
             if (!String.IsNullOrWhiteSpace(RequestUrlPrefix) && RequestUrlPrefix.Contains('/'))
             {
                 yield return new ValidationResult("The RequestUrlPrefix can not contain more than one segment.");

--- a/src/OrchardCore.Modules/OrchardCore.AutoSetup/Options/TenantSetupOptions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AutoSetup/Options/TenantSetupOptions.cs
@@ -111,10 +111,10 @@ namespace OrchardCore.AutoSetup.Options
                 yield return new ValidationResult("The tenant name is in conflict with the 'Default' tenant name.");
             }
 
-            if (!IsDefault && String.IsNullOrWhiteSpace(RequestUrlPrefix) && String.IsNullOrWhiteSpace(RequestUrlHost))
-            {
-                yield return new ValidationResult("RequestUrlPrefix or RequestUrlHost should be provided for a non 'Default' Tenant.");
-            }
+            //if (!IsDefault && String.IsNullOrWhiteSpace(RequestUrlPrefix) && String.IsNullOrWhiteSpace(RequestUrlHost))
+            //{
+            //    yield return new ValidationResult("RequestUrlPrefix or RequestUrlHost should be provided for a non 'Default' Tenant.");
+            //}
 
             if (!String.IsNullOrWhiteSpace(RequestUrlPrefix) && RequestUrlPrefix.Contains('/'))
             {

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Services/TenantValidator.cs
@@ -63,13 +63,6 @@ namespace OrchardCore.Tenants.Services
 
             _ = _shellHost.TryGetSettings(model.Name, out var existingShellSettings);
 
-            if (!existingShellSettings.IsDefaultShell() &&
-                String.IsNullOrWhiteSpace(model.RequestUrlHost) &&
-                String.IsNullOrWhiteSpace(model.RequestUrlPrefix))
-            {
-                errors.Add(new ModelError(nameof(model.RequestUrlPrefix), S["Host and url prefix can not be empty at the same time."]));
-            }
-
             if (!String.IsNullOrWhiteSpace(model.RequestUrlPrefix) && model.RequestUrlPrefix.Contains('/'))
             {
                 errors.Add(new ModelError(nameof(model.RequestUrlPrefix), S["The url prefix can not contain more than one segment."]));

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
@@ -25,7 +25,7 @@ namespace OrchardCore.Modules.Tenants.Services.Tests
         [InlineData("", "tenant7", "example1.com", "Feature Profile", new[] { "The tenant name is mandatory." })]
         [InlineData("Tenant7", "tenant7", "", "Feature", new[] { "The feature profile does not exist." })]
         [InlineData("@Invalid Tenant", "tenant7", "example1.com", "Feature Profile", new[] { "Invalid tenant name. Must contain characters only and no spaces." })]
-        [InlineData("Tenant7", null, "  ", "Feature Profile", new[] { "Host and url prefix can not be empty at the same time.", "A tenant with the same host and prefix already exists." })]
+        [InlineData("Tenant7", null, "  ", "Feature Profile", new[] { "A tenant with the same host and prefix already exists." })]
         [InlineData("Tenant7", "/tenant7", "", "Feature Profile", new[] { "The url prefix can not contain more than one segment." })]
         [InlineData("@Invalid Tenant", "/tenant7", "", "Feature Profile", new[] { "Invalid tenant name. Must contain characters only and no spaces.", "The url prefix can not contain more than one segment." })]
         [InlineData("Tenant8", "tenant4", "example6.com,example4.com, example5.com", "Feature Profile", new[] { "A tenant with the same host and prefix already exists." })]


### PR DESCRIPTION
Fixes #13952 

Meaning to AutoSetup the Default tenant but with a non empty `RequestUrlPrefix`. And then also allows to Autosetup a non Default tenant being at the root, meaning having a null/empty `RequestUrlPrefix`.

Todo: Also allow the same from the admin UI or API controller, as it was before.

Okay done by updating the `TenantValidator` but we still check if 2 tenants (including the Default) have both the same `RequestUrlPrefix` and a shared `RequestUrlHost`.
