### PR TITLE
Rename "IpAddress" to "IPAddress"

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/AuditTrailManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/AuditTrailManager.cs
@@ -30,7 +30,7 @@ namespace OrchardCore.AuditTrail.Services
         private readonly ILookupNormalizer _keyNormalizer;
         private readonly IAuditTrailIdGenerator _auditTrailIdGenerator;
         private readonly IEnumerable<IAuditTrailEventHandler> _auditTrailEventHandlers;
-        private readonly IClientIpAddressAccessor _clientIpAddressAccessor;
+        private readonly IClientIPAddressAccessor _clientIPAddressAccessor;
         private readonly ShellSettings _shellSettings;
         private readonly ILogger _logger;
 
@@ -42,7 +42,7 @@ namespace OrchardCore.AuditTrail.Services
             IHttpContextAccessor httpContextAccessor,
             ILookupNormalizer keyNormalizer,
             IEnumerable<IAuditTrailEventHandler> auditTrailEventHandlers,
-            IClientIpAddressAccessor clientIpAddressAccessor,
+            IClientIPAddressAccessor clientIPAddressAccessor,
             IAuditTrailIdGenerator auditTrailIdGenerator,
             ShellSettings shellSettings,
             ILogger<AuditTrailManager> logger)
@@ -54,7 +54,7 @@ namespace OrchardCore.AuditTrail.Services
             _httpContextAccessor = httpContextAccessor;
             _keyNormalizer = keyNormalizer;
             _auditTrailEventHandlers = auditTrailEventHandlers;
-            _clientIpAddressAccessor = clientIpAddressAccessor;
+            _clientIPAddressAccessor = clientIPAddressAccessor;
             _auditTrailIdGenerator = auditTrailIdGenerator;
             _shellSettings = shellSettings;
             _logger = logger;
@@ -165,7 +165,7 @@ namespace OrchardCore.AuditTrail.Services
                 return null;
             }
 
-            return (await _clientIpAddressAccessor.GetIpAddressAsync())?.ToString();
+            return (await _clientIPAddressAccessor.GetIPAddressAsync())?.ToString();
         }
 
         private async Task<AuditTrailSettings> GetAuditTrailSettingsAsync() =>

--- a/src/OrchardCore.Modules/OrchardCore.ReverseProxy/Views/ReverseProxySettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ReverseProxy/Views/ReverseProxySettings.Edit.cshtml
@@ -2,7 +2,7 @@
 
 @model ReverseProxySettingsViewModel
 
-@inject IClientIpAddressAccessor ClientIpAddressAccessor
+@inject IClientIPAddressAccessor ClientIPAddressAccessor
 
 <p class="alert alert-warning">
     @T["The current tenant will be reloaded when the settings are saved."]
@@ -16,7 +16,7 @@
         </label>
     </div>
     <span class="hint">@T["Enables the forwarding of the HTTP header X-Forwarded-For"]</span>
-    <span class="hint">@T["Current request value;"] @await ClientIpAddressAccessor.GetIpAddressAsync()</span>
+    <span class="hint">@T["Current request value;"] @await ClientIPAddressAccessor.GetIPAddressAsync()</span>
 </div>
 
 <div class="mb-3" asp-validation-class-for="EnableXForwardedProto">

--- a/src/OrchardCore/OrchardCore.Abstractions/IClientIpAddressAccessor.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/IClientIpAddressAccessor.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace OrchardCore;
 
