### PR TITLE
Change how AdminMenu is registered and remove trapping errors in default serialize

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Services/AdminMenuNavigationProvidersCoordinator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Services/AdminMenuNavigationProvidersCoordinator.cs
@@ -59,7 +59,7 @@ namespace OrchardCore.AdminMenu.Services
 
         private async Task BuildTreeAsync(Models.AdminMenu tree, NavigationBuilder builder)
         {
-            foreach (MenuItem node in tree.MenuItems)
+            foreach (var node in tree.MenuItems)
             {
                 var nodeBuilder = _nodeBuilders.FirstOrDefault(x => x.Name == node.GetType().Name);
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Startup.cs
@@ -10,7 +10,6 @@ using OrchardCore.AdminMenu.Deployment;
 using OrchardCore.AdminMenu.Recipes;
 using OrchardCore.AdminMenu.Services;
 using OrchardCore.Deployment;
-using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
 using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Navigation;
@@ -42,17 +41,10 @@ namespace OrchardCore.AdminMenu
             services.AddDeployment<AdminMenuDeploymentSource, AdminMenuDeploymentStep, AdminMenuDeploymentStepDriver>();
 
             // placeholder treeNode
-            services.AddSingleton<IAdminNodeProviderFactory>(new AdminNodeProviderFactory<PlaceholderAdminNode>());
-            services.AddScoped<IAdminNodeNavigationBuilder, PlaceholderAdminNodeNavigationBuilder>();
-            services.AddScoped<IDisplayDriver<MenuItem>, PlaceholderAdminNodeDriver>();
+            services.AddAdminMenu<PlaceholderAdminNode, PlaceholderAdminNodeNavigationBuilder, PlaceholderAdminNodeDriver>();
 
             // link treeNode
-            services.AddSingleton<IAdminNodeProviderFactory>(new AdminNodeProviderFactory<LinkAdminNode>());
-            services.AddScoped<IAdminNodeNavigationBuilder, LinkAdminNodeNavigationBuilder>();
-            services.AddScoped<IDisplayDriver<MenuItem>, LinkAdminNodeDriver>();
-
-            services.AddAdminNode<LinkAdminNode>();
-            services.AddAdminNode<PlaceholderAdminNode>();
+            services.AddAdminMenu<LinkAdminNode, LinkAdminNodeNavigationBuilder, LinkAdminNodeDriver>();
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Startup.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OrchardCore.Admin;
 using OrchardCore.AdminMenu;
-using OrchardCore.AdminMenu.Services;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
@@ -218,9 +217,6 @@ namespace OrchardCore.Contents
             });
 
             services.AddTransient<IContentsAdminListFilterProvider, DefaultContentsAdminListFilterProvider>();
-
-            // Allows to serialize 'AdminNode' derived types.
-            services.AddAdminNode<ContentTypesAdminNode>();
         }
 
         public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -332,9 +328,7 @@ namespace OrchardCore.Contents
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<IAdminNodeProviderFactory>(new AdminNodeProviderFactory<ContentTypesAdminNode>());
-            services.AddScoped<IAdminNodeNavigationBuilder, ContentTypesAdminNodeNavigationBuilder>();
-            services.AddScoped<IDisplayDriver<MenuItem>, ContentTypesAdminNodeDriver>();
+            services.AddAdminMenu<ContentTypesAdminNode, ContentTypesAdminNodeNavigationBuilder, ContentTypesAdminNodeDriver>();
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Startup.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OrchardCore.Admin;
 using OrchardCore.AdminMenu;
-using OrchardCore.AdminMenu.Services;
 using OrchardCore.ContentLocalization.Handlers;
 using OrchardCore.ContentLocalization.Models;
 using OrchardCore.ContentManagement;
@@ -32,7 +31,6 @@ using OrchardCore.Lists.Services;
 using OrchardCore.Lists.Settings;
 using OrchardCore.Lists.ViewModels;
 using OrchardCore.Modules;
