### PR TITLE
Add missing string comparison type to equals comparisons

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,4 +5,58 @@
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
+  <PropertyGroup Label="Analysis rules">
+
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
+
+    <!-- Member is explicitly initialized to its default value -->
+    <NoWarn>$(NoWarn);CA1805</NoWarn>
+
+    <!-- The behavior could vary based on the current user's locale setting -->
+    <NoWarn>$(NoWarn);CA1304;CA1305;CA1310</NoWarn>
+
+    <!-- Specify a culture or use an invariant version to avoid implicit dependency on current culture -->
+    <NoWarn>$(NoWarn);CA1311</NoWarn>
+
+    <!-- Do not declare static members on generic types -->
+    <NoWarn>$(NoWarn);CA1000</NoWarn>
+
+    <!-- For improved performance, use the LoggerMessage delegates -->
+    <NoWarn>$(NoWarn);CA1848</NoWarn>
+
+    <!-- Identifier contains type name -->
+    <NoWarn>$(NoWarn);CA1720</NoWarn>
+
+    <!-- Do not declare visible instance fields -->
+    <NoWarn>$(NoWarn);CA1051</NoWarn>
+
+    <!-- Avoid using cref tags with a prefix -->
+    <NoWarn>$(NoWarn);CA1200</NoWarn>
+
+    <!--Rename type name X so that it does not end in 'Delegate', 'EventHandler', 'Permission' etc -->
+    <NoWarn>$(NoWarn);CA1711</NoWarn>
+
+    <!-- Parameter name differs from original overriden implemented name -->
+    <NoWarn>$(NoWarn);CA1725</NoWarn>
+
+    <!-- Reserved keyword -->
+    <NoWarn>$(NoWarn);CA1716</NoWarn>
+
+    <!-- Type owns disposable field(s) -->
+    <NoWarn>$(NoWarn);CA1001</NoWarn>
+
+    <!-- Exception type is not sufficiently specific -->
+    <NoWarn>$(NoWarn);CA2201</NoWarn>
+
+    <!-- Remove the underscores from member name -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn>
+
+    <!-- Use PascalCase for named placeholders in the logging message template -->
+    <NoWarn>$(NoWarn);CA1727</NoWarn>
+
+    <!--CA1861 : Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array -->
+    <NoWarn>$(NoWarn);CA1861</NoWarn>
+
+  </PropertyGroup>
+
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
@@ -124,7 +124,7 @@ namespace OrchardCore.Alias.Handlers
         private async Task<string> GetPatternAsync(AliasPart part)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(AliasPart)));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(AliasPart), System.StringComparison.Ordinal));
             var pattern = contentTypePartDefinition.GetSettings<AliasPartSettings>().Pattern;
 
             return pattern;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -124,7 +125,7 @@ namespace OrchardCore.Alias.Handlers
         private async Task<string> GetPatternAsync(AliasPart part)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(AliasPart), System.StringComparison.Ordinal));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(AliasPart), StringComparison.Ordinal));
             var pattern = contentTypePartDefinition.GetSettings<AliasPartSettings>().Pattern;
 
             return pattern;

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Handlers/AutoroutePartHandler.cs
@@ -157,7 +157,7 @@ namespace OrchardCore.Autoroute.Handlers
             return context.ForAsync<RouteHandlerAspect>(async aspect =>
             {
                 var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-                var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "AutoroutePart"));
+                var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "AutoroutePart", StringComparison.Ordinal));
                 var settings = contentTypePartDefinition.GetSettings<AutoroutePartSettings>();
                 if (settings.ManageContainedItemRoutes)
                 {
@@ -425,7 +425,7 @@ namespace OrchardCore.Autoroute.Handlers
         private async Task<string> GetPatternAsync(AutoroutePart part)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(AutoroutePart)));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(AutoroutePart), StringComparison.Ordinal));
             var pattern = contentTypePartDefinition.GetSettings<AutoroutePartSettings>().Pattern;
 
             return pattern;

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/HtmlFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/HtmlFieldQueryObjectType.cs
@@ -45,8 +45,8 @@ namespace OrchardCore.ContentFields.GraphQL
             var partName = paths[0];
             var fieldName = paths[1];
             var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(ctx.Source.ContentItem.ContentType);
-            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName));
-            var contentPartFieldDefinition = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName));
+            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName, System.StringComparison.Ordinal));
+            var contentPartFieldDefinition = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName, System.StringComparison.Ordinal));
             var settings = contentPartFieldDefinition.GetSettings<HtmlFieldSettings>();
 
             var html = ctx.Source.Html;

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/HtmlFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/HtmlFieldQueryObjectType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -45,8 +46,8 @@ namespace OrchardCore.ContentFields.GraphQL
             var partName = paths[0];
             var fieldName = paths[1];
             var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(ctx.Source.ContentItem.ContentType);
-            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName, System.StringComparison.Ordinal));
-            var contentPartFieldDefinition = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName, System.StringComparison.Ordinal));
+            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName, StringComparison.Ordinal));
+            var contentPartFieldDefinition = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName, StringComparison.Ordinal));
             var settings = contentPartFieldDefinition.GetSettings<HtmlFieldSettings>();
 
             var html = ctx.Source.Html;

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Sitemaps/LocalizedContentItemsQueryProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Sitemaps/LocalizedContentItemsQueryProvider.cs
@@ -54,14 +54,14 @@ namespace OrchardCore.ContentLocalization.Sitemaps
             {
                 // Test that content type is still valid to include in sitemap.
                 var contentType = routeableContentTypeDefinitions
-                    .FirstOrDefault(ctd => string.Equals(source.LimitedContentType.ContentTypeName, ctd.Name));
+                    .FirstOrDefault(ctd => string.Equals(source.LimitedContentType.ContentTypeName, ctd.Name, System.StringComparison.Ordinal));
 
                 if (contentType == null)
                 {
                     return;
                 }
 
-                if (contentType.Parts.Any(ctd => string.Equals(ctd.Name, nameof(LocalizationPart))))
+                if (contentType.Parts.Any(ctd => string.Equals(ctd.Name, nameof(LocalizationPart), System.StringComparison.Ordinal)))
                 {
                     // Get all content items here for reference. Then reduce by default culture.
                     // We know that the content item should be localized.
@@ -77,7 +77,7 @@ namespace OrchardCore.ContentLocalization.Sitemaps
 
                     // Reduce by default culture.
                     var items = queryResults
-                        .Where(ci => string.Equals(ci.As<LocalizationPart>().Culture, defaultCulture))
+                        .Where(ci => string.Equals(ci.As<LocalizationPart>().Culture, defaultCulture, System.StringComparison.Ordinal))
                         .Skip(source.LimitedContentType.Skip)
                         .Take(source.LimitedContentType.Take);
 
@@ -104,7 +104,7 @@ namespace OrchardCore.ContentLocalization.Sitemaps
             {
                 // Test that content types are still valid to include in sitemap.
                 var typesToIndex = routeableContentTypeDefinitions
-                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName)))
+                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName, System.StringComparison.Ordinal)))
                     .Select(x => x.Name);
 
                 // No advantage here in reducing with localized index.

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Sitemaps/LocalizedContentItemsQueryProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Sitemaps/LocalizedContentItemsQueryProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentLocalization.Models;
@@ -54,14 +55,14 @@ namespace OrchardCore.ContentLocalization.Sitemaps
             {
                 // Test that content type is still valid to include in sitemap.
                 var contentType = routeableContentTypeDefinitions
-                    .FirstOrDefault(ctd => string.Equals(source.LimitedContentType.ContentTypeName, ctd.Name, System.StringComparison.Ordinal));
+                    .FirstOrDefault(ctd => string.Equals(source.LimitedContentType.ContentTypeName, ctd.Name, StringComparison.Ordinal));
 
                 if (contentType == null)
                 {
                     return;
                 }
 
-                if (contentType.Parts.Any(ctd => string.Equals(ctd.Name, nameof(LocalizationPart), System.StringComparison.Ordinal)))
+                if (contentType.Parts.Any(ctd => string.Equals(ctd.Name, nameof(LocalizationPart), StringComparison.Ordinal)))
                 {
                     // Get all content items here for reference. Then reduce by default culture.
                     // We know that the content item should be localized.
@@ -77,7 +78,7 @@ namespace OrchardCore.ContentLocalization.Sitemaps
 
                     // Reduce by default culture.
                     var items = queryResults
-                        .Where(ci => string.Equals(ci.As<LocalizationPart>().Culture, defaultCulture, System.StringComparison.Ordinal))
+                        .Where(ci => string.Equals(ci.As<LocalizationPart>().Culture, defaultCulture, StringComparison.Ordinal))
                         .Skip(source.LimitedContentType.Skip)
                         .Take(source.LimitedContentType.Take);
 
@@ -104,7 +105,7 @@ namespace OrchardCore.ContentLocalization.Sitemaps
             {
                 // Test that content types are still valid to include in sitemap.
                 var typesToIndex = routeableContentTypeDefinitions
-                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName, System.StringComparison.Ordinal)))
+                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName, StringComparison.Ordinal)))
                     .Select(x => x.Name);
 
                 // No advantage here in reducing with localized index.

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Handlers/PreviewPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Handlers/PreviewPartHandler.cs
@@ -31,7 +31,7 @@ namespace OrchardCore.ContentPreview.Handlers
         private async Task<string> GetPatternAsync(PreviewPart part)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "PreviewPart"));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "PreviewPart", System.StringComparison.Ordinal));
             var pattern = contentTypePartDefinition.GetSettings<PreviewPartSettings>().Pattern;
 
             return pattern;

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Handlers/PreviewPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Handlers/PreviewPartHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -31,7 +32,7 @@ namespace OrchardCore.ContentPreview.Handlers
         private async Task<string> GetPatternAsync(PreviewPart part)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "PreviewPart", System.StringComparison.Ordinal));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "PreviewPart", StringComparison.Ordinal));
             var pattern = contentTypePartDefinition.GetSettings<PreviewPartSettings>().Pattern;
 
             return pattern;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Drivers/AuditTrailPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Drivers/AuditTrailPartSettingsDisplayDriver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.Contents.AuditTrail.Models;
