### PR TITLE
Prevent some 404 or failures

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
@@ -264,7 +264,7 @@ namespace OrchardCore.Media.Controllers
             // If we got this far, something failed, redisplay form
             BuildViewModel(model);
 
-            // If the name was changed or removed, prevent a 404 or from failing on the next post.
+            // If the name was changed or removed, prevent a 404 or a failure on the next post.
             model.Name = sourceName;
 
             return View(model);

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
@@ -264,6 +264,9 @@ namespace OrchardCore.Media.Controllers
             // If we got this far, something failed, redisplay form
             BuildViewModel(model);
 
+            // If the name was changed or removed, prevent a 404 or from failing on the next post.
+            model.Name = sourceName;
+
             return View(model);
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -279,6 +279,10 @@ namespace OrchardCore.Shortcodes.Controllers
             }
 
             // If we got this far, something failed, redisplay form
+
+            // If the name was changed or removed, prevent a 404 or a failure on the next post.
+            model.Name = sourceName;
+
             return View(model);
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/TemplateController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/TemplateController.cs
@@ -293,6 +293,10 @@ namespace OrchardCore.Templates.Controllers
 
             // If we got this far, something failed, redisplay form.
             ViewData["ReturnUrl"] = returnUrl;
+
+            // If the name was changed or removed, prevent a 404 or a failure on the next post.
+            model.Name = sourceName;
+
             return View(model);
         }
 


### PR DESCRIPTION
Fixes #14236 

In some controllers as for `Templates` and `Shortcodes`.

1. Edit an item, change the `Name`.
2. Fill wrong values and save, you are redirected to the same edit view.
3. Correct the values and save, you get a `Page not found`.

Note: If in `1.` the `Name` is removed, the next post in `3.` throws an exception.
