### PR TITLE
[OrchardCore.Modules.Cms.Alias] Add thread-safety for YesSql session queries. Fixes #16069

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Razor/AliasPartRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Razor/AliasPartRazorHelperExtensions.cs
@@ -31,7 +31,7 @@ public static class AliasPartRazorHelperExtensions
         }
 
         var session = orchardHelper.HttpContext.RequestServices.GetService<ISession>();
-        var aliasPartIndex = await AliasPartContentHandleHelper.QueryAliasIndex(session, alias);
+        var aliasPartIndex = await AliasPartContentHandleHelper.QueryAliasIndexAsync(session, alias);
 
         return aliasPartIndex?.ContentItemId;
     }

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleHelper.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using OrchardCore.Alias.Indexes;
+using OrchardCore.ContentManagement;
+using YesSql;
+
+namespace OrchardCore.Alias.Services
+{
+    internal sealed class AliasPartContentHandleHelper
+    {
+        private static readonly SemaphoreSlim _yesSqlLock = new(1, 1);
+
+#pragma warning disable CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
+        internal static async Task<ContentItem> QueryAliasIndexAsync(ISession session, string alias)
+        {
+            // NOTE: YesSql/Dapper does not support parallel or concurrent requests.
+            // Doing so can cause an `InvalidOperationException`, with the connection stuck within a "connecting" state.
+            await _yesSqlLock.WaitAsync();
+            try
+            {
+                return await session.Query<ContentItem, AliasPartIndex>(x => x.Alias == alias.ToLowerInvariant()).FirstOrDefaultAsync();
+            }
+            finally
+            {
+                _yesSqlLock?.Release();
+            }
+        }
+#pragma warning restore CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using YesSql;

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleProvider.cs
@@ -1,6 +1,6 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
-using OrchardCore.Alias.Indexes;
 using OrchardCore.ContentManagement;
 using YesSql;
 
@@ -23,19 +23,11 @@ namespace OrchardCore.Alias.Services
             {
                 handle = handle[6..];
 
-                var aliasPartIndex = await AliasPartContentHandleHelper.QueryAliasIndex(_session, handle);
+                var aliasPartIndex = await AliasPartContentHandleHelper.QueryAliasIndexAsync(_session, handle);
                 return aliasPartIndex?.ContentItemId;
             }
 
             return null;
         }
-    }
-
-    internal sealed class AliasPartContentHandleHelper
-    {
-#pragma warning disable CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
-        internal static Task<ContentItem> QueryAliasIndex(ISession session, string alias) =>
-            session.Query<ContentItem, AliasPartIndex>(x => x.Alias == alias.ToLowerInvariant()).FirstOrDefaultAsync();
-#pragma warning restore CA1862 // Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
     }
 }


### PR DESCRIPTION
Fixes #16069 

Added a `SemaphoreSlim` to synchronise requests, using the `AliasPartContentHandleHelper.QueryAliasIndexAsync` method

### Original Bug:

When loading multiple pages of a site quickly in multiple tabs, a `InvalidOperationException` exception is thrown, due to calling the `IOrchardHelper.GetContentItemByAliasAsync()` method.

```
InvalidOperationException: BeginExecuteReader requires an open and available Connection. The connection's current state is connecting.

    System.Threading.Tasks.ContinuationResultTaskFromResultTask<TAntecedentResult, TResult>.InnerInvoke()
    System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, object state)
    System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, object state)
    System.Threading.Tasks.Task.ExecuteWithThreadLocal(ref Task currentTaskSlot, Thread threadPoolThread)
    Dapper.SqlMapper.QueryAsync<T>(IDbConnection cnn, Type effectiveType, CommandDefinition command) in SqlMapper.Async.cs
    YesSql.Store.ProduceAsync<T, TState>(WorkerQueryKey key, Func<TState, Task<T>> work, TState state)
    YesSql.Services.DefaultQuery+Query<T>.FirstOrDefaultImpl()
    YesSql.Services.DefaultQuery+Query<T>.FirstOrDefaultImpl()
    AliasPartRazorHelperExtensions.GetContentItemIdByAliasAsync(IOrchardHelper orchardHelper, string alias)
    AliasPartRazorHelperExtensions.GetContentItemByAliasAsync(IOrchardHelper orchardHelper, string alias, bool latest)
```