### PR TITLE
Convert Themes views to shapes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Themes/Drivers/ThemeEntryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Drivers/ThemeEntryDisplayDriver.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Themes.Models;
+
+namespace OrchardCore.Themes.Drivers;
+
+public class ThemeEntryDisplayDriver : DisplayDriver<ThemeEntry>
+{
+    public override IDisplayResult Display(ThemeEntry model)
+    {
+        var results = new List<ShapeResult>()
+        {
+            View("ThemeEntry_SummaryAdmin__Thumbnail", model).Location("SummaryAdmin", "Thumbnail:5"),
+            View("ThemeEntry_SummaryAdmin__Title", model).Location("SummaryAdmin", "Header:5"),
+            View("ThemeEntry_SummaryAdmin__Descriptions", model).Location("SummaryAdmin", "Content:5"),
+            View("ThemeEntry_SummaryAdmin__Attributes", model).Location("SummaryAdmin", "Tags:5"),
+         };
+
+        if (model.IsCurrent)
+        {
+            results.Add(View("ThemeEntry_SummaryAdmin__Current", model).Location("SummaryAdmin", "FooterBelow:5"));
+        }
+        else
+        {
+            results.AddRange([
+                View("ThemeEntry_SummaryAdmin__ButtonsMakeCurrent", model).Location("SummaryAdmin", "FooterStart:5"),
+                View("ThemeEntry_SummaryAdmin__ButtonsToggleState", model).Location("SummaryAdmin", "FooterEnd:5")
+            ]);
+        }
+
+        return Combine(results);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
@@ -9,6 +9,7 @@ using OrchardCore.Recipes;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Themes.Deployment;
 using OrchardCore.Themes.Drivers;
+using OrchardCore.Themes.Models;
 using OrchardCore.Themes.Recipes;
 using OrchardCore.Themes.Services;
 
@@ -33,6 +34,7 @@ namespace OrchardCore.Themes
             services.AddScoped<ThemeTogglerService>();
             services.AddDeployment<ThemesDeploymentSource, ThemesDeploymentStep, ThemesDeploymentStepDriver>();
             services.AddScoped<IDisplayDriver<Navbar>, ToggleThemeNavbarDisplayDriver>();
+            services.AddScoped<IDisplayDriver<ThemeEntry>, ThemeEntryDisplayDriver>();
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Admin/Index.cshtml
@@ -1,4 +1,12 @@
-@model OrchardCore.Themes.Models.SelectThemesViewModel
+@using OrchardCore.DisplayManagement
+@using OrchardCore.DisplayManagement.ModelBinding
+@using OrchardCore.Themes.Models
+
+@inject IDisplayManager<ThemeEntry> ThemeEntryDisplayManager
+@inject IUpdateModelAccessor UpdateModelAccessor
+
+@model SelectThemesViewModel
+
 <style asp-src="~/OrchardCore.Themes/Styles/themes.admin.css"></style>
 <zone Name="Title"><h1>@RenderTitleSegments(T["Themes"])</h1></zone>
 
@@ -12,67 +20,7 @@ else
         @foreach (var themeEntry in Model.Themes)
         {
             <div class="col-sm-12 col-md-6 col-lg-4 d-flex align-items-stretch">
-                <div class="card theme-card w-100">
-                    <div class="card-theme-thumbnail" style="    background-image: url('@Url.Content($"~/{themeEntry.Extension.Id}/Theme.png")');"></div>
-                    <div class="card-body">
-                        <h4 class="card-title">@themeEntry.Name</h4>
-                        <p class="card-text">
-                            @themeEntry.Extension.Manifest.Description
-                            <ul class="list-group list-group-flush">
-                                @if (!string.IsNullOrWhiteSpace(themeEntry.Extension.Manifest.Author))
-                                {
-                                    <li class="list-group-item"><small><i class="fa-solid fa-user fa-fw" aria-hidden="true"></i> @themeEntry.Extension.Manifest.Author</small></li>
-                                }
-                                @if (!string.IsNullOrWhiteSpace(themeEntry.Extension.Manifest.Website))
-                                {
-                                    <li class="list-group-item"><small><i class="fa-solid fa-external-link fa-fw" aria-hidden="true"></i> <a href="@themeEntry.Extension.Manifest.Website" target="_blank">@themeEntry.Extension.Manifest.Website</a></small></li>
-                                }
-                                @if (themeEntry.Extension.Manifest.Tags.Any())
-                                {
-                                    <li class="list-group-item"><small><i class="fa-solid fa-tags fa-fw" aria-hidden="true"></i> @string.Join(", ", themeEntry.Extension.Manifest.Tags.ToArray())</small></li>
-                                }
-                                <li class="list-group-item"><small><i class="fa-solid fa-code-branch fa-fw" aria-hidden="true"></i> @themeEntry.Extension.Manifest.Version</small></li>
-                            </ul>
-                        </p>
-                    </div>
-                    <div class="card-footer">
-                        @if (!themeEntry.IsCurrent)
-                        {
-                            <div class="row">
-                                <div class="col-sm-6 text-start">
-                                    <form asp-route-action="SetCurrentTheme" asp-route-id="@themeEntry.Extension.Id" method="post" class="no-multisubmit">
-                                        <button type="submit" class="btn btn-sm btn-primary">@T["Make Current"]</button>
-                                    </form>
-                                </div>
-                                <div class="col-sm-6 text-end">
-                                    @if (themeEntry.Enabled)
-                                    {
-                                        <form asp-route-action="Disable" asp-route-id="@themeEntry.Extension.Id" method="post" class="no-multisubmit">
-                                            <button type="submit" class="btn btn-sm btn-secondary">@T["Disable"]</button>
-                                        </form>
-                                    }
-                                    else
-                                    {
-                                        <form asp-route-action="Enable" asp-route-id="@themeEntry.Extension.Id" method="post" class="no-multisubmit">
-                                            <button type="submit" class="btn btn-sm btn-secondary">@T["Enable"]</button>
-                                        </form>
-                                    }
-                                </div>
-                            </div>
-                        }
-                        else
-                        {
-                            if (themeEntry.IsAdmin)
-                            {
-                                <span class="text-muted">@T["This is the current Admin theme"]</span>
-                            }
-                            else
-                            {
-                                <span class="text-muted">@T["This is the current Site theme"]</span>
-                            }
-                        }
-                    </div>
-                </div>
+                @await DisplayAsync(await ThemeEntryDisplayManager.BuildDisplayAsync(themeEntry, UpdateModelAccessor.ModelUpdater, "SummaryAdmin"))
             </div>
         }
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Attributes.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Attributes.SummaryAdmin.cshtml
@@ -1,0 +1,37 @@
+@using OrchardCore.DisplayManagement.Views
+@using OrchardCore.Themes.Models
+
+@model ShapeViewModel<ThemeEntry>
+
+@if (!string.IsNullOrWhiteSpace(Model.Value.Extension.Manifest.Author))
+{
+    <li class="list-group-item">
+        <small>
+            <i class="fa-solid fa-user fa-fw" aria-hidden="true"></i>
+            @Model.Value.Extension.Manifest.Author
+        </small>
+    </li>
+}
+@if (!string.IsNullOrWhiteSpace(Model.Value.Extension.Manifest.Website))
+{
+    <li class="list-group-item">
+        <small>
+            <i class="fa-solid fa-external-link fa-fw" aria-hidden="true"></i>
+            <a href="@Model.Value.Extension.Manifest.Website" target="_blank">@Model.Value.Extension.Manifest.Website</a>
+        </small>
+    </li>
+}
+@if (Model.Value.Extension.Manifest.Tags.Any())
+{
+    <li class="list-group-item">
+        <small>
+            <i class="fa-solid fa-tags fa-fw" aria-hidden="true"></i> @string.Join(", ", Model.Value.Extension.Manifest.Tags.ToArray())
+        </small>
+    </li>
+}
+<li class="list-group-item">
+    <small>
+        <i class="fa-solid fa-code-branch fa-fw" aria-hidden="true"></i> @Model.Value.Extension.Manifest.Version
+    </small>
+</li>
+

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-ButtonsMakeCurrent.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-ButtonsMakeCurrent.SummaryAdmin.cshtml
@@ -1,0 +1,8 @@
+@using OrchardCore.DisplayManagement.Views
+@using OrchardCore.Themes.Models
+
+@model ShapeViewModel<ThemeEntry>
+
+<form asp-route-action="SetCurrentTheme" asp-route-id="@Model.Value.Extension.Id" method="post" class="no-multisubmit">
+    <button type="submit" class="btn btn-sm btn-primary">@T["Make Current"]</button>
+</form>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-ButtonsToggleState.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-ButtonsToggleState.SummaryAdmin.cshtml
@@ -1,0 +1,17 @@
+@using OrchardCore.DisplayManagement.Views
+@using OrchardCore.Themes.Models
+
+@model ShapeViewModel<ThemeEntry>
+
+@if (Model.Value.Enabled)
+{
+    <form asp-route-action="Disable" asp-route-id="@Model.Value.Extension.Id" method="post" class="no-multisubmit">
+        <button type="submit" class="btn btn-sm btn-secondary">@T["Disable"]</button>
+    </form>
+
+    return;
+}
+
+<form asp-route-action="Enable" asp-route-id="@Model.Value.Extension.Id" method="post" class="no-multisubmit">
+    <button type="submit" class="btn btn-sm btn-secondary">@T["Enable"]</button>
+</form>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Current.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Current.SummaryAdmin.cshtml
@@ -1,0 +1,13 @@
+@using OrchardCore.DisplayManagement.Views
+@using OrchardCore.Themes.Models
+
+@model ShapeViewModel<ThemeEntry>
+
+@if (Model.Value.IsAdmin)
+{
+    <span class="text-muted">@T["This is the current Admin theme"]</span>
+}
+else
+{
+    <span class="text-muted">@T["This is the current Site theme"]</span>
+}

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Current.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Current.SummaryAdmin.cshtml
@@ -6,8 +6,8 @@
 @if (Model.Value.IsAdmin)
 {
     <span class="text-muted">@T["This is the current Admin theme"]</span>
+
+    return;
 }
-else
-{
-    <span class="text-muted">@T["This is the current Site theme"]</span>
-}
+
+<span class="text-muted">@T["This is the current Site theme"]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Descriptions.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Descriptions.SummaryAdmin.cshtml
@@ -3,6 +3,6 @@
 
 @model ShapeViewModel<ThemeEntry>
 
-<span>
+<span class="theme-entry-description">
     @Model.Value.Extension.Manifest.Description
 </span>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Descriptions.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Descriptions.SummaryAdmin.cshtml
@@ -1,0 +1,8 @@
+@using OrchardCore.DisplayManagement.Views
+@using OrchardCore.Themes.Models
+
+@model ShapeViewModel<ThemeEntry>
+
+<span>
+    @Model.Value.Extension.Manifest.Description
+</span>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Thumbnail.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Thumbnail.SummaryAdmin.cshtml
@@ -1,0 +1,6 @@
+@using OrchardCore.DisplayManagement.Views
+@using OrchardCore.Themes.Models
+
+@model ShapeViewModel<ThemeEntry>
+
+<div class="card-theme-thumbnail" style="background-image: url('@Url.Content($"~/{Model.Value.Extension.Id}/Theme.png")');"></div>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Title.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Title.SummaryAdmin.cshtml
@@ -1,0 +1,6 @@
+@using OrchardCore.DisplayManagement.Views
+@using OrchardCore.Themes.Models
+
+@model ShapeViewModel<ThemeEntry>
+
+<h4 class="card-title">@Model.Value.Name</h4>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/ThemeEntry.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/ThemeEntry.SummaryAdmin.cshtml
@@ -1,0 +1,64 @@
+<div class="card theme-card w-100">
+
+    @if (Model.Thumbnail != null)
+    {
+        @await DisplayAsync(Model.Thumbnail)
+    }
+
+    <div class="card-body">
+
+        @if (Model.Header != null)
+        {
+            @await DisplayAsync(Model.Header)
+        }
+
+        @if (Model.Content != null || Model.Attributes != null)
+        {
+            <p class="card-text">
+                @if (Model.Content != null)
+                {
+                    @await DisplayAsync(Model.Content)
+                }
+
+                @if (Model.Tags != null)
+                {
+                    <ul class="list-group list-group-flush">
+                        @await DisplayAsync(Model.Tags)
+                    </ul>
+                }
+            </p>
+        }
+
+    </div>
+
+    @if (Model.FooterStart != null || Model.FooterEnd != null || Model.FooterBelow != null)
+    {
+        <div class="card-footer">
+
+            @if (Model.FooterStart != null || Model.FooterEnd != null)
+            {
+                <div class="d-flex justify-content-between">
+
+                    <div>
+                        @if (Model.FooterStart != null)
+                        {
+                            @await DisplayAsync(Model.FooterStart)
+                        }
+                    </div>
+                    <div>
+                        @if (Model.FooterEnd != null)
+                        {
+                            @await DisplayAsync(Model.FooterEnd)
+                        }
+                    </div>
+                </div>
+            }
+
+            @if (Model.FooterBelow != null)
+            {
+                @await DisplayAsync(Model.FooterBelow)
+            }
+        </div>
+    }
+
+</div>

--- a/src/docs/releases/1.9.0.md
+++ b/src/docs/releases/1.9.0.md
@@ -8,24 +8,6 @@ Release date: Not yet released
 
 The utilization of [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json) has been discontinued in both **YesSql** and **OrchardCore**. Instead, we have transitioned to utilize `System.Text.Json` due to its enhanced performance capabilities. To ensure compatibility with `System.Text.Json` during the serialization or deserialization of objects, the following steps need to be undertaken:
 
- - If your custom `Document` includes a collection with a getter-only property, it is imperative to incorporate a setter or utilize the `init` modifier to facilitate the assignment of values by `System.Text.Json`. For instance:
-
-```csharp
-public class MediaProfilesDocument : Document
-{
-    public Dictionary<string, MediaProfile> MediaProfiles { get; } = new(StringComparer.OrdinalIgnoreCase);
-}
-```
-
-Should be changed to the following instead:
-
-```csharp
-public class MediaProfilesDocument : Document
-{
-    public Dictionary<string, MediaProfile> MediaProfiles { get; init; } = new(StringComparer.OrdinalIgnoreCase);
-}
-```
-
   - If you are using a custom deployment steps, change how you register it by using the new `AddDeployment<>` extension. This extension adds a new service that is required for proper serialization. For instance, instead of registering your deployment step like this:
 
 ```csharp


### PR DESCRIPTION
Fix #15588

As you can see, the outcome is the same. The only difference is that people can inject shapes into variance zones now.

![image](https://github.com/OrchardCMS/OrchardCore/assets/24724371/01152277-c8b9-4679-b1a6-a0beb82affc7)