@@ -13,7 +14,7 @@ namespace OrchardCore.Contents.AuditTrail.Drivers
     {
         public override IDisplayResult Edit(ContentTypePartDefinition model, IUpdateModel updater)
         {
-            if (!string.Equals(nameof(AuditTrailPart), model.PartDefinition.Name, System.StringComparison.Ordinal))
+            if (!string.Equals(nameof(AuditTrailPart), model.PartDefinition.Name, StringComparison.Ordinal))
             {
                 return null;
             }
@@ -27,7 +28,7 @@ namespace OrchardCore.Contents.AuditTrail.Drivers
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition model, UpdateTypePartEditorContext context)
         {
-            if (!string.Equals(nameof(AuditTrailPart), model.PartDefinition.Name, System.StringComparison.Ordinal))
+            if (!string.Equals(nameof(AuditTrailPart), model.PartDefinition.Name, StringComparison.Ordinal))
             {
                 return null;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Drivers/AuditTrailPartSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Drivers/AuditTrailPartSettingsDisplayDriver.cs
@@ -13,7 +13,10 @@ namespace OrchardCore.Contents.AuditTrail.Drivers
     {
         public override IDisplayResult Edit(ContentTypePartDefinition model, IUpdateModel updater)
         {
-            if (!string.Equals(nameof(AuditTrailPart), model.PartDefinition.Name)) return null;
+            if (!string.Equals(nameof(AuditTrailPart), model.PartDefinition.Name, System.StringComparison.Ordinal))
+            {
+                return null;
+            }
 
             return Initialize<AuditTrailPartSettingsViewModel>("AuditTrailPartSettings_Edit", viewModel =>
             {
@@ -24,7 +27,10 @@ namespace OrchardCore.Contents.AuditTrail.Drivers
 
         public override async Task<IDisplayResult> UpdateAsync(ContentTypePartDefinition model, UpdateTypePartEditorContext context)
         {
-            if (!string.Equals(nameof(AuditTrailPart), model.PartDefinition.Name)) return null;
+            if (!string.Equals(nameof(AuditTrailPart), model.PartDefinition.Name, System.StringComparison.Ordinal))
+            {
+                return null;
+            }
 
             var viewModel = new AuditTrailPartSettingsViewModel();
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -777,7 +777,7 @@ namespace OrchardCore.Contents.Controllers
                     continue;
                 }
 
-                items.Add(new SelectListItem(definition.DisplayName, definition.Name, string.Equals(definition.Name, selectedContentType)));
+                items.Add(new SelectListItem(definition.DisplayName, definition.Name, string.Equals(definition.Name, selectedContentType, StringComparison.Ordinal)));
             }
 
             return items;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Services/ContentItemIdHandleProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Services/ContentItemIdHandleProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 
@@ -9,7 +10,7 @@ namespace OrchardCore.Contents.Services
 
         public Task<string> GetContentItemIdAsync(string handle)
         {
-            if (handle.StartsWith("contentitemid:", System.StringComparison.OrdinalIgnoreCase))
+            if (handle.StartsWith("contentitemid:", StringComparison.OrdinalIgnoreCase))
             {
                 var contentItemId = handle[14..];
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceBuilder.cs
@@ -118,7 +118,7 @@ namespace OrchardCore.Contents.Sitemaps
                 else
                 {
                     var sitemapEntry = source.ContentTypes
-                        .FirstOrDefault(ct => string.Equals(ct.ContentTypeName, contentItem.ContentType));
+                        .FirstOrDefault(ct => string.Equals(ct.ContentTypeName, contentItem.ContentType, System.StringComparison.Ordinal));
 
                     changeFrequencyValue = sitemapEntry.ChangeFrequency.ToString();
                 }
@@ -138,7 +138,7 @@ namespace OrchardCore.Contents.Sitemaps
                 else
                 {
                     var sitemapEntry = source.ContentTypes
-                        .FirstOrDefault(ct => string.Equals(ct.ContentTypeName, contentItem.ContentType));
+                        .FirstOrDefault(ct => string.Equals(ct.ContentTypeName, contentItem.ContentType, System.StringComparison.Ordinal));
 
                     priorityIntValue = sitemapEntry.Priority;
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -118,7 +119,7 @@ namespace OrchardCore.Contents.Sitemaps
                 else
                 {
                     var sitemapEntry = source.ContentTypes
-                        .FirstOrDefault(ct => string.Equals(ct.ContentTypeName, contentItem.ContentType, System.StringComparison.Ordinal));
+                        .FirstOrDefault(ct => string.Equals(ct.ContentTypeName, contentItem.ContentType, StringComparison.Ordinal));
 
                     changeFrequencyValue = sitemapEntry.ChangeFrequency.ToString();
                 }
@@ -138,7 +139,7 @@ namespace OrchardCore.Contents.Sitemaps
                 else
                 {
                     var sitemapEntry = source.ContentTypes
-                        .FirstOrDefault(ct => string.Equals(ct.ContentTypeName, contentItem.ContentType, System.StringComparison.Ordinal));
+                        .FirstOrDefault(ct => string.Equals(ct.ContentTypeName, contentItem.ContentType, StringComparison.Ordinal));
 
                     priorityIntValue = sitemapEntry.Priority;
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceDriver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.DisplayManagement.Handlers;
@@ -36,9 +37,9 @@ namespace OrchardCore.Contents.Sitemaps
                 {
                     ContentTypeName = ctd.Name,
                     ContentTypeDisplayName = ctd.DisplayName,
-                    IsChecked = sitemapSource.ContentTypes.Any(s => string.Equals(s.ContentTypeName, ctd.Name, System.StringComparison.Ordinal)),
-                    ChangeFrequency = sitemapSource.ContentTypes.FirstOrDefault(s => string.Equals(s.ContentTypeName, ctd.Name, System.StringComparison.Ordinal))?.ChangeFrequency ?? ChangeFrequency.Daily,
-                    Priority = sitemapSource.ContentTypes.FirstOrDefault(s => string.Equals(s.ContentTypeName, ctd.Name, System.StringComparison.Ordinal))?.Priority ?? 5,
+                    IsChecked = sitemapSource.ContentTypes.Any(s => string.Equals(s.ContentTypeName, ctd.Name, StringComparison.Ordinal)),
+                    ChangeFrequency = sitemapSource.ContentTypes.FirstOrDefault(s => string.Equals(s.ContentTypeName, ctd.Name, StringComparison.Ordinal))?.ChangeFrequency ?? ChangeFrequency.Daily,
+                    Priority = sitemapSource.ContentTypes.FirstOrDefault(s => string.Equals(s.ContentTypeName, ctd.Name, StringComparison.Ordinal))?.Priority ?? 5,
                 })
                 .OrderBy(ctd => ctd.ContentTypeDisplayName)
                 .ToArray();
@@ -53,11 +54,11 @@ namespace OrchardCore.Contents.Sitemaps
                 .ToArray();
 
             var limitedCtd = contentTypeDefinitions
-                .FirstOrDefault(ctd => string.Equals(sitemapSource.LimitedContentType.ContentTypeName, ctd.Name, System.StringComparison.Ordinal));
+                .FirstOrDefault(ctd => string.Equals(sitemapSource.LimitedContentType.ContentTypeName, ctd.Name, StringComparison.Ordinal));
 
             if (limitedCtd != null)
             {
-                var limitedEntry = limitedEntries.FirstOrDefault(le => string.Equals(le.ContentTypeName, limitedCtd.Name, System.StringComparison.Ordinal));
+                var limitedEntry = limitedEntries.FirstOrDefault(le => string.Equals(le.ContentTypeName, limitedCtd.Name, StringComparison.Ordinal));
                 limitedEntry.Priority = sitemapSource.LimitedContentType.Priority;
                 limitedEntry.ChangeFrequency = sitemapSource.LimitedContentType.ChangeFrequency;
                 limitedEntry.Skip = sitemapSource.LimitedContentType.Skip;
@@ -106,7 +107,7 @@ namespace OrchardCore.Contents.Sitemaps
                     })
                     .ToArray();
 
-                var limitedEntry = model.LimitedContentTypes.FirstOrDefault(lct => string.Equals(lct.ContentTypeName, model.LimitedContentType, System.StringComparison.Ordinal));
+                var limitedEntry = model.LimitedContentTypes.FirstOrDefault(lct => string.Equals(lct.ContentTypeName, model.LimitedContentType, StringComparison.Ordinal));
                 if (limitedEntry != null)
                 {
                     sitemap.LimitedContentType.ContentTypeName = limitedEntry.ContentTypeName;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceDriver.cs
@@ -36,9 +36,9 @@ namespace OrchardCore.Contents.Sitemaps
                 {
                     ContentTypeName = ctd.Name,
                     ContentTypeDisplayName = ctd.DisplayName,
-                    IsChecked = sitemapSource.ContentTypes.Any(s => string.Equals(s.ContentTypeName, ctd.Name)),
-                    ChangeFrequency = sitemapSource.ContentTypes.FirstOrDefault(s => string.Equals(s.ContentTypeName, ctd.Name))?.ChangeFrequency ?? ChangeFrequency.Daily,
-                    Priority = sitemapSource.ContentTypes.FirstOrDefault(s => string.Equals(s.ContentTypeName, ctd.Name))?.Priority ?? 5,
+                    IsChecked = sitemapSource.ContentTypes.Any(s => string.Equals(s.ContentTypeName, ctd.Name, System.StringComparison.Ordinal)),
+                    ChangeFrequency = sitemapSource.ContentTypes.FirstOrDefault(s => string.Equals(s.ContentTypeName, ctd.Name, System.StringComparison.Ordinal))?.ChangeFrequency ?? ChangeFrequency.Daily,
+                    Priority = sitemapSource.ContentTypes.FirstOrDefault(s => string.Equals(s.ContentTypeName, ctd.Name, System.StringComparison.Ordinal))?.Priority ?? 5,
                 })
                 .OrderBy(ctd => ctd.ContentTypeDisplayName)
                 .ToArray();
@@ -53,11 +53,11 @@ namespace OrchardCore.Contents.Sitemaps
                 .ToArray();
 
             var limitedCtd = contentTypeDefinitions
-                .FirstOrDefault(ctd => string.Equals(sitemapSource.LimitedContentType.ContentTypeName, ctd.Name));
+                .FirstOrDefault(ctd => string.Equals(sitemapSource.LimitedContentType.ContentTypeName, ctd.Name, System.StringComparison.Ordinal));
 
             if (limitedCtd != null)
             {
-                var limitedEntry = limitedEntries.FirstOrDefault(le => string.Equals(le.ContentTypeName, limitedCtd.Name));
+                var limitedEntry = limitedEntries.FirstOrDefault(le => string.Equals(le.ContentTypeName, limitedCtd.Name, System.StringComparison.Ordinal));
                 limitedEntry.Priority = sitemapSource.LimitedContentType.Priority;
                 limitedEntry.ChangeFrequency = sitemapSource.LimitedContentType.ChangeFrequency;
                 limitedEntry.Skip = sitemapSource.LimitedContentType.Skip;
@@ -106,7 +106,7 @@ namespace OrchardCore.Contents.Sitemaps
                     })
                     .ToArray();
 
-                var limitedEntry = model.LimitedContentTypes.FirstOrDefault(lct => string.Equals(lct.ContentTypeName, model.LimitedContentType));
+                var limitedEntry = model.LimitedContentTypes.FirstOrDefault(lct => string.Equals(lct.ContentTypeName, model.LimitedContentType, System.StringComparison.Ordinal));
                 if (limitedEntry != null)
                 {
                     sitemap.LimitedContentType.ContentTypeName = limitedEntry.ContentTypeName;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceModifiedDateProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceModifiedDateProvider.cs
@@ -51,7 +51,7 @@ namespace OrchardCore.Contents.Sitemaps
             else
             {
                 var typesToIndex = (await _routeableContentTypeCoordinator.ListRoutableTypeDefinitionsAsync())
-                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName)))
+                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName, StringComparison.Ordinal)))
                     .Select(ctd => ctd.Name);
 
                 // This is an estimate, so doesn't take into account Take/Skip values.

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceUpdateHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceUpdateHandler.cs
@@ -51,12 +51,12 @@ namespace OrchardCore.Contents.Sitemaps
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;
                     }
-                    else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName))
+                    else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName, System.StringComparison.Ordinal))
                     {
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;
                     }
