### PR TITLE
Throw when SQLite file not found

### DIFF
--- a/src/OrchardCore/OrchardCore.Data.Abstractions/DbConnectionValidatorContext.cs
+++ b/src/OrchardCore/OrchardCore.Data.Abstractions/DbConnectionValidatorContext.cs
@@ -11,6 +11,7 @@ public class DbConnectionValidatorContext : IDbConnectionInfo
         ConnectionString = shellSettings["ConnectionString"];
         TablePrefix = shellSettings["TablePrefix"];
         Schema = shellSettings["Schema"];
+        ShellSettings = shellSettings;
 
         TableOptions = shellSettings.GetDatabaseTableOptions();
     }
@@ -22,6 +23,7 @@ public class DbConnectionValidatorContext : IDbConnectionInfo
         ConnectionString = dbConnectionInfo.ConnectionString;
         TablePrefix = dbConnectionInfo.TablePrefix;
         Schema = dbConnectionInfo.Schema;
+        ShellSettings = shellSettings;
 
         TableOptions = shellSettings.GetDatabaseTableOptions();
     }
@@ -35,6 +37,8 @@ public class DbConnectionValidatorContext : IDbConnectionInfo
     public string TablePrefix { get; }
 
     public string Schema { get; }
+
+    public ShellSettings ShellSettings { get; }
 
     public DatabaseTableOptions TableOptions { get; }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -32,13 +32,11 @@ public class DbConnectionValidator : IDbConnectionValidator
     private readonly ILogger _logger;
     private readonly SqliteOptions _sqliteOptions;
     private readonly ShellOptions _shellOptions;
-    private readonly ShellSettings _shellSettings;
 
     public DbConnectionValidator(
         IEnumerable<DatabaseProvider> databaseProviders,
         IOptions<SqliteOptions> sqliteOptions,
         IOptions<ShellOptions> shellOptions,
-        ShellSettings shellSettings,
         ITableNameConventionFactory tableNameConventionFactory,
         ILogger<DbConnectionValidator> logger)
     {
@@ -47,7 +45,6 @@ public class DbConnectionValidator : IDbConnectionValidator
         _logger = logger;
         _sqliteOptions = sqliteOptions.Value;
         _shellOptions = shellOptions.Value;
-        _shellSettings = shellSettings;
     }
 
     public async Task<DbConnectionValidatorResult> ValidateAsync(DbConnectionValidatorContext context)
@@ -73,7 +70,7 @@ public class DbConnectionValidator : IDbConnectionValidator
                 return DbConnectionValidatorResult.DocumentTableNotFound;
             }
 
-            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, _shellSettings);
+            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, context.ShellSettings);
         }
 
         if (string.IsNullOrWhiteSpace(connectionString))

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -70,7 +70,7 @@ public class DbConnectionValidator : IDbConnectionValidator
                 return DbConnectionValidatorResult.DocumentTableNotFound;
             }
 
-            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, context);
+            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, context.ShellSettings);
         }
 
         if (string.IsNullOrWhiteSpace(connectionString))

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -32,11 +32,13 @@ public class DbConnectionValidator : IDbConnectionValidator
     private readonly ILogger _logger;
     private readonly SqliteOptions _sqliteOptions;
     private readonly ShellOptions _shellOptions;
+    private readonly ShellSettings _shellSettings;
 
     public DbConnectionValidator(
         IEnumerable<DatabaseProvider> databaseProviders,
         IOptions<SqliteOptions> sqliteOptions,
         IOptions<ShellOptions> shellOptions,
+        ShellSettings shellSettings,
         ITableNameConventionFactory tableNameConventionFactory,
         ILogger<DbConnectionValidator> logger)
     {
@@ -45,6 +47,7 @@ public class DbConnectionValidator : IDbConnectionValidator
         _logger = logger;
         _sqliteOptions = sqliteOptions.Value;
         _shellOptions = shellOptions.Value;
+        _shellSettings = shellSettings;
     }
 
     public async Task<DbConnectionValidatorResult> ValidateAsync(DbConnectionValidatorContext context)
