### PR TITLE
Update NuGet references automatically once a week

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    groups:
+       # Grouped version updates configuration
+       all-dependencies:
+          patterns:
+            - "*"
+
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/src/docs/resources/libraries/README.md
+++ b/src/docs/resources/libraries/README.md
@@ -4,101 +4,101 @@ The below table lists the different .NET libraries used in Orchard Core:
 
 | Library | Usage | Version | License |
 |--- | --- | --- | --- |
-| [Angle Sharp](https://github.com/AngleSharp/AngleSharp) | Angle brackets parser library. | 1.1.2 |[MIT](https://github.com/AngleSharp/AngleSharp/blob/devel/LICENSE) |
-| [AWSSDK S3](https://github.com/aws/aws-sdk-net) | AWS SDK for .NET. | 3.7.104.11 |[Apache-2.0 license](https://github.com/aws/aws-sdk-net/blob/master/License.txt) |
-| [AWSSDK SecurityToken](https://github.com/aws/aws-sdk-net) | AWS SDK for .NET. | 3.7.101.60 |[Apache-2.0 license](https://github.com/aws/aws-sdk-net/blob/master/License.txt) |
-| [AWSSDK Extensions Setup](https://github.com/aws/aws-sdk-net) | AWS SDK for .NET. | 3.7.7 |[Apache-2.0 license](https://github.com/aws/aws-sdk-net/blob/master/License.txt) |
-| [Azure Identity](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/README.md) | Azure Active Directory token authentication support. | 1.11.3 |[MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
-| [Azure Communication Services](https://github.com/Azure/Communication) | Azure Communication Services are cloud-based services with REST APIs and client library SDKs to help you integrate communication into your applications | 1.0.1 |[MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
-| [Azure Configuration Secrets](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Extensions.AspNetCore.Configuration.Secrets_1.3.1/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/README.md) | Azure Key Vault configuration provider implementation for Microsoft.Extensions.Configuration. | 1.3.1 |[MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
-| [Azure Storage Blobs](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Azure.Storage.Blobs/README.md) | Azure Storage Blobs client library for .NET. | 12.20.0 |[MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
-| [Azure Storage Blobs for DataProtection](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Extensions.AspNetCore.DataProtection.Blobs_1.3.2/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/README.md) | Allows storing ASP.NET Core DataProtection keys in Azure Blob Storage. | 1.3.4 |[MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
-| [Castle.Core](https://github.com/castleproject/Core) | Castle DynamicProxy. | 5.1.1 |[Apache-2.0](https://github.com/castleproject/Core/blob/master/LICENSE) |
-| [DocumentFormat.OpenXML](https://github.com/dotnet/Open-XML-SDK) | The Open XML SDK provides tools for working with Office Word, Excel, and PowerPoint documents | 3.0.2 | [MIT](https://github.com/dotnet/Open-XML-SDK/blob/main/LICENSE) |
-| [Fluid.Core](https://github.com/sebastienros/fluid) | .NET Liquid template engine. | 2.10.0 | [MIT](https://github.com/sebastienros/fluid/blob/dev/LICENSE) |
-| [GraphQL](https://github.com/graphql/graphiql) | GraphiQL & GraphQL. | 7.8.0 | [MIT](https://github.com/graphql/graphiql/blob/main/LICENSE) |
-| [HtmlSanitizer](https://github.com/mganss/HtmlSanitizer) | Cleans HTML to avoid XSS attacks. | 8.1.860-beta | [MIT](https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md) |
-| [ImageSharp](https://github.com/SixLabors/ImageSharp.Web) | Middleware for ASP.NET-Core for image manipulation. | 3.1.2 |[Apache-2.0](https://github.com/SixLabors/ImageSharp.Web/blob/master/LICENSE) |
-| [Irony.Core](https://github.com/daxnet/irony) | A modified version of the Irony project with .NET Core support | 1.0.7 | [MIT](https://github.com/daxnet/irony/blob/master/LICENSE) |
-| [Jint](https://github.com/sebastienros/jint) | Javascript Interpreter for .NET. | 3.1.2 | [MIT](https://github.com/sebastienros/jint/blob/dev/LICENSE) |
-| [JsonPath.NET](https://github.com/gregsdennis/json-everything/tree/master/JsonPath) | A string syntax for selecting and extracting JSON values from within a given JSON value. | 1.1.0 | [MIT](https://github.com/gregsdennis/json-everything/blob/master/LICENSE) |
-| [libphonenumber-csharp](https://github.com/twcclegg/libphonenumber-csharp) | .NET library for parsing, formatting, and validating international phone numbers | 8.13.38 | [Apache-2.0](https://github.com/twcclegg/libphonenumber-csharp/blob/main/LICENSE) |
-| [Lorem.NET for netstandard](https://github.com/trichards57/Lorem.Universal.NET) | A .NET library for all things random! | 4.0.80 | [MIT](https://github.com/trichards57/Lorem.Universal.NET/blob/master/license.md) |
-| [Lucene.Net](https://github.com/apache/lucenenet) | .NET full-text search engine. | 4.8.0-beta00016 | [Apache-2.0](https://github.com/apache/lucenenet/blob/master/LICENSE.txt) |
-| [MailKit](https://github.com/jstedfast/MailKit) | A cross-platform .NET library for IMAP, POP3, and SMTP. | 4.6.0 | [MIT](https://github.com/jstedfast/MailKit/blob/master/LICENSE) |
-| [Markdig](https://github.com/lunet-io/markdig) | .NET Markdown engine. | 0.36.2 | [BSD-2-Clause](https://github.com/lunet-io/markdig/blob/master/license.txt) |
-| [MessagePack](https://github.com/neuecc/MessagePack-CSharp) | Extremely Fast MessagePack Serializer for C# | 2.2.60 | [MIT](https://github.com/neuecc/MessagePack-CSharp/blob/master/LICENSE) |
-| [Microsoft.Extensions.Http.Resilience](https://github.com/dotnet/extensions/tree/main/src/Libraries/Microsoft.Extensions.Http.Resilience) | Resilience mechanisms for HttpClient built on the Polly framework. | 8.5.0 | [MIT](https://github.com/dotnet/extensions/blob/main/LICENSE) |
-| [Microsoft.Identity.Web](https://github.com/AzureAD/microsoft-identity-web) | Helps creating protected web apps and web APIs with Microsoft identity platform and Azure AD B2C. | 2.19.0 | [MIT](https://github.com/AzureAD/microsoft-identity-web/blob/master/LICENSE) |
-| [Microsoft.SourceLink.GitHub](https://github.com/dotnet/sourcelink) | Source Link enables a great source debugging experience. | 8.0.0 | [MIT](https://github.com/dotnet/sourcelink/blob/main/License.txt) |
-| [MimeKit](https://github.com/jstedfast/MailKit) | A cross-platform .NET library for IMAP, POP3, and SMTP. | 4.6.0 | [MIT](https://github.com/jstedfast/MailKit/blob/master/LICENSE) |
-| [MiniProfiler](https://github.com/MiniProfiler/dotnet) | A simple but effective mini-profiler for ASP.NET (and Core) websites | 4.3.8 | [MIT](https://github.com/MiniProfiler/dotnet/blob/main/LICENSE.txt) |
-| [NCrontab](https://github.com/atifaziz/NCrontab) | Crontab for .NET | 3.3.3 | [Apache-2.0](https://github.com/atifaziz/NCrontab/blob/master/COPYING.txt) |
-| [NEST](https://github.com/elastic/elasticsearch-net) | .NET Library for Elasticsearch | 7.17.5 | [Apache-2.0](https://github.com/elastic/elasticsearch-net/blob/main/LICENSE.txt) |
-| [Azure.Search.Documents](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Search.Documents_11.5.1/sdk/search/Azure.Search.Documents/README.md) | Azure AI Search client library for .NET | 11.5.1 | [MIT](https://github.com/AzureAD/microsoft-identity-web/blob/master/LICENSE) |
-| [Microsoft.Extensions.Azure](https://github.com/Azure/azure-sdk-for-net/blob/Microsoft.Extensions.Azure_1.7.3/sdk/extensions/Microsoft.Extensions.Azure/README.md) | Azure client library integration for ASP.NET Core | 1.7.3 | [MIT](https://github.com/AzureAD/microsoft-identity-web/blob/master/LICENSE) |
-| [NJsonSchema](https://github.com/RicoSuter/NJsonSchema) | JSON Schema reader, generator and validator for .NET | 11.0.0 | [MIT](https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md) |
-| [NLog.Web.AspNetCore](https://github.com/NLog/NLog.Web/tree/master/src/NLog.Web.AspNetCore) | NLog integration for ASP.NET. | 5.3.11 | [BSD-3-Clause](https://github.com/NLog/NLog.Web/blob/master/LICENSE) |
-| [Noda Time](https://github.com/nodatime/nodatime) | A better date and time API for .NET. | 3.1.11 | [Apache-2.0](https://github.com/nodatime/nodatime/blob/master/LICENSE.txt) |
-| [OpenIddict](https://github.com/openiddict/openiddict-core) | Flexible and versatile OAuth 2.0/OpenID Connect stack for .NET. | 5.6.0 | [Apache-2.0](https://github.com/openiddict/openiddict-core/blob/dev/LICENSE.md) |
-| [PdfPig](https://github.com/UglyToad/PdfPig/) | Library to read and extract text and other content from PDF files. | 0.1.8 | [Apache-2.0](https://github.com/UglyToad/PdfPig/blob/master/LICENSE) |
-| [Serilog.AspNetCore](https://github.com/serilog/serilog-aspnetcore) | Serilog integration for ASP.NET Core. | 8.0.1 | [Apache-2.0](https://github.com/serilog/serilog-aspnetcore/blob/dev/LICENSE) |
-| [Shortcodes](https://github.com/sebastienros/shortcodes) | Shortcodes processor for .NET. | 1.3.3 | [MIT](https://github.com/sebastienros/shortcodes/blob/dev/LICENSE) |
-| [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis) | General purpose redis client. | 2.7.33 | [MIT](https://github.com/StackExchange/StackExchange.Redis/blob/main/LICENSE) |
-| [YesSql](https://github.com/sebastienros/yessql) | .NET document database working on any RDBMS. | 5.0.0 | [MIT](https://github.com/sebastienros/yessql/blob/dev/LICENSE) |
-| [ZString](https://github.com/Cysharp/ZString) | Zero Allocation StringBuilder for .NET Core and Unity. | 2.6.0 | [MIT](https://github.com/Cysharp/ZString/blob/master/LICENSE) |
+| [Angle Sharp](https://github.com/AngleSharp/AngleSharp) | Angle brackets parser library. | [MIT](https://github.com/AngleSharp/AngleSharp/blob/devel/LICENSE) |
+| [AWSSDK S3](https://github.com/aws/aws-sdk-net) | AWS SDK for .NET. | [Apache-2.0 license](https://github.com/aws/aws-sdk-net/blob/master/License.txt) |
+| [AWSSDK SecurityToken](https://github.com/aws/aws-sdk-net) | AWS SDK for .NET. | [Apache-2.0 license](https://github.com/aws/aws-sdk-net/blob/master/License.txt) |
+| [AWSSDK Extensions Setup](https://github.com/aws/aws-sdk-net) | AWS SDK for .NET. | [Apache-2.0 license](https://github.com/aws/aws-sdk-net/blob/master/License.txt) |
+| [Azure Identity](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/README.md) | Azure Active Directory token authentication support. | [MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
+| [Azure Communication Services](https://github.com/Azure/Communication) | Azure Communication Services are cloud-based services with REST APIs and client library SDKs to help you integrate communication into your applications | [MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
+| [Azure Configuration Secrets](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Extensions.AspNetCore.Configuration.Secrets_1.3.1/sdk/extensions/Azure.Extensions.AspNetCore.Configuration.Secrets/README.md) | Azure Key Vault configuration provider implementation for Microsoft.Extensions.Configuration. | [MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
+| [Azure Storage Blobs](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Azure.Storage.Blobs/README.md) | Azure Storage Blobs client library for .NET. | [MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
+| [Azure Storage Blobs for DataProtection](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Extensions.AspNetCore.DataProtection.Blobs_1.3.2/sdk/extensions/Azure.Extensions.AspNetCore.DataProtection.Blobs/README.md) | Allows storing ASP.NET Core DataProtection keys in Azure Blob Storage. | [MIT](https://github.com/Azure/azure-sdk-for-net/blob/master/LICENSE.txt) |
+| [Castle.Core](https://github.com/castleproject/Core) | Castle DynamicProxy. | [Apache-2.0](https://github.com/castleproject/Core/blob/master/LICENSE) |
+| [DocumentFormat.OpenXML](https://github.com/dotnet/Open-XML-SDK) | The Open XML SDK provides tools for working with Office Word, Excel, and PowerPoint documents | [MIT](https://github.com/dotnet/Open-XML-SDK/blob/main/LICENSE) |
+| [Fluid.Core](https://github.com/sebastienros/fluid) | .NET Liquid template engine. | [MIT](https://github.com/sebastienros/fluid/blob/dev/LICENSE) |
+| [GraphQL](https://github.com/graphql/graphiql) | GraphiQL & GraphQL. | [MIT](https://github.com/graphql/graphiql/blob/main/LICENSE) |
+| [HtmlSanitizer](https://github.com/mganss/HtmlSanitizer) | Cleans HTML to avoid XSS attacks. | [MIT](https://github.com/mganss/HtmlSanitizer/blob/master/LICENSE.md) |
+| [ImageSharp](https://github.com/SixLabors/ImageSharp.Web) | Middleware for ASP.NET-Core for image manipulation. | [Apache-2.0](https://github.com/SixLabors/ImageSharp.Web/blob/master/LICENSE) |
+| [Irony.Core](https://github.com/daxnet/irony) | A modified version of the Irony project with .NET Core support | [MIT](https://github.com/daxnet/irony/blob/master/LICENSE) |
+| [Jint](https://github.com/sebastienros/jint) | Javascript Interpreter for .NET. | [MIT](https://github.com/sebastienros/jint/blob/dev/LICENSE) |
+| [JsonPath.NET](https://github.com/gregsdennis/json-everything/tree/master/JsonPath) | A string syntax for selecting and extracting JSON values from within a given JSON value. | [MIT](https://github.com/gregsdennis/json-everything/blob/master/LICENSE) |
+| [libphonenumber-csharp](https://github.com/twcclegg/libphonenumber-csharp) | .NET library for parsing, formatting, and validating international phone numbers | [Apache-2.0](https://github.com/twcclegg/libphonenumber-csharp/blob/main/LICENSE) |
+| [Lorem.NET for netstandard](https://github.com/trichards57/Lorem.Universal.NET) | A .NET library for all things random! | [MIT](https://github.com/trichards57/Lorem.Universal.NET/blob/master/license.md) |
+| [Lucene.Net](https://github.com/apache/lucenenet) | .NET full-text search engine. | [Apache-2.0](https://github.com/apache/lucenenet/blob/master/LICENSE.txt) |
+| [MailKit](https://github.com/jstedfast/MailKit) | A cross-platform .NET library for IMAP, POP3, and SMTP. | [MIT](https://github.com/jstedfast/MailKit/blob/master/LICENSE) |
+| [Markdig](https://github.com/lunet-io/markdig) | .NET Markdown engine. | [BSD-2-Clause](https://github.com/lunet-io/markdig/blob/master/license.txt) |
+| [MessagePack](https://github.com/neuecc/MessagePack-CSharp) | Extremely Fast MessagePack Serializer for C# | [MIT](https://github.com/neuecc/MessagePack-CSharp/blob/master/LICENSE) |
+| [Microsoft.Extensions.Http.Resilience](https://github.com/dotnet/extensions/tree/main/src/Libraries/Microsoft.Extensions.Http.Resilience) | Resilience mechanisms for HttpClient built on the Polly framework. | [MIT](https://github.com/dotnet/extensions/blob/main/LICENSE) |
+| [Microsoft.Identity.Web](https://github.com/AzureAD/microsoft-identity-web) | Helps creating protected web apps and web APIs with Microsoft identity platform and Azure AD B2C. | [MIT](https://github.com/AzureAD/microsoft-identity-web/blob/master/LICENSE) |
+| [Microsoft.SourceLink.GitHub](https://github.com/dotnet/sourcelink) | Source Link enables a great source debugging experience. | [MIT](https://github.com/dotnet/sourcelink/blob/main/License.txt) |
+| [MimeKit](https://github.com/jstedfast/MailKit) | A cross-platform .NET library for IMAP, POP3, and SMTP. | [MIT](https://github.com/jstedfast/MailKit/blob/master/LICENSE) |
+| [MiniProfiler](https://github.com/MiniProfiler/dotnet) | A simple but effective mini-profiler for ASP.NET (and Core) websites | [MIT](https://github.com/MiniProfiler/dotnet/blob/main/LICENSE.txt) |
+| [NCrontab](https://github.com/atifaziz/NCrontab) | Crontab for .NET | [Apache-2.0](https://github.com/atifaziz/NCrontab/blob/master/COPYING.txt) |
+| [NEST](https://github.com/elastic/elasticsearch-net) | .NET Library for Elasticsearch | [Apache-2.0](https://github.com/elastic/elasticsearch-net/blob/main/LICENSE.txt) |
+| [Azure.Search.Documents](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Search.Documents_11.5.1/sdk/search/Azure.Search.Documents/README.md) | Azure AI Search client library for .NET | [MIT](https://github.com/AzureAD/microsoft-identity-web/blob/master/LICENSE) |
+| [Microsoft.Extensions.Azure](https://github.com/Azure/azure-sdk-for-net/blob/Microsoft.Extensions.Azure_1.7.3/sdk/extensions/Microsoft.Extensions.Azure/README.md) | Azure client library integration for ASP.NET Core | [MIT](https://github.com/AzureAD/microsoft-identity-web/blob/master/LICENSE) |
+| [NJsonSchema](https://github.com/RicoSuter/NJsonSchema) | JSON Schema reader, generator and validator for .NET | [MIT](https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md) |
+| [NLog.Web.AspNetCore](https://github.com/NLog/NLog.Web/tree/master/src/NLog.Web.AspNetCore) | NLog integration for ASP.NET. | [BSD-3-Clause](https://github.com/NLog/NLog.Web/blob/master/LICENSE) |
+| [Noda Time](https://github.com/nodatime/nodatime) | A better date and time API for .NET. | [Apache-2.0](https://github.com/nodatime/nodatime/blob/master/LICENSE.txt) |
+| [OpenIddict](https://github.com/openiddict/openiddict-core) | Flexible and versatile OAuth 2.0/OpenID Connect stack for .NET. | [Apache-2.0](https://github.com/openiddict/openiddict-core/blob/dev/LICENSE.md) |
+| [PdfPig](https://github.com/UglyToad/PdfPig/) | Library to read and extract text and other content from PDF files. | [Apache-2.0](https://github.com/UglyToad/PdfPig/blob/master/LICENSE) |
+| [Serilog.AspNetCore](https://github.com/serilog/serilog-aspnetcore) | Serilog integration for ASP.NET Core. | [Apache-2.0](https://github.com/serilog/serilog-aspnetcore/blob/dev/LICENSE) |
+| [Shortcodes](https://github.com/sebastienros/shortcodes) | Shortcodes processor for .NET. | [MIT](https://github.com/sebastienros/shortcodes/blob/dev/LICENSE) |
+| [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis) | General purpose redis client. | [MIT](https://github.com/StackExchange/StackExchange.Redis/blob/main/LICENSE) |
+| [YesSql](https://github.com/sebastienros/yessql) | .NET document database working on any RDBMS. | [MIT](https://github.com/sebastienros/yessql/blob/dev/LICENSE) |
+| [ZString](https://github.com/Cysharp/ZString) | Zero Allocation StringBuilder for .NET Core and Unity. | [MIT](https://github.com/Cysharp/ZString/blob/master/LICENSE) |
 
 The below table lists the different libraries used as Resources:
 
 | Library | Usage | Version | License |
 |--- | --- | --- | --- |
-| [Bootstrap](https://github.com/twbs/bootstrap) | HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web. | 5.3.3 | [MIT](https://github.com/twbs/bootstrap/blob/main/LICENSE) |
-| [bootstrap-select](https://github.com/snapappointments/bootstrap-select) | jQuery plugin for select elements. | 1.14.0-beta3 | [MIT](https://github.com/snapappointments/bootstrap-select/blob/v1.14-dev/LICENSE) |
-| [Code Mirror](https://github.com/codemirror/CodeMirror) | In-browser code editor. | 5.65.7 | [MIT](https://github.com/codemirror/CodeMirror/blob/master/LICENSE) |
-| [Font Awesome](https://github.com/FortAwesome/Font-Awesome) | The iconic SVG, font, and CSS toolkit. | 6.5.2 | [Font Awesome Free License](https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt) |
-| [jQuery](https://github.com/jquery/jquery) | jQuery JavaScript Library. | 3.7.1 | [MIT](https://github.com/jquery/jquery/blob/master/LICENSE.txt) |
-| [jQuery UI](https://github.com/jquery/jquery-ui) | jQuery user interface library. | 1.12.1 | [MIT](https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt) |
-| [jQuery UI i18n](https://github.com/jquery/jquery-ui/tree/master/ui/i18n) | jQuery UI internationalization. | 1.7.2 | [MIT](https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt) |
-| [jQuery Easing](https://github.com/gdsmith/jquery.easing) | jQuery Easing Plugin. | 1.4.1 | [MIT](https://github.com/gdsmith/jquery.easing/blob/master/LICENSE-BSD-3-Clause.txt) |
-| [jquery-resizable-dom](https://github.com/RickStrahl/jquery-resizable) | jQuery plug-in to make DOM components resizable. | 0.35.0 | [MIT](https://github.com/RickStrahl/jquery-resizable/blob/master/LICENSE.md) |
-| [js-cookie](https://github.com/js-cookie/js-cookie) | A simple, lightweight JavaScript API for handling browser cookies. | 3.0.5 | [MIT](https://github.com/js-cookie/js-cookie/blob/master/LICENSE) |
-| [Material icons](https://github.com/marella/material-icons) | Latest icon fonts and CSS for self-hosting material design icons. | 1.12.0 | [Apache-2.0](https://github.com/marella/material-icons/blob/main/LICENSE) |
-| [Monaco Editor](https://microsoft.github.io/monaco-editor) | Lightweight source code editor | 0.46.0 | [MIT](https://github.com/microsoft/monaco-editor/blob/main/LICENSE.md) |
-| [noUiSlider](https://github.com/leongersen/noUiSlider) | noUiSlider is a lightweight JavaScript range slider. | 15.6.1 | [MIT](https://github.com/leongersen/noUiSlider/blob/master/LICENSE.md) |
-| [Popper](https://github.com/popperjs/popper-core) | Positioning tooltips and popovers. | 2.11.8 | [MIT](https://github.com/popperjs/popper-core/blob/master/LICENSE.md) |
-| [Sortable](https://github.com/SortableJS/sortablejs) | Create and reorder lists with drag-and-drop. | 1.15.0 | [MIT](https://github.com/SortableJS/sortablejs/blob/master/LICENSE) |
-| [Trumbowyg](https://github.com/Alex-D/Trumbowyg) | A lightweight and amazing WYSIWYG JavaScript editor. | 2.28.0 | [MIT](https://github.com/Alex-D/Trumbowyg/blob/develop/LICENSE) |
-| [vue-multiselect](https://github.com/shentao/vue-multiselect) | Universal select/multiselect/tagging component for Vue.js. | 2.1.6 | [MIT](https://github.com/shentao/vue-multiselect/blob/master/LICENSE) |
-| [Vue.Draggable](https://github.com/SortableJS/Vue.Draggable) | Vue drag-and-drop component based on Sortable.js. | 2.24.3 | [MIT](https://github.com/SortableJS/Vue.Draggable/blob/master/LICENSE) |
+| [Bootstrap](https://github.com/twbs/bootstrap) | HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web. | [MIT](https://github.com/twbs/bootstrap/blob/main/LICENSE) |
+| [bootstrap-select](https://github.com/snapappointments/bootstrap-select) | jQuery plugin for select elements. | [MIT](https://github.com/snapappointments/bootstrap-select/blob/v1.14-dev/LICENSE) |
+| [Code Mirror](https://github.com/codemirror/CodeMirror) | In-browser code editor. | [MIT](https://github.com/codemirror/CodeMirror/blob/master/LICENSE) |
+| [Font Awesome](https://github.com/FortAwesome/Font-Awesome) | The iconic SVG, font, and CSS toolkit. | [Font Awesome Free License](https://github.com/FortAwesome/Font-Awesome/blob/master/LICENSE.txt) |
+| [jQuery](https://github.com/jquery/jquery) | jQuery JavaScript Library. | [MIT](https://github.com/jquery/jquery/blob/master/LICENSE.txt) |
+| [jQuery UI](https://github.com/jquery/jquery-ui) | jQuery user interface library. | [MIT](https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt) |
+| [jQuery UI i18n](https://github.com/jquery/jquery-ui/tree/master/ui/i18n) | jQuery UI internationalization. | [MIT](https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt) |
+| [jQuery Easing](https://github.com/gdsmith/jquery.easing) | jQuery Easing Plugin. | [MIT](https://github.com/gdsmith/jquery.easing/blob/master/LICENSE-BSD-3-Clause.txt) |
+| [jquery-resizable-dom](https://github.com/RickStrahl/jquery-resizable) | jQuery plug-in to make DOM components resizable. | [MIT](https://github.com/RickStrahl/jquery-resizable/blob/master/LICENSE.md) |
+| [js-cookie](https://github.com/js-cookie/js-cookie) | A simple, lightweight JavaScript API for handling browser cookies. | [MIT](https://github.com/js-cookie/js-cookie/blob/master/LICENSE) |
+| [Material icons](https://github.com/marella/material-icons) | Latest icon fonts and CSS for self-hosting material design icons. | [Apache-2.0](https://github.com/marella/material-icons/blob/main/LICENSE) |
+| [Monaco Editor](https://microsoft.github.io/monaco-editor) | Lightweight source code editor | [MIT](https://github.com/microsoft/monaco-editor/blob/main/LICENSE.md) |
+| [noUiSlider](https://github.com/leongersen/noUiSlider) | noUiSlider is a lightweight JavaScript range slider. | [MIT](https://github.com/leongersen/noUiSlider/blob/master/LICENSE.md) |
+| [Popper](https://github.com/popperjs/popper-core) | Positioning tooltips and popovers. | [MIT](https://github.com/popperjs/popper-core/blob/master/LICENSE.md) |
+| [Sortable](https://github.com/SortableJS/sortablejs) | Create and reorder lists with drag-and-drop. | [MIT](https://github.com/SortableJS/sortablejs/blob/master/LICENSE) |
+| [Trumbowyg](https://github.com/Alex-D/Trumbowyg) | A lightweight and amazing WYSIWYG JavaScript editor. | [MIT](https://github.com/Alex-D/Trumbowyg/blob/develop/LICENSE) |
+| [vue-multiselect](https://github.com/shentao/vue-multiselect) | Universal select/multiselect/tagging component for Vue.js. | | [MIT](https://github.com/shentao/vue-multiselect/blob/master/LICENSE) |
+| [Vue.Draggable](https://github.com/SortableJS/Vue.Draggable) | Vue drag-and-drop component based on Sortable.js. | [MIT](https://github.com/SortableJS/Vue.Draggable/blob/master/LICENSE) |
 
 The below table lists the different Client side libraries:
 
 | Library | Usage | Version | License |
 |--- | --- | --- | --- |
-| [EasyMDE](https://github.com/Ionaru/easy-markdown-editor) | A simple, beautiful, and embeddable JavaScript Markdown editor. | 2.18.0 | [MIT](https://github.com/Ionaru/easy-markdown-editor/blob/master/LICENSE) |
-| [GraphiQL](https://github.com/graphql/graphiql) | GraphQL editor. | 1.11.5 | [MIT](https://github.com/graphql/graphiql/blob/main/LICENSE) |
-| [GraphiQL explorer](https://github.com/onegraph/graphiql-explorer) | Explorer plugin for GraphiQL. | 0.6.3 | [MIT](https://github.com/OneGraph/graphiql-explorer/blob/master/LICENSE) |
-| [GraphQL](https://github.com/graphql/graphql-js) | A reference implementation of GraphQL for JavaScript. | 15.8.0 | [MIT](https://github.com/graphql/graphql-js/blob/main/LICENSE) |
-| [Gulp](https://github.com/gulpjs/gulp) | A toolkit to automate & enhance your workflow. | 4.0.2 | [MIT](https://github.com/gulpjs/gulp/blob/master/LICENSE) |
-| [Gulp](https://github.com/gulpjs/gulp-cli) | Command Line Interface for gulp. | 2.3.0 | [MIT](https://github.com/gulpjs/gulp-cli/blob/master/LICENSE) |
-| [jQuery-File-Upload](https://github.com/blueimp/jQuery-File-Upload) | File Upload widget for jQuery. | 10.32.0 | [MIT](https://github.com/blueimp/jQuery-File-Upload/blob/master/LICENSE.txt) |
-| [jsPlumb](https://github.com/jsplumb/jsplumb) | Visual connectivity for webapps. | 2.15.6 | [MIT and GPLv2](https://github.com/jsplumb/jsplumb/blob/master/jsPlumb-LICENSE.txt) |
-| [Leaflet](https://github.com/Leaflet/Leaflet) | JavaScript library for mobile-friendly interactive maps. | 1.9.4 | [BSD-2-Clause License](https://github.com/Leaflet/Leaflet/blob/main/LICENSE) |
-| [React](https://github.com/facebook/react) | JavaScript library for building user interface. | 16.14.0 | [MIT](https://github.com/facebook/react/blob/master/LICENSE) |
-| [TypeScript](https://github.com/microsoft/TypeScript) | Superset of JavaScript that compiles to clean JavaScript output. | 4.9.3 | [Apache-2.0](https://github.com/microsoft/TypeScript/blob/master/LICENSE.txt) |
-| [Vue](https://github.com/vuejs/vue) | JavaScript framework for building UI on the web. | 2.6.14 | [MIT](https://github.com/vuejs/vue/blob/dev/LICENSE) |
-| [Webpack](https://github.com/webpack/webpack) | A bundler for javascript and friends. | 5.75.0 | [MIT](https://github.com/webpack/webpack/blob/master/LICENSE) |
-| [Webpack CLI](https://github.com/webpack/webpack-cli) | Webpack's Command Line Interface | 5.0.0 | [MIT](https://github.com/webpack/webpack-cli/blob/master/LICENSE) |
+| [EasyMDE](https://github.com/Ionaru/easy-markdown-editor) | A simple, beautiful, and embeddable JavaScript Markdown editor. | [MIT](https://github.com/Ionaru/easy-markdown-editor/blob/master/LICENSE) |
+| [GraphiQL](https://github.com/graphql/graphiql) | GraphQL editor. | [MIT](https://github.com/graphql/graphiql/blob/main/LICENSE) |
+| [GraphiQL explorer](https://github.com/onegraph/graphiql-explorer) | Explorer plugin for GraphiQL. | [MIT](https://github.com/OneGraph/graphiql-explorer/blob/master/LICENSE) |
+| [GraphQL](https://github.com/graphql/graphql-js) | A reference implementation of GraphQL for JavaScript. | [MIT](https://github.com/graphql/graphql-js/blob/main/LICENSE) |
+| [Gulp](https://github.com/gulpjs/gulp) | A toolkit to automate & enhance your workflow. | [MIT](https://github.com/gulpjs/gulp/blob/master/LICENSE) |
+| [Gulp](https://github.com/gulpjs/gulp-cli) | Command Line Interface for gulp. | [MIT](https://github.com/gulpjs/gulp-cli/blob/master/LICENSE) |
+| [jQuery-File-Upload](https://github.com/blueimp/jQuery-File-Upload) | File Upload widget for jQuery. | [MIT](https://github.com/blueimp/jQuery-File-Upload/blob/master/LICENSE.txt) |
+| [jsPlumb](https://github.com/jsplumb/jsplumb) | Visual connectivity for webapps. | [MIT and GPLv2](https://github.com/jsplumb/jsplumb/blob/master/jsPlumb-LICENSE.txt) |
+| [Leaflet](https://github.com/Leaflet/Leaflet) | JavaScript library for mobile-friendly interactive maps. | [BSD-2-Clause License](https://github.com/Leaflet/Leaflet/blob/main/LICENSE) |
+| [React](https://github.com/facebook/react) | JavaScript library for building user interface. | [MIT](https://github.com/facebook/react/blob/master/LICENSE) |
+| [TypeScript](https://github.com/microsoft/TypeScript) | Superset of JavaScript that compiles to clean JavaScript output. | [Apache-2.0](https://github.com/microsoft/TypeScript/blob/master/LICENSE.txt) |
+| [Vue](https://github.com/vuejs/vue) | JavaScript framework for building UI on the web. | [MIT](https://github.com/vuejs/vue/blob/dev/LICENSE) |
+| [Webpack](https://github.com/webpack/webpack) | A bundler for javascript and friends. | [MIT](https://github.com/webpack/webpack/blob/master/LICENSE) |
+| [Webpack CLI](https://github.com/webpack/webpack-cli) | Webpack's Command Line Interface | [MIT](https://github.com/webpack/webpack-cli/blob/master/LICENSE) |
 
 The below table lists the different Tests libraries:
 
 | Library | Usage | Version | License |
 |--- | --- | --- | --- |
-| [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) | Powerful .NET library for benchmarking. | 0.13.12 | [MIT](https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md) |
-| [Cypress](https://github.com/cypress-io/cypress) | Fast, easy and reliable testing for anything that runs in a browser. | 9.6.1 | [MIT](https://github.com/cypress-io/cypress/blob/develop/LICENSE) |
-| [Cypress Orchard](https://www.npmjs.com/package/cypress-orchardcore) | A collection of cypress commands for Orchard Core. | 0.4.5 | MIT |
-| [Moq](https://github.com/moq/moq) | The most popular and friendly mocking framework for .NET. | 4.20.70 | [MIT](https://github.com/moq/moq/blob/main/LICENSE) |
-| [VS Test SDK](https://github.com/microsoft/vstest/) | Visual Studio Test Platform. | 17.9.0 | [MIT](https://github.com/microsoft/vstest/blob/master/LICENSE) |
-| [xUnit](https://github.com/xunit/xunit) | Free, open source, community-focused unit testing tool for the .NET Framework. | 2.8.1 | [MIT](https://github.com/xunit/xunit/blob/main/LICENSE) |
-| [xUnit Analyzers](https://github.com/xunit/xunit.analyzers) | Roslyn analyzers for xUnit.net. | 1.14.0 | [MIT](https://github.com/xunit/xunit.analyzers/blob/main/LICENSE) |
-| [xUnit VS runner](https://github.com/xunit/visualstudio.xunit) | VSTest runner for xUnit.net. | 2.8.1 | [MIT](https://github.com/xunit/visualstudio.xunit/blob/main/License.txt) |
+| [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) | Powerful .NET library for benchmarking. | [MIT](https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md) |
+| [Cypress](https://github.com/cypress-io/cypress) | Fast, easy and reliable testing for anything that runs in a browser. | [MIT](https://github.com/cypress-io/cypress/blob/develop/LICENSE) |
+| [Cypress Orchard](https://www.npmjs.com/package/cypress-orchardcore) | A collection of cypress commands for Orchard Core. | MIT |
+| [Moq](https://github.com/moq/moq) | The most popular and friendly mocking framework for .NET. | [MIT](https://github.com/moq/moq/blob/main/LICENSE) |
+| [VS Test SDK](https://github.com/microsoft/vstest/) | Visual Studio Test Platform. | [MIT](https://github.com/microsoft/vstest/blob/master/LICENSE) |
+| [xUnit](https://github.com/xunit/xunit) | Free, open source, community-focused unit testing tool for the .NET Framework. | [MIT](https://github.com/xunit/xunit/blob/main/LICENSE) |
+| [xUnit Analyzers](https://github.com/xunit/xunit.analyzers) | Roslyn analyzers for xUnit.net. | [MIT](https://github.com/xunit/xunit.analyzers/blob/main/LICENSE) |
+| [xUnit VS runner](https://github.com/xunit/visualstudio.xunit) | VSTest runner for xUnit.net. | [MIT](https://github.com/xunit/visualstudio.xunit/blob/main/License.txt) |

--- a/src/docs/resources/libraries/README.md
+++ b/src/docs/resources/libraries/README.md
@@ -2,8 +2,8 @@
 
 The below table lists the different .NET libraries used in Orchard Core:
 
-| Library | Usage | Version | License |
-|--- | --- | --- | --- |
+| Library | Usage | License |
+|--- | --- | --- |
 | [Angle Sharp](https://github.com/AngleSharp/AngleSharp) | Angle brackets parser library. | [MIT](https://github.com/AngleSharp/AngleSharp/blob/devel/LICENSE) |
 | [AWSSDK S3](https://github.com/aws/aws-sdk-net) | AWS SDK for .NET. | [Apache-2.0 license](https://github.com/aws/aws-sdk-net/blob/master/License.txt) |
 | [AWSSDK SecurityToken](https://github.com/aws/aws-sdk-net) | AWS SDK for .NET. | [Apache-2.0 license](https://github.com/aws/aws-sdk-net/blob/master/License.txt) |
@@ -50,8 +50,8 @@ The below table lists the different .NET libraries used in Orchard Core:
 
 The below table lists the different libraries used as Resources:
 
-| Library | Usage | Version | License |
-|--- | --- | --- | --- |
+| Library | Usage | License |
+|--- | --- | --- |
 | [Bootstrap](https://github.com/twbs/bootstrap) | HTML, CSS, and JavaScript framework for developing responsive, mobile first projects on the web. | [MIT](https://github.com/twbs/bootstrap/blob/main/LICENSE) |
 | [bootstrap-select](https://github.com/snapappointments/bootstrap-select) | jQuery plugin for select elements. | [MIT](https://github.com/snapappointments/bootstrap-select/blob/v1.14-dev/LICENSE) |
 | [Code Mirror](https://github.com/codemirror/CodeMirror) | In-browser code editor. | [MIT](https://github.com/codemirror/CodeMirror/blob/master/LICENSE) |
@@ -73,8 +73,8 @@ The below table lists the different libraries used as Resources:
 
 The below table lists the different Client side libraries:
 
-| Library | Usage | Version | License |
-|--- | --- | --- | --- |
+| Library | Usage | License |
+|--- | --- | --- |
 | [EasyMDE](https://github.com/Ionaru/easy-markdown-editor) | A simple, beautiful, and embeddable JavaScript Markdown editor. | [MIT](https://github.com/Ionaru/easy-markdown-editor/blob/master/LICENSE) |
 | [GraphiQL](https://github.com/graphql/graphiql) | GraphQL editor. | [MIT](https://github.com/graphql/graphiql/blob/main/LICENSE) |
 | [GraphiQL explorer](https://github.com/onegraph/graphiql-explorer) | Explorer plugin for GraphiQL. | [MIT](https://github.com/OneGraph/graphiql-explorer/blob/master/LICENSE) |
@@ -92,8 +92,8 @@ The below table lists the different Client side libraries:
 
 The below table lists the different Tests libraries:
 
-| Library | Usage | Version | License |
-|--- | --- | --- | --- |
+| Library | Usage | License |
+|--- | --- | --- |
 | [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet) | Powerful .NET library for benchmarking. | [MIT](https://github.com/dotnet/BenchmarkDotNet/blob/master/LICENSE.md) |
 | [Cypress](https://github.com/cypress-io/cypress) | Fast, easy and reliable testing for anything that runs in a browser. | [MIT](https://github.com/cypress-io/cypress/blob/develop/LICENSE) |
 | [Cypress Orchard](https://www.npmjs.com/package/cypress-orchardcore) | A collection of cypress commands for Orchard Core. | MIT |


### PR DESCRIPTION
This will create a single PR weekly with all the minor version updates for the referenced packages.
If we think that some of them should be updated less often, or with different rules (no patch version for instance), or not updated automatically, then we can add more groups.

These PRs also reference the release notes from each package update if available, which helps us understand what we are getting.