### PR TITLE
 Treat warnings as errors during CI build (Lombiq Technologies: OCORE-157)

### DIFF
--- a/.github/workflows/mac_unit_test_ci.yml
+++ b/.github/workflows/mac_unit_test_ci.yml
@@ -13,5 +13,5 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build and test
       run: |
-        dotnet build -c Release
+        dotnet build -c Release --warnaserror -p:RunAnalyzersDuringBuild=True
         dotnet test -c Release --no-restore --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -27,7 +27,7 @@ jobs:
         dotnet-version: '8.0.x'
     - name: Build
       run: |
-        dotnet build -c Release
+        dotnet build -c Release --warnaserror -p:RunAnalyzersDuringBuild=True
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -26,7 +26,7 @@ jobs:
         dotnet-version: '8.0.x'
     - name: Build
       run: |
-        dotnet build -c Release
+        dotnet build -c Release --warnaserror -p:RunAnalyzersDuringBuild=True
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Build
       if: steps.check-publish.outputs.should-publish == 'true'
       run: |
-        dotnet build -c Release
+        dotnet build -c Release --warnaserror -p:RunAnalyzersDuringBuild=True
     - name: Unit Tests
       if: steps.check-publish.outputs.should-publish == 'true'
       run: |

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -41,7 +41,7 @@ jobs:
       run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 15471 ))" >> $GITHUB_ENV
     - name: Build
       run: |
-        dotnet build -c Release -p:Version=${{ steps.get_version.outputs.VERSION }}
+        dotnet build -c Release --warnaserror -p:RunAnalyzersDuringBuild=True -p:Version=${{ steps.get_version.outputs.VERSION }}
     - name: Unit Tests
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,7 @@
     <!-- Avoid using cref tags with a prefix -->
     <NoWarn>$(NoWarn);CA1200</NoWarn>
 
-    <!--Rename type name X so that it does not end in 'Delegate', 'EventHandler', 'Permission' etc -->
+    <!-- Rename type name X so that it does not end in 'Delegate', 'EventHandler', 'Permission' etc -->
     <NoWarn>$(NoWarn);CA1711</NoWarn>
 
     <!-- Parameter name differs from original overriden implemented name -->
@@ -54,8 +54,11 @@
     <!-- Use PascalCase for named placeholders in the logging message template -->
     <NoWarn>$(NoWarn);CA1727</NoWarn>
 
-    <!--CA1861 : Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array -->
+    <!-- CA1861: Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array -->
     <NoWarn>$(NoWarn);CA1861</NoWarn>
+
+    <!-- "CA1016: Mark assemblies with AssemblyVersionAttribute" is not needed since the Preview and Main CI builds add these. -->
+    <NoWarn>$(NoWarn);CA1016</NoWarn>
 
   </PropertyGroup>
 


### PR DESCRIPTION
After https://github.com/OrchardCMS/OrchardCore/pull/15707 we have no build warnings in CI. To ensure that this stays this way, this PR makes the CI builds fail if you leave any build warnings in the code. (Locally you can still prototype with warnings.)

This is the very first rudimentary step on the way to #7950.