### PR TITLE
Fix "Full-Text Search for Admin UI" docs formatting (Lombiq Technologies: OCORE-125)

### DIFF
--- a/src/docs/releases/1.7.0.md
+++ b/src/docs/releases/1.7.0.md
@@ -98,37 +98,35 @@ For instance, consider a content type called `Product.` Currently, when a user p
 
 With the newly added options, we can now allow searching for products based on either the display text or the serial number. To modify the default behavior, two steps need to be taken:
 
- 1. Implement `IContentsAdminListFilterProvider` interface by defining a custom lookup logic. For example
-
- ```C#
-public class ProductContentsAdminListFilterProvider : IContentsAdminListFilterProvider
-{
-    public void Build(QueryEngineBuilder<ContentItem> builder)
+ 1. Implement `IContentsAdminListFilterProvider` interface by defining a custom lookup logic. For example:
+    ```csharp
+    public class ProductContentsAdminListFilterProvider : IContentsAdminListFilterProvider
     {
-        builder
-            .WithNamedTerm("producttext", builder => builder
-                .ManyCondition(
-                    (val, query) => query.Any(
-                        (q) => q.With<ContentItemIndex>(i => i.DisplayText != null && i.DisplayText.Contains(val)),
-                        (q) => q.With<ProductIndex>(i => i.SerialNumber != null && i.SerialNumber.Contains(val))
-                    ),
-                    (val, query) => query.All(
-                        (q) => q.With<ContentItemIndex>(i => i.DisplayText == null || i.DisplayText.NotContains(val)),
-                        (q) => q.With<ProductIndex>(i => i.SerialNumber == null || i.SerialNumber.NotContains(val))
+        public void Build(QueryEngineBuilder<ContentItem> builder)
+        {
+            builder
+                .WithNamedTerm("producttext", builder => builder
+                    .ManyCondition(
+                        (val, query) => query.Any(
+                            (q) => q.With<ContentItemIndex>(i => i.DisplayText != null && i.DisplayText.Contains(val)),
+                            (q) => q.With<ProductIndex>(i => i.SerialNumber != null && i.SerialNumber.Contains(val))
+                        ),
+                        (val, query) => query.All(
+                            (q) => q.With<ContentItemIndex>(i => i.DisplayText == null || i.DisplayText.NotContains(val)),
+                            (q) => q.With<ProductIndex>(i => i.SerialNumber == null || i.SerialNumber.NotContains(val))
+                        )
                     )
-                )
-            );
+                );
+        }
     }
-}
-```
- 2. Register the custom default term name as a search option by adding it to the `ContentsAdminListFilterOptions.` For example
-
- ```C#
-services.Configure<ContentsAdminListFilterOptions>(options =>
-{
-    options.DefaultTermNames.Add("Product", "producttext");
-});
- ```
+    ```
+ 2. Register the custom default term name as a search option by adding it to the `ContentsAdminListFilterOptions.` For example:
+    ```csharp
+    services.Configure<ContentsAdminListFilterOptions>(options =>
+    {
+        options.DefaultTermNames.Add("Product", "producttext");
+    });
+    ```
 
 Now, when a user searches for a product's serial number in the administration UI, we will utilize the `producttext` filter instead of the default `text` filter to perform the search.
 

--- a/src/docs/releases/1.7.0.md
+++ b/src/docs/releases/1.7.0.md
@@ -90,7 +90,7 @@ The Contents admin UI now provides a way to manage content items of content type
 
 For example, lets say we want list all content items of a content types that use `Test` stereotype. To do that, add an admin menu item that directs the user to `/Admin/Contents/ContentItems?stereotype=Test`. Adding `stereotype=Test` to the URL will render the UI using any content type that has `Test` as it's stereotype.
 
-#### Full-Text Search for Admin UI.
+#### Full-Text Search for Admin UI
 
 Additional options have been introduced to enable control over the behavior of the full-text search in the administration user interface for content items.
 


### PR DESCRIPTION
Fixing the formatting of [this](https://docs.orchardcore.net/en/latest/docs/releases/1.7.0/#full-text-search-for-admin-ui):

![image](https://github.com/OrchardCMS/OrchardCore/assets/1976647/944a1e67-ef93-46bf-b435-303725c6fdb7)

To this:

![image](https://github.com/OrchardCMS/OrchardCore/assets/1976647/eb97c4e0-2879-43f5-a92a-309ed98ea6aa)
