### PR TITLE
Fix Monaco doc link

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldMonacoEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/HtmlFieldMonacoEditorSettings.Edit.cshtml
@@ -8,7 +8,7 @@
     <div class="mb-3">
         <label asp-for="Options">@T["Enter the editor options, language is always set to `html` when saved."]</label>
         <div id="@Html.IdFor(m => m)_editor" style="min-height: 200px;" class="form-control"></div>
-        <span class="hint"><a href="https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html" target="_blank">@T["Documentation for options"]</a></span>
+        <span class="hint"><a href="https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html" target="_blank">@T["Documentation for options"]</a></span>
         <textarea asp-for="Options" hidden>@Html.Raw(Model.Options)</textarea>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextFieldMonacoEditorSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/TextFieldMonacoEditorSettings.Edit.cshtml
@@ -8,7 +8,7 @@
     <div class="mb-3">
         <label asp-for="Options">@T["Enter the editor options."]</label>
         <div id="@Html.IdFor(m => m)_editor" style="min-height: 200px;" class="form-control"></div>
-        <span class="hint"><a href="https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html" target="_blank">@T["Documentation for options"]</a></span>
+        <span class="hint"><a href="https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html" target="_blank">@T["Documentation for options"]</a></span>
         <textarea asp-for="Options" hidden>@Html.Raw(Model.Options)</textarea>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartMonacoSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Views/HtmlBodyPartMonacoSettings.Edit.cshtml
@@ -8,7 +8,7 @@
     <div class="mb-3">
         <label asp-for="Options">@T["Enter the editor options, language is always set to `html` when saved."]</label>
         <div id="@Html.IdFor(m => m)_editor" style="min-height: 200px;" class="form-control"></div>
-        <span class="hint"><a href="https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html" target="_blank">@T["Documentation for options"]</a></span>
+        <span class="hint"><a href="https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html" target="_blank">@T["Documentation for options"]</a></span>
         <textarea asp-for="Options" hidden>@Html.Raw(Model.Options)</textarea>
     </div>
 </div>


### PR DESCRIPTION
Change link 
https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html
to 
https://microsoft.github.io/monaco-editor/typedoc/interfaces/editor.IStandaloneEditorConstructionOptions.html