### PR TITLE
Remove Gitter references (Lombiq Technologies: OCORE-181)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Do you need some help with Orchard Core? Don't worry, there are ways to get help
 
 - Did you find a bug or have a feature request? Open an issue [in the issue tracker](https://github.com/OrchardCMS/OrchardCore/issues).
 - Do you have a question about how to do something with Orchard Core, or would like a second opinion on your code? Open [a discussion](https://github.com/OrchardCMS/OrchardCore/discussions).
-- Do you want to chat with other community members? Check out [our Discord server](https://discord.gg/s3e2HtyPZc) and [Gitter chatroom](https://gitter.im/OrchardCMS/OrchardCore]).
+- Do you want to chat with other community members? Check out [our Discord server](https://orchardcore.net/discord).
 
 ## Get in Touch
 

--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Recipes/dashboard-widgets-samples.recipe.json
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Recipes/dashboard-widgets-samples.recipe.json
@@ -25,7 +25,7 @@
             "Height": 2.0
           },
           "HtmlBodyPart": {
-            "Html": "<ul class=\"list-group list-group-flush\">\n\t<li class=\"list-group-item\"><a href=\"https://orchardcore.net\" target=\"_blank\">Orchard Core site</a></li>\n\t<li class=\"list-group-item\"><a href=\"https://docs.orchardcore.net\" target=\"_blank\">Orchard Core docs</a></li>\n\t<li class=\"list-group-item\"><a href=\"https://github.com/OrchardCMS/OrchardCore\" target=\"_blank\">Orchard Core repo</a></li>\n\t<li class=\"list-group-item\"><a href=\"https://gitter.im/OrchardCMS/OrchardCore\" target=\"_blank\">Orchard Core chat</a></li>\n</ul>"
+            "Html": "<ul class=\"list-group list-group-flush\">\n\t<li class=\"list-group-item\"><a href=\"https://orchardcore.net\" target=\"_blank\">Orchard Core site</a></li>\n\t<li class=\"list-group-item\"><a href=\"https://docs.orchardcore.net\" target=\"_blank\">Orchard Core docs</a></li>\n\t<li class=\"list-group-item\"><a href=\"https://github.com/OrchardCMS/OrchardCore\" target=\"_blank\">Orchard Core repo</a></li>\n\t<li class=\"list-group-item\"><a href=\"https://orchardcore.net/discord\" target=\"_blank\">Orchard Core chat</a></li>\n</ul>"
           },
           "TitlePart": {
             "Title": "Orchard Core"


### PR DESCRIPTION
Related to https://github.com/OrchardCMS/OrchardCore/issues/13707. This is removing the remaining Gitter references/links on the codebase.