### PR TITLE
Added unit tests for populating the type feature provider

### DIFF
--- a/test/OrchardCore.Tests.Modules/BaseThemeSample/DependentTypes.cs
+++ b/test/OrchardCore.Tests.Modules/BaseThemeSample/DependentTypes.cs
@@ -7,7 +7,11 @@ using OrchardCore.Modules;
 
 namespace BaseThemeSample;
 
-public class BaseThemeFeatureIndependentStartup : StartupBase { }
+public class BaseThemeFeatureIndependentStartup : StartupBase 
+{ 
+}
 
 [Feature("BaseThemeSample")]
-public class BaseThemeSampleStartup : StartupBase { }
+public class BaseThemeSampleStartup : StartupBase 
+{
+}

--- a/test/OrchardCore.Tests.Modules/BaseThemeSample/DependentTypes.cs
+++ b/test/OrchardCore.Tests.Modules/BaseThemeSample/DependentTypes.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OrchardCore.Modules;
+
+namespace BaseThemeSample;
+
+public class BaseThemeFeatureIndependentStartup : StartupBase { }
+
+[Feature("BaseThemeSample")]
+public class BaseThemeSampleStartup : StartupBase { }

--- a/test/OrchardCore.Tests.Modules/ModuleSample/DependentTypes.cs
+++ b/test/OrchardCore.Tests.Modules/ModuleSample/DependentTypes.cs
@@ -1,0 +1,14 @@
+using OrchardCore.Environment.Extensions;
+using OrchardCore.Modules;
+
+namespace ModuleSample;
+
+public class FeatureIndependentStartup : StartupBase { }
+
+
+[Feature("Sample1")]
+public class Sample1Startup : StartupBase { }
+
+[Feature("Sample2")]
+[FeatureTypeDiscovery(SkipExtension = true)]
+public class SkippedDependentType { }

--- a/test/OrchardCore.Tests.Modules/ModuleSample/DependentTypes.cs
+++ b/test/OrchardCore.Tests.Modules/ModuleSample/DependentTypes.cs
@@ -5,10 +5,13 @@ namespace ModuleSample;
 
 public class FeatureIndependentStartup : StartupBase { }
 
-
 [Feature("Sample1")]
-public class Sample1Startup : StartupBase { }
+public class Sample1Startup : StartupBase 
+{
+}
 
 [Feature("Sample2")]
 [FeatureTypeDiscovery(SkipExtension = true)]
-public class SkippedDependentType { }
+public class SkippedDependentType 
+{
+}

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Tests.Extensions
         private readonly ExtensionManager _moduleScopedExtensionManager;
         private readonly ExtensionManager _themeScopedExtensionManager;
         private readonly ExtensionManager _moduleThemeScopedExtensionManager;
-
+        
         private readonly TypeFeatureProvider _moduleScopedTypeFeatureProvider = new TypeFeatureProvider();
 
         public ExtensionManagerTests()

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -27,9 +27,7 @@ namespace OrchardCore.Tests.Extensions
         private readonly ExtensionManager _themeScopedExtensionManager;
         private readonly ExtensionManager _moduleThemeScopedExtensionManager;
 
