### PR TITLE
Decorate the interactive OpenID endpoints with `[DisableCors]`

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,7 +46,7 @@ namespace OrchardCore.OpenId.Controllers
             _shellSettings = shellSettings;
         }
 
-        [AllowAnonymous, HttpGet, HttpPost, IgnoreAntiforgeryToken]
+        [AllowAnonymous, DisableCors, HttpGet, HttpPost, IgnoreAntiforgeryToken]
         public async Task<IActionResult> Authorize()
         {
             var response = HttpContext.GetOpenIddictServerResponse();
@@ -182,7 +183,7 @@ namespace OrchardCore.OpenId.Controllers
             }
         }
 
-        [ActionName(nameof(Authorize))]
+        [ActionName(nameof(Authorize)), DisableCors]
         [FormValueRequired("submit.Accept"), HttpPost]
         public async Task<IActionResult> AuthorizeAccept()
         {
@@ -266,7 +267,7 @@ namespace OrchardCore.OpenId.Controllers
             }
         }
 
-        [ActionName(nameof(Authorize))]
+        [ActionName(nameof(Authorize)), DisableCors]
         [FormValueRequired("submit.Deny"), HttpPost]
         public IActionResult AuthorizeDeny()
         {
@@ -289,7 +290,7 @@ namespace OrchardCore.OpenId.Controllers
             return Forbid(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
 
-        [AllowAnonymous, HttpGet, HttpPost, IgnoreAntiforgeryToken]
+        [AllowAnonymous, DisableCors, HttpGet, HttpPost, IgnoreAntiforgeryToken]
         public async Task<IActionResult> Logout()
         {
             var response = HttpContext.GetOpenIddictServerResponse();
@@ -325,7 +326,7 @@ namespace OrchardCore.OpenId.Controllers
             });
         }
 
-        [ActionName(nameof(Logout)), AllowAnonymous]
+        [ActionName(nameof(Logout)), AllowAnonymous, DisableCors]
         [FormValueRequired("submit.Accept"), HttpPost]
         public async Task<IActionResult> LogoutAccept()
         {
@@ -362,7 +363,7 @@ namespace OrchardCore.OpenId.Controllers
             return SignOut(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
         }
 
-        [ActionName(nameof(Logout)), AllowAnonymous]
+        [ActionName(nameof(Logout)), AllowAnonymous, DisableCors]
         [FormValueRequired("submit.Deny"), HttpPost]
         public IActionResult LogoutDeny()
         {


### PR DESCRIPTION
This PR adds `[DisableCors]` to the interactiive OpenID endpoints that are not meant to be called programmatically (e.g by JS clients) to ensure no CORS policy is ever applied to them by accident by the CORS module.