### PR TITLE
Seal private and internal types

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminPageRouteModelProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminPageRouteModelProvider.cs
@@ -12,7 +12,7 @@ using OrchardCore.Mvc;
 
 namespace OrchardCore.Admin
 {
-    internal class AdminPageRouteModelProvider : IPageRouteModelProvider
+    internal sealed class AdminPageRouteModelProvider : IPageRouteModelProvider
     {
         private readonly IHostEnvironment _hostingEnvironment;
         private readonly ApplicationPartManager _applicationManager;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleProvider.cs
@@ -31,7 +31,7 @@ namespace OrchardCore.Alias.Services
         }
     }
 
-    internal class AliasPartContentHandleHelper
+    internal sealed class AliasPartContentHandleHelper
     {
 #pragma warning disable CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
         internal static Task<ContentItem> QueryAliasIndex(ISession session, string alias) =>

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Services/AlwaysHasChangedToken.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Services/AlwaysHasChangedToken.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.BackgroundTasks.Services
     /// <summary>
     /// An empty change token that is always in the changed state but without raising any change callbacks.
     /// </summary>
-    internal class AlwaysHasChangedToken : IChangeToken
+    internal sealed class AlwaysHasChangedToken : IChangeToken
     {
         public static AlwaysHasChangedToken Singleton { get; } = new AlwaysHasChangedToken();
 
@@ -24,7 +24,7 @@ namespace OrchardCore.BackgroundTasks.Services
         }
     }
 
-    internal class EmptyDisposable : IDisposable
+    internal sealed class EmptyDisposable : IDisposable
     {
         public static EmptyDisposable Instance { get; } = new EmptyDisposable();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Fields/ContentFieldsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Fields/ContentFieldsProvider.cs
@@ -116,7 +116,7 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
             };
         }
 
-        private class FieldTypeDescriptor
+        private sealed class FieldTypeDescriptor
         {
             public string Description { get; set; }
             public Type FieldType { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Handlers/ContentLocalizationPartHandlerCoordinator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Handlers/ContentLocalizationPartHandlerCoordinator.cs
@@ -7,7 +7,7 @@ using OrchardCore.Modules;
 
 namespace OrchardCore.ContentLocalization.Handlers
 {
-    internal class ContentLocalizationPartHandlerCoordinator : ContentLocalizationHandlerBase
+    internal sealed class ContentLocalizationPartHandlerCoordinator : ContentLocalizationHandlerBase
     {
         private readonly ITypeActivatorFactory<ContentPart> _contentPartFactory;
         private readonly IEnumerable<IContentLocalizationPartHandler> _partHandlers;

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/RecipeSteps/ContentDefinitionStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/RecipeSteps/ContentDefinitionStep.cs
@@ -77,7 +77,7 @@ namespace OrchardCore.ContentTypes.RecipeSteps
                 }
             });
 
-        private class ContentDefinitionStepModel
+        private sealed class ContentDefinitionStepModel
         {
             public ContentTypeDefinitionRecord[] ContentTypes { get; set; } = [];
             public ContentPartDefinitionRecord[] ContentParts { get; set; } = [];

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/RecipeSteps/DeleteContentDefinitionStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/RecipeSteps/DeleteContentDefinitionStep.cs
@@ -41,7 +41,7 @@ namespace OrchardCore.ContentTypes.RecipeSteps
             }
         }
 
-        private class DeleteContentDefinitionStepModel
+        private sealed class DeleteContentDefinitionStepModel
         {
             public string[] ContentTypes { get; set; } = [];
             public string[] ContentParts { get; set; } = [];

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/RecipeSteps/ReplaceContentDefinitionStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/RecipeSteps/ReplaceContentDefinitionStep.cs
@@ -81,7 +81,7 @@ namespace OrchardCore.ContentTypes.RecipeSteps
             });
         }
 
-        private class ReplaceContentDefinitionStepModel
+        private sealed class ReplaceContentDefinitionStepModel
         {
             public ContentTypeDefinitionRecord[] ContentTypes { get; set; } = [];
             public ContentPartDefinitionRecord[] ContentParts { get; set; } = [];

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Recipes/LuceneRecipeEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Recipes/LuceneRecipeEventHandler.cs
@@ -78,7 +78,7 @@ namespace OrchardCore.ContentTypes
             return Task.CompletedTask;
         }
 
