### PR TITLE
Revert Microsoft.SourceLink.GitHub update

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -38,7 +38,7 @@
     <PackageManagement Include="MessagePack" Version="2.2.60" />
     <PackageManagement Include="Microsoft.Identity.Web" Version="2.15.3" />
     <PackageManagement Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageManagement Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageManagement Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageManagement Include="MimeKit" Version="4.3.0" />
     <PackageManagement Include="MiniProfiler.AspNetCore.Mvc" Version="4.3.8" />
     <PackageManagement Include="Moq" Version="4.20.69" />

--- a/src/docs/resources/libraries/README.md
+++ b/src/docs/resources/libraries/README.md
@@ -27,7 +27,7 @@ The below table lists the different .NET libraries used in Orchard Core:
 | [Markdig](https://github.com/lunet-io/markdig) | .NET Markdown engine. | 0.33.0 | [BSD-2-Clause](https://github.com/lunet-io/markdig/blob/master/license.txt) |
 | [MessagePack](https://github.com/neuecc/MessagePack-CSharp) | Extremely Fast MessagePack Serializer for C# | 2.2.60 | [MIT](https://github.com/neuecc/MessagePack-CSharp/blob/master/LICENSE) |
 | [Microsoft.Identity.Web](https://github.com/AzureAD/microsoft-identity-web) | Helps creating protected web apps and web APIs with Microsoft identity platform and Azure AD B2C. | 2.15.3 | [MIT](https://github.com/AzureAD/microsoft-identity-web/blob/master/LICENSE) |
-| [Microsoft.SourceLink.GitHub](https://github.com/dotnet/sourcelink) | Source Link enables a great source debugging experience. | 8.0.0 | [MIT](https://github.com/dotnet/sourcelink/blob/main/License.txt) |
+| [Microsoft.SourceLink.GitHub](https://github.com/dotnet/sourcelink) | Source Link enables a great source debugging experience. | 1.1.1 | [MIT](https://github.com/dotnet/sourcelink/blob/main/License.txt) |
 | [MimeKit](https://github.com/jstedfast/MailKit) | A cross-platform .NET library for IMAP, POP3, and SMTP. | 4.3.0 | [MIT](https://github.com/jstedfast/MailKit/blob/master/LICENSE) |
 | [MiniProfiler](https://github.com/MiniProfiler/dotnet) | A simple but effective mini-profiler for ASP.NET (and Core) websites | 4.3.8 | [MIT](https://github.com/MiniProfiler/dotnet/blob/main/LICENSE.txt) |
 | [NCrontab](https://github.com/atifaziz/NCrontab) | Crontab for .NET | 3.3.3 | [Apache-2.0](https://github.com/atifaziz/NCrontab/blob/master/COPYING.txt) |


### PR DESCRIPTION
I just noticed that PR #14714 failed on Windows only for an unknown reason. Here is the actions list https://github.com/OrchardCMS/OrchardCore/actions/runs/6905925179

The merged PRs afterward are failing too. I'm not sure if the main reason is upgrading the package - which is weird - or the git workflow changes

/cc @MikeAlhayek @jtkech 