### PR TITLE
Add an option to allow the user to change the full-text search behavior in the Users admin UI.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListFilterProvider.cs
@@ -104,7 +104,7 @@ namespace OrchardCore.Users.Services
                     .MapTo<UserIndexOptions>((val, model) => model.SelectedRole = val)
                     .MapFrom<UserIndexOptions>((model) => (!String.IsNullOrEmpty(model.SelectedRole), model.SelectedRole))
                 )
-                .WithDefaultTerm("name", builder => builder
+                .WithDefaultTerm(UsersAdminListFilterOptions.DefaultTermName, builder => builder
                     .ManyCondition(
                         (val, query, ctx) =>
                         {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListQueryService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/DefaultUsersAdminListQueryService.cs
@@ -1,44 +1,81 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.Modules;
 using OrchardCore.Users.Models;
 using OrchardCore.Users.ViewModels;
 using YesSql;
+using YesSql.Filters.Abstractions.Nodes;
 
-namespace OrchardCore.Users.Services
+namespace OrchardCore.Users.Services;
+
+public class DefaultUsersAdminListQueryService : IUsersAdminListQueryService
 {
-    public class DefaultUsersAdminListQueryService : IUsersAdminListQueryService
+    private readonly static string[] _operators = new[] { "OR", "AND", "||", "&&" };
+
+    private readonly ISession _session;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger _logger;
+    private readonly UsersAdminListFilterOptions _userAdminListFilterOptions;
+    private readonly IEnumerable<IUsersAdminListFilter> _usersAdminListFilters;
+
+    public DefaultUsersAdminListQueryService(
+        ISession session,
+        IServiceProvider serviceProvider,
+        ILogger<DefaultUsersAdminListQueryService> logger,
+        IOptions<UsersAdminListFilterOptions> userAdminListFilterOptions,
+        IEnumerable<IUsersAdminListFilter> usersAdminListFilters)
     {
-        private readonly ISession _session;
-        private readonly IServiceProvider _serviceProvider;
-        private readonly ILogger _logger;
-        private readonly IEnumerable<IUsersAdminListFilter> _usersAdminListFilters;
+        _session = session;
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+        _userAdminListFilterOptions = userAdminListFilterOptions.Value;
+        _usersAdminListFilters = usersAdminListFilters;
+    }
 
-        public DefaultUsersAdminListQueryService(
-            ISession session,
-            IServiceProvider serviceProvider,
-            ILogger<DefaultUsersAdminListQueryService> logger,
-            IEnumerable<IUsersAdminListFilter> usersAdminListFilters)
+    public async Task<IQuery<User>> QueryAsync(UserIndexOptions options, IUpdateModel updater)
+    {
+        var defaultTermNode = options.FilterResult.OfType<DefaultTermNode>().FirstOrDefault();
+        var defaultOperator = defaultTermNode?.Operation;
+        var defaultTermName = String.IsNullOrEmpty(_userAdminListFilterOptions.TermName)
+            ? UsersAdminListFilterOptions.DefaultTermName
+            : _userAdminListFilterOptions.TermName;
+
+        if (defaultTermNode is not null)
         {
-            _session = session;
-            _serviceProvider = serviceProvider;
-            _logger = logger;
-            _usersAdminListFilters = usersAdminListFilters;
+            var value = defaultTermNode.ToString();
+            if (_userAdminListFilterOptions.UseExactMatch
+                && !_operators.Any(op => value.Contains(op, StringComparison.Ordinal)))
+            {
+                // Use an unary operator based on a full quoted string.
+                defaultOperator = new UnaryNode(value.Trim('"'), OperateNodeQuotes.Double);
+            }
+
+            if (defaultTermName != defaultTermNode.TermName || defaultOperator != defaultTermNode.Operation)
+            {
+                options.FilterResult.TryRemove(defaultTermNode.TermName);
+                options.FilterResult.TryAddOrReplace(new DefaultTermNode(defaultTermName, defaultOperator));
+            }
         }
 
-        public async Task<IQuery<User>> QueryAsync(UserIndexOptions options, IUpdateModel updater)
+        // Because admin filters can add a different index to the query this must be added as a Query<User>().
+        var query = _session.Query<User>();
+
+        query = await options.FilterResult.ExecuteAsync(new UserQueryContext(_serviceProvider, query));
+
+        await _usersAdminListFilters.InvokeAsync((filter, model, query, updater) => filter.FilterAsync(model, query, updater), options, query, updater, _logger);
+
+        if (defaultOperator != defaultTermNode?.Operation)
         {
-            // Because admin filters can add a different index to the query this must be added as a Query<User>()
-            var query = _session.Query<User>();
-
-            query = await options.FilterResult.ExecuteAsync(new UserQueryContext(_serviceProvider, query));
-
-            await _usersAdminListFilters.InvokeAsync((filter, model, query, updater) => filter.FilterAsync(model, query, updater), options, query, updater, _logger);
-
-            return query;
+            // Restore the original 'defaultTermNode'.
+            options.FilterResult.TryRemove(defaultTermName);
+            options.FilterResult.TryAddOrReplace(defaultTermNode);
         }
+
+        return query;
     }
 }

--- a/src/OrchardCore/OrchardCore.Users.Core/Models/UsersAdminListFilterOptions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Models/UsersAdminListFilterOptions.cs
@@ -1,0 +1,20 @@
+namespace OrchardCore.Users.Models;
+
+public class UsersAdminListFilterOptions
+{
+    /// <summary>
+    /// The default term name to use if not defined in <see cref="TermName"/>.
+    /// </summary>
+    public const string DefaultTermName = "name";
+
+    /// <summary>
+    /// The term name to use when performing text search.
+    /// </summary>
+    public string TermName { get; set; } = DefaultTermName;
+
+    /// <summary>
+    /// Whether or not the entire text should be parsed as a single term, enabling an exact match search.
+    /// This means that search engines will treat the text as a whole rather than individual words.
+    /// </summary>
+    public bool UseExactMatch { get; set; }
+}

--- a/src/docs/releases/1.7.0.md
+++ b/src/docs/releases/1.7.0.md
@@ -75,6 +75,72 @@ Added support for complete two-factor authentication out of the box. [Click here
 
 A phone number is now supported in the `UserStore` and the `User` object.
 
+#### Full-Text Search for Admin UI
+
+Additional options have been introduced to enable control over the behavior of the full-text search in the administration user interface for users.
+
+For instance, when a user performs a search, the default behavior is to check if the search terms are present in the `NormalizedUserName` column of the `UserIndex` table. However, what if a user wants to search for a user using other logic like First or Last name, which is not part of the `UserName` field?
+
+With the newly added options, we can now allow searching for user based on either the username or any custom logic. To modify the default behavior, two steps need to be taken:
+
+ 1. Implement `IUsersAdminListFilterProvider` interface by defining a custom lookup logic. For example:
+    ```csharp
+    public class FullnameUsersAdminListFilterProvider : IUsersAdminListFilterProvider
+    {
+        public void Build(QueryEngineBuilder<User> builder)
+        {
+            builder
+                .WithNamedTerm("fullname", builder => builder
+                    .ManyCondition(
+                        (val, query, ctx) =>
+                        {
+                            var context = (UserQueryContext)ctx;
+                            var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
+                            var normalizedUserName = userManager.NormalizeName(val);
+
+                            // The index name 'UserFullnameIndex' does not exists. 
+                            // It is a custom index that you would create or use other custom index or logic.
+                            var filteredQuery = query.Any(
+                                (q) => q.With<UserIndex>(i => i.NormalizedUserName != null && i.NormalizedUserName.Contains(normalizedUserName)),
+                                (q) => q.With<UserFullnameIndex>(i =>
+                                   (i.FirstName != null && i.FirstName.Contains(val)) ||
+                                   (i.LastName != null && i.LastName.Contains(val)) ||
+                                   (i.MiddleName != null && i.MiddleName.Contains(val))
+                                )
+                            );
+
+                            return new ValueTask<IQuery<User>>(filteredQuery);
+                        },
+                        (val, query, ctx) =>
+                        {
+                            var context = (UserQueryContext)ctx;
+                            var userManager = context.ServiceProvider.GetRequiredService<UserManager<IUser>>();
+                            var normalizedUserName = userManager.NormalizeName(val);
+
+                            var filteredQuery = query.All(
+                                (q) => q.With<UserIndex>(i => i.NormalizedUserName == null || i.NormalizedUserName.NotContains(normalizedUserName)),
+                                (q) => q.With<UserFullnameIndex>(i =>
+                                   (i.FirstName == null || i.FirstName.NotContains(val)) &&
+                                   (i.LastName == null || i.LastName.NotContains(val)) &&
+                                   (i.MiddleName == null || i.MiddleName.NotContains(val))
+                                )
+                            );
+
+                            return new ValueTask<IQuery<User>>(filteredQuery);
+                        }
+                    )
+                );
+        }
+    }
+    ```
+ 2. Register the custom default term name as a search option by adding it to the `UsersAdminListFilterOptions.` For example:
+    ```csharp
+    services.Configure<UsersAdminListFilterOptions>(options =>
+    {
+        options.TermName = "fullname";
+    });
+    ```
+
 ### `OrchardCore.Seo` Module
 
 The `Seo` feature now provides `robots.txt` out of the box when the filesystem does not contain one. New settings are available at **Configuration** >> **Settings** >> **SEO** to allow you to configure what should be included into the `robots.txt` file.


### PR DESCRIPTION
@jtkech We did the same thing in PR #13919 where we added an option to change the text-search behavior for Contents UI.

Here we allow the user to change the default text-search for the Users UI.