### PR TITLE
Fix GraphQL Explorer

### DIFF
--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
@@ -15,11 +15,9 @@ namespace OrchardCore.Apis
             where TObject : class
             where TObjectType : InputObjectGraphType<TObject>
         {
-            // Instances are registered as singletons as their constructor holds the logic to configure the type
-            // and doesn't need to run every time
-            services.AddSingleton<TObjectType>();
-            services.AddSingleton<InputObjectGraphType<TObject>, TObjectType>(s => s.GetRequiredService<TObjectType>());
-            services.AddSingleton<IInputObjectGraphType, TObjectType>(s => s.GetRequiredService<TObjectType>());
+            services.AddScoped<TObjectType>();
+            services.AddScoped<InputObjectGraphType<TObject>, TObjectType>(s => s.GetRequiredService<TObjectType>());
+            services.AddScoped<IInputObjectGraphType, TObjectType>(s => s.GetRequiredService<TObjectType>());
         }
 
         /// <summary>
@@ -34,9 +32,9 @@ namespace OrchardCore.Apis
         {
             // Instances are registered as singletons as their constructor holds the logic to configure the type
             // and doesn't need to run every time
-            services.AddSingleton<TInputType>();
-            services.AddSingleton<ObjectGraphType<TInput>, TInputType>(s => s.GetRequiredService<TInputType>());
-            services.AddSingleton<IObjectGraphType, TInputType>(s => s.GetRequiredService<TInputType>());
+            services.AddScoped<TInputType>();
+            services.AddScoped<ObjectGraphType<TInput>, TInputType>(s => s.GetRequiredService<TInputType>());
+            services.AddScoped<IObjectGraphType, TInputType>(s => s.GetRequiredService<TInputType>());
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
@@ -16,8 +16,8 @@ public static class ServiceCollectionExtensions
         where TObjectType : InputObjectGraphType<TObject>
     {
         services.AddScoped<TObjectType>();
-        services.AddScoped<InputObjectGraphType<TObject>, TObjectType>(s => s.GetRequiredService<TObjectType>());
-        services.AddScoped<IInputObjectGraphType, TObjectType>(s => s.GetRequiredService<TObjectType>());
+        services.AddTransient<InputObjectGraphType<TObject>, TObjectType>(s => s.GetRequiredService<TObjectType>());
+        services.AddTransient<IInputObjectGraphType, TObjectType>(s => s.GetRequiredService<TObjectType>());
     }
 
     /// <summary>
@@ -31,7 +31,7 @@ public static class ServiceCollectionExtensions
         where TInputType : ObjectGraphType<TInput>
     {
         services.AddScoped<TInputType>();
-        services.AddScoped<ObjectGraphType<TInput>, TInputType>(s => s.GetRequiredService<TInputType>());
-        services.AddScoped<IObjectGraphType, TInputType>(s => s.GetRequiredService<TInputType>());
+        services.AddTransient<ObjectGraphType<TInput>, TInputType>(s => s.GetRequiredService<TInputType>());
+        services.AddTransient<IObjectGraphType, TInputType>(s => s.GetRequiredService<TInputType>());
     }
 }

--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
@@ -1,40 +1,37 @@
 using GraphQL.Types;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace OrchardCore.Apis
