### PR TITLE
Linking Orchard Core Walkthroughs module in tutorials README (Lombiq Technologies: NEST-113)

### DIFF
--- a/src/docs/resources/tutorials/README.md
+++ b/src/docs/resources/tutorials/README.md
@@ -4,7 +4,7 @@ If you want to learn or improve your knowledge about Orchard Core, you can follo
 
 ## Lombiq
 
-[Lombiq](https://lombiq.com) created a video playlist and a Demo Orchard Core module for training purposes guiding you to become an Orchard Core developer:
+[Lombiq](https://lombiq.com) created a video playlist a Demo Orchard Core module and a Walkthroughs Orchard Core module for training purposes guiding you to become an Orchard Core developer:
 
 - [Dojo Course 3 - the full Orchard Core tutorial](https://orcharddojo.net/orchard-training/dojo-course-3-the-full-orchard-core-tutorial)
 - [Orchard Core Training Demo module](https://github.com/Lombiq/Orchard-Training-Demo-Module)

--- a/src/docs/resources/tutorials/README.md
+++ b/src/docs/resources/tutorials/README.md
@@ -4,7 +4,7 @@ If you want to learn or improve your knowledge about Orchard Core, you can follo
 
 ## Lombiq
 
-[Lombiq](https://lombiq.com) created a video playlist a Demo Orchard Core module and a Walkthroughs Orchard Core module for training purposes guiding you to become an Orchard Core developer:
+[Lombiq](https://lombiq.com) created a video playlist, a Demo Orchard Core module and a Walkthroughs Orchard Core module for training purposes guiding you to become an Orchard Core developer:
 
 - [Dojo Course 3 - the full Orchard Core tutorial](https://orcharddojo.net/orchard-training/dojo-course-3-the-full-orchard-core-tutorial)
 - [Orchard Core Training Demo module](https://github.com/Lombiq/Orchard-Training-Demo-Module)

--- a/src/docs/resources/tutorials/README.md
+++ b/src/docs/resources/tutorials/README.md
@@ -8,6 +8,7 @@ If you want to learn or improve your knowledge about Orchard Core, you can follo
 
 - [Dojo Course 3 - the full Orchard Core tutorial](https://orcharddojo.net/orchard-training/dojo-course-3-the-full-orchard-core-tutorial)
 - [Orchard Core Training Demo module](https://github.com/Lombiq/Orchard-Training-Demo-Module)
+- [Orchard Core Walkthroughs module](https://github.com/Lombiq/Orchard-Walkthroughs)
 
 !!! warning
     The module assumes that you have a good understanding of basic Orchard Core concepts, and that you can get around the Orchard admin area. You should also be familiar with how to use Visual Studio and write C#, as well as the concepts of ASP.NET Core MVC.

--- a/src/docs/resources/tutorials/README.md
+++ b/src/docs/resources/tutorials/README.md
@@ -11,4 +11,4 @@ If you want to learn or improve your knowledge about Orchard Core, you can follo
 - [Orchard Core Walkthroughs module](https://github.com/Lombiq/Orchard-Walkthroughs)
 
 !!! warning
-    The module assumes that you have a good understanding of basic Orchard Core concepts, and that you can get around the Orchard admin area. You should also be familiar with how to use Visual Studio and write C#, as well as the concepts of ASP.NET Core MVC.
+    The Orchard Core Training Demo module assumes that you have a good understanding of basic Orchard Core concepts, and that you can get around the Orchard admin area. You should also be familiar with how to use Visual Studio and write C#, as well as the concepts of ASP.NET Core MVC.


### PR DESCRIPTION
I think a mention about this module belongs on the "Tutorials" page too, since it helps new users to learn Orchard Core.

Here is the demo about the module: https://youtu.be/mWfngBADvX0?si=bKST4F_ih9zKBAv7