### PR TITLE
Auto-close old community metrics issue(s) (Lombiq Technologies: OCORE-175)

### DIFF
--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -19,7 +19,7 @@ jobs:
         $issues = gh issue list --repo '${{ github.repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {
-            gh issue close $issue --repo '${{ github.repository }}' --comment 'Closing this issue as newer community metrics are available.'
+            gh issue close $issue --repo '${{ github.repository }}'
         }
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Close Previous Issue
       shell: pwsh
       run: |
-        $issues = gh issue list --repo '${{ github.repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
+        $issues = gh issue list --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {
             Write-Output "Closing issue $issue"

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -70,7 +70,18 @@ jobs:
       shell: pwsh
       run: |
         Get-Content ./community_metrics.md >> $env:GITHUB_STEP_SUMMARY
-          
+
+    - name: Close Previous Issue
+      shell: pwsh
+      run: |
+        $issues = gh issue list --label "community metrics" --state open --json number --jq '.[].number'
+        foreach ($issue in $issues)
+        {
+            gh issue close $issue --comment 'Closing this issue as newer community metrics are available.'
+        }
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Create Issue
       # v5.0.0
       uses: peter-evans/create-issue-from-file@24452a72d85239eacf1468b0f1982a9f3fec4c94

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Close Previous Issue
       shell: pwsh
       run: |
-        $issues = gh issue list --label 'community metrics' --state open --json number --jq '.[].number'
+        $issues = gh issue list --repo '${{ github.repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {
             Write-Output "Closing issue $issue"

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -1,10 +1,7 @@
 name: Community Metrics
 on:
-  workflow_dispatch:
-  schedule:
-    # Run on the first day of every month at 2:19 AM UTC.
-    - cron: '19 2 1 * *'
-
+  pull_request:
+    
 permissions:
   issues: write
   pull-requests: read
@@ -14,63 +11,6 @@ jobs:
     name: Generate Community Metrics
     runs-on: ubuntu-latest
     steps:
-    - name: Get Dates For Last Month
-      shell: pwsh
-      run: |
-        # Calculate the first day of the previous month.
-        $firstDay = (Get-Date).AddMonths(-1).ToString("yyyy-MM-01")
-    
-        # Calculate the last day of the previous month.
-        $lastDay = (Get-Date $firstDay).AddMonths(1).AddDays(-1).ToString("yyyy-MM-dd")
-    
-        # Set an environment variable with the date range.
-        Write-Output "$firstDay..$lastDay"
-        Write-Output "LAST_MONTH=$firstDay..$lastDay" >> $env:GITHUB_ENV
-
-    - name: Compute Issue Metrics
-      uses: github/issue-metrics@v3
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SEARCH_QUERY: 'repo:OrchardCMS/OrchardCore is:issue created:${{ env.LAST_MONTH }} -reason:"not planned" -label:"community metrics"'
-        HIDE_TIME_TO_ANSWER: true
-
-    - name: Rename Issue Metrics File
-      shell: pwsh
-      run: |
-        # Renaming the file wouldn't work since other scripts will be denied access to it for some reason.
-        Add-Content -Path ./community_metrics.md -Value (Get-Content -Path ./issue_metrics.md -Raw)
-
-    - name: Compute Pull Request Metrics
-      uses: github/issue-metrics@v3
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SEARCH_QUERY: 'repo:OrchardCMS/OrchardCore is:pr created:${{ env.LAST_MONTH }} -label:dontmerge -label:notready -is:draft'
-        HIDE_TIME_TO_ANSWER: true
-
-    - name: Concatenate Issue and Pull Request Metrics
-      shell: pwsh
-      run: |
-        $content = (Get-Content -Path ./issue_metrics.md -Raw) -replace '# Issue Metrics', '# Pull Request Metrics'
-        Add-Content -Path ./community_metrics.md -Value ([Environment]::NewLine + $content)
-
-    - name: Compute Q&A Discussion Request Metrics
-      uses: github/issue-metrics@v3
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SEARCH_QUERY: 'repo:OrchardCMS/OrchardCore type:discussions created:${{ env.LAST_MONTH }} category:Q&A'
-        HIDE_TIME_TO_CLOSE: true
-
-    - name: Concatenate Issue/PR and Discussion Metrics
-      shell: pwsh
-      run: |
-        $content = (Get-Content -Path ./issue_metrics.md -Raw) -replace '# Issue Metrics', '# Discussion Metrics'
-        Add-Content -Path ./community_metrics.md -Value ([Environment]::NewLine + $content)
-
-    - name: Display Issue Metrics in Summary
-      shell: pwsh
-      run: |
-        Get-Content ./community_metrics.md >> $env:GITHUB_STEP_SUMMARY
-
     - name: Close Previous Issue
       shell: pwsh
       run: |
@@ -82,11 +22,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Create Issue
-      # v5.0.0
-      uses: peter-evans/create-issue-from-file@24452a72d85239eacf1468b0f1982a9f3fec4c94
-      with:
-        title: Monthly community metrics report for ${{ env.LAST_MONTH }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        content-filepath: ./community_metrics.md
-        labels: community metrics

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -19,7 +19,7 @@ jobs:
         $issues = gh issue list --repo '${{ github.repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {
-            gh issue close $issue --repo '${{ github.repository }}'
+            gh issue close $issue --repo '${{ github.repository }}' --comment 'Closing this issue as newer community metrics are available.'
         }
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -14,6 +14,8 @@ jobs:
     - name: Close Previous Issue
       shell: pwsh
       run: |
+        # Without the --repo switch, the GH CLI will try to look it up from the current clone, which doesn't exist
+        # because we don't otherwise need checkout.
         $issues = gh issue list --repo '${{ github.repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -17,7 +17,7 @@ jobs:
         $issues = gh issue list --repo '${{ github.repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {
-            Write-Output "Closing issue $issue"
+            gh issue close $issue --repo '${{ github.repository }}' --comment 'Closing this issue as newer community metrics are available.'
         }
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Close Previous Issue
       shell: pwsh
       run: |
