### PR TITLE
Add EnableThreadSafetyChecks support and Enable it for all test

### DIFF
--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/YesSqlOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/YesSqlOptions.cs
@@ -15,4 +15,6 @@ public class YesSqlOptions
     public IAccessorFactory VersionAccessorFactory { get; set; }
 
     public IContentSerializer ContentSerializer { get; set; }
+
+    public bool EnableThreadSafetyChecks { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -186,10 +186,11 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 CommandsPageSize = yesSqlOptions.CommandsPageSize,
                 QueryGatingEnabled = yesSqlOptions.QueryGatingEnabled,
+                EnableThreadSafetyChecks = yesSqlOptions.EnableThreadSafetyChecks,
                 TableNameConvention = tableNameFactory.Create(databaseTableOptions),
                 IdentityColumnSize = Enum.Parse<IdentityColumnSize>(databaseTableOptions.IdentityColumnSize),
                 Logger = loggerFactory.CreateLogger("YesSql"),
-                ContentSerializer = new DefaultContentJsonSerializer(serializerOptions.Value.SerializerOptions)
+                ContentSerializer = new DefaultContentJsonSerializer(serializerOptions.Value.SerializerOptions),
             };
 
             if (yesSqlOptions.IdGenerator != null)

--- a/test/OrchardCore.Tests/Apis/Context/SiteStartup.cs
+++ b/test/OrchardCore.Tests/Apis/Context/SiteStartup.cs
@@ -1,3 +1,4 @@
+using OrchardCore.Data.YesSql;
 using OrchardCore.Modules;
 using OrchardCore.Modules.Manifest;
 using OrchardCore.Recipes.Services;
@@ -26,6 +27,12 @@ namespace OrchardCore.Tests.Apis.Context
                 )
                 .ConfigureServices(collection =>
                 {
+                    collection.Configure<YesSqlOptions>(options =>
+                    {
+                        // To ensure we don't encounter any concurrent issue, enable EnableThreadSafetyChecks for all test.
+                        options.EnableThreadSafetyChecks = true;
+                    });
+
                     collection.AddScoped<IRecipeHarvester, TestRecipeHarvester>();
 
                     collection.AddScoped<IAuthorizationHandler, PermissionContextAuthorizationHandler>(sp =>


### PR DESCRIPTION
With the release of YesSQL 5.0, a new option was added `EnableThreadSafetyChecks` to detect any concurrent issue and throw an exception. 
 
With this PR, anyone can enable it on their project to debug a specific issue. Also, in OC I enabled it by default in all tests so we test against concurrent issues