### PR TITLE
Fix docs broken logo and redirect from old URLs (Lombiq Technologies: OCORE-165)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/docs/guides/contributing/. -->
+<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->

--- a/.github/workflows/assets_validation.yml
+++ b/.github/workflows/assets_validation.yml
@@ -31,7 +31,7 @@ jobs:
 
         if ($changes)
         {
-            Write-Output 'Please make sure to build the assets properly before pushing, see https://docs.orchardcore.net/en/latest/docs/guides/gulp-pipeline/.'
+            Write-Output 'Please make sure to build the assets properly before pushing, see https://docs.orchardcore.net/en/latest/guides/gulp-pipeline/.'
             Write-Output 'The following files changed:'
             Write-Output $changes
             Write-Output 'You can also download the attached artifact to see the changes.'

--- a/.github/workflows/first_time_contributor.yml
+++ b/.github/workflows/first_time_contributor.yml
@@ -22,7 +22,7 @@ jobs:
           request or bug report. A core team member will review your issue and get back to you.
         FIRST_PR_COMMENT: >
           Thank you for submitting your first pull request, awesome! 🚀 If you haven't already, please take a moment 
-          to review our [contribution guide](https://docs.orchardcore.net/en/latest/docs/guides/contributing/). This 
+          to review our [contribution guide](https://docs.orchardcore.net/en/latest/guides/contributing/). This 
           guide provides helpful information to ensure your contribution aligns with our standards. A core team member 
           will review your pull request.
         FIRST_PR_MERGED_COMMENT: >

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-See [Contributing to Orchard Core](https://docs.orchardcore.net/en/latest/docs/guides/contributing/) on the documentation site.
+See [Contributing to Orchard Core](https://docs.orchardcore.net/en/latest/guides/contributing/) on the documentation site.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # How to contribute
 
-See [Contributing to Orchard Core](https://docs.orchardcore.net/en/latest/docs/guides/contributing/) on the documentation site.
+See [Contributing to Orchard Core](https://docs.orchardcore.net/en/latest/guides/contributing/) on the documentation site.

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Nightly (`main`):
 
 The software is production-ready, and capable of serving large mission-critical applications as well, and we're not aware of any fundamental bugs or missing features we deem crucial. Orchard Core continues to evolve, with each version bringing new improvements, and keeping up with the cutting-edge of .NET.
 
-Check out [the Reference of Built-in Modules](https://docs.orchardcore.net/en/latest/docs/reference/) to see what kind of features Orchard Core provides built-in.
+Check out [the Reference of Built-in Modules](https://docs.orchardcore.net/en/latest/reference/) to see what kind of features Orchard Core provides built-in.
 
 See the [issue milestones](https://github.com/OrchardCMS/OrchardCore/milestones) for information on what we have planned for the next releases and what are the priorities.
 
 ## Getting Started and Documentation
 
-The documentation can be accessed under <https://docs.orchardcore.net/>. See the homepage for an overview, and [the getting started docs](https://docs.orchardcore.net/en/latest/docs/getting-started/) on how to start building apps with Orchard Core. If you'd just like to test drive Orchard Core as a user, check out [Test drive Orchard Core](https://docs.orchardcore.net/en/latest/docs/getting-started/test-drive-orchard-core/).
+The documentation can be accessed under <https://docs.orchardcore.net/>. See the homepage for an overview, and [the getting started docs](https://docs.orchardcore.net/en/latest/getting-started/) on how to start building apps with Orchard Core. If you'd just like to test drive Orchard Core as a user, check out [Test drive Orchard Core](https://docs.orchardcore.net/en/latest/getting-started/test-drive-orchard-core/).
 
 ## Help and Support
 
@@ -54,25 +54,25 @@ Do you need some help with Orchard Core? Don't worry, there are ways to get help
 
 中文资源
 
-[![Orchard Core CN 中文讨论组](https://docs.orchardcore.net/en/latest/docs/assets/images/orchard-core-cn-community-logo.png)](https://shang.qq.com/wpa/qunwpa?idkey=48721591a71ee7586316604a7a4ee99d26fd977c6120370a06585085a5936f62)
+[![Orchard Core CN 中文讨论组](https://docs.orchardcore.net/en/latest/assets/images/orchard-core-cn-community-logo.png)](https://shang.qq.com/wpa/qunwpa?idkey=48721591a71ee7586316604a7a4ee99d26fd977c6120370a06585085a5936f62)
 
 ## Contributing
 
-It's great that you're thinking about contributing to Orchard Core! You'd join [our wonderful community of contributors](https://docs.orchardcore.net/en/latest/docs/community/).
+It's great that you're thinking about contributing to Orchard Core! You'd join [our wonderful community of contributors](https://docs.orchardcore.net/en/latest/community/).
 
-Check out the docs [on contributing to Orchard Core](https://docs.orchardcore.net/en/latest/docs/guides/contributing/).
+Check out the docs [on contributing to Orchard Core](https://docs.orchardcore.net/en/latest/guides/contributing/).
 
 ## Preview Package Feed
 
 [![Hosted By: Cloudsmith](https://img.shields.io/badge/OSS%20hosting%20by-cloudsmith-blue?logo=cloudsmith&style=for-the-badge)](https://cloudsmith.com)
 
-NuGet package repository hosting for the preview feed is graciously provided by [Cloudsmith](https://cloudsmith.com). Check out [the docs on using the preview package feed](https://docs.orchardcore.net/en/latest/docs/getting-started/preview-package-source/).
+NuGet package repository hosting for the preview feed is graciously provided by [Cloudsmith](https://cloudsmith.com). Check out [the docs on using the preview package feed](https://docs.orchardcore.net/en/latest/getting-started/preview-package-source/).
 
 Cloudsmith is the only fully hosted, cloud-native, universal package management solution, that enables your organization to create, store, and share packages in any format, to any place, with total confidence.
 
 ## Code of Conduct
 
-See [our Code of Conduct](https://docs.orchardcore.net/en/latest/docs/guides/contributing/#code-of-conduct).
+See [our Code of Conduct](https://docs.orchardcore.net/en/latest/guides/contributing/#code-of-conduct).
 
 ## .NET Foundation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,8 @@ site_name: Orchard Core Documentation
 theme:
   name: material
   custom_dir: src/docs/theme
-  logo: docs/assets/images/orchard-logo.png
-  favicon: docs/assets/images/favicon.png
+  logo: assets/images/orchard-logo.png
+  favicon: assets/images/favicon.png
   features:
     - navigation.footer
     - header.autohide

--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -7,36 +7,36 @@
   },
   //"AllowedHosts": "example.com;localhost", // A semicolon-delimited list of host names without port numbers. Set it for public-facing edge servers or when the Host header is directly forwarded.
   "OrchardCore": {
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Admin/#custom-admin-prefix
+    // See https://docs.orchardcore.net/en/latest/reference/modules/Admin/#custom-admin-prefix
     //"OrchardCore_Admin": {
     //   "AdminUrlPrefix": "Admin"
     // },
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/ContentLocalization/#configuration to configure content localization.
+    // See https://docs.orchardcore.net/en/latest/reference/modules/ContentLocalization/#configuration to configure content localization.
     //"OrchardCore_ContentLocalization_CulturePickerOptions": {
     //  "CookieLifeTime": 14 // Set the culture picker cookie life time (in days).
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/core/Data/#sqlite.
+    // See https://docs.orchardcore.net/en/latest/reference/core/Data/#sqlite.
     //"OrchardCore_Data_Sqlite": {
     //  "UseConnectionPooling": false
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/core/Data/#database-table to configure database table presets used before a given tenant is setup.
+    // See https://docs.orchardcore.net/en/latest/reference/core/Data/#database-table to configure database table presets used before a given tenant is setup.
     //"OrchardCore_Data_TableOptions": {
     //  "DefaultDocumentTable": "Document", // Document table name, defaults to 'Document'.
     //  "DefaultTableNameSeparator": "_", // Table name separator, one or multiple '_', "NULL" means no separator, defaults to '_'.
     //  "DefaultIdentityColumnSize": "Int64" // Identity column size, 'Int32' or 'Int64', defaults to 'Int64'.
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/DataProtection.Azure/#configuration to configure data protection key storage in Azure Blob Storage.
+    // See https://docs.orchardcore.net/en/latest/reference/modules/DataProtection.Azure/#configuration to configure data protection key storage in Azure Blob Storage.
     //"OrchardCore_DataProtection_Azure": {
     //  "ConnectionString": "", // Set to your Azure Storage account connection string.
     //  "ContainerName": "dataprotection", // Default to dataprotection. Templatable, refer to docs.
     //  "BlobName": "", // Optional, defaults to Sites/tenant_name/DataProtectionKeys.xml. Templatable, refer to docs.
     //  "CreateContainer": true // Creates the container during app startup if it does not already exist.
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Markdown/#markdown-configuration
+    // See https://docs.orchardcore.net/en/latest/reference/modules/Markdown/#markdown-configuration
     //"OrchardCore_Markdown": {
     //  "Extensions": "nohtml+advanced"
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Media/#configuration to configure media.
+    // See https://docs.orchardcore.net/en/latest/reference/modules/Media/#configuration to configure media.
     //"OrchardCore_Media": {
     //  "SupportedSizes": [ 16, 32, 50, 100, 160, 240, 480, 600, 1024, 2048 ],
     //  "MaxBrowserCacheDays": 30,
@@ -54,7 +54,7 @@
     //  "MaxUploadChunkSize": 104857600,
     //  "TemporaryFileLifetime": "01:00:00"
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Media.AmazonS3/#configuration to configure media storage in Amazon S3 Storage.
+    // See https://docs.orchardcore.net/en/latest/reference/modules/Media.AmazonS3/#configuration to configure media storage in Amazon S3 Storage.
     //"OrchardCore_Media_AmazonS3": {
     //  "Region": "eu-central-1",
     //  "Profile": "default",
@@ -68,7 +68,7 @@
     //  "RemoveBucket": true, // Whether the 'Bucket' is deleted if the tenant is removed, false by default.
     //  "BucketName": "media" // Set the bucket's name (mandatory). Templatable, refer to docs.
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Media.AmazonS3/#configuration_1 to configure media storage in Amazon S3 Storage.
+    // See https://docs.orchardcore.net/en/latest/reference/modules/Media.AmazonS3/#configuration_1 to configure media storage in Amazon S3 Storage.
     //"OrchardCore_Media_AmazonS3_ImageSharp_Cache": {
     //  "Region": "eu-central-1",
     //  "Profile": "default",
@@ -82,7 +82,7 @@
     //  "RemoveBucket": true, // Whether the 'Bucket' is deleted if the tenant is removed, false by default.
     //  "BucketName": "imagesharp" // Set the bucket's name (mandatory). Templatable, refer to docs.
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Media.Azure/#configuration to configure media storage in Azure Blob Storage.
+    // See https://docs.orchardcore.net/en/latest/reference/modules/Media.Azure/#configuration to configure media storage in Azure Blob Storage.
     //"OrchardCore_Media_Azure": {
     //  "ConnectionString": "", // Set to your Azure Storage account connection string.
     //  "ContainerName": "somecontainer", // Set to the Azure Blob container name. Templatable, refer to docs.
@@ -104,13 +104,13 @@
     //  "InstancePrefix": "", // Optional prefix allowing a Redis instance to be shared by different applications.
     //  "DisableCertificateVerification": false // Disable SSL/TLS certificate verification.
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Security/#security-settings-configuration to configure security settings.
+    // See https://docs.orchardcore.net/en/latest/reference/modules/Security/#security-settings-configuration to configure security settings.
     //"OrchardCore_Security": {
     //  "ContentSecurityPolicy": {},
     //  "PermissionsPolicy": { "fullscreen": "self" },
     //  "ReferrerPolicy": "no-referrer"
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/core/Shells/#enable-azure-shells-configuration to configure shell and tenant configuration in Azure Blob Storage.
+    // See https://docs.orchardcore.net/en/latest/reference/core/Shells/#enable-azure-shells-configuration to configure shell and tenant configuration in Azure Blob Storage.
     // Add a reference to the OrchardCore.Shells.Azure NuGet package.
     // Add '.AddAzureShellsConfiguration()' to your Host Startup AddOrchardCms() section.
     //"OrchardCore_Shells_Azure": {
@@ -119,7 +119,7 @@
     //  "BasePath": "some/base/path", // Optionally, set to a subdirectory inside your container.
     //  "MigrateFromFiles": true // Optionally, enable to migrate existing App_Data files to Blob automatically.
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/core/Shells/#enable-database-shells-configuration to configure shell and tenant configuration in the database store.
+    // See https://docs.orchardcore.net/en/latest/reference/core/Shells/#enable-database-shells-configuration to configure shell and tenant configuration in the database store.
     // Add '.AddDatabaseShellsConfiguration()' to your Host Startup AddOrchardCms() section.
     //"OrchardCore_Shells_Database": {
     //  "DatabaseProvider": "SqlConnection", // Set to a supported database provider.
@@ -136,7 +136,7 @@
     //  "KeyVaultName": "", // Set the name of your Azure Key Vault.
     //  "ReloadInterval": null // Optional, timespan to wait between attempts at polling the Azure KeyVault for changes. Leave blank to disable reloading.
     //},
-    // See https://docs.orchardcore.net/en/latest/docs/reference/modules/Users/Configuration/#custom-paths
+    // See https://docs.orchardcore.net/en/latest/reference/modules/Users/Configuration/#custom-paths
     //"OrchardCore_Users": {
     //  "LoginPath": "Login",
     //  "LogoffPath": "Users/LogOff",

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Options.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/Admin/Options.cshtml
@@ -7,7 +7,7 @@
 
 <p class="alert alert-secondary">
     @T["Media is configured with appsettings.json."]
-    <a class="seedoc" href="https://docs.orchardcore.net/en/latest/docs/reference/modules/Media/#configuration" target="_blank">@T["See documentation"]</a>
+    <a class="seedoc" href="https://docs.orchardcore.net/en/latest/reference/modules/Media/#configuration" target="_blank">@T["See documentation"]</a>
 </p>
 
 <div class="mb-3 row">

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Manifest.cs
@@ -26,7 +26,7 @@ using OrchardCore.Modules.Manifest;
 [assembly: Feature(
     Id = "OrchardCore.Tenants.Distributed",
     Name = "Distributed Tenants",
-    Description = "Keeps in sync tenants states, needs a distributed cache e.g. 'Redis Cache' and a stateless configuration, see: https://docs.orchardcore.net/en/latest/docs/reference/core/Shells/index.html",
+    Description = "Keeps in sync tenants states, needs a distributed cache e.g. 'Redis Cache' and a stateless configuration, see: https://docs.orchardcore.net/en/latest/reference/core/Shells/index.html",
     Category = "Distributed",
     DefaultTenantOnly = true
 )]

--- a/src/OrchardCore/OrchardCore.Admin.Abstractions/Constants.cs
+++ b/src/OrchardCore/OrchardCore.Admin.Abstractions/Constants.cs
@@ -3,6 +3,6 @@ namespace OrchardCore.Admin
 {
     public static class Constants
     {
-        public const string DocsUrl = "https://docs.orchardcore.net/en/latest/docs/";
+        public const string DocsUrl = "https://docs.orchardcore.net/en/latest/";
     }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Options/SqliteOptions.cs
@@ -2,7 +2,7 @@ namespace OrchardCore.Data
 {
     /// <summary>
     /// Sqlite-specific configuration for the Orchard Core database. 
-    /// See <see href="https://docs.orchardcore.net/en/latest/docs/reference/core/Data/#sqlite" />.
+    /// See <see href="https://docs.orchardcore.net/en/latest/reference/core/Data/#sqlite" />.
     /// </summary>
     public class SqliteOptions
     {

--- a/src/docs/topics/publishing-releases/README.md
+++ b/src/docs/topics/publishing-releases/README.md
@@ -36,11 +36,11 @@ Update the source so everything looks like on the new version.
 Make sure everything works all right.
 
 - [ ] Make sure that [`OrchardCore.Samples` works](https://github.com/OrchardCMS/OrchardCore.Samples).
-- [ ] Test the [guides](https://docs.orchardcore.net/en/latest/docs/guides/) with the NuGet packages from the Cloudsmith feed (branches under `release/` are automatically published too). Test at least the following guides:
-    - [Creating a modular ASP.NET Core application](https://docs.orchardcore.net/en/latest/docs/guides/create-modular-application-mvc/)
-    - [Creating an Orchard Core CMS website](https://docs.orchardcore.net/en/latest/docs/guides/create-cms-application/)
-    - [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/docs/guides/decoupled-cms/)
-- [ ] If there's a more recent major version of Red Hat Enterprise Linux (like v10 after v9) that Orchard Core was certified for, then re-certify it. See Orchard's [Red Hat Ecosystem Catalog profile](https://catalog.redhat.com/software/applications/detail/223797) for the version it was certified for, the [Red hat Customer Portal](https://access.redhat.com/articles/3078) for the latest released version, and [https://docs.orchardcore.net/en/latest/docs/topics/red-hat-ecosystem-catalog-certification/](our certification guide) for the steps to renew the certification.
+- [ ] Test the [guides](https://docs.orchardcore.net/en/latest/guides/) with the NuGet packages from the Cloudsmith feed (branches under `release/` are automatically published too). Test at least the following guides:
+    - [Creating a modular ASP.NET Core application](https://docs.orchardcore.net/en/latest/guides/create-modular-application-mvc/)
+    - [Creating an Orchard Core CMS website](https://docs.orchardcore.net/en/latest/guides/create-cms-application/)
+    - [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/)
+- [ ] If there's a more recent major version of Red Hat Enterprise Linux (like v10 after v9) that Orchard Core was certified for, then re-certify it. See Orchard's [Red Hat Ecosystem Catalog profile](https://catalog.redhat.com/software/applications/detail/223797) for the version it was certified for, the [Red hat Customer Portal](https://access.redhat.com/articles/3078) for the latest released version, and [https://docs.orchardcore.net/en/latest/topics/red-hat-ecosystem-catalog-certification/](our certification guide) for the steps to renew the certification.
 
 ### Prepare and publish Orchard Core Translations
 
@@ -68,17 +68,17 @@ Do the harder parts of making the release public. This should come after everyth
     - Merges to `main` need two approvals so you'll need to create a pull request.
     - Merge it as a merge commit, not squash merge.
 - [ ] Publish the Draft release.
-- [ ] Test the [guides](https://docs.orchardcore.net/en/latest/docs/guides/) with the packages now automatically published to NuGet. Test at least the following guides:
-    - [Creating a modular ASP.NET Core application](https://docs.orchardcore.net/en/latest/docs/guides/create-modular-application-mvc/)
-    - [Creating an Orchard Core CMS website](https://docs.orchardcore.net/en/latest/docs/guides/create-cms-application/)
-    - [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/docs/guides/decoupled-cms/)
+- [ ] Test the [guides](https://docs.orchardcore.net/en/latest/guides/) with the packages now automatically published to NuGet. Test at least the following guides:
+    - [Creating a modular ASP.NET Core application](https://docs.orchardcore.net/en/latest/guides/create-modular-application-mvc/)
+    - [Creating an Orchard Core CMS website](https://docs.orchardcore.net/en/latest/guides/create-cms-application/)
+    - [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/)
 - [ ] Update [Try Orchard Core](https://github.com/OrchardCMS/TryOrchardCore).
 
 ### Publicize the release
 
 Let the whole world know about our shiny new release. Savor this part! These steps will make the release public so only do them once everything else is ready.
 
-- [ ] Update the documentation to mention the version in all places where the latest version is referenced, for example, but not limited to (do a search for the package version string): [Status in the root README](https://docs.orchardcore.net/en/latest/#status), CLI templates, commands, the [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/docs/guides/decoupled-cms/) guide.
+- [ ] Update the documentation to mention the version in all places where the latest version is referenced, for example, but not limited to (do a search for the package version string): [Status in the root README](https://docs.orchardcore.net/en/latest/#status), CLI templates, commands, the [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/) guide.
 - [ ] Update the tagged [release](https://github.com/OrchardCMS/OrchardCore/releases) on GitHub: Change its title to something more descriptive (e.g. "Orchard Core 1.0.0 RC 2"), add a link in its description to the release notes in the documentation (something like `For details on this version see the [release notes in the documentation](link here).`).
 - [ ] Tweet
 - [ ] Post to the [Orchard Core LinkedIn group](https://www.linkedin.com/groups/13605669/)

--- a/test/OrchardCore.Tests.Functional/cypress-commands/README.md
+++ b/test/OrchardCore.Tests.Functional/cypress-commands/README.md
@@ -32,7 +32,7 @@ First thing to do to use this package is to add the credentials to be used to in
 
 ### Orchard default tenant 
 
-This library assumes that you will be testing OrchardCore by leveraging the [Tenants](https://docs.orchardcore.net/en/latest/docs/glossary/#tenant) feature. You **must** create a test that runs first and sets up the Default tenant using the [Software as a service ](https://docs.orchardcore.net/en/dev/docs/getting-started/starter-recipes/#saas-recipe-with-thetheme) setup recipe.
+This library assumes that you will be testing OrchardCore by leveraging the [Tenants](https://docs.orchardcore.net/en/latest/glossary/#tenant) feature. You **must** create a test that runs first and sets up the Default tenant using the [Software as a service ](https://docs.orchardcore.net/en/latest/getting-started/starter-recipes/#saas-recipe-with-thetheme) setup recipe.
 
 To do so we suggest you create a test named `integration\000-setup-saas-site.js` with the following contents.
 


### PR DESCRIPTION
I've broken the logo on the docs page in https://github.com/OrchardCMS/OrchardCore/pull/15887, ironically, and fixing that here (didn't realize that `docs_dir` also affects the public URLs).

![image](https://github.com/OrchardCMS/OrchardCore/assets/1976647/af4d9e10-3365-4bd9-9958-05494800f907)

Also, due to the same thing, docs URLs including the /docs prefix were broken; I've added a redirect rule for that under https://readthedocs.org/dashboard/orchardcore/redirects/. So, all old links continue to work, but I've updated them in the repo.

This isn't how I wanted to do this, sorry about it.