### PR TITLE
Missing SmtpSettings Options Setup

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpSettingsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Services/SmtpSettingsConfiguration.cs
@@ -1,8 +1,6 @@
-using System;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using OrchardCore.Entities;
 using OrchardCore.Settings;
 
 namespace OrchardCore.Email.Services
@@ -34,11 +32,15 @@ namespace OrchardCore.Email.Services
             options.PickupDirectoryLocation = settings.PickupDirectoryLocation;
             options.Host = settings.Host;
             options.Port = settings.Port;
+            options.ProxyHost = settings.ProxyHost;
+            options.ProxyPort = settings.ProxyPort;
             options.EncryptionMethod = settings.EncryptionMethod;
             options.AutoSelectEncryption = settings.AutoSelectEncryption;
             options.RequireCredentials = settings.RequireCredentials;
             options.UseDefaultCredentials = settings.UseDefaultCredentials;
             options.UserName = settings.UserName;
+            options.Password = settings.Password;
+            options.IgnoreInvalidSslCertificate = settings.IgnoreInvalidSslCertificate;
 
             // Decrypt the password
             if (!string.IsNullOrWhiteSpace(settings.Password))


### PR DESCRIPTION
`SmtpSettingsConfiguration : IConfigureOptions<SmtpSettings>` gets `SmtpSettings` from Site Settings to setup an `SmtpSettings` as options allowing to inject these settings through `IOptions<SmtpSettings>`.

But some fields (I assume new fields) are not setup, so when injecting `IOptions<SmtpSettings>` as it is done in `SmtpService` these fields are not retrieved (unless if set by another tenant configuration).

@hishamco For example, how can we expect that `SmtpService` retrieve `IgnoreInvalidSslCertificate` through  `IOptions<SmtpSettings>` if it is not set in `SmtpSettingsConfiguration`.
