### PR TITLE
Fix JsonDynamicArray enumeration in dynamic usages

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Json/Dynamic/JsonDynamicArray.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/Dynamic/JsonDynamicArray.cs
@@ -140,7 +140,8 @@ public class JsonDynamicArray : DynamicObject, IEnumerable<object?>, IEnumerable
         }
     }
 
-    IEnumerator<JsonNode?> IEnumerable<JsonNode?>.GetEnumerator() => _jsonArray.AsEnumerable().GetEnumerator();
+    IEnumerator<JsonNode?> IEnumerable<JsonNode?>.GetEnumerator() 
+        => _jsonArray.AsEnumerable().GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/Dynamic/JsonDynamicArray.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/Dynamic/JsonDynamicArray.cs
@@ -11,11 +11,10 @@ using System.Text.Json.Nodes;
 namespace System.Text.Json.Dynamic;
 
 [DebuggerDisplay("JsonDynamicArray[{Count}]")]
-public class JsonDynamicArray : DynamicObject, IEnumerable<JsonNode?>
+public class JsonDynamicArray : DynamicObject, IEnumerable<object?>, IEnumerable<JsonNode?>
 {
     private readonly JsonArray _jsonArray;
-
-    public readonly Dictionary<int, object?> _dictionary = [];
+    private readonly Dictionary<int, object?> _dictionary = [];
 
     public JsonDynamicArray() => _jsonArray = [];
 
@@ -133,7 +132,15 @@ public class JsonDynamicArray : DynamicObject, IEnumerable<JsonNode?>
         }
     }
 
-    public IEnumerator<JsonNode?> GetEnumerator() => _jsonArray.AsEnumerable().GetEnumerator();
+    public IEnumerator<object?> GetEnumerator()
+    {
+        for (var i = 0; i < _jsonArray.Count; i++)
+        {
+            yield return GetValue(i);
+        }
+    }
+
+    IEnumerator<JsonNode?> IEnumerable<JsonNode?>.GetEnumerator() => _jsonArray.AsEnumerable().GetEnumerator();
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 


### PR DESCRIPTION
Implements `IEnumerable<object>` on `JsonDynamicArray` and returns that enumerator from `IEnumerable.GetEnumerator()`. The existing `IEnumerable<JsonNode>` is kept, but is now implemented explicitly. 

Anyone currently using an enumerator from JsonDynamicArray will now by default get an enumerable of objects, which are instances of our dynamic wrappers. Those are also implicitly convertible to `JsonNode` again, so callers should not lose anything. 

Address an issue in #16233