### PR TITLE
ensure delegate isn't null and does'nt throw

### DIFF
--- a/src/OrchardCore.Components/OrchardCore.Common.Components/OptionEditor.razor
+++ b/src/OrchardCore.Components/OrchardCore.Common.Components/OptionEditor.razor
@@ -173,11 +173,23 @@
 
 	private async Task OptionItemChangeAsync(Action update)
 	{
-		update();
+        // validate provided delegate
+        if (update is not null)
+        {
+            try
+            {
+		        update();
+            }
+            catch(Exception)
+            {
+                // ignore
+            }
+        }
+
+        // Options may have changed independent of "update" delegate, e.g. inline, so we apply update routine anyway
 		TryUpdateOptionsJson(Options);
 		await TriggerEventAsync();
 	}
-
 
 	protected override Task OnInitializedAsync()
 	{


### PR DESCRIPTION
just a little patch to stay on the safe side (https://github.com/OrchardCMS/OrchardCore/commit/c2bb83c32109df38e69bc7123af9cf6a1dfc53ca#r138753050)