### PR TITLE
fix for "wrong environment variable value can be saved"

### DIFF
--- a/src/OrchardCore/OrchardCore/Shell/ShellSettingsManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellSettingsManager.cs
@@ -115,9 +115,9 @@ namespace OrchardCore.Environment.Shell
                 await ReloadTenantsSettingsAsync();
 
                 var tenantSettingsBuilder = new ConfigurationBuilder()
-                    .AddConfiguration(_configuration)
                     .AddConfiguration(_configuration.GetSection(tenant))
-                    .AddConfiguration(_tenantsSettingsRoot.GetSection(tenant));
+                    .AddConfiguration(_tenantsSettingsRoot.GetSection(tenant))
+                    .AddConfiguration(_configuration);
 
                 var settings = new ShellConfiguration(tenantSettingsBuilder);
                 var configuration = new ShellConfiguration(tenant, _tenantConfigFactoryAsync);
@@ -276,8 +276,8 @@ namespace OrchardCore.Environment.Shell
                 try
                 {
                     var builder = await new ConfigurationBuilder()
-                        .AddConfiguration(_configuration)
                         .AddConfiguration(_configuration.GetSection(tenant))
+                        .AddConfiguration(_configuration)
                         .AddSourcesAsync(tenant, _tenantConfigSources);
 
                     configure(builder);

--- a/src/OrchardCore/OrchardCore/Shell/ShellSettingsManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/ShellSettingsManager.cs
@@ -143,8 +143,8 @@ namespace OrchardCore.Environment.Shell
                 ArgumentNullException.ThrowIfNull(settings);
 
                 var configuration = new ConfigurationBuilder()
-                    .AddConfiguration(_configuration)
                     .AddConfiguration(_configuration.GetSection(settings.Name))
+                    .AddConfiguration(_configuration)
                     .Build();
 
                 var shellSettings = new ShellSettings()


### PR DESCRIPTION
@rjpowers10 could you check if this will fix the issue #15275 

I've aded a few variables:

![image](https://github.com/OrchardCMS/OrchardCore/assets/6403130/8f882481-fe9a-4cd1-b653-8fa0df5d5913)

Here it is my `Default\appsettings.json`, as you can see I have correct value.

![image](https://github.com/OrchardCMS/OrchardCore/assets/6403130/f50984f2-b9b2-4f78-9dfa-e2ba4d027870)