-        $issues = gh issue list --label "community metrics" --state open --json number --jq '.[].number'
+        $issues = gh issue list --repo '${{ github.action_repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {
             gh issue close $issue --comment 'Closing this issue as newer community metrics are available.'

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Close Previous Issue
       shell: pwsh
       run: |
-        $issues = gh issue list --repo '${{ github.action_repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
+        $issues = gh issue list --repo '${{ github.repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {
             gh issue close $issue --comment 'Closing this issue as newer community metrics are available.'

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -1,7 +1,10 @@
 name: Community Metrics
 on:
-  pull_request:
-    
+  workflow_dispatch:
+  schedule:
+    # Run on the first day of every month at 2:19 AM UTC.
+    - cron: '19 2 1 * *'
+
 permissions:
   issues: write
   pull-requests: read
@@ -11,6 +14,63 @@ jobs:
     name: Generate Community Metrics
     runs-on: ubuntu-latest
     steps:
+    - name: Get Dates For Last Month
+      shell: pwsh
+      run: |
+        # Calculate the first day of the previous month.
+        $firstDay = (Get-Date).AddMonths(-1).ToString("yyyy-MM-01")
+    
+        # Calculate the last day of the previous month.
+        $lastDay = (Get-Date $firstDay).AddMonths(1).AddDays(-1).ToString("yyyy-MM-dd")
+    
+        # Set an environment variable with the date range.
+        Write-Output "$firstDay..$lastDay"
+        Write-Output "LAST_MONTH=$firstDay..$lastDay" >> $env:GITHUB_ENV
+
+    - name: Compute Issue Metrics
+      uses: github/issue-metrics@v3
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SEARCH_QUERY: 'repo:OrchardCMS/OrchardCore is:issue created:${{ env.LAST_MONTH }} -reason:"not planned" -label:"community metrics"'
+        HIDE_TIME_TO_ANSWER: true
+
+    - name: Rename Issue Metrics File
+      shell: pwsh
+      run: |
+        # Renaming the file wouldn't work since other scripts will be denied access to it for some reason.
+        Add-Content -Path ./community_metrics.md -Value (Get-Content -Path ./issue_metrics.md -Raw)
+
+    - name: Compute Pull Request Metrics
+      uses: github/issue-metrics@v3
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SEARCH_QUERY: 'repo:OrchardCMS/OrchardCore is:pr created:${{ env.LAST_MONTH }} -label:dontmerge -label:notready -is:draft'
+        HIDE_TIME_TO_ANSWER: true
+
+    - name: Concatenate Issue and Pull Request Metrics
+      shell: pwsh
+      run: |
+        $content = (Get-Content -Path ./issue_metrics.md -Raw) -replace '# Issue Metrics', '# Pull Request Metrics'
+        Add-Content -Path ./community_metrics.md -Value ([Environment]::NewLine + $content)
+
+    - name: Compute Q&A Discussion Request Metrics
+      uses: github/issue-metrics@v3
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SEARCH_QUERY: 'repo:OrchardCMS/OrchardCore type:discussions created:${{ env.LAST_MONTH }} category:Q&A'
+        HIDE_TIME_TO_CLOSE: true
+
+    - name: Concatenate Issue/PR and Discussion Metrics
+      shell: pwsh
+      run: |
+        $content = (Get-Content -Path ./issue_metrics.md -Raw) -replace '# Issue Metrics', '# Discussion Metrics'
+        Add-Content -Path ./community_metrics.md -Value ([Environment]::NewLine + $content)
+
+    - name: Display Issue Metrics in Summary
+      shell: pwsh
+      run: |
+        Get-Content ./community_metrics.md >> $env:GITHUB_STEP_SUMMARY
+
     - name: Close Previous Issue
       shell: pwsh
       run: |
@@ -24,3 +84,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Create Issue
+      # v5.0.0
+      uses: peter-evans/create-issue-from-file@24452a72d85239eacf1468b0f1982a9f3fec4c94
+      with:
+        title: Monthly community metrics report for ${{ env.LAST_MONTH }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        content-filepath: ./community_metrics.md
+        labels: community metrics

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -17,7 +17,7 @@ jobs:
         $issues = gh issue list --repo '${{ github.repository }}' --label 'community metrics' --state open --json number --jq '.[].number'
         foreach ($issue in $issues)
         {
-            gh issue close $issue --comment 'Closing this issue as newer community metrics are available.'
+            Write-Output "Closing issue $issue"
         }
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This now closes previous [community metrics issues](https://github.com/OrchardCMS/OrchardCore/issues?q=is%3Aopen+is%3Aissue+label%3A%22community+metrics%22) when creating a new one. So, we don't need to close them by hand.

This is what it looks like:

![image](https://github.com/OrchardCMS/OrchardCore/assets/1976647/b6cf6610-7eaf-457e-b528-4698bcfcd091)
