### PR TITLE
Suppress incorrect "CA1822:Mark members as static" analyzer violation in ShapeProxyBenchmark (Lombiq Technologies: OCORE-156)

### DIFF
--- a/test/OrchardCore.Benchmarks/ShapeProxyBenchmark.cs
+++ b/test/OrchardCore.Benchmarks/ShapeProxyBenchmark.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using BenchmarkDotNet.Attributes;
 using Castle.DynamicProxy;
 using OrchardCore.ContentManagement.Display.ViewModels;
@@ -19,6 +20,10 @@ namespace OrchardCore.Benchmark
 
     [MemoryDiagnoser]
     [ShortRunJob]
+    [SuppressMessage(
+        "Performance",
+        "CA1822:Mark members as static",
+        Justification = "BenchmarkDotNet needs all benchmark methods to be instance-level.")]
     public class ShapeProxyBenchmark
     {
         private static ConcurrentDictionary<Type, Type> _proxyTypesCache = [];


### PR DESCRIPTION
Fixing warnings like these:

![image](https://github.com/OrchardCMS/OrchardCore/assets/1976647/42526c90-3961-43e7-a35d-74ebce06f002)

Started from here: https://github.com/OrchardCMS/OrchardCore/pull/15696#pullrequestreview-1989450105