-using OrchardCore.Navigation;
 
 namespace OrchardCore.Lists
 {
@@ -72,8 +70,6 @@ namespace OrchardCore.Lists
             services.AddDataMigration<Migrations>();
             services.AddScoped<IContentItemIndexHandler, ContainedPartContentIndexHandler>();
             services.AddScoped<IContainerService, ContainerService>();
-
-            services.AddAdminNode<ListsAdminNode>();
         }
 
         public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)
@@ -92,9 +88,7 @@ namespace OrchardCore.Lists
     {
         public override void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<IAdminNodeProviderFactory>(new AdminNodeProviderFactory<ListsAdminNode>());
-            services.AddScoped<IAdminNodeNavigationBuilder, ListsAdminNodeNavigationBuilder>();
-            services.AddScoped<IDisplayDriver<MenuItem>, ListsAdminNodeDriver>();
+            services.AddAdminMenu<ListsAdminNode, ListsAdminNodeNavigationBuilder, ListsAdminNodeDriver>();
         }
     }
 

--- a/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/AdminMenuExtensions.cs
+++ b/src/OrchardCore/OrchardCore.AdminMenu.Abstractions/AdminMenuExtensions.cs
@@ -1,20 +1,47 @@
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.AdminMenu.Models;
+using OrchardCore.AdminMenu.Services;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Navigation;
 
 namespace OrchardCore.AdminMenu;
 public static class AdminMenuExtensions
 {
+    public static IServiceCollection AddAdminMenu<TNode, TNodeBuilder, TNodeDriver>(this IServiceCollection services)
+        where TNode : AdminNode, new()
+        where TNodeBuilder : class, IAdminNodeNavigationBuilder
+        where TNodeDriver : class, IDisplayDriver<MenuItem>
+    {
+        services.AddAdminMenu<TNode, TNodeBuilder>();
+
+        services.AddScoped<IDisplayDriver<MenuItem>, TNodeDriver>();
+
+        return services;
+    }
+
+    public static IServiceCollection AddAdminMenu<TNode, TNodeBuilder>(this IServiceCollection services)
+        where TNode : AdminNode, new()
+        where TNodeBuilder : class, IAdminNodeNavigationBuilder
+    {
+        services.AddSingleton<IAdminNodeProviderFactory>(new AdminNodeProviderFactory<TNode>());
+        services.AddScoped<IAdminNodeNavigationBuilder, TNodeBuilder>();
+
+        services.AddAdminNodeDerivedType<TNode>();
+
+        return services;
+    }
+
     /// <summary>
     /// Registers an <see cref="AdminNode"/> implementation with JSON serialization.
     /// </summary>
     /// <typeparam name="T">The type to register.</typeparam>
     /// <param name="services">The service collection.</param>
-    public static void AddAdminNode<T>(this IServiceCollection services) where T : AdminNode
+    public static IServiceCollection AddAdminNodeDerivedType<T>(this IServiceCollection services) where T : AdminNode
     {
         services.AddJsonDerivedTypeInfo<T, AdminNode>();
         services.AddJsonDerivedTypeInfo<T, MenuItem>();
+
+        return services;
     }
-    
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/DefaultJsonContentSerializer.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DefaultJsonContentSerializer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using OrchardCore.Json.Serialization;
 
@@ -33,16 +32,7 @@ namespace YesSql.Serialization
         public DefaultJsonContentSerializer(JsonSerializerOptions options) => _options = options;
 
         public object Deserialize(string content, Type type)
-        {
-            try
-            {
-                return JsonSerializer.Deserialize(content, type, _options);
-            }
-            catch
-            {
-                return default;
-            }
-        }
+            => JsonSerializer.Deserialize(content, type, _options);
 
         public dynamic DeserializeDynamic(string content) => JsonSerializer.Deserialize<dynamic>(content, _options);
 

--- a/src/docs/reference/modules/AdminMenu/README.md
+++ b/src/docs/reference/modules/AdminMenu/README.md
@@ -48,7 +48,7 @@ Note that each one of these nodes can have other nodes nested on it. The nesting
 
 The Admin Menu that OrchardCore provides out of the box it's built broadly speaking like this:
 
-1. NavigationManager retrieves all classes that implement INavigationProvider. There are many of them through many modules with the file name of "AdminMenu.cs".
+1. NavigationManager retrieves all classes that implement `INavigationProvider`. There are many of them through many modules with the file name of "AdminMenu.cs".
 
 2. On each AdminMenu the NavigationManager calls the BuildNavigationAsync method, passing a builder to it. The builder is the object where each AdminMenu can add their own menuItems.
 
@@ -56,7 +56,7 @@ The Admin Menu that OrchardCore provides out of the box it's built broadly speak
 
 ### What changes when the Admin Menu is Enabled
 
-1. The AdminMenu module declares it's own INavigationProvider and so it will be called too by NavigationManager. The name of that INavigationProvider is AdminMenuNavigationProvidersCoordinator.
+1. The AdminMenu module declares it's own `INavigationProvider` and so it will be called too by NavigationManager. The name of that `INavigationProvider` is AdminMenuNavigationProvidersCoordinator.
 
 2. The coordinator retrieves all AdminMenu stored on the database and for each one of them call a BuildTreeAsync method, where each node add recursively its own menu items to the builder.
 
@@ -79,14 +79,11 @@ Any module can add it's own custom admin node types so that they can be used by 
 Commonly the steps that you follow in order to do that are:
 
 1. Add a class that inherits from `AdminNode`. On this class add the specific properties that you want for your node type. This is the info that will go into the database.
-
 2. Add a Driver to handle the display and edit of your admin node on the Admin. This won't handle the actual rendering of the admin menu. Drivers are only about the views required to create and edit the admin menu.
-
 3. Optionally, you could implement a ViewModel to move info between the edit views and the driver.
-
 4. Add a class that implements IAdminNodeNavigationBuilder. Its BuildNavigationAsync() method will be called by the AdminMenuNavigationProvidersCoordinator class when it is time to render the menu.
-
 5. Create the views required to create and edit the admin nodes based on your node type.
+6. Register the new services `services.AddAdminMenu<CustomAdminNode, CustomAdminNodeNavigationBuilder, CustomAdminNodeDriver>();`
 
 By convention you should store all these non-view classes on a "AdminNodes" folder. This is optional.
 
@@ -100,96 +97,96 @@ This is the LinkAdminNode.cs
 
 ```csharp
 
-    public class LinkAdminNode : AdminNode
-    {
-        [Required]
-        public string LinkText { get; set; }
+public class LinkAdminNode : AdminNode
+{
+    [Required]
+    public string LinkText { get; set; }
 
-        [Required]
-        public string LinkUrl { get; set; }
+    [Required]
+    public string LinkUrl { get; set; }
 
-        public string IconClass { get; set; }
+    public string IconClass { get; set; }
 
-        /// <summary>
-        /// The names of the permissions required to view this admin menu node
-        /// </summary>
-        public string[] PermissionNames { get; set; } = Array.Empty<string>();
-    }
+    /// <summary>
+    /// The names of the permissions required to view this admin menu node
+    /// </summary>
+    public string[] PermissionNames { get; set; } = Array.Empty<string>();
+}
 ```
 
-This is how LinkAdminNodeBuilder builds a link.
+This is how `LinkAdminNodeBuilder` builds a link.
 
 This class is responsible for:
 
 * Converting the admin node info in the database to menuItems and adding them to the global builder.
 
-* Calling the same BuildNavigationAsync() method on each of their AdminNode's children.
+* Calling the same `BuildNavigationAsync()` method on each of their AdminNode's children.
 
 This pattern ensures that at the end of the process the full tree will be processed.
 
 ```csharp
-        public Task BuildNavigationAsync(MenuItem menuItem, NavigationBuilder builder, IEnumerable<IAdminNodeNavigationBuilder> treeNodeBuilders)
+public Task BuildNavigationAsync(MenuItem menuItem, NavigationBuilder builder, IEnumerable<IAdminNodeNavigationBuilder> treeNodeBuilders)
+{
+    // Cast the received item to the concrete admin node type we are handling.
+    var node = menuItem as LinkAdminNode;
+    if (node == null || String.IsNullOrEmpty(node.LinkText) || !node.Enabled)
+    {
+        return Task.CompletedTask;
+    }
+
+    // This is the standard Orchard Core way of adding menuItems to a builder.
+    return builder.AddAsync(new LocalizedString(node.LinkText, node.LinkText), async itemBuilder =>
+    {
+        var nodeLinkUrl = node.LinkUrl;
+        if (!String.IsNullOrEmpty(nodeLinkUrl) && nodeLinkUrl[0] != '/' && !nodeLinkUrl.Contains("://"))
         {
-            // Cast the received item to the concrete admin node type we are handling.
-            var node = menuItem as LinkAdminNode;
-            if (node == null || String.IsNullOrEmpty(node.LinkText) || !node.Enabled)
+            if (nodeLinkUrl.StartsWith("~/", StringComparison.Ordinal))
             {
-                return Task.CompletedTask;
+                nodeLinkUrl = nodeLinkUrl[2..];
             }
 
-            // This is the standard Orchard Core way of adding menuItems to a builder.
-            return builder.AddAsync(new LocalizedString(node.LinkText, node.LinkText), async itemBuilder =>
+            // Check if the first segment of 'nodeLinkUrl' is not equal to the admin prefix.
+            if (!nodeLinkUrl.StartsWith($"{_adminOptions.AdminUrlPrefix}", StringComparison.OrdinalIgnoreCase) ||
+                (nodeLinkUrl.Length != _adminOptions.AdminUrlPrefix.Length
+                && nodeLinkUrl[_adminOptions.AdminUrlPrefix.Length] != '/'))
             {
-                var nodeLinkUrl = node.LinkUrl;
-                if (!String.IsNullOrEmpty(nodeLinkUrl) && nodeLinkUrl[0] != '/' && !nodeLinkUrl.Contains("://"))
-                {
-                    if (nodeLinkUrl.StartsWith("~/", StringComparison.Ordinal))
-                    {
-                        nodeLinkUrl = nodeLinkUrl[2..];
-                    }
-
-                    // Check if the first segment of 'nodeLinkUrl' is not equal to the admin prefix.
-                    if (!nodeLinkUrl.StartsWith($"{_adminOptions.AdminUrlPrefix}", StringComparison.OrdinalIgnoreCase) ||
-                        (nodeLinkUrl.Length != _adminOptions.AdminUrlPrefix.Length
-                        && nodeLinkUrl[_adminOptions.AdminUrlPrefix.Length] != '/'))
-                    {
-                        nodeLinkUrl = $"{_adminOptions.AdminUrlPrefix}/{nodeLinkUrl}";
-                    }
-                }
-
-                // Add the actual link.
-                itemBuilder.Url(nodeLinkUrl);
-                itemBuilder.Priority(node.Priority);
-                itemBuilder.Position(node.Position);
-
-                if (node.PermissionNames.Any())
-                {
-                    var permissions = await _adminMenuPermissionService.GetPermissionsAsync();
-                    // Find the actual permissions and apply them to the menu.
-                    var selectedPermissions = permissions.Where(p => node.PermissionNames.Contains(p.Name));
-                    itemBuilder.Permissions(selectedPermissions);
-                }
-
-                // Add adminNode's IconClass property values to menuItem.Classes.
-                // Add them with a prefix so that later the shape template can extract them to use them on a <i> tag.
-                node.IconClass?.Split(' ').ToList().ForEach(c => itemBuilder.AddClass("icon-class-" + c));
-
-                // Let children build themselves inside this MenuItem.
-                // Todo: This logic can be shared by all TreeNodeNavigationBuilders.
-                foreach (var childTreeNode in menuItem.Items)
-                {
-                    try
-                    {
-                        var treeBuilder = treeNodeBuilders.FirstOrDefault(x => x.Name == childTreeNode.GetType().Name);
-                        await treeBuilder.BuildNavigationAsync(childTreeNode, itemBuilder, treeNodeBuilders);
-                    }
-                    catch (Exception e)
-                    {
-                        _logger.LogError(e, "An exception occurred while building the '{MenuItem}' child Menu Item.", childTreeNode.GetType().Name);
-                    }
-                }
-            });
+                nodeLinkUrl = $"{_adminOptions.AdminUrlPrefix}/{nodeLinkUrl}";
+            }
         }
+
+        // Add the actual link.
+        itemBuilder.Url(nodeLinkUrl);
+        itemBuilder.Priority(node.Priority);
+        itemBuilder.Position(node.Position);
+
+        if (node.PermissionNames.Any())
+        {
+            var permissions = await _adminMenuPermissionService.GetPermissionsAsync();
+            // Find the actual permissions and apply them to the menu.
+            var selectedPermissions = permissions.Where(p => node.PermissionNames.Contains(p.Name));
+            itemBuilder.Permissions(selectedPermissions);
+        }
+
+        // Add adminNode's IconClass property values to menuItem.Classes.
+        // Add them with a prefix so that later the shape template can extract them to use them on a <i> tag.
+        node.IconClass?.Split(' ').ToList().ForEach(c => itemBuilder.AddClass("icon-class-" + c));
+
+        // Let children build themselves inside this MenuItem.
+        // Todo: This logic can be shared by all TreeNodeNavigationBuilders.
+        foreach (var childTreeNode in menuItem.Items)
+        {
+            try
+            {
+                var treeBuilder = treeNodeBuilders.FirstOrDefault(x => x.Name == childTreeNode.GetType().Name);
+                await treeBuilder.BuildNavigationAsync(childTreeNode, itemBuilder, treeNodeBuilders);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "An exception occurred while building the '{MenuItem}' child Menu Item.", childTreeNode.GetType().Name);
+            }
+        }
+    });
+}
 ```
 
 ## CREDITS

--- a/src/docs/releases/1.9.0.md
+++ b/src/docs/releases/1.9.0.md
@@ -4,7 +4,7 @@ Release date: Not yet released
 
 ## Breaking Changes
 
-### Drop Newtonsoft.Json support
+### Drop `Newtonsoft.Json` Support
 
 The utilization of [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json) has been discontinued in both **YesSql** and **OrchardCore**. Instead, we have transitioned to utilize `System.Text.Json` due to its enhanced performance capabilities. To ensure compatibility with `System.Text.Json` during the serialization or deserialization of objects, the following steps need to be undertaken:
 
@@ -38,6 +38,20 @@ change it to the following:
 
 ```csharp
 services.AddDeployment<AdminMenuDeploymentSource, AdminMenuDeploymentStep, AdminMenuDeploymentStepDriver>();
+```
+
+  - If you are using a custom AdminMenu node, change how you register it by using the new `AddAdminMenu<>` extension. This extension adds a new service that is required for proper serialization. For instance, instead of registering your custom admin menu nodep like this:
+
+```csharp
+services.AddSingleton<IAdminNodeProviderFactory>(new AdminNodeProviderFactory<PlaceholderAdminNode>());
+services.AddScoped<IAdminNodeNavigationBuilder, PlaceholderAdminNodeNavigationBuilder>();
+services.AddScoped<IDisplayDriver<MenuItem>, PlaceholderAdminNodeDriver>();
+```
+
+change it to the following:
+
+```csharp
+services.AddAdminMenu<PlaceholderAdminNode, PlaceholderAdminNodeNavigationBuilder, PlaceholderAdminNodeDriver>();
 ```
 
   - Any serializable object that contains a polymorphic property (a base type that can contain sub-classes instances) needs to register all possible sub-classes this way:


### PR DESCRIPTION
@sebastienros let me know if you disagree here with removing the exception trapping in the `DefaultJsonContentSerializer` Being able to get an exception should help us understand the serialization error.

I also added `AddMenuAdmin<>` and update the docs.

Also Fix #15246

cc: @kevinchalet in this PR, I am proposing to remove exception trapping in the `DefaultJsonContentSerializer`. 