-{
-    public static class ServiceCollectionExtensions
-    {
-        /// <summary>
-        /// Registers a type describing input arguments.
-        /// </summary>
-        /// <typeparam name="TObject"></typeparam>
-        /// <typeparam name="TObjectType"></typeparam>
-        /// <param name="services"></param>
-        public static void AddInputObjectGraphType<TObject, TObjectType>(this IServiceCollection services)
-            where TObject : class
-            where TObjectType : InputObjectGraphType<TObject>
-        {
-            services.AddScoped<TObjectType>();
-            services.AddScoped<InputObjectGraphType<TObject>, TObjectType>(s => s.GetRequiredService<TObjectType>());
-            services.AddScoped<IInputObjectGraphType, TObjectType>(s => s.GetRequiredService<TObjectType>());
-        }
+namespace OrchardCore.Apis;
 
-        /// <summary>
-        /// Registers a type describing output arguments.
-        /// </summary>
-        /// <typeparam name="TInput"></typeparam>
-        /// <typeparam name="TInputType"></typeparam>
-        /// <param name="services"></param>
-        public static void AddObjectGraphType<TInput, TInputType>(this IServiceCollection services)
-            where TInput : class
-            where TInputType : ObjectGraphType<TInput>
-        {
-            // Instances are registered as singletons as their constructor holds the logic to configure the type
-            // and doesn't need to run every time
-            services.AddScoped<TInputType>();
-            services.AddScoped<ObjectGraphType<TInput>, TInputType>(s => s.GetRequiredService<TInputType>());
-            services.AddScoped<IObjectGraphType, TInputType>(s => s.GetRequiredService<TInputType>());
-        }
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers a type describing input arguments.
+    /// </summary>
+    /// <typeparam name="TObject"></typeparam>
+    /// <typeparam name="TObjectType"></typeparam>
+    /// <param name="services"></param>
+    public static void AddInputObjectGraphType<TObject, TObjectType>(this IServiceCollection services)
+        where TObject : class
+        where TObjectType : InputObjectGraphType<TObject>
+    {
+        services.AddScoped<TObjectType>();
+        services.AddScoped<InputObjectGraphType<TObject>, TObjectType>(s => s.GetRequiredService<TObjectType>());
+        services.AddScoped<IInputObjectGraphType, TObjectType>(s => s.GetRequiredService<TObjectType>());
+    }
+
+    /// <summary>
+    /// Registers a type describing output arguments.
+    /// </summary>
+    /// <typeparam name="TInput"></typeparam>
+    /// <typeparam name="TInputType"></typeparam>
+    /// <param name="services"></param>
+    public static void AddObjectGraphType<TInput, TInputType>(this IServiceCollection services)
+        where TInput : class
+        where TInputType : ObjectGraphType<TInput>
+    {
+        services.AddScoped<TInputType>();
+        services.AddScoped<ObjectGraphType<TInput>, TInputType>(s => s.GetRequiredService<TInputType>());
+        services.AddScoped<IObjectGraphType, TInputType>(s => s.GetRequiredService<TInputType>());
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
@@ -15,11 +15,12 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
 {
     public class TypedContentTypeBuilder : IContentTypeBuilder
     {
-        private readonly IHttpContextAccessor _httpContextAccessor;
-        private readonly GraphQLContentOptions _contentOptions;
         private static readonly ConcurrentDictionary<string, Type> _partTypes = new();
         private static readonly ConcurrentDictionary<string, IObjectGraphType> _partObjectGraphTypes = new();
         private static readonly ConcurrentDictionary<string, IInputObjectGraphType> _partInputObjectGraphTypes = new();
+
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly GraphQLContentOptions _contentOptions;
 
         public TypedContentTypeBuilder(IHttpContextAccessor httpContextAccessor,
             IOptions<GraphQLContentOptions> contentOptionsAccessor)
@@ -57,13 +58,14 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                 }
 
                 var partType = _partTypes.GetOrAdd(part.PartDefinition.Name, key => typeActivator.GetTypeActivator(key).Type);
-                var queryGraphType = _partObjectGraphTypes.GetOrAdd(part.PartDefinition.Name,
-                                                                    partName =>
-                                                                    {
-                                                                        queryObjectGraphTypes ??= serviceProvider.GetService<IEnumerable<IObjectGraphType>>();
-                                                                        return queryObjectGraphTypes?.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().First().Name == partName);
-                                                                    }
-                                                                );
+                var queryGraphType = _partObjectGraphTypes
+                    .GetOrAdd(part.PartDefinition.Name,
+                        partName =>
+                        {
+                            queryObjectGraphTypes ??= serviceProvider.GetServices<IObjectGraphType>();
+                            return queryObjectGraphTypes?.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().First().Name == partName);
+                        }
+                    );
 
                 var collapsePart = _contentOptions.ShouldCollapse(part);
 
@@ -73,7 +75,10 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                     {
                         foreach (var field in queryGraphType.Fields)
                         {
-                            if (_contentOptions.ShouldSkip(queryGraphType.GetType(), field.Name)) continue;
+                            if (_contentOptions.ShouldSkip(queryGraphType.GetType(), field.Name))
+                            {
+                                continue;
+                            }
 
                             var rolledUpField = new FieldType
                             {
@@ -123,7 +128,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
 
                 var inputGraphTypeResolved = _partInputObjectGraphTypes.GetOrAdd(part.PartDefinition.Name, partName =>
                 {
-                    queryInputGraphTypes ??= serviceProvider.GetService<IEnumerable<IInputObjectGraphType>>();
+                    queryInputGraphTypes ??= serviceProvider.GetServices<IInputObjectGraphType>();
                     return queryInputGraphTypes?.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().FirstOrDefault()?.Name == part.PartDefinition.Name);
                 });
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
@@ -38,6 +38,9 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                 return;
             }
 
+            var queryObjectGraphTypes = serviceProvider.GetServices<IObjectGraphType>();
+            var queryInputGraphTypes = serviceProvider.GetServices<IInputObjectGraphType>();
+
             foreach (var part in contentTypeDefinition.Parts)
             {
                 if (_contentOptions.ShouldSkip(part))
@@ -58,8 +61,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                     .GetOrAdd(part.PartDefinition.Name,
                         partName =>
                         {
-                            var queryObjectGraphTypes = serviceProvider.GetServices<IObjectGraphType>();
-                            return queryObjectGraphTypes?.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().First().Name == partName);
+                            return queryObjectGraphTypes.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().First().Name == partName);
                         }
                     );
 
@@ -124,8 +126,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
 
                 var inputGraphTypeResolved = _partInputObjectGraphTypes.GetOrAdd(part.PartDefinition.Name, partName =>
                 {
-                    var queryInputGraphTypes = serviceProvider.GetServices<IInputObjectGraphType>();
-                    return queryInputGraphTypes?.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().FirstOrDefault()?.Name == part.PartDefinition.Name);
+                    return queryInputGraphTypes.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().FirstOrDefault()?.Name == part.PartDefinition.Name);
                 });
 
                 if (inputGraphTypeResolved != null)

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Types/TypedContentTypeBuilder.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using GraphQL;
 using GraphQL.Resolvers;
