### PR TITLE
Release packages when a preview workflow is manually triggered

### DIFF
--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         $hasCommitFromLastDay = ![string]::IsNullOrEmpty((git log --oneline --since '24 hours ago'))
         Write-Output "Commits found in the last 24 hours: $hasCommitFromLastDay."
-        $shouldPublish = $hasCommitFromLastDay -and '${{ github.event_name }}' -eq 'schedule'
+        $shouldPublish = ($hasCommitFromLastDay -and '${{ github.event_name }}' -eq 'schedule') -or ('${{ github.event_name }}' -eq 'workflow_dispatch')
         "should-publish=$($shouldPublish ? 'true' : 'false')" >> $Env:GITHUB_OUTPUT
     - uses: actions/setup-node@v4
       if: steps.check-publish.outputs.should-publish == 'true'


### PR DESCRIPTION
Packages should be release with the preview workflow is manually triggered.