### PR TITLE
Set index length limit for MySQL

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Migrations.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.AdminDashboard
             SchemaBuilder.AlterIndexTable<DashboardPartIndex>(table => table
                 .CreateIndex("IDX_DashboardPart_DocumentId",
                     "DocumentId",
-                    nameof(DashboardPartIndex.Position))
+                    "Position")
             );
 
             _contentDefinitionManager.AlterPartDefinition("DashboardPart", builder => builder
@@ -56,7 +56,7 @@ namespace OrchardCore.AdminDashboard
             SchemaBuilder.AlterIndexTable<DashboardPartIndex>(table => table
                 .CreateIndex("IDX_DashboardPart_DocumentId",
                     "DocumentId",
-                    nameof(DashboardPartIndex.Position))
+                    "Position")
             );
 
             return 3;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -30,11 +30,11 @@ namespace OrchardCore.Alias
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + Alias (714) + ContentItemId (26) + Published (1) + Latest (1) = 768
+            // DocumentId (2) + Alias (734) + ContentItemId (26) + Published (1) + Latest (1) = 768
             SchemaBuilder.AlterIndexTable<AliasPartIndex>(table => table
                 .CreateIndex("IDX_AliasPartIndex_DocumentId",
                     "DocumentId",
-                    "Alias(714)",
+                    "Alias(734)",
                     "ContentItemId",
                     "Published",
                     "Latest")
@@ -72,7 +72,7 @@ namespace OrchardCore.Alias
 
                 .CreateIndex("IDX_AliasPartIndex_DocumentId",
                     "DocumentId",
-                    "Alias")
+                    "Alias(734)")
             );
 
             return 3;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -22,9 +22,6 @@ namespace OrchardCore.Alias
                 .Attachable()
                 .WithDescription("Provides a way to define custom aliases for content items."));
 
-            // NOTE: The Alias Length has been upgraded from 64 characters to 767.
-            // For existing SQL databases update the AliasPartIndex tables Alias column length manually.
-            // INFO: The Alias Length is now of 735 chars, but this is only used on a new installation.
             SchemaBuilder.CreateMapIndexTable<AliasPartIndex>(table => table
                 .Column<string>("Alias", col => col.WithLength(AliasPart.MaxAliasLength))
                 .Column<string>("ContentItemId", c => c.WithLength(26))
@@ -32,10 +29,12 @@ namespace OrchardCore.Alias
                 .Column<bool>("Published", c => c.WithDefault(true))
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + Alias (714) + ContentItemId (26) + Published (1) + Latest (1) = 768
             SchemaBuilder.AlterIndexTable<AliasPartIndex>(table => table
                 .CreateIndex("IDX_AliasPartIndex_DocumentId",
                     "DocumentId",
-                    "Alias",
+                    "Alias(714)",
                     "ContentItemId",
                     "Published",
                     "Latest")

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Migrations.cs
@@ -29,12 +29,10 @@ namespace OrchardCore.Alias
                 .Column<bool>("Published", c => c.WithDefault(true))
             );
 
-            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (2) + Alias (734) + ContentItemId (26) + Published (1) + Latest (1) = 768
             SchemaBuilder.AlterIndexTable<AliasPartIndex>(table => table
                 .CreateIndex("IDX_AliasPartIndex_DocumentId",
                     "DocumentId",
-                    "Alias(734)",
+                    "Alias",
                     "ContentItemId",
                     "Published",
                     "Latest")
@@ -72,7 +70,7 @@ namespace OrchardCore.Alias
 
                 .CreateIndex("IDX_AliasPartIndex_DocumentId",
                     "DocumentId",
-                    "Alias(734)")
+                    "Alias")
             );
 
             return 3;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Models/AliasPart.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Models/AliasPart.cs
