### PR TITLE
Configure JsonOptions by default

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Json/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/Extensions/JsonSerializerOptionsExtensions.cs
@@ -18,11 +18,21 @@ public static class JsonSerializerOptionsExtensions
 
         foreach (var resolver in source.TypeInfoResolverChain)
         {
+            if (destenation.TypeInfoResolverChain.Contains(resolver))
+            {
+                continue;
+            }
+
             destenation.TypeInfoResolverChain.Add(resolver);
         }
 
         foreach (var converter in source.Converters)
         {
+            if (destenation.Converters.Contains(converter))
+            {
+                continue;
+            }
+
             destenation.Converters.Add(converter);
         }
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/Extensions/JsonSerializerOptionsExtensions.cs
@@ -7,38 +7,38 @@ public static class JsonSerializerOptionsExtensions
     /// <summary>
     /// Merges the given <see cref="JsonSerializerOptions"/> into the current options.
     /// </summary>
-    public static JsonSerializerOptions Merge(this JsonSerializerOptions destenation, JsonSerializerOptions source)
+    public static JsonSerializerOptions Merge(this JsonSerializerOptions destination, JsonSerializerOptions source)
     {
-        destenation.DefaultIgnoreCondition = source.DefaultIgnoreCondition;
-        destenation.ReferenceHandler = source.ReferenceHandler;
-        destenation.ReadCommentHandling = source.ReadCommentHandling;
-        destenation.PropertyNameCaseInsensitive = source.PropertyNameCaseInsensitive;
-        destenation.AllowTrailingCommas = source.AllowTrailingCommas;
-        destenation.WriteIndented = source.WriteIndented;
-        destenation.PropertyNamingPolicy = source.PropertyNamingPolicy;
-        destenation.Encoder = source.Encoder;
-        destenation.TypeInfoResolver = source.TypeInfoResolver;
+        destination.DefaultIgnoreCondition = source.DefaultIgnoreCondition;
+        destination.ReferenceHandler = source.ReferenceHandler;
+        destination.ReadCommentHandling = source.ReadCommentHandling;
+        destination.PropertyNameCaseInsensitive = source.PropertyNameCaseInsensitive;
+        destination.AllowTrailingCommas = source.AllowTrailingCommas;
+        destination.WriteIndented = source.WriteIndented;
+        destination.PropertyNamingPolicy = source.PropertyNamingPolicy;
+        destination.Encoder = source.Encoder;
+        destination.TypeInfoResolver = source.TypeInfoResolver;
 
         foreach (var resolver in source.TypeInfoResolverChain)
         {
-            if (destenation.TypeInfoResolverChain.Contains(resolver))
+            if (destination.TypeInfoResolverChain.Contains(resolver))
             {
                 continue;
             }
 
-            destenation.TypeInfoResolverChain.Add(resolver);
+            destination.TypeInfoResolverChain.Add(resolver);
         }
 
         foreach (var converter in source.Converters)
         {
-            if (destenation.Converters.Contains(converter))
+            if (destination.Converters.Contains(converter))
             {
                 continue;
             }
 
-            destenation.Converters.Add(converter);
+            destination.Converters.Add(converter);
         }
 
-        return destenation;
+        return destination;
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/Extensions/JsonSerializerOptionsExtensions.cs
@@ -4,7 +4,10 @@ namespace OrchardCore.Json.Extensions;
 
 public static class JsonSerializerOptionsExtensions
 {
-    public static JsonSerializerOptions Apply(this JsonSerializerOptions destenation, JsonSerializerOptions source)
+    /// <summary>
+    /// Merges the given <see cref="JsonSerializerOptions"/> into the current options.
+    /// </summary>
+    public static JsonSerializerOptions Merge(this JsonSerializerOptions destenation, JsonSerializerOptions source)
     {
         destenation.DefaultIgnoreCondition = source.DefaultIgnoreCondition;
         destenation.ReferenceHandler = source.ReferenceHandler;

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/Extensions/JsonSerializerOptionsExtensions.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+
+namespace OrchardCore.Json.Extensions;
+
+public static class JsonSerializerOptionsExtensions
+{
+    public static JsonSerializerOptions Apply(this JsonSerializerOptions destenation, JsonSerializerOptions source)
+    {
+        destenation.DefaultIgnoreCondition = source.DefaultIgnoreCondition;
+        destenation.ReferenceHandler = source.ReferenceHandler;
+        destenation.ReadCommentHandling = source.ReadCommentHandling;
+        destenation.PropertyNameCaseInsensitive = source.PropertyNameCaseInsensitive;
+        destenation.AllowTrailingCommas = source.AllowTrailingCommas;
+        destenation.WriteIndented = source.WriteIndented;
+        destenation.PropertyNamingPolicy = source.PropertyNamingPolicy;
+        destenation.Encoder = source.Encoder;
+        destenation.TypeInfoResolver = source.TypeInfoResolver;
+
+        foreach (var resolver in source.TypeInfoResolverChain)
+        {
+            destenation.TypeInfoResolverChain.Add(resolver);
+        }
+
+        foreach (var converter in source.Converters)
+        {
+            destenation.Converters.Add(converter);
+        }
+
+        return destenation;
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/JsonOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/JsonOptionsConfigurations.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.Options;
+using OrchardCore.Json.Extensions;
 
 namespace OrchardCore.Json;
 
@@ -15,24 +16,6 @@ public class JsonOptionsConfigurations : IConfigureOptions<JsonOptions>
 
     public void Configure(JsonOptions options)
     {
-        options.SerializerOptions.DefaultIgnoreCondition = _jsonSerializerOptions.DefaultIgnoreCondition;
-        options.SerializerOptions.ReferenceHandler = _jsonSerializerOptions.ReferenceHandler;
-        options.SerializerOptions.ReadCommentHandling = _jsonSerializerOptions.ReadCommentHandling;
-        options.SerializerOptions.PropertyNameCaseInsensitive = _jsonSerializerOptions.PropertyNameCaseInsensitive;
-        options.SerializerOptions.AllowTrailingCommas = _jsonSerializerOptions.AllowTrailingCommas;
-        options.SerializerOptions.WriteIndented = _jsonSerializerOptions.WriteIndented;
-        options.SerializerOptions.PropertyNamingPolicy = _jsonSerializerOptions.PropertyNamingPolicy;
-        options.SerializerOptions.Encoder = _jsonSerializerOptions.Encoder;
-        options.SerializerOptions.TypeInfoResolver = _jsonSerializerOptions.TypeInfoResolver;
-
-        foreach (var resolver in _jsonSerializerOptions.TypeInfoResolverChain)
-        {
-            options.SerializerOptions.TypeInfoResolverChain.Add(resolver);
-        }
-
-        foreach (var converter in _jsonSerializerOptions.Converters)
-        {
-            options.SerializerOptions.Converters.Add(converter);
-        }
+        options.SerializerOptions.Apply(_jsonSerializerOptions);
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/JsonOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/JsonOptionsConfigurations.cs
@@ -16,6 +16,6 @@ public class JsonOptionsConfigurations : IConfigureOptions<JsonOptions>
 
     public void Configure(JsonOptions options)
     {
-        options.SerializerOptions.Apply(_jsonSerializerOptions);
+        options.SerializerOptions.Merge(_jsonSerializerOptions);
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/JsonOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/JsonOptionsConfigurations.cs
@@ -1,0 +1,38 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
+
+namespace OrchardCore.Json;
+
+public class JsonOptionsConfigurations : IConfigureOptions<JsonOptions>
+{
+    private readonly JsonSerializerOptions _jsonSerializerOptions;
+
+    public JsonOptionsConfigurations(IOptions<JsonSerializerOptions> jsonSerializerOptions)
+    {
+        _jsonSerializerOptions = jsonSerializerOptions.Value;
+    }
+
+    public void Configure(JsonOptions options)
+    {
+        options.SerializerOptions.DefaultIgnoreCondition = _jsonSerializerOptions.DefaultIgnoreCondition;
+        options.SerializerOptions.ReferenceHandler = _jsonSerializerOptions.ReferenceHandler;
+        options.SerializerOptions.ReadCommentHandling = _jsonSerializerOptions.ReadCommentHandling;
+        options.SerializerOptions.PropertyNameCaseInsensitive = _jsonSerializerOptions.PropertyNameCaseInsensitive;
+        options.SerializerOptions.AllowTrailingCommas = _jsonSerializerOptions.AllowTrailingCommas;
+        options.SerializerOptions.WriteIndented = _jsonSerializerOptions.WriteIndented;
+        options.SerializerOptions.PropertyNamingPolicy = _jsonSerializerOptions.PropertyNamingPolicy;
+        options.SerializerOptions.Encoder = _jsonSerializerOptions.Encoder;
+        options.SerializerOptions.TypeInfoResolver = _jsonSerializerOptions.TypeInfoResolver;
+
+        foreach (var resolver in _jsonSerializerOptions.TypeInfoResolverChain)
+        {
+            options.SerializerOptions.TypeInfoResolverChain.Add(resolver);
+        }
+
+        foreach (var converter in _jsonSerializerOptions.Converters)
+        {
+            options.SerializerOptions.Converters.Add(converter);
+        }
+    }
+}

--- a/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Extensions/ServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.DataProtection.XmlEncryption;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Json;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Localization;
@@ -30,6 +31,7 @@ using OrchardCore.Environment.Shell.Builders;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Environment.Shell.Descriptor.Models;
 using OrchardCore.Extensions;
+using OrchardCore.Json;
 using OrchardCore.Localization;
 using OrchardCore.Locking;
 using OrchardCore.Locking.Distributed;
@@ -154,6 +156,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddSingleton<IPoweredByMiddlewareOptions, PoweredByMiddlewareOptions>();
 
+            services.AddTransient<IConfigureOptions<JsonOptions>, JsonOptionsConfigurations>();
             services.AddTransient<IConfigureOptions<JsonSerializerOptions>, JsonSerializerOptionsConfiguration>();
 
             services.AddScoped<IOrchardHelper, DefaultOrchardHelper>();


### PR DESCRIPTION
Fix #15416

@hyzx86 can you please give this PR a try to make sure the serializer is working?

@sebastienros this pr will make the default JsonOptions mirror the options we use in `JsonSerializerOptions`. We could also by default use `JOptions.Default` or `JOptions.Base`. Thoughts?