### PR TITLE
Should not invalidate the cache of a Volatile Document.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
@@ -1,13 +1,9 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
-using OrchardCore.Data.Documents;
 using OrchardCore.DisplayManagement.ModelBinding;
-using OrchardCore.Environment.Shell.Scope;
-using OrchardCore.Settings;
 
 namespace OrchardCore.Contents.Controllers
 {
@@ -32,19 +28,6 @@ namespace OrchardCore.Contents.Controllers
 
         public async Task<IActionResult> Display(string contentItemId, string jsonPath)
         {
-            //var siteService = ShellScope.Services.GetService<ISiteService>();
-            //var documentStore = ShellScope.Services.GetService<IDocumentStore>();
-
-            //var siteSettings = await siteService.LoadSiteSettingsAsync();
-            //await siteService.UpdateSiteSettingsAsync(siteSettings);
-
-            //await documentStore.CommitAsync();
-
-            //siteSettings = await siteService.LoadSiteSettingsAsync();
-            //await siteService.UpdateSiteSettingsAsync(siteSettings);
-
-            // await documentStore.CommitAsync();
-
             var contentItem = await _contentManager.GetAsync(contentItemId, jsonPath);
 
             if (contentItem == null)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/ItemController.cs
@@ -1,9 +1,13 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
+using OrchardCore.Data.Documents;
 using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.Environment.Shell.Scope;
+using OrchardCore.Settings;
 
 namespace OrchardCore.Contents.Controllers
 {
@@ -28,6 +32,19 @@ namespace OrchardCore.Contents.Controllers
 
         public async Task<IActionResult> Display(string contentItemId, string jsonPath)
         {
+            //var siteService = ShellScope.Services.GetService<ISiteService>();
+            //var documentStore = ShellScope.Services.GetService<IDocumentStore>();
+
+            //var siteSettings = await siteService.LoadSiteSettingsAsync();
+            //await siteService.UpdateSiteSettingsAsync(siteSettings);
+
+            //await documentStore.CommitAsync();
+
+            //siteSettings = await siteService.LoadSiteSettingsAsync();
+            //await siteService.UpdateSiteSettingsAsync(siteSettings);
+
+            // await documentStore.CommitAsync();
+
             var contentItem = await _contentManager.GetAsync(contentItemId, jsonPath);
 
             if (contentItem == null)

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Documents/DocumentStore.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Documents/DocumentStore.cs
@@ -21,7 +21,6 @@ namespace OrchardCore.Data.Documents
         private DocumentStoreCommitFailureDelegate _afterCommitFailure;
 
         private bool _canceled;
-        private bool _committed;
 
         public DocumentStore(ISession session)
         {
@@ -54,27 +53,10 @@ namespace OrchardCore.Data.Documents
                 return (false, loaded as T);
             }
 
-            T document = null;
-
-            // For consistency checking a document may be queried after 'SaveChangesAsync()'.
-            if (_committed)
+            var document = await _session.Query<T>().FirstOrDefaultAsync();
+            if (document is not null)
             {
-                // So we create a new session to not get a cached version from 'YesSql'.
-                await using var session = _session.Store.CreateSession();
-                document = await session.Query<T>().FirstOrDefaultAsync();
-            }
-            else
-            {
-                document = await _session.Query<T>().FirstOrDefaultAsync();
-            }
-
-            if (document != null)
-            {
-                if (!_committed)
-                {
-                    _session.Detach(document);
-                }
-
+                _session.Detach(document);
                 return (true, document);
             }
 
@@ -131,7 +113,7 @@ namespace OrchardCore.Data.Documents
         /// <inheritdoc />
         public async Task CommitAsync()
         {
-            if (_session == null)
+            if (_session is null)
             {
                 return;
             }
@@ -140,10 +122,9 @@ namespace OrchardCore.Data.Documents
             {
                 await _session.SaveChangesAsync();
 
-                _committed = true;
                 _loaded.Clear();
 
-                if (!_canceled && _afterCommitSuccess != null)
+                if (!_canceled && _afterCommitSuccess is not null)
                 {
                     foreach (var d in _afterCommitSuccess.GetInvocationList())
                     {
@@ -153,7 +134,7 @@ namespace OrchardCore.Data.Documents
             }
             catch (ConcurrencyException exception)
             {
-                if (_afterCommitFailure != null)
+                if (_afterCommitFailure is not null)
                 {
                     foreach (var d in _afterCommitFailure.GetInvocationList())
                     {

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
@@ -204,7 +204,7 @@ namespace OrchardCore.Documents
             // But still update the shared cache after committing.
             DocumentStore.AfterCommitSuccess<TDocument>(async () =>
             {
-                await InvalidateInternalAsync(document);
+                await SetInternalAsync(document);
 
                 if (afterUpdateAsync != null)
                 {

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
@@ -52,7 +52,7 @@ namespace OrchardCore.Documents
             get
             {
                 var documentStore = (IDocumentStore)ShellScope.Get(DocumentStoreServiceType);
-                if (documentStore == null)
+                if (documentStore is null)
                 {
                     documentStore = (IDocumentStore)ShellScope.Services.GetRequiredService(DocumentStoreServiceType);
                     ShellScope.Set(DocumentStoreServiceType, documentStore);
@@ -78,7 +78,7 @@ namespace OrchardCore.Documents
             else
             {
                 var volatileCache = ShellScope.Get<TDocument>(typeof(TDocument));
-                if (volatileCache != null)
+                if (volatileCache is not null)
                 {
                     document = volatileCache;
                 }
@@ -133,7 +133,7 @@ namespace OrchardCore.Documents
                 });
             }
 
-            if (document == null)
+            if (document is null)
             {
                 var cacheable = true;
 
@@ -186,6 +186,7 @@ namespace OrchardCore.Documents
             {
                 await DocumentStore.UpdateAsync(document, async document =>
                 {
+                    // A non volatile document can be invalidated.
                     await InvalidateInternalAsync(document);
 
                     if (afterUpdateAsync != null)
@@ -204,9 +205,10 @@ namespace OrchardCore.Documents
             // But still update the shared cache after committing.
             DocumentStore.AfterCommitSuccess<TDocument>(async () =>
             {
+                // A volatile document can't be invalidated.
                 await SetInternalAsync(document);
 
-                if (afterUpdateAsync != null)
+                if (afterUpdateAsync is not null)
                 {
                     await afterUpdateAsync(document);
                 }
@@ -239,7 +241,7 @@ namespace OrchardCore.Documents
                 id = _memoryCache.Get<string>(_options.CacheIdKey);
             }
 
-            if (id == null)
+            if (id is null)
             {
                 return null;
             }
@@ -279,7 +281,7 @@ namespace OrchardCore.Documents
 
             document = await GetFromDistributedCacheAsync();
 
-            if (document == null)
+            if (document is null)
             {
                 return null;
             }
@@ -340,14 +342,7 @@ namespace OrchardCore.Documents
 
                 if (stored.Identifier != document.Identifier)
                 {
-                    if (_isDistributed)
-                    {
-                        await _distributedCache.RemoveAsync(_options.CacheIdKey);
-                    }
-                    else
-                    {
-                        _memoryCache.Remove(_options.CacheIdKey);
-                    }
+                    await InvalidateInternalAsync(document);
                 }
             }
         }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
@@ -99,7 +99,7 @@ namespace OrchardCore.Documents
 
                 document.Identifier ??= IdGenerator.GenerateId();
 
-                await InvalidateInternalAsync(document);
+                await SetInternalAsync(document);
 
                 if (delegates.AfterUpdateDelegateAsync != null)
                 {

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
@@ -99,6 +99,7 @@ namespace OrchardCore.Documents
 
                 document.Identifier ??= IdGenerator.GenerateId();
 
+                // A volatile document can't be invalidated.
                 await SetInternalAsync(document);
 
                 if (delegates.AfterUpdateDelegateAsync != null)

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
@@ -63,7 +63,7 @@ namespace OrchardCore.Documents
                 delegates.UpdateDelegateAsync += updateDelegate;
             }
 
-            if (afterUpdateAsync != null)
+            if (afterUpdateAsync is not null)
             {
                 var afterUpdateDelegate = new AfterUpdateDelegate(afterUpdateAsync);
                 if (delegates.Targets.Add(afterUpdateDelegate.Target))
@@ -92,7 +92,7 @@ namespace OrchardCore.Documents
                     document = await ((UpdateDelegate)d)();
                 }
 
-                if (document == null)
+                if (document is null)
                 {
                     return;
                 }
@@ -102,7 +102,7 @@ namespace OrchardCore.Documents
                 // A volatile document can't be invalidated.
                 await SetInternalAsync(document);
 
-                if (delegates.AfterUpdateDelegateAsync != null)
+                if (delegates.AfterUpdateDelegateAsync is not null)
                 {
                     foreach (var d in delegates.AfterUpdateDelegateAsync.GetInvocationList())
                     {
@@ -116,7 +116,7 @@ namespace OrchardCore.Documents
         {
             public UpdateDelegate UpdateDelegateAsync;
             public AfterUpdateDelegate AfterUpdateDelegateAsync;
-            public HashSet<object> Targets = new();
+            public HashSet<object> Targets = [];
         }
     }
 }


### PR DESCRIPTION
Since #14612 we no longer set the cache but invalidate it on updating.

- That's okay for a non Volatile document, so here it is still only invalidated.

- But a Volatile document like `LayerState` is never persisted, so it can't be retrieved from a given store. So here, for a Volatile document we no longer invalidate the cache but set it as before.

    Currently if we move a widget to another layer zone, we have to reload the tenant.


- In `DocumentStore` I also did a cleanup related to consistency checking on updating which is now less useful and because in a rare use case, but possible as we saw in #14574, I had a database dead lock that this change fixed.