@@ -70,7 +73,7 @@ public class DbConnectionValidator : IDbConnectionValidator
                 return DbConnectionValidatorResult.DocumentTableNotFound;
             }
 
-            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, context.ShellName);
+            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, _shellSettings);
         }
 
         if (string.IsNullOrWhiteSpace(connectionString))

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -70,7 +70,7 @@ public class DbConnectionValidator : IDbConnectionValidator
                 return DbConnectionValidatorResult.DocumentTableNotFound;
             }
 
-            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, context.ShellSettings);
+            connectionString = SqliteHelper.GetConnectionString(_sqliteOptions, _shellOptions, context);
         }
 
         if (string.IsNullOrWhiteSpace(connectionString))

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -12,6 +12,7 @@ using OrchardCore.Data.Documents;
 using OrchardCore.Data.Migration;
 using OrchardCore.Data.YesSql;
 using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Models;
 using OrchardCore.Environment.Shell.Removing;
 using OrchardCore.Environment.Shell.Scope;
 using OrchardCore.Json;
@@ -83,7 +84,9 @@ namespace Microsoft.Extensions.DependencyInjection
                             var databaseFolder = SqliteHelper.GetDatabaseFolder(shellOptions, shellSettings.Name);
                             Directory.CreateDirectory(databaseFolder);
 
-                            var connectionString = SqliteHelper.GetConnectionString(sqliteOptions, databaseFolder, shellSettings["DatabaseName"]);
+                            // Only allow creating a file DB when a tenant is in the Initializing state
+                            var connectionString = SqliteHelper.GetConnectionString(sqliteOptions, databaseFolder, shellSettings.State == TenantState.Initializing, shellSettings["DatabaseName"]);
+
                             storeConfiguration
                                 .UseSqLite(connectionString, IsolationLevel.ReadUncommitted)
                                 .UseDefaultIdGenerator();

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Extensions.DependencyInjection
                             Directory.CreateDirectory(databaseFolder);
 
                             // Only allow creating a file DB when a tenant is in the Initializing state
-                            var connectionString = SqliteHelper.GetConnectionString(sqliteOptions, databaseFolder, shellSettings.State == TenantState.Initializing, shellSettings["DatabaseName"]);
+                            var connectionString = SqliteHelper.GetConnectionString(sqliteOptions, databaseFolder, shellSettings["DatabaseName"], shellSettings.State == TenantState.Initializing);
 
                             storeConfiguration
                                 .UseSqLite(connectionString, IsolationLevel.ReadUncommitted)

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Extensions.DependencyInjection
                             Directory.CreateDirectory(databaseFolder);
 
                             // Only allow creating a file DB when a tenant is in the Initializing state
-                            var connectionString = SqliteHelper.GetConnectionString(sqliteOptions, databaseFolder, shellSettings["DatabaseName"], shellSettings.State == TenantState.Initializing);
+                            var connectionString = SqliteHelper.GetConnectionString(sqliteOptions, databaseFolder, shellSettings);
 
                             storeConfiguration
                                 .UseSqLite(connectionString, IsolationLevel.ReadUncommitted)

--- a/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
@@ -51,8 +51,8 @@ public static class SqliteHelper
         return new SqliteConnectionStringBuilder
         {
             DataSource = string.IsNullOrEmpty(databaseFolder)
-            ? databaseName
-            : Path.Combine(databaseFolder, databaseName),
+                ? databaseName
+                : Path.Combine(databaseFolder, databaseName),
             Cache = SqliteCacheMode.Shared,
             Pooling = sqliteOptions.UseConnectionPooling,
             Mode = SqliteOpenMode.ReadWrite

--- a/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
@@ -28,14 +28,9 @@ public static class SqliteHelper
             databaseName = "yessql.db";
         }
 
