### PR TITLE
Show warnings when Azure AI Search is not configured

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Controllers/AdminController.cs
@@ -29,6 +29,8 @@ namespace OrchardCore.Search.AzureAI.Controllers;
 
 public class AdminController : Controller
 {
+    private const string _optionsSearch = "Options.Search";
+
     private readonly ISiteService _siteService;
     private readonly IAuthorizationService _authorizationService;
     private readonly AzureAISearchIndexManager _indexManager;
@@ -82,6 +84,11 @@ public class AdminController : Controller
             return Forbid();
         }
 
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return NotConfigured();
+        }
+
         var indexes = (await _indexSettingsService.GetSettingsAsync())
             .Select(i => new IndexViewModel { Name = i.IndexName })
             .ToList();
@@ -100,20 +107,19 @@ public class AdminController : Controller
             .Skip(pager.GetStartIndex())
             .Take(pager.PageSize).ToList();
 
-        // Maintain previous route data when generating page links.S
-        RouteValueDictionary routeValues = null;
+        // Maintain previous route data when generating page links.
+        var routeData = new RouteData();
 
-        if (!string.IsNullOrWhiteSpace(options.Search))
+        if (!string.IsNullOrEmpty(options.Search))
         {
-            routeValues = [];
-            routeValues.TryAdd("Options.Search", options.Search);
+            routeData.Values.TryAdd(_optionsSearch, options.Search);
         }
 
         var model = new AdminIndexViewModel
         {
             Indexes = indexes,
             Options = options,
-            Pager = await _shapeFactory.PagerAsync(pager, totalIndexes, routeValues)
+            Pager = await _shapeFactory.PagerAsync(pager, totalIndexes, routeData)
         };
 
         model.Options.ContentsBulkAction =
@@ -130,17 +136,22 @@ public class AdminController : Controller
         => RedirectToAction(nameof(Index),
             new RouteValueDictionary
             {
-                { "Options.Search", model.Options.Search }
+                { _optionsSearch, model.Options.Search }
             });
-    
+
 
     [HttpPost, ActionName(nameof(Index))]
     [FormValueRequired("submit.BulkAction")]
-    public async Task<ActionResult> IndexPost(AzureAIIndexOptions options, IEnumerable<string> itemIds)
+    public async Task<IActionResult> IndexPost(AzureAIIndexOptions options, IEnumerable<string> itemIds)
     {
         if (!await _authorizationService.AuthorizeAsync(User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
             return Forbid();
+        }
+
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return BadRequest();
         }
 
         if (itemIds?.Count() > 0)
@@ -169,11 +180,16 @@ public class AdminController : Controller
         return RedirectToAction(nameof(Index));
     }
 
-    public async Task<ActionResult> Create()
+    public async Task<IActionResult> Create()
     {
         if (!await _authorizationService.AuthorizeAsync(User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
             return Forbid();
+        }
+
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return NotConfigured();
         }
 
         var model = new AzureAISettingsViewModel
@@ -187,11 +203,16 @@ public class AdminController : Controller
     }
 
     [HttpPost, ActionName(nameof(Create))]
-    public async Task<ActionResult> CreatePost(AzureAISettingsViewModel model)
+    public async Task<IActionResult> CreatePost(AzureAISettingsViewModel model)
     {
         if (!await _authorizationService.AuthorizeAsync(User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
             return Forbid();
+        }
+
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return BadRequest();
         }
 
         if (ModelState.IsValid && await _indexManager.ExistsAsync(model.IndexName))
@@ -244,11 +265,16 @@ public class AdminController : Controller
         return View(model);
     }
 
-    public async Task<ActionResult> Edit(string indexName)
+    public async Task<IActionResult> Edit(string indexName)
     {
         if (!await _authorizationService.AuthorizeAsync(User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
             return Forbid();
+        }
+
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return NotConfigured();
         }
 
         var settings = await _indexSettingsService.GetAsync(indexName);
@@ -283,11 +309,16 @@ public class AdminController : Controller
     }
 
     [HttpPost, ActionName(nameof(Edit))]
-    public async Task<ActionResult> EditPost(AzureAISettingsViewModel model)
+    public async Task<IActionResult> EditPost(AzureAISettingsViewModel model)
     {
         if (!await _authorizationService.AuthorizeAsync(User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
             return Forbid();
+        }
+
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return BadRequest();
         }
 
         if (ModelState.IsValid && !await _indexManager.ExistsAsync(model.IndexName))
@@ -353,11 +384,16 @@ public class AdminController : Controller
     }
 
     [HttpPost]
-    public async Task<ActionResult> Delete(string indexName)
+    public async Task<IActionResult> Delete(string indexName)
     {
         if (!await _authorizationService.AuthorizeAsync(User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
             return Forbid();
+        }
+
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return BadRequest();
         }
 
         var exists = await _indexManager.ExistsAsync(indexName);
@@ -384,11 +420,16 @@ public class AdminController : Controller
     }
 
     [HttpPost]
-    public async Task<ActionResult> Rebuild(string indexName)
+    public async Task<IActionResult> Rebuild(string indexName)
     {
         if (!await _authorizationService.AuthorizeAsync(User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
             return Forbid();
+        }
+
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return BadRequest();
         }
 
         var settings = await _indexSettingsService.GetAsync(indexName);
@@ -413,11 +454,16 @@ public class AdminController : Controller
     }
 
     [HttpPost]
