### PR TITLE
ImplicitUsings always enabled

### DIFF
--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -10,7 +10,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
-    <RazorRuntimeCompilation>true</RazorRuntimeCompilation>
+    <RazorRuntimeCompilation>false</RazorRuntimeCompilation>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -10,9 +10,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
-    <RazorRuntimeCompilation>false</RazorRuntimeCompilation>
+    <RazorRuntimeCompilation>true</RazorRuntimeCompilation>
+    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <ImplicitUsings Condition="'$(RazorRuntimeCompilation)' == 'false'">enable</ImplicitUsings>
   </PropertyGroup>
   <!-- For Unit Tests-->
   <ItemGroup>


### PR DESCRIPTION
In our web app project file, `ImplicitUsings` is not enabled if `RazorRuntimeCompilation` is true.

But in that case, for example `Program.cs` fails to build.

So here, `ImplicitUsings` is now always true, in this context `RazorRuntimeCompilation` seems to work for both net7.0 and net6.0, anyway before, because of the above, in our solution we were not able to use it.