@@ -39,9 +38,6 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                 return;
             }
 
-            IEnumerable<IObjectGraphType> queryObjectGraphTypes = null;
-            IEnumerable<IInputObjectGraphType> queryInputGraphTypes = null;
-
             foreach (var part in contentTypeDefinition.Parts)
             {
                 if (_contentOptions.ShouldSkip(part))
@@ -62,7 +58,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
                     .GetOrAdd(part.PartDefinition.Name,
                         partName =>
                         {
-                            queryObjectGraphTypes ??= serviceProvider.GetServices<IObjectGraphType>();
+                            var queryObjectGraphTypes = serviceProvider.GetServices<IObjectGraphType>();
                             return queryObjectGraphTypes?.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().First().Name == partName);
                         }
                     );
@@ -128,7 +124,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Types
 
                 var inputGraphTypeResolved = _partInputObjectGraphTypes.GetOrAdd(part.PartDefinition.Name, partName =>
                 {
-                    queryInputGraphTypes ??= serviceProvider.GetServices<IInputObjectGraphType>();
+                    var queryInputGraphTypes = serviceProvider.GetServices<IInputObjectGraphType>();
                     return queryInputGraphTypes?.FirstOrDefault(x => x.GetType().BaseType.GetGenericArguments().FirstOrDefault()?.Name == part.PartDefinition.Name);
                 });
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.ContentManagement.GraphQL
         {
             services.AddSingleton<ISchemaBuilder, ContentItemQuery>();
             services.AddSingleton<ISchemaBuilder, ContentTypeQuery>();
-            services.AddSingleton<ContentItemInterface>();
+            services.AddTransient<ContentItemInterface>();
 
             services.AddTransient<ContentItemType>();
 


### PR DESCRIPTION
Fix #15304

@lampersky can you please checkout this branch and confirm that it fixes your issues?

The exception states 


> System.InvalidOperationException: 'This graph type 'AliasInputObjectType' with name 'AliasPartInput' has already been initialized. Make sure that you do not use the same instance of a graph type in multiple schemas. It may be so if you registered this graph type as singleton; see https://graphql-dotnet.github.io/docs/getting-started/dependency-injection/ for more info.'