-public interface IClientIpAddressAccessor
+public interface IClientIPAddressAccessor
 {
-    Task<IPAddress> GetIpAddressAsync();
+    Task<IPAddress> GetIPAddressAsync();
 }

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/ActionFilters/Detection/IpAddressRobotDetector.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/ActionFilters/Detection/IpAddressRobotDetector.cs
@@ -5,16 +5,16 @@ using OrchardCore.ReCaptcha.Configuration;
 
 namespace OrchardCore.ReCaptcha.ActionFilters.Detection
 {
-    public class IpAddressRobotDetector : IDetectRobots
+    public class IPAddressRobotDetector : IDetectRobots
     {
         private const string IpAddressAbuseDetectorCacheKey = "IpAddressRobotDetector";
 
         private readonly IMemoryCache _memoryCache;
-        private readonly IClientIpAddressAccessor _clientIpAddressAccessor;
+        private readonly IClientIPAddressAccessor _clientIpAddressAccessor;
         private readonly ReCaptchaSettings _settings;
 
-        public IpAddressRobotDetector(
-            IClientIpAddressAccessor clientIpAddressAccessor,
+        public IPAddressRobotDetector(
+            IClientIPAddressAccessor clientIpAddressAccessor,
             IMemoryCache memoryCache,
             IOptions<ReCaptchaSettings> settingsAccessor)
         {
@@ -31,7 +31,7 @@ namespace OrchardCore.ReCaptcha.ActionFilters.Detection
 
         private string GetIpAddressCacheKey()
         {
-            var address = _clientIpAddressAccessor.GetIpAddressAsync().GetAwaiter().GetResult();
+            var address = _clientIpAddressAccessor.GetIPAddressAsync().GetAwaiter().GetResult();
 
             return $"{IpAddressAbuseDetectorCacheKey}:{address?.ToString() ?? String.Empty}";
         }

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/ServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ namespace OrchardCore.ReCaptcha.Core
             services.AddHttpClient<ReCaptchaClient>()
                 .AddTransientHttpErrorPolicy(policy => policy.WaitAndRetryAsync(3, attempt => TimeSpan.FromSeconds(0.5 * attempt)));
 
-            services.AddTransient<IDetectRobots, IpAddressRobotDetector>();
+            services.AddTransient<IDetectRobots, IPAddressRobotDetector>();
             services.AddTransient<IConfigureOptions<ReCaptchaSettings>, ReCaptchaSettingsConfiguration>();
             services.AddTransient<ReCaptchaService>();
             services.AddTagHelpers<ReCaptchaTagHelper>();

--- a/src/OrchardCore/OrchardCore/Modules/DefaultClientIpAddressAccessor.cs
+++ b/src/OrchardCore/OrchardCore/Modules/DefaultClientIpAddressAccessor.cs
@@ -4,16 +4,16 @@ using Microsoft.AspNetCore.Http;
 
 namespace OrchardCore.Modules;
 
-public class DefaultClientIpAddressAccessor : IClientIpAddressAccessor
+public class DefaultClientIPAddressAccessor : IClientIPAddressAccessor
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public DefaultClientIpAddressAccessor(IHttpContextAccessor httpContextAccessor)
+    public DefaultClientIPAddressAccessor(IHttpContextAccessor httpContextAccessor)
     {
         _httpContextAccessor = httpContextAccessor;
     }
 
-    public Task<IPAddress> GetIpAddressAsync()
+    public Task<IPAddress> GetIPAddressAsync()
     {
         var address = _httpContextAccessor.HttpContext?.Connection?.RemoteIpAddress;
 

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton<IPoweredByMiddlewareOptions, PoweredByMiddlewareOptions>();
 
             services.AddScoped<IOrchardHelper, DefaultOrchardHelper>();
-            services.AddScoped<IClientIpAddressAccessor, DefaultClientIpAddressAccessor>();
+            services.AddScoped<IClientIPAddressAccessor, DefaultClientIPAddressAccessor>();
 
             builder.ConfigureServices((services, serviceProvider) =>
             {


### PR DESCRIPTION
Based on @sebastienros feedback in a meeting, I am renaming `IpAddress` to `IPAddress`. The original decision to name `IpAddress` was to follow what was previously used in `IpAddressRobotDetector` class name.

For constancy I renamed the class `IpAddressRobotDetector` to `IPAddressRobotDetector`  which could "highly unlikely" break someone out there if there are using the class directly or replacing that implementation. 

