### PR TITLE
Display selected culture as native name in content culture picker

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePicker.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/ContentCulturePicker.cshtml
@@ -16,7 +16,7 @@
 }
 
 <li class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" id="oc-culture-picker" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">@currentCulture</a>
+    <a class="nav-link dropdown-toggle" href="#" id="oc-culture-picker" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">@currentCulture.NativeName</a>
     <div class="dropdown-menu" aria-labelledby="oc-culture-picker">
         @foreach (var culture in supportedCultures)
         {


### PR DESCRIPTION
Fixes #15774

![Screenshot 2024-04-17 021824](https://github.com/OrchardCMS/OrchardCore/assets/3237266/321ed63e-f448-4d37-9261-19a867ba6e9d)
