### PR TITLE
Update README.md, Custom User Settings, wrong link to the video

### DIFF
--- a/src/docs/reference/modules/Users/CustomUserSettings/README.md
+++ b/src/docs/reference/modules/Users/CustomUserSettings/README.md
@@ -12,7 +12,7 @@ To enable the "Custom User Settings" module, select it from the "Features" list.
     Don't mark any existing Content Type with this `CustomUserSettings` stereotype, as this will break existing content items of this type.
 
 Custom User Settings are then comprised of parts and fields like any other content type.  
-After creation, go to Security >> Users to either create a new user or modify an existing one. Each of these sections will be accessible through distinct tabs. For further information, refer to the video located at the [bottom of this page.](#Video). 
+After creation, go to Security >> Users to either create a new user or modify an existing one. Each of these sections will be accessible through distinct tabs. For further information, refer to the video located at the [bottom of this page](#video). 
 
 ## Usage
 


### PR DESCRIPTION
As discussed here https://github.com/OrchardCMS/OrchardCore/commit/4ad0cd921a0be305f944bb528ce4e4d06ec64f68#commitcomment-139612621, this is a fix for the wrong video anchor, it was uppercase (#Video) instead to be lowercase (#video).