### PR TITLE
Fix HTML style for ThemeEntry

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Themes/Drivers/ThemeEntryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Drivers/ThemeEntryDisplayDriver.cs
@@ -15,11 +15,11 @@ public class ThemeEntryDisplayDriver : DisplayDriver<ThemeEntry>
             View("ThemeEntry_SummaryAdmin__Title", model).Location("SummaryAdmin", "Header:5"),
             View("ThemeEntry_SummaryAdmin__Descriptions", model).Location("SummaryAdmin", "Content:5"),
             View("ThemeEntry_SummaryAdmin__Attributes", model).Location("SummaryAdmin", "Tags:5"),
-         };
+        };
 
         if (model.IsCurrent)
         {
-            results.Add(View("ThemeEntry_SummaryAdmin__Current", model).Location("SummaryAdmin", "FooterBelow:5"));
+            results.Add(View("ThemeEntry_SummaryAdmin__Current", model).Location("SummaryAdmin", "FooterStart:5"));
         }
         else
         {

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Descriptions.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/Items/ThemeEntry-Descriptions.SummaryAdmin.cshtml
@@ -3,6 +3,11 @@
 
 @model ShapeViewModel<ThemeEntry>
 
-<span class="theme-entry-description">
+@if (string.IsNullOrEmpty(Model.Value.Extension.Manifest.Description))
+{
+    return;
+}
+
+<p class="text-muted mb-2">
     @Model.Value.Extension.Manifest.Description
-</span>
+</p>

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/ThemeEntry.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/ThemeEntry.SummaryAdmin.cshtml
@@ -14,19 +14,17 @@
 
         @if (Model.Content != null || Model.Attributes != null)
         {
-            <p class="card-text">
-                @if (Model.Content != null)
-                {
-                    @await DisplayAsync(Model.Content)
-                }
+            @if (Model.Content != null)
+            {
+                @await DisplayAsync(Model.Content)
+            }
 
-                @if (Model.Tags != null)
-                {
-                    <ul class="list-group list-group-flush">
-                        @await DisplayAsync(Model.Tags)
-                    </ul>
-                }
-            </p>
+            @if (Model.Tags != null)
+            {
+                <ul class="list-group list-group-flush">
+                    @await DisplayAsync(Model.Tags)
+                </ul>
+            }
         }
 
     </div>
@@ -39,13 +37,13 @@
             {
                 <div class="d-flex justify-content-between">
 
-                    <div>
+                    <div class="d-inline-flex">
                         @if (Model.FooterStart != null)
                         {
                             @await DisplayAsync(Model.FooterStart)
                         }
                     </div>
-                    <div>
+                    <div class="d-inline-flex">
                         @if (Model.FooterEnd != null)
                         {
                             @await DisplayAsync(Model.FooterEnd)


### PR DESCRIPTION
Currently we have bad HTML where we wrap list tag with a paragraph tag. 

Also, fix placement to allow placing multiple buttons inline.

Due to the wrapped paragraph tag, we get this large white-space.
![image](https://github.com/OrchardCMS/OrchardCore/assets/24724371/8f028319-4dc7-418b-bfa3-f1dd65b14cfe)


Also, if you try to inject a new button, it does not nicely fit inline

![image](https://github.com/OrchardCMS/OrchardCore/assets/24724371/755cda83-fd11-4781-87d1-e3f6cf01f928)


After the change, the buttons can be placed inline and the white-space is gone.

![image](https://github.com/OrchardCMS/OrchardCore/assets/24724371/8ea8631f-6a50-41d6-911f-c5274bb89f45)

