### PR TITLE
Replace Irony.Core deprecated package

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -29,7 +29,7 @@
     <PackageManagement Include="Jint" Version="3.1.1" />
     <PackageManagement Include="JsonPath.Net" Version="1.0.0" />
     <PackageManagement Include="HtmlSanitizer" Version="8.1.860-beta" />
-    <PackageManagement Include="Irony.Core" Version="1.0.7" />
+    <PackageManagement Include="Irony" Version="1.5.1" />
     <PackageManagement Include="libphonenumber-csharp" Version="8.13.36" />
     <PackageManagement Include="Lorem.Universal.NET" Version="4.0.80" />
     <PackageManagement Include="Lucene.Net" Version="4.8.0-beta00016" />

--- a/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Irony.Core" />
+    <PackageReference Include="Irony" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The `Irony.Core` package has been deprecated according to https://www.nuget.org/packages/Irony.Core/1.0.7/ and `Irony` is the suggested replacement https://www.nuget.org/packages/Irony/