### PR TITLE
Make General settings page extensible

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Navigation;
+using OrchardCore.Settings.Drivers;
 
 namespace OrchardCore.Settings
 {
@@ -28,7 +29,7 @@ namespace OrchardCore.Settings
                     .Add(S["Settings"], "1", settings => settings
                     .Add(S["General"], "1", entry => entry
                     .AddClass("general").Id("general")
-                        .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = "general" })
+                        .Action("Index", "Admin", new { area = "OrchardCore.Settings", groupId = DefaultSiteSettingsDisplayDriver.GroupId })
                         .Permission(Permissions.ManageGroupSettings)
                         .LocalNav()
                     ),

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
@@ -33,15 +33,12 @@ namespace OrchardCore.Settings.Drivers
             context.Shape.Metadata.Wrappers.Add("GeneralSettingsWrapper");
 
             var result = Combine(
-
                 Initialize<SiteSettingsViewModel>("Settings_Edit", model => PopulateProperties(site, model))
                     .Location("Content:1#Site;10")
                     .OnGroup(GroupId),
-
                 Initialize<SiteSettingsViewModel>("SettingsResources_Edit", model => PopulateProperties(site, model))
                     .Location("Content:1#Resources;20")
                     .OnGroup(GroupId),
-
                 Initialize<SiteSettingsViewModel>("SettingsCache_Edit", model => PopulateProperties(site, model))
                     .Location("Content:1#Cache;30")
                     .OnGroup(GroupId)

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/GeneralSettingsWrapper.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/GeneralSettingsWrapper.cshtml
@@ -1,4 +1,4 @@
-@using Microsoft.AspNetCore.Html;
+@using Microsoft.AspNetCore.Html
 
 <p class="alert alert-warning">
     @T["The current tenant will be reloaded when the settings are saved."]

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/GeneralSettingsWrapper.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/GeneralSettingsWrapper.cshtml
@@ -1,0 +1,7 @@
+@using Microsoft.AspNetCore.Html;
+
+<p class="alert alert-warning">
+    @T["The current tenant will be reloaded when the settings are saved."]
+</p>
+
+@await DisplayAsync((IHtmlContent)Model.Metadata.ChildContent)

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
@@ -1,6 +1,7 @@
+@using System.Globalization
+
 @model SiteSettingsViewModel
 @inject OrchardCore.Modules.IClock Clock
-@using System.Globalization
 
 <div class="mb-3" asp-validation-class-for="SiteName">
     <label asp-for="SiteName">@T["Site name"]</label>

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/Settings.Edit.cshtml
@@ -2,117 +2,49 @@
 @inject OrchardCore.Modules.IClock Clock
 @using System.Globalization
 
-<p class="alert alert-warning">@T["The current tenant will be reloaded when the settings are saved."]</p>
-<ul class="nav nav-tabs">
-    <li class="nav-item pe-md-2">
-        <a class="nav-link active" id="site-tab" data-bs-toggle="tab" href="#site" role="tab" aria-controls="site" aria-selected="true">@T["Site"]</a>
-    </li>
-    <li class="nav-item pe-md-2">
-        <a class="nav-link" id="resources-tab" data-bs-toggle="tab" href="#resources" role="tab" aria-controls="resources">@T["Resources"]</a>
-    </li>    
-    <li class="nav-item">
-        <a class="nav-link" id="cache-tab" data-bs-toggle="tab" href="#cache" role="tab" aria-controls="cache">@T["Cache"]</a>
-    </li>
-</ul>
-<div class="tab-content" id="tabs">
-    <div class="tab-pane fade show active" id="site" role="tabpanel" aria-labelledby="site-tab">
-        <div class="mb-3" asp-validation-class-for="SiteName">
-            <label asp-for="SiteName">@T["Site name"]</label>
-            <input asp-for="SiteName" class="form-control" />
-            <span asp-validation-for="SiteName"></span>
-            <span class="hint">@T["The site name."]</span>
-        </div>
+<div class="mb-3" asp-validation-class-for="SiteName">
+    <label asp-for="SiteName">@T["Site name"]</label>
+    <input asp-for="SiteName" class="form-control" />
+    <span asp-validation-for="SiteName"></span>
+    <span class="hint">@T["The site name."]</span>
+</div>
 
-        <div class="mb-3" asp-validation-class-for="PageTitleFormat">
-            <label asp-for="PageTitleFormat">@T["Page title format"]</label>
-            <input asp-for="PageTitleFormat" class="form-control" />
-            <span asp-validation-for="PageTitleFormat"></span>
-            <span class="hint">@T["The default format of page titles."]</span>
-        </div>
+<div class="mb-3" asp-validation-class-for="PageTitleFormat">
+    <label asp-for="PageTitleFormat">@T["Page title format"]</label>
+    <input asp-for="PageTitleFormat" class="form-control" />
+    <span asp-validation-for="PageTitleFormat"></span>
+    <span class="hint">@T["The default format of page titles."]</span>
+</div>
 
-        <div class="mb-3" asp-validation-class-for="BaseUrl">
-            <label asp-for="BaseUrl">@T["Base url"]</label>
-            <input asp-for="BaseUrl" class="form-control" />
-            <span asp-validation-for="BaseUrl"></span>
-            <span class="hint">@T["Enter the fully qualified base URL of the web site."]</span>
-        </div>
+<div class="mb-3" asp-validation-class-for="BaseUrl">
+    <label asp-for="BaseUrl">@T["Base url"]</label>
+    <input asp-for="BaseUrl" class="form-control" />
+    <span asp-validation-for="BaseUrl"></span>
+    <span class="hint">@T["Enter the fully qualified base URL of the web site."]</span>
+</div>
 
-        <div class="row">
-            <div class="mb-3 col-xl-8" asp-validation-class-for="TimeZone">
-                <label asp-for="TimeZone">@T["Default Time Zone"]</label>
-                <select asp-for="TimeZone" class="form-select">
-                    <option value="">@T["Local to server"]</option>
-                    @foreach (var timezone in Clock.GetTimeZones().OrderBy(t => t.ToString()))
-                    {
-                        <option value="@timezone.TimeZoneId" selected="@(Model.TimeZone == timezone.TimeZoneId)">
-                            @timezone
-                        </option>
-                    }
-                </select>
-                <span asp-validation-for="TimeZone"></span>
-                <span class="hint">@T["Determines the default time zone used when displaying and editing dates and times. DST (daylight saving time) will be applied automatically per time zone if available."]</span>
-            </div>
-        </div>
-
-        <div class="mb-3">
-            <div class="col-xl-4" asp-validation-class-for="PageSize">
-                <label asp-for="PageSize">@T["Page size"]</label>
-                <input asp-for="PageSize" type="number" class="form-control" />
-                <span asp-validation-for="PageSize"></span>
-                <span class="hint">@T["The default page size."]</span>
-            </div>
-        </div>
+<div class="row">
+    <div class="mb-3 col-xl-8" asp-validation-class-for="TimeZone">
+        <label asp-for="TimeZone">@T["Default Time Zone"]</label>
+        <select asp-for="TimeZone" class="form-select">
+            <option value="">@T["Local to server"]</option>
+            @foreach (var timezone in Clock.GetTimeZones().OrderBy(t => t.ToString()))
+            {
+                <option value="@timezone.TimeZoneId" selected="@(Model.TimeZone == timezone.TimeZoneId)">
+                    @timezone
+                </option>
+            }
+        </select>
+        <span asp-validation-for="TimeZone"></span>
+        <span class="hint">@T["Determines the default time zone used when displaying and editing dates and times. DST (daylight saving time) will be applied automatically per time zone if available."]</span>
     </div>
-    <div class="tab-pane fade" id="resources" role="tabpanel" aria-labelledby="resources-tab">
-        <h5>@T["Settings for scripts and stylesheets"]</h5>
-        <div class="mb-3" asp-validation-class-for="AppendVersion">
-            <div class="form-check">
-                <input type="checkbox" class="form-check-input" asp-for="@Model.AppendVersion" />
-                <label class="form-check-label" asp-for="@Model.AppendVersion">@T["Use resources cache busting"]</label>
-                <span class="hint dashed">@T["Whether cache busting (append a version) is used for scripts and stylesheets"]</span>
-            </div>
-        </div>
+</div>
 
-        <div class="mb-3" asp-validation-class-for="UseCdn">
-            <div class="form-check">
-                <input type="checkbox" class="form-check-input" asp-for="@Model.UseCdn" />
-                <label class="form-check-label" asp-for="@Model.UseCdn">@T["Use framework CDN (Content Delivery Network)"]</label>
-                <span class="hint dashed">@T["Whether a framework CDN is used for registered scripts and stylesheets, such as jQuery, or their local version"]</span>
-            </div>
-        </div>
-
-        <div class="mb-3" asp-validation-class-for="CdnBaseUrl">
-            <label asp-for="CdnBaseUrl">@T["Site CDN (Content Delivery Network) base url"]</label>
-            <input asp-for="CdnBaseUrl" class="form-control" />
-            <span asp-validation-for="CdnBaseUrl"></span>
-            <span class="hint">@T["A base CDN URL prefixed to the local scripts and stylesheets. It is disabled if the value is empty or if the Resource Debug Mode is enabled, e.g. <em>https://cdn.mysite.com</em>"]</span>
-        </div>
-
-        <div class="mb-3">
-            <div class="col-xl-6" asp-validation-class-for="ResourceDebugMode">
-                <label asp-for="ResourceDebugMode">@T["Resource Debug Mode"]</label>
-                <select asp-for="ResourceDebugMode" class="form-select">
-                    <option value="@ResourceDebugMode.FromConfiguration.ToString()">@T["From environment — disabled in <em>Production</em>, enabled otherwise"]</option>
-                    <option value="@ResourceDebugMode.Enabled.ToString()">@T["Enabled — use debuggable version of resources"]</option>
-                    <option value="@ResourceDebugMode.Disabled.ToString()">@T["Disabled — use minified version of resources"]</option>
-                </select>
-                <span class="hint">@T["Determines whether scripts and stylesheets load in their debuggable or minified form."]</span>
-            </div>
-        </div>
+<div class="mb-3">
+    <div class="col-xl-4" asp-validation-class-for="PageSize">
+        <label asp-for="PageSize">@T["Page size"]</label>
+        <input asp-for="PageSize" type="number" class="form-control" />
+        <span asp-validation-for="PageSize"></span>
+        <span class="hint">@T["The default page size."]</span>
     </div>
-    <div class="tab-pane fade" id="cache" role="tabpanel" aria-labelledby="cache-tab">
-        <h5>@T["Settings for dynamic caches"]</h5>
-        <div class="mb-3">
-            <div class="col-xl-6" asp-validation-class-for="CacheMode">
-                <label asp-for="CacheMode">@T["Cache Mode"]</label>
-                <select asp-for="CacheMode" class="form-select">
-                    <option value="@CacheMode.FromConfiguration.ToString()">@T["From environment — enabled in <em>Production</em>, disabled otherwise"]</option>
-                    <option value="@CacheMode.Enabled.ToString()">@T["Enabled"]</option>
-                    <option value="@CacheMode.DebugEnabled.ToString()">@T["Enabled with cache debug mode"]</option>
-                    <option value="@CacheMode.Disabled.ToString()">@T["Disabled"]</option>
-                </select>
-                <span class="hint">@T["Determines whether caches are enabled or disabled."]</span>
-            </div>
-        </div>
-    </div>    
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/SettingsCache.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/SettingsCache.Edit.cshtml
@@ -1,0 +1,16 @@
+@model SiteSettingsViewModel
+
+<h5>@T["Settings for dynamic caches"]</h5>
+
+<div class="mb-3">
+    <div class="col-xl-6" asp-validation-class-for="CacheMode">
+        <label asp-for="CacheMode">@T["Cache Mode"]</label>
+        <select asp-for="CacheMode" class="form-select">
+            <option value="@CacheMode.FromConfiguration.ToString()">@T["From environment — enabled in <em>Production</em>, disabled otherwise"]</option>
+            <option value="@CacheMode.Enabled.ToString()">@T["Enabled"]</option>
+            <option value="@CacheMode.DebugEnabled.ToString()">@T["Enabled with cache debug mode"]</option>
+            <option value="@CacheMode.Disabled.ToString()">@T["Disabled"]</option>
+        </select>
+        <span class="hint">@T["Determines whether caches are enabled or disabled."]</span>
+    </div>
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/SettingsResources.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/SettingsResources.Edit.cshtml
@@ -1,0 +1,38 @@
+@model SiteSettingsViewModel
+
+<h5>@T["Settings for scripts and stylesheets"]</h5>
+
+<div class="mb-3" asp-validation-class-for="AppendVersion">
+    <div class="form-check">
+        <input type="checkbox" class="form-check-input" asp-for="@Model.AppendVersion" />
+        <label class="form-check-label" asp-for="@Model.AppendVersion">@T["Use resources cache busting"]</label>
+        <span class="hint dashed">@T["Whether cache busting (append a version) is used for scripts and stylesheets"]</span>
+    </div>
+</div>
+
+<div class="mb-3" asp-validation-class-for="UseCdn">
+    <div class="form-check">
+        <input type="checkbox" class="form-check-input" asp-for="@Model.UseCdn" />
+        <label class="form-check-label" asp-for="@Model.UseCdn">@T["Use framework CDN (Content Delivery Network)"]</label>
+        <span class="hint dashed">@T["Whether a framework CDN is used for registered scripts and stylesheets, such as jQuery, or their local version"]</span>
+    </div>
+</div>
+
+<div class="mb-3" asp-validation-class-for="CdnBaseUrl">
+    <label asp-for="CdnBaseUrl">@T["Site CDN (Content Delivery Network) base url"]</label>
+    <input asp-for="CdnBaseUrl" class="form-control" />
+    <span asp-validation-for="CdnBaseUrl"></span>
+    <span class="hint">@T["A base CDN URL prefixed to the local scripts and stylesheets. It is disabled if the value is empty or if the Resource Debug Mode is enabled, e.g. <em>https://cdn.mysite.com</em>"]</span>
+</div>
+
+<div class="mb-3">
+    <div class="col-xl-6" asp-validation-class-for="ResourceDebugMode">
+        <label asp-for="ResourceDebugMode">@T["Resource Debug Mode"]</label>
+        <select asp-for="ResourceDebugMode" class="form-select">
+            <option value="@ResourceDebugMode.FromConfiguration.ToString()">@T["From environment — disabled in <em>Production</em>, enabled otherwise"]</option>
+            <option value="@ResourceDebugMode.Enabled.ToString()">@T["Enabled — use debuggable version of resources"]</option>
+            <option value="@ResourceDebugMode.Disabled.ToString()">@T["Disabled — use minified version of resources"]</option>
+        </select>
+        <span class="hint">@T["Determines whether scripts and stylesheets load in their debuggable or minified form."]</span>
+    </div>
+</div>

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -1,21 +1,3 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Primitives;
-using OrchardCore.BackgroundTasks;
-using OrchardCore.Environment.Shell;
-using OrchardCore.Environment.Shell.Builders;
-using OrchardCore.Locking.Distributed;
-using OrchardCore.Settings;
 
 namespace OrchardCore.Modules
 {

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -1,3 +1,21 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using OrchardCore.BackgroundTasks;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Builders;
+using OrchardCore.Locking.Distributed;
+using OrchardCore.Settings;
 
 namespace OrchardCore.Modules
 {


### PR DESCRIPTION
Currently, the General settings page does not allow us to add more settings to it. With this simple change, anyone that wants to add settings to the general settings is able to using drivers. The UI itself did not change.

To extend these views, create a new display driver using "general" as the group id. Then place your custom settings into one of the 3 existing tabs or a new custom tab. Here is an example to inject a custom settings from `MyCustomSettings` class into a new tab on the general settings called "New Tab"
```
public class MyCustomSettingsDisplayDriver : SectionDisplayDriver<ISite, MyCustomSettings>
  {
      public override IDisplayResult Async(MyCustomSettings settings)
      {
          Initialize<SiteSettingsViewModel>("MyCustomSettings_Edit", model => {
              //...
          }).Location("Content:1#New Tab;40")
          .OnGroup(DefaultSiteSettingsDisplayDriver.GroupId); // Or "general" if you prefer a string
      }
  }
```

![image](https://github.com/OrchardCMS/OrchardCore/assets/24724371/58e7279b-fe60-4b5c-a397-fa6bb3e04364)
