### PR TITLE
Allow binding RememberMe settings during login

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
@@ -77,7 +77,7 @@ namespace OrchardCore.Users.Controllers
 
         [HttpGet]
         [AllowAnonymous]
-        public async Task<IActionResult> Login(string returnUrl = null)
+        public async Task<IActionResult> Login(bool rememberMe = false, string returnUrl = null)
         {
             if (HttpContext.User?.Identity?.IsAuthenticated ?? false)
             {
@@ -108,7 +108,10 @@ namespace OrchardCore.Users.Controllers
             CopyTempDataErrorsToModelState();
             ViewData["ReturnUrl"] = returnUrl;
 
-            return View();
+            return View(new LoginViewModel
+            {
+                RememberMe = rememberMe,
+            });
         }
 
         [HttpGet]


### PR DESCRIPTION
When we redirect the user to the login page, it is helpful to pass the "Remember Me" settings in the URL.

![image](https://github.com/OrchardCMS/OrchardCore/assets/24724371/f726c05a-0bf3-4c18-a728-e398d3f85e8d)
