### PR TITLE
Fix SixLabors.ImageSharp.Web reference in 1.8.3 release notes (Lombiq Technologies: OCORE-173)

### DIFF
--- a/src/docs/releases/1.8.3.md
+++ b/src/docs/releases/1.8.3.md
@@ -6,7 +6,7 @@ Release date: April 25, 2024
 
 ## What's Changed
 
-* Update `SixLabors.ImageSharp` to v3.1.2 with a fix for [CVE-2024-27929](https://nvd.nist.gov/vuln/detail/CVE-2024-27929).
+* Update `SixLabors.ImageSharp.Web` to v3.1.2 (and thus transitively to `SixLabors.ImageSharp` v3.1.4) with a fix for [CVE-2024-27929](https://nvd.nist.gov/vuln/detail/CVE-2024-27929).
 * Update `Azure.Identity` to v1.11.2 with a fix for [CVE-2024-29992](https://nvd.nist.gov/vuln/detail/CVE-2024-29992).
 
 **Full Changelog**: <https://github.com/OrchardCMS/OrchardCore/compare/v1.8.2...v1.8.3>


### PR DESCRIPTION
We use `SixLabors.ImageSharp.Web`, what was updated to v3.1.2, not `SixLabors.ImageSharp` (which was actually updated to v3.1.4).