### PR TITLE
Update OrchardCore.OpenId to explicitly reference Microsoft.IdentityModel.Protocols.OpenIdConnect

### DIFF
--- a/src/OrchardCore.Build/Dependencies.props
+++ b/src/OrchardCore.Build/Dependencies.props
@@ -42,6 +42,7 @@
     <PackageManagement Include="Microsoft.Extensions.Azure" Version="1.7.3" />
     <PackageManagement Include="Microsoft.Extensions.Http.Resilience" Version="8.4.0" />
     <PackageManagement Include="Microsoft.Identity.Web" Version="2.18.1" />
+    <PackageManagement Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.5.1" />
     <PackageManagement Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageManagement Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageManagement Include="MimeKit" Version="4.5.0" />

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OrchardCore.OpenId.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
     <PackageReference Include="OpenIddict.Server.AspNetCore" />
     <PackageReference Include="OpenIddict.Server.DataProtection" />
     <PackageReference Include="OpenIddict.Validation.AspNetCore" />


### PR DESCRIPTION
The OpenID module uses both the MSFT OIDC handler and OpenIddict and both projects depend on IdentityModel. Unfortunately, while OpenIddict references a recent version (7.5.1), the MSFT OIDC handler package still references an old version (7.1.2):

![image](https://github.com/OrchardCMS/OrchardCore/assets/6998306/73b4539c-1ab6-423d-919c-2a82bd730b12)

Unfortunately, having mismatched versions of the `System.IdentityModel.*` or `Microsoft.IdentityModel.*` packages is explicitly NOT supported by the Wilson team has recently caused a lot of pain due to very-hard-to-find bugs:

  - https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2059
  - https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/issues/2514

This PR fixes that by explicitly referencing `Microsoft.IdentityModel.Protocols.OpenIdConnect` to ensure it uses the same IdentityModel version as OpenIddict:

![image](https://github.com/OrchardCMS/OrchardCore/assets/6998306/74ec7ac3-5d34-4746-aeee-2f26ac370630)

(I strongly recommend including this change in 2.0, hence the explicit `2.0` milestone 🤣)