### PR TITLE
Set html classes to make the scripts work again (removed in #9371)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesSitemapSource.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Items/ContentTypesSitemapSource.Edit.cshtml
@@ -68,7 +68,7 @@
                                 <input type="hidden" name="@Html.NameFor(m => m.ContentTypes[i].ContentTypeName)"
                                        value="@Model.ContentTypes[i].ContentTypeName" />
                                 <div class="mb-3 form-check">
-                                    <input asp-for="ContentTypes[i].IsChecked" type="checkbox" class="form-check-input" />
+                                    <input asp-for="ContentTypes[i].IsChecked" type="checkbox" class="form-check-input content-type-checkbox" />
                                     <label asp-for="ContentTypes[i].IsChecked" class="form-check-label">@Model.ContentTypes[i].ContentTypeDisplayName</label>
                                 </div>
                             </div>
@@ -126,7 +126,7 @@
                                 <input type="hidden" name="@Html.NameFor(m => m.LimitedContentTypes[i].ContentTypeName)"
                                        value="@Model.LimitedContentTypes[i].ContentTypeName" />
                                 <div class="mb-3 form-check">
-                                    <input type="radio" id="LimitedContentTypes_@i" asp-for="LimitedContentType" value="@Model.LimitedContentTypes[i].ContentTypeName" class="form-check-input" />
+                                    <input type="radio" id="LimitedContentTypes_@i" asp-for="LimitedContentType" value="@Model.LimitedContentTypes[i].ContentTypeName" class="form-check-input content-type-radio" />
                                     <label for="LimitedContentTypes_@i" class="form-check-label">@Model.LimitedContentTypes[i].ContentTypeDisplayName</label>
                                 </div>
                             </div>


### PR DESCRIPTION
Javascript on the page has selectors `$('.content-type-checkbox')` and `$('.content-type-radio')`.

These classes were lost when migrating to Bootstrap 5.