### PR TITLE
Add OrchardCore_Redis:DisableSSLCertificate option (#15077)

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -79,7 +79,8 @@
     // See https://stackexchange.github.io/StackExchange.Redis/Configuration.html
     //"OrchardCore_Redis": {
     //  "Configuration": "192.168.99.100:6379,allowAdmin=true", // Redis Configuration string.
-    //  "InstancePrefix": "" // Optional prefix allowing a Redis instance to be shared by different applications.
+    //  "InstancePrefix": "", // Optional prefix allowing a Redis instance to be shared by different applications.
+    //  "DisableCertificateVerification": false // Disable SSL/TLS certificate verification.
     //},
     // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Security/#security-settings-configuration to configure security settings.
     //"OrchardCore_Security": {


### PR DESCRIPTION
Fixs #15077
As discussed in #15077. this adds a new "DisableSSLCertificate" option to the OrchardCore_Redis section.

If used, this option allows the SSL certificate to be accepted even if the certificate is both self-signed (SslPolicyErrors.RemoteCertificateChainErrors) and is issued for a different DNS alias than the one you're trying to connect to (SslPolicyErrors.RemoteCertificateNameMismatch), both of which are the case for Heroku's highly-available Redis servers.