### PR TITLE
Fix eagerly executed task in CustomSettingService

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/Services/CustomSettingsService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/Services/CustomSettingsService.cs
@@ -33,7 +33,7 @@ namespace OrchardCore.CustomSettings.Services
             _httpContextAccessor = httpContextAccessor;
             _authorizationService = authorizationService;
             _contentDefinitionManager = contentDefinitionManager;
-            _settingsTypes = new Lazy<Task<IDictionary<string, ContentTypeDefinition>>>(GetContentTypeAsync());
+            _settingsTypes = new Lazy<Task<IDictionary<string, ContentTypeDefinition>>>(GetContentTypeAsync);
         }
 
         public async Task<IEnumerable<string>> GetAllSettingsTypeNamesAsync()


### PR DESCRIPTION
Fix #15794
Fix #15628

How I found it:

- I have a local patched version of YesSql that can detect when the same session has been used by two threads by counting when it enters/leaves Save/Flush
- I trigger the debugger when this happens (System.Diagnostics.Debugger.Break) which open VS at that point in debug mode.
- I opened the "Parallel Tasks" window which shows this:

![image](https://github.com/OrchardCMS/OrchardCore/assets/1165805/1dcbdaad-a7aa-4ff6-8503-9471a07bd0e1)

On the right the DocumentManager saved a document (Roles) and this is rooted by an HttpRequest. On the left there is no specific root, which seems weird. So I looked at this `CustomSettingService.GetContentTypeAsync`. Weirdly, it's invoked in a `Lazy<>` in the constructor ...

```c#
_settingsTypes = new Lazy<Task<IDictionary<string, ContentTypeDefinition>>>(GetContentTypeAsync());
```

and this is it, the lazy is initialized with the running Task because the method is invoked directly: `GetContentTypeAsync()`

It used to work, before [this commit](https://github.com/OrchardCMS/OrchardCore/commit/a92ebbffb4c3b23b2ab3d226b92b9bd7a21f35a0#diff-ea8c1c76be7c23ad3c5bf41428a2c62aeec99a40afe00c5a242617aa540aa322) as the code was 

```c#
_settingsTypes = new Lazy<Task<IDictionary<string, ContentTypeDefinition>>>(async () => await GetContentTypeAsync());
```

The important thing is not `async/await` it's the fact that it's a lambda, so `Lazy<>` will invoke it only when `.Value` is called. After the recent change it was actually invoking the `Lazy<T>(T value)` overload which is not lazy at all.

The solution is to have a lambda or a method group, which this PR is doing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the initialization process in settings management to enhance performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->