### PR TITLE
Remove unnecessary RequireSettings.Condition check in ResourceRequiredContext

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceRequiredContext.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/ResourceRequiredContext.cs
@@ -33,16 +33,13 @@ namespace OrchardCore.ResourceManagement
 
             tagBuilder.WriteTo(writer, NullHtmlEncoder.Default);
 
-            if (!string.IsNullOrEmpty(Settings.Condition))
+            if (Settings.Condition == NotIE)
             {
-                if (Settings.Condition == NotIE)
-                {
-                    writer.Write("<!--<![endif]-->");
-                }
-                else
-                {
-                    writer.Write("<![endif]-->");
-                }
+                writer.Write("<!--<![endif]-->");
+            }
+            else
+            {
+                writer.Write("<![endif]-->");
             }
         }
     }


### PR DESCRIPTION
Need to be removed because we already checked `Settings.Condition`

```csharp
if (string.IsNullOrEmpty(Settings.Condition))
{
    tagBuilder.WriteTo(writer, NullHtmlEncoder.Default);
    return;
}
```