-        private class ContentDefinitionStepModel
+        private sealed class ContentDefinitionStepModel
         {
             public string Name { get; set; }
             public ContentTypeDefinitionRecord[] ContentTypes { get; set; } = [];

--- a/src/OrchardCore.Modules/OrchardCore.Demo/Services/UserProfileClaimsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/Services/UserProfileClaimsProvider.cs
@@ -11,7 +11,7 @@ using OrchardCore.Users.Services;
 
 namespace OrchardCore.Demo.Services
 {
-    internal class UserProfileClaimsProvider : IUserClaimsProvider
+    internal sealed class UserProfileClaimsProvider : IUserClaimsProvider
     {
         public Task GenerateAsync(IUser user, ClaimsIdentity claims)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Recipes/DeploymentPlansRecipeStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Recipes/DeploymentPlansRecipeStep.cs
@@ -80,19 +80,19 @@ namespace OrchardCore.Deployment.Recipes
             return _deploymentPlanService.CreateOrUpdateDeploymentPlansAsync(deploymentPlans);
         }
 
-        private class DeploymentPlansModel
+        private sealed class DeploymentPlansModel
         {
             public DeploymentPlanModel[] Plans { get; set; }
         }
 
-        private class DeploymentPlanModel
+        private sealed class DeploymentPlanModel
         {
             public string Name { get; set; }
 
             public DeploymentStepModel[] Steps { get; set; }
         }
 
-        private class DeploymentStepModel
+        private sealed class DeploymentStepModel
         {
             public string Type { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Features/Recipes/Executors/FeatureStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Recipes/Executors/FeatureStep.cs
@@ -41,7 +41,7 @@ namespace OrchardCore.Features.Recipes.Executors
             }
         }
 
-        private class FeatureStepModel
+        private sealed class FeatureStepModel
         {
             public string Name { get; set; }
             public string[] Disable { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Helpers/ModelStateHelpers.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Helpers/ModelStateHelpers.cs
@@ -38,7 +38,7 @@ namespace OrchardCore.Forms.Helpers
             return modelState;
         }
 
-        private class ModelStateTransferValue
+        private sealed class ModelStateTransferValue
         {
             public string Key { get; set; }
             public string AttemptedValue { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Migrations.cs
@@ -259,7 +259,7 @@ namespace OrchardCore.Forms
             return 4;
         }
 
-        internal class TitlePartSettings
+        internal sealed class TitlePartSettings
         {
             public int Options { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
@@ -143,7 +143,7 @@ namespace OrchardCore.Layers.Services
             await next.Invoke();
         }
 
-        internal class CacheEntry : Document
+        internal sealed class CacheEntry : Document
         {
             public IEnumerable<LayerMetadata> Widgets { get; set; }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Deployment/MediaDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Deployment/MediaDeploymentSource.cs
@@ -57,7 +57,7 @@ namespace OrchardCore.Media.Deployment
             });
         }
 
-        private class MediaDeploymentStepModel
+        private sealed class MediaDeploymentStepModel
         {
             public string SourcePath { get; set; }
             public string TargetPath { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Processing/ImageSharpUrlFormatter.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.Media.Processing
         WebP
     }
 
-    internal class ImageSharpUrlFormatter
+    internal sealed class ImageSharpUrlFormatter
     {
         public static string GetImageResizeUrl(string path, IDictionary<string, string> queryStringParams = null, int? width = null, int? height = null, ResizeMode resizeMode = ResizeMode.Undefined, int? quality = null, Format format = Format.Undefined, Anchor anchor = null, string bgcolor = null)
         {
@@ -53,7 +53,7 @@ namespace OrchardCore.Media.Processing
                 queryStringParams["rmode"] = resizeMode.ToString().ToLower();
             }
 
-            // The format is set before quality such that the quality is not 
+            // The format is set before quality such that the quality is not
             // invalidated when the url is generated.
             if (format != Format.Undefined)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Recipes/MediaStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Recipes/MediaStep.cs
@@ -91,7 +91,7 @@ namespace OrchardCore.Media.Recipes
             }
         }
 
-        private class MediaStepModel
+        private sealed class MediaStepModel
         {
             /// <summary>
             /// Collection of <see cref="MediaStepFile"/> objects.
@@ -99,7 +99,7 @@ namespace OrchardCore.Media.Recipes
             public MediaStepFile[] Files { get; set; }
         }
 
-        private class MediaStepFile
+        private sealed class MediaStepFile
         {
             /// <summary>
             /// Path where the content will be written.

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/CookieOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/CookieOptionsConfiguration.cs
@@ -6,7 +6,7 @@ using MicrosoftIdentityDefaults = Microsoft.Identity.Web.Constants;
 
 namespace OrchardCore.Microsoft.Authentication.Configuration
 {
-    internal class CookieOptionsConfiguration : IConfigureNamedOptions<CookieAuthenticationOptions>
+    internal sealed class CookieOptionsConfiguration : IConfigureNamedOptions<CookieAuthenticationOptions>
     {
         private readonly string _tenantPrefix;
 

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/OpenIdConnectOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/OpenIdConnectOptionsConfiguration.cs
@@ -8,7 +8,7 @@ using MicrosoftIdentityDefaults = Microsoft.Identity.Web.Constants;
 
 namespace OrchardCore.Microsoft.Authentication.Configuration
 {
-    internal class OpenIdConnectOptionsConfiguration : IConfigureNamedOptions<OpenIdConnectOptions>
+    internal sealed class OpenIdConnectOptionsConfiguration : IConfigureNamedOptions<OpenIdConnectOptions>
     {
         private readonly IOptionsMonitor<MicrosoftIdentityOptions> _azureADOptions;
         private readonly AzureADSettings _azureADSettings;

--- a/src/OrchardCore.Modules/OrchardCore.MiniProfiler/CurrentDbProfiler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.MiniProfiler/CurrentDbProfiler.cs
@@ -5,7 +5,7 @@ using StackExchange.Profiling.Data;
 
 namespace OrchardCore.MiniProfiler
 {
-    internal class CurrentDbProfiler : IDbProfiler
+    internal sealed class CurrentDbProfiler : IDbProfiler
     {
         private Func<IDbProfiler> GetProfiler { get; }
         public CurrentDbProfiler(Func<IDbProfiler> getProfiler) => GetProfiler = getProfiler;

--- a/src/OrchardCore.Modules/OrchardCore.MiniProfiler/MiniProfilerConnectionFactory.cs
+++ b/src/OrchardCore.Modules/OrchardCore.MiniProfiler/MiniProfilerConnectionFactory.cs
@@ -5,9 +5,9 @@ using YesSql;
 
 namespace OrchardCore.MiniProfiler
 {
-    internal class MiniProfilerConnectionFactory : IConnectionFactory
+    internal sealed class MiniProfilerConnectionFactory : IConnectionFactory
     {
-        protected static readonly string ConnectionName = nameof(ProfiledDbConnection).ToLower();
+        private static readonly string ConnectionName = nameof(ProfiledDbConnection).ToLower();
 
         private readonly IConnectionFactory _factory;
 

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/CommandStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/CommandStep.cs
@@ -54,7 +54,7 @@ namespace OrchardCore.Recipes.RecipeSteps
             }
         }
 
-        private class CommandStepModel
+        private sealed class CommandStepModel
         {
             public string[] Commands { get; set; }
         }

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/RecipesStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/RecipeSteps/RecipesStep.cs
@@ -46,12 +46,12 @@ namespace OrchardCore.Recipes.RecipeSteps
             context.InnerRecipes = innerRecipes;
         }
 
-        private class InternalStep
+        private sealed class InternalStep
         {
             public InternalStepValue[] Values { get; set; }
         }
 
-        private class InternalStepValue
+        private sealed class InternalStepValue
         {
             public string ExecutionId { get; set; }
             public string Name { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisLock.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Services/RedisLock.cs
@@ -146,7 +146,7 @@ namespace OrchardCore.Redis.Services
             }
         }
 
-        private class Locker : ILocker
+        private sealed class Locker : ILocker
         {
             private readonly RedisLock _lock;
             private readonly string _key;

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Recipes/LuceneIndexRebuildStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Recipes/LuceneIndexRebuildStep.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.Search.Lucene.Recipes
             }
         }
 
-        private class LuceneIndexRebuildStepModel
+        private sealed class LuceneIndexRebuildStepModel
         {
             public bool IncludeAll { get; set; } = false;
             public string[] Indices { get; set; } = [];

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Recipes/LuceneIndexResetStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Recipes/LuceneIndexResetStep.cs
@@ -53,7 +53,7 @@ namespace OrchardCore.Search.Lucene.Recipes
             }
         }
 
-        private class LuceneIndexResetStepModel
+        private sealed class LuceneIndexResetStepModel
         {
             public bool IncludeAll { get; set; } = false;
             public string[] Indices { get; set; } = [];

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
@@ -520,7 +520,7 @@ namespace OrchardCore.Search.Lucene
         }
     }
 
-    internal class IndexWriterWrapper : IndexWriter
+    internal sealed class IndexWriterWrapper : IndexWriter
     {
         public IndexWriterWrapper(LDirectory directory, IndexWriterConfig config) : base(directory, config)
         {
@@ -530,7 +530,7 @@ namespace OrchardCore.Search.Lucene
         public bool IsClosing { get; set; }
     }
 
-    internal class IndexReaderPool : IDisposable
+    internal sealed class IndexReaderPool : IDisposable
     {
         private bool _dirty;
         private int _count;

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Services/TemplateShortcodeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Services/TemplateShortcodeProvider.cs
@@ -65,7 +65,7 @@ namespace OrchardCore.Shortcodes.Services
             return result;
         }
 
-        internal class Content : LiquidContentAccessor
+        internal sealed class Content : LiquidContentAccessor
         {
             public readonly string _content;
             public Content(string content) => _content = content;

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Migrations.cs
@@ -169,12 +169,12 @@ namespace OrchardCore.Taxonomies
         }
     }
 
-    internal class AliasPartSettings
+    internal sealed class AliasPartSettings
     {
         public string Pattern { get; set; }
     }
 
-    internal class AutoroutePartSettings
+    internal sealed class AutoroutePartSettings
     {
         public string Pattern { get; set; }
         public bool AllowRouteContainedItems { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Users/GraphQL/CurrentUserQuery.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/GraphQL/CurrentUserQuery.cs
@@ -18,11 +18,11 @@ namespace OrchardCore.Users.GraphQL;
 /// <summary>
 /// Registers the current user including its custom user settings as a query.
 /// </summary>
-internal class CurrentUserQuery : ISchemaBuilder
+internal sealed class CurrentUserQuery : ISchemaBuilder
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IOptions<GraphQLContentOptions> _contentOptionsAccessor;
-    protected readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public CurrentUserQuery(
         IHttpContextAccessor httpContextAccessor,

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Filters/WorkflowActionFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Filters/WorkflowActionFilter.cs
@@ -8,7 +8,7 @@ using OrchardCore.Workflows.Services;
 
 namespace OrchardCore.Workflows.Http.Filters
 {
-    internal class WorkflowActionFilter : IAsyncActionFilter
+    internal sealed class WorkflowActionFilter : IAsyncActionFilter
     {
         private readonly IWorkflowManager _workflowManager;
         private readonly IWorkflowTypeRouteEntries _workflowTypeRouteEntries;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Handlers/WorkflowRoutesHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Handlers/WorkflowRoutesHandler.cs
@@ -5,7 +5,7 @@ using OrchardCore.Workflows.Services;
 
 namespace OrchardCore.Workflows.Http.Handlers
 {
-    internal class WorkflowRoutesHandler : WorkflowHandlerBase
+    internal sealed class WorkflowRoutesHandler : WorkflowHandlerBase
     {
         private readonly IWorkflowInstanceRouteEntries _workflowRouteEntries;
         private readonly IWorkflowTypeStore _workflowTypeStore;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Handlers/WorkflowTypeRoutesHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Handlers/WorkflowTypeRoutesHandler.cs
@@ -5,7 +5,7 @@ using OrchardCore.Workflows.Services;
 
 namespace OrchardCore.Workflows.Http.Handlers
 {
-    internal class WorkflowTypeRoutesHandler : WorkflowTypeHandlerBase
+    internal sealed class WorkflowTypeRoutesHandler : WorkflowTypeHandlerBase
     {
         private readonly IWorkflowTypeRouteEntries _workflowRouteEntries;
         private readonly IActivityLibrary _activityLibrary;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Services/WorkflowInstanceRouteEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Services/WorkflowInstanceRouteEntries.cs
@@ -11,7 +11,7 @@ using YesSql;
 
 namespace OrchardCore.Workflows.Http.Services
 {
-    internal class WorkflowInstanceRouteEntries : WorkflowRouteEntries<WorkflowRouteDocument>, IWorkflowInstanceRouteEntries
+    internal sealed class WorkflowInstanceRouteEntries : WorkflowRouteEntries<WorkflowRouteDocument>, IWorkflowInstanceRouteEntries
     {
         public WorkflowInstanceRouteEntries(IVolatileDocumentManager<WorkflowRouteDocument> documentManager) : base(documentManager) { }
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Services/WorkflowTypeRouteEntries.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Services/WorkflowTypeRouteEntries.cs
@@ -11,7 +11,7 @@ using YesSql;
 
 namespace OrchardCore.Workflows.Http.Services
 {
-    internal class WorkflowTypeRouteEntries : WorkflowRouteEntries<WorkflowTypeRouteDocument>, IWorkflowTypeRouteEntries
+    internal sealed class WorkflowTypeRouteEntries : WorkflowRouteEntries<WorkflowTypeRouteDocument>, IWorkflowTypeRouteEntries
     {
         public WorkflowTypeRouteEntries(IVolatileDocumentManager<WorkflowTypeRouteDocument> documentManager) : base(documentManager) { }
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Utility/DependencyOrdering.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Utility/DependencyOrdering.cs
@@ -6,7 +6,7 @@ namespace OrchardCore.Environment.Extensions.Utility
 {
     public static class DependencyOrdering
     {
-        private class Node<T>
+        private sealed class Node<T>
         {
             public T Item { get; set; }
             public bool Used { get; set; }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Builder/StartupActions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Builder/StartupActions.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
-    internal class StartupActions
+    internal sealed class StartupActions
     {
         public StartupActions(int order)
         {

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Builder/StartupActionsStartup.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Builder/StartupActionsStartup.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Modules
     /// <summary>
     /// Represents a fake Startup class that is composed of Configure and ConfigureServices lambdas.
     /// </summary>
-    internal class StartupActionsStartup : StartupBase
+    internal sealed class StartupActionsStartup : StartupBase
     {
         private readonly IServiceProvider _serviceProvider;
         private readonly StartupActions _actions;

--- a/src/OrchardCore/OrchardCore.Abstractions/Routing/FormValueRequiredMatcherPolicy.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Routing/FormValueRequiredMatcherPolicy.cs
@@ -67,7 +67,7 @@ namespace OrchardCore.Routing
 
         public IComparer<Endpoint> Comparer => new FormValueRequiredEndpointComparer();
 
-        private class FormValueRequiredEndpointComparer : EndpointMetadataComparer<FormValueRequiredAttribute>
+        private sealed class FormValueRequiredEndpointComparer : EndpointMetadataComparer<FormValueRequiredAttribute>
         {
             protected override int CompareMetadata(FormValueRequiredAttribute x, FormValueRequiredAttribute y)
             {

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContainerOptions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/ShellContainerOptions.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace OrchardCore.Environment.Shell.Builders;
 
-internal class ShellContainerOptions
+internal sealed class ShellContainerOptions
 {
     /// <summary>
     /// Delegates to be invoked asynchronously after a tenant container is created.

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -565,7 +565,7 @@ namespace OrchardCore.Environment.Shell.Scope
             }
         }
 
-        private class ShellScopeHolder
+        private sealed class ShellScopeHolder
         {
             public ShellScope Scope;
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentPartDefinitionBuilder.cs
@@ -212,7 +212,7 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             return this;
         }
 
-        private class FieldConfigurerImpl : ContentPartFieldDefinitionBuilder
+        private sealed class FieldConfigurerImpl : ContentPartFieldDefinitionBuilder
         {
             private ContentFieldDefinition _fieldDefinition;
             private readonly ContentPartDefinition _partDefinition;

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Metadata/Builders/ContentTypeDefinitionBuilder.cs
@@ -195,7 +195,7 @@ namespace OrchardCore.ContentManagement.Metadata.Builders
             return this;
         }
 
-        private class PartConfigurerImpl : ContentTypePartDefinitionBuilder
+        private sealed class PartConfigurerImpl : ContentTypePartDefinitionBuilder
         {
             private readonly ContentPartDefinition _partDefinition;
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentPartDisplayDriverTPart.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentPartDisplayDriverTPart.cs
@@ -345,7 +345,7 @@ namespace OrchardCore.ContentManagement.Display.ContentDisplay
         /// <summary>
         /// Restores the previous prefix automatically.
         /// </summary>
-        private class TempPrefix : IDisposable
+        private sealed class TempPrefix : IDisposable
         {
             private readonly ContentPartDisplayDriver<TPart> _driver;
             private readonly string _originalPrefix;

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/MatchOptions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/Queries/Predicates/MatchOptions.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
         /// <summary>
         /// The <see cref="MatchOptions" /> that matches if the string starts with the pattern.
         /// </summary>
-        private class StartsWithMatchOptions : MatchOptions
+        private sealed class StartsWithMatchOptions : MatchOptions
         {
             /// <inheritdoc />
             public override string ToMatchString(string pattern)
@@ -45,7 +45,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
         /// <summary>
         /// The <see cref="MatchOptions" /> that matches if the string ends with the pattern.
         /// </summary>
-        private class EndsWithMatchOptions : MatchOptions
+        private sealed class EndsWithMatchOptions : MatchOptions
         {
             /// <inheritdoc />
             public override string ToMatchString(string pattern)
@@ -57,7 +57,7 @@ namespace OrchardCore.ContentManagement.GraphQL.Queries.Predicates
         /// <summary>
         /// The <see cref="MatchOptions" /> that matches if the string contains the pattern.
         /// </summary>
-        private class ContainsMatchOptions : MatchOptions
+        private sealed class ContainsMatchOptions : MatchOptions
         {
             /// <inheritdoc />
             public override string ToMatchString(string pattern)

--- a/src/OrchardCore/OrchardCore.ContentManagement/GenericTypeActivator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/GenericTypeActivator.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace OrchardCore.ContentManagement
 {
-    internal class GenericTypeActivator<T, TInstance> : ITypeActivator<TInstance> where T : TInstance, new()
+    internal sealed class GenericTypeActivator<T, TInstance> : ITypeActivator<TInstance> where T : TInstance, new()
     {
         /// <inheritdoc />
         public Type Type => typeof(T);

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Removing/ShellDbTablesInfo.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Removing/ShellDbTablesInfo.cs
@@ -13,7 +13,7 @@ using YesSql.Sql.Schema;
 
 namespace OrchardCore.Environment.Shell.Removing;
 
-internal class ShellDbTablesInfo : ISchemaBuilder
+internal sealed class ShellDbTablesInfo : ISchemaBuilder
 {
     private ICommandInterpreter _commandInterpreter;
     public string TablePrefix { get; set; }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -99,7 +99,7 @@ namespace OrchardCore.DisplayManagement.Liquid
         }
     }
 
-    internal class ShapeAccessor : DelegateAccessor<object, object>
+    internal sealed class ShapeAccessor : DelegateAccessor<object, object>
     {
         public ShapeAccessor() : base((obj, name, ctx) => _getter(obj, name))
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
-        private class CookieCollectionWrapper
+        private sealed class CookieCollectionWrapper
         {
             public readonly IRequestCookieCollection RequestCookieCollection;
 
@@ -188,7 +188,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        private class HeaderDictionaryWrapper
+        private sealed class HeaderDictionaryWrapper
         {
             public readonly IHeaderDictionary HeaderDictionary;
 
@@ -198,7 +198,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        private class HttpContextItemsWrapper
+        private sealed class HttpContextItemsWrapper
         {
             public readonly IDictionary<object, object> Items;
 
@@ -208,7 +208,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        private class RouteValueDictionaryWrapper
+        private sealed class RouteValueDictionaryWrapper
         {
             public readonly IReadOnlyDictionary<string, object> RouteValueDictionary;
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/LiquidTagHelperActivator.cs
@@ -214,7 +214,7 @@ namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
             return tagHelper;
         }
 
-        private class ReusableTagHelperFactory<T> where T : class, ITagHelper
+        private sealed class ReusableTagHelperFactory<T> where T : class, ITagHelper
         {
             public static ITagHelper CreateTagHelper(ITagHelperFactory tagHelperFactory, ViewContext viewContext)
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/RequiredAttributeParser.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TagHelpers/RequiredAttributeParser.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.DisplayManagement.Liquid.TagHelpers
             requiredAttributeParser.AddRequiredAttributes(ruleBuilder);
         }
 
-        private class DefaultRequiredAttributeParser
+        private sealed class DefaultRequiredAttributeParser
         {
             private const char RequiredAttributeWildcardSuffix = '*';
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Arguments.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Arguments.cs
@@ -49,7 +49,7 @@ namespace OrchardCore.DisplayManagement
             return propertiesAccessor(propertyObject);
         }
 
-        private class NamedEnumerable<T> : INamedEnumerable<T>
+        private sealed class NamedEnumerable<T> : INamedEnumerable<T>
         {
             private readonly List<T> _arguments;
             private readonly List<string> _names;
@@ -91,7 +91,7 @@ namespace OrchardCore.DisplayManagement
                 get { return _named ??= new Named(_arguments, _names); }
             }
 
-            private class Named : IDictionary<string, T>
+            private sealed class Named : IDictionary<string, T>
             {
                 private readonly IList<T> _arguments;
                 private readonly IList<string> _names;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTablePlacementProvider.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeTablePlacementProvider.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
             return new ShapeTablePlacementResolver(shapeTable);
         }
 
-        private class ShapeTablePlacementResolver : IPlacementInfoResolver
+        private sealed class ShapeTablePlacementResolver : IPlacementInfoResolver
         {
             private readonly ShapeTable _shapeTable;
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyEntryComparer.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyEntryComparer.cs
@@ -4,7 +4,7 @@ using System.Text.Encodings.Web;
 
 namespace OrchardCore.DisplayManagement.Notify
 {
-    internal class NotifyEntryComparer : IEqualityComparer<NotifyEntry>
+    internal sealed class NotifyEntryComparer : IEqualityComparer<NotifyEntry>
     {
         private readonly HtmlEncoder _htmlEncoder;
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/ObjectPool.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/ObjectPool.cs
@@ -24,7 +24,7 @@ namespace OrchardCore.DisplayManagement
     /// Rationale:
     ///    If there is no intent for reusing the object, do not use pool - just use "new".
     /// </summary>
-    internal class ObjectPool<T> where T : class
+    internal sealed class ObjectPool<T> where T : class
     {
         [DebuggerDisplay("{Value,nq}")]
         private struct Element
@@ -52,7 +52,7 @@ namespace OrchardCore.DisplayManagement
 #if DETECT_LEAKS
         private static readonly ConditionalWeakTable<T, LeakTracker> leakTrackers = new ConditionalWeakTable<T, LeakTracker>();
 
-        private class LeakTracker : IDisposable
+        private sealed class LeakTracker : IDisposable
         {
             private volatile bool disposed;
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardDisplayHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardDisplayHelper.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Http;
 
 namespace OrchardCore.DisplayManagement.Razor
 {
-    internal class OrchardDisplayHelper : IOrchardDisplayHelper
+    internal sealed class OrchardDisplayHelper : IOrchardDisplayHelper
     {
         public OrchardDisplayHelper(HttpContext context, IDisplayHelper displayHelper)
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/AlternatesCollection.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/AlternatesCollection.cs
@@ -122,7 +122,7 @@ namespace OrchardCore.DisplayManagement.Shapes
             return GetEnumerator();
         }
 
-        private class KeyedAlternateCollection : KeyedCollection<string, string>
+        private sealed class KeyedAlternateCollection : KeyedCollection<string, string>
         {
             protected override string GetKeyForItem(string item)
             {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Title/PageTitleBuilder.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Title/PageTitleBuilder.cs
@@ -88,7 +88,7 @@ namespace OrchardCore.DisplayManagement.Title
         }
     }
 
-    internal class PositionalTitlePart : IPositioned
+    internal sealed class PositionalTitlePart : IPositioned
     {
         public string Position { get; set; }
         public IHtmlContent Value { get; set; }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneShapes.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneShapes.cs
@@ -438,7 +438,7 @@ namespace OrchardCore.DisplayManagement.Zones
         }
     }
 
-    internal class PositionalGrouping : IPositioned
+    internal sealed class PositionalGrouping : IPositioned
     {
         public PositionalGrouping()
         {

--- a/src/OrchardCore/OrchardCore.Infrastructure/Commands/DefaultCommandManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Commands/DefaultCommandManager.cs
@@ -93,7 +93,7 @@ namespace OrchardCore.Environment.Commands
             }
         }
 
-        private class Match
+        private sealed class Match
         {
             public CommandContext Context { get; set; }
             public ICommandHandler CommandHandler { get; set; }

--- a/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Shell/ShellDescriptorManager.cs
@@ -140,7 +140,7 @@ namespace OrchardCore.Environment.Shell.Data.Descriptors
                 handler.ChangedAsync(shellDescriptor, _shellSettings), shellDescriptor, _shellSettings, _logger);
         }
 
-        private class ConfiguredFeatures
+        private sealed class ConfiguredFeatures
         {
             public string[] Features { get; set; } = [];
         }

--- a/src/OrchardCore/OrchardCore.Localization.Core/DataAnnotations/LocalizedDataAnnotationsMvcOptions.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/DataAnnotations/LocalizedDataAnnotationsMvcOptions.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace OrchardCore.Localization.DataAnnotations
 {
-    internal class LocalizedDataAnnotationsMvcOptions : IConfigureOptions<MvcOptions>
+    internal sealed class LocalizedDataAnnotationsMvcOptions : IConfigureOptions<MvcOptions>
     {
         private readonly IStringLocalizerFactory _stringLocalizerFactory;
 

--- a/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PoParser.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Core/PortableObject/PoParser.cs
@@ -138,7 +138,7 @@ namespace OrchardCore.Localization.PortableObject
             };
         }
 
-        private class DictionaryRecordBuilder
+        private sealed class DictionaryRecordBuilder
         {
             private readonly List<string> _values;
             private IEnumerable<string> _validValues => _values.Where(value => !string.IsNullOrEmpty(value));

--- a/src/OrchardCore/OrchardCore.Mvc.Core/LocationExpander/CompositeViewLocationExpanderProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/LocationExpander/CompositeViewLocationExpanderProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace OrchardCore.Mvc.LocationExpander
 {
-    internal class CompositeViewLocationExpanderProvider : IViewLocationExpanderProvider
+    internal sealed class CompositeViewLocationExpanderProvider : IViewLocationExpanderProvider
     {
         public int Priority
         {

--- a/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/PageEndpointComparerPolicy.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/RazorPages/PageEndpointComparerPolicy.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Mvc.RazorPages
 
         public IComparer<Endpoint> Comparer => new PageEndpointComparer();
 
-        private class PageEndpointComparer : EndpointMetadataComparer<PageActionDescriptor>
+        private sealed class PageEndpointComparer : EndpointMetadataComparer<PageActionDescriptor>
         {
             protected override int CompareMetadata(PageActionDescriptor x, PageActionDescriptor y)
             {

--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Migrations/OpenIdMigrations.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Migrations/OpenIdMigrations.cs
@@ -172,9 +172,9 @@ namespace OrchardCore.OpenId.YesSql.Migrations
             return 2;
         }
 
-        private class OpenIdApplicationByPostLogoutRedirectUriIndex { }
-        private class OpenIdApplicationByRedirectUriIndex { }
-        private class OpenIdApplicationByRoleNameIndex { }
+        private sealed class OpenIdApplicationByPostLogoutRedirectUriIndex { }
+        private sealed class OpenIdApplicationByRedirectUriIndex { }
+        private sealed class OpenIdApplicationByRoleNameIndex { }
 
         // This code can be removed in a later version.
         public async Task<int> UpdateFrom2Async()
@@ -402,7 +402,7 @@ namespace OrchardCore.OpenId.YesSql.Migrations
         // This code can be removed in a later version.
         public async Task<int> UpdateFrom7Async()
         {
-            // Create all index tables with the new collection value.  
+            // Create all index tables with the new collection value.
             await SchemaBuilder.CreateMapIndexTableAsync<OpenIdApplicationIndex>(table => table
                 .Column<string>("ApplicationId", column => column.WithLength(48))
                 .Column<string>("ClientId", column => column.Unique()),

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Mappings/ContainedPartModel.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Mappings/ContainedPartModel.cs
@@ -2,7 +2,7 @@ using Nest;
 
 namespace OrchardCore.Search.Elasticsearch.Core.Mappings
 {
-    internal class ContainedPartModel
+    internal sealed class ContainedPartModel
     {
         [Keyword(Name = "Ids")]
         public string Ids { get; set; }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Mappings/DisplayTextModel.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Mappings/DisplayTextModel.cs
@@ -2,7 +2,7 @@ using Nest;
 
 namespace OrchardCore.Search.Elasticsearch.Core.Mappings
 {
-    internal class DisplayTextModel
+    internal sealed class DisplayTextModel
     {
         [Text(Name = "Analyzed")]
         public string Analyzed { get; set; }

--- a/src/OrchardCore/OrchardCore/Locking/LocalLock.cs
+++ b/src/OrchardCore/OrchardCore/Locking/LocalLock.cs
@@ -87,7 +87,7 @@ namespace OrchardCore.Locking
             }
         }
 
-        private class Semaphore
+        private sealed class Semaphore
         {
             public Semaphore(string key, SemaphoreSlim value)
             {
@@ -101,7 +101,7 @@ namespace OrchardCore.Locking
             internal int RefCount { get; set; }
         }
 
-        private class Locker : ILocker
+        private sealed class Locker : ILocker
         {
             private readonly LocalLock _localLock;
             private readonly Semaphore _semaphore;

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -19,7 +19,7 @@ using OrchardCore.Settings;
 
 namespace OrchardCore.Modules
 {
-    internal class ModularBackgroundService : BackgroundService
+    internal sealed class ModularBackgroundService : BackgroundService
     {
         private static readonly TimeSpan _pollingTime = TimeSpan.FromMinutes(1);
         private static readonly TimeSpan _minIdleTime = TimeSpan.FromSeconds(10);

--- a/src/OrchardCore/OrchardCore/Modules/PoweredByMiddleware.cs
+++ b/src/OrchardCore/OrchardCore/Modules/PoweredByMiddleware.cs
@@ -35,7 +35,7 @@ namespace OrchardCore.Modules
         string HeaderValue { get; set; }
     }
 
-    internal class PoweredByMiddlewareOptions : IPoweredByMiddlewareOptions
+    internal sealed class PoweredByMiddlewareOptions : IPoweredByMiddlewareOptions
     {
         private const string PoweredByHeaderName = "X-Powered-By";
         private const string PoweredByHeaderValue = "OrchardCore";

--- a/src/OrchardCore/OrchardCore/Shell/Builders/StartupBaseMock.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/StartupBaseMock.cs
@@ -8,7 +8,7 @@ using OrchardCore.Modules;
 
 namespace OrchardCore.Environment.Shell.Builders
 {
-    internal class StartupBaseMock : StartupBase
+    internal sealed class StartupBaseMock : StartupBase
     {
         private readonly object _startup;
         private readonly MethodInfo _configureService;

--- a/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/ConfiguredFeaturesShellDescriptorManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Descriptor/Settings/ConfiguredFeaturesShellDescriptorManager.cs
@@ -63,7 +63,7 @@ namespace OrchardCore.Environment.Shell.Descriptor.Settings
             return Task.CompletedTask;
         }
 
-        private class ConfiguredFeatures
+        private sealed class ConfiguredFeatures
         {
             public string[] Features { get; set; } = [];
         }

--- a/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedContext.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedContext.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Environment.Shell.Distributed
     /// <summary>
     /// Isolated context based on the default tenant settings used to resolve the <see cref="IDistributedCache"/>.
     /// </summary>
-    internal class DistributedContext : IDisposable, IAsyncDisposable
+    internal sealed class DistributedContext : IDisposable, IAsyncDisposable
     {
         private readonly ShellContext _context;
         private volatile int _count;

--- a/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/DistributedShellHostedService.cs
@@ -16,7 +16,7 @@ namespace OrchardCore.Environment.Shell.Distributed
     /// <summary>
     /// Keep in sync tenants by sharing shell identifiers through an <see cref="IDistributedCache"/>.
     /// </summary>
-    internal class DistributedShellHostedService : BackgroundService
+    internal sealed class DistributedShellHostedService : BackgroundService
     {
         private const string DistributedFeatureId = "OrchardCore.Tenants.Distributed";
 

--- a/src/OrchardCore/OrchardCore/Shell/Distributed/ShellIdentifier.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Distributed/ShellIdentifier.cs
@@ -1,6 +1,6 @@
 namespace OrchardCore.Environment.Shell.Distributed
 {
-    internal class ShellIdentifier
+    internal sealed class ShellIdentifier
     {
         public string ReleaseId { get; set; }
         public string ReloadId { get; set; }

--- a/test/OrchardCore.Benchmarks/Support/FakeFileProvider.cs
+++ b/test/OrchardCore.Benchmarks/Support/FakeFileProvider.cs
@@ -5,7 +5,7 @@ using OrchardCore.DisplayManagement.FileProviders;
 
 namespace OrchardCore.Benchmark.Support
 {
-    internal class FakeFileProvider : IFileProvider
+    internal sealed class FakeFileProvider : IFileProvider
     {
         public IDirectoryContents GetDirectoryContents(string subpath)
         {

--- a/test/OrchardCore.Tests.Features/Examples.Features.AssyAttrib/Root.cs
+++ b/test/OrchardCore.Tests.Features/Examples.Features.AssyAttrib/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.Features.AssyAttrib
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Modules/Errors.OrchardCoreModules.TwoPlus/Root.cs
+++ b/test/OrchardCore.Tests.Modules/Errors.OrchardCoreModules.TwoPlus/Root.cs
@@ -4,7 +4,7 @@ namespace Errors.OrchardCoreModules.TwoPlus
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Alpha/Root.cs
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Alpha/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.Modules.AssyAttrib.Alpha
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Bravo/Root.cs
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Bravo/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.Modules.AssyAttrib.Bravo
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Charlie/Root.cs
+++ b/test/OrchardCore.Tests.Modules/Examples.Modules.AssyAttrib.Charlie/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.Modules.AssyAttrib.Charlie
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Modules/Examples.OrchardCoreModules.Alpha/Root.cs
+++ b/test/OrchardCore.Tests.Modules/Examples.OrchardCoreModules.Alpha/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.OrchardCoreModules.Alpha
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Themes/Errors.OrchardCoreThemes.ThemeAndModule/Root.cs
+++ b/test/OrchardCore.Tests.Themes/Errors.OrchardCoreThemes.ThemeAndModule/Root.cs
@@ -4,7 +4,7 @@ namespace Errors.OrchardCoreThemes.ThemeAndModule
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Themes/Errors.OrchardCoreThemes.TwoPlus/Root.cs
+++ b/test/OrchardCore.Tests.Themes/Errors.OrchardCoreThemes.TwoPlus/Root.cs
@@ -4,7 +4,7 @@ namespace Errors.OrchardCoreThemes.TwoPlus
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Themes/Examples.OrchardCoreThemes.Alpha/Root.cs
+++ b/test/OrchardCore.Tests.Themes/Examples.OrchardCoreThemes.Alpha/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.OrchardCoreThemes.Alpha
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Alpha/Root.cs
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Alpha/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.Themes.AssyAttrib.Alpha
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Bravo/Root.cs
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Bravo/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.Themes.AssyAttrib.Bravo
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Charlie/Root.cs
+++ b/test/OrchardCore.Tests.Themes/Examples.Themes.AssyAttrib.Charlie/Root.cs
@@ -3,7 +3,7 @@ namespace Examples.Themes.AssyAttrib.Charlie
     /// <summary>
     /// Hooks provided for purposes of identifying the class and assembly context.
     /// </summary>
-    internal class Root
+    internal sealed class Root
     {
     }
 }

--- a/test/OrchardCore.Tests/Apis/Context/AuthenticationContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/AuthenticationContext.cs
@@ -3,7 +3,7 @@ using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Tests.Apis.Context
 {
-    internal class PermissionContextAuthorizationHandler : AuthorizationHandler<PermissionRequirement>
+    internal sealed class PermissionContextAuthorizationHandler : AuthorizationHandler<PermissionRequirement>
     {
         private readonly PermissionsContext _permissionsContext;
 
@@ -96,7 +96,7 @@ namespace OrchardCore.Tests.Apis.Context
         public bool UsePermissionsContext { get; set; } = false;
     }
 
-    internal class StubIdentity : IIdentity
+    internal sealed class StubIdentity : IIdentity
     {
         public string AuthenticationType => "TEST TEST";
 

--- a/test/OrchardCore.Tests/Apis/Context/SiteStartup.cs
+++ b/test/OrchardCore.Tests/Apis/Context/SiteStartup.cs
@@ -45,7 +45,7 @@ namespace OrchardCore.Tests.Apis.Context
             app.UseOrchardCore();
         }
 
-        private class ModuleNamesProvider : IModuleNamesProvider
+        private sealed class ModuleNamesProvider : IModuleNamesProvider
         {
             private readonly string[] _moduleNames;
 

--- a/test/OrchardCore.Tests/Apis/Context/TablePrefixGenerator.cs
+++ b/test/OrchardCore.Tests/Apis/Context/TablePrefixGenerator.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Tests.Apis.Context
     /// <remarks>
     /// Does not guarantee uniqueness.
     /// </remarks>
-    internal class TablePrefixGenerator
+    internal sealed class TablePrefixGenerator
     {
         private static readonly char[] _charList = "abcdefghijklmnopqrstuvwxyz".ToCharArray();
 

--- a/test/OrchardCore.Tests/Apis/GraphQL/ValidationRules/RequiresPermissionValidationRuleTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ValidationRules/RequiresPermissionValidationRuleTests.cs
@@ -131,7 +131,7 @@ namespace OrchardCore.Tests.Apis.GraphQL.ValidationRules
             };
         }
 
-        private class ValidationSchema : Schema
+        private sealed class ValidationSchema : Schema
         {
             public ValidationSchema()
             {
@@ -141,7 +141,7 @@ namespace OrchardCore.Tests.Apis.GraphQL.ValidationRules
             }
         }
 
-        private class ValidationQueryRoot : ObjectGraphType
+        private sealed class ValidationQueryRoot : ObjectGraphType
         {
             public ValidationQueryRoot()
             {
@@ -151,7 +151,7 @@ namespace OrchardCore.Tests.Apis.GraphQL.ValidationRules
             }
         }
 
-        private class TestField : ObjectGraphType
+        private sealed class TestField : ObjectGraphType
         {
             public TestField()
             {

--- a/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Decriptors/DefaultShapeTableManagerTests.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Tests.DisplayManagement.Descriptors
     {
         private readonly IServiceProvider _serviceProvider;
 
-        private class TestModuleExtensionInfo : IExtensionInfo
+        private sealed class TestModuleExtensionInfo : IExtensionInfo
         {
             public TestModuleExtensionInfo(string name)
             {
@@ -49,7 +49,7 @@ namespace OrchardCore.Tests.DisplayManagement.Descriptors
             public bool Exists => true;
         }
 
-        private class TestThemeExtensionInfo : IThemeExtensionInfo
+        private sealed class TestThemeExtensionInfo : IThemeExtensionInfo
         {
             public TestThemeExtensionInfo(string name)
             {

--- a/test/OrchardCore.Tests/DisplayManagement/DefaultDisplayManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/DefaultDisplayManagerTests.cs
@@ -44,7 +44,7 @@ namespace OrchardCore.Tests.DisplayManagement
             _serviceProvider = serviceCollection.BuildServiceProvider();
         }
 
-        private class TestDisplayEvents : IShapeDisplayEvents
+        private sealed class TestDisplayEvents : IShapeDisplayEvents
         {
             public Action<ShapeDisplayContext> Displaying = ctx => { };
             public Action<ShapeDisplayContext> Displayed = ctx => { };

--- a/test/OrchardCore.Tests/DisplayManagement/ShapeFactoryTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/ShapeFactoryTests.cs
@@ -126,7 +126,7 @@ namespace OrchardCore.Tests.DisplayManagement
             Assert.Equal("Baz", foo.Baz);
         }
 
-        private class SubShape : Shape
+        private sealed class SubShape : Shape
         {
         }
     }

--- a/test/OrchardCore.Tests/Email/EmailAddressValidatorTests.cs
+++ b/test/OrchardCore.Tests/Email/EmailAddressValidatorTests.cs
@@ -31,7 +31,7 @@ namespace OrchardCore.Tests.Email
             Assert.Equal(isValid, emailAddressValidator.Validate(address));
         }
 
-        private class OrchardCoreEmailValidator : IEmailAddressValidator
+        private sealed class OrchardCoreEmailValidator : IEmailAddressValidator
         {
             public bool Validate(string emailAddress)
                 => emailAddress.EndsWith("@orchardcore.net");

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -55,7 +55,7 @@ namespace OrchardCore.Tests.Extensions
                 );
         }
 
-        private class ModuleNamesProvider : IModuleNamesProvider
+        private sealed class ModuleNamesProvider : IModuleNamesProvider
         {
             private readonly string[] _moduleNames;
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Email/Workflows/EmailTaskTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Email/Workflows/EmailTaskTests.cs
@@ -79,7 +79,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Email.Workflows
                 emailServiceLocalizer.Object);
         }
 
-        private class SimpleWorkflowExpressionEvaluator : IWorkflowExpressionEvaluator
+        private sealed class SimpleWorkflowExpressionEvaluator : IWorkflowExpressionEvaluator
         {
             public async Task<T> EvaluateAsync<T>(WorkflowExpression<T> expression, WorkflowExecutionContext workflowContext, TextEncoder encoder)
                 => await Task.FromResult((T)Convert.ChangeType(expression.Expression, typeof(T)));

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
@@ -2,7 +2,7 @@ using OrchardCore.OpenId.Abstractions.Descriptors;
 
 namespace OrchardCore.Tests.Modules.OrchardCore.OpenId
 {
-    internal class OpenIdApplicationStepTestsData
+    internal sealed class OpenIdApplicationStepTestsData
         : TheoryData<string, OpenIdApplicationDescriptor>
     {
         public OpenIdApplicationStepTestsData()

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ApiControllerTests.cs
@@ -197,7 +197,7 @@ public class ApiControllerTests
         return httpContext;
     }
 
-    private class FakeDataProtector : IDataProtector
+    private sealed class FakeDataProtector : IDataProtector
     {
         public IDataProtector CreateProtector(string purpose) => this;
 

--- a/test/OrchardCore.Tests/Recipes/RecipeExecutorTests.cs
+++ b/test/OrchardCore.Tests/Recipes/RecipeExecutorTests.cs
@@ -72,7 +72,7 @@ namespace OrchardCore.Recipes
             return new EmbeddedFileProvider(assembly).GetFileInfo(path);
         }
 
-        private class RecipeEventHandler : IRecipeEventHandler
+        private sealed class RecipeEventHandler : IRecipeEventHandler
         {
             public RecipeExecutionContext Context { get; private set; }
 

--- a/test/OrchardCore.Tests/ResourceManagement/ResourceDefinitionTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/ResourceDefinitionTests.cs
@@ -283,7 +283,7 @@ namespace OrchardCore.Tests.ResourceManagement
         #endregion
 
         #region Stubs
-        private class StubFileVersionProvider : IFileVersionProvider
+        private sealed class StubFileVersionProvider : IFileVersionProvider
         {
             public static StubFileVersionProvider Instance { get; } = new StubFileVersionProvider();
 

--- a/test/OrchardCore.Tests/ResourceManagement/ResourceManagerTests.cs
+++ b/test/OrchardCore.Tests/ResourceManagement/ResourceManagerTests.cs
@@ -900,7 +900,7 @@ namespace OrchardCore.Tests.ResourceManagement
         #endregion
 
         #region Stubs
-        private class StubResourceManifestProvider : IConfigureOptions<ResourceManagementOptions>
+        private sealed class StubResourceManifestProvider : IConfigureOptions<ResourceManagementOptions>
         {
             private readonly Action<ResourceManagementOptions> _configureManifestAction;
 
@@ -915,7 +915,7 @@ namespace OrchardCore.Tests.ResourceManagement
             }
         }
 
-        private class StubFileVersionProvider : IFileVersionProvider
+        private sealed class StubFileVersionProvider : IFileVersionProvider
         {
             public static StubFileVersionProvider Instance { get; } = new StubFileVersionProvider();
 

--- a/test/OrchardCore.Tests/Routing/AutorouteEntriesTests.cs
+++ b/test/OrchardCore.Tests/Routing/AutorouteEntriesTests.cs
@@ -247,7 +247,7 @@ namespace OrchardCore.Tests.Routing
             void RemoveEntries(IEnumerable<AutorouteEntry> entries);
         }
 
-        private class StubAutorouteEntries : AutorouteEntries, IStubAutorouteEntries
+        private sealed class StubAutorouteEntries : AutorouteEntries, IStubAutorouteEntries
         {
             public StubAutorouteEntries() : base(null) { }
             public new void AddEntries(IEnumerable<AutorouteEntry> entries) => base.AddEntries(entries);

--- a/test/OrchardCore.Tests/Security/PermissionHandlerHelper.cs
+++ b/test/OrchardCore.Tests/Security/PermissionHandlerHelper.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.Tests.Security
             await handler.HandleAsync(context);
         }
 
-        private class FakePermissionHandler : AuthorizationHandler<PermissionRequirement>
+        private sealed class FakePermissionHandler : AuthorizationHandler<PermissionRequirement>
         {
             private readonly HashSet<string> _permissionNames;
 

--- a/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
@@ -170,15 +170,15 @@ namespace OrchardCore.Tests.Shell
         {
         }
 
-        private class TestService : ITestService
+        private sealed class TestService : ITestService
         {
         }
 
-        private class CustomTestService : ITestService
+        private sealed class CustomTestService : ITestService
         {
         }
 
-        private class RegisterServiceStartup : StartupBase
+        private sealed class RegisterServiceStartup : StartupBase
         {
             public override int Order => 1;
 
@@ -188,7 +188,7 @@ namespace OrchardCore.Tests.Shell
             }
         }
 
-        private class ReplaceServiceStartup : StartupBase
+        private sealed class ReplaceServiceStartup : StartupBase
         {
             public override int Order => 2;
 
@@ -204,31 +204,31 @@ namespace OrchardCore.Tests.Shell
 
         private interface ITestScoped { }
 
-        private class TestSingleton : ITestSingleton { }
+        private sealed class TestSingleton : ITestSingleton { }
 
-        private class TestTransient : ITestTransient { }
+        private sealed class TestTransient : ITestTransient { }
 
-        private class TestScoped : ITestScoped { }
+        private sealed class TestScoped : ITestScoped { }
 
         private interface ITwoHostSingletonsOfTheSameType { }
 
-        private class FirstHostSingletonsOfTheSameType : ITwoHostSingletonsOfTheSameType { }
+        private sealed class FirstHostSingletonsOfTheSameType : ITwoHostSingletonsOfTheSameType { }
 
-        private class SecondHostSingletonsOfTheSameType : ITwoHostSingletonsOfTheSameType { }
+        private sealed class SecondHostSingletonsOfTheSameType : ITwoHostSingletonsOfTheSameType { }
 
-        private class ShellSingletonOfTheSametype : ITwoHostSingletonsOfTheSameType { }
+        private sealed class ShellSingletonOfTheSametype : ITwoHostSingletonsOfTheSameType { }
 
-        private class ShellTransientOfTheSametype : ITwoHostSingletonsOfTheSameType { }
+        private sealed class ShellTransientOfTheSametype : ITwoHostSingletonsOfTheSameType { }
 
-        private class ShellScopedOfTheSametype : ITwoHostSingletonsOfTheSameType { }
+        private sealed class ShellScopedOfTheSametype : ITwoHostSingletonsOfTheSameType { }
 
         private interface IHostSingletonAndScopedOfTheSameType { }
 
-        private class HostSingletonOfTheSameTypeAsScoped : IHostSingletonAndScopedOfTheSameType { }
+        private sealed class HostSingletonOfTheSameTypeAsScoped : IHostSingletonAndScopedOfTheSameType { }
 
-        private class HostScopedOfTheSameTypeAsSingleton : IHostSingletonAndScopedOfTheSameType { }
+        private sealed class HostScopedOfTheSameTypeAsSingleton : IHostSingletonAndScopedOfTheSameType { }
 
-        private class ServicesOfTheSameTypeStartup : StartupBase
+        private sealed class ServicesOfTheSameTypeStartup : StartupBase
         {
             public override int Order => 1;
 


### PR DESCRIPTION
While checking warnings/errors with MS recommended analyzers (maybe a separate PR), found out that there are quite a few internal/private types that can be made sealed (may improve performance and diagnosers issue a waning about these).