-        return new SqliteConnectionStringBuilder
-        {
-            DataSource = string.IsNullOrEmpty(databaseFolder) ? databaseName : Path.Combine(databaseFolder, databaseName),
-            Cache = SqliteCacheMode.Shared,
-            Pooling = sqliteOptions.UseConnectionPooling,
-            Mode = shellSettings.IsInitializing() ? SqliteOpenMode.ReadWriteCreate : SqliteOpenMode.ReadWrite
-        }
-        .ToString();
+        var sqliteOpenMode = shellSettings.IsInitializing() ? SqliteOpenMode.ReadWriteCreate : SqliteOpenMode.ReadWrite;
+
+        return GetSqliteConnectionStringBuilder(sqliteOptions, databaseFolder, databaseName, sqliteOpenMode).ToString();
     }
 
     /// <summary>
@@ -51,16 +46,19 @@ public static class SqliteHelper
         ArgumentException.ThrowIfNullOrEmpty(databaseFolder, nameof(databaseFolder));
         ArgumentException.ThrowIfNullOrEmpty(databaseName, nameof(databaseName));
 
+        return GetSqliteConnectionStringBuilder(sqliteOptions, databaseFolder, databaseName, sqliteOpenMode).ToString();
+    }
+
+    public static string GetDatabaseFolder(ShellOptions shellOptions, string shellName) =>
+        Path.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellName);
+
+    private static SqliteConnectionStringBuilder GetSqliteConnectionStringBuilder(SqliteOptions sqliteOptions, string databaseFolder, string databaseName, SqliteOpenMode sqliteOpenMode){
         return new SqliteConnectionStringBuilder
         {
             DataSource = string.IsNullOrEmpty(databaseFolder) ? databaseName : Path.Combine(databaseFolder, databaseName),
             Cache = SqliteCacheMode.Shared,
             Pooling = sqliteOptions.UseConnectionPooling,
             Mode = sqliteOpenMode
-        }
-        .ToString();
+        };
     }
-
-    public static string GetDatabaseFolder(ShellOptions shellOptions, string shellName) =>
-        Path.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellName);
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
@@ -6,11 +6,21 @@ namespace OrchardCore.Data;
 
 public static class SqliteHelper
 {
-    public static string GetConnectionString(SqliteOptions sqliteOptions, ShellOptions shellOptions, string shellName, string databaseName = "", bool createFile = false)
-        => GetConnectionString(sqliteOptions, GetDatabaseFolder(shellOptions, shellName), databaseName, createFile);
+    public static string GetConnectionString(SqliteOptions sqliteOptions, ShellOptions shellOptions, ShellSettings shellSettings)
+        => GetConnectionString(sqliteOptions, GetDatabaseFolder(shellOptions, shellSettings.Name), shellSettings);
 
-    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder,  string databaseName = "", bool createFile = false)
+    /// <summary>
+    /// Orchard Core SQLite connection string helper that requires ShellSettings to be passed
+    /// to define the databaseName and the SQLite mode.
+    /// </summary>
+    /// <param name="sqliteOptions"></param>
+    /// <param name="databaseFolder"></param>
+    /// <param name="shellSettings"></param>
+    /// <returns></returns>
+    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder, ShellSettings shellSettings)
     {
+        var databaseName = shellSettings["DatabaseName"];
+
         if (string.IsNullOrEmpty(databaseName))
         {
             // For backward compatibility, we assume that the database name is 'yessql.db'.
@@ -24,7 +34,28 @@ public static class SqliteHelper
             : Path.Combine(databaseFolder, databaseName),
             Cache = SqliteCacheMode.Shared,
             Pooling = sqliteOptions.UseConnectionPooling,
-            Mode = createFile ? SqliteOpenMode.ReadWriteCreate : SqliteOpenMode.ReadWrite
+            Mode = shellSettings.IsInitializing() ? SqliteOpenMode.ReadWriteCreate : SqliteOpenMode.ReadWrite
+        }
+        .ToString();
+    }
+
+    /// <summary>
+    /// Generic helper for any other SQLite connection. Restricted to ReadWrite.
+    /// </summary>
+    /// <param name="sqliteOptions"></param>
+    /// <param name="databaseFolder"></param>
+    /// <param name="databaseName"></param>
+    /// <returns></returns>
+    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder, string databaseName)
+    {
+        return new SqliteConnectionStringBuilder
+        {
+            DataSource = string.IsNullOrEmpty(databaseFolder)
+            ? databaseName
+            : Path.Combine(databaseFolder, databaseName),
+            Cache = SqliteCacheMode.Shared,
+            Pooling = sqliteOptions.UseConnectionPooling,
+            Mode = SqliteOpenMode.ReadWrite
         }
         .ToString();
     }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Microsoft.Data.Sqlite;
 using OrchardCore.Environment.Shell;