@@ -4,6 +4,10 @@ namespace OrchardCore.Alias.Models
 {
     public class AliasPart : ContentPart
     {
+        // Maximum length that MySql can support in an index under utf8mb4 collation is 768,
+        // minus 2 for the `DocumentId` integer (bigint size = 8 bytes = 2 character size),
+        // minus 26 for the `ContentItemId` and 1 for the 'Published' and 'Latest' bools.
+        // minus 4 to allow at least to add a new integer column.
         public const int MaxAliasLength = 735;
 
         public string Alias { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Models/AliasPart.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Models/AliasPart.cs
@@ -4,10 +4,6 @@ namespace OrchardCore.Alias.Models
 {
     public class AliasPart : ContentPart
     {
-        // Maximum length that MySql can support in an index under utf8mb4 collation is 768,
-        // minus 2 for the `DocumentId` integer (bigint size = 8 bytes = 2 character size),
-        // minus 26 for the `ContentItemId` and 1 for the 'Published' and 'Latest' bools.
-        // minus 4 to allow at least to add a new integer column.
         public const int MaxAliasLength = 735;
 
         public string Alias { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ArchiveLater/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ArchiveLater/Migrations.cs
@@ -3,7 +3,6 @@ using OrchardCore.ArchiveLater.Indexes;
 using OrchardCore.ArchiveLater.Models;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
-using OrchardCore.ContentManagement.Records;
 using OrchardCore.Data.Migration;
 using YesSql.Sql;
 
@@ -25,20 +24,20 @@ public class Migrations : DataMigration
             .WithDescription("Adds the ability to schedule content items to be archived at a given future date and time."));
 
         SchemaBuilder.CreateMapIndexTable<ArchiveLaterPartIndex>(table => table
-            .Column<string>(nameof(ArchiveLaterPartIndex.ContentItemId))
-            .Column<DateTime>(nameof(ArchiveLaterPartIndex.ScheduledArchiveDateTimeUtc))
-            .Column<bool>(nameof(ArchiveLaterPartIndex.Published))
-            .Column<bool>(nameof(ArchiveLaterPartIndex.Latest))
+            .Column<string>("ContentItemId")
+            .Column<DateTime>("ScheduledArchiveDateTimeUtc")
+            .Column<bool>("Published")
+            .Column<bool>("Latest")
         );
 
         SchemaBuilder.AlterIndexTable<ArchiveLaterPartIndex>(table => table
-            .CreateIndex($"IDX_{nameof(ArchiveLaterPartIndex)}_{nameof(ContentItemIndex.DocumentId)}",
+            .CreateIndex("IDX_ArchiveLaterPartIndex_DocumentId",
                 "Id",
-                nameof(ContentItemIndex.DocumentId),
-                nameof(ArchiveLaterPartIndex.ContentItemId),
-                nameof(ArchiveLaterPartIndex.ScheduledArchiveDateTimeUtc),
-                nameof(ArchiveLaterPartIndex.Published),
-                nameof(ArchiveLaterPartIndex.Latest))
+                "DocumentId",
+                "ContentItemId",
+                "ScheduledArchiveDateTimeUtc",
+                "Published",
+                "Latest")
         );
 
         return 1;

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Migrations.cs
@@ -23,13 +23,13 @@ namespace OrchardCore.AuditTrail
             SchemaBuilder.AlterIndexTable<AuditTrailEventIndex>(table => table
                 .CreateIndex("IDX_AuditTrailEventIndex_DocumentId",
                     "DocumentId",
-                    nameof(AuditTrailEventIndex.EventId),
-                    nameof(AuditTrailEventIndex.Category),
-                    nameof(AuditTrailEventIndex.Name),
-                    nameof(AuditTrailEventIndex.CorrelationId),
-                    nameof(AuditTrailEventIndex.UserId),
-                    nameof(AuditTrailEventIndex.NormalizedUserName),
-                    nameof(AuditTrailEventIndex.CreatedUtc)
+                    "EventId",
+                    "Category",
+                    "Name",
+                    "CorrelationId",
+                    "UserId",
+                    "NormalizedUserName",
+                    "CreatedUtc"
                     ),
                 collection: AuditTrailEvent.Collection
             );

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
@@ -42,12 +42,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
                 .CreateIndex("IDX_TextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -80,12 +82,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Boolean (1) + Published (1) + Latest (1) = 767 (less than 768)
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
                 .CreateIndex("IDX_BooleanFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Boolean",
                     "Published",
                     "Latest")
@@ -111,12 +115,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
                 .CreateIndex("IDX_NumericFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -149,12 +155,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
                 .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -187,12 +195,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
                 .CreateIndex("IDX_DateFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -226,12 +236,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
                 .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -264,12 +276,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
                 .CreateIndex("IDX_TimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -309,12 +323,15 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
                 .CreateIndex("IDX_LinkFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -355,12 +372,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
                 .CreateIndex("IDX_HtmlFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -386,12 +405,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
                 .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -453,9 +474,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
                 .CreateIndex("IDX_TextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -481,9 +502,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
                 .CreateIndex("IDX_BooleanFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Boolean",
                     "Published",
                     "Latest")
@@ -501,9 +522,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
                 .CreateIndex("IDX_NumericFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -528,9 +549,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
                 .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -555,9 +576,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
                 .CreateIndex("IDX_DateFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -582,9 +603,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
                 .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -609,9 +630,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
                 .CreateIndex("IDX_TimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -636,9 +657,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
                 .CreateIndex("IDX_LinkFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -673,9 +694,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
                 .CreateIndex("IDX_HtmlFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );
@@ -692,9 +713,9 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
                 .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(246)",
+                    "ContentPart(246)",
+                    "ContentField(246)",
                     "Published",
                     "Latest")
             );

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/Migrations.cs
@@ -43,13 +43,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
                 .CreateIndex("IDX_TextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -83,13 +83,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Boolean (1) + Published (1) + Latest (1) = 767 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Boolean (1) + Published (1) + Latest (1) = 767 (less than 768)
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
                 .CreateIndex("IDX_BooleanFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Boolean",
                     "Published",
                     "Latest")
@@ -116,13 +116,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
                 .CreateIndex("IDX_NumericFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -156,13 +156,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
                 .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -196,13 +196,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
                 .CreateIndex("IDX_DateFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -237,13 +237,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
                 .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -277,13 +277,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
                 .CreateIndex("IDX_TimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -325,13 +325,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
 
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
                 .CreateIndex("IDX_LinkFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -373,13 +373,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
                 .CreateIndex("IDX_HtmlFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -406,13 +406,13 @@ namespace OrchardCore.ContentFields.Indexing.SQL
             );
 
             // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
-            // DocumentId (26) + ContentType (246) + ContentPart (246) + ContentField (246) + Published (1) + Latest (1) = 766 (less than 768)
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
                 .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -471,12 +471,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<TextFieldIndex>(table => table
                 .CreateIndex("IDX_TextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -499,12 +501,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<BooleanFieldIndex>(table => table
                 .CreateIndex("IDX_BooleanFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Boolean",
                     "Published",
                     "Latest")
@@ -519,12 +523,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<NumericFieldIndex>(table => table
                 .CreateIndex("IDX_NumericFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -546,12 +552,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<DateTimeFieldIndex>(table => table
                 .CreateIndex("IDX_DateTimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -573,12 +581,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<DateFieldIndex>(table => table
                 .CreateIndex("IDX_DateFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -600,12 +610,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<ContentPickerFieldIndex>(table => table
                 .CreateIndex("IDX_ContentPickerFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -627,12 +639,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<TimeFieldIndex>(table => table
                 .CreateIndex("IDX_TimeFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -654,12 +668,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<LinkFieldIndex>(table => table
                 .CreateIndex("IDX_LinkFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -691,12 +707,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<HtmlFieldIndex>(table => table
                 .CreateIndex("IDX_HtmlFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -710,12 +728,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<MultiTextFieldIndex>(table => table
                 .CreateIndex("IDX_MultiTextFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType(246)",
-                    "ContentPart(246)",
-                    "ContentField(246)",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/UserPickerMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Indexing/SQL/UserPickerMigrations.cs
@@ -30,12 +30,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<UserPickerFieldIndex>(table => table
                 .CreateIndex("IDX_UserPickerFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );
@@ -64,12 +66,14 @@ namespace OrchardCore.ContentFields.Indexing.SQL
                     "Latest")
             );
 
+            // The index in MySQL can accommodate up to 768 characters or 3072 bytes.
+            // DocumentId (2) + ContentType (254) + ContentPart (254) + ContentField (254) + Published (1) + Latest (1) = 766 (less than 768)
             SchemaBuilder.AlterIndexTable<UserPickerFieldIndex>(table => table
                 .CreateIndex("IDX_UserPickerFieldIndex_DocumentId_ContentType",
                     "DocumentId",
-                    "ContentType",
-                    "ContentPart",
-                    "ContentField",
+                    "ContentType(254)",
+                    "ContentPart(254)",
+                    "ContentField(254)",
                     "Published",
                     "Latest")
             );

--- a/src/OrchardCore.Modules/OrchardCore.PublishLater/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.PublishLater/Migrations.cs
@@ -73,12 +73,12 @@ public class Migrations : DataMigration
 
         SchemaBuilder.AlterIndexTable<PublishLaterPartIndex>(table =>
         {
-            table.DropIndex($"IDX_PublishLaterPartIndex_ScheduledPublishDateTimeUtc");
+            table.DropIndex("IDX_PublishLaterPartIndex_ScheduledPublishDateTimeUtc");
         });
 
         SchemaBuilder.AlterIndexTable<PublishLaterPartIndex>(table =>
         {
-            table.CreateIndex($"IDX_PublishLaterPartIndex_ScheduledPublishDateTimeUtc",
+            table.CreateIndex("IDX_PublishLaterPartIndex_ScheduledPublishDateTimeUtc",
                 "Id",
                 "DocumentId",
                 "ContentItemId",

--- a/src/OrchardCore.Modules/OrchardCore.PublishLater/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.PublishLater/Migrations.cs
@@ -1,7 +1,6 @@
 using System;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Settings;
-using OrchardCore.ContentManagement.Records;
 using OrchardCore.Data.Migration;
 using OrchardCore.PublishLater.Indexes;
 using OrchardCore.PublishLater.Models;
@@ -25,20 +24,20 @@ public class Migrations : DataMigration
             .WithDescription("Adds the ability to schedule content items to be published at a given future date and time."));
 
         SchemaBuilder.CreateMapIndexTable<PublishLaterPartIndex>(table => table
-            .Column<string>(nameof(PublishLaterPartIndex.ContentItemId))
-            .Column<DateTime>(nameof(PublishLaterPartIndex.ScheduledPublishDateTimeUtc))
-            .Column<bool>(nameof(PublishLaterPartIndex.Published))
-            .Column<bool>(nameof(PublishLaterPartIndex.Latest))
+            .Column<string>("ContentItemId")
+            .Column<DateTime>("ScheduledPublishDateTimeUtc")
+            .Column<bool>("Published")
+            .Column<bool>("Latest")
         );
 
         SchemaBuilder.AlterIndexTable<PublishLaterPartIndex>(table => table
-            .CreateIndex($"IDX_{nameof(PublishLaterPartIndex)}_{nameof(ContentItemIndex.DocumentId)}",
+            .CreateIndex("IDX_PublishLaterPartIndex_DocumentId",
                 "Id",
-                nameof(ContentItemIndex.DocumentId),
-                nameof(PublishLaterPartIndex.ContentItemId),
-                nameof(PublishLaterPartIndex.ScheduledPublishDateTimeUtc),
-                nameof(PublishLaterPartIndex.Published),
-                nameof(PublishLaterPartIndex.Latest))
+                "DocumentId",
+                "ContentItemId",
+                "ScheduledPublishDateTimeUtc",
+                "Published",
+                "Latest")
         );
 
         return 3;
@@ -55,9 +54,9 @@ public class Migrations : DataMigration
         );
 
         SchemaBuilder.AlterIndexTable<PublishLaterPartIndex>(table => table
-            .CreateIndex($"IDX_{nameof(PublishLaterPartIndex)}_{nameof(PublishLaterPartIndex.ScheduledPublishDateTimeUtc)}",
-                nameof(ContentItemIndex.DocumentId),
-                nameof(PublishLaterPartIndex.ScheduledPublishDateTimeUtc))
+            .CreateIndex($"IDX_PublishLaterPartIndex_ScheduledPublishDateTimeUtc",
+                "DocumentId",
+                "ScheduledPublishDateTimeUtc")
         );
 
         return 2;
@@ -67,25 +66,25 @@ public class Migrations : DataMigration
     {
         SchemaBuilder.AlterIndexTable<PublishLaterPartIndex>(table =>
         {
-            table.AddColumn<string>(nameof(PublishLaterPartIndex.ContentItemId));
-            table.AddColumn<bool>(nameof(PublishLaterPartIndex.Published));
-            table.AddColumn<bool>(nameof(PublishLaterPartIndex.Latest));
+            table.AddColumn<string>("ContentItemId");
+            table.AddColumn<bool>("Published");
+            table.AddColumn<bool>("Latest");
         });
 
         SchemaBuilder.AlterIndexTable<PublishLaterPartIndex>(table =>
         {
-            table.DropIndex($"IDX_{nameof(PublishLaterPartIndex)}_{nameof(PublishLaterPartIndex.ScheduledPublishDateTimeUtc)}");
+            table.DropIndex($"IDX_PublishLaterPartIndex_ScheduledPublishDateTimeUtc");
         });
 
         SchemaBuilder.AlterIndexTable<PublishLaterPartIndex>(table =>
         {
-            table.CreateIndex($"IDX_{nameof(PublishLaterPartIndex)}_{nameof(PublishLaterPartIndex.ScheduledPublishDateTimeUtc)}",
+            table.CreateIndex($"IDX_PublishLaterPartIndex_ScheduledPublishDateTimeUtc",
                 "Id",
-                nameof(ContentItemIndex.DocumentId),
-                nameof(PublishLaterPartIndex.ContentItemId),
-                nameof(PublishLaterPartIndex.ScheduledPublishDateTimeUtc),
-                nameof(PublishLaterPartIndex.Published),
-                nameof(PublishLaterPartIndex.Latest));
+                "DocumentId",
+                "ContentItemId",
+                "ScheduledPublishDateTimeUtc",
+                "Published",
+                "Latest");
         });
 
         return 3;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Migrations.cs
@@ -67,15 +67,15 @@ namespace OrchardCore.Users
             );
 
             SchemaBuilder.CreateMapIndexTable<UserByClaimIndex>(table => table
-               .Column<string>(nameof(UserByClaimIndex.ClaimType))
-               .Column<string>(nameof(UserByClaimIndex.ClaimValue)),
+               .Column<string>("ClaimType")
+               .Column<string>("ClaimValue"),
                 null);
 
             SchemaBuilder.AlterIndexTable<UserByClaimIndex>(table => table
                 .CreateIndex("IDX_UserByClaimIndex_DocumentId",
                     "DocumentId",
-                    nameof(UserByClaimIndex.ClaimType),
-                    nameof(UserByClaimIndex.ClaimValue))
+                    "ClaimType",
+                    "ClaimValue")
             );
 
             // Shortcut other migration steps on new content definition schemas.
@@ -96,8 +96,8 @@ namespace OrchardCore.Users
         public int UpdateFrom2()
         {
             SchemaBuilder.CreateMapIndexTable<UserByClaimIndex>(table => table
-               .Column<string>(nameof(UserByClaimIndex.ClaimType))
-               .Column<string>(nameof(UserByClaimIndex.ClaimValue)),
+               .Column<string>("ClaimType")
+               .Column<string>("ClaimValue"),
                 null);
 
             return 3;
@@ -107,7 +107,7 @@ namespace OrchardCore.Users
         public int UpdateFrom3()
         {
             SchemaBuilder.AlterIndexTable<UserIndex>(table => table
-                .AddColumn<bool>(nameof(UserIndex.IsEnabled), c => c.NotNull().WithDefault(true)));
+                .AddColumn<bool>("IsEnabled", c => c.NotNull().WithDefault(true)));
 
             return 4;
         }
@@ -198,8 +198,8 @@ namespace OrchardCore.Users
             SchemaBuilder.AlterIndexTable<UserByClaimIndex>(table => table
                 .CreateIndex("IDX_UserByClaimIndex_DocumentId",
                     "DocumentId",
-                    nameof(UserByClaimIndex.ClaimType),
-                    nameof(UserByClaimIndex.ClaimValue))
+                    "ClaimType",
+                    "ClaimValue")
             );
 
             return 9;
@@ -219,13 +219,13 @@ namespace OrchardCore.Users
         public int UpdateFrom10()
         {
             SchemaBuilder.AlterIndexTable<UserIndex>(table => table
-                .AddColumn<bool>(nameof(UserIndex.IsLockoutEnabled), c => c.NotNull().WithDefault(false)));
+                .AddColumn<bool>("IsLockoutEnabled", c => c.NotNull().WithDefault(false)));
 
             SchemaBuilder.AlterIndexTable<UserIndex>(table => table
-                .AddColumn<DateTime?>(nameof(UserIndex.LockoutEndUtc), c => c.Nullable()));
+                .AddColumn<DateTime?>("LockoutEndUtc", c => c.Nullable()));
 
             SchemaBuilder.AlterIndexTable<UserIndex>(table => table
-                .AddColumn<int>(nameof(UserIndex.AccessFailedCount), c => c.NotNull().WithDefault(0)));
+                .AddColumn<int>("AccessFailedCount", c => c.NotNull().WithDefault(0)));
 
             return 11;
         }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Migrations/OpenIdMigrations.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Migrations/OpenIdMigrations.cs
@@ -32,133 +32,130 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             SchemaBuilder.AlterIndexTable<OpenIdApplicationIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdApplication",
                     "DocumentId",
-                    nameof(OpenIdApplicationIndex.ApplicationId),
-                    nameof(OpenIdApplicationIndex.ClientId)),
+                    "ApplicationId",
+                    "ClientId"),
                 collection: OpenIdApplicationCollection
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri))
-                .Column<int>(nameof(OpenIdAppByLogoutUriIndex.Count)),
+                .Column<string>("LogoutRedirectUri")
+                .Column<int>("Count"),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .CreateIndex("IDX_COL_OpenIdAppByLogoutUri_LogoutRedirectUri",
-                    nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri)),
+                .CreateIndex("IDX_COL_OpenIdAppByLogoutUri_LogoutRedirectUri", "LogoutRedirectUri"),
                 collection: OpenIdApplicationCollection
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri))
-                .Column<int>(nameof(OpenIdAppByRedirectUriIndex.Count)),
+                .Column<string>("RedirectUri")
+                .Column<int>("Count"),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .CreateIndex("IDX_COL_OpenIdAppByRedirectUri_RedirectUri",
-                    nameof(OpenIdAppByRedirectUriIndex.RedirectUri)),
+                .CreateIndex("IDX_COL_OpenIdAppByRedirectUri_RedirectUri", "RedirectUri"),
                 collection: OpenIdApplicationCollection
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName))
-                .Column<int>(nameof(OpenIdAppByRoleNameIndex.Count)),
+                .Column<string>("RoleName")
+                .Column<int>("Count"),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .CreateIndex("IDX_COL_OpenIdAppByRoleName_RoleName",
-                    nameof(OpenIdAppByRoleNameIndex.RoleName)),
+                .CreateIndex("IDX_COL_OpenIdAppByRoleName_RoleName", "RoleName"),
                 collection: OpenIdApplicationCollection
             );
 
             SchemaBuilder.CreateMapIndexTable<OpenIdAuthorizationIndex>(table => table
-                .Column<string>(nameof(OpenIdAuthorizationIndex.AuthorizationId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.ApplicationId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.Status))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.Subject))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.Type))
-                .Column<DateTime>(nameof(OpenIdAuthorizationIndex.CreationDate)),
+                .Column<string>("AuthorizationId", column => column.WithLength(48))
+                .Column<string>("ApplicationId", column => column.WithLength(48))
+                .Column<string>("Status")
+                .Column<string>("Subject")
+                .Column<string>("Type")
+                .Column<DateTime>("CreationDate"),
                 collection: OpenIdAuthorizationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAuthorizationIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdAuthorization_ApplicationId",
                     "DocumentId",
-                    nameof(OpenIdAuthorizationIndex.ApplicationId),
-                    nameof(OpenIdAuthorizationIndex.Status),
-                    nameof(OpenIdAuthorizationIndex.Subject)),
+                    "ApplicationId",
+                    "Status",
+                    "Subject"),
                 collection: OpenIdAuthorizationCollection
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdAuthorizationIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdAuthorization_AuthorizationId",
                     "DocumentId",
-                    nameof(OpenIdAuthorizationIndex.AuthorizationId),
-                    nameof(OpenIdAuthorizationIndex.Status),
-                    nameof(OpenIdAuthorizationIndex.Type),
-                    nameof(OpenIdAuthorizationIndex.CreationDate)),
+                    "AuthorizationId",
+                    "Status",
+                    "Type",
+                    "CreationDate"),
                 collection: OpenIdAuthorizationCollection
             );
 
             SchemaBuilder.CreateMapIndexTable<OpenIdScopeIndex>(table => table
-                .Column<string>(nameof(OpenIdScopeIndex.Name), column => column.Unique())
-                .Column<string>(nameof(OpenIdScopeIndex.ScopeId), column => column.WithLength(48)),
+                .Column<string>("Name", column => column.Unique())
+                .Column<string>("ScopeId", column => column.WithLength(48)),
                 collection: OpenIdScopeCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdScopeIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdScope",
                     "DocumentId",
-                    nameof(OpenIdScopeIndex.Name),
-                    nameof(OpenIdScopeIndex.ScopeId)),
+                    "Name",
+                    "ScopeId"),
                 collection: OpenIdScopeCollection
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdScopeByResourceIndex>(table => table
-                .Column<string>(nameof(OpenIdScopeByResourceIndex.Resource))
-                .Column<int>(nameof(OpenIdScopeByResourceIndex.Count)),
+                .Column<string>("Resource")
+                .Column<int>("Count"),
                 collection: OpenIdScopeCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdScopeByResourceIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdScopeByResource_Resource",
-                    nameof(OpenIdScopeByResourceIndex.Resource)),
+                    "Resource"),
                 collection: OpenIdScopeCollection
             );
 
             SchemaBuilder.CreateMapIndexTable<OpenIdTokenIndex>(table => table
-                .Column<string>(nameof(OpenIdTokenIndex.TokenId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdTokenIndex.ApplicationId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdTokenIndex.AuthorizationId), column => column.WithLength(48))
-                .Column<DateTime>(nameof(OpenIdTokenIndex.ExpirationDate))
-                .Column<string>(nameof(OpenIdTokenIndex.ReferenceId))
-                .Column<string>(nameof(OpenIdTokenIndex.Status))
-                .Column<string>(nameof(OpenIdTokenIndex.Subject))
-                .Column<string>(nameof(OpenIdTokenIndex.Type))
-                .Column<DateTime>(nameof(OpenIdTokenIndex.CreationDate)),
+                .Column<string>("TokenId", column => column.WithLength(48))
+                .Column<string>("ApplicationId", column => column.WithLength(48))
+                .Column<string>("AuthorizationId", column => column.WithLength(48))
+                .Column<DateTime>("ExpirationDate")
+                .Column<string>("ReferenceId")
+                .Column<string>("Status")
+                .Column<string>("Subject")
+                .Column<string>("Type")
+                .Column<DateTime>("CreationDate"),
                 collection: OpenIdTokenCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdToken_ApplicationId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.ApplicationId),
-                    nameof(OpenIdTokenIndex.Status),
-                    nameof(OpenIdTokenIndex.Subject)),
+                    "ApplicationId",
+                    "Status",
+                    "Subject"),
                 collection: OpenIdTokenCollection
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdToken_AuthorizationId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.AuthorizationId),
-                    nameof(OpenIdTokenIndex.Status),
-                    nameof(OpenIdTokenIndex.Type),
-                    nameof(OpenIdTokenIndex.CreationDate),
-                    nameof(OpenIdTokenIndex.ExpirationDate)),
+                    "AuthorizationId",
+                    "Status",
+                    "Type",
+                    "CreationDate",
+                    "ExpirationDate"),
                 collection: OpenIdTokenCollection
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdToken_TokenId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.TokenId),
-                    nameof(OpenIdTokenIndex.ReferenceId)),
+                    "TokenId",
+                    "ReferenceId"),
                 collection: OpenIdTokenCollection
             );
 
