### PR TITLE
Update README.md added missing parts in "From VS (manual way)"

### DIFF
--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -73,12 +73,14 @@ Fire up Visual Studio, create a new solution file (`.sln`) by creating a new ASP
 ![image](../assets/images/templates/orchard-screencast-1.gif)
 
 Now that we created a new Web Application we need to add proper dependencies so that this new Web Application be targeted as an Orchard Core application.
+Orchard Core is available for use via two different NuGet meta packages: `OrchardCore.Application.Cms.Core.Targets`, `OrchardCore.Application.Cms.Targets`. More details about these packages can be found [here](https://docs.orchardcore.net/en/main/docs/getting-started/starter-recipes/). Add these NuGet packages to your Web Application.
 
 !!! note
     If you want to use the `preview` packages, [configure the OrchardCore Preview url in your Package sources](../preview-package-source.md)
 
 ![image](../assets/images/templates/orchard-screencast-2.gif)
 
+After creating a new Web Application, Visual Studio automatically adds `Models`, `Views` and `Controllers` folders with files. We can delete them for now.
 Finally, we will need to register Orchard CMS service in our `Program.cs` file like this:
 
 ```csharp

--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -80,7 +80,7 @@ Orchard Core is available for use via two different NuGet meta packages: `Orchar
 
 ![image](../assets/images/templates/orchard-screencast-2.gif)
 
-After creating a new Web Application, Visual Studio automatically adds `Models`, `Views` and `Controllers` folders with files. We can delete them for now.
+Visual Studio may automatically include Models, Views, and Controllers folders with boilerplate code, depending on the template used to create the web application. To prevent potential conflicts with OrchardCore services, it is advisable to delete these folders.
 Finally, we will need to register Orchard CMS service in our `Program.cs` file like this:
 
 ```csharp

--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -73,7 +73,7 @@ Fire up Visual Studio, create a new solution file (`.sln`) by creating a new ASP
 ![image](../assets/images/templates/orchard-screencast-1.gif)
 
 Now that we created a new Web Application we need to add proper dependencies so that this new Web Application be targeted as an Orchard Core application.
-Orchard Core can be added through two distinct NuGet meta packages: `OrchardCore.Application.Cms.Core.Targets` and `OrchardCore.Application.Cms.Targets`. For additional information regarding these packages, please refer to [this link](../../getting-started/starter-recipes/). You must add one of these NuGet packages in your Web Application.
+Orchard Core can be added through two distinct NuGet meta packages: `OrchardCore.Application.Cms.Core.Targets` and `OrchardCore.Application.Cms.Targets`. For additional information regarding these packages, please refer to [this link](../starter-recipes/README.md). You must add one of these NuGet packages in your Web Application.
 
 !!! note
     If you want to use the `preview` packages, [configure the OrchardCore Preview url in your Package sources](../preview-package-source.md)

--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -73,7 +73,7 @@ Fire up Visual Studio, create a new solution file (`.sln`) by creating a new ASP
 ![image](../assets/images/templates/orchard-screencast-1.gif)
 
 Now that we created a new Web Application we need to add proper dependencies so that this new Web Application be targeted as an Orchard Core application.
-Orchard Core is available for use via two different NuGet meta packages: `OrchardCore.Application.Cms.Core.Targets`, `OrchardCore.Application.Cms.Targets`. More details about these packages can be found [here](https://docs.orchardcore.net/en/main/docs/getting-started/starter-recipes/). Add these NuGet packages to your Web Application.
+Orchard Core can be added through two distinct NuGet meta packages: `OrchardCore.Application.Cms.Core.Targets` and `OrchardCore.Application.Cms.Targets`. For additional information regarding these packages, please refer to [this link](../../getting-started/starter-recipes/). You must add one of these NuGet packages in your Web Application.
 
 !!! note
     If you want to use the `preview` packages, [configure the OrchardCore Preview url in your Package sources](../preview-package-source.md)


### PR DESCRIPTION
As discussed in this issue https://github.com/OrchardCMS/OrchardCore/issues/15267 I added the NuGet packages names to the guide, and the instruction to delete "Models", "Views" and "Controllers" folder, automatically added by the Visual Studio scaffolding.