### PR TITLE
Declare known-converters and use them in DocumentJsonSerializerOptions

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/DocumentJsonSerializerOptionsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/DocumentJsonSerializerOptionsConfiguration.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Options;
 using OrchardCore.Json;
-using OrchardCore.Json.Serialization;
 
 namespace OrchardCore.Extensions;
 
@@ -25,7 +24,10 @@ public sealed class DocumentJsonSerializerOptionsConfiguration : IConfigureOptio
         options.SerializerOptions.WriteIndented = JOptions.Base.WriteIndented;
 
         options.SerializerOptions.TypeInfoResolverChain.Add(new PolymorphicJsonTypeInfoResolver(_derivedTypesOptions));
-        options.SerializerOptions.Converters.Add(DynamicJsonConverter.Instance);
-        options.SerializerOptions.Converters.Add(PathStringJsonConverter.Instance);
+
+        foreach (var converter in JOptions.KnownConverters)
+        {
+            options.SerializerOptions.Converters.Add(converter);
+        }
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/JOptions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/JOptions.cs
@@ -10,6 +10,14 @@ namespace System.Text.Json;
 /// </summary>
 public static class JOptions
 {
+    public static readonly JsonConverter[] KnownConverters =
+    [
+        DynamicJsonConverter.Instance,
+        PathStringJsonConverter.Instance,
+        TimeSpanJsonConverter.Instance,
+        DateTimeJsonConverter.Instance,
+    ];
+
     public static readonly JsonSerializerOptions Base = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -34,10 +42,11 @@ public static class JOptions
     static JOptions()
     {
         Default = new JsonSerializerOptions(Base);
-        Default.Converters.Add(new DynamicJsonConverter());
-        Default.Converters.Add(new PathStringJsonConverter());
-        Default.Converters.Add(new TimeSpanJsonConverter());
-        Default.Converters.Add(new DateTimeJsonConverter());
+
+        foreach (var converter in KnownConverters)
+        {
+            Default.Converters.Add(converter);
+        }
 
         Indented = new JsonSerializerOptions(Default)
         {

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/Serialization/DateTimeJsonConverter.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/Serialization/DateTimeJsonConverter.cs
@@ -7,6 +7,8 @@ namespace OrchardCore.Json.Serialization;
 
 public class DateTimeJsonConverter : JsonConverter<DateTime>
 {
+    public static readonly DateTimeJsonConverter Instance = new();
+
     public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (typeToConvert != typeof(DateTime))
@@ -14,7 +16,7 @@ public class DateTimeJsonConverter : JsonConverter<DateTime>
             throw new ArgumentException("Unexpected type to convert.", nameof(typeToConvert));
         }
 
-        if (!reader.TryGetDateTime(out DateTime value) && DateTime.TryParse(reader.GetString()!, out value))
+        if (!reader.TryGetDateTime(out var value) && DateTime.TryParse(reader.GetString()!, out value))
         {
             return value;
         }

--- a/src/OrchardCore/OrchardCore.Abstractions/Json/Serialization/TimeSpanJsonConverter.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/Serialization/TimeSpanJsonConverter.cs
@@ -6,6 +6,8 @@ namespace OrchardCore.Json.Serialization;
 
 public class TimeSpanJsonConverter : JsonConverter<TimeSpan>
 {
+    public static readonly TimeSpanJsonConverter Instance = new();
+
     public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         if (reader.TokenType != JsonTokenType.String)
@@ -14,7 +16,7 @@ public class TimeSpanJsonConverter : JsonConverter<TimeSpan>
         }
 
         var stringValue = reader.GetString();
-        
+
         if (TimeSpan.TryParse(stringValue, out var timeSpan))
         {
             return timeSpan;

--- a/src/OrchardCore/OrchardCore.Users.Core/Extensions/UsersServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Extensions/UsersServiceCollectionExtensions.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.Configure<DocumentJsonSerializerOptions>(options =>
             {
-                options.SerializerOptions.Converters.Add(new LoginInfoJsonConverter());
+                options.SerializerOptions.Converters.Add(LoginInfoJsonConverter.Instance);
             });
 
             return services;


### PR DESCRIPTION
Reuse more static instances of converters and define jnown-converters that we can use in the `Default` and `DocumentJsonSerializerOptions` options.