### PR TITLE
Add a way to provide a custom Elasticsearch query

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticSettingsDisplayDriver.cs
@@ -80,9 +80,9 @@ namespace OrchardCore.Search.Elasticsearch.Drivers
 #pragma warning restore CS0618 // Type or member is obsolete
 
                 model.SearchTypes = [
-                    new(S["Multi-match query"], string.Empty),
-                    new(S["String query"], ElasticsearchService.QueryStringSearchType),
-                    new(S["Raw query"], ElasticsearchService.RawSearchType),
+                    new(S["Multi-Match Query (Default)"], string.Empty),
+                    new(S["Query String Query"], ElasticsearchService.QueryStringSearchType),
+                    new(S["Raw Query"], ElasticsearchService.RawSearchType),
                 ];
             }).Location("Content:2")
             .OnGroup(GroupId);

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticSettingsDisplayDriver.cs
@@ -17,106 +17,103 @@ using OrchardCore.Search.Elasticsearch.Core.Services;
 using OrchardCore.Search.Elasticsearch.ViewModels;
 using OrchardCore.Settings;
 
-namespace OrchardCore.Search.Elasticsearch.Drivers
+namespace OrchardCore.Search.Elasticsearch.Drivers;
+
+public class ElasticSettingsDisplayDriver : SectionDisplayDriver<ISite, ElasticSettings>
 {
-    public class ElasticSettingsDisplayDriver : SectionDisplayDriver<ISite, ElasticSettings>
+    public const string GroupId = "elasticsearch";
+
+    private static readonly char[] _separator = [',', ' '];
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
-        public const string GroupId = "elasticsearch";
+        WriteIndented = true,
+    };
+    private readonly ElasticIndexSettingsService _elasticIndexSettingsService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IElasticClient _elasticClient;
+    protected readonly IStringLocalizer S;
 
-        private static readonly char[] _separator = [',', ' '];
-        private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    public ElasticSettingsDisplayDriver(
+        ElasticIndexSettingsService elasticIndexSettingsService,
+        IHttpContextAccessor httpContextAccessor,
+        IAuthorizationService authorizationService,
+        IElasticClient elasticClient,
+        IStringLocalizer<ElasticSettingsDisplayDriver> stringLocalizer
+        )
+    {
+        _elasticIndexSettingsService = elasticIndexSettingsService;
+        _httpContextAccessor = httpContextAccessor;
+        _authorizationService = authorizationService;
+        _elasticClient = elasticClient;
+        S = stringLocalizer;
+    }
+
+    public override IDisplayResult Edit(ElasticSettings settings)
+        => Initialize<ElasticSettingsViewModel>("ElasticSettings_Edit", async model =>
         {
-            WriteIndented = true,
+            model.SearchIndex = settings.SearchIndex;
+            model.SearchFields = string.Join(", ", settings.DefaultSearchFields ?? []);
+            model.SearchIndexes = (await _elasticIndexSettingsService.GetSettingsAsync()).Select(x => x.IndexName);
+            model.DefaultQuery = settings.DefaultQuery;
+            model.SearchType = settings.GetSearchType();
+            model.SearchTypes = [
+                new(S["Multi-Match Query (Default)"], string.Empty),
+                new(S["Query String Query"], ElasticSettings.QueryStringSearchType),
+                new(S["Custom Query"], ElasticSettings.CustomSearchType),
+            ];
+        }).Location("Content:2")
+        .RenderWhen(() => _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, Permissions.ManageElasticIndexes))
+        .OnGroup(GroupId);
 
