### PR TITLE
Hide "Number of items closed" from Discussion Metrics (Lombiq Technologies: OCORE-183)

### DIFF
--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -59,6 +59,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SEARCH_QUERY: 'repo:OrchardCMS/OrchardCore type:discussions created:${{ env.LAST_MONTH }} category:Q&A'
         HIDE_TIME_TO_CLOSE: true
+        HIDE_ITEMS_CLOSED_COUNT: true
 
     - name: Concatenate Issue/PR and Discussion Metrics
       shell: pwsh


### PR DESCRIPTION
This is hiding this useless line from the [community metrics](https://github.com/OrchardCMS/OrchardCore/labels/community%20metrics):

![image](https://github.com/OrchardCMS/OrchardCore/assets/1976647/94923fa7-626e-4c7b-bd78-cca5f49154a7)

It's useless because it doesn't show the number of _answered_ discussions (which would be useful) but counts only those where somebody separately clicked on the close discussion button.

This was made possible by this update: https://github.com/github/issue-metrics/pull/313.