### PR TITLE
Remove old non-async Alter* content definition method references from the docs and templates (Lombiq Technologies: OCORE-177)

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Migrations.cs
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Migrations.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using OrchardCore.ContentManagement.Metadata.Settings;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Data.Migration;
@@ -13,9 +14,9 @@ namespace OrchardCore.Templates.Cms.Module
             _contentDefinitionManager = contentDefinitionManager;
         }
 
-        public int Create()
+        public Task<int> CreateAsync()
         {
-            _contentDefinitionManager.AlterPartDefinition("MyTestPart", builder => builder
+            await _contentDefinitionManager.AlterPartDefinitionAsync("MyTestPart", builder => builder
                 .Attachable()
                 .WithDescription("Provides a MyTest part for your content item."));
 

--- a/src/docs/reference/modules/ContentTypes/README.md
+++ b/src/docs/reference/modules/ContentTypes/README.md
@@ -40,7 +40,7 @@ public class Migrations : DataMigration
         _contentDefinitionManager = contentDefinitionManager;
     }
 
-    public int Create()
+    public Task<int> CreateAsync()
     {
         // This code will be run when the feature is enabled
 
@@ -54,7 +54,7 @@ public class Migrations : DataMigration
 The following example creates a new Content Type named `Product`.
 
 ```csharp
-_contentDefinitionManager.AlterTypeDefinition("Product");
+await _contentDefinitionManager.AlterTypeDefinitionAsync("Product");
 ```
 
 ### Changing the metadata of a Content Type
@@ -62,7 +62,7 @@ _contentDefinitionManager.AlterTypeDefinition("Product");
 To change specific properties of the content type, an argument can be used to configure it:
 
 ```csharp
-_contentDefinitionManager.AlterTypeDefinition("Product", type => type
+await _contentDefinitionManager.AlterTypeDefinitionAsync("Product", type => type
     // content items of this type can have drafts
     .Draftable()
     // content items versions of this type have saved
@@ -79,7 +79,7 @@ _contentDefinitionManager.AlterTypeDefinition("Product", type => type
 The following example adds the `TitlePart` content part to the `Product` type.
 
 ```csharp
-_contentDefinitionManager.AlterTypeDefinition("Product", type => type
+await _contentDefinitionManager.AlterTypeDefinitionAsync("Product", type => type
     .WithPart("TitlePart")
 );
 ```
@@ -87,7 +87,7 @@ _contentDefinitionManager.AlterTypeDefinition("Product", type => type
 Each part can also be configured in the context of a type. For instance the `AutoroutePart` requires a __Liquid__ template as its pattern to generate custom routes. It's defined in a custom setting for this part.
 
 ```csharp
-_contentDefinitionManager.AlterTypeDefinition("Product", type => type
+await _contentDefinitionManager.AlterTypeDefinitionAsync("Product", type => type
     .WithPart("AutoroutePart", part => part
         // sets the position among other parts
         .WithPosition("2")
@@ -104,11 +104,11 @@ For a list of all the settings each type can use, please refer to their respecti
 Fields can not be attached directly to a Content Type. To add fields to a content type, create a part with the same name as the type, and add fields to this part.
 
 ```csharp
-_contentDefinitionManager.AlterTypeDefinition("Product", type => type
+await _contentDefinitionManager.AlterTypeDefinitionAsync("Product", type => type
     .WithPart("Product")
 );
 
-_contentDefinitionManager.AlterPartDefinition("Product", part => part
+await _contentDefinitionManager.AlterPartDefinitionAsync("Product", part => part
     .WithField("Image", field => field
         .OfType("MediaField")
         .WithDisplayName("Main image")

--- a/src/docs/reference/modules/Migrations/README.md
+++ b/src/docs/reference/modules/Migrations/README.md
@@ -59,9 +59,9 @@ namespace Members
             return 2;
         }
 
-        public int UpdateFrom2()
+        public Task<int> UpdateFrom2Async()
         {
-            _contentDefinitionManager.AlterTypeDefinition("Product", type => type
+            await _contentDefinitionManager.AlterTypeDefinitionAsync("Product", type => type
                 // Content items of this type can have drafts
                 .Draftable()
                 // Content items versions of this type are versionable
@@ -74,9 +74,9 @@ namespace Members
             return 3;
         }
 
-        public int UpdateFrom3()
+        public Task<int> UpdateFrom3Async()
         {
-            _contentDefinitionManager.AlterTypeDefinition("Product", type => type
+            await _contentDefinitionManager.AlterTypeDefinitionAsync("Product", type => type
                 .WithPart("TitlePart")
             );
             return 4;


### PR DESCRIPTION
These wouldn't even compile now.