-        };
-        private readonly ElasticIndexSettingsService _elasticIndexSettingsService;
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly IAuthorizationService _authorizationService;
-        private readonly IElasticClient _elasticClient;
-        protected readonly IStringLocalizer S;
-
-        public ElasticSettingsDisplayDriver(
-            ElasticIndexSettingsService elasticIndexSettingsService,
-            IHttpContextAccessor httpContextAccessor,
-            IAuthorizationService authorizationService,
-            IElasticClient elasticClient,
-            IStringLocalizer<ElasticSettingsDisplayDriver> stringLocalizer
-
-            )
+    public override async Task<IDisplayResult> UpdateAsync(ElasticSettings section, BuildEditorContext context)
+    {
+        if (!string.Equals(GroupId, context.GroupId, StringComparison.OrdinalIgnoreCase))
         {
-            _elasticIndexSettingsService = elasticIndexSettingsService;
-            _httpContextAccessor = httpContextAccessor;
-            _authorizationService = authorizationService;
-            _elasticClient = elasticClient;
-            S = stringLocalizer;
+            return null;
         }
 
-        public override IDisplayResult Edit(ElasticSettings settings)
-            => Initialize<ElasticSettingsViewModel>("ElasticSettings_Edit", async model =>
-            {
-                model.SearchIndex = settings.SearchIndex;
-                model.SearchFields = string.Join(", ", settings.DefaultSearchFields ?? []);
-                model.SearchIndexes = (await _elasticIndexSettingsService.GetSettingsAsync()).Select(x => x.IndexName);
-                model.DefaultQuery = settings.DefaultQuery;
-                model.SearchType = settings.GetSearchType();
-                model.SearchTypes = [
-                    new(S["Multi-Match Query (Default)"], string.Empty),
-                    new(S["Query String Query"], ElasticSettings.QueryStringSearchType),
-                    new(S["Custom Query"], ElasticSettings.CustomSearchType),
-                ];
-            }).Location("Content:2")
-            .RenderWhen(() => _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, Permissions.ManageElasticIndexes))
-            .OnGroup(GroupId);
-
-        public override async Task<IDisplayResult> UpdateAsync(ElasticSettings section, BuildEditorContext context)
+        if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext?.User, Permissions.ManageElasticIndexes))
         {
-            if (!string.Equals(GroupId, context.GroupId, StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-
-            if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext?.User, Permissions.ManageElasticIndexes))
-            {
-                return null;
-            }
-
-            var model = new ElasticSettingsViewModel();
-
-            await context.Updater.TryUpdateModelAsync(model, Prefix);
-
-            section.DefaultQuery = null;
-            section.SearchIndex = model.SearchIndex;
-            section.DefaultSearchFields = model.SearchFields?.Split(_separator, StringSplitOptions.RemoveEmptyEntries);
-            section.SearchType = model.SearchType ?? string.Empty;
-
-            if (model.SearchType == ElasticSettings.CustomSearchType)
-            {
-                if (string.IsNullOrWhiteSpace(model.DefaultQuery))
-                {
-                    context.Updater.ModelState.AddModelError(Prefix, nameof(model.DefaultQuery), S["Please provide the default query."]);
-                }
-                else if (!JsonHelpers.TryParse(model.DefaultQuery, out var document))
-                {
-                    context.Updater.ModelState.AddModelError(Prefix, nameof(model.DefaultQuery), S["The provided query is not formatted correctly."]);
-                }
-                else
-                {
-                    section.DefaultQuery = JsonSerializer.Serialize(document, _jsonSerializerOptions);
-
-                    try
-                    {
-                        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(model.DefaultQuery));
-
-                        var searchRequest = await _elasticClient.RequestResponseSerializer.DeserializeAsync<SearchRequest>(stream);
-                    }
-                    catch
-                    {
-                        context.Updater.ModelState.AddModelError(Prefix, nameof(model.DefaultQuery), S["Invalid query provided."]);
-                    }
-                }
-            }
-
-            return await EditAsync(section, context);
+            return null;
         }
+
+        var model = new ElasticSettingsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        section.DefaultQuery = null;
+        section.SearchIndex = model.SearchIndex;
+        section.DefaultSearchFields = model.SearchFields?.Split(_separator, StringSplitOptions.RemoveEmptyEntries);
+        section.SearchType = model.SearchType ?? string.Empty;
+
+        if (model.SearchType == ElasticSettings.CustomSearchType)
+        {
+            if (string.IsNullOrWhiteSpace(model.DefaultQuery))
+            {
+                context.Updater.ModelState.AddModelError(Prefix, nameof(model.DefaultQuery), S["Please provide the default query."]);
+            }
+            else if (!JsonHelpers.TryParse(model.DefaultQuery, out var document))
+            {
+                context.Updater.ModelState.AddModelError(Prefix, nameof(model.DefaultQuery), S["The provided query is not formatted correctly."]);
+            }
+            else
+            {
+                section.DefaultQuery = JsonSerializer.Serialize(document, _jsonSerializerOptions);
+
+                try
+                {
+                    using var stream = new MemoryStream(Encoding.UTF8.GetBytes(model.DefaultQuery));
+
+                    var searchRequest = await _elasticClient.RequestResponseSerializer.DeserializeAsync<SearchRequest>(stream);
+                }
+                catch
+                {
+                    context.Updater.ModelState.AddModelError(Prefix, nameof(model.DefaultQuery), S["Invalid query provided."]);
+                }
+            }
+        }
+
+        return await EditAsync(section, context);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Services/ElasticSearchService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Services/ElasticSearchService.cs
@@ -75,13 +75,12 @@ public class ElasticsearchService : ISearchService
             return result;
         }
 
