### PR TITLE
Fix multi-targeting file locks

### DIFF
--- a/.github/workflows/mac_unit_test_ci.yml
+++ b/.github/workflows/mac_unit_test_ci.yml
@@ -13,5 +13,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build and test
       run: |
-        dotnet build -c Release -f net8.0
+        dotnet build -c Release
         dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -26,7 +26,7 @@ jobs:
         dotnet-version: '8.0.x'
     - name: Build
       run: |
-        dotnet build -c Release -f net8.0
+        dotnet build -c Release
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 16368 ))" >> $GITHUB_ENV
     - name: Build
       run: |
-        dotnet build -c Release -f net8.0
+        dotnet build -c Release
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -41,7 +41,7 @@ jobs:
       run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 15471 ))" >> $GITHUB_ENV
     - name: Build
       run: |
-        dotnet build -c Release -f net8.0 -p:Version=${{ steps.get_version.outputs.VERSION }}
+        dotnet build -c Release -p:Version=${{ steps.get_version.outputs.VERSION }}
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -9,7 +9,7 @@
 
     <!-- TFMs used to build the abstractions and modules, by convention the default TFM is at the first position -->
     <!-- In a cross-targeting build, some assets are only copied on the first TFM, by convention the default TFM -->
-    <CommonTargetFrameworks Condition="'$(CommonTargetFrameworks)' == ''">net8.0</CommonTargetFrameworks>
+    <CommonTargetFrameworks Condition="'$(CommonTargetFrameworks)' == ''">net8.0;net7.0</CommonTargetFrameworks>
   </PropertyGroup>
 
   <!-- Detect if the solution is opened in VS to limit the TFMs that are analyzed by Roslyn for performance reasons -->
@@ -26,10 +26,10 @@
 
   <!-- When dual-targeting frameworks, add both of them to CommonTargetFrameworks above, when add PropertyGroups like
   below. -->
-  <!--<PropertyGroup Condition="$(TargetFramework) == 'net7.0'">
+  <PropertyGroup Condition="$(TargetFramework) == 'net7.0'">
     <AspNetCorePackagesVersion>7.0.14</AspNetCorePackagesVersion>
     <MicrosoftExtensionsPackagesVersion>7.0.14</MicrosoftExtensionsPackagesVersion>
-  </PropertyGroup>-->
+  </PropertyGroup>
 
   <!-- 'Microsoft.AspNetCore' packages that are not included in the ASP.NET Core shared framework -->
   <ItemGroup>

--- a/src/OrchardCore.Build/Dependencies.AspNetCore.props
+++ b/src/OrchardCore.Build/Dependencies.AspNetCore.props
@@ -9,7 +9,7 @@
 
     <!-- TFMs used to build the abstractions and modules, by convention the default TFM is at the first position -->
     <!-- In a cross-targeting build, some assets are only copied on the first TFM, by convention the default TFM -->
-    <CommonTargetFrameworks Condition="'$(CommonTargetFrameworks)' == ''">net8.0;net7.0</CommonTargetFrameworks>
+    <CommonTargetFrameworks Condition="'$(CommonTargetFrameworks)' == ''">net8.0</CommonTargetFrameworks>
   </PropertyGroup>
 
   <!-- Detect if the solution is opened in VS to limit the TFMs that are analyzed by Roslyn for performance reasons -->
@@ -26,10 +26,10 @@
 
   <!-- When dual-targeting frameworks, add both of them to CommonTargetFrameworks above, when add PropertyGroups like
   below. -->
-  <PropertyGroup Condition="$(TargetFramework) == 'net7.0'">
+  <!--<PropertyGroup Condition="$(TargetFramework) == 'net7.0'">
     <AspNetCorePackagesVersion>7.0.14</AspNetCorePackagesVersion>
     <MicrosoftExtensionsPackagesVersion>7.0.14</MicrosoftExtensionsPackagesVersion>
-  </PropertyGroup>
+  </PropertyGroup>-->
 
   <!-- 'Microsoft.AspNetCore' packages that are not included in the ASP.NET Core shared framework -->
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.props
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.props
@@ -4,10 +4,4 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);wwwroot\is-cache\**;wwwroot\ms-cache\**</DefaultItemExcludes>
   </PropertyGroup>
 
-  <ItemDefinitionGroup>
-    <_InnerBuildProjects>
-      <Properties>IsCrossTargetedBuild=$(IsCrossTargetingBuild)</Properties>
-    </_InnerBuildProjects>
-  </ItemDefinitionGroup>
-
 </Project>

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -23,15 +23,14 @@
 
   <Target
     Name="CopyPackageTranslationFiles"
