### PR TITLE
Fix solution build file references (Lombiq Technologies: OCORE-180)

### DIFF
--- a/OrchardCore.sln
+++ b/OrchardCore.sln
@@ -216,11 +216,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{184139CF
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
-		src\OrchardCore\Directory.Build.targets = src\OrchardCore\Directory.Build.targets
 		NuGet.config = NuGet.config
 		src\OrchardCore.Build\OrchardCore.Commons.props = src\OrchardCore.Build\OrchardCore.Commons.props
 		src\OrchardCore.Build\OrchardCore.Commons.targets = src\OrchardCore.Build\OrchardCore.Commons.targets
-		src\OrchardCore.Build\TargetFrameworks.props = src\OrchardCore.Build\TargetFrameworks.targets
+		src\OrchardCore.Build\TargetFrameworks.props = src\OrchardCore.Build\TargetFrameworks.props
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrchardCore.Email", "src\OrchardCore.Modules\OrchardCore.Email\OrchardCore.Email.csproj", "{B3E9EC5B-171E-43FB-8620-7FC24D0A985A}"


### PR DESCRIPTION
After merging https://github.com/OrchardCMS/OrchardCore/pull/16235 you get the following warning in VS:

![image](https://github.com/OrchardCMS/OrchardCore/assets/1976647/bffddf8e-bf7b-460b-8be3-1b4d3075cc8e)

There aren't any details in the output window apart from a generic "Some of the properties associated with the solution could not be read." but the issue was with the references fixed in this PR.