### PR TITLE
Add support for multiple media files in Elasticsearch

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Indexing/MediaFieldIndexHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Indexing/MediaFieldIndexHandler.cs
@@ -41,6 +41,8 @@ namespace OrchardCore.Media.Indexing
                     context.DocumentIndex.Set(key + _mediaTextKeySuffix, "NULL", options);
                     context.DocumentIndex.Set(key + _fileTextKeySuffix, "NULL", options);
                 }
+
+                return;
             }
 
             if (settings.AllowMediaText)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Indexing/MediaFieldIndexHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Indexing/MediaFieldIndexHandler.cs
@@ -63,13 +63,13 @@ namespace OrchardCore.Media.Indexing
                 }
             }
 
-            var processedNames = new HashSet<string>();
+            var paths = new HashSet<string>();
 
             foreach (var path in field.Paths)
             {
-                if (!processedNames.Add(path))
+                if (!paths.Add(path))
                 {
-                    // When a file is already processed, skip it.
+                    // When a path is already processed, skip it.
                     continue;
                 }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Indexing/MediaFieldIndexHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Indexing/MediaFieldIndexHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Options;
@@ -11,8 +12,8 @@ namespace OrchardCore.Media.Indexing
 {
     public class MediaFieldIndexHandler : ContentFieldIndexHandler<MediaField>
     {
-        private const string MediaTextKeySuffix = ".MediaText";
-        private const string FileTextKeySuffix = ".FileText";
+        private const string _mediaTextKeySuffix = ".MediaText";
+        private const string _fileTextKeySuffix = ".FileText";
 
         private readonly IMediaFileStore _mediaFileStore;
         private readonly MediaFileIndexingOptions _mediaFileIndexingOptions;
@@ -33,54 +34,60 @@ namespace OrchardCore.Media.Indexing
             var options = context.Settings.ToOptions();
             var settings = context.ContentPartFieldDefinition.GetSettings<MediaFieldSettings>();
 
-            if (field.Paths?.Length > 0)
-            {
-                if (settings.AllowMediaText)
-                {
-                    foreach (var key in context.Keys)
-                    {
-                        if (field.MediaTexts != null)
-                        {
-                            foreach (var mediaText in field.MediaTexts)
-                            {
-                                context.DocumentIndex.Set(key + MediaTextKeySuffix, mediaText, options);
-                            }
-                        }
-                        else
-                        {
-                            context.DocumentIndex.Set(key + MediaTextKeySuffix, "NULL", options);
-                        }
-                    }
-                }
-
-                foreach (var path in field.Paths)
-                {
-                    var providerType = _mediaFileIndexingOptions.GetRegisteredMediaFileTextProvider(Path.GetExtension(path));
-
-                    if (providerType != null)
-                    {
-                        using var fileStream = await _mediaFileStore.GetFileStreamAsync(path);
-
-                        if (fileStream != null)
-                        {
-                            var fileText = await _serviceProvider
-                                .CreateInstance<IMediaFileTextProvider>(providerType)
-                                .GetTextAsync(path, fileStream);
-
-                            foreach (var key in context.Keys)
-                            {
-                                context.DocumentIndex.Set(key + FileTextKeySuffix, fileText, options);
-                            }
-                        }
-                    }
-                }
-            }
-            else
+            if (field.Paths?.Length == 0)
             {
                 foreach (var key in context.Keys)
                 {
-                    context.DocumentIndex.Set(key + MediaTextKeySuffix, "NULL", options);
-                    context.DocumentIndex.Set(key + FileTextKeySuffix, "NULL", options);
+                    context.DocumentIndex.Set(key + _mediaTextKeySuffix, "NULL", options);
+                    context.DocumentIndex.Set(key + _fileTextKeySuffix, "NULL", options);
+                }
+            }
+
+            if (settings.AllowMediaText)
+            {
+                foreach (var key in context.Keys)
+                {
+                    if (field.MediaTexts != null)
+                    {
+                        foreach (var mediaText in field.MediaTexts)
+                        {
+                            context.DocumentIndex.Set(key + _mediaTextKeySuffix, mediaText, options);
+                        }
+                    }
+                    else
+                    {
+                        context.DocumentIndex.Set(key + _mediaTextKeySuffix, "NULL", options);
+                    }
+                }
+            }
+
+            var processedNames = new HashSet<string>();
+
+            foreach (var path in field.Paths)
+            {
+                if (!processedNames.Add(path))
+                {
+                    // When a file is already processed, skip it.
+                    continue;
+                }
+
+                var providerType = _mediaFileIndexingOptions.GetRegisteredMediaFileTextProvider(Path.GetExtension(path));
+
+                if (providerType != null)
+                {
+                    using var fileStream = await _mediaFileStore.GetFileStreamAsync(path);
+
+                    if (fileStream != null)
+                    {
+                        var fileText = await _serviceProvider
+                            .CreateInstance<IMediaFileTextProvider>(providerType)
+                            .GetTextAsync(path, fileStream);
+
+                        foreach (var key in context.Keys)
+                        {
+                            context.DocumentIndex.Set(key + _fileTextKeySuffix, fileText, options);
+                        }
+                    }
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
@@ -1,3 +1,4 @@
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
@@ -529,13 +529,10 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
                 switch (entry.Type)
                 {
                     case DocumentIndex.Types.Boolean:
-
-                        // Store "true"/"false" for booleans.
                         if (entry.Value is bool boolValue)
                         {
                             AddValue(entries, entry.Name, boolValue);
                         }
-
                         break;
 
                     case DocumentIndex.Types.DateTime:
@@ -556,7 +553,6 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
                         if (entry.Value != null && Int64.TryParse(entry.Value.ToString(), out var value))
                         {
                             AddValue(entries, entry.Name, value);
-
                         }
 
                         break;
@@ -569,7 +565,6 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
                         break;
 
                     case DocumentIndex.Types.Text:
-
                         if (entry.Value != null)
                         {
                             var stringValue = Convert.ToString(entry.Value);
@@ -596,31 +591,33 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
             return GetIndexPrefix() + "_" + indexName;
         }
 
-
         private static void AddValue<T>(Dictionary<string, object> entries, string key, T value)
         {
-            if (!entries.TryAdd(key, value))
+            if (entries.TryAdd(key, value))
             {
-                // At this point, we know that a value already exists.
-                if (entries[key] is List<T> list)
-                {
-                    list.Add(value);
-
-                    entries[key] = list;
-
-                    return;
-                }
-
-                // Convert the existing value to a list to support multiple values.
-                var values = new List<T>()
-                {
-                    (T)entries[key],
-                    value,
-                };
-
-                entries[key] = values;
+                return;
             }
+
+            // At this point, we know that a value already exists.
+            if (entries[key] is List<T> list)
+            {
+                list.Add(value);
+
+                entries[key] = list;
+
+                return;
+            }
+
+            // Convert the existing value to a list of values.
+            var values = new List<T>()
+            {
+                (T)entries[key],
+                value,
+            };
+
+            entries[key] = values;
         }
+
         private string GetIndexPrefix()
         {
             if (_indexPrefix == null)

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
@@ -601,22 +601,24 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
         {
             if (!entries.TryAdd(key, value))
             {
+                // At this point, we know that a value already exists.
                 if (entries[key] is List<T> list)
                 {
                     list.Add(value);
 
                     entries[key] = list;
-                }
-                else
-                {
-                    var values = new List<T>()
-                    {
-                        (T)entries[key],
-                        value,
-                    };
 
-                    entries[key] = values;
+                    return;
                 }
+
+                // Convert the existing value to a list to support multiple values.
+                var values = new List<T>()
+                {
+                    (T)entries[key],
+                    value,
+                };
+
+                entries[key] = values;
             }
         }
         private string GetIndexPrefix()

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
@@ -537,17 +537,16 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
                         break;
 
                     case DocumentIndex.Types.DateTime:
-                        if (entry.Value != null)
+
+                        if (entry.Value is DateTimeOffset offsetValue)
                         {
-                            if (entry.Value is DateTimeOffset offsetValue)
-                            {
-                                AddValue(entries, entry.Name, offsetValue);
-                            }
-                            else if (entry.Value is DateTime dateTimeValue)
-                            {
-                                AddValue(entries, entry.Name, dateTimeValue.ToUniversalTime());
-                            }
+                            AddValue(entries, entry.Name, offsetValue);
                         }
+                        else if (entry.Value is DateTime dateTimeValue)
+                        {
+                            AddValue(entries, entry.Name, dateTimeValue.ToUniversalTime());
+                        }
+
                         break;
 
                     case DocumentIndex.Types.Integer:
@@ -592,7 +591,7 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
             return GetIndexPrefix() + "_" + indexName;
         }
 
-        private static void AddValue<T>(Dictionary<string, object> entries, string key, T value)
+        private static void AddValue(Dictionary<string, object> entries, string key, object value)
         {
             if (entries.TryAdd(key, value))
             {
@@ -600,7 +599,7 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
             }
 
             // At this point, we know that a value already exists.
-            if (entries[key] is List<T> list)
+            if (entries[key] is List<object> list)
             {
                 list.Add(value);
 
@@ -610,9 +609,9 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
             }
 
             // Convert the existing value to a list of values.
-            var values = new List<T>()
+            var values = new List<object>()
             {
-                (T)entries[key],
+                entries[key],
                 value,
             };
 

--- a/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/OrchardCore.ProjectTemplates.csproj
@@ -2,6 +2,7 @@
   <Import Project="..\..\OrchardCore.Build\OrchardCore.Commons.props" />
   <ItemGroup>
     <PackageReference Remove="Microsoft.SourceLink.GitHub" />
+    <PackageReference Remove="StyleCop.Analyzers" />
   </ItemGroup>
   <PropertyGroup>
     <TargetFrameworks>$(CommonTargetFrameworks)</TargetFrameworks>


### PR DESCRIPTION
Fix #14153

Alternately, we can store `Dictionary<string, List<object>>()` where every key always has a list of objects. With this PR we only use List<object> only if the key contains more than one value. 