### PR TITLE
Clear HttpContext in background, also allows bg job from bg task.

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
@@ -25,9 +25,9 @@ public static class HttpBackgroundJob
             return Task.CompletedTask;
         }
 
-        // Can't be executed outside the context of a real http request scope.
+        // Can't be executed outside of an http context.
         var httpContextAccessor = scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
-        if (httpContextAccessor.HttpContext == null || httpContextAccessor.HttpContext.Items.TryGetValue("IsBackground", out _))
+        if (httpContextAccessor.HttpContext == null)
         {
             return Task.CompletedTask;
         }
@@ -57,7 +57,7 @@ public static class HttpBackgroundJob
                 return;
             }
 
-            // Initialize a new 'HttpContext' to be used in the background.
+            // Create a new 'HttpContext' to be used in the background.
             httpContextAccessor.HttpContext = shellContext.CreateHttpContext();
 
             // Here the 'IActionContextAccessor.ActionContext' need to be cleared, this 'AsyncLocal'
@@ -87,6 +87,9 @@ public static class HttpBackgroundJob
                         scope.ShellContext.Settings.Name);
                 }
             });
+
+            // Clear the 'HttpContext' for this async flow.
+            httpContextAccessor.HttpContext = null;
         });
 
         return Task.CompletedTask;

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -107,6 +107,7 @@ namespace OrchardCore.Modules
             {
                 var tenant = shell.Settings.Name;
 
+                // Create a new 'HttpContext' to be used in the background.
                 _httpContextAccessor.HttpContext = shell.CreateHttpContext();
 
                 var schedulers = GetSchedulersToRun(tenant);
@@ -183,6 +184,9 @@ namespace OrchardCore.Modules
                         await handlers.InvokeAsync((handler, context, token) => handler.ExecutedAsync(context, token), context, stoppingToken, _logger);
                     });
                 }
+
+                // Clear the 'HttpContext' for this async flow.
+                _httpContextAccessor.HttpContext = null;
             });
         }
 
@@ -199,6 +203,7 @@ namespace OrchardCore.Modules
                     return;
                 }
 
+                // Create a new 'HttpContext' to be used in the background.
                 _httpContextAccessor.HttpContext = shell.CreateHttpContext();
 
                 var shellScope = await _shellHost.GetScopeAsync(shell.Settings);
@@ -274,6 +279,9 @@ namespace OrchardCore.Modules
                         scheduler.Updated = true;
                     }
                 });
+
+                // Clear the 'HttpContext' for this async flow.
+                _httpContextAccessor.HttpContext = null;
             });
         }
 


### PR DESCRIPTION
While working on #14105 I saw other tweaks to do that are not directly related.

So here

- Anytime we create an HttpContext in the background we clear it at the end of the related async flow.

- Which is better, and it also allows to trigger a background job from a background task.