@@ -47,6 +48,9 @@ public static class SqliteHelper
     /// <returns></returns>
     public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder, string databaseName, SqliteOpenMode sqliteOpenMode)
     {
+        ArgumentException.ThrowIfNullOrEmpty(databaseFolder, nameof(databaseFolder));
+        ArgumentException.ThrowIfNullOrEmpty(databaseName, nameof(databaseName));
+
         return new SqliteConnectionStringBuilder
         {
             DataSource = string.IsNullOrEmpty(databaseFolder) ? databaseName : Path.Combine(databaseFolder, databaseName),

--- a/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
@@ -29,9 +29,7 @@ public static class SqliteHelper
 
         return new SqliteConnectionStringBuilder
         {
-            DataSource = string.IsNullOrEmpty(databaseFolder)
-            ? databaseName
-            : Path.Combine(databaseFolder, databaseName),
+            DataSource = string.IsNullOrEmpty(databaseFolder) ? databaseName : Path.Combine(databaseFolder, databaseName),
             Cache = SqliteCacheMode.Shared,
             Pooling = sqliteOptions.UseConnectionPooling,
             Mode = shellSettings.IsInitializing() ? SqliteOpenMode.ReadWriteCreate : SqliteOpenMode.ReadWrite
@@ -40,22 +38,21 @@ public static class SqliteHelper
     }
 
     /// <summary>
-    /// Generic helper for any other SQLite connection. Restricted to ReadWrite.
+    /// Generic helper for any other SQLite connection.
     /// </summary>
     /// <param name="sqliteOptions"></param>
     /// <param name="databaseFolder"></param>
     /// <param name="databaseName"></param>
+    /// <param name="sqliteOpenMode"></param>
     /// <returns></returns>
-    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder, string databaseName)
+    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder, string databaseName, SqliteOpenMode sqliteOpenMode)
     {
         return new SqliteConnectionStringBuilder
         {
-            DataSource = string.IsNullOrEmpty(databaseFolder)
-                ? databaseName
-                : Path.Combine(databaseFolder, databaseName),
+            DataSource = string.IsNullOrEmpty(databaseFolder) ? databaseName : Path.Combine(databaseFolder, databaseName),
             Cache = SqliteCacheMode.Shared,
             Pooling = sqliteOptions.UseConnectionPooling,
-            Mode = SqliteOpenMode.ReadWrite
+            Mode = sqliteOpenMode
         }
         .ToString();
     }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