-                    else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName)))
+                    else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName, System.StringComparison.Ordinal)))
                     {
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceUpdateHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceUpdateHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
@@ -51,12 +52,12 @@ namespace OrchardCore.Contents.Sitemaps
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;
                     }
-                    else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName, System.StringComparison.Ordinal))
+                    else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName, StringComparison.Ordinal))
                     {
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;
                     }
-                    else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName, System.StringComparison.Ordinal)))
+                    else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName, StringComparison.Ordinal)))
                     {
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/DefaultContentItemsQueryProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/DefaultContentItemsQueryProvider.cs
@@ -43,7 +43,7 @@ namespace OrchardCore.Contents.Sitemaps
             {
                 // Test that content type is still valid to include in sitemap.
                 var typeIsValid = routeableContentTypeDefinitions
-                    .Any(ctd => string.Equals(source.LimitedContentType.ContentTypeName, ctd.Name));
+                    .Any(ctd => string.Equals(source.LimitedContentType.ContentTypeName, ctd.Name, System.StringComparison.Ordinal));
 
                 if (typeIsValid)
                 {
@@ -61,7 +61,7 @@ namespace OrchardCore.Contents.Sitemaps
             {
                 // Test that content types are still valid to include in sitemap.
                 var typesToIndex = routeableContentTypeDefinitions
-                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName)))
+                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName, System.StringComparison.Ordinal)))
                     .Select(x => x.Name);
 
                 var queryResults = await _session.Query<ContentItem>()

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/DefaultContentItemsQueryProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/DefaultContentItemsQueryProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
@@ -43,7 +44,7 @@ namespace OrchardCore.Contents.Sitemaps
             {
                 // Test that content type is still valid to include in sitemap.
                 var typeIsValid = routeableContentTypeDefinitions
-                    .Any(ctd => string.Equals(source.LimitedContentType.ContentTypeName, ctd.Name, System.StringComparison.Ordinal));
+                    .Any(ctd => string.Equals(source.LimitedContentType.ContentTypeName, ctd.Name, StringComparison.Ordinal));
 
                 if (typeIsValid)
                 {
@@ -61,7 +62,7 @@ namespace OrchardCore.Contents.Sitemaps
             {
                 // Test that content types are still valid to include in sitemap.
                 var typesToIndex = routeableContentTypeDefinitions
-                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName, System.StringComparison.Ordinal)))
+                    .Where(ctd => source.ContentTypes.Any(s => string.Equals(ctd.Name, s.ContentTypeName, StringComparison.Ordinal)))
                     .Select(x => x.Name);
 
                 var queryResults = await _session.Query<ContentItem>()

--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpService.cs
@@ -9,7 +9,7 @@ using OrchardCore.Environment.Shell.Builders;
 
 namespace OrchardCore.Email.Services;
 
-[Obsolete]
+[Obsolete("Use IEmailService and its implementations instead")]
 public class SmtpService : ISmtpService
 {
     private readonly EmailProviderOptions _emailProviderOptions;

--- a/src/OrchardCore.Modules/OrchardCore.Email/Migrations/EmailMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Migrations/EmailMigrations.cs
@@ -12,7 +12,9 @@ public class EmailMigrations : DataMigration
 {
     private const string SmtpFeatureId = "OrchardCore.Email.Smtp";
 
+#pragma warning disable CA1822 // Member can be static
     public int Create()
+#pragma warning restore CA1822
     {
         // In version 1.9, the OrchardCore.Email.Smtp was split from OrchardCore.Email. To ensure we keep the change
         // backward compatible, we added this migration step to auto-enable the new SMTP feature for sites that use the

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Login/Configuration/FacebookLoginConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Login/Configuration/FacebookLoginConfiguration.cs
@@ -67,7 +67,7 @@ namespace OrchardCore.Facebook.Login.Configuration
         public void Configure(string name, FacebookOptions options)
         {
             // Ignore OpenID Connect client handler instances that don't correspond to the instance managed by the OpenID module.
-            if (!string.Equals(name, FacebookDefaults.AuthenticationScheme))
+            if (!string.Equals(name, FacebookDefaults.AuthenticationScheme, System.StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Login/Configuration/FacebookLoginConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Login/Configuration/FacebookLoginConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Linq;
@@ -67,7 +68,7 @@ namespace OrchardCore.Facebook.Login.Configuration
         public void Configure(string name, FacebookOptions options)
         {
             // Ignore OpenID Connect client handler instances that don't correspond to the instance managed by the OpenID module.
-            if (!string.Equals(name, FacebookDefaults.AuthenticationScheme, System.StringComparison.Ordinal))
+            if (!string.Equals(name, FacebookDefaults.AuthenticationScheme, StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Widgets/Drivers/FacebookPluginPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Widgets/Drivers/FacebookPluginPartDisplayDriver.cs
@@ -65,7 +65,7 @@ namespace OrchardCore.Facebook.Widgets.Drivers
             ArgumentNullException.ThrowIfNull(part);
 
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(FacebookPluginPart)));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(FacebookPluginPart), StringComparison.Ordinal));
             return contentTypePartDefinition.GetSettings<FacebookPluginPartSettings>();
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubOptionsConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.DataProtection;
@@ -51,7 +52,7 @@ namespace OrchardCore.GitHub.Configuration
         public void Configure(string name, GitHubOptions options)
         {
             // Ignore OpenID Connect client handler instances that don't correspond to the instance managed by the OpenID module.
-            if (!string.Equals(name, GitHubDefaults.AuthenticationScheme, System.StringComparison.Ordinal))
+            if (!string.Equals(name, GitHubDefaults.AuthenticationScheme, StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/Configuration/GithubOptionsConfiguration.cs
@@ -51,7 +51,7 @@ namespace OrchardCore.GitHub.Configuration
         public void Configure(string name, GitHubOptions options)
         {
             // Ignore OpenID Connect client handler instances that don't correspond to the instance managed by the OpenID module.
-            if (!string.Equals(name, GitHubDefaults.AuthenticationScheme))
+            if (!string.Equals(name, GitHubDefaults.AuthenticationScheme, System.StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Configuration/GoogleOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Configuration/GoogleOptionsConfiguration.cs
@@ -50,7 +50,7 @@ namespace OrchardCore.Google.Authentication.Configuration
 
         public void Configure(string name, GoogleOptions options)
         {
-            if (!string.Equals(name, GoogleDefaults.AuthenticationScheme))
+            if (!string.Equals(name, GoogleDefaults.AuthenticationScheme, System.StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Configuration/GoogleOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/Authentication/Configuration/GoogleOptionsConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Google;
@@ -50,7 +51,7 @@ namespace OrchardCore.Google.Authentication.Configuration
 
         public void Configure(string name, GoogleOptions options)
         {
-            if (!string.Equals(name, GoogleDefaults.AuthenticationScheme, System.StringComparison.Ordinal))
+            if (!string.Equals(name, GoogleDefaults.AuthenticationScheme, StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Html/GraphQL/HtmlBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/GraphQL/HtmlBodyQueryObjectType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -36,7 +37,7 @@ namespace OrchardCore.Html.GraphQL
             var contentDefinitionManager = ctx.RequestServices.GetRequiredService<IContentDefinitionManager>();
 
             var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(ctx.Source.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "HtmlBodyPart", System.StringComparison.Ordinal));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "HtmlBodyPart", StringComparison.Ordinal));
             var settings = contentTypePartDefinition.GetSettings<HtmlBodyPartSettings>();
 
             var html = ctx.Source.Html;

--- a/src/OrchardCore.Modules/OrchardCore.Html/GraphQL/HtmlBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/GraphQL/HtmlBodyQueryObjectType.cs
@@ -36,7 +36,7 @@ namespace OrchardCore.Html.GraphQL
             var contentDefinitionManager = ctx.RequestServices.GetRequiredService<IContentDefinitionManager>();
 
             var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(ctx.Source.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "HtmlBodyPart"));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "HtmlBodyPart", System.StringComparison.Ordinal));
             var settings = contentTypePartDefinition.GetSettings<HtmlBodyPartSettings>();
 
             var html = ctx.Source.Html;

--- a/src/OrchardCore.Modules/OrchardCore.Html/Handlers/HtmlBodyPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Handlers/HtmlBodyPartHandler.cs
@@ -41,7 +41,7 @@ namespace OrchardCore.Html.Handlers
                 try
                 {
                     var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "HtmlBodyPart"));
+                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "HtmlBodyPart", System.StringComparison.Ordinal));
                     var settings = contentTypePartDefinition.GetSettings<HtmlBodyPartSettings>();
 
                     var html = part.Html;

--- a/src/OrchardCore.Modules/OrchardCore.Html/Handlers/HtmlBodyPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Handlers/HtmlBodyPartHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -41,7 +42,7 @@ namespace OrchardCore.Html.Handlers
                 try
                 {
                     var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "HtmlBodyPart", System.StringComparison.Ordinal));
+                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "HtmlBodyPart", StringComparison.Ordinal));
                     var settings = contentTypePartDefinition.GetSettings<HtmlBodyPartSettings>();
 
                     var html = part.Html;

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
@@ -191,7 +191,7 @@ namespace OrchardCore.Layers.Controllers
 
             var layers = await _layerService.GetLayersAsync();
 
-            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name));
+            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
 
             if (layer == null)
             {
@@ -236,7 +236,7 @@ namespace OrchardCore.Layers.Controllers
 
             if (ModelState.IsValid)
             {
-                var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, model.Name));
+                var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, model.Name, StringComparison.Ordinal));
 
                 if (layer == null)
                 {
@@ -264,7 +264,7 @@ namespace OrchardCore.Layers.Controllers
 
             var layers = await _layerService.LoadLayersAsync();
 
-            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name));
+            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
 
             if (layer == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/LayerRuleController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/LayerRuleController.cs
@@ -57,7 +57,7 @@ namespace OrchardCore.Layers.Controllers
             }
 
             var layers = await _layerService.GetLayersAsync();
-            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name));
+            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
 
             if (layer == null)
             {
@@ -98,7 +98,7 @@ namespace OrchardCore.Layers.Controllers
             }
 
             var layers = await _layerService.LoadLayersAsync();
-            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, model.Name));
+            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, model.Name, StringComparison.Ordinal));
 
             if (layer == null)
             {
@@ -144,7 +144,7 @@ namespace OrchardCore.Layers.Controllers
             }
 
             var layers = await _layerService.GetLayersAsync();
