### PR TITLE
More automatic documentation build checks (Lombiq Technologies: OCORE-164)

### DIFF
--- a/OrchardCore.sln
+++ b/OrchardCore.sln
@@ -381,7 +381,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{E33D95DF-E864-4D14-A561-D59E8AC06811}"
 	ProjectSection(SolutionItems) = preProject
 		mkdocs.yml = mkdocs.yml
-		src\README.md = src\README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.Docs", "src\docs\OrchardCore.Docs.csproj", "{A37CD7CB-6B26-483A-9D5A-3E80B6CB115F}"
@@ -500,7 +499,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.Notifications.C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.Notifications", "src\OrchardCore.Modules\OrchardCore.Notifications\OrchardCore.Notifications.csproj", "{19594A96-A033-4820-820B-C6186D00D507}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OrchardCore.HealthChecks.Abstractions", "src\OrchardCore\OrchardCore.HealthChecks.Abstractions\OrchardCore.HealthChecks.Abstractions.csproj", "{91CED599-45B1-474D-A7F2-231BF857A5F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.HealthChecks.Abstractions", "src\OrchardCore\OrchardCore.HealthChecks.Abstractions\OrchardCore.HealthChecks.Abstractions.csproj", "{91CED599-45B1-474D-A7F2-231BF857A5F2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.Seo.Abstractions", "src\OrchardCore\OrchardCore.Seo.Abstractions\OrchardCore.Seo.Abstractions.csproj", "{C61CC748-39BD-4900-9FEE-A2483259573D}"
 EndProject

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,15 @@ edit_uri: edit/main/src/
 
 # Options
 docs_dir: src/docs
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+# Add files here that are intentionally not in the navigation and thus omitted_files shouldn't warn about them.
+not_in_nav: |
+  samples/
+  releases/1.9.0.md
 
 # Extensions
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,7 +43,7 @@ repo_url: https://github.com/OrchardCMS/OrchardCore
 edit_uri: edit/main/src/
 
 # Options
-docs_dir: src
+docs_dir: src/docs
 
 # Extensions
 markdown_extensions:
@@ -82,207 +82,207 @@ plugins:
         - "*node_modules*"
   - redirects:
       redirect_maps:
-        'docs/topics/docs-contributions/README.md': 'docs/guides/contributing/contributing-documentation.md'
+        'topics/docs-contributions/README.md': 'guides/contributing/contributing-documentation.md'
 
 # Page tree
 nav:
   - About Orchard Core: README.md
   - Getting started:
-      - Create a CMS Web application: docs/getting-started/README.md
-      - Test drive Orchard Core: docs/getting-started/test-drive-orchard-core.md
-      - Configure Preview package source: docs/getting-started/preview-package-source.md
-      - Recipes and Starter Themes: docs/getting-started/starter-recipes.md
-      - Code Generation Templates: docs/getting-started/templates/README.md
-      - Create a Theme: docs/getting-started/theme.md
+      - Create a CMS Web application: getting-started/README.md
+      - Test drive Orchard Core: getting-started/test-drive-orchard-core.md
+      - Configure Preview package source: getting-started/preview-package-source.md
+      - Recipes and Starter Themes: getting-started/starter-recipes.md
+      - Code Generation Templates: getting-started/templates/README.md
+      - Create a Theme: getting-started/theme.md
   - Glossary:
-      - Terms and Concepts: docs/glossary/README.md
+      - Terms and Concepts: glossary/README.md
   - How-to guides:
-      - Follow the Guides: docs/guides/README.md
-      - Create a modular application: docs/guides/create-modular-application-mvc/README.md
-      - Create a website: docs/guides/create-cms-application/README.md
-      - Leverage CSPROJ meta information: docs/guides/leverage-csproj-meta-info/README.md
-      - Create a Decoupled CMS site: docs/guides/decoupled-cms/README.md
+      - Follow the Guides: guides/README.md
+      - Create a modular application: guides/create-modular-application-mvc/README.md
+      - Create a website: guides/create-cms-application/README.md
+      - Leverage CSPROJ meta information: guides/leverage-csproj-meta-info/README.md
+      - Create a Decoupled CMS site: guides/decoupled-cms/README.md
       - Create a webshop using the Commerce module: https://commerce.orchardcore.net/en/latest/guides/create-webshop/
-      - Add an admin menu: docs/guides/add-admin-menu/README.md
-      - Implement Full Text search: docs/guides/implement-fulltext-search/README.md
-      - Install localization files: docs/guides/install-localization-files/README.md
-      - Integrate Facebook plugins: docs/guides/integrate-facebook-plugins/README.md
-      - Run code on startup: docs/guides/run-code-on-startup/README.md
-      - Create a custom admin theme: docs/guides/create-admin-theme/README.md
-      - Customize encoding settings: docs/guides/encoding-settings/README.md
-      - Understanding Content Definitions Stores: docs/guides/content-definitions/README.md
-      - Change password configuration: docs/guides/password-configuration/README.md
-      - Change lockout configuration: docs/guides/lockout-configuration/README.md
-      - Microsoft Entra ID (Azure AD) integration: docs/guides/microsoft-entra-id-integration/README.md
-      - Create a Liquid Widget: docs/guides/create-liquid-widget/README.md
-      - Query Content Items Based on Taxonomy: docs/guides/query-content-items-based-on-taxonomy/README.md
+      - Add an admin menu: guides/add-admin-menu/README.md
+      - Implement Full Text search: guides/implement-fulltext-search/README.md
+      - Install localization files: guides/install-localization-files/README.md
+      - Integrate Facebook plugins: guides/integrate-facebook-plugins/README.md
+      - Run code on startup: guides/run-code-on-startup/README.md
+      - Create a custom admin theme: guides/create-admin-theme/README.md
+      - Customize encoding settings: guides/encoding-settings/README.md
+      - Understanding Content Definitions Stores: guides/content-definitions/README.md
+      - Change password configuration: guides/password-configuration/README.md
+      - Change lockout configuration: guides/lockout-configuration/README.md
+      - Microsoft Entra ID (Azure AD) integration: guides/microsoft-entra-id-integration/README.md
+      - Create a Liquid Widget: guides/create-liquid-widget/README.md
+      - Query Content Items Based on Taxonomy: guides/query-content-items-based-on-taxonomy/README.md
       - Contributing:
-          - Contributing to Orchard Core: docs/guides/contributing/README.md
-          - Contributing code: docs/guides/contributing/contributing-code.md
-          - Contributing documentation: docs/guides/contributing/contributing-documentation.md
-          - Reviewing pull requests: docs/guides/contributing/reviewing-pull-requests.md
-      - Gulp pipeline: docs/guides/gulp-pipeline/README.md
+          - Contributing to Orchard Core: guides/contributing/README.md
+          - Contributing code: guides/contributing/contributing-code.md
+          - Contributing documentation: guides/contributing/contributing-documentation.md
+          - Reviewing pull requests: guides/contributing/reviewing-pull-requests.md
+      - Gulp pipeline: guides/gulp-pipeline/README.md
   - Key Topics:
-      - Manage your Content: docs/topics/content-management/README.md
-      - Content Relationships: docs/topics/content-relationships/README.md
-      - Customize the Display: docs/topics/display/README.md
-      - Localize your site: docs/topics/localize/README.md
-      - Handle the Media: docs/topics/media/README.md
-      - Navigate between pages: docs/topics/navigation/README.md
-      - Query and Search data: docs/topics/search/README.md
-      - Secure your application: docs/topics/security/README.md
-      - Data: docs/topics/data/README.md
-      - Configuration: docs/topics/configuration/README.md
-      - Workflows: docs/topics/workflows/README.md
-      - Publishing a new release: docs/topics/publishing-releases/README.md
-      - Using Docker: docs/topics/docker/README.md
-      - Using local NuGet packages: docs/topics/local-nuget-packages/README.md
-      - Managing the Orchard Core Red Hat Ecosystem Catalog certification: docs/topics/red-hat-ecosystem-catalog-certification/README.md
+      - Manage your Content: topics/content-management/README.md
+      - Content Relationships: topics/content-relationships/README.md
+      - Customize the Display: topics/display/README.md
+      - Localize your site: topics/localize/README.md
+      - Handle the Media: topics/media/README.md
+      - Navigate between pages: topics/navigation/README.md
+      - Query and Search data: topics/search/README.md
+      - Secure your application: topics/security/README.md
+      - Data: topics/data/README.md
+      - Configuration: topics/configuration/README.md
+      - Workflows: topics/workflows/README.md
+      - Publishing a new release: topics/publishing-releases/README.md
+      - Using Docker: topics/docker/README.md
+      - Using local NuGet packages: topics/local-nuget-packages/README.md
+      - Managing the Orchard Core Red Hat Ecosystem Catalog certification: topics/red-hat-ecosystem-catalog-certification/README.md
   - Reference:
-      - docs/reference/README.md
+      - reference/README.md
       - CMS Modules:
-          - Content Types: docs/reference/modules/ContentTypes/README.md
+          - Content Types: reference/modules/ContentTypes/README.md
           - Content Parts:
-              - Add Parts to your Content: docs/reference/modules/ContentParts/README.md
-              - Title: docs/reference/modules/Title/README.md
-              - Autoroute: docs/reference/modules/Autoroute/README.md
-              - Alias: docs/reference/modules/Alias/README.md
-              - Html: docs/reference/modules/Html/README.md
-              - Markdown: docs/reference/modules/Markdown/README.md
-              - List: docs/reference/modules/Lists/README.md
-              - Flow: docs/reference/modules/Flow/README.md
-              - Bag: docs/reference/modules/Flow/BagPart.md
-              - Publish Later: docs/reference/modules/PublishLater/README.md
-              - SEO Meta: docs/reference/modules/Seo/README.md
-          - Content Fields: docs/reference/modules/ContentFields/README.md
-          - Content Preview: docs/reference/modules/ContentPreview/README.md
-          - Content Localization: docs/reference/modules/ContentLocalization/README.md
-          - Layers: docs/reference/modules/Layers/README.md
-          - Widgets: docs/reference/modules/Widgets/README.md
-          - Forms: docs/reference/modules/Forms/README.md
-          - Templates: docs/reference/modules/Templates/README.md
-          - Placements: docs/reference/modules/Placements/README.md
-          - Themes: docs/reference/modules/Themes/README.md
-          - Liquid: docs/reference/modules/Liquid/README.md
+              - Add Parts to your Content: reference/modules/ContentParts/README.md
+              - Title: reference/modules/Title/README.md
+              - Autoroute: reference/modules/Autoroute/README.md
+              - Alias: reference/modules/Alias/README.md
+              - Html: reference/modules/Html/README.md
+              - Markdown: reference/modules/Markdown/README.md
+              - List: reference/modules/Lists/README.md
+              - Flow: reference/modules/Flow/README.md
+              - Bag: reference/modules/Flow/BagPart.md
+              - Publish Later: reference/modules/PublishLater/README.md
+              - SEO Meta: reference/modules/Seo/README.md
+          - Content Fields: reference/modules/ContentFields/README.md
+          - Content Preview: reference/modules/ContentPreview/README.md
+          - Content Localization: reference/modules/ContentLocalization/README.md
+          - Layers: reference/modules/Layers/README.md
+          - Widgets: reference/modules/Widgets/README.md
+          - Forms: reference/modules/Forms/README.md
+          - Templates: reference/modules/Templates/README.md
+          - Placements: reference/modules/Placements/README.md
+          - Themes: reference/modules/Themes/README.md
+          - Liquid: reference/modules/Liquid/README.md
           - Media:
-              - Media: docs/reference/modules/Media/README.md
-              - Media Slugify: docs/reference/modules/Media.Slugify/README.md
-              - Media Amazon S3: docs/reference/modules/Media.AmazonS3/README.md
-              - Media Azure: docs/reference/modules/Media.Azure/README.md
-          - ReCaptcha: docs/reference/modules/ReCaptcha/README.md
-          - Resources: docs/reference/modules/Resources/README.md
-          - Rules: docs/reference/modules/Rules/README.md
+              - Media: reference/modules/Media/README.md
+              - Media Slugify: reference/modules/Media.Slugify/README.md
+              - Media Amazon S3: reference/modules/Media.AmazonS3/README.md
+              - Media Azure: reference/modules/Media.Azure/README.md
+          - ReCaptcha: reference/modules/ReCaptcha/README.md
+          - Resources: reference/modules/Resources/README.md
+          - Rules: reference/modules/Rules/README.md
           - Search, Indexing, Querying:
-              - Azure AI Search: docs/reference/modules/AzureAISearch/README.md
-              - Elasticsearch: docs/reference/modules/Elasticsearch/README.md
-              - Indexing: docs/reference/modules/Indexing/README.md
-              - Lucene: docs/reference/modules/Lucene/README.md
-              - SQL Indexing: docs/reference/modules/SQLIndexing/README.md
-              - Queries: docs/reference/modules/Queries/README.md
-          - Shortcodes: docs/reference/modules/Shortcodes/README.md
-          - Sitemaps: docs/reference/modules/Sitemaps/README.md
-          - SMS: docs/reference/modules/Sms/README.md
-          - Spatial: docs/reference/modules/Spatial/README.md
-          - XML-RPC: docs/reference/modules/XmlRpc/README.md
-          - Menu: docs/reference/modules/Menu/README.md
-          - Navigation: docs/reference/modules/Navigation/README.md
-          - Admin: docs/reference/modules/Admin/README.md
-          - Admin Dashboard: docs/reference/modules/AdminDashboard/README.md
-          - Admin Menu: docs/reference/modules/AdminMenu/README.md
-          - Taxonomies: docs/reference/modules/Taxonomies/README.md
+              - Azure AI Search: reference/modules/AzureAISearch/README.md
+              - Elasticsearch: reference/modules/Elasticsearch/README.md
+              - Indexing: reference/modules/Indexing/README.md
+              - Lucene: reference/modules/Lucene/README.md
+              - SQL Indexing: reference/modules/SQLIndexing/README.md
+              - Queries: reference/modules/Queries/README.md
+          - Shortcodes: reference/modules/Shortcodes/README.md
+          - Sitemaps: reference/modules/Sitemaps/README.md
+          - SMS: reference/modules/Sms/README.md
+          - Spatial: reference/modules/Spatial/README.md
+          - XML-RPC: reference/modules/XmlRpc/README.md
+          - Menu: reference/modules/Menu/README.md
+          - Navigation: reference/modules/Navigation/README.md
+          - Admin: reference/modules/Admin/README.md
+          - Admin Dashboard: reference/modules/AdminDashboard/README.md
+          - Admin Menu: reference/modules/AdminMenu/README.md
+          - Taxonomies: reference/modules/Taxonomies/README.md
           - Authentication:
-              - Microsoft: docs/reference/modules/Microsoft.Authentication/README.md
-              - Facebook: docs/reference/modules/Facebook/README.md
-              - X (Twitter): docs/reference/modules/X/README.md
-              - GitHub: docs/reference/modules/GitHub/README.md
-              - Google: docs/reference/modules/Google/README.md
+              - Microsoft: reference/modules/Microsoft.Authentication/README.md
+              - Facebook: reference/modules/Facebook/README.md
+              - X (Twitter): reference/modules/X/README.md
+              - GitHub: reference/modules/GitHub/README.md
+              - Google: reference/modules/Google/README.md
           - Users:
-              - Overview: docs/reference/modules/Users/README.md
-              - Custom User Settings: docs/reference/modules/Users/CustomUserSettings/README.md
-              - Notifications: docs/reference/modules/Notifications/README.md
-              - Ticket store: docs/reference/modules/Users/TicketStore.md
-          - Home Route: docs/reference/modules/HomeRoute/README.md
-          - Feeds: docs/reference/modules/Feeds/README.md
+              - Overview: reference/modules/Users/README.md
+              - Custom User Settings: reference/modules/Users/CustomUserSettings/README.md
+              - Notifications: reference/modules/Notifications/README.md
+              - Ticket store: reference/modules/Users/TicketStore.md
+          - Home Route: reference/modules/HomeRoute/README.md
+          - Feeds: reference/modules/Feeds/README.md
           - Commerce: https://commerce.orchardcore.net/en/latest
       - Core Modules:
-          - Audit Trail: docs/reference/modules/AuditTrail/README.md
-          - Auto Setup: docs/reference/modules/AutoSetup/README.md
-          - Features: docs/reference/modules/Features/README.md
-          - Contents: docs/reference/modules/Contents/README.md
-          - Configuration: docs/reference/core/Configuration/README.md
-          - Cors: docs/reference/modules/Cors/README.md
-          - Custom Settings: docs/reference/modules/CustomSettings/README.md
-          - Deployment: docs/reference/modules/Deployment/README.md
-          - Placement: docs/reference/core/Placement/README.md
-          - Data: docs/reference/core/Data/README.md
-          - Data Migrations: docs/reference/modules/Migrations/README.md
-          - Diagnostics: docs/reference/modules/Diagnostics/README.md
-          - Dynamic Cache: docs/reference/modules/DynamicCache/README.md
-          - Email: docs/reference/modules/Email/README.md
-          - SMTP Provider: docs/reference/modules/Email.Smtp/README.md
-          - Azure Email Provider: docs/reference/modules/Email.Azure/README.md
-          - GraphQL: docs/reference/modules/Apis.GraphQL/README.md
-          - GraphQL queries: docs/reference/core/Apis.GraphQL.Abstractions/README.md
-          - Health Check: docs/reference/modules/HealthChecks/README.md
-          - HTTPS: docs/reference/modules/Https/README.md
-          - Key Vault (Azure): docs/reference/core/KeyVault.Azure/README.md
-          - Localization: docs/reference/modules/Localize/README.md
-          - Logging Serilog: docs/reference/core/Logging.Serilog/README.md
-          - Mini Profiler: docs/reference/modules/MiniProfiler/README.md
-          - Modules: docs/reference/core/Modules/README.md
-          - OpenId: docs/reference/modules/OpenId/README.md
-          - Razor Helpers: docs/reference/core/Razor/README.md
-          - Recipes: docs/reference/modules/Recipes/README.md
-          - Redis: docs/reference/modules/Redis/README.md
-          - Remote Deployment: docs/reference/modules/Deployment.Remote/README.md
-          - Response Compression: docs/reference/modules/ResponseCompression/README.md
-          - Roles: docs/reference/modules/Roles/README.md
-          - Sanitizer: docs/reference/core/Sanitizer/README.md
-          - Scripting: docs/reference/modules/Scripting/README.md
-          - Security: docs/reference/modules/Security/README.md
-          - Setup: docs/reference/modules/Setup/README.md
-          - Shells: docs/reference/core/Shells/README.md
-          - Tenants: docs/reference/modules/Tenants/README.md
-          - Workflows: docs/reference/modules/Workflows/README.md
-          - DataProtection (Azure Storage): docs/reference/modules/DataProtection.Azure/README.md
-          - Background Tasks: docs/reference/modules/BackgroundTasks/README.md
-          - Reverse Proxy: docs/reference/modules/ReverseProxy/README.md
+          - Audit Trail: reference/modules/AuditTrail/README.md
+          - Auto Setup: reference/modules/AutoSetup/README.md
+          - Features: reference/modules/Features/README.md
+          - Contents: reference/modules/Contents/README.md
+          - Configuration: reference/core/Configuration/README.md
+          - Cors: reference/modules/Cors/README.md
+          - Custom Settings: reference/modules/CustomSettings/README.md
+          - Deployment: reference/modules/Deployment/README.md
+          - Placement: reference/core/Placement/README.md
+          - Data: reference/core/Data/README.md
+          - Data Migrations: reference/modules/Migrations/README.md
+          - Diagnostics: reference/modules/Diagnostics/README.md
+          - Dynamic Cache: reference/modules/DynamicCache/README.md
+          - Email: reference/modules/Email/README.md
+          - SMTP Provider: reference/modules/Email.Smtp/README.md
+          - Azure Email Provider: reference/modules/Email.Azure/README.md
+          - GraphQL: reference/modules/Apis.GraphQL/README.md
+          - GraphQL queries: reference/core/Apis.GraphQL.Abstractions/README.md
+          - Health Check: reference/modules/HealthChecks/README.md
+          - HTTPS: reference/modules/Https/README.md
+          - Key Vault (Azure): reference/core/KeyVault.Azure/README.md
+          - Localization: reference/modules/Localize/README.md
+          - Logging Serilog: reference/core/Logging.Serilog/README.md
+          - Mini Profiler: reference/modules/MiniProfiler/README.md
+          - Modules: reference/core/Modules/README.md
+          - OpenId: reference/modules/OpenId/README.md
+          - Razor Helpers: reference/core/Razor/README.md
+          - Recipes: reference/modules/Recipes/README.md
+          - Redis: reference/modules/Redis/README.md
+          - Remote Deployment: reference/modules/Deployment.Remote/README.md
+          - Response Compression: reference/modules/ResponseCompression/README.md
+          - Roles: reference/modules/Roles/README.md
+          - Sanitizer: reference/core/Sanitizer/README.md
+          - Scripting: reference/modules/Scripting/README.md
+          - Security: reference/modules/Security/README.md
+          - Setup: reference/modules/Setup/README.md
+          - Shells: reference/core/Shells/README.md
+          - Tenants: reference/modules/Tenants/README.md
+          - Workflows: reference/modules/Workflows/README.md
+          - DataProtection (Azure Storage): reference/modules/DataProtection.Azure/README.md
+          - Background Tasks: reference/modules/BackgroundTasks/README.md
+          - Reverse Proxy: reference/modules/ReverseProxy/README.md
   - Resources:
-      - Learning: docs/resources/README.md
-      - Tutorials: docs/resources/tutorials/README.md
-      - Development Tools: docs/resources/development-tools/README.md
-      - Meeting: docs/resources/meeting/README.md
-      - Branding: docs/resources/branding/README.md
-      - Libraries: docs/resources/libraries/README.md
-      - Owners: docs/resources/owners/README.md
-      - Workshops: docs/resources/workshops/README.md
+      - Learning: resources/README.md
+      - Tutorials: resources/tutorials/README.md
+      - Development Tools: resources/development-tools/README.md
+      - Meeting: resources/meeting/README.md
+      - Branding: resources/branding/README.md
+      - Libraries: resources/libraries/README.md
+      - Owners: resources/owners/README.md
+      - Workshops: resources/workshops/README.md
   - Releases:
-      - 1.8.3: docs/releases/1.8.3.md
-      - 1.8.2: docs/releases/1.8.2.md
-      - 1.8.1: docs/releases/1.8.1.md
-      - 1.8.0: docs/releases/1.8.0.md
-      - 1.7.2: docs/releases/1.7.2.md
-      - 1.7.1: docs/releases/1.7.1.md
-      - 1.7.0: docs/releases/1.7.0.md
-      - 1.6.0: docs/releases/1.6.0.md
-      - 1.5.0: docs/releases/1.5.0.md
-      - 1.4.0: docs/releases/1.4.0.md
-      - 1.3.0: docs/releases/1.3.0.md
-      - 1.2.2: docs/releases/1.2.2.md
-      - 1.2.1: docs/releases/1.2.1.md
-      - 1.2.0: docs/releases/1.2.0.md
-      - 1.1.0: docs/releases/1.1.0.md
-      - 1.0.0: docs/releases/1.0.0.md
-      - 1.0.0-rc2: docs/releases/1.0.0-rc2.md
-      - 1.0.0-rc1: docs/releases/1.0.0-rc1.md
-      - 1.0.0-beta3: docs/releases/1.0.0-beta3.md
-      - 1.0.0-beta2: docs/releases/1.0.0-beta2.md
-      - 1.0.0-beta1: docs/releases/1.0.0-beta1.md
+      - 1.8.3: releases/1.8.3.md
+      - 1.8.2: releases/1.8.2.md
+      - 1.8.1: releases/1.8.1.md
+      - 1.8.0: releases/1.8.0.md
+      - 1.7.2: releases/1.7.2.md
+      - 1.7.1: releases/1.7.1.md
+      - 1.7.0: releases/1.7.0.md
+      - 1.6.0: releases/1.6.0.md
+      - 1.5.0: releases/1.5.0.md
+      - 1.4.0: releases/1.4.0.md
+      - 1.3.0: releases/1.3.0.md
+      - 1.2.2: releases/1.2.2.md
+      - 1.2.1: releases/1.2.1.md
+      - 1.2.0: releases/1.2.0.md
+      - 1.1.0: releases/1.1.0.md
+      - 1.0.0: releases/1.0.0.md
+      - 1.0.0-rc2: releases/1.0.0-rc2.md
+      - 1.0.0-rc1: releases/1.0.0-rc1.md
+      - 1.0.0-beta3: releases/1.0.0-beta3.md
+      - 1.0.0-beta2: releases/1.0.0-beta2.md
+      - 1.0.0-beta1: releases/1.0.0-beta1.md
   - Community:
-      - Overview: docs/community/README.md
+      - Overview: community/README.md
       - Contributors:
-          - Our wonderful contributors: docs/community/contributors/README.md
-          - Contributors Map: docs/community/contributors/Map.md
+          - Our wonderful contributors: community/contributors/README.md
+          - Contributors Map: community/contributors/Map.md
       - Honorable Members:
-          - Jean-Thierry Kéchichian: docs/community/jean-thierry/README.md
-      - Jean-Thierry Kéchichian Community Award: docs/community/jean-thierry-community-award/README.md
+          - Jean-Thierry Kéchichian: community/jean-thierry/README.md
+      - Jean-Thierry Kéchichian Community Award: community/jean-thierry-community-award/README.md

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -44,7 +44,7 @@ Orchard Core CMS is a complete rewrite of Orchard CMS on ASP.NET Core. It’s no
 
 
 !!! tip
-    Check out [the Reference of Built-in Modules](docs/reference/README.md) to see what kind of features Orchard Core provides built-in.
+    Check out [the Reference of Built-in Modules](reference/README.md) to see what kind of features Orchard Core provides built-in.
 
 ## Different website building strategies
 
@@ -58,11 +58,11 @@ Orchard Core CMS supports all major site building strategies:
 
 ## Status
 
-The latest released version of Orchard Core is `1.8.3`. The release notes can be found under [Releases](docs/releases/1.8.3.md).
+The latest released version of Orchard Core is `1.8.3`. The release notes can be found under [Releases](releases/1.8.3.md).
 
 ## Getting Started
 
-- See [our getting started guide](docs/getting-started/README.md) or [test drive Orchard Core](docs/getting-started/test-drive-orchard-core.md).
+- See [our getting started guide](getting-started/README.md) or [test drive Orchard Core](getting-started/test-drive-orchard-core.md).
 - Watch the [ASP.NET Community Standup video where Orchard Core was demonstrated](https://www.youtube.com/watch?v=HeDjv3blBjQ&t=2246s&list=PL1rZQsJPBU2StolNg0aqvQswETPcYnNKL&index=24).
 - Follow the samples on <https://github.com/OrchardCMS/OrchardCore.Samples> that will guide you on how to build **modular** and **multi-tenant** applications
 - Follow the tutorial inside the [Training Demo Module](https://github.com/Lombiq/Orchard-Training-Demo-Module) to learn how to develop Orchard Core modules.

--- a/src/docs/community/contributors/README.md
+++ b/src/docs/community/contributors/README.md
@@ -12,6 +12,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 !!! tip
     You can add new contributors by [using the All Contributors bot](https://allcontributors.org/docs/en/bot/usage).
 
+<a id="contributors-"></a>
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->

--- a/src/docs/community/contributors/README.md
+++ b/src/docs/community/contributors/README.md
@@ -12,6 +12,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 !!! tip
     You can add new contributors by [using the All Contributors bot](https://allcontributors.org/docs/en/bot/usage).
 
+<!-- This is for the auto-generated All Contributors badge to point somewhere. -->
 <a id="contributors-"></a>
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->

--- a/src/docs/guides/contributing/contributing-documentation.md
+++ b/src/docs/guides/contributing/contributing-documentation.md
@@ -33,7 +33,7 @@ With MkDocs you can get the full docs.orchardcore.net experience locally too. If
 1. Follow the [MkDocs installation guide](https://www.mkdocs.org/user-guide/installation/) to install Python, PIP and MkDocs. If you already have a fresh enough Python installation, you can simply run `pip install mkdocs`.
 2. Open a command line in the root of your clone of the repository.
 3. Run `pip install -r src/docs/requirements.txt` to install dependencies.
-4. Run `python -m mkdocs serve` to start the site. You'll then be able to browse it under <http://127.0.0.1:8000>. If you use Visual Studio under Windows, we recommend NOT running the command from a Windows PowerShell prompt opened from Visual Studio's Solution Explorer. Instead, open CMD or a PowerShell 7+ window; for some reason, the MkDocs build is really slow under Windows PowerShell.
+4. Run `python -m mkdocs serve` to start the site. You'll then be able to browse it under <http://127.0.0.1:8000>.
 
 ## Submitting a pull request and gathering feedback
 

--- a/src/docs/reference/core/Modules/README.md
+++ b/src/docs/reference/core/Modules/README.md
@@ -54,7 +54,7 @@ Next, within `Startup.cs`, modify the method `ConfigureServices` to look like th
 
 Asp.Net Mvc is now part of your pipeline.
 
-You can find a sample application here: [`OrchardCore.Mvc.Web`](../../../../OrchardCore.Mvc.Web/Program.cs)
+You can find a sample application here: [`OrchardCore.Mvc.Web`](https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Mvc.Web/Program.cs)
 
 ## Configuration
 

--- a/src/docs/reference/modules/Contents/README.md
+++ b/src/docs/reference/modules/Contents/README.md
@@ -242,7 +242,7 @@ The available options depend on the scalar and part fields defined on the type i
 ##### Single Filters
 
 If you supply exactly one parameter to the `where` argument, the query response will only contain content items that adhere to this constraint.  
-Multiple filters can be combined using `AND` and/or `OR`, see [below](#arbitrary-combination-of-filters-with-and-and-or) for more details.
+Multiple filters can be combined using `AND` and/or `OR`, see [below](#arbitrary-combination-of-filters-with-and-or-and-not) for more details.
 
 ##### Filtering by a publication status
 

--- a/src/docs/reference/modules/Resources/README.md
+++ b/src/docs/reference/modules/Resources/README.md
@@ -466,7 +466,7 @@ The style block will only be injected once based on its name and can optionally 
 
 #### Link tag
 
-A link tag is used to define the relationship between the current document and an external resource such as a favicon or stylesheet. For a stylesheet, however, use the [style helper](#register-a-named-script).
+A link tag is used to define the relationship between the current document and an external resource such as a favicon or stylesheet. For a stylesheet, however, use the [style helper](#register-a-named-script-or-stylesheet).
 
 === "Liquid"
 

--- a/src/docs/reference/modules/Themes/README.md
+++ b/src/docs/reference/modules/Themes/README.md
@@ -102,7 +102,7 @@ Each of these drivers return one or more shapes that are added to named zones (o
 
 For instance the `TitleDisplayDriver` class will return a shape of type `TitlePart` in the `Header` zone of the main shape at position `5`. See [`TitlePartDisplayDriver`](https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplayDriver.cs)
 
-Then the `BagPart` shape is added in the `Content` zone of the main shape at the position `5`. See [BagPartDisplayDriver](https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs).
+Then the `BagPart` shape is added in the `Content` zone of the main shape at the position `5`. See [`BagPartDisplayDriver`](https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs).
 
 Once all the drivers for all the parts and all the fields have returned their shapes to specific zones of the main `Content` shape, Orchard will look for a matching template.
 Template matching is done dynamically, and if no specific ones are created for a Content Type, then the file `Content.cshtml` (or `Content.liquid`) is used.  

--- a/src/docs/reference/modules/Themes/README.md
+++ b/src/docs/reference/modules/Themes/README.md
@@ -100,14 +100,14 @@ The __Bag__ part will invoke all available display drivers recursively, to rende
 
 Each of these drivers return one or more shapes that are added to named zones (or sections) of a global __Shape__ called the `Content` shape.
 
-For instance the `TitleDisplayDriver` class will return a shape of type `TitlePart` in the `Header` zone of the main shape at position `5`. See [TitlePartDisplayDriver](../../../../OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplayDriver.cs#L14-L20)
+For instance the `TitleDisplayDriver` class will return a shape of type `TitlePart` in the `Header` zone of the main shape at position `5`. See [`TitlePartDisplayDriver`](https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplayDriver.cs)
 
-Then the `BagPart` shape is added in the `Content` zone of the main shape at the position `5`. See [BagPartDisplayDriver](../../../../OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs#L39-L45).
+Then the `BagPart` shape is added in the `Content` zone of the main shape at the position `5`. See [BagPartDisplayDriver](https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs).
 
 Once all the drivers for all the parts and all the fields have returned their shapes to specific zones of the main `Content` shape, Orchard will look for a matching template.
 Template matching is done dynamically, and if no specific ones are created for a Content Type, then the file `Content.cshtml` (or `Content.liquid`) is used.  
 The default template will go over all the zones it knows about and render the shapes that are inside each of them.  
-See [Header](../../../../OrchardCore.Modules/OrchardCore.Contents/Views/Content.cshtml#L17) where the `Header` zone shapes are rendered (the `TitlePart` shape) and also [Content](../../../../OrchardCore.Modules/OrchardCore.Contents/Views/Content.cshtml#L24) where the `Content` zone shapes are rendered (`BagPart` and `TextField` shapes).
+See [the source file](https://github.com/OrchardCMS/OrchardCore/blob/main/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.cshtml) where the `Header` zone shapes are rendered (the `TitlePart` shape) and also `Content` where the `Content` zone shapes are rendered (`BagPart` and `TextField` shapes).
 
 ## Customizing templates
 

--- a/src/docs/topics/configuration/README.md
+++ b/src/docs/topics/configuration/README.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Orchard Core allows you to create your own setup templates (know as [Recipes](../../glossary/README.md#recipe)) and configure your [Tenants](../../glossary/README.md#tenant) individually.
+Orchard Core allows you to create your own setup templates (known as [Recipes](../../glossary/README.md#recipe)) and configure your [Tenants](../../glossary/README.md#tenant) individually.
 
 ## Configure your Orchard Core instance
 

--- a/src/docs/topics/configuration/README.md
+++ b/src/docs/topics/configuration/README.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Orchard Core allows you to create your own setup templates (know as [Recipes](../../glossary/README.md#Recipe)) and configure your [Tenants](../../glossary/README.md#Tenant) individually.
+Orchard Core allows you to create your own setup templates (know as [Recipes](../../glossary/README.md#recipe)) and configure your [Tenants](../../glossary/README.md#tenant) individually.
 
 ## Configure your Orchard Core instance
 

--- a/src/docs/topics/display/README.md
+++ b/src/docs/topics/display/README.md
@@ -1,6 +1,6 @@
 # Display
 
-Orchard Core allows you to customize the look and feel of your application by integrating your own [theme](../../glossary/README.md#Theme) or by overriding the rendering of the [templates](../../glossary/README.md#Template) in Razor or Liquid syntax.
+Orchard Core allows you to customize the look and feel of your application by integrating your own [theme](../../glossary/README.md#theme) or by overriding the rendering of the [templates](../../glossary/README.md#template) in Razor or Liquid syntax.
 
 ## Customize your Display
 

--- a/src/docs/topics/search/README.md
+++ b/src/docs/topics/search/README.md
@@ -1,6 +1,6 @@
 # Search
 
-Orchard Core allows you to define the information to [index](../../glossary/README.md#Indexing) and to [query](../../glossary/README.md#Query) them in order to provide an integrated Search experience.
+Orchard Core allows you to define the information to [index](../../glossary/README.md#indexing) and to [query](../../glossary/README.md#query) them in order to provide an integrated Search experience.
 
 ## Query and Search
 

--- a/src/docs/topics/search/README.md
+++ b/src/docs/topics/search/README.md
@@ -1,6 +1,6 @@
 # Search
 
-Orchard Core allows you to define the information to [index](../../glossary/README.md#indexing) and to [query](../../glossary/README.md#query) them in order to provide an integrated Search experience.
+Orchard Core allows you to define the information to [index](../../glossary/README.md#indexing) and to [query](../../glossary/README.md#query) them to provide an integrated Search experience.
 
 ## Query and Search
 


### PR DESCRIPTION
There were some INFO console entries coming from the docs build, see e.g. [here](https://github.com/OrchardCMS/OrchardCore/actions/runs/8840561092/job/24276122110#step:4:7). This PR fixes those and with stricter validation makes the build check for more issues, preventing further mistakes. By configuring MkDocs to only consider the actual `src/docs` folder the docs site's folder, the docs site build is much faster too (most notably under Windows).