### PR TITLE
Migrate the OpenID module to OpenIddict 5.0

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -48,8 +48,8 @@
     <PackageManagement Include="NJsonSchema" Version="10.9.0" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="5.3.7" />
     <PackageManagement Include="NodaTime" Version="3.1.9" />
-    <PackageManagement Include="OpenIddict.AspNetCore" Version="4.10.1" />
-    <PackageManagement Include="OpenIddict.Core" Version="4.10.1" />
+    <PackageManagement Include="OpenIddict.AspNetCore" Version="5.0.0" />
+    <PackageManagement Include="OpenIddict.Core" Version="5.0.0" />
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.7.1" />
     <PackageManagement Include="PdfPig" Version="0.1.8" />
     <PackageManagement Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OpenIdApplicationSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OpenIdApplicationSettings.cs
@@ -44,14 +44,14 @@ namespace OrchardCore.OpenId
             descriptor.ClientId = model.ClientId;
             descriptor.ConsentType = model.ConsentType;
             descriptor.DisplayName = model.DisplayName;
-            descriptor.Type = model.Type;
+            descriptor.ClientType = model.Type;
 
             if (!string.IsNullOrEmpty(model.ClientSecret))
             {
                 descriptor.ClientSecret = model.ClientSecret;
             }
 
-            if (string.Equals(descriptor.Type, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(descriptor.ClientType, OpenIddictConstants.ClientTypes.Public, StringComparison.OrdinalIgnoreCase))
             {
                 descriptor.ClientSecret = null;
             }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdApplicationManager.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/Services/Managers/OpenIdApplicationManager.cs
@@ -98,7 +98,7 @@ namespace OrchardCore.OpenId.Services.Managers
                     return builder.ToImmutable();
                 }
 
-                return ImmutableArray.Create<string>();
+                return [];
             }
         }
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdApplication.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdApplication.cs
@@ -17,6 +17,11 @@ namespace OrchardCore.OpenId.YesSql.Models
         public string ApplicationId { get; set; }
 
         /// <summary>
+        /// Gets or sets the application type associated with the current application.
+        /// </summary>
+        public string ApplicationType { get; set; }
+
+        /// <summary>
         /// Gets or sets the client identifier associated with the current application.
         /// </summary>
         public string ClientId { get; set; }
@@ -50,16 +55,20 @@ namespace OrchardCore.OpenId.YesSql.Models
         public long Id { get; set; }
 
         /// <summary>
+        /// Gets or sets the JSON Web Key Set associated with the current application.
+        /// </summary>
+        // TODO: change the property type to JsonWebKeySet after migrating to System.Text.Json.
+        public JObject JsonWebKeySet { get; set; }
+
+        /// <summary>
         /// Gets or sets the permissions associated with the application.
         /// </summary>
-        public ImmutableArray<string> Permissions { get; set; }
-            = ImmutableArray.Create<string>();
+        public ImmutableArray<string> Permissions { get; set; } = [];
 
         /// <summary>
         /// Gets the logout callback URLs associated with the current application.
         /// </summary>
