### PR TITLE
Correct zero length check expressions

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
@@ -111,7 +111,7 @@ namespace OrchardCore.Flows.Controllers
         {
             var settings = (await _contentDefinitionManager.GetTypeDefinitionAsync(contentType))?.Parts.SingleOrDefault(x => x.Name == partName)?.GetSettings<FlowPartSettings>();
 
-            if (settings?.ContainedContentTypes?.Length == 0)
+            if (settings?.ContainedContentTypes == null || settings.ContainedContentTypes.Length == 0)
             {
                 return (await _contentDefinitionManager.ListTypeDefinitionsAsync()).Where(t => t.StereotypeEquals("Widget"));
             }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -132,7 +132,7 @@ namespace OrchardCore.Flows.Drivers
         {
             var settings = typePartDefinition.GetSettings<FlowPartSettings>();
 
-            if (settings?.ContainedContentTypes?.Length == 0)
+            if (settings?.ContainedContentTypes == null || settings.ContainedContentTypes.Length == 0)
             {
                 return (await _contentDefinitionManager.ListTypeDefinitionsAsync())
                     .Where(t => t.StereotypeEquals("Widget"));

--- a/src/OrchardCore.Modules/OrchardCore.Media/Settings/MediaFieldSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Settings/MediaFieldSettingsDriver.cs
@@ -41,7 +41,7 @@ namespace OrchardCore.Media.Settings
                 model.Multiple = settings.Multiple;
                 model.AllowMediaText = settings.AllowMediaText;
                 model.AllowAnchors = settings.AllowAnchors;
-                model.AllowAllDefaultMediaTypes = settings.AllowedExtensions?.Length == 0;
+                model.AllowAllDefaultMediaTypes = settings.AllowedExtensions == null || settings.AllowedExtensions.Length == 0;
 
                 var items = new List<MediaTypeViewModel>();
                 foreach (var extension in _mediaOptions.AllowedFileExtensions)

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Views/AzureAISearchSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Views/AzureAISearchSettings.Edit.cshtml
@@ -28,7 +28,7 @@
     return;
 }
 
-@if (Model.SearchIndexes == null || Model.SearchIndexes?.Count == 0)
+@if (Model.SearchIndexes == null || Model.SearchIndexes.Count == 0)
 {
     <div class="alert alert-warning" role="alert">
         @T["No indices exist! Please create at least one index to configure Azure AI Search service."]

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -201,7 +201,7 @@ namespace OrchardCore.ContentManagement
                 .Distinct()
                 .ToArray();
 
-            if (ids?.Length == 0)
+            if (ids == null || ids.Length == 0)
             {
                 return [];
             }

--- a/src/OrchardCore/OrchardCore.Queries.Core/Services/DefaultQueryManager.cs
+++ b/src/OrchardCore/OrchardCore.Queries.Core/Services/DefaultQueryManager.cs
@@ -205,7 +205,7 @@ public sealed class DefaultQueryManager : IQueryManager
 
     public async Task SaveAsync(params Query[] queries)
     {
-        if (queries?.Length == 0)
+        if (queries == null || queries.Length == 0)
         {
             return;
         }

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Recipes/AzureAISearchIndexSettingsStep.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Recipes/AzureAISearchIndexSettingsStep.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
-using Microsoft.Extensions.Logging;
 using OrchardCore.BackgroundJobs;
 using OrchardCore.Recipes.Models;
 using OrchardCore.Recipes.Services;
@@ -22,7 +21,6 @@ public sealed class AzureAISearchIndexSettingsStep : IRecipeStepHandler
     private readonly AzureAISearchIndexManager _indexManager;
     private readonly AzureAIIndexDocumentManager _azureAIIndexDocumentManager;
     private readonly AzureAISearchIndexSettingsService _azureAISearchIndexSettingsService;
-    private readonly ILogger _logger;
 
     internal IStringLocalizer S;
 
@@ -30,13 +28,11 @@ public sealed class AzureAISearchIndexSettingsStep : IRecipeStepHandler
         AzureAISearchIndexManager indexManager,
         AzureAIIndexDocumentManager azureAIIndexDocumentManager,
         AzureAISearchIndexSettingsService azureAISearchIndexSettingsService,
-        ILogger<AzureAISearchIndexSettingsStep> logger,
         IStringLocalizer<AzureAISearchIndexSettingsStep> stringLocalizer)
     {
         _indexManager = indexManager;
         _azureAIIndexDocumentManager = azureAIIndexDocumentManager;
         _azureAISearchIndexSettingsService = azureAISearchIndexSettingsService;
-        _logger = logger;
         S = stringLocalizer;
     }
 

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticConnectionOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticConnectionOptionsConfigurations.cs
@@ -62,7 +62,7 @@ public sealed class ElasticConnectionOptionsConfigurations : IConfigureOptions<E
             optionsAreValid = false;
         }
 
-        if (elasticConnectionOptions.Ports?.Length == 0)
+        if (elasticConnectionOptions.Ports == null || elasticConnectionOptions.Ports.Length == 0)
         {
             _logger.LogError("Elasticsearch is enabled but not active because a port is missing in application configuration.");
             optionsAreValid = false;


### PR DESCRIPTION
I noticed many invalid expression used in OC when checking for a zero elements in a collection.

Here is explanation

```
List<string> items = null;

if(items?.Count == 0)
{
	// This will evaluate false since null does not equals 0.
}

if(items == null || items.Count == 0)
{
	// This will evaluate true since items either null OR is not null and it's count is 0.
}

if(items?.Count > 0)
{
	// This check is okay because null items will return false and if the Count is 0 will also false.
}
```

@Piedone it would be nice to add an analyzer to guard against such a count check. Maybe related to #7950