### PR TITLE
Register GraphQL types as transient

### DIFF
--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/ServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ public static class ServiceCollectionExtensions
         where TObject : class
         where TObjectType : InputObjectGraphType<TObject>
     {
-        services.AddScoped<TObjectType>();
+        services.AddTransient<TObjectType>();
         services.AddTransient<InputObjectGraphType<TObject>, TObjectType>(s => s.GetRequiredService<TObjectType>());
         services.AddTransient<IInputObjectGraphType, TObjectType>(s => s.GetRequiredService<TObjectType>());
     }
@@ -30,7 +30,7 @@ public static class ServiceCollectionExtensions
         where TInput : class
         where TInputType : ObjectGraphType<TInput>
     {
-        services.AddScoped<TInputType>();
+        services.AddTransient<TInputType>();
         services.AddTransient<ObjectGraphType<TInput>, TInputType>(s => s.GetRequiredService<TInputType>());
         services.AddTransient<IObjectGraphType, TInputType>(s => s.GetRequiredService<TInputType>());
     }


### PR DESCRIPTION
GraphQL types cannot be resolved while the schema is being build as a singleton. This causes problems like in #16140. 

I think the types must be transient, but I'm not fully sure about the implications this may cause.

Fixes #16140.

/cc @MikeAlhayek @tropcicstefan 