### PR TITLE
Adjust content type condition to evaluate to true when no content is displayed and the operation for the given condition is a negation to address. Fixes #15452.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Rules/Drivers/ContentTypeConditionEvaluatorDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Drivers/ContentTypeConditionEvaluatorDriver.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
@@ -43,6 +44,14 @@ namespace OrchardCore.Rules.Drivers
         private ValueTask<bool> EvaluateAsync(ContentTypeCondition condition)
         {
             var operatorComparer = _operatorResolver.GetOperatorComparer(condition.Operation);
+
+            // If no content types are considered and the operation is an INegateOperator, return true,
+            // since displaying no content type should match any negative comparision on any content type
+            if (!_contentTypes.Any() && condition.Operation is INegateOperator)
+            {
+                return ValueTask.FromResult(true);
+            }
+
             foreach (var contentType in _contentTypes)
             {
                 if (operatorComparer.Compare(condition.Operation, contentType, condition.Value))

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Drivers/ContentTypeConditionEvaluatorDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Drivers/ContentTypeConditionEvaluatorDriver.cs
@@ -45,11 +45,11 @@ namespace OrchardCore.Rules.Drivers
         {
             var operatorComparer = _operatorResolver.GetOperatorComparer(condition.Operation);
 
-            // If no content types are considered and the operation is an INegateOperator, return true,
-            // since displaying no content type should match any negative comparision on any content type
-            if (!_contentTypes.Any() && condition.Operation is INegateOperator)
+            // If no content types are considered, use the empty string as the value to compare against,
+            // since we still want comparisons such as "Does Not Equal", "Does Not Start With", etc. to evaluate to true in this case.
+            if (!_contentTypes.Any())
             {
-                return ValueTask.FromResult(true);
+                return ValueTask.FromResult(operatorComparer.Compare(condition.Operation, string.Empty, condition.Value));
             }
 
             foreach (var contentType in _contentTypes)


### PR DESCRIPTION
Adjust content type condition to evaluate to true when no content is displayed and the operation for the given condition is a negation to address. Fixes #15452.