### PR TITLE
Bug report and issue management improvements (Lombiq Technologies: OCORE-174)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a bug report to help us improve
 title: ''
 labels: 'bug :bug:'
 assignees: ''
@@ -9,6 +9,10 @@ assignees: ''
 <!-- Please also see the docs on how we manage issues: https://docs.orchardcore.net/en/latest/docs/guides/contributing/managing-issues/. -->
 
 ### Describe the bug
+
+### Orchard Core version
+
+Add the version of the Orchard Core NuGet packages you use, or the commit hash if you can reproduce this with the source code.
 
 ### To Reproduce
 Steps to reproduce the behavior:
@@ -20,5 +24,5 @@ Steps to reproduce the behavior:
 ### Expected behavior
 A clear and concise description of what you expected to happen.
 
-### Screenshots
-If applicable, add screenshots to help explain your problem.
+### Logs and screenshots
+If applicable, add log files, browser console logs, and screenshots (or screen recording videos) to help explain your problem.

--- a/.github/workflows/close_stale_prs_issues.yml
+++ b/.github/workflows/close_stale_prs_issues.yml
@@ -23,12 +23,12 @@ jobs:
             Closing this pull request because it has been stale for very long. If you think this is still relevant, 
             feel free to reopen it.
           stale-issue-message: >
-            It seems that this issue didn't really move for quite a while. Is this something you'd like to revisit 
-            any time soon or should we close? Please reply.
+            It seems that this issue didn't really move for quite a while despite us asking the author for further 
+            feedback. Is this something you'd like to revisit any time soon or should we close? Please reply.
           stale-issue-label: stale
           days-before-issue-stale: 15
           days-before-issue-close: 7
           only-issue-labels: needs author feedback
           close-issue-message: >
-            Closing this issue because it has been stale for very long. If you think this is still relevant, 
-            feel free to reopen it.
+            Closing this issue because it didn't receive further feedback from the author for very long. If you think 
+            this is still relevant, feel free to reopen it with the requested details.

--- a/src/docs/guides/contributing/managing-issues.md
+++ b/src/docs/guides/contributing/managing-issues.md
@@ -22,8 +22,8 @@ Once your issue is triaged, one of the following things will happen:
 
 This is what [issue milestones](https://github.com/OrchardCMS/OrchardCore/milestones) mean:
 
-- The next patch version (`1.2.something`, e.g. if the current version is `1.2.3`, then `1.2.4`) indicates the highest priority for serious regressions and other urgent bug fixes that we intend to fix ASAP and publish in a patch release.
-- The next minor version (`1.something`, e.g. `1.3` if the current version if `1.2.0`) is for less urgent bug fixes and feature requests that we still think should be addressed in the next planned release. Regressions since the last release found by those from the community who live on the edge and use the [preview releases](../../getting-started/preview-package-source.md) are marked as such too.
+- The next patch version (e.g. if the current version is `1.2.3`, then `1.2.4`) indicates the highest priority for serious regressions and other urgent bug fixes that we intend to fix ASAP and publish in a patch release.
+- The next minor version (e.g. `1.3` if the current version is `1.2.0`) is for less urgent bug fixes and feature requests that we still think should be addressed in the next planned release. Regressions since the last release found by those from the community who live on the edge and use the [preview releases](../../getting-started/preview-package-source.md) are marked as such too.
 - Some later minor version (literally `1.x` if the current version is `1.anything`) is for issues that we intend to address eventually, maybe.
 - The `backlog` milestone is for everything else that we think is a valid request, but we won't work on it any time soon.
 
@@ -32,6 +32,8 @@ This is what [issue milestones](https://github.com/OrchardCMS/OrchardCore/milest
 Some tips on issue management:
 
 - An issue should be about a concrete task, some change in Orchard Core or how we run the project. If it's a question or discussion, then [convert it into a discussion](https://docs.github.com/en/discussions/managing-discussions-for-your-community/moderating-discussions#converting-an-issue-to-a-discussion).
+- If you asked the author something and the issue should be closed if they don't reply, add the `needs author feedback` label. This will automatically mark the issue as stale after 15 days, and then close it after another 7.
+- You can list all issues to be triaged [here](https://github.com/OrchardCMS/OrchardCore/issues?q=is%3Aopen+is%3Aissue+no%3Amilestone+-label%3A%22needs+author+feedback%22+-label%3A%22community+metrics%22+sort%3Acreated-asc).
 - Set the milestone according to the above logic, or close the issue with a comment elaborating the reason.
 - Add further labels for categorization (external contributors can't add labels). E.g.:
     - Add "good first issue" if the issue looks suitable for a novice contributor.
@@ -39,4 +41,3 @@ Some tips on issue management:
     - Add module/feature set-related labels, like "Media" or "OpenId".
     - Add "security" for security issues.
 - Change the issue's title if it contains errors or is unclear/incorrect.
-- If you asked the author something and the issue should be closed if they don't reply, add the `needs author feedback` label. This will automatically mark the issue as stale after 15 days, and then close it after another 7.


### PR DESCRIPTION
- The bug report template now asks for the OC version, something we commonly ask in follow-up comments. It also asks not just for screenshots, but any of logs and screenshots.
- Added a link to the issues waiting for triage, something we used yesterday, and some minor wording clean-up in the issue management docs.
- Changed the wording of the automatic stale issue comments so they're clear that we're not just waiting for the issue to be bumped, but specifically, the author was asked for feedback.