### PR TITLE
Fixed an issue where feature profile expressions could not be serialized.

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/FeatureProfile.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/FeatureProfile.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Environment.Shell.Models
 
         public string Name { get; set; }
 
-        public List<FeatureRule> FeatureRules = [];
+        public List<FeatureRule> FeatureRules { get; set; } = [];
     }
 
     public class FeatureRule

--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/VolatileDocumentManager.cs
@@ -116,7 +116,7 @@ namespace OrchardCore.Documents
         {
             public UpdateDelegate UpdateDelegateAsync;
             public AfterUpdateDelegate AfterUpdateDelegateAsync;
-            public HashSet<object> Targets = [];
+            public HashSet<object> Targets { get; set; } = [];
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/XmlRpcContext.cs
+++ b/src/OrchardCore/OrchardCore.XmlRpc.Abstractions/XmlRpcContext.cs
@@ -12,6 +12,6 @@ namespace OrchardCore.XmlRpc
         public IUrlHelper Url { get; set; }
         public XRpcMethodCall RpcMethodCall { get; set; }
         public XRpcMethodResponse RpcMethodResponse { get; set; }
-        public ICollection<IXmlRpcDriver> Drivers = [];
+        public ICollection<IXmlRpcDriver> Drivers { get; set; } = [];
     }
 }


### PR DESCRIPTION
The FeatureRules is declared as a field, please see below code. But System.Text.Json don't serialize the field by default. I changed it to a property for now. 

https://github.com/OrchardCMS/OrchardCore/blob/dcf83bca479ad06eeb41b9a09292a67fa26a2b21/src/OrchardCore/OrchardCore.Abstractions/Shell/Models/FeatureProfile.cs#L12

Fixes #15975.

Please review and let me know if there are any questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced flexibility in managing feature rules, target updates, and XML-RPC drivers by allowing dynamic modifications through setters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->