### PR TITLE
Use CultureInfo.GetCultureInfo() whenever it's possible

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/ViewModels/LocalizationPartViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/ViewModels/LocalizationPartViewModel.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.ContentLocalization.ViewModels
         public string Culture { get; set; }
 
         [BindNever]
-        public CultureInfo CultureInfo { get { return new CultureInfo(Culture); } }
+        public CultureInfo CultureInfo => CultureInfo.GetCultureInfo(Culture);
 
         [BindNever]
         public LocalizationPart LocalizationPart { get; set; }

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceDefinition.cs
@@ -338,7 +338,7 @@ namespace OrchardCore.ResourceManagement
                 return Cultures[selectedIndex];
             }
             // Try parent culture if any.
-            var cultureInfo = new CultureInfo(culture);
+            var cultureInfo = CultureInfo.GetCultureInfo(culture);
             if (cultureInfo.Parent.Name != culture)
             {
                 var selectedCulture = FindNearestCulture(cultureInfo.Parent.Name);

--- a/test/OrchardCore.Tests/Localization/LocalizationManagerTests.cs
+++ b/test/OrchardCore.Tests/Localization/LocalizationManagerTests.cs
@@ -29,7 +29,7 @@ namespace OrchardCore.Tests.Localization
 
             var manager = new LocalizationManager(new[] { _pluralRuleProvider.Object }, new[] { _translationProvider.Object }, _memoryCache);
 
-            var dictionary = manager.GetDictionary(new CultureInfo("cs"));
+            var dictionary = manager.GetDictionary(CultureInfo.GetCultureInfo("cs"));
 
             Assert.Equal("cs", dictionary.CultureName);
             Assert.Equal(PluralizationRule.Czech, dictionary.PluralRule);
@@ -45,7 +45,7 @@ namespace OrchardCore.Tests.Localization
 
             var manager = new LocalizationManager(new[] { _pluralRuleProvider.Object }, new[] { _translationProvider.Object }, _memoryCache);
 
-            var dictionary = manager.GetDictionary(new CultureInfo("cs"));
+            var dictionary = manager.GetDictionary(CultureInfo.GetCultureInfo("cs"));
             var key = new CultureDictionaryRecordKey { MessageId = "ball" };
 
             dictionary.Translations.TryGetValue(key, out var translations);
@@ -69,7 +69,7 @@ namespace OrchardCore.Tests.Localization
 
             var manager = new LocalizationManager(new[] { _pluralRuleProvider.Object, highPriorityRuleProvider.Object }, new[] { _translationProvider.Object }, _memoryCache);
 
-            var dictionary = manager.GetDictionary(new CultureInfo("cs"));
+            var dictionary = manager.GetDictionary(CultureInfo.GetCultureInfo("cs"));
 
             Assert.Equal(dictionary.PluralRule, csPluralRuleOverride);
         }

--- a/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
+++ b/test/OrchardCore.Tests/Localization/PortableObjectStringLocalizerTests.cs
@@ -337,7 +337,7 @@ namespace OrchardCore.Tests.Localization
             SetupDictionary(culture, Array.Empty<CultureDictionaryRecord>());
 
             var localizer = new PortableObjectStringLocalizer("context", _localizationManager.Object, true, _logger.Object);
-            CultureInfo.CurrentUICulture = new CultureInfo(culture);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(culture);
 
             // Act
             var translation = localizer["Hello"];

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Shortcodes/LocaleShortcodeTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Shortcodes/LocaleShortcodeTests.cs
@@ -15,7 +15,7 @@ namespace OrchardCore.Tests.Modules.OrchardCore.Shortcodes
         [InlineData("fr", "foo [locale en]bar[/locale][locale fr]far[/locale] baz", @"foo far baz")]
         public async Task ShouldProcess(string currentCulture, string text, string expected)
         {
-            CultureInfo.CurrentUICulture = new CultureInfo(currentCulture);
+            CultureInfo.CurrentUICulture = CultureInfo.GetCultureInfo(currentCulture);
 
             var localeProvider = new LocaleShortcodeProvider();
             var processor = new ShortcodeService(new IShortcodeProvider[] { localeProvider }, []);


### PR DESCRIPTION
`CultureInfo.GetCultureInfo()` allocates less than `new CultureInfo()` also it's faster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Optimized culture information handling across various modules by replacing direct `CultureInfo` instantiations with `CultureInfo.GetCultureInfo` method calls. This enhances performance and consistency in cultural settings management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->