### PR TITLE
Use display_text helper to generate TitlePattern

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettings.cs
@@ -6,16 +6,21 @@ namespace OrchardCore.ContentFields.Settings
     public class ContentPickerFieldSettings
     {
         public string Hint { get; set; }
+
         public bool Required { get; set; }
+
         public bool Multiple { get; set; }
+
         public bool DisplayAllContentTypes { get; set; }
+
         public string[] DisplayedContentTypes { get; set; } = Array.Empty<string>();
+
         public string[] DisplayedStereotypes { get; set; } = Array.Empty<string>();
 
         /// <summary>
-        /// The pattern used to build custom title
+        /// The pattern used to build title.
         /// </summary>
-        [DefaultValue("{{ Model.ContentItem.DisplayText }}")]
-        public string TitlePattern { get; set; } = "{{ Model.ContentItem.DisplayText }}";
+        [DefaultValue("{{ Model.ContentItem | display_text }}")]
+        public string TitlePattern { get; set; } = "{{ Model.ContentItem | display_text }}";
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/ContentPickerFieldSettings.cs
@@ -18,7 +18,7 @@ namespace OrchardCore.ContentFields.Settings
         public string[] DisplayedStereotypes { get; set; } = Array.Empty<string>();
 
         /// <summary>
-        /// The pattern used to build title.
+        /// The Liquid pattern used to build the title.
         /// </summary>
         [DefaultValue("{{ Model.ContentItem | display_text }}")]
         public string TitlePattern { get; set; } = "{{ Model.ContentItem | display_text }}";


### PR DESCRIPTION
Instead of using `DisplayText` directly, use the `display_text` helper instead. It does the same thing, but with this change if we change the `display_text` logic, it'll reflect here too.