### PR TITLE
Fix get duplicate items

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -236,7 +237,7 @@ namespace OrchardCore.ContentManagement
             var contentItem = await contentManager.GetAsync(id, options);
 
             // It represents a contained content item
-            if (!string.IsNullOrEmpty(jsonPath))
+            if (!String.IsNullOrEmpty(jsonPath))
             {
                 var root = contentItem.Content as JObject;
                 contentItem = root.SelectToken(jsonPath)?.ToObject<ContentItem>();

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -92,7 +92,7 @@ namespace OrchardCore.ContentManagement
             contentItemIds = contentItemIds
                 ?.Where(id => id is not null)
                 .Distinct()
-                ?? throw new ArgumentNullException(nameof(contentItemIds)); 
+                ?? throw new ArgumentNullException(nameof(contentItemIds));
 
             List<ContentItem> contentItems = null;
             List<ContentItem> storedItems = null;

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -92,7 +92,7 @@ namespace OrchardCore.ContentManagement
             contentItemIds = contentItemIds
                 ?.Where(id => id is not null)
                 .Distinct()
-                ?? throw new ArgumentNullException(nameof(contentItemIds)); ;
+                ?? throw new ArgumentNullException(nameof(contentItemIds)); 
 
             List<ContentItem> contentItems = null;
             List<ContentItem> storedItems = null;


### PR DESCRIPTION
Fix #14018 

We loop on each id of the passed `contentItemIds` to check if it is session cached, so if there is a duplicate id related to a cached item, we enlist this cached item twice.

So this is not an issue of the cahe, we only need to make `contentItemIds` a collection of distinct ids, which is also useful when used through the `.IsIn()` of the query predicate.