-    AfterTargets="Build"
-    Condition="'$(IsCrossTargetingBuild)' == 'true'">
-    <Message Text="Copying translation files: $(MSBuildProjectName) ('$(TargetFramework)'/'$(TargetFrameworks)')" Importance="high" />
-    <Message Text="TargetFrameworks.EndsWith(TargetFramework): '$(TargetFrameworks.EndsWith($(TargetFramework)))'" Importance="high" />
+    AfterTargets="Build">
+    <Message Text="Copying translation files: $(MSBuildProjectName)" Importance="high" />
     <Copy
       SourceFiles="%(PackageTranslationFiles.FullPath)"
       DestinationFolder="Localization\%(RecursiveDir)"
       Condition="'@(PackageTranslationFiles)' != ''"
-      SkipUnchangedFiles="true" />
+      SkipUnchangedFiles="true"
+      OverwriteReadOnlyFiles="false" />
   </Target>
 
   <Target

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -23,9 +23,10 @@
 
   <Target
     Name="CopyPackageTranslationFiles"
-    Condition="'$(TargetFramework)' != '' AND $(TargetFrameworks.EndsWith($(TargetFramework)))"
-    AfterTargets="Build">
-    <Message Text="Copying translation files: $(MSBuildProjectName)" Importance="high" />
+    AfterTargets="Build"
+    Condition="'$(IsCrossTargetingBuild)' == 'true'">
+    <Message Text="Copying translation files: $(MSBuildProjectName) ('$(TargetFramework)'/'$(TargetFrameworks)')" Importance="high" />
+    <Message Text="TargetFrameworks.EndsWith(TargetFramework): '$(TargetFrameworks.EndsWith($(TargetFramework)))'" Importance="high" />
     <Copy
       SourceFiles="%(PackageTranslationFiles.FullPath)"
       DestinationFolder="Localization\%(RecursiveDir)"
@@ -33,6 +34,18 @@
       SkipUnchangedFiles="true" />
   </Target>
 
+  <Target
+    Name="CopyPackageTranslationFiles2"    
+    AfterTargets="Build">
+    <Message Text="IsInnerBuild: '$(IsInnerBuild)' IsCrossTargetingBuild: '$(IsCrossTargetingBuild)' TargetFrameworks: '$(TargetFrameworks)' TargetFramework: '$(TargetFramework)'" Importance="high" />
+  </Target>
+
+  <Target
+    Name="CopyPackageTranslationFiles3"
+    BeforeTargets="DispatchToInnerBuilds">
+    <Message Text="########## DispatchToInnerBuilds %%%%%%%%%% ICTB: '$(IsCrossTargetingBuild)' TFS: '$(TargetFrameworks)' TF: '$(TargetFramework)'" Importance="high" />
+  </Target>
+  
   <Target Name="PublishTranslationFiles" BeforeTargets="GetCopyToPublishDirectoryItems">
     <Message Text="Publishing translation files: $(MSBuildProjectName)" Importance="high" />
     <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -23,9 +23,8 @@
 
   <Target
     Name="CopyPackageTranslationFiles"
-    Condition="'$(IsCrossTargetingBuild)' != 'true' and ('$(IsCrossTargetedBuild)' != 'true' or '$(TargetFrameworks' == '' or '$(TargetFrameworks.IndexOf($(TargetFramework)))' == '0')"
+    Condition="'$(TargetFramework)' != '' AND $(TargetFrameworks.EndsWith($(TargetFramework)))"
     AfterTargets="Build">
-
     <Message Text="Copying translation files: $(MSBuildProjectName)" Importance="high" />
     <Copy
       SourceFiles="%(PackageTranslationFiles.FullPath)"

--- a/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
+++ b/src/OrchardCore/OrchardCore.Application.Cms.Core.Targets/OrchardCore.Application.Cms.Core.Targets.targets
@@ -33,18 +33,6 @@
       OverwriteReadOnlyFiles="false" />
   </Target>
 
-  <Target
-    Name="CopyPackageTranslationFiles2"    
-    AfterTargets="Build">
-    <Message Text="IsInnerBuild: '$(IsInnerBuild)' IsCrossTargetingBuild: '$(IsCrossTargetingBuild)' TargetFrameworks: '$(TargetFrameworks)' TargetFramework: '$(TargetFramework)'" Importance="high" />
-  </Target>
-
-  <Target
-    Name="CopyPackageTranslationFiles3"
-    BeforeTargets="DispatchToInnerBuilds">
-    <Message Text="########## DispatchToInnerBuilds %%%%%%%%%% ICTB: '$(IsCrossTargetingBuild)' TFS: '$(TargetFrameworks)' TF: '$(TargetFramework)'" Importance="high" />
-  </Target>
-  
   <Target Name="PublishTranslationFiles" BeforeTargets="GetCopyToPublishDirectoryItems">
     <Message Text="Publishing translation files: $(MSBuildProjectName)" Importance="high" />
     <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/14721

This step would be executed with `'$(TargetFramework)'/'$(TargetFrameworks)'` of `''/'net8.0'` and `'net8.0'/'net8.0'`. When fixed I can't reproduce the file locks.