### PR TITLE
Jtkech/shell timeout

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -77,10 +77,10 @@
     //  "RemoveContainer": true // Whether the 'Container' is deleted if the tenant is removed, false by default.
     //},
     // See https://stackexchange.github.io/StackExchange.Redis/Configuration.html
-    "OrchardCore_Redis": {
-      "Configuration": "localhost:49153, password=redispw,allowAdmin=true", // Redis Configuration string.
-      "InstancePrefix": "" // Optional prefix allowing a Redis instance to be shared by different applications.
-    }
+    //"OrchardCore_Redis": {
+    //  "Configuration": "192.168.99.100:6379,allowAdmin=true", // Redis Configuration string.
+    //  "InstancePrefix": "" // Optional prefix allowing a Redis instance to be shared by different applications.
+    //},
     // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Security/#security-settings-configuration to configure security settings.
     //"OrchardCore_Security": {
     //  "ContentSecurityPolicy": {},

--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -77,10 +77,10 @@
     //  "RemoveContainer": true // Whether the 'Container' is deleted if the tenant is removed, false by default.
     //},
     // See https://stackexchange.github.io/StackExchange.Redis/Configuration.html
-    //"OrchardCore_Redis": {
-    //  "Configuration": "192.168.99.100:6379,allowAdmin=true", // Redis Configuration string.
-    //  "InstancePrefix": "" // Optional prefix allowing a Redis instance to be shared by different applications.
-    //},
+    "OrchardCore_Redis": {
+      "Configuration": "localhost:49153, password=redispw,allowAdmin=true", // Redis Configuration string.
+      "InstancePrefix": "" // Optional prefix allowing a Redis instance to be shared by different applications.
+    }
     // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Security/#security-settings-configuration to configure security settings.
     //"OrchardCore_Security": {
     //  "ContentSecurityPolicy": {},

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -301,6 +301,14 @@ namespace OrchardCore.Environment.Shell.Scope
             (var locker, var locked) = await ShellContext.TryAcquireShellActivateLockAsync();
             if (!locked)
             {
+                // The retry logic increases the delay between 2 attempts (max of 10s), so if there are too
+                // many concurrent requests, one may experience a timeout while waiting before a new retry.
+                if (ShellContext.IsActivated)
+                {
+                    // Don't throw if the shell is activated.
+                    return;
+                }
+
                 throw new TimeoutException($"Failed to acquire a lock before activating the tenant: {ShellContext.Settings.Name}");
             }
 


### PR DESCRIPTION
Fixes #14381 

When activating a shell using a distributed lock, if on an initial startup there are too many concurrent requests, because of the following a timeout exception may be thrown.

> The retry logic increases the delay between 2 attempts (max of 10s), so if there are too many concurrent requests, one may experience a timeout while waiting before a new retry.

Here we don't throw if the shell activation for which we tried to acquire a lock has been done.
