### PR TITLE
Dashboard card padding

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/DashboardWidget.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/DashboardWidget.DetailAdmin.cshtml
@@ -24,7 +24,7 @@
             @await DisplayAsync(Model.Tags)
         </div>
     }
-    <div class="card-body p-0">
+    <div class="card-body">
         @await DisplayAsync(Model.Content)
     </div>
     @if (Model.Footer != null)


### PR DESCRIPTION
Remove `p-0` on `card-body`.

Fixes #14464

![image](https://github.com/OrchardCMS/OrchardCore/assets/703248/90396f4e-cdc6-429f-aa4d-63372975686b)