@@ -170,7 +167,7 @@ namespace OrchardCore.OpenId.YesSql.Migrations
         public int UpdateFrom1()
         {
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
-                .AddColumn<string>(nameof(OpenIdTokenIndex.Type)));
+                .AddColumn<string>("Type"));
 
             return 2;
         }
@@ -187,16 +184,16 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             SchemaBuilder.DropReduceIndexTable<OpenIdApplicationByRoleNameIndex>(null);
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri))
-                .Column<int>(nameof(OpenIdAppByLogoutUriIndex.Count)));
+                .Column<string>("LogoutRedirectUri")
+                .Column<int>("Count"));
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri))
-                .Column<int>(nameof(OpenIdAppByRedirectUriIndex.Count)));
+                .Column<string>("RedirectUri")
+                .Column<int>("Count"));
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName))
-                .Column<int>(nameof(OpenIdAppByRoleNameIndex.Count)));
+                .Column<string>("RoleName")
+                .Column<int>("Count"));
 
             return 3;
         }
@@ -205,10 +202,10 @@ namespace OrchardCore.OpenId.YesSql.Migrations
         public int UpdateFrom3()
         {
             SchemaBuilder.AlterIndexTable<OpenIdAuthorizationIndex>(table => table
-                .AddColumn<DateTime>(nameof(OpenIdAuthorizationIndex.CreationDate)));
+                .AddColumn<DateTime>("CreationDate"));
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
-                .AddColumn<DateTime>(nameof(OpenIdTokenIndex.CreationDate)));
+                .AddColumn<DateTime>("CreationDate"));
 
             return 4;
         }
