### PR TITLE
Invalidate cache on updating store

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
@@ -186,7 +186,7 @@ namespace OrchardCore.Documents
             {
                 await DocumentStore.UpdateAsync(document, async document =>
                 {
-                    await SetInternalAsync(document);
+                    await InvalidateInternalAsync(document);
 
                     if (afterUpdateAsync != null)
                     {
@@ -204,7 +204,7 @@ namespace OrchardCore.Documents
             // But still update the shared cache after committing.
             DocumentStore.AfterCommitSuccess<TDocument>(async () =>
             {
-                await SetInternalAsync(document);
+                await InvalidateInternalAsync(document);
 
                 if (afterUpdateAsync != null)
                 {
@@ -349,6 +349,18 @@ namespace OrchardCore.Documents
                         _memoryCache.Remove(_options.CacheIdKey);
                     }
                 }
+            }
+        }
+
+        protected async Task InvalidateInternalAsync(TDocument document, bool failover = false)
+        {
+            if (_isDistributed)
+            {
+                await _distributedCache.RemoveAsync(_options.CacheIdKey);
+            }
+            else
+            {
+                _memoryCache.Remove(_options.CacheIdKey);
             }
         }
 

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
@@ -99,7 +99,7 @@ namespace OrchardCore.Documents
 
                 document.Identifier ??= IdGenerator.GenerateId();
 
-                await SetInternalAsync(document);
+                await InvalidateInternalAsync(document);
 
                 if (delegates.AfterUpdateDelegateAsync != null)
                 {


### PR DESCRIPTION
Fixes #14574 

This in place of setting the shared cache, so that if between 2 updates the document store is eagerly committed, it doesn't fail on `Can't load for update a cached object`.

This is closer to the original pattern, we didn't do it for perf reason and because we also have a consistency checking that would no longer be necessary on updating the store.

The instance that updated the document will trigger a database query on a next demand but only once.

