### PR TITLE
Add supported_cultures liquid filter

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Startup.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using Fluid;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -35,7 +34,6 @@ namespace OrchardCore.ContentLocalization
             services.Configure<TemplateOptions>(o =>
             {
                 o.MemberAccessStrategy.Register<LocalizationPartViewModel>();
-                o.MemberAccessStrategy.Register<CultureInfo>();
             })
             .AddLiquidFilter<ContentLocalizationFilter>("localization_set");
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/SupportedCulturesFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/SupportedCulturesFilter.cs
@@ -1,0 +1,26 @@
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Fluid;
+using Fluid.Values;
+using OrchardCore.Liquid;
+using OrchardCore.Localization;
+
+namespace OrchardCore.DisplayManagement.Liquid.Filters;
+
+public class SupportedCulturesFilter : ILiquidFilter
+{
+    private readonly ILocalizationService _localizationService;
+
+    public SupportedCulturesFilter(ILocalizationService localizationService)
+    {
+        _localizationService = localizationService;
+    }
+
+    public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
+    {
+        var supportedCultures = await _localizationService.GetSupportedCulturesAsync();
+
+        return new ArrayValue(supportedCultures.Select(x => new ObjectValue(CultureInfo.GetCultureInfo(x))).ToArray());
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     o.MemberAccessStrategy.Register<Shape>("*", new ShapeAccessor());
                     o.MemberAccessStrategy.Register<ZoneHolding>("*", new ShapeAccessor());
                     o.MemberAccessStrategy.Register<ShapeMetadata>();
+                    o.MemberAccessStrategy.Register<CultureInfo>();
 
                     o.Scope.SetValue("Culture", new ObjectValue(new LiquidCultureAccessor()));
                     o.MemberAccessStrategy.Register<LiquidCultureAccessor, FluidValue>((obj, name, ctx) =>
@@ -168,11 +169,11 @@ namespace Microsoft.Extensions.DependencyInjection
                     o.MemberAccessStrategy.Register<CookieCollectionWrapper, string>((cookies, name) => cookies.RequestCookieCollection[name]);
                     o.MemberAccessStrategy.Register<HeaderDictionaryWrapper, string[]>((headers, name) => headers.HeaderDictionary[name].ToArray());
                     o.MemberAccessStrategy.Register<RouteValueDictionaryWrapper, object>((headers, name) => headers.RouteValueDictionary[name]);
-
                 })
                 .AddLiquidFilter<AppendVersionFilter>("append_version")
                 .AddLiquidFilter<ResourceUrlFilter>("resource_url")
-                .AddLiquidFilter<SanitizeHtmlFilter>("sanitize_html");
+                .AddLiquidFilter<SanitizeHtmlFilter>("sanitize_html")
+                .AddLiquidFilter<SupportedCulturesFilter>("supported_cultures");
             });
 
             return builder;

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Extensions.DependencyInjection
                         {
                             nameof(CultureInfo.Name) => new StringValue(CultureInfo.CurrentUICulture.Name),
                             "Dir" => new StringValue(CultureInfo.CurrentUICulture.GetLanguageDirection()),
+                            nameof(CultureInfo.NativeName) => new StringValue(CultureInfo.CurrentUICulture.NativeName),
+                            nameof(CultureInfo.DisplayName) => new StringValue(CultureInfo.CurrentUICulture.DisplayName),
+                            nameof(CultureInfo.TwoLetterISOLanguageName) => new StringValue(CultureInfo.CurrentUICulture.TwoLetterISOLanguageName),
                             _ => NilValue.Instance
                         };
                     });

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -504,8 +504,11 @@ The following properties are available on the `Culture` object.
 
 | Property | Example | Description |
 | --------- | ---- |------------ |
-| `Name` | `en-US` | The request's culture as an ISO language code. |
+| `Name` | `en-US` | The ISO language code of the current culture. |
 | `Dir` | `rtl` | The text writing direction. |
+| `DisplayName` | `English (United States)` | The display name of the current culture. |
+| `NativeName` | `English (United States)` | The native name of the current culture. |
+| `TwoLetterISOLanguageName` | `en` | The two-letter ISO language name of the current culture. |
 
 ##### supported_cultures filter
 

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -521,6 +521,7 @@ Returns the currently supported cultures. Here is an example of how to print the
     <li>{{ culture.Name }}</li>
 {% endfor %}
 </ul>
+```
 
 ### Environment
 

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -507,6 +507,14 @@ The following properties are available on the `Culture` object.
 | `Name` | `en-US` | The request's culture as an ISO language code. |
 | `Dir` | `rtl` | The text writing direction. |
 
+##### supported_cultures filter
+
+Returns the currently supported cultures.
+
+```liquid
+{{ Culture | supported_cultures }}
+```
+
 ### Environment
 
 Represents the current hosting environment.

--- a/src/docs/reference/modules/Liquid/README.md
+++ b/src/docs/reference/modules/Liquid/README.md
@@ -512,11 +512,15 @@ The following properties are available on the `Culture` object.
 
 ##### supported_cultures filter
 
-Returns the currently supported cultures.
+Returns the currently supported cultures. Here is an example of how to print the names of supported cultures using a list:
 
 ```liquid
-{{ Culture | supported_cultures }}
-```
+{% assign cultures = Culture | supported_cultures %}
+<ul>
+{% for culture in cultures %}
+    <li>{{ culture.Name }}</li>
+{% endfor %}
+</ul>
 
 ### Environment
 

--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -535,3 +535,17 @@ Previously, achieving the same result required more code:
 Before this release, the `MarkdownField` used a single-line input field by default (named the Standard editor) and offered two different editors: Multi-line with a simple `textarea` and WYSIWYG with a rich editor. Now, by default, it uses a `textarea` as the Standard editor, and the separate Multi-line option has been removed.
 
 You have nothing to do, fields configured with the Standard or Multi-line editors previously will both continue to work. Note though, that their editors will now be a `textarea`.
+
+### Liquid
+
+New filter named `supported_cultures` was added to allow you to get a list of supported cultures. Here is an example of how to print the name of supported cultures using a list
+
+```
+{% assign cultures = Culture | supported_cultures %}
+
+<ul>
+{% for culture in cultures %}
+    <li>{{ culture.Name }}</li>
+{% endfor %}
+</ul>
+```

--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -538,7 +538,9 @@ You have nothing to do, fields configured with the Standard or Multi-line editor
 
 ### Liquid
 
-New filter named `supported_cultures` was added to allow you to get a list of supported cultures. Here is an example of how to print the name of supported cultures using a list
+The `Culture` context variable got the new properties for a fuller Liquid culture support: `DisplayName`, `NativeName`, and `TwoLetterISOLanguageName`. These are the same as their .NET counterparts.
+
+A new filter named `supported_cultures` was added to allow you to get a list of supported cultures. Here is an example of how to print the names of supported cultures using a list:
 
 ```
 {% assign cultures = Culture | supported_cultures %}


### PR DESCRIPTION
Fix #16202


#### Usage Example

```
{% assign cultures = Culture | supported_cultures %}

<ul>
{% for culture in cultures %}
    <li>{{ culture.Name }}</li>
{% endfor %}
</ul>
```