-#pragma warning disable CA1859 // Use concrete types when possible for improved performance - not relevant for unit tests.
-        private readonly ITypeFeatureProvider _moduleScopedTypeFeatureProvider = new TypeFeatureProvider();
-#pragma warning restore CA1859 // Use concrete types when possible for improved performance
+        private readonly TypeFeatureProvider _moduleScopedTypeFeatureProvider = new TypeFeatureProvider();
 
         public ExtensionManagerTests()
         {

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -27,7 +27,9 @@ namespace OrchardCore.Tests.Extensions
         private readonly ExtensionManager _themeScopedExtensionManager;
         private readonly ExtensionManager _moduleThemeScopedExtensionManager;
 
+#pragma warning disable CA1859 // Use concrete types when possible for improved performance - not relevant for unit tests.
         private readonly ITypeFeatureProvider _moduleScopedTypeFeatureProvider = new TypeFeatureProvider();
+#pragma warning restore CA1859 // Use concrete types when possible for improved performance
 
         public ExtensionManagerTests()
         {

--- a/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
+++ b/test/OrchardCore.Tests/Extensions/ExtensionManagerTests.cs
@@ -1,3 +1,5 @@
+using BaseThemeSample;
+using ModuleSample;
 using OrchardCore.DisplayManagement.Events;
 using OrchardCore.DisplayManagement.Extensions;
 using OrchardCore.Environment.Extensions;
@@ -25,13 +27,15 @@ namespace OrchardCore.Tests.Extensions
         private readonly ExtensionManager _themeScopedExtensionManager;
         private readonly ExtensionManager _moduleThemeScopedExtensionManager;
 
+        private readonly ITypeFeatureProvider _moduleScopedTypeFeatureProvider = new TypeFeatureProvider();
+
         public ExtensionManagerTests()
         {
             _moduleScopedExtensionManager = new ExtensionManager(
                 _applicationContext,
                 new[] { new ExtensionDependencyStrategy() },
                 new[] { new ExtensionPriorityStrategy() },
-                new TypeFeatureProvider(),
+                _moduleScopedTypeFeatureProvider,
                 _moduleFeatureProvider,
                 new NullLogger<ExtensionManager>()
                 );
@@ -167,7 +171,7 @@ namespace OrchardCore.Tests.Extensions
         /* Theme Base Theme Dependencies */
 
         [Fact]
-        public void GetFeaturesShouldReturnCorrectThemeHeirarchy()
+        public void GetFeaturesShouldReturnCorrectThemeHierarchy()
         {
             var features = _themeScopedExtensionManager.GetFeatures(["DerivedThemeSample"]);
 
@@ -221,6 +225,54 @@ namespace OrchardCore.Tests.Extensions
             var extension = _moduleThemeScopedExtensionManager.GetExtension("NotFound");
 
             Assert.False(extension.Exists);
+        }
+
+        /* The extension manager must populate the ITypeFeatureProvider correctly */
+
+        [Fact]
+        public void TypeFeatureProviderIsPopulatedWithComponentTypes()
+        {
+            var feature = _moduleScopedExtensionManager.GetFeatures(["Sample1"]).First();
+            var types = _moduleScopedTypeFeatureProvider.GetTypesForFeature(feature);
+
+            Assert.Equal(2, types.Count());
+            Assert.Contains(typeof(Sample1Startup), types);
+            Assert.Contains(typeof(FeatureIndependentStartup), types);
+        }
+
+        [Fact]
+        public void TypeFeatureProviderTypeMustBeMappedToAllFeatures()
+        {
+            // Types in modules that have no feature that matches the extension ID must be mapped to all features.
+            var features = _moduleScopedExtensionManager.GetFeatures(["Sample1", "Sample2", "Sample3", "Sample4"]);
+
+            foreach (var feature in features)
+            {
+                var types = _moduleScopedTypeFeatureProvider.GetTypesForFeature(feature);
+
+                Assert.Contains(typeof(FeatureIndependentStartup), types);
+            }
+        }
+
+        [Fact]
+        public void TypeFeatureProviderTypeMustBeMappedToExtensionFeature()
+        {
+            // Types in modules that have a feature that matches the extension ID must be mapped to that feature.
+            var feature = _moduleScopedExtensionManager.GetFeatures(["BaseThemeSample"]).First();
+            var types = _moduleScopedTypeFeatureProvider.GetTypesForFeature(feature);
+
+            Assert.Equal(2, types.Count());
+            Assert.Contains(typeof(BaseThemeSampleStartup), types);
+            Assert.Contains(typeof(BaseThemeFeatureIndependentStartup), types);
+        }
+
+        [Fact]
+        public void TypeFeatureProviderTypeMustBeSkipped()
+        {
+            var feature = _moduleScopedExtensionManager.GetFeatures(["Sample2"]).First();
+            var types = _moduleScopedTypeFeatureProvider.GetTypesForFeature(feature);
+
+            Assert.DoesNotContain(typeof(SkippedDependentType), types);
         }
     }
 }


### PR DESCRIPTION
Added some basic unit tests for how the `ExtensionManager` populates the `ITypeFeatureProvider`.

The test `TypeFeatureProviderTypeMustBeMappedToAllFeatures` is related to the new behavior added by #16379.