### PR TITLE
Update Jint 3.0.0-beta-2051

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -27,7 +27,7 @@
     <PackageManagement Include="Jint" Version="3.0.0-beta-2051" />
     <PackageManagement Include="HtmlSanitizer" Version="8.0.692" />
     <PackageManagement Include="Irony.Core" Version="1.0.7" />
-    <PackageManagement Include="Jint" Version="3.0.0-beta-2049" />
+    <PackageManagement Include="Jint" Version="3.0.0-beta-2051" />
     <PackageManagement Include="libphonenumber-csharp" Version="8.13.20" />
     <PackageManagement Include="Lorem.Universal.NET" Version="4.0.80" />
     <PackageManagement Include="Lucene.Net" Version="4.8.0-beta00016" />


### PR DESCRIPTION
For unknown reasons, I don't know why `Jint 3.0.0-beta-2051` has been reverted

Related to #14072