### PR TITLE
Makes sure data migrations are assigned to a single feature only

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/FeatureTypeDiscoveryAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/FeatureTypeDiscoveryAttribute.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace OrchardCore.Environment.Extensions;
+
+/// <summary>
+/// Configures how the <see cref="ITypeFeatureProvider" /> will assign the type to features.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface)]
+public class FeatureTypeDiscoveryAttribute : Attribute
+{
+    /// <summary>
+    /// Prevents assignment of a public type to the main feature.
+    /// </summary>
+    /// <remarks>
+    /// If <c>SkipExtension</c> is set to true, the type is only added to the same feature
+    /// as its startup class. 
+    /// </remarks>
+    public bool SkipExtension { get; set; }
+
+    /// <summary>
+    /// Ensures a type is only registered with a single feature.
+    /// </summary>
+    /// <remarks>
+    /// If <c>SingleFeatureOnly</c> is set to true, the <c>TypeFeatureProvider</c> will throw
+    /// an <c>InvalidOperationException</c> if the type gets assigned to more than one feature.
+    /// </remarks>
+    public bool SingleFeatureOnly { get; set; }
+
+    public static FeatureTypeDiscoveryAttribute GetFeatureTypeDiscoveryForType(Type type)
+    {
+        return type.GetCustomAttribute<FeatureTypeDiscoveryAttribute>(true)
+            ?? type.GetInterfaces()
+                    .Select(i => i.GetCustomAttribute<FeatureTypeDiscoveryAttribute>(true))
+                    .FirstOrDefault(c => c != null);
+    }
+}

--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/FeatureTypeDiscoveryAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/FeatureTypeDiscoveryAttribute.cs
@@ -32,7 +32,7 @@ public class FeatureTypeDiscoveryAttribute : Attribute
     {
         return type.GetCustomAttribute<FeatureTypeDiscoveryAttribute>(true)
             ?? type.GetInterfaces()
-                    .Select(i => i.GetCustomAttribute<FeatureTypeDiscoveryAttribute>(true))
-                    .FirstOrDefault(c => c != null);
+                    .Select(dmType => dmType.GetCustomAttribute<FeatureTypeDiscoveryAttribute>(true))
+                    .FirstOrDefault(featureTypeDiscoveryAttr => featureTypeDiscoveryAttr != null);
     }
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/IDataMigration.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/IDataMigration.cs
@@ -1,3 +1,4 @@
+using OrchardCore.Environment.Extensions;
 using YesSql.Sql;
 
 namespace OrchardCore.Data.Migration
@@ -5,6 +6,7 @@ namespace OrchardCore.Data.Migration
     /// <summary>
     /// Represents a contract for a database migration.
     /// </summary>
+    [FeatureTypeDiscovery(SingleFeatureOnly = true, SkipExtension = true)]
     public interface IDataMigration
     {
         /// <summary>

--- a/src/OrchardCore/OrchardCore.Data.YesSql/Migration/DataMigrationManager.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/Migration/DataMigrationManager.cs
@@ -276,7 +276,7 @@ namespace OrchardCore.Data.Migration
         private IDataMigration[] GetDataMigrations(string featureId)
         {
             var migrations = _dataMigrations
-                    .Where(dm => _typeFeatureProvider.GetFeaturesForDependency(dm.GetType()).Any(feature => feature.Id == featureId))
+                    .Where(dm => _typeFeatureProvider.GetFeatureForDependency(dm.GetType()).Id == featureId)
                     .ToArray();
 
             return migrations;

--- a/src/OrchardCore/OrchardCore/Extensions/Features/TypeFeatureProvider.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/TypeFeatureProvider.cs
@@ -53,7 +53,7 @@ namespace OrchardCore.Environment.Extensions
 
             if (features.Count() > 1 && (FeatureTypeDiscoveryAttribute.GetFeatureTypeDiscoveryForType(type)?.SingleFeatureOnly ?? false))
             {
-                throw new InvalidOperationException($"The type {type} can only be assigned to a single feature. Make sure the type is not added to DI by mulitple startup classes.");
+                throw new InvalidOperationException($"The type {type} can only be assigned to a single feature. Make sure the type is not added to DI by multiple startup classes.");
             }
         }
     }

