### PR TITLE
Fixing async voids (Lombiq Technologies: OCORE-192)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
@@ -61,7 +61,7 @@ public class AdminController : Controller
             Provider = _emailOptions.DefaultProviderName,
         };
 
-        PopulateModelAsync(model);
+        await PopulateModelAsync(model);
 
         return View(model);
     }
@@ -107,7 +107,7 @@ public class AdminController : Controller
             }
         }
 
-        PopulateModelAsync(model);
+        await PopulateModelAsync(model);
 
         return View(model);
     }

--- a/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
@@ -61,7 +61,7 @@ public class AdminController : Controller
             Provider = _emailOptions.DefaultProviderName,
         };
 
-        PopulateModel(model);
+        PopulateModelAsync(model);
 
         return View(model);
     }
@@ -107,7 +107,7 @@ public class AdminController : Controller
             }
         }
 
-        PopulateModel(model);
+        PopulateModelAsync(model);
 
         return View(model);
     }
@@ -140,7 +140,7 @@ public class AdminController : Controller
         return message;
     }
 
-    private async void PopulateModel(EmailTestViewModel model)
+    private async Task PopulateModelAsync(EmailTestViewModel model)
     {
         var options = new List<SelectListItem>();
 

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchDefaultOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchDefaultOptionsConfigurations.cs
@@ -26,7 +26,7 @@ public sealed class AzureAISearchDefaultOptionsConfigurations : IConfigureOption
         _siteService = siteService;
     }
 
-    public async void Configure(AzureAISearchDefaultOptions options)
+    public void Configure(AzureAISearchDefaultOptions options)
     {
         var fileOptions = _shellConfiguration.GetSection("OrchardCore_AzureAISearch")
             .Get<AzureAISearchDefaultOptions>()
@@ -49,7 +49,9 @@ public sealed class AzureAISearchDefaultOptionsConfigurations : IConfigureOption
         else
         {
             // At this point, we can allow the user to update the settings from UI.
-            var settings = await _siteService.GetSettingsAsync<AzureAISearchDefaultSettings>();
+            var settings = _siteService.GetSettingsAsync<AzureAISearchDefaultSettings>()
+                .GetAwaiter()
+                .GetResult();
 
             if (settings.UseCustomConfiguration)
             {


### PR DESCRIPTION
`async void` is fire-and-forget, meaning that the code may or may not complete before the next line, making it unreliable. Exceptions thrown from such methods can also bring down the whole app. The only case where it's recommended for are event handles, [see the official docs](https://learn.microsoft.com/en-us/dotnet/csharp/asynchronous-programming/async-return-types#void-return-type). So, fixing those here.

I also searched for less trivial cases with `async (?!(Task|ValueTask|scope|override)\b)\w+` but couldn't find any.