### PR TITLE
Remove the ReturnUrl from the user's profile link

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
@@ -418,19 +418,14 @@ namespace OrchardCore.Users.Controllers
 
             await _notifier.SuccessAsync(H["User updated successfully."]);
 
-            if (editingOwnUser)
-            {
-                if (!string.IsNullOrEmpty(returnUrl))
-                {
-                    return this.LocalRedirect(returnUrl, true);
-                }
-
-                return RedirectToAction(nameof(Edit));
-            }
-
             if (!string.IsNullOrEmpty(returnUrl))
             {
                 return this.LocalRedirect(returnUrl, true);
+            }
+
+            if (editingOwnUser)
+            {
+                return RedirectToAction(nameof(Edit));
             }
 
             return RedirectToAction(nameof(Index));

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenuItems-Profile.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenuItems-Profile.cshtml
@@ -5,7 +5,7 @@
 @if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditOwnUser))
 {
     <li>
-        <a class="dropdown-item" asp-area="OrchardCore.Users" asp-action="Edit" asp-controller="Admin" asp-route-returnUrl="@FullRequestPath">
+        <a class="dropdown-item" asp-area="OrchardCore.Users" asp-action="Edit" asp-controller="Admin" asp-route-id="@User.FindFirstValue(ClaimTypes.NameIdentifier)">
             <i class="far fa-address-card" aria-hidden="true"></i> @T["Profile"]
         </a>
     </li>
@@ -13,7 +13,7 @@
 else if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.ViewUsers))
 {
     <li>
-        <a class="dropdown-item" asp-area="OrchardCore.Users" asp-action="Display" asp-controller="Admin" asp-route-id="@User.FindFirstValue(ClaimTypes.NameIdentifier)" asp-route-returnUrl="@FullRequestPath">
+        <a class="dropdown-item" asp-area="OrchardCore.Users" asp-action="Display" asp-controller="Admin" asp-route-id="@User.FindFirstValue(ClaimTypes.NameIdentifier)">
             <i class="far fa-address-card" aria-hidden="true"></i> @T["Profile"]
         </a>
     </li>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenuItems-Profile.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenuItems-Profile.cshtml
@@ -5,7 +5,7 @@
 @if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditOwnUser))
 {
     <li>
-        <a class="dropdown-item" asp-area="OrchardCore.Users" asp-action="Edit" asp-controller="Admin" asp-route-id="@User.FindFirstValue(ClaimTypes.NameIdentifier)">
+        <a class="dropdown-item" asp-area="OrchardCore.Users" asp-action="Edit" asp-controller="Admin">
             <i class="far fa-address-card" aria-hidden="true"></i> @T["Profile"]
         </a>
     </li>


### PR DESCRIPTION
Currently, when a user is on Contents page, then clicks on their profile menu item. If they save they profile, they'll auto redirected back to Contents page which is weird and leaves that users in "what just happens" face.

If a user updates their profile, they should see the updated profile instead of redirecting them back to a previous page "assuming that is what they want".