-            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name));
+            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
 
             if (layer == null)
             {
@@ -176,7 +176,7 @@ namespace OrchardCore.Layers.Controllers
             }
 
             var layers = await _layerService.LoadLayersAsync();
-            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, model.Name));
+            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, model.Name, StringComparison.Ordinal));
 
             if (layer == null)
             {
@@ -215,7 +215,7 @@ namespace OrchardCore.Layers.Controllers
             }
 
             var layers = await _layerService.LoadLayersAsync();
-            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name));
+            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
 
             if (layer == null)
             {
@@ -247,7 +247,7 @@ namespace OrchardCore.Layers.Controllers
             }
 
             var layers = await _layerService.LoadLayersAsync();
-            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name));
+            var layer = layers.Layers.FirstOrDefault(x => string.Equals(x.Name, name, StringComparison.Ordinal));
 
             if (layer == null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Handlers/ContainedPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Handlers/ContainedPartHandler.cs
@@ -32,7 +32,7 @@ namespace OrchardCore.Lists.Handlers
                 {
                     var contentDefinitionManager = _serviceProvider.GetRequiredService<IContentDefinitionManager>();
                     var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(listContentItem.ContentType);
-                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "ListPart"));
+                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "ListPart", StringComparison.Ordinal));
                     var settings = contentTypePartDefinition.GetSettings<ListPartSettings>();
                     if (settings.EnableOrdering)
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Lists/RemotePublishing/MetaWeblogHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/RemotePublishing/MetaWeblogHandler.cs
@@ -486,7 +486,7 @@ namespace OrchardCore.Lists.RemotePublishing
         private async Task<IEnumerable<ContentTypeDefinition>> GetContainedContentTypesAsync(ContentItem contentItem)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "ListPart"));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "ListPart", StringComparison.Ordinal));
             var settings = contentTypePartDefinition.GetSettings<ListPartSettings>();
             var contentTypes = settings.ContainedContentTypes ?? [];
 

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.Markdown.GraphQL
             var contentDefinitionManager = serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
             var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(ctx.Source.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "MarkdownBodyPart"));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "MarkdownBodyPart", System.StringComparison.Ordinal));
             var settings = contentTypePartDefinition.GetSettings<MarkdownBodyPartSettings>();
 
             // The default Markdown option is to entity escape html

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownBodyQueryObjectType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -47,7 +48,7 @@ namespace OrchardCore.Markdown.GraphQL
             var contentDefinitionManager = serviceProvider.GetRequiredService<IContentDefinitionManager>();
 
             var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(ctx.Source.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "MarkdownBodyPart", System.StringComparison.Ordinal));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "MarkdownBodyPart", StringComparison.Ordinal));
             var settings = contentTypePartDefinition.GetSettings<MarkdownBodyPartSettings>();
 
             // The default Markdown option is to entity escape html

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownFieldQueryObjectType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -56,8 +57,8 @@ namespace OrchardCore.Markdown.GraphQL
             var partName = paths[0];
             var fieldName = paths[1];
             var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(ctx.Source.ContentItem.ContentType);
-            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName, System.StringComparison.Ordinal));
-            var contentPartFieldDefinition = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName, System.StringComparison.Ordinal));
+            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName, StringComparison.Ordinal));
+            var contentPartFieldDefinition = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName, StringComparison.Ordinal));
 
             var settings = contentPartFieldDefinition.GetSettings<MarkdownFieldSettings>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/GraphQL/MarkdownFieldQueryObjectType.cs
@@ -56,8 +56,8 @@ namespace OrchardCore.Markdown.GraphQL
             var partName = paths[0];
             var fieldName = paths[1];
             var contentTypeDefinition = await contentDefinitionManager.GetTypeDefinitionAsync(ctx.Source.ContentItem.ContentType);
-            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName));
-            var contentPartFieldDefinition = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName));
+            var contentPartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.Name, partName, System.StringComparison.Ordinal));
+            var contentPartFieldDefinition = contentPartDefinition.PartDefinition.Fields.FirstOrDefault(x => string.Equals(x.Name, fieldName, System.StringComparison.Ordinal));
 
             var settings = contentPartFieldDefinition.GetSettings<MarkdownFieldSettings>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Handlers/MarkdownBodyPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Handlers/MarkdownBodyPartHandler.cs
@@ -49,7 +49,7 @@ namespace OrchardCore.Markdown.Handlers
                 try
                 {
                     var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "MarkdownBodyPart"));
+                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "MarkdownBodyPart", System.StringComparison.Ordinal));
                     var settings = contentTypePartDefinition.GetSettings<MarkdownBodyPartSettings>();
 
                     // The default Markdown option is to entity escape html

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Handlers/MarkdownBodyPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Handlers/MarkdownBodyPartHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
@@ -49,7 +50,7 @@ namespace OrchardCore.Markdown.Handlers
                 try
                 {
                     var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "MarkdownBodyPart", System.StringComparison.Ordinal));
+                    var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, "MarkdownBodyPart", StringComparison.Ordinal));
                     var settings = contentTypePartDefinition.GetSettings<MarkdownBodyPartSettings>();
 
                     // The default Markdown option is to entity escape html

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/ManageMediaFolderAuthorizationHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/ManageMediaFolderAuthorizationHandler.cs
@@ -101,7 +101,7 @@ namespace OrchardCore.Media.Services
             childPath = _fileStore.NormalizePath(childPath)
                         .TrimEnd(_pathSeparator) + _pathSeparator;
 
