### PR TITLE
Validate Media path if configured in the background

### DIFF
--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
@@ -190,18 +190,14 @@ namespace OrchardCore.Media.Core
                 var httpContext = ShellScope.Services?.GetRequiredService<IHttpContextAccessor>().HttpContext;
                 if (httpContext is not null && !httpContext.Items.ContainsKey("IsBackground"))
                 {
-                    var originalPathBase = httpContext
-                        ?.Features.Get<ShellContextFeature>()
-                        ?.OriginalPathBase
-                        ?? PathString.Empty;
-
-                    var requestBasePath = _requestBasePath;
-                    if (originalPathBase.HasValue &&
-                        !requestBasePath.StartsWith(originalPathBase.Value, StringComparison.OrdinalIgnoreCase))
+                    var originalPathBase = httpContext.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? PathString.Empty;
+                    if (originalPathBase.HasValue)
                     {
-                        requestBasePath = _fileStore.Combine(originalPathBase.Value, requestBasePath);
-
-                        _requestBasePath = requestBasePath;
+                        var requestBasePath = _requestBasePath;
+                        if (!requestBasePath.StartsWith(originalPathBase.Value, StringComparison.OrdinalIgnoreCase))
+                        {
+                            _requestBasePath = _fileStore.Combine(originalPathBase.Value, requestBasePath);
+                        }
                     }
 
                     _requestBasePathValidated = true;

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -190,21 +191,25 @@ namespace OrchardCore.Media.Core
                 var httpContext = ShellScope.Services?.GetRequiredService<IHttpContextAccessor>().HttpContext;
                 if (httpContext is not null && !httpContext.Items.ContainsKey("IsBackground"))
                 {
-                    var originalPathBase = httpContext.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? PathString.Empty;
-                    if (originalPathBase.HasValue)
-                    {
-                        var requestBasePath = _requestBasePath;
-                        if (!requestBasePath.StartsWith(originalPathBase.Value, StringComparison.OrdinalIgnoreCase))
-                        {
-                            _requestBasePath = _fileStore.Combine(originalPathBase.Value, requestBasePath);
-                        }
-                    }
-
+                    ValidateRequestBasePath(httpContext);
                     _requestBasePathValidated = true;
                 }
             }
 
             return _cdnBaseUrl + _requestBasePath + "/" + _fileStore.NormalizePath(path);
+        }
+
+        private void ValidateRequestBasePath(HttpContext httpContext)
+        {
+            var originalPathBase = httpContext.Features.Get<ShellContextFeature>()?.OriginalPathBase ?? PathString.Empty;
+            if (originalPathBase.HasValue)
+            {
+                var requestBasePath = _requestBasePath;
+                if (!requestBasePath.StartsWith(originalPathBase.Value, StringComparison.OrdinalIgnoreCase))
+                {
+                    _requestBasePath = _fileStore.Combine(originalPathBase.Value, requestBasePath);
+                }
+            }
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStore.cs
@@ -1,8 +1,13 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Scope;
 using OrchardCore.FileStorage;
 using OrchardCore.Media.Events;
 using OrchardCore.Modules;
@@ -12,11 +17,13 @@ namespace OrchardCore.Media.Core
     public class DefaultMediaFileStore : IMediaFileStore
     {
         private readonly IFileStore _fileStore;
-        private readonly string _requestBasePath;
+        private string _requestBasePath;
         private readonly string _cdnBaseUrl;
         private readonly IEnumerable<IMediaEventHandler> _mediaEventHandlers;
         private readonly IEnumerable<IMediaCreatingEventHandler> _mediaCreatingEventHandlers;
         private readonly ILogger _logger;
+
+        private bool _requestBasePathValidated;
 
         public DefaultMediaFileStore(
             IFileStore fileStore,
@@ -178,6 +185,29 @@ namespace OrchardCore.Media.Core
 
         public virtual string MapPathToPublicUrl(string path)
         {
+            if (!_requestBasePathValidated)
+            {
+                var httpContext = ShellScope.Services?.GetRequiredService<IHttpContextAccessor>().HttpContext;
+                if (httpContext is not null && !httpContext.Items.ContainsKey("IsBackground"))
+                {
+                    var originalPathBase = httpContext
+                        ?.Features.Get<ShellContextFeature>()
+                        ?.OriginalPathBase
+                        ?? PathString.Empty;
+
+                    var requestBasePath = _requestBasePath;
+                    if (originalPathBase.HasValue &&
+                        !requestBasePath.StartsWith(originalPathBase.Value, StringComparison.OrdinalIgnoreCase))
+                    {
+                        requestBasePath = _fileStore.Combine(originalPathBase.Value, requestBasePath);
+
+                        _requestBasePath = requestBasePath;
+                    }
+
+                    _requestBasePathValidated = true;
+                }
+            }
+
             return _cdnBaseUrl + _requestBasePath + "/" + _fileStore.NormalizePath(path);
         }
     }


### PR DESCRIPTION
Fixes #14145 

When under a virtual folder and we use the `ShellWarmup` option, if the shell container is built in the background, the media file store is not correctly registered, this because the service resolution uses the `PathBase` that doesn't include the virtual folder that we are not aware of in the background.

So `_requestBasePath` would need to be updated on the first real http request, the problem is that the media store is a singleton, maybe too late to make it a scoped service, but `_requestBasePath` is only used in one method that seems to be only called in a scope context.

So, as we do for our `IDocumentManager` singletons fo which methods are executed in a scope context that we retrieve, here we validate once the `_requestBasePath` on the first real http request.
