### PR TITLE
CultureScopeTests tweaks

### DIFF
--- a/test/OrchardCore.Tests/Localization/CultureScopeTests.cs
+++ b/test/OrchardCore.Tests/Localization/CultureScopeTests.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Tests.Localization
     public class CultureScopeTests
     {
         [Fact]
-        public void CultureScopeSetUICultureAutomaticallyIfNotSet()
+        public void CultureScopeSetsUICultureIfNotProvided()
         {
             // Arrange
             var culture = "ar-YE";
@@ -14,12 +14,12 @@ namespace OrchardCore.Tests.Localization
             using var cultureScope = CultureScope.Create(culture);
 
             // Assert
-            Assert.Equal(culture, cultureScope.Culture.Name);
-            Assert.Equal(culture, cultureScope.UICulture.Name);
+            Assert.Equal(culture, CultureInfo.CurrentCulture.Name);
+            Assert.Equal(culture, CultureInfo.CurrentUICulture.Name);
         }
 
         [Fact]
-        public void CultureScopeRetrievesBothCultureAndUICulture()
+        public void CultureScopeSetsBothCultureAndUICulture()
         {
             // Arrange
             var culture = "ar";
@@ -29,12 +29,12 @@ namespace OrchardCore.Tests.Localization
             using var cultureScope = CultureScope.Create(culture, uiCulture);
 
             // Assert
-            Assert.Equal(culture, cultureScope.Culture.Name);
-            Assert.Equal(uiCulture, cultureScope.UICulture.Name);
+            Assert.Equal(culture, CultureInfo.CurrentCulture.Name);
+            Assert.Equal(uiCulture, CultureInfo.CurrentUICulture.Name);
         }
 
         [Fact]
-        public void CultureScopeRetrievesTheOrginalCulturesAfterScopeEnded()
+        public void CultureScopeSetsOrginalCulturesAfterEndOfScope()
         {
             // Arrange
             var culture = CultureInfo.CurrentCulture;
@@ -52,7 +52,7 @@ namespace OrchardCore.Tests.Localization
         }
 
         [Fact]
-        public async Task CultureScopeRetrievesTheOrginalCulturesIfExceptionOccurs()
+        public async Task CultureScopeSetsOrginalCulturesOnException()
         {
             // Arrange
             var culture = CultureInfo.CurrentCulture;


### PR DESCRIPTION
Fixes #14115 

`CultureScopeTests` check that the cultures are well passed but never check that the `CultureScope` sets the thread cultures accordingly, which is what it is intended to do and to be tested.

As a POC just use the following testing class that does nothing at all.

    public sealed class CultureScopeTest : IDisposable
    {
        private CultureScopeTest(string culture, string uiCulture)
        {
            Culture = new CultureInfo(culture);
            UICulture = new CultureInfo(uiCulture);
        }

        public CultureInfo Culture { get; }

        public CultureInfo UICulture { get; }

        public static CultureScopeTest Create(string culture, string uiCulture = null)
            => new(culture, uiCulture ?? culture);

        public void Dispose() { }
    }

Then uses the above class that does nothing in the unit tests, you will see that they all pass ;)