-        public ImmutableArray<string> PostLogoutRedirectUris { get; set; }
-            = ImmutableArray.Create<string>();
+        public ImmutableArray<string> PostLogoutRedirectUris { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the additional properties associated with the current application.
@@ -69,23 +78,26 @@ namespace OrchardCore.OpenId.YesSql.Models
         /// <summary>
         /// Gets or sets the callback URLs associated with the current application.
         /// </summary>
-        public ImmutableArray<string> RedirectUris { get; set; }
-            = ImmutableArray.Create<string>();
+        public ImmutableArray<string> RedirectUris { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the requirements associated with the current application.
         /// </summary>
-        public ImmutableArray<string> Requirements { get; set; }
-            = ImmutableArray.Create<string>();
+        public ImmutableArray<string> Requirements { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the roles associated with the application.
         /// </summary>
-        public ImmutableArray<string> Roles { get; set; }
-            = ImmutableArray.Create<string>();
+        public ImmutableArray<string> Roles { get; set; } = [];
 
         /// <summary>
-        /// Gets or sets the application type associated with the current application.
+        /// Gets or sets the settings associated with the application.
+        /// </summary>
+        public ImmutableDictionary<string, string> Settings { get; set; }
+            = ImmutableDictionary.Create<string, string>();
+
+        /// <summary>
+        /// Gets or sets the client type associated with the current application.
         /// </summary>
         public string Type { get; set; }
     }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdAuthorization.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdAuthorization.cs
@@ -40,8 +40,7 @@ namespace OrchardCore.OpenId.YesSql.Models
         /// <summary>
         /// Gets or sets the scopes associated with the current authorization.
         /// </summary>
-        public ImmutableArray<string> Scopes { get; set; }
-            = ImmutableArray.Create<string>();
+        public ImmutableArray<string> Scopes { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the status of the current authorization.

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdScope.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Models/OpenIdScope.cs
@@ -56,7 +56,6 @@ namespace OrchardCore.OpenId.YesSql.Models
         /// <summary>
         /// Gets or sets the resources associated with the current scope.
         /// </summary>
-        public ImmutableArray<string> Resources { get; set; }
-            = ImmutableArray.Create<string>();
+        public ImmutableArray<string> Resources { get; set; } = [];
     }
 }

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdApplicationStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdApplicationStore.cs
@@ -8,6 +8,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Linq;
 using OpenIddict.Abstractions;
 using OrchardCore.OpenId.Abstractions.Stores;
@@ -43,10 +44,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask CreateAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -57,10 +55,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask DeleteAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -71,10 +66,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TApplication> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -84,10 +76,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TApplication> FindByClientIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -97,10 +86,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TApplication> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -110,10 +96,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual IAsyncEnumerable<TApplication> FindByPostLogoutRedirectUriAsync(string uri, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(uri))
-            {
-                throw new ArgumentException("The URI cannot be null or empty.", nameof(uri));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(uri);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -125,16 +108,20 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual IAsyncEnumerable<TApplication> FindByRedirectUriAsync(string uri, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(uri))
-            {
-                throw new ArgumentException("The URI cannot be null or empty.", nameof(uri));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(uri);
 
             cancellationToken.ThrowIfCancellationRequested();
 
             return _session.Query<TApplication, OpenIdAppByRedirectUriIndex>(
                 index => index.RedirectUri == uri,
                 collection: OpenIdCollection).ToAsyncEnumerable();
+        }
+
+        public virtual ValueTask<string> GetApplicationTypeAsync(TApplication application, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(application);
+
+            return new ValueTask<string>(application.ApplicationType);
         }
 
         /// <inheritdoc/>
@@ -146,10 +133,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetClientIdAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<string>(application.ClientId);
         }
@@ -157,10 +141,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetClientSecretAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<string>(application.ClientSecret);
         }
@@ -168,10 +149,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetClientTypeAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<string>(application.Type);
         }
@@ -179,10 +157,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetConsentTypeAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<string>(application.ConsentType);
         }
@@ -190,10 +165,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetDisplayNameAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<string>(application.DisplayName);
         }
@@ -202,10 +174,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask<ImmutableDictionary<CultureInfo, string>> GetDisplayNamesAsync(
             TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             if (application.DisplayNames == null)
             {
@@ -218,21 +187,27 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetIdAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<string>(application.ApplicationId);
+        }
+
+        public virtual ValueTask<JsonWebKeySet> GetJsonWebKeySetAsync(TApplication application, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(application);
+
+            if (application.JsonWebKeySet is null)
+            {
+                return new ValueTask<JsonWebKeySet>(result: null);
+            }
+
+            return new ValueTask<JsonWebKeySet>(JsonSerializer.Deserialize<JsonWebKeySet>(application.JsonWebKeySet.ToString()));
         }
 
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetPermissionsAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<ImmutableArray<string>>(application.Permissions);
         }
@@ -240,10 +215,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetPhysicalIdAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<string>(application.Id.ToString(CultureInfo.InvariantCulture));
         }
@@ -251,10 +223,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetPostLogoutRedirectUrisAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<ImmutableArray<string>>(application.PostLogoutRedirectUris);
         }
@@ -262,10 +231,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             if (application.Properties == null)
             {
@@ -279,10 +245,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetRedirectUrisAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<ImmutableArray<string>>(application.RedirectUris);
         }
