### PR TITLE
Remove unnecessary FrozenDictionary

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Placements/Models/PlacementsDocument.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Models/PlacementsDocument.cs
@@ -7,6 +7,6 @@ namespace OrchardCore.Placements.Models
 {
     public class PlacementsDocument : Document
     {
-        public Dictionary<string, PlacementNode[]> Placements { get; set; } = new Dictionary<string, PlacementNode[]>(StringComparer.OrdinalIgnoreCase);
+        public Dictionary<string, PlacementNode[]> Placements { get; } = new Dictionary<string, PlacementNode[]>(StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementProvider.cs
@@ -30,11 +30,11 @@ namespace OrchardCore.Placements.Services
 
         public class PlacementInfoResolver : IPlacementInfoResolver
         {
-            private readonly IReadOnlyDictionary<string, IEnumerable<PlacementNode>> _placements;
+            private readonly IReadOnlyDictionary<string, PlacementNode[]> _placements;
             private readonly IEnumerable<IPlacementNodeFilterProvider> _placementNodeFilterProviders;
 
             public PlacementInfoResolver(
-                IReadOnlyDictionary<string, IEnumerable<PlacementNode>> placements,
+                IReadOnlyDictionary<string, PlacementNode[]> placements,
                 IEnumerable<IPlacementNodeFilterProvider> placementNodeFilterProviders)
             {
                 _placements = placements;

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementsManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Services/PlacementsManager.cs
@@ -1,4 +1,3 @@
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -6,21 +5,23 @@ using OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy;
 
 namespace OrchardCore.Placements.Services
 {
-    public class PlacementsManager
+    public sealed class PlacementsManager
     {
         private readonly IPlacementStore _placementStore;
 
         public PlacementsManager(IPlacementStore placementStore)
-            => _placementStore = placementStore;
+        {
+            _placementStore = placementStore;
+        }
 
-        public async Task<IReadOnlyDictionary<string, IEnumerable<PlacementNode>>> ListShapePlacementsAsync()
+        public async Task<IReadOnlyDictionary<string, PlacementNode[]>> ListShapePlacementsAsync()
         {
             var document = await _placementStore.GetPlacementsAsync();
 
-            return document.Placements.ToFrozenDictionary(kvp => kvp.Key, kvp => kvp.Value.AsEnumerable());
+            return document.Placements;
         }
 
-        public async Task<IEnumerable<PlacementNode>> GetShapePlacementsAsync(string shapeType)
+        public async Task<PlacementNode[]> GetShapePlacementsAsync(string shapeType)
         {
             var document = await _placementStore.GetPlacementsAsync();
 


### PR DESCRIPTION
Appears in traces and is more expensive than useful since it's built on every call. There are multiple calls to this same service during a single request.