-        var searchType = searchSettings.GetSearchType();
-
         try
         {
+            var searchType = searchSettings.GetSearchType();
             QueryContainer query = null;
 
-            if (searchType == ElasticSettings.CustomSearchType)
+            if (searchType == ElasticSettings.CustomSearchType && !string.IsNullOrWhiteSpace(searchSettings.DefaultQuery))
             {
                 var tokenizedContent = await _liquidTemplateManager.RenderStringAsync(searchSettings.DefaultQuery, _javaScriptEncoder,
                     new Dictionary<string, FluidValue>()

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Services/ElasticSearchService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Services/ElasticSearchService.cs
@@ -81,7 +81,7 @@ public class ElasticsearchService : ISearchService
         {
             QueryContainer query = null;
 
-            if (searchType == ElasticSettings.RawSearchType && !string.IsNullOrWhiteSpace(searchSettings.DefaultQuery))
+            if (searchType == ElasticSettings.CustomSearchType)
             {
                 var tokenizedContent = await _liquidTemplateManager.RenderStringAsync(searchSettings.DefaultQuery, _javaScriptEncoder,
                     new Dictionary<string, FluidValue>()

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Services/ElasticSearchService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Services/ElasticSearchService.cs
@@ -17,9 +17,6 @@ namespace OrchardCore.Search.Elasticsearch.Services;
 
 public class ElasticsearchService : ISearchService
 {
-    public const string RawSearchType = "raw";
-    public const string QueryStringSearchType = "query_string";
-
     private readonly ISiteService _siteService;
     private readonly ElasticIndexManager _elasticIndexManager;
     private readonly ElasticIndexSettingsService _elasticIndexSettingsService;
@@ -78,11 +75,13 @@ public class ElasticsearchService : ISearchService
             return result;
         }
 
+        var searchType = searchSettings.GetSearchType();
+
         try
         {
             QueryContainer query = null;
 
-            if (searchSettings.SearchType == RawSearchType)
+            if (searchType == ElasticSettings.RawSearchType)
             {
                 var tokenizedContent = await _liquidTemplateManager.RenderStringAsync(searchSettings.DefaultQuery, _javaScriptEncoder,
                     new Dictionary<string, FluidValue>()
@@ -100,7 +99,7 @@ public class ElasticsearchService : ISearchService
                 }
                 catch { }
             }
-            else if (searchSettings.SearchType == "query_string")
+            else if (searchType == ElasticSettings.QueryStringSearchType)
             {
                 query = new QueryStringQuery
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/ViewModels/ElasticSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/ViewModels/ElasticSettingsViewModel.cs
@@ -1,13 +1,24 @@
 using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace OrchardCore.Search.Elasticsearch.ViewModels
 {
     public class ElasticSettingsViewModel
     {
         public string Analyzer { get; set; }
+
         public string SearchIndex { get; set; }
+
         public IEnumerable<string> SearchIndexes { get; set; }
+
         public string SearchFields { get; set; }
-        public bool AllowElasticQueryStringQueryInSearch { get; set; }
+
+        public string DefaultQuery { get; set; }
+
+        public string SearchType { get; set; }
+
+        [BindNever]
+        public IEnumerable<SelectListItem> SearchTypes { get; set; }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Views/ElasticSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Views/ElasticSettings.Edit.cshtml
@@ -1,4 +1,4 @@
-@using OrchardCore.Search.Elasticsearch.Services
+@using OrchardCore.Search.Elasticsearch.Core.Models
 
 @model ElasticSettingsViewModel
 
@@ -23,7 +23,7 @@
 
 <div class="mb-3" asp-validation-class-for="SearchType">
     <label asp-for="SearchType" class="form-label">@T["Default search index"]</label>
-    <select asp-for="SearchType" class="form-select" asp-items="Model.SearchTypes" data-raw-type="@ElasticsearchService.RawSearchType"></select>
+    <select asp-for="SearchType" class="form-select" asp-items="Model.SearchTypes" data-raw-type="@ElasticSettings.RawSearchType"></select>
     <span asp-validation-for="SearchType"></span>
 </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Views/ElasticSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Views/ElasticSettings.Edit.cshtml
@@ -23,7 +23,7 @@
 
 <div class="mb-3" asp-validation-class-for="SearchType">
     <label asp-for="SearchType" class="form-label">@T["Default search type"]</label>
-    <select asp-for="SearchType" class="form-select" asp-items="Model.SearchTypes" data-raw-type="@ElasticSettings.RawSearchType"></select>
+    <select asp-for="SearchType" class="form-select" asp-items="Model.SearchTypes" data-raw-type="@ElasticSettings.CustomSearchType"></select>
     <span asp-validation-for="SearchType"></span>
 </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Views/ElasticSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Views/ElasticSettings.Edit.cshtml
@@ -22,7 +22,7 @@
 </div>
 
 <div class="mb-3" asp-validation-class-for="SearchType">
-    <label asp-for="SearchType" class="form-label">@T["Default search index"]</label>
+    <label asp-for="SearchType" class="form-label">@T["Default search type"]</label>
     <select asp-for="SearchType" class="form-select" asp-items="Model.SearchTypes" data-raw-type="@ElasticSettings.RawSearchType"></select>
     <span asp-validation-for="SearchType"></span>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Views/ElasticSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Views/ElasticSettings.Edit.cshtml
@@ -1,35 +1,63 @@
+@using OrchardCore.Search.Elasticsearch.Services
+
 @model ElasticSettingsViewModel
 
-@if (Model.SearchIndexes.Any())
-{
-    <div class="mb-3" asp-validation-class-for="SearchIndex">
-        <label asp-for="SearchIndex" class="form-label">@T["Default search index"]</label>
-        <select asp-for="SearchIndex" class="form-select">
-            @foreach (var index in Model.SearchIndexes)
-            {
-                <option value="@index" selected="@(Model.SearchIndex == index)">@index</option>
-            }
-        </select>
-        <span asp-validation-for="SearchIndex"></span>
-        <span class="hint">@T["The default index to use for the search page."]</span>
-    </div>
-}
-else
+@if (!Model.SearchIndexes.Any())
 {
     <div class="alert alert-warning">@T["You need to create at least an index to set as the Search index."]</div>
+
+    return;
 }
 
-<div class="mb-3" asp-validation-class-for="SearchFields">
+<div class="mb-3" asp-validation-class-for="SearchIndex">
+    <label asp-for="SearchIndex" class="form-label">@T["Default search index"]</label>
+    <select asp-for="SearchIndex" class="form-select">
+        @foreach (var index in Model.SearchIndexes)
+        {
+            <option value="@index" selected="@(Model.SearchIndex == index)">@index</option>
+        }
+    </select>
+    <span asp-validation-for="SearchIndex"></span>
+    <span class="hint">@T["The default index to use for the search page."]</span>
+</div>
+
+<div class="mb-3" asp-validation-class-for="SearchType">
+    <label asp-for="SearchType" class="form-label">@T["Default search index"]</label>
+    <select asp-for="SearchType" class="form-select" asp-items="Model.SearchTypes" data-raw-type="@ElasticsearchService.RawSearchType"></select>
+    <span asp-validation-for="SearchType"></span>
+</div>
+
+<div class="mb-3" asp-validation-class-for="DefaultQuery" id="DefaultQueryContainer">
+    <label asp-for="DefaultQuery" class="form-label">@T["Default query"]</label>
+    <textarea asp-for="DefaultQuery" class="form-control" rows="10"></textarea>
+    <span asp-validation-for="DefaultQuery"></span>
+    <span class="hint">@T["Create a custom Elasticsearch query to be utilized for each search request. Liquid is supported, so use <code>{0}</code> template as a substitute for the user-provided search term.", "{{ term }}"]</span>
+</div>
+
+<div class="mb-3" asp-validation-class-for="SearchFields" id="DefaultQueryFields">
     <label asp-for="SearchFields" class="form-label">@T["Default searched fields"]</label>
     <input asp-for="SearchFields" class="form-control" />
     <span asp-validation-for="SearchFields"></span>
     <span class="hint">@T["A comma separated list of fields to use for search pages. The default value is <code>Content.ContentItem.FullText</code>."]</span>
 </div>
 
-<div class="mb-3" asp-validation-class-for="AllowElasticQueryStringQueryInSearch">
-    <div class="form-check">
-        <input type="checkbox" class="form-check-input" asp-for="AllowElasticQueryStringQueryInSearch" />
-        <label class="form-check-label" asp-for="AllowElasticQueryStringQueryInSearch">@T["Allow Elasticsearch \"query string query\" in search forms"]</label>
-        <span class="hint dashed">@T["Whether search queries should be allowed to use <a href=\"https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-dsl-query-string-query\">Elasticsearch \"query string query\" syntax</a>."] <a class="seedoc" href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-dsl-query-string-query" target="_blank">@T["See documentation"]</a></span>
-    </div>
-</div>
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        const menu = document.getElementById('@Html.IdFor(m => m.SearchType)');
+        const queryContainer = document.getElementById('DefaultQueryContainer');
+        const fieldsContainer = document.getElementById('DefaultQueryFields');
+
+        menu.addEventListener('change', function (e) {
+
+            if (e.target.value == e.target.getAttribute('data-raw-type')) {
+                queryContainer.classList.remove('d-none');
+                fieldsContainer.classList.add('d-none');
+            } else {
+                queryContainer.classList.add('d-none');
+                fieldsContainer.classList.remove('d-none');
+            }
+        });
+
+        menu.dispatchEvent(new Event('change'));
+    });
+</script>

--- a/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.elastic.search.recipe.json
+++ b/src/OrchardCore.Themes/TheBlogTheme/Recipes/blog.elastic.search.recipe.json
@@ -59,8 +59,9 @@
         "DefaultSearchFields": [
           "Content.ContentItem.FullText"
         ],
-        "AllowElasticQueryStringQueryInSearch": false,
-        "SyncWithLucene":  true
+        "SearchType": "",
+        "DefaultQuery": null,
+        "SyncWithLucene": true
       }
     },
     {

--- a/src/OrchardCore/OrchardCore.Abstractions/JsonHelpers.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/JsonHelpers.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace OrchardCore;
+
+public class JsonHelpers
+{
+    public static bool IsValid(string json, JsonDocumentOptions options = default)
+    {
+        try
+        {
+            JsonDocument.Parse(json, options);
+
+            return true;
+        }
+        catch { }
+
+        return false;
+    }
+
+    public static bool TryParse(string json, out JsonDocument document, JsonDocumentOptions options = default)
+    {
+        try
+        {
+            document = JsonDocument.Parse(json, options);
+
+            return true;
+        }
+        catch { }
+
+        document = null;
+        return false;
+    }
+}

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Models/ElasticSettings.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Models/ElasticSettings.cs
@@ -1,40 +1,39 @@
 using System;
 using OrchardCore.Contents.Indexing;
 
-namespace OrchardCore.Search.Elasticsearch.Core.Models
+namespace OrchardCore.Search.Elasticsearch.Core.Models;
+
+public class ElasticSettings
 {
-    public class ElasticSettings
+    public const string CustomSearchType = "custom";
+
+    public const string QueryStringSearchType = "query_string";
+
+    public static readonly string[] FullTextField = [IndexingConstants.FullTextKey];
+
+    public string SearchIndex { get; set; }
+
+    public string DefaultQuery { get; set; }
+
+    public string[] DefaultSearchFields { get; set; } = FullTextField;
+
+    public string SearchType { get; set; }
+
+    [Obsolete("This property will be removed in future releases.")]
+    public const string StandardAnalyzer = "standardanalyzer";
+
+    [Obsolete($"This property will be removed in future releases. Instead use {nameof(SearchType)} property.")]
+    public bool AllowElasticQueryStringQueryInSearch { get; set; } = false;
+
+    public string GetSearchType()
     {
-        public const string RawSearchType = "raw";
-
-        public const string QueryStringSearchType = "query_string";
-
-        public static readonly string[] FullTextField = [IndexingConstants.FullTextKey];
-
-        public string SearchIndex { get; set; }
-
-        public string DefaultQuery { get; set; }
-
-        public string[] DefaultSearchFields { get; set; } = FullTextField;
-
-        public string SearchType { get; set; }
-
-        [Obsolete("This property will be removed in future releases.")]
-        public const string StandardAnalyzer = "standardanalyzer";
-
-        [Obsolete($"This property will be removed in future releases. Instead use {nameof(SearchType)} property.")]
-        public bool AllowElasticQueryStringQueryInSearch { get; set; } = false;
-
-        public string GetSearchType()
-        {
 #pragma warning disable CS0618 // Type or member is obsolete
-            if (SearchType == null && AllowElasticQueryStringQueryInSearch)
-            {
-                return QueryStringSearchType;
-            }
+        if (SearchType == null && AllowElasticQueryStringQueryInSearch)
+        {
+            return QueryStringSearchType;
+        }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            return SearchType;
-        }
+        return SearchType;
     }
 }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Models/ElasticSettings.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Models/ElasticSettings.cs
@@ -5,15 +5,20 @@ namespace OrchardCore.Search.Elasticsearch.Core.Models
 {
     public class ElasticSettings
     {
-        public static readonly string[] FullTextField = new string[] { IndexingConstants.FullTextKey };
+        public static readonly string[] FullTextField = [IndexingConstants.FullTextKey];
 
         [Obsolete("This property will be removed in future releases.")]
         public const string StandardAnalyzer = "standardanalyzer";
 
         public string SearchIndex { get; set; }
 
+        public string DefaultQuery { get; set; }
+
         public string[] DefaultSearchFields { get; set; } = FullTextField;
 
+        [Obsolete("Instead use SearchType property.")]
         public bool AllowElasticQueryStringQueryInSearch { get; set; } = false;
+
+        public string SearchType { get; set; }
     }
 }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Models/ElasticSettings.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Models/ElasticSettings.cs
@@ -5,10 +5,11 @@ namespace OrchardCore.Search.Elasticsearch.Core.Models
 {
     public class ElasticSettings
     {
-        public static readonly string[] FullTextField = [IndexingConstants.FullTextKey];
+        public const string RawSearchType = "raw";
 
-        [Obsolete("This property will be removed in future releases.")]
-        public const string StandardAnalyzer = "standardanalyzer";
+        public const string QueryStringSearchType = "query_string";
+
+        public static readonly string[] FullTextField = [IndexingConstants.FullTextKey];
 
         public string SearchIndex { get; set; }
 
@@ -16,9 +17,24 @@ namespace OrchardCore.Search.Elasticsearch.Core.Models
 
         public string[] DefaultSearchFields { get; set; } = FullTextField;
 
-        [Obsolete("Instead use SearchType property.")]
+        public string SearchType { get; set; }
+
+        [Obsolete("This property will be removed in future releases.")]
+        public const string StandardAnalyzer = "standardanalyzer";
+
+        [Obsolete($"This property will be removed in future releases. Instead use {nameof(SearchType)} property.")]
         public bool AllowElasticQueryStringQueryInSearch { get; set; } = false;
 
-        public string SearchType { get; set; }
+        public string GetSearchType()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            if (SearchType == null && AllowElasticQueryStringQueryInSearch)
+            {
+                return QueryStringSearchType;
+            }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            return SearchType;
+        }
     }
 }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticIndexManager.cs
@@ -102,7 +102,7 @@ namespace OrchardCore.Search.Elasticsearch.Core.Services
             var indexSettingsDescriptor = new IndexSettingsDescriptor();
 
             // The name "standardanalyzer" is a legacy used prior OC 1.6 release. It can be removed in future releases.
-            var analyzerName = elasticIndexSettings.AnalyzerName == "standardanalyzer" ? "standard" : elasticIndexSettings.AnalyzerName;
+            var analyzerName = (elasticIndexSettings.AnalyzerName == "standardanalyzer" ? null : elasticIndexSettings.AnalyzerName) ?? "standard";
 
             if (_elasticsearchOptions.Analyzers.TryGetValue(analyzerName, out var analyzerProperties))
             {

--- a/src/docs/reference/modules/Elasticsearch/README.md
+++ b/src/docs/reference/modules/Elasticsearch/README.md
@@ -90,7 +90,8 @@ Here is an example for setting default search settings:
         "DefaultSearchFields":[
           "Content.ContentItem.FullText"
         ],
-        "AllowElasticQueryStringQueryInSearch":false,
+        "SearchType": "", // Use 'raw' for a custom query in DefaultQuery and 'query_string' for a Query String Query search. Leave it blank for the default, which is a Multi-Match Query search.
+        "DefaultQuery": null,
         "SyncWithLucene":true // Allows to sync content index settings.
       }
     }
@@ -169,11 +170,14 @@ Here is an example for creating a Elasticsearch query from a Queries recipe step
 
 ```json
 {
-  "Source": "Elasticsearch",
-  "Name": "RecentBlogPosts",
-  "Index": "Search",
-  "Template": "...", // json encoded query template
-  "ReturnContentItems": true
+  "steps":[
+    {
+        "Source": "Elasticsearch",
+        "Name": "RecentBlogPosts",
+        "Index": "Search",
+        "Template": "...", // json encoded query template
+        "ReturnContentItems": true
+    }
 }
 ```
 

--- a/src/docs/reference/modules/Elasticsearch/README.md
+++ b/src/docs/reference/modules/Elasticsearch/README.md
@@ -90,7 +90,7 @@ Here is an example for setting default search settings:
         "DefaultSearchFields":[
           "Content.ContentItem.FullText"
         ],
-        "SearchType": "", // Use 'raw' for a custom query in DefaultQuery and 'query_string' for a Query String Query search. Leave it blank for the default, which is a Multi-Match Query search.
+        "SearchType": "", // Use 'custom' for a custom query in DefaultQuery and 'query_string' for a Query String Query search. Leave it blank for the default, which is a Multi-Match Query search.
         "DefaultQuery": null,
         "SyncWithLucene":true // Allows to sync content index settings.
       }

--- a/src/docs/releases/1.8.0.md
+++ b/src/docs/releases/1.8.0.md
@@ -48,13 +48,13 @@ Additionally, if you've customized the `Error.cshtml` view, it should be renamed
 
 The following interfaces have been updated to incorporate new asynchronous methods, corresponding to each synchronous method. All synchronous methods have been deprecated and should no longer be utilized.
 
-- IStereotypeService
-- IStereotypesProvider
-- IRouteableContentTypeProvider
-- IRouteableContentTypeCoordinator
-- IContentDefinitionService
-- IContentDefinitionManager
-- IContentDefinitionService
+- `IStereotypeService`
+- `IStereotypesProvider`
+- `IRouteableContentTypeProvider`
+- `IRouteableContentTypeCoordinator`
+- `IContentDefinitionService`
+- `IContentDefinitionManager`
+- `IContentDefinitionService`
 
 ## Change Logs
 
@@ -104,3 +104,23 @@ To add the `Navbar` shape into your own back-end theme, add the following code i
 
 @await DisplayAsync(await DisplayManager.BuildDisplayAsync<Navbar>(UpdateModelAccessor.ModelUpdater, "DetailAdmin"))
 ```
+
+### Elasticsearch Module
+
+Introduced a new option in `ElasticSettings` that permits the definition of a custom query for the default search. For instance, the following is an example of a search query supporting the [fuzziness](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/common-options.html#fuzziness) option:
+
+```
+{
+  "query": {
+    "match": {
+      "Content.ContentItem.FullText": {
+        "query": "{{ term }}",
+        "fuzziness": "AUTO",
+        "analyzer": "whitespace"
+      }
+    }
+  }
+}
+```
+
+![elastic-search-ex](https://github.com/OrchardCMS/OrchardCore/assets/24724371/15aae13e-0fc0-4df6-98be-352a441618c0)


### PR DESCRIPTION
Fix #14842

Are you can see in the following screencast, I was able to define a the following custom query to perform advance operation like `fuzziness`
```
{
  "query": {
    "match": {
      "Content.ContentItem.FullText": {
        "query": "{{ term }}",
        "fuzziness": "AUTO",
        "analyzer": "whitespace"
      }
    }
  }
}
```
![elastic-search-ex](https://github.com/OrchardCMS/OrchardCore/assets/24724371/15aae13e-0fc0-4df6-98be-352a441618c0)
