### PR TITLE
Fix non-debug version loaded for certain static resources when debug mode is enabled

### DIFF
--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -258,8 +258,8 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
-        public RequireSettings New() =>
-            new()
+        public RequireSettings New(ResourceManagementOptions options) =>
+            new(options)
             {
                 Name = Name,
                 Type = Type,
@@ -267,8 +267,8 @@ namespace OrchardCore.ResourceManagement
                 Position = Position
             };
 
-        public RequireSettings NewAndCombine(RequireSettings other) =>
-            New().Combine(other);
+        public RequireSettings NewAndCombine(ResourceManagementOptions options, RequireSettings other) =>
+            New(options).Combine(other);
 
         public RequireSettings Combine(RequireSettings other)
         {

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -39,7 +39,6 @@ namespace OrchardCore.ResourceManagement
         public RequireSettings(ResourceManagementOptions options)
         {
             _options = options;
-
             CdnMode = options.UseCdn;
             DebugMode = options.DebugMode;
             Culture = options.Culture;
@@ -264,8 +263,9 @@ namespace OrchardCore.ResourceManagement
 
         public RequireSettings New()
         {
-            RequireSettings settings = _options != null ? new(_options) : new();
-
+            RequireSettings settings = _options != null
+                ? new(_options)
+                : new();
             settings.Name = Name;
             settings.Type = Type;
             settings.Location = Location;

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -7,6 +7,8 @@ namespace OrchardCore.ResourceManagement
 {
     public class RequireSettings
     {
+        private readonly ResourceManagementOptions _options;
+
         private Dictionary<string, string> _attributes;
 
         public string BasePath { get; set; }
@@ -36,6 +38,8 @@ namespace OrchardCore.ResourceManagement
 
         public RequireSettings(ResourceManagementOptions options)
         {
+            _options = options;
+
             CdnMode = options.UseCdn;
             DebugMode = options.DebugMode;
             Culture = options.Culture;
@@ -258,8 +262,8 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
-        public RequireSettings New(ResourceManagementOptions options) =>
-            new(options)
+        public RequireSettings New() =>
+            _options != null ? new(_options) : new()
             {
                 Name = Name,
                 Type = Type,
@@ -267,8 +271,8 @@ namespace OrchardCore.ResourceManagement
                 Position = Position
             };
 
-        public RequireSettings NewAndCombine(ResourceManagementOptions options, RequireSettings other) =>
-            New(options).Combine(other);
+        public RequireSettings NewAndCombine(RequireSettings other) =>
+            New().Combine(other);
 
         public RequireSettings Combine(RequireSettings other)
         {

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -262,14 +262,17 @@ namespace OrchardCore.ResourceManagement
             return this;
         }
 
-        public RequireSettings New() =>
-            _options != null ? new(_options) : new()
-            {
-                Name = Name,
-                Type = Type,
-                Location = Location,
-                Position = Position
-            };
+        public RequireSettings New()
+        {
+            var settings = _options != null ? new RequireSettings(_options) : new RequireSettings();
+
+            settings.Name = Name;
+            settings.Type = Type;
+            settings.Location = Location;
+            settings.Position = Position;
+
+            return settings;
+        }
 
         public RequireSettings NewAndCombine(RequireSettings other) =>
             New().Combine(other);

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -266,6 +266,7 @@ namespace OrchardCore.ResourceManagement
             RequireSettings settings = _options != null
                 ? new(_options)
                 : new();
+
             settings.Name = Name;
             settings.Type = Type;
             settings.Location = Location;

--- a/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement.Abstractions/RequireSettings.cs
@@ -264,7 +264,7 @@ namespace OrchardCore.ResourceManagement
 
         public RequireSettings New()
         {
-            var settings = _options != null ? new RequireSettings(_options) : new RequireSettings();
+            RequireSettings settings = _options != null ? new(_options) : new();
 
             settings.Name = Name;
             settings.Type = Type;

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -396,7 +396,7 @@ namespace OrchardCore.ResourceManagement
             // and Foo's required location is Head, so too should Bar's location, similarly, if Foo is First positioned,
             // Bar dependency should be too. This behavior only applies to the dependencies.
 
-            var dependencySettings = ((RequireSettings)allResources[resource])?.New() ?? new RequireSettings(_options, resource);
+            var dependencySettings = ((RequireSettings)allResources[resource])?.New(_options) ?? new RequireSettings(_options, resource);
             dependencySettings = isTopLevel ? dependencySettings.Combine(settings) : dependencySettings.AtLocation(settings.Location);
             dependencySettings = dependencySettings.CombinePosition(settings);
 

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ResourceManager.cs
@@ -396,7 +396,7 @@ namespace OrchardCore.ResourceManagement
             // and Foo's required location is Head, so too should Bar's location, similarly, if Foo is First positioned,
             // Bar dependency should be too. This behavior only applies to the dependencies.
 
-            var dependencySettings = ((RequireSettings)allResources[resource])?.New(_options) ?? new RequireSettings(_options, resource);
+            var dependencySettings = ((RequireSettings)allResources[resource])?.New() ?? new RequireSettings(_options, resource);
             dependencySettings = isTopLevel ? dependencySettings.Combine(settings) : dependencySettings.AtLocation(settings.Location);
             dependencySettings = dependencySettings.CombinePosition(settings);
 


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->

Fix #16401 

This fix addresses an issue where `ResourceManagementOptions` were not inherited by dependent resources. As a result, dependencies were always loaded in their minified versions without versioning. The following images illustrate the changes:

Before:

![image](https://github.com/OrchardCMS/OrchardCore/assets/2022320/1bab7355-cdd0-43f3-9b4f-937f475a6f67)

After:

![image](https://github.com/OrchardCMS/OrchardCore/assets/2022320/59c3be2e-8287-41d5-9859-c78e95e03411)