--- a/src/OrchardCore/OrchardCore/Extensions/Features/TypeFeatureProvider.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/TypeFeatureProvider.cs
@@ -49,7 +49,12 @@ namespace OrchardCore.Environment.Extensions
 
         public void TryAdd(Type type, IFeatureInfo feature)
         {
-            _features.AddOrUpdate(type, (key, value) => [value], (key, features, value) => features.Contains(value) ? features : features.Append(value).ToArray(), feature);
+            var features = _features.AddOrUpdate(type, (key, value) => [value], (key, features, value) => features.Contains(value) ? features : features.Append(value).ToArray(), feature);
+
+            if (features.Count() > 1 && (FeatureTypeDiscoveryAttribute.GetFeatureTypeDiscoveryForType(type)?.SingleFeatureOnly ?? false))
+            {
+                throw new InvalidOperationException($"The type {type} can only be assigned to a single feature. Make sure the type is not added to DI by mulitple startup classes.");
+            }
         }
     }
 }

--- a/src/OrchardCore/OrchardCore/Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/ShellContainerFactory.cs
@@ -182,6 +182,8 @@ namespace OrchardCore.Environment.Shell.Builders
                     {
                         foreach (var type in featureTypes)
                         {
+                            // If the attribute is present then we explicitly ignore the backward compatibility and skip the registration
+                            // in the main feature.
                             if (!SkipExtensionFeatureRegistration(type))
                             {
                                 typeFeatureProvider.TryAdd(type, feature);

--- a/src/OrchardCore/OrchardCore/Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/ShellContainerFactory.cs
@@ -180,6 +180,8 @@ namespace OrchardCore.Environment.Shell.Builders
                     // Features can have no types.
                     if (typesByFeature.TryGetValue(feature.Id, out var featureTypes))
                     {
+                        // This is adding the types to the main feature for backward compatibility.
+                        // In the future we could stop doing it as we don't expect this to be necessary, and remove the FeatureTypeDiscovery attribute.
                         foreach (var type in featureTypes)
                         {
                             // If the attribute is present then we explicitly ignore the backward compatibility and skip the registration

--- a/src/OrchardCore/OrchardCore/Shell/Builders/ShellContainerFactory.cs
+++ b/src/OrchardCore/OrchardCore/Shell/Builders/ShellContainerFactory.cs
@@ -182,7 +182,10 @@ namespace OrchardCore.Environment.Shell.Builders
                     {
                         foreach (var type in featureTypes)
                         {
-                            typeFeatureProvider.TryAdd(type, feature);
+                            if (!SkipExtensionFeatureRegistration(type))
+                            {
+                                typeFeatureProvider.TryAdd(type, feature);
+                            }
                         }
                     }
                 }
@@ -227,6 +230,11 @@ namespace OrchardCore.Environment.Shell.Builders
         private static bool IsComponentType(Type type)
         {
             return type.IsClass && !type.IsAbstract && type.IsPublic;
+        }
+
+        private static bool SkipExtensionFeatureRegistration(Type type)
+        {
+            return FeatureTypeDiscoveryAttribute.GetFeatureTypeDiscoveryForType(type)?.SkipExtension ?? false;
         }
     }
 }


### PR DESCRIPTION
Since we now have the ability to assign any type to more than one feature, and we also want to avoid having to decorate everything with the `FeatureAttribute`, we need a way to ensure that some features like migrations are only ever assigned to a single feature.
To do this, I've created a new attribute that can be applied to interfaces and classes. This will allow us to decorate only the `IDataMigration` interface, which will avoid having to configure all the other migration classes.

Fixes #16248 