### PR TITLE
Add missing Cloudsmith attribution (Lombiq Technologies: OCORE-150)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ First, clone the repository using the command `git clone https://github.com/Orch
 2. Launch the solution by clicking on `OrchardCore.sln`. Give Visual Studio time to restore all missing Nuget packages.
 3. Ensure `OrchardCore.Cms.Web` is set as the startup project. Then run the app.
 
+## Preview Package Feed
+
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=for-the-badge)](https://cloudsmith.com)
+
+NuGet package repository hosting for the preview feed is graciously provided by [Cloudsmith](https://cloudsmith.com).
+
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.
+
 ## Code of Conduct
 
 See [our Code of Conduct](./CODE-OF-CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ First, clone the repository using the command `git clone https://github.com/Orch
 NuGet package repository hosting for the preview feed is graciously provided by [Cloudsmith](https://cloudsmith.com).
 
 Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
-enables your organization to create, store and share packages in any format, to any place, with total
+enables your organization to create, store, and share packages in any format, to any place, with total
 confidence.
 
 ## Code of Conduct

--- a/src/README.md
+++ b/src/README.md
@@ -105,3 +105,13 @@ Docker images and parameters can be found at <https://hub.docker.com/u/orchardpr
 ## Showcasing Orchard Core CMS
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gfy5SCACyL8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+## Preview Package Feed
+
+[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=for-the-badge)](https://cloudsmith.com)
+
+NuGet package repository hosting for the preview feed is graciously provided by [Cloudsmith](https://cloudsmith.com).
+
+Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
+enables your organization to create, store and share packages in any format, to any place, with total
+confidence.

--- a/src/README.md
+++ b/src/README.md
@@ -105,13 +105,3 @@ Docker images and parameters can be found at <https://hub.docker.com/u/orchardpr
 ## Showcasing Orchard Core CMS
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Gfy5SCACyL8" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-## Preview Package Feed
-
-[![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=for-the-badge)](https://cloudsmith.com)
-
-NuGet package repository hosting for the preview feed is graciously provided by [Cloudsmith](https://cloudsmith.com).
-
-Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that
-enables your organization to create, store and share packages in any format, to any place, with total
-confidence.


### PR DESCRIPTION
Our preview package feed is hosted by Cloudsmith for free. For this, they require some attribution, see https://help.cloudsmith.io/docs/open-source-hosting-policy, what we failed to do. Fixing that now.