### PR TITLE
Refresh and simplify mkdocs instructions, and fix warnings emitted by mkdocs

### DIFF
--- a/src/docs/guides/create-modular-application-mvc/README.md
+++ b/src/docs/guides/create-modular-application-mvc/README.md
@@ -16,7 +16,7 @@ You will build a modular ASP.NET Core MVC web application similar to the sample 
 
 There are different ways to create sites and modules for Orchard Core. You can learn more about them [here](../../getting-started/templates/README.md).
 
-In this guide we will use our [Code Generation Templates](../../getting-started/templates/). You can install the latest stable release of the templates using this command:
+In this guide we will use our [Code Generation Templates](../../getting-started/templates/README.md). You can install the latest stable release of the templates using this command:
 
 ```dotnet new install OrchardCore.ProjectTemplates::1.8.2-*```
 

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -416,7 +416,7 @@ When specifying a media profile with either the liquid, razor helper, or tag hel
     ```
 
 !!! note
-    Media Profiles are only available from the [Preview Feed](../../../getting-started/preview-package-source)
+    Media Profiles are only available from the [Preview Feed](../../../getting-started/preview-package-source.md)
 
 ## Media Text
 
@@ -458,7 +458,7 @@ The `Anchors[]` is a less well known property of a `MediaField` and can be acces
 The `Anchors[]` is kept in sync with the `Paths[]` array and the index for a given path represents the index of a `Anchor` value.
 
 !!! note
-    Anchors are only available from the [Preview Feed](../../../getting-started/preview-package-source)
+    Anchors are only available from the [Preview Feed](../../../getting-started/preview-package-source.md)
 
 ## Query string tokens
 
@@ -478,7 +478,7 @@ When the query string is signed with a token any width, height value may be used
 `<img src="/media/kittens.jpg?width=101&height=241&token=0J3hyv6jIPEsSdlvTCrf30fIdygkpmrF6mphqgYQyas%3D">`
 
 !!! note
-    Tokens are only available from the [Preview Feed](../../../getting-started/preview-package-source)
+    Tokens are only available from the [Preview Feed](../../../getting-started/preview-package-source.md)
     Prior to this the width or height values are limited to `16`, `32`, `50`, `100`, `160`, `240`, `480`, `600`, `1024`, `2048`.
 
 ## Media Content Search

--- a/src/docs/reference/modules/Scripting/README.md
+++ b/src/docs/reference/modules/Scripting/README.md
@@ -114,7 +114,7 @@ Here is a list of javascript methods provided by Orchard Modules.
 | Function | Description
 | -------- | ----------- |
 | `variables()` | Declare variables at the root of a recipe. Ex: `"variables": { "blogContentItemId": "[js:uuid()]" }`  Retrieve a variable value like this: `"ContentItemId": "[js: variables('blogContentItemId')]"` |
-| `parameters()` | Retrieves the parameters specified during the setup. Ex: `"Owner": "[js: parameters('AdminUserId')]"` See the available [Setup Recipe parameters](../Setup/#recipe-parameters) |
+| `parameters()` | Retrieves the parameters specified during the setup. Ex: `"Owner": "[js: parameters('AdminUserId')]"` See the available [Setup Recipe parameters](../Setup/README.md#recipe-parameters) |
 | `configuration(key: String, defaultValue: String)` | Retrieves the specified configuration setting by its key, optionally providing a default. Ex: `[js: configuration('OrchardCore_Admin:AdminUrlPrefix', 'Admin')]` See [IShellConfiguration](../../core/Configuration/README.md) |
 
 #### Workflows (`OrchardCore.Workflows.Http`)

--- a/src/docs/reference/modules/Seo/README.md
+++ b/src/docs/reference/modules/Seo/README.md
@@ -20,10 +20,10 @@ Starting at version 1.7, the feature of creating a robots.txt file via site sett
 These default settings aim to provide a basic configuration that ensures search engines can access the necessary files and directories while restricting access to sensitive areas of the site. However, website owners can modify these settings according to their specific requirements by navigating to the admin dashboard then **Configuration** >> **Settings** >> **SEO**.
 
 !!! note
-    If the [Sitemaps](../Sitemaps) feature is enabled, all sitemap indexes and sitemaps are added to the `robots.txt` by default.
+    If the [Sitemaps](../Sitemaps/README.md) feature is enabled, all sitemap indexes and sitemaps are added to the `robots.txt` by default.
 
 !!! warning
-    If the site's [filesystem](../Tenants/#static-file-provider-feature) contains a `robots.txt`, this file will take precedence and the site settings to generate the files will be ignored.
+    If the site's [filesystem](../Tenants/README.md#static-file-provider-feature) contains a `robots.txt`, this file will take precedence and the site settings to generate the files will be ignored.
 
 ## Video
 

--- a/src/docs/reference/modules/Shortcodes/README.md
+++ b/src/docs/reference/modules/Shortcodes/README.md
@@ -8,7 +8,7 @@ Shortcodes can be implemented by enabling the Shortcode Templates feature or thr
 
 ## Shortcode Templates
 
-Shortcode templates with [Liquid](../Liquid/) are created through the _Design -> Shortcodes_ menu.
+Shortcode templates with [Liquid](../Liquid/README.md) are created through the _Design -> Shortcodes_ menu.
 
 Shortcode templates are designed to be able to override a code based Shortcode of the same name.
 
@@ -123,7 +123,7 @@ services.AddShortcode<ImageShortcodeProvider>("image", describe => {
 !!! note
     When upgrading from version `1.0.0-rc2-13450` you may need to re-enable the Shortcodes feature, through _Configuration -> Features_
 
-    The Shortcode Templates feature is only available from the [Preview Feed](../../../getting-started/preview-package-source)
+    The Shortcode Templates feature is only available from the [Preview Feed](../../../getting-started/preview-package-source.md)
 
 ## Available Shortcodes
 

--- a/src/docs/reference/modules/Templates/README.md
+++ b/src/docs/reference/modules/Templates/README.md
@@ -488,7 +488,7 @@ This template is called when a content field shape type is rendered for a given 
 The differentiator uniquely identifies a shape in a zone. When rendering a content item, the shape has a `Content` property that contains
 all the shapes provided by content display drivers, including the ones for content parts and content fields.
 
-Differentiators can be used to configure the placement information (c.f. [Placement documentation page](../../core/Placement/)), or to access specific shapes in a zone using these template helpers:
+Differentiators can be used to configure the placement information (c.f. [Placement documentation page](../../core/Placement/README.md)), or to access specific shapes in a zone using these template helpers:
 
 ### Content Part differentiator
 

--- a/src/docs/reference/modules/Workflows/README.md
+++ b/src/docs/reference/modules/Workflows/README.md
@@ -155,7 +155,7 @@ The following JavaScript functions are available by default to any activity that
 | `output` | Sets an output parameter with the specified name. Workflow output can be collected by the invoker of the workflow. | `output(name: string, value: any): void` |
 | `property` | Returns the property value with the specified name. Properties are a dictionary that workflow activities can read and write information from and to. | `property(name: string): any` |
 | `setProperty` | Stores the specified data in workflow properties. | `setProperty(name: string,data:any):void` |
-| `executeQuery` | Returns the result of the query, see [more](../Queries/#scripting). | `executeQuery(name: String, parameters: Dictionary<string,object>): IEnumerable<object>` |
+| `executeQuery` | Returns the result of the query, see [more](../Queries/README.md#scripting). | `executeQuery(name: String, parameters: Dictionary<string,object>): IEnumerable<object>` |
 | `log` | Output logs according to the specified log level. Allowed log levels : `'Trace','Debug','Information','Warning','Error','Critical','None'` | `log(level: string, text: string, param: object): void` |
 | `lastResult` | Returns the value that the previous activity provided, if any. | `lastResult(): any` |
 | `correlationId` | Returns the correlation value of the workflow instance. | `correlationId(): string` |

--- a/src/docs/releases/1.7.0.md
+++ b/src/docs/releases/1.7.0.md
@@ -148,7 +148,7 @@ With the newly added options, we can now allow searching for user based on eithe
 The `Seo` feature now provides `robots.txt` out of the box when the filesystem does not contain one. New settings are available at **Configuration** >> **Settings** >> **SEO** to allow you to configure what should be included into the `robots.txt` file.
 
 !!! note
-    If the [Sitemaps](../modules/Sitemaps) feature is enabled, all sitemap indexes and sitemaps are added to the `robots.txt` by default.
+    If the [Sitemaps](../reference/modules/Sitemaps/README.md) feature is enabled, all sitemap indexes and sitemaps are added to the `robots.txt` by default.
 
 ### `OrchardCore.Contents` Module
 

--- a/src/docs/resources/README.md
+++ b/src/docs/resources/README.md
@@ -4,13 +4,13 @@ Many external resources are available in order to teach you how to develop with 
 
 ## Overview
 
-- [Tutorials](tutorials): List of tutorials to discover Orchard Core.
-- [Development Tools](development-tools): List of tools that help you developing with Orchard Core.
-- [Meeting](meeting): Join us for our weekly meetings each Tuesdays and Thursdays.
-- [Branding](branding): Get some official assets and share about the project philosophy.
-- [Libraries](libraries): List of external libraries and licenses used in Orchard Core.
-- [Owners](owners): List of the main contributors and their contribution areas.
-- [Workshops](workshops): Training sessions developed by our contributors.
+- [Tutorials](tutorials/README.md): List of tutorials to discover Orchard Core.
+- [Development Tools](development-tools/README.md): List of tools that help you developing with Orchard Core.
+- [Meeting](meeting/README.md): Join us for our weekly meetings each Tuesdays and Thursdays.
+- [Branding](branding/README.md): Get some official assets and share about the project philosophy.
+- [Libraries](libraries/README.md): List of external libraries and licenses used in Orchard Core.
+- [Owners](owners/README.md): List of the main contributors and their contribution areas.
+- [Workshops](workshops/README.md): Training sessions developed by our contributors.
 
 ## Newsletter
 

--- a/src/docs/topics/configuration/README.md
+++ b/src/docs/topics/configuration/README.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Orchard Core allows you to create your own setup templates (know as [Recipes](../glossary/#Recipe)) and configure your [Tenants](../glossary/#Tenant) individually.
+Orchard Core allows you to create your own setup templates (know as [Recipes](../../glossary/README.md#Recipe)) and configure your [Tenants](../../glossary/README.md#Tenant) individually.
 
 ## Configure your Orchard Core instance
 

--- a/src/docs/topics/docs-contributions/README.md
+++ b/src/docs/topics/docs-contributions/README.md
@@ -26,7 +26,7 @@ Do the following if you're adding docs for a newly developed extension, or if yo
 
 With MkDocs you can get the full docs.orchardcore.net experience locally too. If you are looking to contribute substantial amount of docs then please do run the site locally to make sure what you write will actually look like it should.
 
-1. Follow the [MkDocs installation guide](https://www.mkdocs.org/#installation) to install Python. once you have Python installed you won't need to install MkDocs by hand, we'll do that in a next step. If you're on Windows be sure to add the Python `Scripts` folder to the `PATH` as noted there, otherwise none of the `mkdocs` commands will be found. You may need to add your user's Scripts folder (something like `C:\Users\<user name>\AppData\Roaming\Python\Python39\Scripts`) to the `PATH` too.
+1. Follow the [MkDocs installation guide](https://www.mkdocs.org/user-guide/installation/) to install Python and PIP if you don't have them yet.
 2. Open a command line in the root of your clone of the repository.
-3. Run `pip3 install -r src/docs/requirements.txt` to install dependencies.
-4. Run `mkdocs serve` to start the site. You'll then be able to browse it under <http://127.0.0.1:8000>.
+3. Run `pip install -r src/docs/requirements.txt` to install dependencies.
+4. Run `python -m mkdocs serve` to start the site. You'll then be able to browse it under <http://127.0.0.1:8000>.

--- a/src/docs/topics/docs-contributions/README.md
+++ b/src/docs/topics/docs-contributions/README.md
@@ -26,7 +26,7 @@ Do the following if you're adding docs for a newly developed extension, or if yo
 
 With MkDocs you can get the full docs.orchardcore.net experience locally too. If you are looking to contribute substantial amount of docs then please do run the site locally to make sure what you write will actually look like it should.
 
-1. Follow the [MkDocs installation guide](https://www.mkdocs.org/user-guide/installation/) to install Python and PIP if you don't have them yet.
+1. Follow the [MkDocs installation guide](https://www.mkdocs.org/user-guide/installation/) to install Python, PIP and MkDocs. If you already have a fresh enough Python installation, you can simply run `pip install mkdocs`.
 2. Open a command line in the root of your clone of the repository.
 3. Run `pip install -r src/docs/requirements.txt` to install dependencies.
 4. Run `python -m mkdocs serve` to start the site. You'll then be able to browse it under <http://127.0.0.1:8000>.

--- a/src/docs/topics/security/README.md
+++ b/src/docs/topics/security/README.md
@@ -6,7 +6,7 @@ Orchard Core provides many security features to give an authenticated access to 
 
 - [Microsoft Authentication](../../reference/modules/Microsoft.Authentication/README.md)
 - [Facebook Authentication](../../reference/modules/Facebook/README.md)
-- [Twitter Authentication](../../reference/modules/Twitter/README.md)
+- [X (Twitter) Authentication](../../reference/modules/X/README.md)
 - [GitHub Authentication](../../reference/modules/GitHub/README.md)
 - [Google Authentication](../../reference/modules/Google/README.md)
 - [OpenId](../../reference/modules/OpenId/README.md)


### PR DESCRIPTION
I have noticed that the [Running the documentation site locally](https://github.com/OrchardCMS/OrchardCore/blob/main/src/docs/topics/docs-contributions/README.md#running-the-documentation-site-locally) documentation is a bit complicated. Specifically, altering the PATH is unnecessary, and the instructions still use `pip3` instead of `pip` even though Python 2 has been fully dead since 2020. Also mkdocs' install guide URL has changed.

Additionally, I fixed every INFO and WARN I saw in the mkdocs output, except the "The following pages exist in the docs directory, but are not included in the "nav" configuration." INFO message because I didn't want to alter the nav config.