### PR TITLE
Issue 15492 bugfix: Prevent session connection closing in WorkflowTypeController

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
@@ -121,7 +121,7 @@ namespace OrchardCore.Workflows.Controllers
                 .Take(pager.PageSize)
                 .ListAsync();
 
-            using var connection = await _session.CreateConnectionAsync();
+            var connection = await _session.CreateConnectionAsync();
 
             var dialect = _session.Store.Configuration.SqlDialect;
             var sqlBuilder = dialect.CreateBuilder(_session.Store.Configuration.TablePrefix);

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
@@ -121,6 +121,7 @@ namespace OrchardCore.Workflows.Controllers
                 .Take(pager.PageSize)
                 .ListAsync();
 
+            // The existing session's connection is returned, don't dispose it
             var connection = await _session.CreateConnectionAsync();
 
             var dialect = _session.Store.Configuration.SqlDialect;


### PR DESCRIPTION
Fixes #15492 

The reason for the error is that in version OrchardCore 1.8.2 WorkflowTypeController was added using (and thereby disposing) when calling CreateConnectionAsync method of Session object. A session object is an object created probably with a scoped lifetime and will be destroyed with a destructor call and mandatory closure with a connection in the finally block at the end of the web request, i.e. there is no need to use using during web request processing when Session calls can still be made.