@@ -219,57 +216,57 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             SchemaBuilder.AlterIndexTable<OpenIdApplicationIndex>(table => table
                 .CreateIndex("IDX_OpenIdApplicationIndex_DocumentId",
                     "DocumentId",
-                    nameof(OpenIdApplicationIndex.ApplicationId),
-                    nameof(OpenIdApplicationIndex.ClientId))
+                    "ApplicationId",
+                    "ClientId")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdAuthorizationIndex>(table => table
                 .CreateIndex("IDX_OpenIdAuthorizationIndex_DocumentId_ApplicationId",
                     "DocumentId",
-                    nameof(OpenIdAuthorizationIndex.ApplicationId),
-                    nameof(OpenIdAuthorizationIndex.Status),
-                    nameof(OpenIdAuthorizationIndex.Subject))
+                    "ApplicationId",
+                    "Status",
+                    "Subject")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdAuthorizationIndex>(table => table
                 .CreateIndex("IDX_OpenIdAuthorizationIndex_DocumentId_AuthorizationId",
                     "DocumentId",
-                    nameof(OpenIdAuthorizationIndex.AuthorizationId),
-                    nameof(OpenIdAuthorizationIndex.Status),
-                    nameof(OpenIdAuthorizationIndex.Type),
-                    nameof(OpenIdAuthorizationIndex.CreationDate))
+                    "AuthorizationId",
+                    "Status",
+                    "Type",
+                    "CreationDate")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdScopeIndex>(table => table
                 .CreateIndex("IDX_OpenIdScopeIndex_DocumentId",
                     "DocumentId",
-                    nameof(OpenIdScopeIndex.Name),
-                    nameof(OpenIdScopeIndex.ScopeId))
+                    "Name",
+                    "ScopeId")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_OpenIdTokenIndex_DocumentId_ApplicationId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.ApplicationId),
-                    nameof(OpenIdTokenIndex.Status),
-                    nameof(OpenIdTokenIndex.Subject))
+                    "ApplicationId",
+                    "Status",
+                    "Subject")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_OpenIdTokenIndex_DocumentId_AuthorizationId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.AuthorizationId),
-                    nameof(OpenIdTokenIndex.Status),
-                    nameof(OpenIdTokenIndex.Type),
-                    nameof(OpenIdTokenIndex.CreationDate),
-                    nameof(OpenIdTokenIndex.ExpirationDate))
+                    "AuthorizationId",
+                    "Status",
+                    "Type",
+                    "CreationDate",
+                    "ExpirationDate")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_OpenIdTokenIndex_DocumentId_TokenId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.TokenId),
-                    nameof(OpenIdTokenIndex.ReferenceId))
+                    "TokenId",
+                    "ReferenceId")
             );
 
             return 5;
