### PR TITLE
Prefill template name when creating a template.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/TemplateController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/TemplateController.cs
@@ -126,7 +126,7 @@ namespace OrchardCore.Templates.Controllers
                 { _optionsSearch, model.Options.Search }
             });
 
-        public async Task<IActionResult> Create(bool adminTemplates = false, string returnUrl = null)
+        public async Task<IActionResult> Create(string name = null, bool adminTemplates = false, string returnUrl = null)
         {
             if (!adminTemplates && !await _authorizationService.AuthorizeAsync(User, Permissions.ManageTemplates))
             {
@@ -138,8 +138,14 @@ namespace OrchardCore.Templates.Controllers
                 return Forbid();
             }
 
+            var model = new TemplateViewModel
+            {
+                AdminTemplates = adminTemplates,
+                Name = name
+            };
+
             ViewData["ReturnUrl"] = returnUrl;
-            return View(new TemplateViewModel() { AdminTemplates = adminTemplates });
+            return View(model);
         }
 
         [HttpPost, ActionName(nameof(Create))]


### PR DESCRIPTION
Prefill the template name when creating a template from a content type or part definition.

Fixes: #15144 