### PR TITLE
Improve the DefaultShellReleaseManager

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/ShellReleaseRequestContext.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/ShellReleaseRequestContext.cs
@@ -2,5 +2,7 @@ namespace OrchardCore.Environment.Shell.Models;
 
 public class ShellReleaseRequestContext
 {
+    public const string ShellScopeKey = nameof(ShellReleaseRequestContext);
+
     public bool Release { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/ShellReleaseRequestContext.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/ShellReleaseRequestContext.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.Environment.Shell.Models;
+
+public class ShellReleaseRequestContext
+{
+    public bool Release { get; set; }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -130,6 +130,42 @@ namespace OrchardCore.Environment.Shell.Scope
         }
 
         /// <summary>
+        /// Gets a shared item of a given type from the current shell scope.
+        /// </summary>
+        public static bool TryGetValue(object key, out object value)
+        {
+            var current = Current;
+
+            if (current == null)
+            {
+                value = default;
+
+                return false;
+            }
+
+            current._items ??= [];
+
+            return current._items.TryGetValue(key, out value);
+        }
+
+        /// <summary>
+        /// Gets a shared item of a given type from the current shell scope.
+        /// </summary>
+        public static bool TryGetValue<T>(object key, out T value)
+        {
+            if (TryGetValue(key, out var existingValue) && existingValue is T item)
+            {
+                value = item;
+
+                return true;
+            }
+
+            value = default;
+
+            return false;
+        }
+
+        /// <summary>
         /// Gets (or creates) a shared item of a given type from the current shell scope.
         /// </summary>
         public static T GetOrCreate<T>(object key, Func<T> factory)
@@ -500,9 +536,7 @@ namespace OrchardCore.Environment.Shell.Scope
                 }
             }
 
-            var releaseContext = Get<ShellReleaseRequestContext>(nameof(ShellReleaseRequestContext));
-
-            if (releaseContext is not null && releaseContext.Release)
+            if (TryGetValue<ShellReleaseRequestContext>(ShellReleaseRequestContext.ShellScopeKey, out var context) && context.Release)
             {
                 await ShellContext.ReleaseAsync();
             }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OrchardCore.Environment.Cache;
 using OrchardCore.Environment.Shell.Builders;
+using OrchardCore.Environment.Shell.Models;
 using OrchardCore.Modules;
 
 namespace OrchardCore.Environment.Shell.Scope
@@ -497,6 +498,13 @@ namespace OrchardCore.Environment.Shell.Scope
                     },
                     activateShell: false);
                 }
+            }
+
+            var releaseContext = Get<ShellReleaseRequestContext>(nameof(ShellReleaseRequestContext));
+
+            if (releaseContext is not null && releaseContext.Release)
+            {
+                await ShellContext.ReleaseAsync();
             }
         }
 

--- a/src/OrchardCore/OrchardCore/Shell/DefaultShellReleaseManager.cs
+++ b/src/OrchardCore/OrchardCore/Shell/DefaultShellReleaseManager.cs
@@ -7,19 +7,17 @@ public class DefaultShellReleaseManager : IShellReleaseManager
 {
     public void SuspendReleaseRequest()
     {
-        var context = ShellScope.Get<ShellReleaseRequestContext>(nameof(ShellReleaseRequestContext));
-
-        if (context is not null)
+        if (ShellScope.TryGetValue<ShellReleaseRequestContext>(ShellReleaseRequestContext.ShellScopeKey, out var context))
         {
             context.Release = false;
 
-            ShellScope.Set(nameof(ShellReleaseRequestContext), context);
+            ShellScope.Set(ShellReleaseRequestContext.ShellScopeKey, context);
         }
     }
 
     public void RequestRelease()
     {
-        ShellScope.Set(nameof(ShellReleaseRequestContext),
+        ShellScope.Set(ShellReleaseRequestContext.ShellScopeKey,
             new ShellReleaseRequestContext()
             {
                 Release = true


### PR DESCRIPTION
With this change, we manage the release request inside the ShellScope.

Also, we ensure that the release happens after all the deferred tasks are executed. 

Instead of using ShellHost to release the shell, we directly release it using ShellContext.

Follow-up to https://github.com/OrchardCMS/OrchardCore/pull/15875.