@@ -279,23 +276,19 @@ namespace OrchardCore.OpenId.YesSql.Migrations
         public int UpdateFrom5()
         {
             SchemaBuilder.AlterIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .CreateIndex("IDX_OpenIdAppByLogoutUriIndex_LogoutRedirectUri",
-                    nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri))
+                .CreateIndex("IDX_OpenIdAppByLogoutUriIndex_LogoutRedirectUri", "LogoutRedirectUri")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .CreateIndex("IDX_OpenIdAppByRedirectUriIndex_RedirectUri",
-                    nameof(OpenIdAppByRedirectUriIndex.RedirectUri))
+                .CreateIndex("IDX_OpenIdAppByRedirectUriIndex_RedirectUri", "RedirectUri")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .CreateIndex("IDX_OpenIdAppByRoleNameIndex_RoleName",
-                    nameof(OpenIdAppByRoleNameIndex.RoleName))
+                .CreateIndex("IDX_OpenIdAppByRoleNameIndex_RoleName", "RoleName")
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdScopeByResourceIndex>(table => table
-                .CreateIndex("IDX_OpenIdScopeByResourceIndex_Resource",
-                    nameof(OpenIdScopeByResourceIndex.Resource))
+                .CreateIndex("IDX_OpenIdScopeByResourceIndex_Resource", "Resource")
             );
 
             return 6;
