### PR TITLE
Remove redirect to index after settings update

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Controllers/AdminController.cs
@@ -92,8 +92,6 @@ namespace OrchardCore.Settings.Controllers
                 {
                     await _notifier.SuccessAsync(H["Site settings updated successfully."]);
                 }
-
-                return RedirectToAction(nameof(Index), new { groupId });
             }
 
             return View(viewModel);


### PR DESCRIPTION
Fixes #15678 

The reason of the issue is that updating database and cache may be performed little later the page is fetched on redirection after postback. The se old values may be shown to the user after saving the settings.

It seems that we don't need to redirect after saving because the data maybe actual and up-to-date with straightforward page life cycle without redirect.