### PR TITLE
Wrong placement is applied

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementInfoExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementInfoExtensions.cs
@@ -22,7 +22,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
             }
             else if (second != null)
             {
-                PlacementInfo combined = new();
+                var combined = new PlacementInfo();
 
                 combined.Alternates = first.Alternates.Combine(second.Alternates);
                 combined.Wrappers = first.Wrappers.Combine(second.Wrappers);
@@ -55,7 +55,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
             }
             else if (second != null)
             {
-                AlternatesCollection combined = new();
+                var combined = new AlternatesCollection();
 
                 combined.AddRange(first);
                 combined.AddRange(second);

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementInfoExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementInfoExtensions.cs
@@ -22,28 +22,19 @@ namespace OrchardCore.DisplayManagement.Descriptors
             }
             else if (second != null)
             {
-                first.Alternates = first.Alternates.Combine(second.Alternates);
-                first.Wrappers = first.Wrappers.Combine(second.Wrappers);
-                if (!string.IsNullOrEmpty(second.ShapeType))
-                {
-                    first.ShapeType = second.ShapeType;
-                }
+                PlacementInfo combined = new();
 
-                if (!string.IsNullOrEmpty(second.Location))
-                {
-                    first.Location = second.Location;
-                }
+                combined.Alternates = first.Alternates.Combine(second.Alternates);
+                combined.Wrappers = first.Wrappers.Combine(second.Wrappers);
 
-                if (!string.IsNullOrEmpty(second.DefaultPosition))
-                {
-                    first.DefaultPosition = second.DefaultPosition;
-                }
+                combined.ShapeType = string.IsNullOrEmpty(second.ShapeType) ? first.ShapeType : second.ShapeType;
+                combined.Location = string.IsNullOrEmpty(second.Location) ? first.Location : second.Location;
+                combined.DefaultPosition = string.IsNullOrEmpty(second.DefaultPosition) ? first.DefaultPosition : second.DefaultPosition;
+                combined.Source = $"{first.Source},{second.Source}";
 
-                if (!string.IsNullOrEmpty(second.Source))
-                {
-                    first.Source += "," + second.Source;
-                }
+                return combined;
             }
+
             return first;
         }
 
@@ -64,7 +55,12 @@ namespace OrchardCore.DisplayManagement.Descriptors
             }
             else if (second != null)
             {
-                first.AddRange(second);
+                AlternatesCollection combined = new();
+
+                combined.AddRange(first);
+                combined.AddRange(second);
+
+                return combined;
             }
 
             return first;


### PR DESCRIPTION
Fixes: #15166 

Changed to not update any in parameters. That caused the resolved value to be cached and returned for other content types and after placement definition overrides were deleted.