### PR TITLE
Check the null for searchResult.Value before call GetResultsAsync()

### DIFF
--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
@@ -60,13 +60,18 @@ public class AzureAIIndexDocumentManager(
         var searchResult = await client.SearchAsync<SearchDocument>(searchText, searchOptions);
         var counter = 0L;
 
+        if (searchResult.Value is null)
+        {
+            return counter;
+        }
+
         await foreach (var doc in searchResult.Value.GetResultsAsync())
         {
             action(doc.Document);
             counter++;
         }
 
-        return searchResult.Value?.TotalCount ?? counter;
+        return searchResult.Value.TotalCount;
     }
 
     public async Task DeleteDocumentsAsync(string indexName, IEnumerable<string> contentItemIds)

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
@@ -71,7 +71,7 @@ public class AzureAIIndexDocumentManager(
             counter++;
         }
 
-        return searchResult.Value.TotalCount;
+        return searchResult.Value.TotalCount ?? counter;
     }
 
     public async Task DeleteDocumentsAsync(string indexName, IEnumerable<string> contentItemIds)


### PR DESCRIPTION
I could use `null` check operator, but I find it easier to check for the nullability one time