### PR TITLE
Initialize logger for Yes SQL to enable logging

### DIFF
--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Data;
 using System.IO;
 using System.Linq;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Data;
 using OrchardCore.Data.Documents;
@@ -101,7 +102,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     {
                         var tablePrefix = shellSettings["TablePrefix"].Trim() + databaseTableOptions.TableNameSeparator;
 
-                        storeConfiguration = storeConfiguration.SetTablePrefix(tablePrefix);
+                        storeConfiguration.SetTablePrefix(tablePrefix);
                     }
 
                     var store = StoreFactory.Create(storeConfiguration);
@@ -170,7 +171,7 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
-        private static IConfiguration GetStoreConfiguration(IServiceProvider sp, YesSqlOptions yesSqlOptions, DatabaseTableOptions databaseTableOptions)
+        private static YesSql.Configuration GetStoreConfiguration(IServiceProvider sp, YesSqlOptions yesSqlOptions, DatabaseTableOptions databaseTableOptions)
         {
             var tableNameFactory = sp.GetRequiredService<ITableNameConventionFactory>();
 
@@ -181,6 +182,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 ContentSerializer = new PoolingJsonContentSerializer(sp.GetService<ArrayPool<char>>()),
                 TableNameConvention = tableNameFactory.Create(databaseTableOptions),
                 IdentityColumnSize = Enum.Parse<IdentityColumnSize>(databaseTableOptions.IdentityColumnSize),
+                Logger = sp.GetService<ILogger<YesSql.Configuration>>(),
             };
 
             if (yesSqlOptions.IdGenerator != null)

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -174,6 +174,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private static YesSql.Configuration GetStoreConfiguration(IServiceProvider sp, YesSqlOptions yesSqlOptions, DatabaseTableOptions databaseTableOptions)
         {
             var tableNameFactory = sp.GetRequiredService<ITableNameConventionFactory>();
+            var loggerFactory = sp.GetRequiredService<ILoggerFactory>();
 
             var storeConfiguration = new YesSql.Configuration
             {
@@ -182,7 +183,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 ContentSerializer = new PoolingJsonContentSerializer(sp.GetService<ArrayPool<char>>()),
                 TableNameConvention = tableNameFactory.Create(databaseTableOptions),
                 IdentityColumnSize = Enum.Parse<IdentityColumnSize>(databaseTableOptions.IdentityColumnSize),
-                Logger = sp.GetService<ILogger<YesSql.Configuration>>(),
+                Logger = loggerFactory.CreateLogger("YesSql"),
             };
 
             if (yesSqlOptions.IdGenerator != null)


### PR DESCRIPTION
Fix #14658

`YesSql` by default will following the logging level we are using in the app because of `*` directive used in the NLog.config file https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Cms.Web/NLog.config#L27


If you want to write Debug info from YesSql only, you may add this line to the `rules` section of your NLog file.

```
<logger name="YesSql" minlevel="Debug" writeTo="file" />
```