-    public async Task<ActionResult> Reset(string indexName)
+    public async Task<IActionResult> Reset(string indexName)
     {
         if (!await _authorizationService.AuthorizeAsync(User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
             return Forbid();
+        }
+
+        if (!_azureAIOptions.IsConfigurationExists())
+        {
+            return BadRequest();
         }
 
         var settings = await _indexSettingsService.GetAsync(indexName);
@@ -440,6 +486,9 @@ public class AdminController : Controller
 
         return RedirectToAction(nameof(Index));
     }
+
+    private IActionResult NotConfigured()
+        => View("NotConfigured");
 
     private static Task AsyncContentItemsAsync(string indexName)
         => HttpBackgroundJob.ExecuteAfterEndOfRequestAsync("sync-content-items-azure-ai-" + indexName, async (scope) =>

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Startup.cs
@@ -16,7 +16,6 @@ using OrchardCore.Search.Abstractions;
 using OrchardCore.Search.AzureAI.Controllers;
 using OrchardCore.Search.AzureAI.Deployment;
 using OrchardCore.Search.AzureAI.Drivers;
-using OrchardCore.Search.AzureAI.Models;
 using OrchardCore.Search.AzureAI.Services;
 using OrchardCore.Settings;
 
@@ -31,23 +30,12 @@ public class Startup(ILogger<Startup> logger, IShellConfiguration shellConfigura
 
     public override void ConfigureServices(IServiceCollection services)
     {
-        if (!services.TryAddAzureAISearchServices(_shellConfiguration, _logger))
-        {
-            return;
-        }
-
+        services.TryAddAzureAISearchServices(_shellConfiguration, _logger);
         services.AddScoped<INavigationProvider, AdminMenu>();
     }
 
     public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
     {
-        var options = serviceProvider.GetRequiredService<IOptions<AzureAISearchDefaultOptions>>().Value;
-
-        if (!options.IsConfigurationExists())
-        {
-            return;
-        }
-
         var adminControllerName = typeof(AdminController).ControllerName();
 
         routes.MapAreaControllerRoute(

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Views/Admin/NotConfigured.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Views/Admin/NotConfigured.cshtml
@@ -1,0 +1,3 @@
+<div class="alert alert-danger" role="alert">
+    @T["Azure AI Search has not been configured yet."]
+</div>

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Views/AzureAISearchSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Views/AzureAISearchSettings.Edit.cshtml
@@ -1,12 +1,25 @@
+@using Microsoft.Extensions.Options
 @using OrchardCore.Search.AzureAI
 @using OrchardCore.Search.AzureAI.Models
 @using OrchardCore.Search.AzureAI.ViewModels
 
 @model AzureAISearchSettingsViewModel
+@inject IOptions<AzureAISearchDefaultOptions> AzureAIOptions
+
+@if (!AzureAIOptions.Value.IsConfigurationExists())
+{
+    <div class="alert alert-danger" role="alert">
+        @T["Azure AI Search has not been configured yet."]
+    </div>
+
+    return;
+}
 
 @if (Model.SearchIndexes == null || Model.SearchIndexes?.Count == 0)
 {
-    <div class="alert alert-warning">@T["No indices exist! Please create at least one index to configure Azure AI Search service."]</div>
+    <div class="alert alert-warning" role="alert">
+        @T["No indices exist! Please create at least one index to configure Azure AI Search service."]
+    </div>
 
     return;
 }

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Extensions/ServiceCollectionExtensions.cs
@@ -21,12 +21,11 @@ public static class ServiceCollectionExtensions
         var section = configuration.GetSection("OrchardCore_AzureAISearch");
 
         var options = section.Get<AzureAISearchDefaultOptions>();
-
+        var configExists = true;
         if (string.IsNullOrWhiteSpace(options?.Endpoint) || string.IsNullOrWhiteSpace(options?.Credential?.Key))
         {
-            logger.LogError("Azure AI Search module is enabled. However, the connection settings are not provided in configuration file..");
-
-            return false;
+            configExists = false;
+            logger.LogError("Azure AI Search module is enabled. However, the connection settings are not provided in configuration file.");
         }
 
         services.Configure<AzureAISearchDefaultOptions>(opts =>
@@ -37,7 +36,7 @@ public static class ServiceCollectionExtensions
             opts.Analyzers = options.Analyzers == null || options.Analyzers.Length == 0
             ? AzureAISearchDefaultOptions.DefaultAnalyzers
             : options.Analyzers;
-            opts.SetConfigurationExists(true);
+            opts.SetConfigurationExists(configExists);
         });
 
         services.AddAzureClients(builder =>
@@ -58,6 +57,6 @@ public static class ServiceCollectionExtensions
         services.AddRecipeExecutionStep<AzureAISearchIndexResetStep>();
         services.AddRecipeExecutionStep<AzureAISearchIndexSettingsStep>();
 
-        return true;
+        return configExists;
     }
 }


### PR DESCRIPTION
@bleroy 

This PR addressed the behavior you encountered in #14984. Basically, we register the services when the feature is enabled. But, if the configuration are missing from the file, then we show warning instead of showing action functions. Here is an example

![image](https://github.com/OrchardCMS/OrchardCore/assets/24724371/441f7882-9fb9-4409-8cc2-03808ab2ee07)

![image](https://github.com/OrchardCMS/OrchardCore/assets/24724371/3456250e-f77b-4f7c-bdd4-d1aaea1831ec)
