### PR TITLE
Removing invalid `[FromForm]` from `TenantApiController.Setup` (Lombiq Technologies: OCORE-191)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/TenantApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/TenantApiController.cs
@@ -295,7 +295,7 @@ namespace OrchardCore.Tenants.Controllers
 
         [HttpPost]
         [Route("setup")]
-        public async Task<ActionResult> Setup(SetupApiViewModel model, [FromForm] IFormFile recipe = null)
+        public async Task<ActionResult> Setup(SetupApiViewModel model)
         {
             if (!_currentShellSettings.IsDefaultShell())
             {
@@ -393,7 +393,7 @@ namespace OrchardCore.Tenants.Controllers
 
             if (string.IsNullOrEmpty(recipeName))
             {
-                if (recipe == null)
+                if (model.Recipe == null)
                 {
                     return BadRequest(S["Either a 'recipe' file or 'RecipeName' is required."]);
                 }
@@ -402,7 +402,7 @@ namespace OrchardCore.Tenants.Controllers
 
                 using (var fs = System.IO.File.Create(tempFilename))
                 {
-                    await recipe.CopyToAsync(fs);
+                    await model.Recipe.CopyToAsync(fs);
                 }
 
                 var fileProvider = new PhysicalFileProvider(Path.GetDirectoryName(tempFilename));

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/TenantApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/TenantApiController.cs
@@ -295,7 +295,7 @@ namespace OrchardCore.Tenants.Controllers
 
         [HttpPost]
         [Route("setup")]
-        public async Task<ActionResult> Setup(SetupApiViewModel model)
+        public async Task<ActionResult> Setup(SetupApiViewModel model, string recipe = null)
         {
             if (!_currentShellSettings.IsDefaultShell())
             {
@@ -393,17 +393,14 @@ namespace OrchardCore.Tenants.Controllers
 
             if (string.IsNullOrEmpty(recipeName))
             {
-                if (model.Recipe == null)
+                if (recipe == null)
                 {
                     return BadRequest(S["Either a 'recipe' file or 'RecipeName' is required."]);
                 }
 
                 var tempFilename = Path.GetTempFileName();
 
-                using (var fs = System.IO.File.Create(tempFilename))
-                {
-                    await model.Recipe.CopyToAsync(fs);
-                }
+                await System.IO.File.WriteAllTextAsync(tempFilename, recipe);
 
                 var fileProvider = new PhysicalFileProvider(Path.GetDirectoryName(tempFilename));
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/TenantApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/TenantApiController.cs
@@ -295,7 +295,7 @@ namespace OrchardCore.Tenants.Controllers
 
         [HttpPost]
         [Route("setup")]
-        public async Task<ActionResult> Setup(SetupApiViewModel model, string recipe = null)
+        public async Task<ActionResult> Setup(SetupApiViewModel model)
         {
             if (!_currentShellSettings.IsDefaultShell())
             {
@@ -393,14 +393,14 @@ namespace OrchardCore.Tenants.Controllers
 
             if (string.IsNullOrEmpty(recipeName))
             {
-                if (recipe == null)
+                if (model.Recipe == null)
                 {
                     return BadRequest(S["Either a 'recipe' file or 'RecipeName' is required."]);
                 }
 
                 var tempFilename = Path.GetTempFileName();
 
-                await System.IO.File.WriteAllTextAsync(tempFilename, recipe);
+                await System.IO.File.WriteAllTextAsync(tempFilename, model.Recipe);
 
                 var fileProvider = new PhysicalFileProvider(Path.GetDirectoryName(tempFilename));
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/ViewModels/SetupApiViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/ViewModels/SetupApiViewModel.cs
@@ -25,7 +25,15 @@ namespace OrchardCore.Tenants.ViewModels
         [DataType(DataType.Password)]
         public string Password { get; set; }
 
+        /// <summary>
+        /// The name of a recipe available in the app.
+        /// </summary>
         public string RecipeName { get; set; }
+
+        /// <summary>
+        /// A JSON string representing a custom recipe.
+        /// </summary>
+        public string Recipe { get; set; }
 
         public string SiteTimeZone { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/ViewModels/SetupApiViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/ViewModels/SetupApiViewModel.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNetCore.Http;
 
 namespace OrchardCore.Tenants.ViewModels
 {
@@ -27,7 +26,6 @@ namespace OrchardCore.Tenants.ViewModels
         public string Password { get; set; }
 
         public string RecipeName { get; set; }
-        public IFormFile Recipe { get; set; }
 
         public string SiteTimeZone { get; set; }
 

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/ViewModels/SetupApiViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/ViewModels/SetupApiViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
 
 namespace OrchardCore.Tenants.ViewModels
 {
@@ -26,6 +27,7 @@ namespace OrchardCore.Tenants.ViewModels
         public string Password { get; set; }
 
         public string RecipeName { get; set; }
+        public IFormFile Recipe { get; set; }
 
         public string SiteTimeZone { get; set; }
 


### PR DESCRIPTION
Fixes #16430.

This is backward compatible, the requests sent to the API remain the same.