### PR TITLE
Fix errors when role names have different casing

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
@@ -282,7 +282,7 @@ namespace OrchardCore.Roles.Controllers
             // Create a fake user to check the actual permissions. If the role is anonymous
             // IsAuthenticated needs to be false.
             var fakeIdentity = new ClaimsIdentity(new[] { new Claim(ClaimTypes.Role, role.RoleName) },
-                role.RoleName != "Anonymous" ? "FakeAuthenticationType" : null);
+                !string.Equals(role.RoleName, "Anonymous", StringComparison.OrdinalIgnoreCase) ? "FakeAuthenticationType" : null);
 
             // Add role claims
             fakeIdentity.AddClaims(role.RoleClaims.Select(c => c.ToClaim()));

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleStore.cs
@@ -102,7 +102,7 @@ namespace OrchardCore.Roles.Services
                 handler.RoleRemovedAsync(roleToRemove.RoleName), roleToRemove, _logger);
 
             var roles = await LoadRolesAsync();
-            roleToRemove = roles.Roles.FirstOrDefault(r => r.RoleName == roleToRemove.RoleName);
+            roleToRemove = roles.Roles.FirstOrDefault(r => string.Equals(r.RoleName, roleToRemove.RoleName, StringComparison.OrdinalIgnoreCase));
             roles.Roles.Remove(roleToRemove);
 
             await UpdateRolesAsync(roles);
@@ -115,7 +115,7 @@ namespace OrchardCore.Roles.Services
             // While updating find a role from the loaded document being mutated.
             var roles = _updating ? await LoadRolesAsync() : await GetRolesAsync();
 
-            var role = roles.Roles.FirstOrDefault(x => x.RoleName == roleId);
+            var role = roles.Roles.FirstOrDefault(x => string.Equals(x.RoleName, roleId, StringComparison.OrdinalIgnoreCase));
 
             if (role == null)
             {
@@ -202,7 +202,7 @@ namespace OrchardCore.Roles.Services
             }
 
             var roles = await LoadRolesAsync();
-            var existingRole = roles.Roles.FirstOrDefault(x => x.RoleName == role.RoleName);
+            var existingRole = roles.Roles.FirstOrDefault(x => string.Equals(x.RoleName, role.RoleName, StringComparison.OrdinalIgnoreCase));
             roles.Roles.Remove(existingRole);
             roles.Roles.Add((Role)role);
 

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
@@ -67,7 +67,7 @@ namespace OrchardCore.Roles.Services
                 var stereotypes = provider.GetDefaultStereotypes();
                 foreach (var stereotype in stereotypes)
                 {
-                    var role = rolesDocument.Roles.FirstOrDefault(role => role.RoleName == stereotype.Name);
+                    var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.RoleName, stereotype.Name, System.StringComparison.OrdinalIgnoreCase));
                     if (role == null)
                     {
                         continue;
@@ -129,7 +129,7 @@ namespace OrchardCore.Roles.Services
         private async Task UpdateRoleForInstalledFeaturesAsync(string roleName)
         {
             var rolesDocument = await _documentManager.GetOrCreateMutableAsync();
-            var role = rolesDocument.Roles.FirstOrDefault(role => role.RoleName == roleName);
+            var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.RoleName, roleName, System.StringComparison.OrdinalIgnoreCase));
             if (role == null)
             {
                 return;
@@ -151,7 +151,7 @@ namespace OrchardCore.Roles.Services
 
             var stereotypes = _permissionProviders
                 .SelectMany(provider => provider.GetDefaultStereotypes())
-                .Where(stereotype => stereotype.Name == roleName);
+                .Where(stereotype => string.Equals(stereotype.Name, roleName, System.StringComparison.OrdinalIgnoreCase));
 
             if (!stereotypes.Any())
             {
@@ -179,7 +179,7 @@ namespace OrchardCore.Roles.Services
         {
             var stereotypes = providers
                 .SelectMany(provider => provider.GetDefaultStereotypes())
-                .Where(stereotype => stereotype.Name == role.RoleName);
+                .Where(stereotype => string.Equals(stereotype.Name, role.RoleName, System.StringComparison.OrdinalIgnoreCase));
 
             if (!stereotypes.Any())
             {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RoleLoginSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RoleLoginSettingsDisplayDriver.cs
@@ -44,7 +44,7 @@ public class RoleLoginSettingsDisplayDriver : SectionDisplayDriver<ISite, RoleLo
             model.Roles = roles.Select(role => new RoleEntry()
             {
                 Role = role.RoleName,
-                IsSelected = settings.Roles != null && settings.Roles.Contains(role.RoleName),
+                IsSelected = settings.Roles != null && settings.Roles.Contains(role.RoleName, StringComparer.OrdinalIgnoreCase),
             }).OrderBy(entry => entry.Role)
             .ToArray();
         }).Location("Content:6#Two-Factor Authentication")

--- a/src/OrchardCore.Themes/TheAdmin/Recipes/headless.recipe.json
+++ b/src/OrchardCore.Themes/TheAdmin/Recipes/headless.recipe.json
@@ -90,7 +90,7 @@
           "Permissions": []
         },
         {
-          "Name": "AUTHENTICATED",
+          "Name": "Authenticated",
           "Description": "Authenticated",
           "Permissions": [
             "ViewContent",
@@ -99,7 +99,7 @@
           ]
         },
         {
-          "Name": "ANONYMOUS",
+          "Name": "Anonymous",
           "Description": "Anonymous",
           "Permissions": []
         }


### PR DESCRIPTION
- Always compare role names with ignored casing. 
- Fixes the casing of Anonymous and Authenticated roles in headless recipe.

I understand you guys don't want to do case-insensitive comparing in the role store, but I'd still argue this is the easiest fix if someone has an existing role which differs in casing only. If you want to do it differently, feel free to close this PR.

Fixes #15057 