### PR TITLE
Make BackgroundTaskSettings ChangeToken dynamic

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Services/BackgroundTaskManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Services/BackgroundTaskManager.cs
@@ -30,6 +30,7 @@ namespace OrchardCore.BackgroundTasks.Services
         {
             var document = await LoadDocumentAsync();
             document.Settings.Remove(name);
+
             await _documentManager.UpdateAsync(document);
             _signal.DeferredSignalToken(nameof(BackgroundTaskSettings));
         }
@@ -38,6 +39,7 @@ namespace OrchardCore.BackgroundTasks.Services
         {
             var document = await LoadDocumentAsync();
             document.Settings[name] = settings;
+
             await _documentManager.UpdateAsync(document);
             _signal.DeferredSignalToken(nameof(BackgroundTaskSettings));
         }

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Services/BackgroundTaskManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Services/BackgroundTaskManager.cs
@@ -1,16 +1,19 @@
 using System.Threading.Tasks;
 using OrchardCore.BackgroundTasks.Models;
 using OrchardCore.Documents;
+using OrchardCore.Environment.Cache;
 
 namespace OrchardCore.BackgroundTasks.Services
 {
     public class BackgroundTaskManager
     {
         private readonly IDocumentManager<BackgroundTaskDocument> _documentManager;
+        private readonly ISignal _signal;
 
-        public BackgroundTaskManager(IDocumentManager<BackgroundTaskDocument> documentManager)
+        public BackgroundTaskManager(IDocumentManager<BackgroundTaskDocument> documentManager, ISignal signal)
         {
             _documentManager = documentManager;
+            _signal = signal;
         }
 
         /// <summary>
@@ -28,6 +31,7 @@ namespace OrchardCore.BackgroundTasks.Services
             var document = await LoadDocumentAsync();
             document.Settings.Remove(name);
             await _documentManager.UpdateAsync(document);
+            _signal.DeferredSignalToken(nameof(BackgroundTaskSettings));
         }
 
         public async Task UpdateAsync(string name, BackgroundTaskSettings settings)
@@ -35,6 +39,7 @@ namespace OrchardCore.BackgroundTasks.Services
             var document = await LoadDocumentAsync();
             document.Settings[name] = settings;
             await _documentManager.UpdateAsync(document);
+            _signal.DeferredSignalToken(nameof(BackgroundTaskSettings));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Services/BackgroundTaskSettingsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Services/BackgroundTaskSettingsProvider.cs
@@ -1,18 +1,21 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Primitives;
+using OrchardCore.Environment.Cache;
 
 namespace OrchardCore.BackgroundTasks.Services
 {
     public class BackgroundTaskSettingsProvider : IBackgroundTaskSettingsProvider
     {
         private readonly BackgroundTaskManager _backgroundTaskManager;
+        private readonly ISignal _signal;
 
-        public BackgroundTaskSettingsProvider(BackgroundTaskManager backgroundTaskManager)
+        public BackgroundTaskSettingsProvider(BackgroundTaskManager backgroundTaskManager, ISignal signal)
         {
             _backgroundTaskManager = backgroundTaskManager;
+            _signal = signal;
         }
 
-        public IChangeToken ChangeToken => AlwaysHasChangedToken.Singleton;
+        public IChangeToken ChangeToken => _signal.GetToken(nameof(BackgroundTaskSettings));
 
         public async Task<BackgroundTaskSettings> GetSettingsAsync(IBackgroundTask task)
         {


### PR DESCRIPTION
Fixes #14158 

When using `BackgroundTaskSettings` from the admin UI we use a `ChangeToken` so that the background service update the scedulers of the related tenant when the token has changed.

Currently we use an `AlwaysHasChangedToken`, so the schedulers are always refreshed, we missed to make it dynamic when the settings are updated.

Here we use `ISignal` to make it dynamic, so that the schedulers are only refreshed if the settings was updated. `ISignal` may be distributed, which is needed for a database Document.