@@ -306,70 +299,70 @@ namespace OrchardCore.OpenId.YesSql.Migrations
         {
             // Create all index tables with the new collection value.
             SchemaBuilder.CreateMapIndexTable<OpenIdTokenIndex>(table => table
-                .Column<string>(nameof(OpenIdTokenIndex.TokenId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdTokenIndex.ApplicationId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdTokenIndex.AuthorizationId), column => column.WithLength(48))
-                .Column<DateTime>(nameof(OpenIdTokenIndex.ExpirationDate))
-                .Column<string>(nameof(OpenIdTokenIndex.ReferenceId))
-                .Column<string>(nameof(OpenIdTokenIndex.Status))
-                .Column<string>(nameof(OpenIdTokenIndex.Subject))
-                .Column<string>(nameof(OpenIdTokenIndex.Type))
-                .Column<DateTime>(nameof(OpenIdTokenIndex.CreationDate)),
+                .Column<string>("TokenId", column => column.WithLength(48))
+                .Column<string>("ApplicationId", column => column.WithLength(48))
+                .Column<string>("AuthorizationId", column => column.WithLength(48))
+                .Column<DateTime>("ExpirationDate")
+                .Column<string>("ReferenceId")
+                .Column<string>("Status")
+                .Column<string>("Subject")
+                .Column<string>("Type")
+                .Column<DateTime>("CreationDate"),
                 collection: OpenIdTokenCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdToken_ApplicationId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.ApplicationId),
-                    nameof(OpenIdTokenIndex.Status),
-                    nameof(OpenIdTokenIndex.Subject)),
+                    "ApplicationId",
+                    "Status",
+                    "Subject"),
                 collection: OpenIdTokenCollection
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdToken_AuthorizationId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.AuthorizationId),
-                    nameof(OpenIdTokenIndex.Status),
-                    nameof(OpenIdTokenIndex.Type),
-                    nameof(OpenIdTokenIndex.CreationDate),
-                    nameof(OpenIdTokenIndex.ExpirationDate)),
+                    "AuthorizationId",
+                    "Status",
+                    "Type",
+                    "CreationDate",
+                    "ExpirationDate"),
                 collection: OpenIdTokenCollection
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdTokenIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdToken_TokenId",
                     "DocumentId",
