### PR TITLE
Run Functional Tests - All Databases automatically (Lombiq Technologies: OCORE-167)

### DIFF
--- a/.github/workflows/functional_all_db.yml
+++ b/.github/workflows/functional_all_db.yml
@@ -1,7 +1,9 @@
-name: Functional Tests - all Databases
+name: Functional Tests - All Databases
 on:
   # Manual trigger.
   workflow_dispatch:
+  pull_request_review:
+    types: [submitted]
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
These tests are now only run manually, when somebody feels like it. However, then trying to correlate code changes to new bugs can be a lot harder, as we've seen in the examples of https://github.com/OrchardCMS/OrchardCore/issues/15628 and https://github.com/OrchardCMS/OrchardCore/issues/15794 which would've been caught by these tests.

So, now that [the tests pass](https://github.com/OrchardCMS/OrchardCore/actions/runs/8928042368), this change makes them trigger on PR reviews being submitted (i.e. when somebody requests changes as well as on approve). This is still a soft guard, since you can merge if they fail (should be rare, but they can be flaky) but at least will help us catch such very fundamental bugs earlier.