### PR TITLE
Bump OpenIddict to 5.2.0 and replace the OpenIddict.AspNetCore metapackage by individual references

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -50,8 +50,12 @@
     <PackageManagement Include="NJsonSchema" Version="11.0.0" />
     <PackageManagement Include="NLog.Web.AspNetCore" Version="5.3.8" />
     <PackageManagement Include="NodaTime" Version="3.1.11" />
-    <PackageManagement Include="OpenIddict.AspNetCore" Version="5.1.0" />
-    <PackageManagement Include="OpenIddict.Core" Version="5.1.0" />
+    <PackageManagement Include="OpenIddict.Core" Version="5.2.0" />
+    <PackageManagement Include="OpenIddict.Server.AspNetCore" Version="5.2.0" />
+    <PackageManagement Include="OpenIddict.Server.DataProtection" Version="5.2.0" />
+    <PackageManagement Include="OpenIddict.Validation.AspNetCore" Version="5.2.0" />
+    <PackageManagement Include="OpenIddict.Validation.DataProtection" Version="5.2.0" />
+    <PackageManagement Include="OpenIddict.Validation.SystemNetHttp" Version="5.2.0" />
     <PackageManagement Include="OrchardCore.Translations.All" Version="1.8.0" />
     <PackageManagement Include="PdfPig" Version="0.1.8" />
     <PackageManagement Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -30,7 +30,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
-    <PackageReference Include="OpenIddict.AspNetCore" />
+    <PackageReference Include="OpenIddict.Server.AspNetCore" />
+    <PackageReference Include="OpenIddict.Server.DataProtection" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" />
+    <PackageReference Include="OpenIddict.Validation.DataProtection" />
+    <PackageReference Include="OpenIddict.Validation.SystemNetHttp" />
   </ItemGroup>
 
 </Project>

--- a/src/docs/resources/libraries/README.md
+++ b/src/docs/resources/libraries/README.md
@@ -38,7 +38,7 @@ The below table lists the different .NET libraries used in Orchard Core:
 | [NJsonSchema](https://github.com/RicoSuter/NJsonSchema) | JSON Schema reader, generator and validator for .NET | 11.0.0 | [MIT](https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md) |
 | [NLog.Web.AspNetCore](https://github.com/NLog/NLog.Web/tree/master/src/NLog.Web.AspNetCore) | NLog integration for ASP.NET. | 5.3.8 | [BSD-3-Clause](https://github.com/NLog/NLog.Web/blob/master/LICENSE) |
 | [Noda Time](https://github.com/nodatime/nodatime) | A better date and time API for .NET. | 3.1.11 | [Apache-2.0](https://github.com/nodatime/nodatime/blob/master/LICENSE.txt) |
-| [OpenIddict](https://github.com/openiddict/openiddict-core) | Flexible and versatile OAuth 2.0/OpenID Connect stack for .NET. | 5.1.0 | [Apache-2.0](https://github.com/openiddict/openiddict-core/blob/dev/LICENSE.md)) |
+| [OpenIddict](https://github.com/openiddict/openiddict-core) | Flexible and versatile OAuth 2.0/OpenID Connect stack for .NET. | 5.2.0 | [Apache-2.0](https://github.com/openiddict/openiddict-core/blob/dev/LICENSE.md)) |
 | [PdfPig](https://github.com/UglyToad/PdfPig/) | Library to read and extract text and other content from PDF files. | 0.1.8 | [Apache-2.0](https://github.com/UglyToad/PdfPig/blob/master/LICENSE) |
 | [Serilog.AspNetCore](https://github.com/serilog/serilog-aspnetcore) | Serilog integration for ASP.NET Core. | 7.0.0 | [Apache-2.0](https://github.com/serilog/serilog-aspnetcore/blob/dev/LICENSE) |
 | [Shortcodes](https://github.com/sebastienros/shortcodes) | Shortcodes processor for .NET. | 1.3.3 | [MIT](https://github.com/sebastienros/shortcodes/blob/dev/LICENSE) |


### PR DESCRIPTION
https://github.com/openiddict/openiddict-core/releases/tag/5.2.0

This PR also replaces the reference to the `OpenIddict.AspNetCore` metapackage in `OrchardCore.OpenId.csproj` by more targeted references to simplify the dependencies graph and avoid including things we don't currently use/need (e.g the OpenIddict client)