### PR TITLE
Use static typing in ContentFieldsProvider instead of dynamic.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Fields/ContentFieldsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Fields/ContentFieldsProvider.cs
@@ -21,7 +21,7 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
                     Description = "Boolean field",
                     FieldType = typeof(BooleanGraphType),
                     UnderlyingType = typeof(BooleanField),
-                    FieldAccessor = field => field.Content.Value,
+                    FieldAccessor = field => ((BooleanField)field).Value,
                 }
             },
             {
@@ -31,7 +31,7 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
                     Description = "Date field",
                     FieldType = typeof(DateGraphType),
                     UnderlyingType = typeof(DateField),
-                    FieldAccessor = field => field.Content.Value,
+                    FieldAccessor = field => ((DateField)field).Value,
                 }
             },
             {
@@ -41,7 +41,7 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
                     Description = "Date & time field",
                     FieldType = typeof(DateTimeGraphType),
                     UnderlyingType = typeof(DateTimeField),
-                    FieldAccessor = field => field.Content.Value,
+                    FieldAccessor = field => ((DateTimeField)field).Value,
                 }
             },
             {
@@ -51,7 +51,7 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
                     Description = "Numeric field",
                     FieldType = typeof(DecimalGraphType),
                     UnderlyingType = typeof(NumericField),
-                    FieldAccessor = field => field.Content.Value,
+                    FieldAccessor = field => ((NumericField)field).Value,
                 }
             },
             {
@@ -61,7 +61,7 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
                     Description = "Text field",
                     FieldType = typeof(StringGraphType),
                     UnderlyingType = typeof(TextField),
-                    FieldAccessor = field => field.Content.Text,
+                    FieldAccessor = field => ((TextField)field).Text,
                 }
             },
             {
@@ -71,7 +71,7 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
                     Description = "Time field",
                     FieldType = typeof(TimeSpanGraphType),
                     UnderlyingType = typeof(TimeField),
-                    FieldAccessor = field => field.Content.Value,
+                    FieldAccessor = field => ((TimeField)field).Value,
                 }
             },
             {
@@ -81,7 +81,7 @@ namespace OrchardCore.ContentFields.GraphQL.Fields
                     Description = "Multi text field",
                     FieldType = typeof(ListGraphType<StringGraphType>),
                     UnderlyingType = typeof(MultiTextField),
-                    FieldAccessor = field => field.Content.Values,
+                    FieldAccessor = field => ((MultiTextField)field).Values,
                 }
             }
         };


### PR DESCRIPTION
Fixed querying content fields with GraphQL by replacing the use of dynamic types with static typing in the `ContentFieldsProvider` class.

This change will not address the underlying issue that dynamic types stopped functioning after upgrading to `System.Text.Json`. However, adopting static typing is more beneficial in the long run.

Fixes #15718