### PR TITLE
Add TypePartDefinition to BagPartEditViewModel

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
@@ -79,6 +79,7 @@ namespace OrchardCore.Flows.Drivers
                 m.Updater = context.Updater;
                 m.ContainedContentTypeDefinitions = await GetContainedContentTypesAsync(context.TypePartDefinition);
                 m.AccessibleWidgets = await GetAccessibleWidgetsAsync(bagPart.ContentItems, contentDefinitionManager);
+                m.TypePartDefinition = context.TypePartDefinition;
             });
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartEditViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/ViewModels/BagPartEditViewModel.cs
@@ -25,5 +25,8 @@ namespace OrchardCore.Flows.ViewModels
 
         [BindNever]
         public IEnumerable<BagPartWidgetViewModel> AccessibleWidgets { get; set; }
+
+        [BindNever]
+        public ContentTypePartDefinition TypePartDefinition { get; set; }
     }
 }


### PR DESCRIPTION
The definition will provide more context for the bag part editor. Usefull for custom editors to get editor specific properties.