-            return childPath.Equals(authorizedFolder);
+            return childPath.Equals(authorizedFolder, StringComparison.Ordinal);
         }
 
         private bool IsDescendantOfauthorizedFolder(string authorizedFolder, string childPath)

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -56,7 +57,7 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
 
         public void Configure(string name, MicrosoftIdentityOptions options)
         {
-            if (!string.Equals(name, MicrosoftIdentityDefaults.AzureAd, System.StringComparison.Ordinal))
+            if (!string.Equals(name, MicrosoftIdentityDefaults.AzureAd, StringComparison.Ordinal))
             {
                 return;
             }
@@ -81,7 +82,7 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
 
         public void Configure(string name, PolicySchemeOptions options)
         {
-            if (!string.Equals(name, MicrosoftIdentityDefaults.AzureAd, System.StringComparison.Ordinal))
+            if (!string.Equals(name, MicrosoftIdentityDefaults.AzureAd, StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs
@@ -56,7 +56,7 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
 
         public void Configure(string name, MicrosoftIdentityOptions options)
         {
-            if (!string.Equals(name, MicrosoftIdentityDefaults.AzureAd))
+            if (!string.Equals(name, MicrosoftIdentityDefaults.AzureAd, System.StringComparison.Ordinal))
             {
                 return;
             }
@@ -81,7 +81,7 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
 
         public void Configure(string name, PolicySchemeOptions options)
         {
-            if (!string.Equals(name, MicrosoftIdentityDefaults.AzureAd))
+            if (!string.Equals(name, MicrosoftIdentityDefaults.AzureAd, System.StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/MicrosoftAccountOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/MicrosoftAccountOptionsConfiguration.cs
@@ -52,7 +52,7 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
         public void Configure(string name, MicrosoftAccountOptions options)
         {
             // Ignore OpenID Connect client handler instances that don't correspond to the instance managed by the OpenID module.
-            if (!string.Equals(name, MicrosoftAccountDefaults.AuthenticationScheme))
+            if (!string.Equals(name, MicrosoftAccountDefaults.AuthenticationScheme, System.StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/MicrosoftAccountOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/MicrosoftAccountOptionsConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.MicrosoftAccount;
@@ -52,7 +53,7 @@ namespace OrchardCore.Microsoft.Authentication.Configuration
         public void Configure(string name, MicrosoftAccountOptions options)
         {
             // Ignore OpenID Connect client handler instances that don't correspond to the instance managed by the OpenID module.
-            if (!string.Equals(name, MicrosoftAccountDefaults.AuthenticationScheme, System.StringComparison.Ordinal))
+            if (!string.Equals(name, MicrosoftAccountDefaults.AuthenticationScheme, StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdClientConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdClientConfiguration.cs
@@ -52,7 +52,7 @@ namespace OrchardCore.OpenId.Configuration
         public void Configure(string name, OpenIdConnectOptions options)
         {
             // Ignore OpenID Connect client handler instances that don't correspond to the instance managed by the OpenID module.
-            if (!string.Equals(name, OpenIdConnectDefaults.AuthenticationScheme))
+            if (!string.Equals(name, OpenIdConnectDefaults.AuthenticationScheme, StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdValidationConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdValidationConfiguration.cs
@@ -181,7 +181,7 @@ namespace OrchardCore.OpenId.Configuration
                         }
 
                         var tenant = _runningShellTable.Match(HostString.FromUriComponent(uri), uri.AbsolutePath);
-                        if (tenant == null || !string.Equals(tenant.Name, settings.Tenant))
+                        if (tenant == null || !string.Equals(tenant.Name, settings.Tenant, StringComparison.Ordinal))
                         {
                             throw new SecurityTokenInvalidIssuerException("The token issuer is not valid.");
                         }
@@ -203,7 +203,7 @@ namespace OrchardCore.OpenId.Configuration
             // If the tokens are issued by an authorization server located in a separate tenant,
             // resolve the isolated data protection provider associated with the specified tenant.
             if (!string.IsNullOrEmpty(settings.Tenant) &&
-                !string.Equals(settings.Tenant, _shellSettings.Name))
+                !string.Equals(settings.Tenant, _shellSettings.Name, StringComparison.Ordinal))
             {
                 CreateTenantScope(settings.Tenant).UsingAsync(async scope =>
                 {
@@ -236,7 +236,7 @@ namespace OrchardCore.OpenId.Configuration
         private ShellScope CreateTenantScope(string tenant)
         {
             // Optimization: if the specified name corresponds to the current tenant, use the current 'ShellScope'.
-            if (string.IsNullOrEmpty(tenant) || string.Equals(tenant, _shellSettings.Name))
+            if (string.IsNullOrEmpty(tenant) || string.Equals(tenant, _shellSettings.Name, StringComparison.Ordinal))
             {
                 return ShellScope.Current;
             }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/AccessController.cs
@@ -571,7 +571,7 @@ namespace OrchardCore.OpenId.Controllers
             if (request.IsRefreshTokenGrantType())
             {
                 var type = info.Principal.FindFirst(OpenIdConstants.Claims.EntityType)?.Value;
-                if (!string.Equals(type, OpenIdConstants.EntityTypes.User))
+                if (!string.Equals(type, OpenIdConstants.EntityTypes.User, StringComparison.Ordinal))
                 {
                     return Forbid(new AuthenticationProperties(new Dictionary<string, string>
                     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ScopeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ScopeController.cs
@@ -99,7 +99,7 @@ namespace OrchardCore.OpenId.Controllers
             {
                 model.Tenants.Add(new CreateOpenIdScopeViewModel.TenantEntry
                 {
-                    Current = string.Equals(tenant.Name, _shellSettings.Name),
+                    Current = string.Equals(tenant.Name, _shellSettings.Name, StringComparison.Ordinal),
                     Name = tenant.Name
                 });
             }
@@ -141,7 +141,7 @@ namespace OrchardCore.OpenId.Controllers
 
             descriptor.Resources.UnionWith(model.Tenants
                 .Where(tenant => tenant.Selected)
-                .Where(tenant => !string.Equals(tenant.Name, _shellSettings.Name))
+                .Where(tenant => !string.Equals(tenant.Name, _shellSettings.Name, StringComparison.Ordinal))
                 .Select(tenant => OpenIdConstants.Prefixes.Tenant + tenant.Name));
 
             await _scopeManager.CreateAsync(descriptor);
@@ -186,7 +186,7 @@ namespace OrchardCore.OpenId.Controllers
             {
                 model.Tenants.Add(new EditOpenIdScopeViewModel.TenantEntry
                 {
-                    Current = string.Equals(tenant.Name, _shellSettings.Name),
+                    Current = string.Equals(tenant.Name, _shellSettings.Name, StringComparison.Ordinal),
                     Name = tenant.Name,
                     Selected = resources.Contains(OpenIdConstants.Prefixes.Tenant + tenant.Name)
                 });
@@ -213,9 +213,7 @@ namespace OrchardCore.OpenId.Controllers
             if (ModelState.IsValid)
             {
                 var other = await _scopeManager.FindByNameAsync(model.Name);
-                if (other != null && !string.Equals(
-                    await _scopeManager.GetIdAsync(other),
-                    await _scopeManager.GetIdAsync(scope)))
+                if (other != null && !string.Equals(await _scopeManager.GetIdAsync(other), await _scopeManager.GetIdAsync(scope), StringComparison.Ordinal))
                 {
                     ModelState.AddModelError(nameof(model.Name), S["The name is already taken by another scope."]);
                 }
@@ -243,7 +241,7 @@ namespace OrchardCore.OpenId.Controllers
 
             descriptor.Resources.UnionWith(model.Tenants
                 .Where(tenant => tenant.Selected)
-                .Where(tenant => !string.Equals(tenant.Name, _shellSettings.Name))
+                .Where(tenant => !string.Equals(tenant.Name, _shellSettings.Name, StringComparison.Ordinal))
                 .Select(tenant => OpenIdConstants.Prefixes.Tenant + tenant.Name));
 
             await _scopeManager.UpdateAsync(scope, descriptor);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/UserInfoController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/UserInfoController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -47,7 +48,7 @@ namespace OrchardCore.OpenId.Controllers
 
             // Ensure the access token represents a user and not an application.
             var type = principal.FindFirst(OpenIdConstants.Claims.EntityType)?.Value;
-            if (!string.Equals(type, OpenIdConstants.EntityTypes.User, System.StringComparison.Ordinal))
+            if (!string.Equals(type, OpenIdConstants.EntityTypes.User, StringComparison.Ordinal))
             {
                 return Forbid(new AuthenticationProperties(new Dictionary<string, string>
                 {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/UserInfoController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/UserInfoController.cs
@@ -47,7 +47,7 @@ namespace OrchardCore.OpenId.Controllers
 
             // Ensure the access token represents a user and not an application.
             var type = principal.FindFirst(OpenIdConstants.Claims.EntityType)?.Value;
-            if (!string.Equals(type, OpenIdConstants.EntityTypes.User))
+            if (!string.Equals(type, OpenIdConstants.EntityTypes.User, System.StringComparison.Ordinal))
             {
                 return Forbid(new AuthenticationProperties(new Dictionary<string, string>
                 {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdValidationService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdValidationService.cs
@@ -178,7 +178,7 @@ namespace OrchardCore.OpenId.Services
             // If a tenant was specified, ensure it is valid, that the OpenID server feature
             // was enabled and that at least a scope linked with the current tenant exists.
             if (!string.IsNullOrEmpty(settings.Tenant) &&
-                !string.Equals(settings.Tenant, _shellSettings.Name))
+                !string.Equals(settings.Tenant, _shellSettings.Name, StringComparison.Ordinal))
             {
                 if (!_shellHost.TryGetSettings(settings.Tenant, out var shellSettings))
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleStore.cs
@@ -84,8 +84,8 @@ namespace OrchardCore.Roles.Services
 
             var roleToRemove = (Role)role;
 
-            if (string.Equals(roleToRemove.NormalizedRoleName, "ANONYMOUS") ||
-                string.Equals(roleToRemove.NormalizedRoleName, "AUTHENTICATED"))
+            if (string.Equals(roleToRemove.NormalizedRoleName, "ANONYMOUS", StringComparison.Ordinal) ||
+                string.Equals(roleToRemove.NormalizedRoleName, "AUTHENTICATED", StringComparison.Ordinal))
             {
                 return IdentityResult.Failed(new IdentityError { Description = S["Can't delete system roles."] });
             }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -67,7 +68,7 @@ namespace OrchardCore.Roles.Services
                 var stereotypes = provider.GetDefaultStereotypes();
                 foreach (var stereotype in stereotypes)
                 {
-                    var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.RoleName, stereotype.Name, System.StringComparison.OrdinalIgnoreCase));
+                    var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.RoleName, stereotype.Name, StringComparison.OrdinalIgnoreCase));
                     if (role == null)
                     {
                         continue;
@@ -129,7 +130,7 @@ namespace OrchardCore.Roles.Services
         private async Task UpdateRoleForInstalledFeaturesAsync(string roleName)
         {
             var rolesDocument = await _documentManager.GetOrCreateMutableAsync();
-            var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.RoleName, roleName, System.StringComparison.OrdinalIgnoreCase));
+            var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.RoleName, roleName, StringComparison.OrdinalIgnoreCase));
             if (role == null)
             {
                 return;
@@ -151,7 +152,7 @@ namespace OrchardCore.Roles.Services
 
             var stereotypes = _permissionProviders
                 .SelectMany(provider => provider.GetDefaultStereotypes())
-                .Where(stereotype => string.Equals(stereotype.Name, roleName, System.StringComparison.OrdinalIgnoreCase));
+                .Where(stereotype => string.Equals(stereotype.Name, roleName, StringComparison.OrdinalIgnoreCase));
 
             if (!stereotypes.Any())
             {
@@ -179,7 +180,7 @@ namespace OrchardCore.Roles.Services
         {
             var stereotypes = providers
                 .SelectMany(provider => provider.GetDefaultStereotypes())
-                .Where(stereotype => string.Equals(stereotype.Name, role.RoleName, System.StringComparison.OrdinalIgnoreCase));
+                .Where(stereotype => string.Equals(stereotype.Name, role.RoleName, StringComparison.OrdinalIgnoreCase));
 
             if (!stereotypes.Any())
             {

--- a/src/OrchardCore.Modules/OrchardCore.Roles/ViewModels/PermissionGroupKey.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/ViewModels/PermissionGroupKey.cs
@@ -31,6 +31,6 @@ public class PermissionGroupKey
     {
         var other = obj as PermissionGroupKey;
 
-        return other != null && Key.Equals(other.Key);
+        return other != null && Key.Equals(other.Key, StringComparison.Ordinal);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Services/StringOperatorComparer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Services/StringOperatorComparer.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Rules.Services
     {
         public override bool Compare(StringOperator conditionOperator, string a, string b)
             => conditionOperator.CaseSensitive ?
-                string.Equals(a, b) :
+                string.Equals(a, b, StringComparison.Ordinal) :
                 string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -15,7 +15,7 @@ namespace OrchardCore.Rules.Services
     {
         public override bool Compare(StringOperator conditionOperator, string a, string b)
             => conditionOperator.CaseSensitive ?
-                !string.Equals(a, b) :
+                !string.Equals(a, b, StringComparison.Ordinal) :
                 !string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ContentPickerFieldElasticEditorSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ContentPickerFieldElasticEditorSettingsDriver.cs
@@ -48,7 +48,7 @@ namespace OrchardCore.Search.Elasticsearch.Drivers
 
         public override bool CanHandleModel(ContentPartFieldDefinition model)
         {
-            return string.Equals("ContentPickerField", model.FieldDefinition.Name);
+            return string.Equals("ContentPickerField", model.FieldDefinition.Name, System.StringComparison.Ordinal);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ContentPickerFieldElasticEditorSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ContentPickerFieldElasticEditorSettingsDriver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -48,7 +49,7 @@ namespace OrchardCore.Search.Elasticsearch.Drivers
 
         public override bool CanHandleModel(ContentPartFieldDefinition model)
         {
-            return string.Equals("ContentPickerField", model.FieldDefinition.Name, System.StringComparison.Ordinal);
+            return string.Equals("ContentPickerField", model.FieldDefinition.Name, StringComparison.Ordinal);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Settings/ContentPickerFieldLuceneEditorSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Settings/ContentPickerFieldLuceneEditorSettingsDriver.cs
@@ -44,7 +44,7 @@ namespace OrchardCore.Search.Lucene.Settings
 
         public override bool CanHandleModel(ContentPartFieldDefinition model)
         {
-            return string.Equals("ContentPickerField", model.FieldDefinition.Name);
+            return string.Equals("ContentPickerField", model.FieldDefinition.Name, System.StringComparison.Ordinal);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Settings/ContentPickerFieldLuceneEditorSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Settings/ContentPickerFieldLuceneEditorSettingsDriver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -44,7 +45,7 @@ namespace OrchardCore.Search.Lucene.Settings
 
         public override bool CanHandleModel(ContentPartFieldDefinition model)
         {
-            return string.Equals("ContentPickerField", model.FieldDefinition.Name, System.StringComparison.Ordinal);
+            return string.Equals("ContentPickerField", model.FieldDefinition.Name, StringComparison.Ordinal);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Providers/LocaleShortcodeProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Providers/LocaleShortcodeProvider.cs
@@ -31,7 +31,7 @@ namespace OrchardCore.Shortcodes.Providers
                 // Fallback to parent culture, if the current culture is en-CA and the shortcode targets en, the html will be output.
                 do
                 {
-                    if (currentCulture.Name.Equals(language, StringComparison.InvariantCultureIgnoreCase))
+                    if (currentCulture.Name.Equals(language, StringComparison.OrdinalIgnoreCase))
                     {
                         return new ValueTask<string>(content);
                     }
@@ -42,7 +42,7 @@ namespace OrchardCore.Shortcodes.Providers
             }
             else
             {
-                if (currentCulture.Name.Equals(language, StringComparison.InvariantCultureIgnoreCase))
+                if (currentCulture.Name.Equals(language, StringComparison.OrdinalIgnoreCase))
                 {
                     return new ValueTask<string>(content);
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/SitemapIndexTypeUpdateHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/SitemapIndexTypeUpdateHandler.cs
@@ -52,12 +52,12 @@ namespace OrchardCore.Sitemaps.Handlers
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;
                     }
-                    else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName))
+                    else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName, System.StringComparison.Ordinal))
                     {
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;
                     }
-                    else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName)))
+                    else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName, System.StringComparison.Ordinal)))
                     {
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/SitemapIndexTypeUpdateHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/SitemapIndexTypeUpdateHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
@@ -52,12 +53,12 @@ namespace OrchardCore.Sitemaps.Handlers
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;
                     }
-                    else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName, System.StringComparison.Ordinal))
+                    else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName, StringComparison.Ordinal))
                     {
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;
                     }
-                    else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName, System.StringComparison.Ordinal)))
+                    else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName, StringComparison.Ordinal)))
                     {
                         sitemap.Identifier = IdGenerator.GenerateId();
                         break;

--- a/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -102,7 +103,7 @@ namespace OrchardCore.Title.Handlers
         private async Task<TitlePartSettings> GetSettingsAsync(TitlePart part)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(TitlePart), System.StringComparison.Ordinal));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(TitlePart), StringComparison.Ordinal));
 
             return contentTypePartDefinition.GetSettings<TitlePartSettings>();
         }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Handlers/TitlePartHandler.cs
@@ -102,7 +102,7 @@ namespace OrchardCore.Title.Handlers
         private async Task<TitlePartSettings> GetSettingsAsync(TitlePart part)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(part.ContentItem.ContentType);
-            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(TitlePart)));
+            var contentTypePartDefinition = contentTypeDefinition.Parts.FirstOrDefault(x => string.Equals(x.PartDefinition.Name, nameof(TitlePart), System.StringComparison.Ordinal));
 
             return contentTypePartDefinition.GetSettings<TitlePartSettings>();
         }

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Services/TwitterClientMessageHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Services/TwitterClientMessageHandler.cs
@@ -100,7 +100,9 @@ namespace OrchardCore.Twitter.Services
 
             var secret = string.Concat(_twitterSettings.ConsumerSecret, "&", _twitterSettings.AccessTokenSecret);
 
+#pragma warning disable CA5350 // Do not use weak cryptographic hashing algorithm
             var signature = Convert.ToBase64String(HMACSHA1.HashData(key: Encoding.UTF8.GetBytes(secret), source: Encoding.UTF8.GetBytes(baseString)));
+#pragma warning restore CA5350
 
             var sb = new StringBuilder();
             sb.Append("oauth_consumer_key=\"").Append(Uri.EscapeDataString(_twitterSettings.ConsumerKey)).Append("\", ");

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/Signin/Configuration/TwitterOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/Signin/Configuration/TwitterOptionsConfiguration.cs
@@ -76,7 +76,7 @@ namespace OrchardCore.Twitter.Signin.Configuration
 
         public void Configure(string name, TwitterOptions options)
         {
-            if (!string.Equals(name, TwitterDefaults.AuthenticationScheme))
+            if (!string.Equals(name, TwitterDefaults.AuthenticationScheme, StringComparison.Ordinal))
             {
                 return;
             }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AuthenticatorAppController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AuthenticatorAppController.cs
@@ -191,7 +191,9 @@ public class AuthenticatorAppController : TwoFactorAuthenticationBaseController
 
         return string.Format(
             CultureInfo.InvariantCulture,
+#pragma warning disable CA1863 // Cache a 'CompositeFormat' for repeated use in this formatting operation
             AuthenticatorUriFormat,
+#pragma warning restore CA1863
             _urlEncoder.Encode(issuer),
             _urlEncoder.Encode(displayName),
             unformattedKey,

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/ContentCardShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/ContentCardShapes.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
@@ -60,7 +61,7 @@ namespace OrchardCore.Widgets
                             // ContentCard_Edit__LandingPage__BagPart__Service, ContentCard_Edit__Form__FlowPart__Label
                             contentCardEditor.Metadata.Alternates.Add($"{ContentCardEdit}__{parentContentType}__{collectionType}__{contentType}");
 
-                            if (!string.IsNullOrWhiteSpace(namedPart) && !(namedPart.Equals(collectionType, System.StringComparison.Ordinal)))
+                            if (!string.IsNullOrWhiteSpace(namedPart) && !(namedPart.Equals(collectionType, StringComparison.Ordinal)))
                             {
                                 // Define edit card shape for selected child  with specific type and partname per parent content type
                                 // ContentCard_Edit__[ParentContentType]__[PartName]
@@ -118,7 +119,7 @@ namespace OrchardCore.Widgets
                         // e.g. ContentCard_Frame__Page__FlowPart__Container, ContentCard_Frame__LandingPage__BagPart__Service, ContentCard_Frame__Form__FlowPart__Label
                         contentCardFrame.Metadata.Alternates.Add($"{ContentCardFrame}__{parentContentType}__{collectionType}__{contentType}");
 
-                        if (!string.IsNullOrWhiteSpace(namedPart) && !namedPart.Equals(collectionType, System.StringComparison.Ordinal))
+                        if (!string.IsNullOrWhiteSpace(namedPart) && !namedPart.Equals(collectionType, StringComparison.Ordinal))
                         {
                             // Define frame card shape for child  with specific partname and parent content type
                             // ContentCard_Frame__[ParentContentType]__[PartName]

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/ContentCardShapes.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/ContentCardShapes.cs
@@ -60,7 +60,7 @@ namespace OrchardCore.Widgets
                             // ContentCard_Edit__LandingPage__BagPart__Service, ContentCard_Edit__Form__FlowPart__Label
                             contentCardEditor.Metadata.Alternates.Add($"{ContentCardEdit}__{parentContentType}__{collectionType}__{contentType}");
 
-                            if (!string.IsNullOrWhiteSpace(namedPart) && !(namedPart.Equals(collectionType)))
+                            if (!string.IsNullOrWhiteSpace(namedPart) && !(namedPart.Equals(collectionType, System.StringComparison.Ordinal)))
                             {
                                 // Define edit card shape for selected child  with specific type and partname per parent content type
                                 // ContentCard_Edit__[ParentContentType]__[PartName]
@@ -118,7 +118,7 @@ namespace OrchardCore.Widgets
                         // e.g. ContentCard_Frame__Page__FlowPart__Container, ContentCard_Frame__LandingPage__BagPart__Service, ContentCard_Frame__Form__FlowPart__Label
                         contentCardFrame.Metadata.Alternates.Add($"{ContentCardFrame}__{parentContentType}__{collectionType}__{contentType}");
 
-                        if (!string.IsNullOrWhiteSpace(namedPart) && !namedPart.Equals(collectionType))
+                        if (!string.IsNullOrWhiteSpace(namedPart) && !namedPart.Equals(collectionType, System.StringComparison.Ordinal))
                         {
                             // Define frame card shape for child  with specific partname and parent content type
                             // ContentCard_Frame__[ParentContentType]__[PartName]

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/LocalizedStringComparer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/LocalizedStringComparer.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.Workflows.Services
     {
         public bool Equals(LocalizedString x, LocalizedString y)
         {
-            return x.Name.Equals(y.Name);
+            return x.Name.Equals(y.Name, System.StringComparison.Ordinal);
         }
 
         public int GetHashCode(LocalizedString obj)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Services/LocalizedStringComparer.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Services/LocalizedStringComparer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Localization;
 
@@ -7,7 +8,7 @@ namespace OrchardCore.Workflows.Services
     {
         public bool Equals(LocalizedString x, LocalizedString y)
         {
-            return x.Name.Equals(y.Name, System.StringComparison.Ordinal);
+            return x.Name.Equals(y.Name, StringComparison.Ordinal);
         }
 
         public int GetHashCode(LocalizedString obj)

--- a/src/OrchardCore/OrchardCore.Autoroute.Core/Services/AutorouteHandleProvider.cs
+++ b/src/OrchardCore/OrchardCore.Autoroute.Core/Services/AutorouteHandleProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Routing;
@@ -14,7 +15,7 @@ namespace OrchardCore.Autoroute.Core.Services
 
         public async Task<string> GetContentItemIdAsync(string handle)
         {
-            if (handle.StartsWith("slug:", System.StringComparison.OrdinalIgnoreCase))
+            if (handle.StartsWith("slug:", StringComparison.OrdinalIgnoreCase))
             {
                 handle = handle[5..];
 

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentFieldDisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentFieldDisplayDriver.cs
@@ -131,8 +131,8 @@ namespace OrchardCore.ContentManagement.Display.ContentDisplay
 
         Task<IDisplayResult> IContentFieldDisplayDriver.BuildDisplayAsync(ContentPart contentPart, ContentPartFieldDefinition partFieldDefinition, ContentTypePartDefinition typePartDefinition, BuildDisplayContext context)
         {
-            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name) &&
-               !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name))
+            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name, StringComparison.Ordinal) &&
+               !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name, StringComparison.Ordinal))
             {
                 return Task.FromResult(default(IDisplayResult));
             }
@@ -160,8 +160,8 @@ namespace OrchardCore.ContentManagement.Display.ContentDisplay
 
         Task<IDisplayResult> IContentFieldDisplayDriver.BuildEditorAsync(ContentPart contentPart, ContentPartFieldDefinition partFieldDefinition, ContentTypePartDefinition typePartDefinition, BuildEditorContext context)
         {
-            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name) &&
-                !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name))
+            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name, StringComparison.Ordinal) &&
+                !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name, StringComparison.Ordinal))
             {
                 return Task.FromResult(default(IDisplayResult));
             }
@@ -190,8 +190,8 @@ namespace OrchardCore.ContentManagement.Display.ContentDisplay
 
         async Task<IDisplayResult> IContentFieldDisplayDriver.UpdateEditorAsync(ContentPart contentPart, ContentPartFieldDefinition partFieldDefinition, ContentTypePartDefinition typePartDefinition, UpdateEditorContext context)
         {
-            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name) &&
-                !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name))
+            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name, StringComparison.Ordinal) &&
+                !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name, StringComparison.Ordinal))
             {
                 return null;
             }

--- a/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.GraphQL/ServiceCollectionExtensions.cs
@@ -32,10 +32,10 @@ namespace OrchardCore.ContentManagement.GraphQL
             return services;
         }
 
-        public static void AddWhereInputIndexPropertyProvider<IIndexType>(this IServiceCollection services)
-            where IIndexType : MapIndex
+        public static void AddWhereInputIndexPropertyProvider<TIndexType>(this IServiceCollection services)
+            where TIndexType : MapIndex
         {
-            services.AddSingleton<IIndexPropertyProvider, IndexPropertyProvider<IIndexType>>();
+            services.AddSingleton<IIndexPropertyProvider, IndexPropertyProvider<TIndexType>>();
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/Editors/ContentPartFieldDefinitionDisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/Editors/ContentPartFieldDefinitionDisplayDriver.cs
@@ -37,7 +37,7 @@ namespace OrchardCore.ContentTypes.Editors
     {
         public override bool CanHandleModel(ContentPartFieldDefinition model)
         {
-            return string.Equals(typeof(TField).Name, model.FieldDefinition.Name);
+            return string.Equals(typeof(TField).Name, model.FieldDefinition.Name, System.StringComparison.Ordinal);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/Editors/ContentPartFieldDefinitionDisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/Editors/ContentPartFieldDefinitionDisplayDriver.cs
@@ -1,3 +1,4 @@
+using System;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.DisplayManagement.Handlers;
@@ -37,7 +38,7 @@ namespace OrchardCore.ContentTypes.Editors
     {
         public override bool CanHandleModel(ContentPartFieldDefinition model)
         {
-            return string.Equals(typeof(TField).Name, model.FieldDefinition.Name, System.StringComparison.Ordinal);
+            return string.Equals(typeof(TField).Name, model.FieldDefinition.Name, StringComparison.Ordinal);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/Editors/ContentTypePartDefinitionDisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/Editors/ContentTypePartDefinitionDisplayDriver.cs
@@ -1,3 +1,4 @@
+using System;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.DisplayManagement.Handlers;
@@ -33,7 +34,7 @@ namespace OrchardCore.ContentTypes.Editors
     {
         public override bool CanHandleModel(ContentTypePartDefinition model)
         {
-            return string.Equals(typeof(TPart).Name, model.PartDefinition.Name, System.StringComparison.Ordinal);
+            return string.Equals(typeof(TPart).Name, model.PartDefinition.Name, StringComparison.Ordinal);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/Editors/ContentTypePartDefinitionDisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.ContentTypes.Abstractions/Editors/ContentTypePartDefinitionDisplayDriver.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.ContentTypes.Editors
     {
         public override bool CanHandleModel(ContentTypePartDefinition model)
         {
-            return string.Equals(typeof(TPart).Name, model.PartDefinition.Name);
+            return string.Equals(typeof(TPart).Name, model.PartDefinition.Name, System.StringComparison.Ordinal);
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementInfo.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/PlacementInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using OrchardCore.DisplayManagement.Shapes;
 
 namespace OrchardCore.DisplayManagement.Descriptors
@@ -15,7 +16,7 @@ namespace OrchardCore.DisplayManagement.Descriptors
 
         public bool IsLayoutZone()
         {
-            return Location.StartsWith("/", System.StringComparison.OrdinalIgnoreCase);
+            return Location.StartsWith("/", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapePlacementStrategy/ShapePlacementParsingStrategy.cs
@@ -129,7 +129,7 @@ namespace OrchardCore.DisplayManagement.Descriptors.ShapePlacementStrategy
         {
             if (placementMatchProviders != null)
             {
-                var providersForTerm = placementMatchProviders.Where(x => x.Key.Equals(term.Key));
+                var providersForTerm = placementMatchProviders.Where(x => x.Key.Equals(term.Key, StringComparison.Ordinal));
                 if (providersForTerm.Any())
                 {
                     var expression = term.Value;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/AlternatesCollection.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/AlternatesCollection.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.DisplayManagement.Shapes
     /// </summary>
     public class AlternatesCollection : IEnumerable<string>
     {
-        public static AlternatesCollection Empty = [];
+        public static readonly AlternatesCollection Empty = [];
 
         private KeyedAlternateCollection _collection;
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/FlatPositionComparer.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/FlatPositionComparer.cs
@@ -89,12 +89,12 @@ namespace OrchardCore.DisplayManagement.Zones
                 return partition;
             }
 
-            if (string.Compare(partition, "before", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(partition, "before", StringComparison.OrdinalIgnoreCase))
             {
                 return "-9999";
             }
 
-            if (string.Compare(partition, "after", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(partition, "after", StringComparison.OrdinalIgnoreCase))
             {
                 return "9999";
             }

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/ContentFieldIndexHandler.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/ContentFieldIndexHandler.cs
@@ -13,8 +13,8 @@ namespace OrchardCore.Indexing
     {
         Task IContentFieldIndexHandler.BuildIndexAsync(ContentPart contentPart, ContentTypePartDefinition typePartDefinition, ContentPartFieldDefinition partFieldDefinition, BuildIndexContext context, IContentIndexSettings settings)
         {
-            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name) &&
-               !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name))
+            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name, System.StringComparison.Ordinal) &&
+               !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name, System.StringComparison.Ordinal))
             {
                 return Task.CompletedTask;
             }

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/ContentFieldIndexHandler.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/ContentFieldIndexHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
@@ -13,8 +14,8 @@ namespace OrchardCore.Indexing
     {
         Task IContentFieldIndexHandler.BuildIndexAsync(ContentPart contentPart, ContentTypePartDefinition typePartDefinition, ContentPartFieldDefinition partFieldDefinition, BuildIndexContext context, IContentIndexSettings settings)
         {
-            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name, System.StringComparison.Ordinal) &&
-               !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name, System.StringComparison.Ordinal))
+            if (!string.Equals(typeof(TField).Name, partFieldDefinition.FieldDefinition.Name, StringComparison.Ordinal) &&
+               !string.Equals(nameof(ContentField), partFieldDefinition.FieldDefinition.Name, StringComparison.Ordinal))
             {
                 return Task.CompletedTask;
             }

--- a/src/OrchardCore/OrchardCore.Media.Core/Services/MediaSizeLimitAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/Services/MediaSizeLimitAttribute.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Media.Services
             return new InternalMediaSizeFilter(options.Value.MaxFileSize);
         }
 
-        private class InternalMediaSizeFilter : IAuthorizationFilter, IRequestFormLimitsPolicy
+        private sealed class InternalMediaSizeFilter : IAuthorizationFilter, IRequestFormLimitsPolicy
         {
             private readonly long _maxFileSize;
 
@@ -55,7 +55,7 @@ namespace OrchardCore.Media.Services
                 }
 
                 var effectiveRequestSizePolicy = context.FindEffectivePolicy<IRequestSizePolicy>();
-                if (effectiveRequestSizePolicy == null || effectiveRequestSizePolicy == this)
+                if (effectiveRequestSizePolicy == null)
                 {
                     // Will only be available when running OutOfProcess with Kestrel.
                     var maxRequestBodySizeFeature = context.HttpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();

--- a/src/OrchardCore/OrchardCore.Mvc.Core/ModuleProjectRazorFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/ModuleProjectRazorFileProvider.cs
@@ -216,7 +216,7 @@ namespace OrchardCore.Mvc
 
             // The view engine uses a watch on "Pages/**/*.cshtml" but only for razor pages.
             // So here, we only use file providers for modules which have a "Pages" folder.
-            else if (path.Equals("Pages/**/*.cshtml"))
+            else if (path.Equals("Pages/**/*.cshtml", StringComparison.Ordinal))
             {
                 var changeTokens = new List<IChangeToken>();
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -358,9 +358,9 @@ namespace OrchardCore.ResourceManagement
             }
 
             var that = (ResourceDefinition)obj;
-            return string.Equals(that.Name, Name) &&
-                string.Equals(that.Type, Type) &&
-                string.Equals(that.Version, Version);
+            return string.Equals(that.Name, Name, StringComparison.Ordinal) &&
+                string.Equals(that.Type, Type, StringComparison.Ordinal) &&
+                string.Equals(that.Version, Version, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceDictionary.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceDictionary.cs
@@ -4,7 +4,9 @@ using System.Collections.Specialized;
 
 namespace OrchardCore.ResourceManagement
 {
+#pragma warning disable CA1010 // Type 'ResourceDictionary' directly or indirectly inherits 'ICollection' without implementing any of 'ICollection<T>', 'IReadOnlyCollection<T>'. Publicly-visible types should implement the generic version to broaden usability.
     public class ResourceDictionary : OrderedDictionary
+#pragma warning restore CA1010
     {
         private readonly Stack<ResourceDefinition> _expanding = new();
 

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
@@ -220,7 +220,7 @@ public class AzureAIIndexDocumentManager(
         return mapping;
     }
 
-    private IEnumerable<SearchDocument> CreateSearchDocuments(IEnumerable<DocumentIndex> indexDocuments, Dictionary<string, IEnumerable<AzureAISearchIndexMap>> mappings)
+    private static IEnumerable<SearchDocument> CreateSearchDocuments(IEnumerable<DocumentIndex> indexDocuments, Dictionary<string, IEnumerable<AzureAISearchIndexMap>> mappings)
     {
         foreach (var indexDocument in indexDocuments)
         {
@@ -228,7 +228,7 @@ public class AzureAIIndexDocumentManager(
         }
     }
 
-    private SearchDocument CreateSearchDocument(DocumentIndex documentIndex, Dictionary<string, IEnumerable<AzureAISearchIndexMap>> mappingDictionary)
+    private static SearchDocument CreateSearchDocument(DocumentIndex documentIndex, Dictionary<string, IEnumerable<AzureAISearchIndexMap>> mappingDictionary)
     {
         var doc = new SearchDocument()
         {

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Providers/ElasticContentPickerResultProvider.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Providers/ElasticContentPickerResultProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -108,7 +109,7 @@ namespace OrchardCore.Search.Elasticsearch.Core.Providers
                         {
                             ContentItemId = doc["ContentItemId"].ToString(),
                             DisplayText = doc["Content.ContentItem.DisplayText.keyword"].ToString(),
-                            HasPublished = doc["Content.ContentItem.Published"].ToString().ToLowerInvariant().Equals("true", System.StringComparison.Ordinal)
+                            HasPublished = doc["Content.ContentItem.Published"].ToString().ToLowerInvariant().Equals("true", StringComparison.Ordinal)
                         });
                     }
                 }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Providers/ElasticContentPickerResultProvider.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Providers/ElasticContentPickerResultProvider.cs
@@ -108,7 +108,7 @@ namespace OrchardCore.Search.Elasticsearch.Core.Providers
                         {
                             ContentItemId = doc["ContentItemId"].ToString(),
                             DisplayText = doc["Content.ContentItem.DisplayText.keyword"].ToString(),
-                            HasPublished = doc["Content.ContentItem.Published"].ToString().ToLowerInvariant().Equals("true")
+                            HasPublished = doc["Content.ContentItem.Published"].ToString().ToLowerInvariant().Equals("true", System.StringComparison.Ordinal)
                         });
                     }
                 }

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeatureHash.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeatureHash.cs
@@ -50,7 +50,7 @@ namespace OrchardCore.Environment.Extensions.Features
             {
                 var enabledFeatures = await _featureManager.GetEnabledFeaturesAsync();
 
-                enabled = enabledFeatures.Any(x => x.Id.Equals(featureId));
+                enabled = enabledFeatures.Any(x => x.Id.Equals(featureId, StringComparison.Ordinal));
 
                 _memoryCache.Set(cacheKey, enabled);
             }

--- a/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
+++ b/src/OrchardCore/OrchardCore/Modules/ModularBackgroundService.cs
@@ -325,7 +325,7 @@ namespace OrchardCore.Modules
                         }
 
                         settings ??= task.GetDefaultSettings();
-                        if (scheduler.Released || !scheduler.Settings.Schedule.Equals(settings.Schedule))
+                        if (scheduler.Released || !scheduler.Settings.Schedule.Equals(settings.Schedule, StringComparison.Ordinal))
                         {
                             scheduler.ReferenceTime = referenceTime;
                         }

--- a/src/OrchardCore/OrchardCore/Modules/Overrides/HttpClient/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Overrides/HttpClient/LifetimeTrackingHttpMessageHandler.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Extensions.Http
         {
         }
 
+#pragma warning disable CA2215 // Dispose methods should call base class dispose
         protected override void Dispose(bool disposing)
+#pragma warning restore CA2215
         {
             // The lifetime of this is tracked separately by ActiveHandlerTrackingEntry.
         }

--- a/src/OrchardCore/OrchardCore/Modules/Overrides/HttpClient/TenantHttpClientFactory.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Overrides/HttpClient/TenantHttpClientFactory.cs
@@ -19,7 +19,7 @@ using Microsoft.Extensions.Options;
 
 namespace Microsoft.Extensions.Http
 {
-    internal class TenantHttpClientFactory : IHttpClientFactory, IHttpMessageHandlerFactory, IDisposable
+    internal sealed class TenantHttpClientFactory : IHttpClientFactory, IHttpMessageHandlerFactory, IDisposable
     {
         private static readonly TimerCallback _cleanupCallback = (s) => ((TenantHttpClientFactory)s!).CleanupTimer_Tick();
         private IServiceProvider? _services;
@@ -242,13 +242,13 @@ namespace Microsoft.Extensions.Http
         }
 
         // Internal so it can be overridden in tests.
-        internal virtual void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry)
+        internal void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry)
         {
             entry.StartExpiryTimer(_expiryCallback);
         }
 
         // Internal so it can be overridden in tests.
-        internal virtual void StartCleanupTimer()
+        internal void StartCleanupTimer()
         {
             lock (_cleanupTimerLock)
             {
@@ -257,7 +257,7 @@ namespace Microsoft.Extensions.Http
         }
 
         // Internal so it can be overridden in tests.
-        internal virtual void StopCleanupTimer()
+        internal void StopCleanupTimer()
         {
             lock (_cleanupTimerLock)
             {

--- a/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.cs
+++ b/test/OrchardCore.Abstractions.Tests/Modules/Manifest/ModuleAttributeTests.cs
@@ -35,7 +35,9 @@ namespace OrchardCore.Modules.Manifest
 
 #pragma warning disable CA1018 // Specify AttributeUsage...
         // No need since the attribute is only here in order to verify Prefix extraction
+#pragma warning disable CA1710 // Rename to end in 'Attribute'
         public class TestAttributePrefix : Attribute { }
+#pragma warning restore CA1710
 #pragma warning restore CA1018
 
         // TODO: MWP: could probably separate this between classes, Theory at one level, InlineData at another...
@@ -644,7 +646,7 @@ namespace OrchardCore.Modules.Manifest
             Assert.Contains(features, _ =>
                 _.Id == string.Join(".", baseId, One) &&
                 _.Name == _.Id &&
-                _.Category.Equals(Two, StringComparison.CurrentCultureIgnoreCase) &&
+                _.Category.Equals(Two, StringComparison.OrdinalIgnoreCase) &&
                 _.InternalPriority == _3 &&
                 _.Description == four &&
                 _.Dependencies.SequenceEqual(GetValues(five, six, seven)) &&

--- a/test/OrchardCore.Tests/Apis/Context/AuthenticationContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/AuthenticationContext.cs
@@ -66,7 +66,7 @@ namespace OrchardCore.Tests.Apis.Context
             return Task.CompletedTask;
         }
 
-        private void GetGrantingNamesInternal(Permission permission, HashSet<string> stack)
+        private static void GetGrantingNamesInternal(Permission permission, HashSet<string> stack)
         {
             // The given name is tested
             stack.Add(permission.Name);

--- a/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/SiteContext.cs
@@ -161,7 +161,9 @@ namespace OrchardCore.Tests.Apis.Context
             return Client.DeleteAsync("api/content/" + contentItemId);
         }
 
+#pragma warning disable CA1816 // Change SiteContext.Dispose() to call GC.SuppressFinalize(object). This will prevent derived types that introduce a finalizer from needing to re-implement 'IDisposable' to call it.
         public void Dispose()
+#pragma warning restore CA1816
         {
             Client?.Dispose();
         }

--- a/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
@@ -195,7 +195,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
             result = await context.GraphQLClient.Content
                 .Query("blogPost(status: LATEST) { displayText, published }");
 
-            Assert.Equal(2, result["data"]["blogPost"].AsArray().Count());
+            Assert.Equal(2, result["data"]["blogPost"].AsArray().Count);
         }
 
         [Fact]

--- a/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
@@ -37,7 +37,7 @@ namespace OrchardCore.Tests.Apis.GraphQL
 
             var nodes = result["data"]["recentBlogPosts"];
 
-            Assert.Equal(2, nodes.AsArray().Count());
+            Assert.Equal(2, nodes.AsArray().Count);
             Assert.Equal("Some sorta blogpost in a Query!", nodes[0]["displayText"].ToString());
             Assert.Equal("Man must explore, and this is exploration at its greatest", nodes[1]["displayText"].ToString());
         }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaEventTests.cs
@@ -19,7 +19,9 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media
             var path = string.Empty;
 
             // This stream will be disposed by the creating stream, or the finally block.
+#pragma warning disable CA1859 // Change type of variable 'inputStream' from 'System.IO.Stream' to 'System.IO.MemoryStream?' for improved performance
             Stream inputStream = null;
+#pragma warning restore CA1859
             try
             {
                 inputStream = new MemoryStream();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Media/MediaTokenTests.cs
@@ -128,7 +128,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Media
             Assert.Equal(tokenizedPath1, tokenizedPath2);
         }
 
-        private IServiceProvider CreateServiceProvider()
+        private ServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Resources/SubResourceIntegrityTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Resources/SubResourceIntegrityTests.cs
@@ -41,7 +41,7 @@ public class SubResourceIntegrityTests
                     {
                         var resourceIntegrity = await GetSubResourceIntegrityAsync(httpClient, resourceDefinition.UrlCdnDebug);
 
-                        Assert.True(resourceIntegrity.Equals(resourceDefinition.CdnDebugIntegrity),
+                        Assert.True(resourceIntegrity.Equals(resourceDefinition.CdnDebugIntegrity, StringComparison.Ordinal),
                             $"The {resourceType} {resourceDefinition.UrlCdnDebug} has invalid SRI hash, please use '{resourceIntegrity}' instead.");
                     }
 
@@ -49,7 +49,7 @@ public class SubResourceIntegrityTests
                     {
                         var resourceIntegrity = await GetSubResourceIntegrityAsync(httpClient, resourceDefinition.UrlCdn);
 
-                        Assert.True(resourceIntegrity.Equals(resourceDefinition.CdnIntegrity),
+                        Assert.True(resourceIntegrity.Equals(resourceDefinition.CdnIntegrity, StringComparison.Ordinal),
                             $"The {resourceType} {resourceDefinition.UrlCdn} has invalid SRI hash, please use '{resourceIntegrity}' instead.");
                     }
                 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Security/Extensions/SecurityHeadersApplicationBuilderExtensionsTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Security/Extensions/SecurityHeadersApplicationBuilderExtensionsTests.cs
@@ -96,7 +96,7 @@ namespace OrchardCore.Security.Extensions.Tests
             Assert.Equal(ReferrerPolicyValue.Origin, context.Response.Headers[SecurityHeaderNames.ReferrerPolicy]);
         }
 
-        private static IApplicationBuilder CreateApplicationBuilder()
+        private static ApplicationBuilder CreateApplicationBuilder()
         {
             var services = new ServiceCollection();
             var serviceProvider = services.BuildServiceProvider();

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/ApiControllerTests.cs
@@ -180,7 +180,7 @@ public class ApiControllerTests
         };
     }
 
-    private static HttpContext CreateHttpContext()
+    private static DefaultHttpContext CreateHttpContext()
     {
         var httpContext = new DefaultHttpContext
         {

--- a/test/OrchardCore.Tests/OrchardCore.Environment.Cache/CacheScopeManagerTests.cs
+++ b/test/OrchardCore.Tests/OrchardCore.Environment.Cache/CacheScopeManagerTests.cs
@@ -67,7 +67,7 @@ namespace OrchardCore.Tests.Environment.Cache
             Assert.Collection(scopeA.Contexts, context => Assert.Contains("1", context),
                                                context => Assert.Contains("2", context));
 
-            Assert.False(scopeB.Contexts.Any());
+            Assert.Empty(scopeB.Contexts);
         }
 
         [Fact]

--- a/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellContainerFactoryTests.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Tests.Shell
             .AsDefaultShell()
             .AsUninitialized();
 
-        private readonly IShellContainerFactory _shellContainerFactory;
+        private readonly ShellContainerFactory _shellContainerFactory;
         private readonly IServiceProvider _applicationServiceProvider;
 
         public ShellContainerFactoryTests()

--- a/test/OrchardCore.Tests/Stubs/StubPoFileLocationProvider.cs
+++ b/test/OrchardCore.Tests/Stubs/StubPoFileLocationProvider.cs
@@ -4,7 +4,7 @@ namespace OrchardCore.Tests
 {
     public class StubPoFileLocationProvider : ILocalizationFileLocationProvider
     {
-        private readonly IFileProvider _fileProvider;
+        private readonly PhysicalFileProvider _fileProvider;
         private readonly string _resourcesContainer;
 
         public StubPoFileLocationProvider(IHostEnvironment hostingEnvironment, IOptions<LocalizationOptions> localizationOptions)

--- a/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
+++ b/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
@@ -69,7 +69,7 @@ namespace OrchardCore.Tests.Workflows
             Assert.Equal(expectedSum, (double)workflowExecutionContext.Output["Sum"]);
         }
 
-        private static IServiceProvider CreateServiceProvider()
+        private static ServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
             services.AddScoped(typeof(Resolver<>));
@@ -80,7 +80,7 @@ namespace OrchardCore.Tests.Workflows
             return services.BuildServiceProvider();
         }
 
-        private static IWorkflowScriptEvaluator CreateWorkflowScriptEvaluator(IServiceProvider serviceProvider)
+        private static JavaScriptWorkflowScriptEvaluator CreateWorkflowScriptEvaluator(IServiceProvider serviceProvider)
         {
             var memoryCache = new MemoryCache(new MemoryCacheOptions());
             var javaScriptEngine = new JavaScriptEngine(memoryCache);


### PR DESCRIPTION
` <AnalysisLevel>latest-Recommended</AnalysisLevel>` is a good starting point as it's basically industry best practices and items can be skipped when needed with `#pragma` with a good reason.

* Use `System.StringComparison.Ordinal` by default
* Fix minor other issues or disable with `#pragma`
* Configure inspection level and allow list in `Directory.Build.props`

https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1309

Now can make separate PRs removing analysis allow list items and making things stricter after this.