-                    nameof(OpenIdTokenIndex.TokenId),
-                    nameof(OpenIdTokenIndex.ReferenceId)),
+                    "TokenId",
+                    "ReferenceId"),
                 collection: OpenIdTokenCollection
             );
 
             SchemaBuilder.CreateMapIndexTable<OpenIdAuthorizationIndex>(table => table
-                .Column<string>(nameof(OpenIdAuthorizationIndex.AuthorizationId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.ApplicationId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.Status))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.Subject))
-                .Column<string>(nameof(OpenIdAuthorizationIndex.Type))
-                .Column<DateTime>(nameof(OpenIdAuthorizationIndex.CreationDate)),
+                .Column<string>("AuthorizationId", column => column.WithLength(48))
+                .Column<string>("ApplicationId", column => column.WithLength(48))
+                .Column<string>("Status")
+                .Column<string>("Subject")
+                .Column<string>("Type")
+                .Column<DateTime>("CreationDate"),
                 collection: OpenIdAuthorizationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAuthorizationIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdAuthorization_ApplicationId",
                     "DocumentId",
-                    nameof(OpenIdAuthorizationIndex.ApplicationId),
-                    nameof(OpenIdAuthorizationIndex.Status),
-                    nameof(OpenIdAuthorizationIndex.Subject)),
+                    "ApplicationId",
+                    "Status",
+                    "Subject"),
                 collection: OpenIdAuthorizationCollection
             );
 
             SchemaBuilder.AlterIndexTable<OpenIdAuthorizationIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdAuthorization_AuthorizationId",
                     "DocumentId",
-                    nameof(OpenIdAuthorizationIndex.AuthorizationId),
-                    nameof(OpenIdAuthorizationIndex.Status),
-                    nameof(OpenIdAuthorizationIndex.Type),
-                    nameof(OpenIdAuthorizationIndex.CreationDate)),
+                    "AuthorizationId",
+                    "Status",
+                    "Type",
+                    "CreationDate"),
                 collection: OpenIdAuthorizationCollection
             );
 