@@ -290,12 +253,17 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetRequirementsAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<ImmutableArray<string>>(application.Requirements);
+        }
+
+        /// <inheritdoc/>
+        public virtual ValueTask<ImmutableDictionary<string, string>> GetSettingsAsync(TApplication application, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(application);
+
+            return new ValueTask<ImmutableDictionary<string, string>>(application.Settings);
         }
 
         /// <inheritdoc/>
@@ -327,13 +295,20 @@ namespace OrchardCore.OpenId.YesSql.Stores
             => throw new NotSupportedException();
 
         /// <inheritdoc/>
+        public virtual ValueTask SetApplicationTypeAsync(TApplication application, string type, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(application);
+
+            application.ApplicationType = type;
+
+            return default;
+        }
+
+        /// <inheritdoc/>
         public virtual ValueTask SetClientIdAsync(TApplication application,
             string identifier, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.ClientId = identifier;
 
@@ -343,10 +318,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetClientSecretAsync(TApplication application, string secret, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.ClientSecret = secret;
 
@@ -356,10 +328,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetClientTypeAsync(TApplication application, string type, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.Type = type;
 
@@ -369,10 +338,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetConsentTypeAsync(TApplication application, string type, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.ConsentType = type;
 
@@ -382,10 +348,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetDisplayNameAsync(TApplication application, string name, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.DisplayName = name;
 
@@ -395,10 +358,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetDisplayNamesAsync(TApplication application, ImmutableDictionary<CultureInfo, string> names, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.DisplayNames = names;
 
@@ -406,12 +366,30 @@ namespace OrchardCore.OpenId.YesSql.Stores
         }
 
         /// <inheritdoc/>
+        public virtual ValueTask SetJsonWebKeySetAsync(TApplication application, JsonWebKeySet set, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(application);
+
+            if (set is not null)
+            {
+                application.JsonWebKeySet = JObject.Parse(JsonSerializer.Serialize(set, new JsonSerializerOptions
+                {
+                    Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+                    WriteIndented = false
+                }));
+
+                return default;
+            }
+
+            application.JsonWebKeySet = null;
+
+            return default;
+        }
+
+        /// <inheritdoc/>
         public virtual ValueTask SetPermissionsAsync(TApplication application, ImmutableArray<string> permissions, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.Permissions = permissions;
 
@@ -422,10 +400,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetPostLogoutRedirectUrisAsync(TApplication application,
             ImmutableArray<string> uris, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.PostLogoutRedirectUris = uris;
 
@@ -435,10 +410,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetPropertiesAsync(TApplication application, ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             if (properties == null || properties.IsEmpty)
             {
@@ -460,10 +432,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetRedirectUrisAsync(TApplication application,
             ImmutableArray<string> uris, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.RedirectUris = uris;
 
@@ -474,10 +443,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetRequirementsAsync(TApplication application,
             ImmutableArray<string> requirements, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.Requirements = requirements;
 
@@ -485,12 +451,20 @@ namespace OrchardCore.OpenId.YesSql.Stores
         }
 
         /// <inheritdoc/>
+        public virtual ValueTask SetSettingsAsync(TApplication application,
+            ImmutableDictionary<string, string> settings, CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(application);
+
+            application.Settings = settings;
+
+            return default;
+        }
+
+        /// <inheritdoc/>
         public virtual async ValueTask UpdateAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -512,10 +486,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetRolesAsync(TApplication application, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             return new ValueTask<ImmutableArray<string>>(application.Roles);
         }
@@ -523,10 +494,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual IAsyncEnumerable<TApplication> ListInRoleAsync(string role, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(role))
-            {
-                throw new ArgumentException("The role name cannot be null or empty.", nameof(role));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(role);
 
             return _session.Query<TApplication, OpenIdAppByRoleNameIndex>(index => index.RoleName == role, collection: OpenIdCollection).ToAsyncEnumerable();
         }
@@ -534,10 +502,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetRolesAsync(TApplication application, ImmutableArray<string> roles, CancellationToken cancellationToken)
         {
-            if (application == null)
-            {
-                throw new ArgumentNullException(nameof(application));
-            }
+            ArgumentNullException.ThrowIfNull(application);
 
             application.Roles = roles;
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdAuthorizationStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdAuthorizationStore.cs
@@ -45,10 +45,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask CreateAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -59,10 +56,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask DeleteAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -74,15 +68,8 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual IAsyncEnumerable<TAuthorization> FindAsync(
             string subject, string client, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
-
-            if (string.IsNullOrEmpty(client))
-            {
-                throw new ArgumentException("The client cannot be null or empty.", nameof(client));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(subject);
+            ArgumentException.ThrowIfNullOrEmpty(client);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -95,20 +82,9 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual IAsyncEnumerable<TAuthorization> FindAsync(
             string subject, string client, string status, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
-
-            if (string.IsNullOrEmpty(client))
-            {
-                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
-            }
-
-            if (string.IsNullOrEmpty(status))
-            {
-                throw new ArgumentException("The status cannot be null or empty.", nameof(client));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(subject);
+            ArgumentException.ThrowIfNullOrEmpty(client);
+            ArgumentException.ThrowIfNullOrEmpty(status);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -122,25 +98,10 @@ namespace OrchardCore.OpenId.YesSql.Stores
             string subject, string client,
             string status, string type, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
-
-            if (string.IsNullOrEmpty(client))
-            {
-                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
-            }
-
-            if (string.IsNullOrEmpty(status))
-            {
-                throw new ArgumentException("The status cannot be null or empty.", nameof(client));
-            }
-
-            if (string.IsNullOrEmpty(type))
-            {
-                throw new ArgumentException("The type cannot be null or empty.", nameof(client));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(subject);
+            ArgumentException.ThrowIfNullOrEmpty(client);
+            ArgumentException.ThrowIfNullOrEmpty(status);
+            ArgumentException.ThrowIfNullOrEmpty(type);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -168,10 +129,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual IAsyncEnumerable<TAuthorization> FindByApplicationIdAsync(
             string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -183,10 +141,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TAuthorization> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -198,10 +153,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TAuthorization> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -212,10 +164,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual IAsyncEnumerable<TAuthorization> FindBySubjectAsync(
             string subject, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(subject);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -227,10 +176,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetApplicationIdAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             return new ValueTask<string>(authorization.ApplicationId);
         }
@@ -244,10 +190,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<DateTimeOffset?> GetCreationDateAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             if (authorization.CreationDate is null)
             {
@@ -260,10 +203,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetIdAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             return new ValueTask<string>(authorization.AuthorizationId);
         }
@@ -271,10 +211,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetPhysicalIdAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             return new ValueTask<string>(authorization.Id.ToString(CultureInfo.InvariantCulture));
         }
@@ -282,10 +219,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             if (authorization.Properties == null)
             {
@@ -299,10 +233,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetScopesAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             return new ValueTask<ImmutableArray<string>>(authorization.Scopes);
         }
@@ -310,10 +241,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetStatusAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             return new ValueTask<string>(authorization.Status);
         }
@@ -321,10 +249,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetSubjectAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             return new ValueTask<string>(authorization.Subject);
         }
@@ -332,10 +257,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetTypeAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             return new ValueTask<string>(authorization.Type);
         }
@@ -369,30 +291,32 @@ namespace OrchardCore.OpenId.YesSql.Stores
             => throw new NotSupportedException();
 
         /// <inheritdoc/>
-        public virtual async ValueTask PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken)
+        public virtual async ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken)
         {
             // Note: YesSql doesn't support set-based deletes, which prevents removing entities
             // in a single command without having to retrieve and materialize them first.
             // To work around this limitation, entities are manually listed and deleted using a batch logic.
 
-            IList<Exception> exceptions = null;
+            List<Exception> exceptions = null;
+
+            var result = 0L;
 
             for (var i = 0; i < 1000; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var authorizations = await _session.Query<TAuthorization, OpenIdAuthorizationIndex>(
+                var authorizations = (await _session.Query<TAuthorization, OpenIdAuthorizationIndex>(
                     authorization => authorization.CreationDate < threshold.UtcDateTime &&
                                     (authorization.Status != OpenIddictConstants.Statuses.Valid ||
                                     (authorization.Type == OpenIddictConstants.AuthorizationTypes.AdHoc &&
                                      authorization.AuthorizationId.IsNotIn<OpenIdTokenIndex>(
                                          token => token.AuthorizationId,
                                          token => token.Id != 0))),
-                    collection: OpenIdCollection).Take(100).ListAsync();
+                    collection: OpenIdCollection).Take(100).ListAsync()).ToList();
 
-                if (!authorizations.Any())
+                if (authorizations.Count is 0)
                 {
-                    return;
+                    break;
                 }
 
                 foreach (var authorization in authorizations)
@@ -407,25 +331,27 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 catch (Exception exception)
                 {
                     exceptions ??= new List<Exception>(capacity: 1);
-
                     exceptions.Add(exception);
+
+                    continue;
                 }
+
+                result += authorizations.Count;
             }
 
             if (exceptions != null)
             {
                 throw new AggregateException("An error occurred while pruning authorizations.", exceptions);
             }
+
+            return result;
         }
 
         /// <inheritdoc/>
         public virtual ValueTask SetApplicationIdAsync(TAuthorization authorization,
             string identifier, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             if (string.IsNullOrEmpty(identifier))
             {
@@ -439,12 +365,10 @@ namespace OrchardCore.OpenId.YesSql.Stores
             return default;
         }
 
-        public ValueTask SetCreationDateAsync(TAuthorization authorization, DateTimeOffset? date, CancellationToken cancellationToken)
+        /// <inheritdoc/>
+        public virtual ValueTask SetCreationDateAsync(TAuthorization authorization, DateTimeOffset? date, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             authorization.CreationDate = date?.UtcDateTime;
 
@@ -454,10 +378,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetPropertiesAsync(TAuthorization authorization, ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             if (properties == null || properties.IsEmpty)
             {
@@ -479,10 +400,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetScopesAsync(TAuthorization authorization,
             ImmutableArray<string> scopes, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             authorization.Scopes = scopes;
 
@@ -493,10 +411,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetStatusAsync(TAuthorization authorization,
             string status, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             authorization.Status = status;
 
@@ -507,10 +422,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetSubjectAsync(TAuthorization authorization,
             string subject, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             authorization.Subject = subject;
 
@@ -521,10 +433,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetTypeAsync(TAuthorization authorization,
             string type, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             authorization.Type = type;
 
@@ -534,10 +443,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask UpdateAsync(TAuthorization authorization, CancellationToken cancellationToken)
         {
-            if (authorization == null)
-            {
-                throw new ArgumentNullException(nameof(authorization));
-            }
+            ArgumentNullException.ThrowIfNull(authorization);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdScopeStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdScopeStore.cs
@@ -44,10 +44,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask CreateAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -58,10 +55,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask DeleteAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -72,10 +66,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TScope> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -85,10 +76,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TScope> FindByNameAsync(string name, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentException("The scope name cannot be null or empty.", nameof(name));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(name);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -112,10 +100,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TScope> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -125,10 +110,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual IAsyncEnumerable<TScope> FindByResourceAsync(string resource, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(resource))
-            {
-                throw new ArgumentException("The resource cannot be null or empty.", nameof(resource));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(resource);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -146,10 +128,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetDescriptionAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             return new ValueTask<string>(scope.Description);
         }
@@ -158,10 +137,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask<ImmutableDictionary<CultureInfo, string>> GetDescriptionsAsync(
             TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             if (scope.Descriptions == null)
             {
@@ -174,10 +150,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetDisplayNameAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             return new ValueTask<string>(scope.DisplayName);
         }
@@ -186,10 +159,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask<ImmutableDictionary<CultureInfo, string>> GetDisplayNamesAsync(
             TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             if (scope.DisplayNames == null)
             {
@@ -202,10 +172,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetIdAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             return new ValueTask<string>(scope.ScopeId);
         }
@@ -213,10 +180,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetNameAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             return new ValueTask<string>(scope.Name);
         }
@@ -224,10 +188,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetPhysicalIdAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             return new ValueTask<string>(scope.Id.ToString(CultureInfo.InvariantCulture));
         }
@@ -235,10 +196,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             if (scope.Properties == null)
             {
@@ -252,10 +210,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableArray<string>> GetResourcesAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             return new ValueTask<ImmutableArray<string>>(scope.Resources);
         }
@@ -291,10 +246,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetDescriptionAsync(TScope scope, string description, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             scope.Description = description;
 
@@ -305,10 +257,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetDescriptionsAsync(TScope scope,
             ImmutableDictionary<CultureInfo, string> descriptions, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             scope.Descriptions = descriptions;
 
@@ -318,10 +267,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetDisplayNameAsync(TScope scope, string name, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             scope.DisplayName = name;
 
@@ -332,10 +278,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual ValueTask SetDisplayNamesAsync(TScope scope,
             ImmutableDictionary<CultureInfo, string> names, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             scope.DisplayNames = names;
 
@@ -345,10 +288,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetNameAsync(TScope scope, string name, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             scope.Name = name;
 
@@ -358,10 +298,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetPropertiesAsync(TScope scope, ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             if (properties == null || properties.IsEmpty)
             {
@@ -382,10 +319,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetResourcesAsync(TScope scope, ImmutableArray<string> resources, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             scope.Resources = resources;
 
@@ -395,10 +329,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask UpdateAsync(TScope scope, CancellationToken cancellationToken)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
+            ArgumentNullException.ThrowIfNull(scope);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
@@ -45,10 +45,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask CreateAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -59,10 +56,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask DeleteAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -74,15 +68,8 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual IAsyncEnumerable<TToken> FindAsync(
             string subject, string client, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
-
-            if (string.IsNullOrEmpty(client))
-            {
-                throw new ArgumentException("The client cannot be null or empty.", nameof(client));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(subject);
+            ArgumentException.ThrowIfNullOrEmpty(client);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -94,20 +81,9 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual IAsyncEnumerable<TToken> FindAsync(
             string subject, string client, string status, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
-
-            if (string.IsNullOrEmpty(client))
-            {
-                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
-            }
-
-            if (string.IsNullOrEmpty(status))
-            {
-                throw new ArgumentException("The status cannot be null or empty.", nameof(status));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(subject);
+            ArgumentException.ThrowIfNullOrEmpty(client);
+            ArgumentException.ThrowIfNullOrEmpty(status);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -119,25 +95,10 @@ namespace OrchardCore.OpenId.YesSql.Stores
         public virtual IAsyncEnumerable<TToken> FindAsync(
             string subject, string client, string status, string type, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
-
-            if (string.IsNullOrEmpty(client))
-            {
-                throw new ArgumentException("The client identifier cannot be null or empty.", nameof(client));
-            }
-
-            if (string.IsNullOrEmpty(status))
-            {
-                throw new ArgumentException("The status cannot be null or empty.", nameof(status));
-            }
-
-            if (string.IsNullOrEmpty(type))
-            {
-                throw new ArgumentException("The type cannot be null or empty.", nameof(type));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(subject);
+            ArgumentException.ThrowIfNullOrEmpty(client);
+            ArgumentException.ThrowIfNullOrEmpty(status);
+            ArgumentException.ThrowIfNullOrEmpty(type);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -149,10 +110,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindByApplicationIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -162,10 +120,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -175,10 +130,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TToken> FindByReferenceIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -188,10 +140,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TToken> FindByIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -201,10 +150,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask<TToken> FindByPhysicalIdAsync(string identifier, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(identifier))
-            {
-                throw new ArgumentException("The identifier cannot be null or empty.", nameof(identifier));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(identifier);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -214,10 +160,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual IAsyncEnumerable<TToken> FindBySubjectAsync(string subject, CancellationToken cancellationToken)
         {
-            if (string.IsNullOrEmpty(subject))
-            {
-                throw new ArgumentException("The subject cannot be null or empty.", nameof(subject));
-            }
+            ArgumentException.ThrowIfNullOrEmpty(subject);
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -233,10 +176,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetApplicationIdAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.ApplicationId?.ToString(CultureInfo.InvariantCulture));
         }
@@ -244,10 +184,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetAuthorizationIdAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.AuthorizationId);
         }
@@ -255,10 +192,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<DateTimeOffset?> GetCreationDateAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             if (token.CreationDate is null)
             {
@@ -271,10 +205,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<DateTimeOffset?> GetExpirationDateAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             if (token.ExpirationDate is null)
             {
@@ -287,10 +218,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetIdAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.TokenId);
         }
@@ -298,10 +226,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetPayloadAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.Payload);
         }
@@ -309,10 +234,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetPhysicalIdAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.Id.ToString(CultureInfo.InvariantCulture));
         }
@@ -320,10 +242,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<ImmutableDictionary<string, JsonElement>> GetPropertiesAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             if (token.Properties == null)
             {
@@ -337,10 +256,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<DateTimeOffset?> GetRedemptionDateAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             if (token.RedemptionDate is null)
             {
@@ -353,10 +269,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetReferenceIdAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.ReferenceId);
         }
@@ -364,10 +277,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetStatusAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.Status);
         }
@@ -375,10 +285,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetSubjectAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.Subject);
         }
@@ -386,10 +293,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask<string> GetTypeAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             return new ValueTask<string>(token.Type);
         }
@@ -423,28 +327,31 @@ namespace OrchardCore.OpenId.YesSql.Stores
             => throw new NotSupportedException();
 
         /// <inheritdoc/>
-        public virtual async ValueTask PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken = default)
+        public virtual async ValueTask<long> PruneAsync(DateTimeOffset threshold, CancellationToken cancellationToken = default)
         {
-            // Note: Entity Framework Core doesn't support set-based deletes, which prevents removing
-            // entities in a single command without having to retrieve and materialize them first.
+            // Note: YesSql doesn't support set-based deletes, which prevents removing entities
+            // in a single command without having to retrieve and materialize them first.
             // To work around this limitation, entities are manually listed and deleted using a batch logic.
 
-            IList<Exception> exceptions = null;
+            List<Exception> exceptions = null;
+
+            var result = 0L;
 
             for (var i = 0; i < 1000; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var tokens = await _session.Query<TToken, OpenIdTokenIndex>(
+                var tokens = (await _session.Query<TToken, OpenIdTokenIndex>(
                     token => token.CreationDate < threshold.UtcDateTime &&
                            ((token.Status != Statuses.Inactive && token.Status != Statuses.Valid) ||
                              token.AuthorizationId.IsNotIn<OpenIdAuthorizationIndex>(
                                 authorization => authorization.AuthorizationId,
                                 authorization => authorization.Status == Statuses.Valid) ||
-                             token.ExpirationDate < DateTime.UtcNow), collection: OpenIdCollection).Take(100).ListAsync();
-                if (!tokens.Any())
+                             token.ExpirationDate < DateTime.UtcNow), collection: OpenIdCollection).Take(100).ListAsync()).ToList();
+
+                if (tokens.Count is 0)
                 {
-                    return;
+                    break;
                 }
 
                 foreach (var token in tokens)
@@ -459,24 +366,55 @@ namespace OrchardCore.OpenId.YesSql.Stores
                 catch (Exception exception)
                 {
                     exceptions ??= new List<Exception>(capacity: 1);
-
                     exceptions.Add(exception);
+
+                    continue;
                 }
+
+                result += tokens.Count;
             }
 
             if (exceptions != null)
             {
                 throw new AggregateException("An error occurred while pruning authorizations.", exceptions);
             }
+
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public virtual async ValueTask<long> RevokeByAuthorizationIdAsync(string identifier, CancellationToken cancellationToken)
+        {
+            // Note: YesSql doesn't support set-based updates, which prevents updating entities
+            // in a single command without having to retrieve and materialize them first.
+            // To work around this limitation, entities are manually listed and updated.
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tokens = (await _session.Query<TToken, OpenIdTokenIndex>(
+                token => token.AuthorizationId == identifier, collection: OpenIdCollection).ListAsync()).ToList();
+
+            if (tokens.Count is 0)
+            {
+                return 0;
+            }
+
+            foreach (var token in tokens)
+            {
+                token.Status = Statuses.Revoked;
+
+                _session.Save(token, checkConcurrency: false, collection: OpenIdCollection);
+            }
+
+            await _session.SaveChangesAsync();
+
+            return tokens.Count;
         }
 
         /// <inheritdoc/>
         public virtual ValueTask SetApplicationIdAsync(TToken token, string identifier, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             if (string.IsNullOrEmpty(identifier))
             {
@@ -493,10 +431,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetAuthorizationIdAsync(TToken token, string identifier, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             if (string.IsNullOrEmpty(identifier))
             {
@@ -513,10 +448,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetCreationDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             token.CreationDate = date?.UtcDateTime;
 
@@ -526,10 +458,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetExpirationDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             token.ExpirationDate = date?.UtcDateTime;
 
@@ -539,10 +468,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetPayloadAsync(TToken token, string payload, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             token.Payload = payload;
 
@@ -552,10 +478,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetPropertiesAsync(TToken token, ImmutableDictionary<string, JsonElement> properties, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             if (properties == null || properties.IsEmpty)
             {
@@ -576,10 +499,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetRedemptionDateAsync(TToken token, DateTimeOffset? date, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             token.RedemptionDate = date?.UtcDateTime;
 
@@ -589,10 +509,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetReferenceIdAsync(TToken token, string identifier, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             token.ReferenceId = identifier;
 
@@ -602,10 +519,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetStatusAsync(TToken token, string status, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             token.Status = status;
 
@@ -615,10 +529,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetSubjectAsync(TToken token, string subject, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             token.Subject = subject;
 
@@ -628,10 +539,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual ValueTask SetTypeAsync(TToken token, string type, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             token.Type = type;
 
@@ -641,10 +549,7 @@ namespace OrchardCore.OpenId.YesSql.Stores
         /// <inheritdoc/>
         public virtual async ValueTask UpdateAsync(TToken token, CancellationToken cancellationToken)
         {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
+            ArgumentNullException.ThrowIfNull(token);
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTests.cs
@@ -57,9 +57,9 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
 
             Assert.Equal(expected.ClientId, actual.ClientId);
             Assert.Equal(expected.ClientSecret, actual.ClientSecret);
+            Assert.Equal(expected.ClientType, actual.ClientType);
             Assert.Equal(expected.ConsentType, actual.ConsentType);
             Assert.Equal(expected.DisplayName, actual.DisplayName);
-            Assert.Equal(expected.Type, actual.Type);
             Assert.Equal(expected.Permissions, actual.Permissions);
             Assert.Equal(expected.PostLogoutRedirectUris, actual.PostLogoutRedirectUris);
             Assert.Equal(expected.RedirectUris, actual.RedirectUris);
@@ -149,9 +149,9 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
 
             Assert.Equal(expected.ClientId, actual.ClientId);
             Assert.Equal(expected.ClientSecret, actual.ClientSecret);
+            Assert.Equal(expected.ClientType, actual.ClientType);
             Assert.Equal(expected.ConsentType, actual.ConsentType);
             Assert.Equal(expected.DisplayName, actual.DisplayName);
-            Assert.Equal(expected.Type, actual.Type);
             Assert.Equal(expected.Permissions, actual.Permissions);
             Assert.Equal(expected.PostLogoutRedirectUris, actual.PostLogoutRedirectUris);
             Assert.Equal(expected.RedirectUris, actual.RedirectUris);

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
@@ -13,9 +13,9 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
                 {
                     ClientId = "a1",
                     ClientSecret = "test-secret",
+                    ClientType = "confidential",
                     ConsentType = "explicit",
-                    DisplayName = "Test Application",
-                    Type = "confidential",
+                    DisplayName = "Test Application"
                 },
                 new[] { new Uri("https://localhost:111/logout-redirect"), new Uri("https://localhost:222/logout-redirect") },
                 new[] { new Uri("https://localhost:111/redirect"), new Uri("https://localhost:222/redirect") },
@@ -35,9 +35,9 @@ namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
                 {
                     ClientId = "a2",
                     ClientSecret = "test-secret",
+                    ClientType = "confidential",
                     ConsentType = "explicit",
-                    DisplayName = "Test Application",
-                    Type = "confidential",
+                    DisplayName = "Test Application"
                 },
                 new[] { new Uri("https://localhost/logout-redirect") },
                 new[] { new Uri("https://localhost/redirect") },


### PR DESCRIPTION
OpenIddict 5.0 RTM is expected to ship later this month. This PR reacts to the breaking changes introduced by this new major by adding new store methods are updating the ones whose signature has changed.

(note: while OpenIddict 5.0 supports new features, this PR doesn't expose them via the OC GUI. If there's some interest from the community, it's certainly something we'll want to consider for another PR)

Edit: 5.0 RTM just shipped: https://kevinchalet.com/2023/12/18/openiddict-5-0-general-availability/