### PR TITLE
Fix distributed cache document invalidation

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Documents/DocumentManager.cs
@@ -358,10 +358,7 @@ namespace OrchardCore.Documents
             {
                 await _distributedCache.RemoveAsync(_options.CacheIdKey);
             }
-            else
-            {
-                _memoryCache.Remove(_options.CacheIdKey);
-            }
+            _memoryCache.Remove(_options.CacheIdKey);
         }
 
         private async Task<TDocument> GetFromDistributedCacheAsync()


### PR DESCRIPTION
Clear both the distributed cache and the memory cache when invalidating a document. The memory cache is still used (with a 1 second duration) for caching document IDs even when a distributed cache is enabled. Resolves #16146.

Not sure if there are any patches planned for 1.8.x but it would be nice to get this one released soon. It's kind of nasty and a distributed cache seems to be required when running on multiple instances.

Fix #16146
Fix #15678 