### PR TITLE
Enable the "plain" code challenge method by default

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
@@ -120,6 +120,7 @@ namespace OrchardCore.OpenId.Configuration
             // configurable and are inferred from the selected flows.
             if (settings.AllowAuthorizationCodeFlow)
             {
+                options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
                 options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
 
                 options.GrantTypes.Add(GrantTypes.AuthorizationCode);
@@ -138,6 +139,7 @@ namespace OrchardCore.OpenId.Configuration
 
             if (settings.AllowHybridFlow)
             {
+                options.CodeChallengeMethods.Add(CodeChallengeMethods.Plain);
                 options.CodeChallengeMethods.Add(CodeChallengeMethods.Sha256);
 
                 options.GrantTypes.Add(GrantTypes.AuthorizationCode);


### PR DESCRIPTION
While `S256` remains the preferred choice as it offers a better security level, OpenIddict 4.5 now enables `plain` when calling `AllowAuthorizationCodeFlow()`/`AllowHybridFlow()` for better interop: https://github.com/openiddict/openiddict-core/pull/1822.

This PR updates Orchard's `OpenIdServerConfiguration`'s to use the same logic.