@@ -6,10 +6,10 @@ namespace OrchardCore.Data;
 
 public static class SqliteHelper
 {
-    public static string GetConnectionString(SqliteOptions sqliteOptions, ShellOptions shellOptions, string shellName, bool createFile, string databaseName = "")
-        => GetConnectionString(sqliteOptions, GetDatabaseFolder(shellOptions, shellName), createFile, databaseName);
+    public static string GetConnectionString(SqliteOptions sqliteOptions, ShellOptions shellOptions, string shellName, string databaseName = "", bool createFile = false)
+        => GetConnectionString(sqliteOptions, GetDatabaseFolder(shellOptions, shellName), databaseName, createFile);
 
-    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder, bool createFile, string databaseName = "")
+    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder,  string databaseName = "", bool createFile = false)
     {
         if (string.IsNullOrEmpty(databaseName))
         {

--- a/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/SqliteHelper.cs
@@ -6,10 +6,10 @@ namespace OrchardCore.Data;
 
 public static class SqliteHelper
 {
-    public static string GetConnectionString(SqliteOptions sqliteOptions, ShellOptions shellOptions, string shellName, string databaseName = "")
-        => GetConnectionString(sqliteOptions, GetDatabaseFolder(shellOptions, shellName), databaseName);
+    public static string GetConnectionString(SqliteOptions sqliteOptions, ShellOptions shellOptions, string shellName, bool createFile, string databaseName = "")
+        => GetConnectionString(sqliteOptions, GetDatabaseFolder(shellOptions, shellName), createFile, databaseName);
 
-    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder, string databaseName = "")
+    public static string GetConnectionString(SqliteOptions sqliteOptions, string databaseFolder, bool createFile, string databaseName = "")
     {
         if (string.IsNullOrEmpty(databaseName))
         {
@@ -23,10 +23,12 @@ public static class SqliteHelper
             ? databaseName
             : Path.Combine(databaseFolder, databaseName),
             Cache = SqliteCacheMode.Shared,
-            Pooling = sqliteOptions.UseConnectionPooling
+            Pooling = sqliteOptions.UseConnectionPooling,
+            Mode = createFile ? SqliteOpenMode.ReadWriteCreate : SqliteOpenMode.ReadWrite
         }
         .ToString();
     }
+
     public static string GetDatabaseFolder(ShellOptions shellOptions, string shellName) =>
         Path.Combine(shellOptions.ShellsApplicationDataPath, shellOptions.ShellsContainerName, shellName);
 }


### PR DESCRIPTION
![image](https://github.com/OrchardCMS/OrchardCore/assets/3228637/669984f7-ee41-4392-8121-019378c7dbcf)

```
2024-02-03 11:51:23.1890|None|00-7517a5e72207e6c33feab830755eb609-96c2554a9d3bbd1d-00|1|Microsoft.AspNetCore.Diagnostics.DeveloperExceptionPageMiddleware|ERROR|An unhandled exception has occurred while executing the request. Microsoft.Data.Sqlite.SqliteException (0x80004005): SQLite Error 14: 'unable to open database file'.
   at Microsoft.Data.Sqlite.SqliteException.ThrowExceptionForRC(Int32 rc, sqlite3 db)
   at Microsoft.Data.Sqlite.SqliteConnectionInternal..ctor(SqliteConnectionStringBuilder connectionOptions, SqliteConnectionPool pool)
   at Microsoft.Data.Sqlite.SqliteConnectionPool.GetConnection()
   at Microsoft.Data.Sqlite.SqliteConnectionFactory.GetConnection(SqliteConnection outerConnection)
   at Microsoft.Data.Sqlite.SqliteConnection.Open()
   at System.Data.Common.DbConnection.OpenAsync(CancellationToken cancellationToken)
--- End of stack trace from previous location ---
   at YesSql.Store.InitializeCollectionAsync(String collection)
   at YesSql.Store.InitializeCollectionAsync(String collection)
   at YesSql.Store.InitializeAsync()
   at Microsoft.Extensions.DependencyInjection.OrchardCoreBuilderExtensions.<>c.<<AddDataAccess>b__0_2>d.MoveNext() in F:\Repositories\OrchardCore\src\OrchardCore\OrchardCore.Data.YesSql\OrchardCoreBuilderExtensions.cs:line 131
```

@MikeAlhayek 