### PR TITLE
Adding helpful methods for ContentPart, ContentType builders and Cont…

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
@@ -6,6 +6,39 @@ namespace OrchardCore.ContentManagement
 {
     public static class ContentItemExtensions
     {
+        public static bool TryGet<TPart>(this ContentItem contentItem, out TPart part) where TPart : ContentPart
+            => contentItem.TryGet(typeof(TPart).Name, out part);
+
+        public static bool TryGet<TPart>(this ContentItem contentItem, string name, out TPart part) where TPart : ContentPart
+        {
+            ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
+
+            try
+            {
+                part = contentItem.Get<TPart>(name);
+            }
+            catch
+            {
+                part = null;
+            }
+
+            return part != null;
+        }
+
+        public static bool TryGet(this ContentItem contentItem, Type contentElementType, string name, out ContentElement part)
+        {
+            try
+            {
+                part = contentItem.Get(contentElementType, name);
+            }
+            catch
+            {
+                part = null;
+            }
+
+            return part != null;
+        }
+
         /// <summary>
         /// Gets a content part by its type.
         /// </summary>
@@ -111,7 +144,7 @@ namespace OrchardCore.ContentManagement
             contentItem.Data.Merge(props, jsonMergeSettings);
             contentItem.Elements.Clear();
 
-            // Return to original value or it will be interpreated as a different object by YesSql.
+            // Return to original value or it will be interpreted as a different object by YesSql.
             contentItem.Id = originalDocumentId;
 
             // After merging content here we need to remove all the well known properties from the Data jObject

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
@@ -6,9 +6,24 @@ namespace OrchardCore.ContentManagement
 {
     public static class ContentItemExtensions
     {
+        /// <summary>
+        /// Tries to get a content part by its type.
+        /// </summary>
+        /// <typeparam name="TPart">The type of the content part.</typeparam>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <param name="part">The <see cref="ContentPart"/> if one existed.</param>
+        /// <returns>true if a part found, otherwise false.</returns>
         public static bool TryGet<TPart>(this ContentItem contentItem, out TPart part) where TPart : ContentPart
             => contentItem.TryGet(typeof(TPart).Name, out part);
 
+        /// <summary>
+        /// Tries to get a content part by its type.
+        /// </summary>
+        /// <typeparam name="TPart">The type of the content part.</typeparam>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <param name="name">The name of the content part.</param>
+        /// <param name="part">The <see cref="ContentPart"/> if one existed.</param>
+        /// <returns>true if a part found, otherwise false.</returns>
         public static bool TryGet<TPart>(this ContentItem contentItem, string name, out TPart part) where TPart : ContentPart
         {
             ArgumentException.ThrowIfNullOrEmpty(name, nameof(name));
@@ -25,6 +40,14 @@ namespace OrchardCore.ContentManagement
             return part != null;
         }
 
+        /// <summary>
+        /// Tries to get a content part by its type.
+        /// </summary>
+        /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
+        /// <param name="contentElementType">The type of the content part.</param>
+        /// <param name="name">The name of the content part.</param>
+        /// <param name="part">The <see cref="ContentPart"/> if one existed.</param>
+        /// <returns>true if a part found, otherwise false.</returns>
         public static bool TryGet(this ContentItem contentItem, Type contentElementType, string name, out ContentElement part)
         {
             try
@@ -46,9 +69,7 @@ namespace OrchardCore.ContentManagement
         /// <typeparam name="TPart">The type of the content part.</typeparam>
         /// <returns>The content part or <code>null</code> if it doesn't exist.</returns>
         public static TPart As<TPart>(this ContentItem contentItem) where TPart : ContentPart
-        {
-            return contentItem.Get<TPart>(typeof(TPart).Name);
-        }
+            => contentItem.Get<TPart>(typeof(TPart).Name);
 
         /// <summary>
         /// Gets a content part by its type or create a new one.
@@ -57,9 +78,7 @@ namespace OrchardCore.ContentManagement
         /// <typeparam name="TPart">The type of the content part.</typeparam>
         /// <returns>The content part instance or a new one if it doesn't exist.</returns>
         public static TPart GetOrCreate<TPart>(this ContentItem contentItem) where TPart : ContentPart, new()
-        {
-            return contentItem.GetOrCreate<TPart>(typeof(TPart).Name);
-        }
+            => contentItem.GetOrCreate<TPart>(typeof(TPart).Name);
 
         /// <summary>
         /// Removes a content part by its type.
@@ -67,9 +86,7 @@ namespace OrchardCore.ContentManagement
         /// <param name="contentItem">The <see cref="ContentItem"/>.</param>
         /// <typeparam name="TPart">The type of the content part.</typeparam>
         public static void Remove<TPart>(this ContentItem contentItem) where TPart : ContentPart, new()
-        {
-            contentItem.Remove(typeof(TPart).Name);
-        }
+            => contentItem.Remove(typeof(TPart).Name);
 
         /// <summary>
         /// Adds a content part by its type.
@@ -81,6 +98,7 @@ namespace OrchardCore.ContentManagement
         public static ContentItem Weld<TPart>(this ContentItem contentItem, TPart part) where TPart : ContentPart
         {
             contentItem.Weld(typeof(TPart).Name, part);
+
             return contentItem;
         }
 
@@ -94,6 +112,7 @@ namespace OrchardCore.ContentManagement
         public static ContentItem Apply<TPart>(this ContentItem contentItem, TPart part) where TPart : ContentPart
         {
             contentItem.Apply(typeof(TPart).Name, part);
+
             return contentItem;
         }
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             if (existing == null)
             {
                 _fields = new List<ContentPartFieldDefinition>();
-                _settings = new JObject();
+                _settings = [];
             }
             else
             {
@@ -106,10 +106,7 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
 
         public ContentPartDefinitionBuilder WithSettings<T>(T settings)
         {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
+            ArgumentNullException.ThrowIfNull(settings, nameof(settings));
 
             var jObject = JObject.FromObject(settings, ContentBuilderSettings.IgnoreDefaultValuesSerializer);
             _settings[typeof(T).Name] = jObject;
@@ -118,16 +115,11 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
         }
 
         public ContentPartDefinitionBuilder WithField(string fieldName)
-        {
-            return WithField(fieldName, configuration => { });
-        }
+            => WithField(fieldName, configuration => { });
 
         public ContentPartDefinitionBuilder WithField(string fieldName, Action<ContentPartFieldDefinitionBuilder> configuration)
         {
-            if (string.IsNullOrWhiteSpace(fieldName))
-            {
-                throw new ArgumentException($"'{nameof(fieldName)}' cannot be null or empty.");
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(fieldName, nameof(fieldName));
 
             var existingField = _fields.FirstOrDefault(x => string.Equals(x.Name, fieldName, StringComparison.OrdinalIgnoreCase));
             if (existingField != null)
@@ -151,12 +143,25 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             return this;
         }
 
+        public ContentPartDefinitionBuilder WithField<TField>(string fieldName, Action<ContentPartFieldDefinitionBuilder> configuration)
+            => WithField(fieldName, part =>
+            {
+                configuration(part);
+
+                part.OfType(typeof(TField).Name);
+            });
+
+        public Task<ContentPartDefinitionBuilder> WithFieldAsync<TField>(string fieldName, Func<ContentPartFieldDefinitionBuilder, Task> configuration)
+            => WithFieldAsync(fieldName, async part =>
+            {
+                await configuration(part);
+
+                part.OfType(typeof(TField).Name);
+            });
+
         public async Task<ContentPartDefinitionBuilder> WithFieldAsync(string fieldName, Func<ContentPartFieldDefinitionBuilder, Task> configurationAsync)
         {
-            if (string.IsNullOrWhiteSpace(fieldName))
-            {
-                throw new ArgumentException($"'{nameof(fieldName)}' cannot be null or empty.");
-            }
+            ArgumentException.ThrowIfNullOrWhiteSpace(fieldName, nameof(fieldName));
 
             var existingField = _fields.FirstOrDefault(x => string.Equals(x.Name, fieldName, StringComparison.OrdinalIgnoreCase));
 
@@ -214,19 +219,14 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             }
 
             public override string Name
-            {
-                get { return _fieldName; }
-            }
+                => _fieldName;
 
             public override string FieldType
-            {
-                get { return _fieldDefinition.Name; }
-            }
+                => _fieldDefinition.Name;
+
 
             public override string PartName
-            {
-                get { return _partDefinition.Name; }
-            }
+                => _partDefinition.Name;
 
             public override ContentPartFieldDefinitionBuilder OfType(ContentFieldDefinition fieldDefinition)
             {

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
@@ -143,20 +143,23 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             return this;
         }
 
-        public ContentPartDefinitionBuilder WithField<TField>(string fieldName, Action<ContentPartFieldDefinitionBuilder> configuration)
-            => WithField(fieldName, part =>
-            {
-                configuration(part);
+        public ContentPartDefinitionBuilder WithField<TField>(string fieldName)
+            => WithField(fieldName, configuration => configuration.OfType(typeof(TField).Name));
 
-                part.OfType(typeof(TField).Name);
+        public ContentPartDefinitionBuilder WithField<TField>(string fieldName, Action<ContentPartFieldDefinitionBuilder> configuration)
+            => WithField(fieldName, field =>
+            {
+                configuration(field);
+
+                field.OfType(typeof(TField).Name);
             });
 
         public Task<ContentPartDefinitionBuilder> WithFieldAsync<TField>(string fieldName, Func<ContentPartFieldDefinitionBuilder, Task> configuration)
-            => WithFieldAsync(fieldName, async part =>
+            => WithFieldAsync(fieldName, async field =>
             {
-                await configuration(part);
+                await configuration(field);
 
-                part.OfType(typeof(TField).Name);
+                field.OfType(typeof(TField).Name);
             });
 
         public async Task<ContentPartDefinitionBuilder> WithFieldAsync(string fieldName, Func<ContentPartFieldDefinitionBuilder, Task> configurationAsync)

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
         private readonly IList<ContentTypePartDefinition> _parts;
         private readonly JObject _settings;
 
-        public ContentTypeDefinition Current { get; private set; }
+        public ContentTypeDefinition Current { get; }
 
         public ContentTypeDefinitionBuilder()
             : this(new ContentTypeDefinition(null, null))
@@ -29,7 +29,7 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             if (existing == null)
             {
                 _parts = new List<ContentTypePartDefinition>();
-                _settings = new JObject();
+                _settings = [];
             }
             else
             {
@@ -123,24 +123,25 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
         }
 
         public ContentTypeDefinitionBuilder WithPart(string partName)
-        {
-            return WithPart(partName, configuration => { });
-        }
+            => WithPart(partName, configuration => { });
 
         public ContentTypeDefinitionBuilder WithPart(string name, string partName)
-        {
-            return WithPart(name, new ContentPartDefinition(partName), configuration => { });
-        }
+            => WithPart(name, new ContentPartDefinition(partName), configuration => { });
 
         public ContentTypeDefinitionBuilder WithPart(string name, string partName, Action<ContentTypePartDefinitionBuilder> configuration)
-        {
-            return WithPart(name, new ContentPartDefinition(partName), configuration);
-        }
+            => WithPart(name, new ContentPartDefinition(partName), configuration);
+
+        public ContentTypeDefinitionBuilder WithPart<TPart>() where TPart : ContentPart
+            => WithPart(typeof(TPart).Name, configuration => { });
+
+        public ContentTypeDefinitionBuilder WithPart<TPart>(string name) where TPart : ContentPart
+            => WithPart(name, new ContentPartDefinition(typeof(TPart).Name), configuration => { });
+
+        public ContentTypeDefinitionBuilder WithPart<TPart>(string name, Action<ContentTypePartDefinitionBuilder> configuration) where TPart : ContentPart
+            => WithPart(name, new ContentPartDefinition(typeof(TPart).Name), configuration);
 
         public ContentTypeDefinitionBuilder WithPart(string partName, Action<ContentTypePartDefinitionBuilder> configuration)
-        {
-            return WithPart(partName, new ContentPartDefinition(partName), configuration);
-        }
+            => WithPart(partName, new ContentPartDefinition(partName), configuration);
 
         public ContentTypeDefinitionBuilder WithPart(string name, ContentPartDefinition partDefinition, Action<ContentTypePartDefinitionBuilder> configuration)
         {
@@ -164,14 +165,10 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
         }
 
         public Task<ContentTypeDefinitionBuilder> WithPartAsync(string name, string partName, Func<ContentTypePartDefinitionBuilder, Task> configurationAsync)
-        {
-            return WithPartAsync(name, new ContentPartDefinition(partName), configurationAsync);
-        }
+            => WithPartAsync(name, new ContentPartDefinition(partName), configurationAsync);
 
         public Task<ContentTypeDefinitionBuilder> WithPartAsync(string partName, Func<ContentTypePartDefinitionBuilder, Task> configurationAsync)
-        {
-            return WithPartAsync(partName, new ContentPartDefinition(partName), configurationAsync);
-        }
+            => WithPartAsync(partName, new ContentPartDefinition(partName), configurationAsync);
 
         public async Task<ContentTypeDefinitionBuilder> WithPartAsync(string name, ContentPartDefinition partDefinition, Func<ContentTypePartDefinitionBuilder, Task> configurationAsync)
         {
@@ -183,7 +180,7 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             }
             else
             {
-                existingPart = new ContentTypePartDefinition(name, partDefinition, new JObject())
+                existingPart = new ContentTypePartDefinition(name, partDefinition, [])
                 {
                     ContentTypeDefinition = Current,
                 };

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
@@ -128,18 +128,6 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
         public ContentTypeDefinitionBuilder WithPart(string name, string partName)
             => WithPart(name, new ContentPartDefinition(partName), configuration => { });
 
-        public ContentTypeDefinitionBuilder WithPart(string name, string partName, Action<ContentTypePartDefinitionBuilder> configuration)
-            => WithPart(name, new ContentPartDefinition(partName), configuration);
-
-        public ContentTypeDefinitionBuilder WithPart<TPart>() where TPart : ContentPart
-            => WithPart(typeof(TPart).Name, configuration => { });
-
-        public ContentTypeDefinitionBuilder WithPart<TPart>(string name) where TPart : ContentPart
-            => WithPart(name, new ContentPartDefinition(typeof(TPart).Name), configuration => { });
-
-        public ContentTypeDefinitionBuilder WithPart<TPart>(string name, Action<ContentTypePartDefinitionBuilder> configuration) where TPart : ContentPart
-            => WithPart(name, new ContentPartDefinition(typeof(TPart).Name), configuration);
-
         public ContentTypeDefinitionBuilder WithPart(string partName, Action<ContentTypePartDefinitionBuilder> configuration)
             => WithPart(partName, new ContentPartDefinition(partName), configuration);
 
@@ -163,6 +151,18 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             _parts.Add(configurer.Build());
             return this;
         }
+
+        public ContentTypeDefinitionBuilder WithPart(string name, string partName, Action<ContentTypePartDefinitionBuilder> configuration)
+            => WithPart(name, new ContentPartDefinition(partName), configuration);
+
+        public ContentTypeDefinitionBuilder WithPart<TPart>() where TPart : ContentPart
+            => WithPart(typeof(TPart).Name, configuration => { });
+
+        public ContentTypeDefinitionBuilder WithPart<TPart>(string name) where TPart : ContentPart
+            => WithPart(name, new ContentPartDefinition(typeof(TPart).Name), configuration => { });
+
+        public ContentTypeDefinitionBuilder WithPart<TPart>(string name, Action<ContentTypePartDefinitionBuilder> configuration) where TPart : ContentPart
+            => WithPart(name, new ContentPartDefinition(typeof(TPart).Name), configuration);
 
         public Task<ContentTypeDefinitionBuilder> WithPartAsync(string name, string partName, Func<ContentTypePartDefinitionBuilder, Task> configurationAsync)
             => WithPartAsync(name, new ContentPartDefinition(partName), configurationAsync);

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Entities/EntityExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Entities/EntityExtensions.cs
@@ -55,13 +55,23 @@ namespace OrchardCore.Entities
         /// <param name="name">The name of the property to check.</param>
         /// <returns>True if the property was found, otherwise false.</returns>
         public static bool Has(this IEntity entity, string name)
-        {
-            return entity.Properties[name] != null;
-        }
+            => entity.Properties[name] != null;
 
         public static IEntity Put<T>(this IEntity entity, T aspect) where T : new()
+            => entity.Put(typeof(T).Name, aspect);
+
+        public static bool TryGet<T>(this IEntity entity, out T aspect) where T : new()
         {
-            return entity.Put(typeof(T).Name, aspect);
+            if (entity.Properties.TryGetValue(typeof(T).Name, out var value))
+            {
+                aspect = value.ToObject<T>();
+
+                return true;
+            }
+
+            aspect = default;
+
+            return false;
         }
 
         public static IEntity Put(this IEntity entity, string name, object property)


### PR DESCRIPTION
Adding
- ContentPartDefinitionBuilder
  -  `ContentPartDefinitionBuilder WithField<TField>(string fieldName)`
  - `ContentPartDefinitionBuilder WithField<TField>(string fieldName, Action<ContentPartFieldDefinitionBuilder> configuration)`
  - `Task<ContentPartDefinitionBuilder> WithFieldAsync<TField>(string fieldName, Func<ContentPartFieldDefinitionBuilder, Task> configuration)`

- ContentTypeDefinitionBuilder
  - `ContentTypeDefinitionBuilder WithPart<TPart>()`
  - `ContentTypeDefinitionBuilder WithPart<TPart>(string name)`
  - `ContentTypeDefinitionBuilder WithPart<TPart>(string name, Action<ContentTypePartDefinitionBuilder> configuration)`

- ContentItemExtensions
  - `bool TryGet<TPart>(this ContentItem contentItem, out TPart part)`
  - `bool TryGet<TPart>(this ContentItem contentItem, string name, out TPart part)`
  - `bool TryGet(this ContentItem contentItem, Type contentElementType, string name, out ContentElement part)`

- EntityExtensions
   - `bool TryGet<T>(this IEntity entity, out T aspect)`