### PR TITLE
Use safer HeaderDictionaryExtensions

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Activities/HttpResponseTask.cs
@@ -80,7 +80,7 @@ namespace OrchardCore.Workflows.Http.Activities
 
             foreach (var header in headers)
             {
-                response.Headers.Add(header);
+                response.Headers.Append(header.Key, header.Value);
             }
 
             if (!String.IsNullOrWhiteSpace(contentType))

--- a/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularTenantContainerMiddleware.cs
@@ -37,7 +37,7 @@ namespace OrchardCore.Modules
             {
                 if (shellSettings.IsInitializing())
                 {
-                    httpContext.Response.Headers.Add(HeaderNames.RetryAfter, "10");
+                    httpContext.Response.Headers.Append(HeaderNames.RetryAfter, "10");
                     httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
                     await httpContext.Response.WriteAsync("The requested tenant is currently initializing.");
                     return;


### PR DESCRIPTION
While trying donet 8 new analyzers suggest to not use `.Headers.Add()` but `.Headers.Append()`, the first is a collection method that may throw if the key already exists, the second is a `IHeaderDictionary` extension that checks if the key already exists and if so merge the provided value to the existing `StringValues`.
