### PR TITLE
OC project templates should shows net8.0 only

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/dotnetcli.host.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/dotnetcli.host.json
@@ -11,7 +11,7 @@
     }
   },
   "usageExamples": [
-    "--framework net7.0",
-    "--orchard-version 1.6.0"
+    "--framework net8.0",
+    "--orchard-version 1.8.3"
   ]
 }

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/template.json
@@ -1,7 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Orchard Core Community and Contributors",
-  "classifications": [ "Web", "Orchard Core", "CMS" ],
+  "classifications": [
+    "Web",
+    "Orchard Core",
+    "CMS"
+  ],
   "name": "Orchard Core Cms Module",
   "identity": "OrchardCore.Templates.Cms.Module",
   "shortName": "ocmodulecms",
@@ -14,14 +18,6 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0"
-        },
-        {
-          "choice": "net7.0",
-          "description": "Target net7.0"
-        },
         {
           "choice": "net8.0",
           "description": "Target net8.0"

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/.template.config.src/dotnetcli.host.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/.template.config.src/dotnetcli.host.json
@@ -15,8 +15,8 @@
     }
   },
   "usageExamples": [
-    "--framework net7.0",
+    "--framework net8.0",
     "--logger none",
-    "--orchard-version 1.6.0"
+    "--orchard-version 1.8.3"
   ]
 }

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/.template.config.src/template.json
@@ -1,7 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Orchard Core Community and Contributors",
-  "classifications": [ "Web", "Orchard Core", "CMS" ],
+  "classifications": [
+    "Web",
+    "Orchard Core",
+    "CMS"
+  ],
   "name": "Orchard Core Cms Web App",
   "identity": "OrchardCore.Templates.Cms.Web",
   "shortName": "occms",
@@ -14,14 +18,6 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0"
-        },
-        {
-          "choice": "net7.0",
-          "description": "Target net7.0"
-        },
         {
           "choice": "net8.0",
           "description": "Target net8.0"

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/.template.config.src/dotnetcli.host.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/.template.config.src/dotnetcli.host.json
@@ -11,7 +11,7 @@
     }
   },
   "usageExamples": [
-    "--framework net7.0",
-    "--orchard-version 1.6.0"
+    "--framework net8.0",
+    "--orchard-version 1.8.3"
   ]
 }

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Module/.template.config.src/template.json
@@ -1,7 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Orchard Core Community and Contributors",
-  "classifications": [ "Web", "Orchard Core", "Mvc" ],
+  "classifications": [
+    "Web",
+    "Orchard Core",
+    "Mvc"
+  ],
   "name": "Orchard Core Mvc Module",
   "identity": "OrchardCore.Templates.Mvc.Module",
   "shortName": "ocmodulemvc",
@@ -14,14 +18,6 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0"
-        },
-        {
-          "choice": "net7.0",
-          "description": "Target net7.0"
-        },
         {
           "choice": "net8.0",
           "description": "Target net8.0"
@@ -40,8 +36,7 @@
   },
   "sources": [
     {
-      "modifiers": [
-      ]
+      "modifiers": []
     }
   ],
   "tags": {

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/.template.config.src/dotnetcli.host.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/.template.config.src/dotnetcli.host.json
@@ -11,7 +11,7 @@
     }
   },
   "usageExamples": [
-    "--framework net7.0",
-    "--orchard-version 1.6.0"
+    "--framework net8.0",
+    "--orchard-version 1.8.3"
   ]
 }

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/.template.config.src/template.json
@@ -1,7 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Orchard Core Community and Contributors",
-  "classifications": [ "Web", "Orchard Core", "Mvc" ],
+  "classifications": [
+    "Web",
+    "Orchard Core",
+    "Mvc"
+  ],
   "name": "Orchard Core Mvc Web App",
   "identity": "OrchardCore.Templates.Mvc.Web",
   "shortName": "ocmvc",
@@ -14,14 +18,6 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0"
-        },
-        {
-          "choice": "net7.0",
-          "description": "Target net7.0"
-        },
         {
           "choice": "net8.0",
           "description": "Target net8.0"
@@ -38,8 +34,7 @@
       "defaultValue": "${TemplateOrchardVersion}"
     }
   },
-  "sources": [
-  ],
+  "sources": [],
   "tags": {
     "language": "C#",
     "type": "project"

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Theme/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Theme/.template.config.src/template.json
@@ -1,7 +1,11 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Orchard Project",
-  "classifications": [ "Web", "Orchard Core", "CMS" ],
+  "classifications": [
+    "Web",
+    "Orchard Core",
+    "CMS"
+  ],
   "name": "Orchard Core Theme",
   "identity": "OrchardCore.Templates.Theme",
   "shortName": "octheme",
@@ -14,14 +18,6 @@
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0"
-        },
-        {
-          "choice": "net7.0",
-          "description": "Target net7.0"
-        },
         {
           "choice": "net8.0",
           "description": "Target net8.0"


### PR DESCRIPTION
While I was working on the project templates, I chose 1.8.3 I just noticed that the previous .NET framework shows up which is wrong .NET 8.0 should be the only option that I can pick