### PR TITLE
Fix that Comment Issue on Triage runs for PR milestone changes too (Lombiq Technologies: OCORE-179)

### DIFF
--- a/.github/workflows/comment_issue_on_triage.yml
+++ b/.github/workflows/comment_issue_on_triage.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-    if: github.event.issue.state == 'open'
+    # Despite the trigger being called "issues", this would still run for setting the milestone of PRs too.
+    if: github.event.issue.pull_request == null && github.event.issue.state == 'open'
     steps:
       - name: Add Comment
         run: gh issue comment "$NUMBER" --body "$BODY"


### PR DESCRIPTION
Despite the trigger being called "issues", the Comment Issue on Triage workflow still runs for setting the milestone of PRs too. I noticed this when adding the milestone to https://github.com/OrchardCMS/OrchardCore/pull/16224 and seen it run and fail: https://github.com/OrchardCMS/OrchardCore/actions/runs/9417564433/job/25943015221.

You can see some test runs here: https://github.com/Lombiq/OCORE-179-test/actions/workflows/comment_issue_on_triage.yml