### PR TITLE
Tweaks on merged PR.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Services/ContainerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Services/ContainerService.cs
@@ -167,7 +167,7 @@ namespace OrchardCore.Lists.Services
             {
                 if (enableOrdering)
                 {
-                    var beforeValue = int.Parse(pager.Before);
+                    var beforeValue = Int32.Parse(pager.Before);
                     query = _session.Query<ContentItem>()
                         .With(CreateOrderedContainedPartIndexFilter(beforeValue, null, contentItemId))
                         .OrderByDescending(x => x.Order);
@@ -233,7 +233,7 @@ namespace OrchardCore.Lists.Services
                 }
                 else
                 {
-                    var afterValue = new DateTime(long.Parse(pager.After));
+                    var afterValue = new DateTime(Int64.Parse(pager.After));
                     query = _session.Query<ContentItem>()
                         .With(CreateOrderedContainedPartIndexFilter(null, null, contentItemId));
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/WorkflowFaultEventDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Drivers/WorkflowFaultEventDisplayDriver.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Workflows.Drivers
         {
             model.ErrorFilter = activity.ErrorFilter.Expression;
         }
-        
+
         protected override void UpdateActivity(WorkflowFaultViewModel model, WorkflowFaultEvent activity)
         {
             activity.ErrorFilter = new WorkflowExpression<bool>(model.ErrorFilter);

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Events/WorkflowFaultEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Events/WorkflowFaultEvent.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Workflows.Events
 {
     public class WorkflowFaultEvent : EventActivity
     {
-        private readonly IStringLocalizer<WorkflowFaultEvent> S;
+        protected readonly IStringLocalizer<WorkflowFaultEvent> S;
         private readonly IWorkflowScriptEvaluator _scriptEvaluator;
 
         public WorkflowFaultEvent(
@@ -20,6 +20,7 @@ namespace OrchardCore.Workflows.Events
             S = stringLocalizer;
             _scriptEvaluator = scriptEvaluator;
         }
+
         public override string Name => nameof(WorkflowFaultEvent);
         public override LocalizedString DisplayText => S["Catch Workflow Fault Event"];
         public override LocalizedString Category => S["Background"];
@@ -44,7 +45,7 @@ namespace OrchardCore.Workflows.Events
         {
             var faultModel = workflowContext.Input[WorkflowFaultModel.WorkflowFaultInputKey] as WorkflowFaultModel;
 
-            //Avoid endless loops
+            // Avoid endless loops.
             if (faultModel == null || faultModel.WorkflowName == workflowContext.WorkflowType.Name)
             {
                 return false;
@@ -53,7 +54,7 @@ namespace OrchardCore.Workflows.Events
             return await _scriptEvaluator.EvaluateAsync(ErrorFilter, workflowContext);
         }
 
-        private string GetDefaultValue()
+        private static string GetDefaultValue()
         {
             var sample = $@"//sample code
 var errorInfo= input('{WorkflowFaultModel.WorkflowFaultInputKey}');

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Handlers/DefaultWorkflowFaultHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Handlers/DefaultWorkflowFaultHandler.cs
@@ -1,16 +1,18 @@
-using OrchardCore.Workflows.Events;
-using OrchardCore.Workflows.Models;
-using OrchardCore.Workflows.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using OrchardCore.Workflows.Events;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Services;
 
 namespace OrchardCore.Workflows.Handlers
 {
     public class DefaultWorkflowFaultHandler : IWorkflowFaultHandler
     {
-        public async Task OnWorkflowFaultAsync(IWorkflowManager workflowManager, WorkflowExecutionContext workflowContext,
+        public async Task OnWorkflowFaultAsync(
+            IWorkflowManager workflowManager,
+            WorkflowExecutionContext workflowContext,
             ActivityContext activityContext,
             Exception exception)
         {
@@ -19,7 +21,7 @@ namespace OrchardCore.Workflows.Handlers
             {
                 WorkflowId = workflowContext.Workflow.WorkflowId,
                 WorkflowName = workflowContext.WorkflowType.Name,
-                ExecutedActivityCount = workflowContext.ExecutedActivities.Count(),
+                ExecutedActivityCount = workflowContext.ExecutedActivities.Count,
                 FaultMessage = workflowContext.Workflow.FaultMessage,
                 ActivityId = activityContext.ActivityRecord.ActivityId,
                 ActivityTypeName = activityContext.Activity.Name,
@@ -30,9 +32,7 @@ namespace OrchardCore.Workflows.Handlers
 
             var input = new Dictionary<string, object>
             {
-                {
-                    WorkflowFaultModel.WorkflowFaultInputKey, faultContext
-                }
+                { WorkflowFaultModel.WorkflowFaultInputKey, faultContext },
             };
 
             await workflowManager.TriggerEventAsync(name, input);

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/WorkflowManager.cs
@@ -22,10 +22,10 @@ namespace OrchardCore.Workflows.Services
 
         private readonly IActivityLibrary _activityLibrary;
         private readonly IWorkflowTypeStore _workflowTypeStore;
-        private readonly IWorkflowFaultHandler _workflowFaultHandler;
         private readonly IWorkflowStore _workflowStore;
         private readonly IWorkflowIdGenerator _workflowIdGenerator;
         private readonly Resolver<IEnumerable<IWorkflowValueSerializer>> _workflowValueSerializers;
+        private readonly IWorkflowFaultHandler _workflowFaultHandler;
         private readonly IDistributedLock _distributedLock;
         private readonly ILogger _logger;
         private readonly ILogger<MissingActivity> _missingActivityLogger;
@@ -42,24 +42,24 @@ namespace OrchardCore.Workflows.Services
             IWorkflowStore workflowRepository,
             IWorkflowIdGenerator workflowIdGenerator,
             Resolver<IEnumerable<IWorkflowValueSerializer>> workflowValueSerializers,
+            IWorkflowFaultHandler workflowFaultHandler,
             IDistributedLock distributedLock,
             ILogger<WorkflowManager> logger,
             ILogger<MissingActivity> missingActivityLogger,
             IStringLocalizer<MissingActivity> missingActivityLocalizer,
-            IClock clock,
-            IWorkflowFaultHandler workflowFaultHandler)
+            IClock clock)
         {
             _activityLibrary = activityLibrary;
             _workflowTypeStore = workflowTypeRepository;
             _workflowStore = workflowRepository;
             _workflowIdGenerator = workflowIdGenerator;
             _workflowValueSerializers = workflowValueSerializers;
+            _workflowFaultHandler = workflowFaultHandler;
             _distributedLock = distributedLock;
             _logger = logger;
             _missingActivityLogger = missingActivityLogger;
             _missingActivityLocalizer = missingActivityLocalizer;
             _clock = clock;
-            _workflowFaultHandler = workflowFaultHandler;
         }
 
         public Workflow NewWorkflow(WorkflowType workflowType, string correlationId = null)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/WorkflowFaultEvent.Fields.Design.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/WorkflowFaultEvent.Fields.Design.cshtml
@@ -2,6 +2,7 @@
 @using OrchardCore.Workflows.Events
 @using OrchardCore.Workflows.Helpers
 @using OrchardCore.Workflows.ViewModels
+
 <header>
     <h4><i class="fa fa-exclamation-circle"></i>@Model.Activity.GetTitleOrDefault(() => T["Workflow Fault Event"])</h4>
 </header>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/WorkflowFaultEvent.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/WorkflowFaultEvent.Fields.Edit.cshtml
@@ -6,7 +6,7 @@
     <div id="@Html.IdFor(x => x.ErrorFilter)_editor" asp-for="Text" style="min-height: 400px;" class="form-control"></div>
     <textarea asp-for="ErrorFilter" hidden>@Html.Raw(Model.ErrorFilter)</textarea>
     <span asp-validation-for="ErrorFilter"></span>
-    <span class="hint">@T["Check the captured workflow error information and return a Boolean value. If it is true, it will be processed by the current workflow. Javascript syntax."]</span><br/>
+    <span class="hint">@T["Check the captured workflow error information and return a Boolean value. If it is true, it will be processed by the current workflow. Javascript syntax."]</span><br />
     <span class="hint">
         @T["You can use input('{0}') to get error information, contains the following attributes：", WorkflowFaultModel.WorkflowFaultInputKey]
     </span>
@@ -29,10 +29,10 @@
 <script at="Foot" depends-on="monaco">
     $(function () {
         require(['vs/editor/editor.main'], function () {
-            var settings=  {
-                  "automaticLayout": true,
-                  "language": "javascript"
-                };
+            var settings = {
+                "automaticLayout": true,
+                "language": "javascript"
+            };
 
             var html = document.getElementsByTagName("html")[0];
             const mutationObserver = new MutationObserver(setTheme);

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowFaultHandler.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/Services/IWorkflowFaultHandler.cs
@@ -1,12 +1,13 @@
-using OrchardCore.Workflows.Models;
 using System;
 using System.Threading.Tasks;
+using OrchardCore.Workflows.Models;
 
 namespace OrchardCore.Workflows.Services
 {
     public interface IWorkflowFaultHandler
     {
-        Task OnWorkflowFaultAsync(IWorkflowManager workflowManager,
+        Task OnWorkflowFaultAsync(
+            IWorkflowManager workflowManager,
             WorkflowExecutionContext workflowContext,
             ActivityContext activityContext,
             Exception exception);

--- a/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
+++ b/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
@@ -112,12 +112,12 @@ namespace OrchardCore.Tests.Workflows
                 workflowStore.Object,
                 workflowIdGenerator.Object,
                 workflowValueSerializers,
+                workflowFaultHandler.Object,
                 distributedLock.Object,
                 workflowManagerLogger.Object,
                 missingActivityLogger.Object,
                 missingActivityLocalizer.Object,
-                clock.Object,
-                workflowFaultHandler.Object
+                clock.Object
                 );
 
             foreach (var activity in activities)


### PR DESCRIPTION
@hyzx86

Some formatting applied on your merged PR #11539, you can take a look if you want.

- Under Visual Studio basic formatting can be done with `Ctrl+K+D`, usings ordering with `Ctrl+R+G`.

- Localizers propety use uppercase e.g. `S`, `H`, there is also the `New` shape factory, to avoid a rule violation on `private` field name that should start with `_` and be camel case, we now declare these fields as `protected` allowing them to be pascal case.

- Under Visual Studio you can run the `Code Analysis` command for a given project and look at the error list window, and then follow the suggested changes.

- For example we use Framework Types, not saying it is better, but part of our current `.editorconfig`.

- Make static methods that don't use instance data (if not part of a public API).

- And so on.

- Some conventions are not yet part of our rules but are implicit.

    - A new line after the ending brace of any code block.
    - Adding an empty line before a code block is okay, but for example we can declare related variables just before (without empty line), this adds readability.
    - If params are defined in multiple lines, each parameter should use a separate line.
    - Idem for Initializers, and at the end of the line of the last initializer we add a comma.
    - For me no need to separate properties by an empty line if each one is defined in one line. If defined in multiple line, we separate it from the previous and the next with empty lines.
    - Idem for Methods defined in multiple lines, code statements and so on.
    - A new line at the end of any file.
    - And so on ;)