@@ -411,72 +404,68 @@ namespace OrchardCore.OpenId.YesSql.Migrations
         {
             // Create all index tables with the new collection value.  
             SchemaBuilder.CreateMapIndexTable<OpenIdApplicationIndex>(table => table
-                .Column<string>(nameof(OpenIdApplicationIndex.ApplicationId), column => column.WithLength(48))
-                .Column<string>(nameof(OpenIdApplicationIndex.ClientId), column => column.Unique()),
+                .Column<string>("ApplicationId", column => column.WithLength(48))
+                .Column<string>("ClientId", column => column.Unique()),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdApplicationIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdApplication",
                     "DocumentId",
-                    nameof(OpenIdApplicationIndex.ApplicationId),
-                    nameof(OpenIdApplicationIndex.ClientId)),
+                    "ApplicationId",
+                    "ClientId"),
                 collection: OpenIdApplicationCollection
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri))
-                .Column<int>(nameof(OpenIdAppByLogoutUriIndex.Count)),
+                .Column<string>("LogoutRedirectUri")
+                .Column<int>("Count"),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByLogoutUriIndex>(table => table
-                .CreateIndex("IDX_COL_OpenIdAppByLogoutUri_LogoutRedirectUri",
-                    nameof(OpenIdAppByLogoutUriIndex.LogoutRedirectUri)),
+                .CreateIndex("IDX_COL_OpenIdAppByLogoutUri_LogoutRedirectUri", "LogoutRedirectUri"),
                 collection: OpenIdApplicationCollection
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRedirectUriIndex.RedirectUri))
-                .Column<int>(nameof(OpenIdAppByRedirectUriIndex.Count)),
+                .Column<string>("RedirectUri")
+                .Column<int>("Count"),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRedirectUriIndex>(table => table
-                .CreateIndex("IDX_COL_OpenIdAppByRedirectUri_RedirectUri",
-                    nameof(OpenIdAppByRedirectUriIndex.RedirectUri)),
+                .CreateIndex("IDX_COL_OpenIdAppByRedirectUri_RedirectUri", "RedirectUri"),
                 collection: OpenIdApplicationCollection
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .Column<string>(nameof(OpenIdAppByRoleNameIndex.RoleName))
-                .Column<int>(nameof(OpenIdAppByRoleNameIndex.Count)),
+                .Column<string>("RoleName")
+                .Column<int>("Count"),
                 collection: OpenIdApplicationCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdAppByRoleNameIndex>(table => table
-                .CreateIndex("IDX_COL_OpenIdAppByRoleName_RoleName",
-                    nameof(OpenIdAppByRoleNameIndex.RoleName)),
+                .CreateIndex("IDX_COL_OpenIdAppByRoleName_RoleName", "RoleName"),
                 collection: OpenIdApplicationCollection
             );
 
             SchemaBuilder.CreateMapIndexTable<OpenIdScopeIndex>(table => table
-                .Column<string>(nameof(OpenIdScopeIndex.Name), column => column.Unique())
-                .Column<string>(nameof(OpenIdScopeIndex.ScopeId), column => column.WithLength(48)),
+                .Column<string>("Name", column => column.Unique())
+                .Column<string>("ScopeId", column => column.WithLength(48)),
                 collection: OpenIdScopeCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdScopeIndex>(table => table
                 .CreateIndex("IDX_COL_OpenIdScope",
                     "DocumentId",
-                    nameof(OpenIdScopeIndex.Name),
-                    nameof(OpenIdScopeIndex.ScopeId)),
+                    "Name",
+                    "ScopeId"),
                 collection: OpenIdScopeCollection
             );
 
             SchemaBuilder.CreateReduceIndexTable<OpenIdScopeByResourceIndex>(table => table
-                .Column<string>(nameof(OpenIdScopeByResourceIndex.Resource))
-                .Column<int>(nameof(OpenIdScopeByResourceIndex.Count)),
+                .Column<string>("Resource")
+                .Column<int>("Count"),
                 collection: OpenIdScopeCollection);
 
             SchemaBuilder.AlterIndexTable<OpenIdScopeByResourceIndex>(table => table
-                .CreateIndex("IDX_COL_OpenIdScopeByResource_Resource",
-                    nameof(OpenIdScopeByResourceIndex.Resource)),
+                .CreateIndex("IDX_COL_OpenIdScopeByResource_Resource", "Resource"),
                 collection: OpenIdScopeCollection
             );
 


### PR DESCRIPTION
Fix #14338

@sebastienros  @jtkech  I did some tests on MySQL and all seems to be working as expected. I also did the same test with Sqlite.

After creating a tenant on MySQL I run this command `SHOW CREATE TABLE oc.textfieldindex`

And it returned as you can see the `246` length on the key

```
CREATE TABLE `textfieldindex` (
   `Id` bigint(20) NOT NULL AUTO_INCREMENT,
   `DocumentId` bigint(20) DEFAULT NULL,
   `ContentItemId` varchar(26) DEFAULT NULL,
   `ContentItemVersionId` varchar(26) DEFAULT NULL,
   `ContentType` varchar(255) DEFAULT NULL,
   `ContentPart` varchar(255) DEFAULT NULL,
   `ContentField` varchar(255) DEFAULT NULL,
   `Published` bit(1) DEFAULT NULL,
   `Latest` bit(1) DEFAULT NULL,
   `Text` varchar(766) DEFAULT NULL,
   `BigText` longtext DEFAULT NULL,
   PRIMARY KEY (`Id`),
   KEY `IDX_FK_TextFieldIndex` (`DocumentId`),
   KEY `IDX_TextFieldIndex_DocumentId` (`DocumentId`,`ContentItemId`,`ContentItemVersionId`,`Published`,`Latest`),
   KEY `IDX_TextFieldIndex_DocumentId_ContentType` (`DocumentId`,`ContentType`(246),`ContentPart`(246),`ContentField`(246),`Published`,`Latest`),
   CONSTRAINT `FK_TextFieldIndex` FOREIGN KEY (`DocumentId`) REFERENCES `document` (`Id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
```