### PR TITLE
Add new Display overload in DisplayDriver and fix Edit overload

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Drivers/AuditTrailContentsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AuditTrail/Drivers/AuditTrailContentsDriver.cs
@@ -4,7 +4,7 @@ using OrchardCore.AuditTrail;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.ViewModels;
-using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 
 namespace OrchardCore.Contents.AuditTrail.Drivers
@@ -22,7 +22,7 @@ namespace OrchardCore.Contents.AuditTrail.Drivers
             _authorizationService = authorizationService;
         }
 
-        public override IDisplayResult Display(ContentItem contentItem, IUpdateModel updater)
+        public override IDisplayResult Display(ContentItem contentItem, BuildDisplayContext context)
         {
             return Initialize<ContentItemViewModel>("AuditTrailContentsAction_SummaryAdmin", m => m.ContentItem = contentItem)
                 .Location("SummaryAdmin", "ActionsMenu:10")

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/ContentsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Drivers/ContentsDriver.cs
@@ -8,7 +8,7 @@ using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.ViewModels;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
-using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 
 namespace OrchardCore.Contents.Drivers
@@ -29,7 +29,7 @@ namespace OrchardCore.Contents.Drivers
             _authorizationService = authorizationService;
         }
 
-        public override async Task<IDisplayResult> DisplayAsync(ContentItem contentItem, IUpdateModel updater)
+        public override async Task<IDisplayResult> DisplayAsync(ContentItem contentItem, BuildDisplayContext context)
         {
             // We add custom alternates. This could be done generically to all shapes coming from ContentDisplayDriver but right now it's
             // only necessary on this shape. Otherwise c.f. ContentPartDisplayDriver
@@ -89,7 +89,7 @@ namespace OrchardCore.Contents.Drivers
             return Combine(results);
         }
 
-        public override async Task<IDisplayResult> EditAsync(ContentItem contentItem, IUpdateModel updater)
+        public override async Task<IDisplayResult> EditAsync(ContentItem contentItem, BuildEditorContext context)
         {
             var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
 
@@ -98,16 +98,16 @@ namespace OrchardCore.Contents.Drivers
                 return null;
             }
 
-            var context = _httpContextAccessor.HttpContext;
+            var user = _httpContextAccessor.HttpContext.User;
 
             return Combine(
                 Dynamic("Content_PublishButton").Location("Actions:10")
-                    .RenderWhen(() => _authorizationService.AuthorizeAsync(context.User, CommonPermissions.PublishContent, contentItem)),
+                    .RenderWhen(() => _authorizationService.AuthorizeAsync(user, CommonPermissions.PublishContent, contentItem)),
                 Dynamic("Content_SaveDraftButton").Location("Actions:20")
                     .RenderWhen(async () =>
                     {
                         return contentTypeDefinition.IsDraftable()
-                        && await _authorizationService.AuthorizeAsync(context.User, CommonPermissions.EditContent, contentItem);
+                        && await _authorizationService.AuthorizeAsync(user, CommonPermissions.EditContent, contentItem);
                     })
                 );
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceDriver.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using OrchardCore.DisplayManagement.Handlers;
-using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Sitemaps.Models;
 using OrchardCore.Sitemaps.Services;
@@ -28,7 +27,7 @@ namespace OrchardCore.Contents.Sitemaps
             );
         }
 
-        public override async Task<IDisplayResult> EditAsync(ContentTypesSitemapSource sitemapSource, IUpdateModel updater)
+        public override async Task<IDisplayResult> EditAsync(ContentTypesSitemapSource sitemapSource, BuildEditorContext context)
         {
             var contentTypeDefinitions = await _routeableContentTypeCoordinator.ListRoutableTypeDefinitionsAsync();
 

--- a/src/OrchardCore.Modules/OrchardCore.Demo/ContentElementDisplays/TestContentElementDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/ContentElementDisplays/TestContentElementDisplayDriver.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.Demo.Models;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 
@@ -13,7 +14,7 @@ namespace OrchardCore.Demo.ContentElementDisplays
         private static int _creating;
         private static int _processing;
 
-        public override IDisplayResult Display(ContentItem contentItem, IUpdateModel updater)
+        public override IDisplayResult Display(ContentItem contentItem, BuildDisplayContext context)
         {
             var testContentPart = contentItem.As<TestContentPartA>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormContentDisplayDriver.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.DisplayManagement.Handlers;
@@ -9,19 +8,19 @@ namespace OrchardCore.Forms.Drivers
 {
     public class FormContentDisplayDriver : ContentDisplayDriver
     {
-        public override Task<IDisplayResult> DisplayAsync(ContentItem model, BuildDisplayContext context)
+        public override IDisplayResult Display(ContentItem model, BuildDisplayContext context)
         {
             var formItemShape = context.Shape;
-            // If the content item contains FormPart add Form Wrapper only in Display type Detail
+            // If the content item contains FormPart add Form Wrapper only in Display type Detail.
             var formPart = model.As<FormPart>();
             if (formPart != null && context.DisplayType == "Detail")
             {
-                // Add wrapper for content type if template is not available it will fall back to Form_Wrapper
+                // Add wrapper for content type if template is not available it will fall back to Form_Wrapper.
                 formItemShape.Metadata.Wrappers.Add($"Form_Wrapper__{model.ContentType}");
             }
 
-            // We don't need to return a shape result
-            return Task.FromResult<IDisplayResult>(null);
+            // We don't need to return a shape result.
+            return null;
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ContainedPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Drivers/ContainedPartDisplayDriver.cs
@@ -5,7 +5,7 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
-using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Lists.Models;
 using OrchardCore.Lists.Services;
@@ -30,7 +30,7 @@ namespace OrchardCore.Lists.Drivers
             _containerService = containerService;
         }
 
-        public override async Task<IDisplayResult> EditAsync(ContentItem model, IUpdateModel updater)
+        public override async Task<IDisplayResult> EditAsync(ContentItem model, BuildEditorContext context)
         {
             // This method can get called when a new content item is created, at that point
             // the query string contains a ListPart.ContainerId value, or when an
@@ -44,7 +44,7 @@ namespace OrchardCore.Lists.Drivers
             }
 
             var viewModel = new EditContainedPartViewModel();
-            await updater.TryUpdateModelAsync(viewModel, nameof(ListPart));
+            await context.Updater.TryUpdateModelAsync(viewModel, nameof(ListPart));
 
             if (viewModel.ContainerId != null && viewModel.ContentType == model.ContentType)
             {
@@ -70,10 +70,10 @@ namespace OrchardCore.Lists.Drivers
             return null;
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(ContentItem model, IUpdateModel updater)
+        public override async Task<IDisplayResult> UpdateAsync(ContentItem model, UpdateEditorContext context)
         {
             var viewModel = new EditContainedPartViewModel();
-            await updater.TryUpdateModelAsync(viewModel, nameof(ListPart));
+            await context.Updater.TryUpdateModelAsync(viewModel, nameof(ListPart));
 
             // The content type must match the value provided in the query string
             // in order for the ContainedPart to be included on the Content Item.
@@ -92,7 +92,7 @@ namespace OrchardCore.Lists.Drivers
                 });
             }
 
-            return await EditAsync(model, updater);
+            return await EditAsync(model, context);
         }
 
         private async Task<IDisplayResult> BuildViewModelAsync(string containerId, string containerContentType, string contentType, bool enableOrdering = false)

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
@@ -19,11 +19,11 @@ namespace OrchardCore.OpenId.Drivers
         public OpenIdValidationSettingsDisplayDriver(IShellHost shellHost)
             => _shellHost = shellHost;
 
-        public override Task<IDisplayResult> EditAsync(OpenIdValidationSettings settings, BuildEditorContext context)
+        public override IDisplayResult Edit(OpenIdValidationSettings settings, BuildEditorContext context)
         {
             context.Shape.Metadata.Wrappers.Add("Settings_Wrapper__Reload");
 
-            return Task.FromResult<IDisplayResult>(Initialize<OpenIdValidationSettingsViewModel>("OpenIdValidationSettings_Edit", async model =>
+            return Initialize<OpenIdValidationSettingsViewModel>("OpenIdValidationSettings_Edit", async model =>
             {
                 model.Authority = settings.Authority?.AbsoluteUri;
                 model.MetadataAddress = settings.MetadataAddress?.AbsoluteUri;
@@ -49,7 +49,7 @@ namespace OrchardCore.OpenId.Drivers
                 }
 
                 model.AvailableTenants = availableTenants;
-            }).Location("Content:2"));
+            }).Location("Content:2");
         }
 
         public override async Task<IDisplayResult> UpdateAsync(OpenIdValidationSettings settings, UpdateEditorContext context)
@@ -64,7 +64,7 @@ namespace OrchardCore.OpenId.Drivers
             settings.DisableTokenTypeValidation = model.DisableTokenTypeValidation;
             settings.Tenant = model.Tenant;
 
-            return await EditAsync(settings, context);
+            return Edit(settings, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Drivers/QueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Drivers/QueryDisplayDriver.cs
@@ -23,7 +23,7 @@ namespace OrchardCore.Queries.Drivers
             S = stringLocalizer;
         }
 
-        public override IDisplayResult Display(Query query, IUpdateModel updater)
+        public override IDisplayResult Display(Query query, BuildDisplayContext context)
         {
             return Combine(
                 Dynamic("Query_Fields_SummaryAdmin", model =>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/Drivers/SqlQueryDisplayDriver.cs
@@ -19,7 +19,7 @@ namespace OrchardCore.Queries.Sql.Drivers
             S = stringLocalizer;
         }
 
-        public override IDisplayResult Display(Query query, IUpdateModel updater)
+        public override IDisplayResult Display(Query query, BuildDisplayContext context)
         {
             if (query.Source != SqlQuerySource.SourceName)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Drivers/ContentTypeConditionEvaluatorDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Drivers/ContentTypeConditionEvaluatorDriver.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Rules.Drivers
             _operatorResolver = operatorResolver;
         }
 
-        public override Task<IDisplayResult> DisplayAsync(ContentItem contentItem, BuildDisplayContext context)
+        public override IDisplayResult Display(ContentItem contentItem, BuildDisplayContext context)
         {
             // Do not include Widgets or any display type other than Detail.
             if (context.DisplayType == "Detail" && (!context.Shape.TryGetProperty(nameof(ContentTypeSettings.Stereotype), out string stereotype) || stereotype != "Widget"))
@@ -34,7 +34,7 @@ namespace OrchardCore.Rules.Drivers
                 _contentTypes.Add(contentItem.ContentType);
             }
 
-            return Task.FromResult<IDisplayResult>(null);
+            return null;
         }
 
         public ValueTask<bool> EvaluateAsync(Condition condition)

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/ContentPartFieldIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/ContentPartFieldIndexSettingsDisplayDriver.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
-using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Search.AzureAI.Models;
 
@@ -15,7 +15,7 @@ public class ContentPartFieldIndexSettingsDisplayDriver(IAuthorizationService au
     private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
     private readonly IAuthorizationService _authorizationService = authorizationService;
 
-    public override async Task<IDisplayResult> EditAsync(ContentPartFieldDefinition contentPartFieldDefinition, IUpdateModel updater)
+    public override async Task<IDisplayResult> EditAsync(ContentPartFieldDefinition contentPartFieldDefinition, BuildEditorContext context)
     {
         if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
@@ -41,6 +41,6 @@ public class ContentPartFieldIndexSettingsDisplayDriver(IAuthorizationService au
 
         context.Builder.WithSettings(settings);
 
-        return await EditAsync(contentPartFieldDefinition, context.Updater);
+        return await EditAsync(contentPartFieldDefinition, context);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/ContentTypePartIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/ContentTypePartIndexSettingsDisplayDriver.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Search.AzureAI.Models;
@@ -15,7 +16,7 @@ public class ContentTypePartIndexSettingsDisplayDriver(IAuthorizationService aut
     private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
     private readonly IAuthorizationService _authorizationService = authorizationService;
 
-    public override async Task<IDisplayResult> EditAsync(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
+    public override async Task<IDisplayResult> EditAsync(ContentTypePartDefinition contentTypePartDefinition, BuildEditorContext context)
     {
         if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, AzureAISearchIndexPermissionHelper.ManageAzureAISearchIndexes))
         {
@@ -41,6 +42,6 @@ public class ContentTypePartIndexSettingsDisplayDriver(IAuthorizationService aut
 
         context.Builder.WithSettings(settings);
 
-        return await EditAsync(contentTypePartDefinition, context.Updater);
+        return await EditAsync(contentTypePartDefinition, context);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ContentPartFieldIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ContentPartFieldIndexSettingsDisplayDriver.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
-using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Search.Elasticsearch.Core.Models;
 using OrchardCore.Search.Elasticsearch.ViewModels;
@@ -21,7 +21,7 @@ namespace OrchardCore.Search.Elasticsearch.Drivers
             _authorizationService = authorizationService;
         }
 
-        public override async Task<IDisplayResult> EditAsync(ContentPartFieldDefinition contentPartFieldDefinition, IUpdateModel updater)
+        public override async Task<IDisplayResult> EditAsync(ContentPartFieldDefinition contentPartFieldDefinition, BuildEditorContext context)
         {
             if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, Permissions.ManageElasticIndexes))
             {
@@ -47,7 +47,7 @@ namespace OrchardCore.Search.Elasticsearch.Drivers
 
             context.Builder.WithSettings(model.ElasticContentIndexSettings);
 
-            return await EditAsync(contentPartFieldDefinition, context.Updater);
+            return await EditAsync(contentPartFieldDefinition, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ContentTypePartIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ContentTypePartIndexSettingsDisplayDriver.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
-using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Search.Elasticsearch.Core.Models;
 using OrchardCore.Search.Elasticsearch.ViewModels;
@@ -21,7 +21,7 @@ namespace OrchardCore.Search.Elasticsearch.Drivers
             _authorizationService = authorizationService;
         }
 
-        public override async Task<IDisplayResult> EditAsync(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
+        public override async Task<IDisplayResult> EditAsync(ContentTypePartDefinition contentTypePartDefinition, BuildEditorContext context)
         {
             if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, Permissions.ManageElasticIndexes))
             {
@@ -47,7 +47,7 @@ namespace OrchardCore.Search.Elasticsearch.Drivers
 
             context.Builder.WithSettings(model.ElasticContentIndexSettings);
 
-            return await EditAsync(contentTypePartDefinition, context.Updater);
+            return await EditAsync(contentTypePartDefinition, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticQueryDisplayDriver.cs
@@ -27,7 +27,7 @@ namespace OrchardCore.Search.Elasticsearch.Drivers
             S = stringLocalizer;
         }
 
-        public override IDisplayResult Display(Query query, IUpdateModel updater)
+        public override IDisplayResult Display(Query query, BuildDisplayContext context)
         {
             if (query.Source != ElasticQuerySource.SourceName)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Drivers/LuceneQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Drivers/LuceneQueryDisplayDriver.cs
@@ -26,7 +26,7 @@ namespace OrchardCore.Search.Lucene.Drivers
             S = stringLocalizer;
         }
 
-        public override IDisplayResult Display(Query query, IUpdateModel updater)
+        public override IDisplayResult Display(Query query, BuildDisplayContext context)
         {
             if (query.Source != LuceneQuerySource.SourceName)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Settings/ContentPartFieldIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Settings/ContentPartFieldIndexSettingsDisplayDriver.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
-using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Search.Lucene.Model;
 using OrchardCore.Search.Lucene.ViewModels;
@@ -21,7 +21,7 @@ namespace OrchardCore.Search.Lucene.Settings
             _authorizationService = authorizationService;
         }
 
-        public override async Task<IDisplayResult> EditAsync(ContentPartFieldDefinition contentPartFieldDefinition, IUpdateModel updater)
+        public override async Task<IDisplayResult> EditAsync(ContentPartFieldDefinition contentPartFieldDefinition, BuildEditorContext context)
         {
             if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, Permissions.ManageLuceneIndexes))
             {
@@ -47,7 +47,7 @@ namespace OrchardCore.Search.Lucene.Settings
 
             context.Builder.WithSettings(model.LuceneContentIndexSettings);
 
-            return await EditAsync(contentPartFieldDefinition, context.Updater);
+            return await EditAsync(contentPartFieldDefinition, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Settings/ContentTypePartIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Settings/ContentTypePartIndexSettingsDisplayDriver.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using OrchardCore.ContentManagement.Metadata.Models;
 using OrchardCore.ContentTypes.Editors;
-using OrchardCore.DisplayManagement.ModelBinding;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Search.Lucene.Model;
 using OrchardCore.Search.Lucene.ViewModels;
@@ -21,7 +21,7 @@ namespace OrchardCore.Search.Lucene.Settings
             _authorizationService = authorizationService;
         }
 
-        public override async Task<IDisplayResult> EditAsync(ContentTypePartDefinition contentTypePartDefinition, IUpdateModel updater)
+        public override async Task<IDisplayResult> EditAsync(ContentTypePartDefinition contentTypePartDefinition, BuildEditorContext context)
         {
             if (!await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, Permissions.ManageLuceneIndexes))
             {
@@ -47,7 +47,7 @@ namespace OrchardCore.Search.Lucene.Settings
 
             context.Builder.WithSettings(model.LuceneContentIndexSettings);
 
-            return await EditAsync(contentTypePartDefinition, context.Updater);
+            return await EditAsync(contentTypePartDefinition, context);
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Seo/Drivers/SeoContentDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/Drivers/SeoContentDriver.cs
@@ -112,7 +112,7 @@ namespace OrchardCore.Seo.Drivers
 
             foreach (var customMetaTag in aspect.CustomMetaTags)
             {
-                // Generate a new meta entry as the builder is preopulated.
+                // Generate a new meta entry as the builder is prepopulated.
                 _resourceManager.RegisterMeta(new MetaEntry(
                     _htmlEncoder.Encode(await _shortcodeService.ProcessAsync(customMetaTag.Name, shortCodeContext)),
                     _htmlEncoder.Encode(await _shortcodeService.ProcessAsync(customMetaTag.Property, shortCodeContext)),

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/ButtonsSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/ButtonsSettingsDisplayDriver.cs
@@ -8,17 +8,16 @@ namespace OrchardCore.Settings.Drivers
     {
         public const string GroupId = "general";
 
-        public override Task<IDisplayResult> EditAsync(ISite site, BuildEditorContext context)
+        public override IDisplayResult Edit(ISite site, BuildEditorContext context)
         {
-            return Task.FromResult<IDisplayResult>(Dynamic("SiteSettings_SaveButton")
+            return Dynamic("SiteSettings_SaveButton")
                 .Location("Actions")
-                .OnGroup(context.GroupId) // Trick to render the shape for all groups
-                );
+                .OnGroup(context.GroupId); // Trick to render the shape for all groups
         }
 
         public override Task<IDisplayResult> UpdateAsync(ISite model, UpdateEditorContext context)
         {
-            return EditAsync(model, context);
+            return Task.FromResult(Edit(model, context));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
@@ -25,11 +25,11 @@ namespace OrchardCore.Settings.Drivers
             S = stringLocalizer;
         }
 
-        public override Task<IDisplayResult> EditAsync(ISite site, BuildEditorContext context)
+        public override IDisplayResult Edit(ISite site, BuildEditorContext context)
         {
             if (!IsGeneralGroup(context))
             {
-                return Task.FromResult<IDisplayResult>(null);
+                return null;
             }
 
             context.Shape.Metadata.Wrappers.Add("Settings_Wrapper__Reload");
@@ -46,7 +46,7 @@ namespace OrchardCore.Settings.Drivers
                     .OnGroup(GroupId)
             );
 
-            return Task.FromResult<IDisplayResult>(result);
+            return result;
         }
 
         public override async Task<IDisplayResult> UpdateAsync(ISite site, UpdateEditorContext context)
@@ -88,7 +88,7 @@ namespace OrchardCore.Settings.Drivers
 
             _shellReleaseManager.RequestRelease();
 
-            return await EditAsync(site, context);
+            return Edit(site, context);
         }
 
         private static void PopulateProperties(ISite site, SiteSettingsViewModel model)

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyContentsAdminListDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyContentsAdminListDisplayDriver.cs
@@ -10,7 +10,6 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.Contents.ViewModels;
 using OrchardCore.DisplayManagement.Handlers;
-using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Entities;
 using OrchardCore.Settings;
@@ -43,7 +42,7 @@ namespace OrchardCore.Taxonomies.Drivers
             S = stringLocalizer;
         }
 
-        public override async Task<IDisplayResult> EditAsync(ContentOptionsViewModel model, IUpdateModel updater)
+        public override async Task<IDisplayResult> EditAsync(ContentOptionsViewModel model, BuildEditorContext context)
         {
             var settings = await _siteService.GetSettingsAsync<TaxonomyContentsAdminListSettings>();
 
@@ -115,13 +114,13 @@ namespace OrchardCore.Taxonomies.Drivers
             return null;
         }
 
-        public override async Task<IDisplayResult> UpdateAsync(ContentOptionsViewModel model, IUpdateModel updater)
+        public override async Task<IDisplayResult> UpdateAsync(ContentOptionsViewModel model, UpdateEditorContext context)
         {
             var settings = await _siteService.GetSettingsAsync<TaxonomyContentsAdminListSettings>();
             foreach (var contentItemId in settings.TaxonomyContentItemIds)
             {
                 var viewModel = new TaxonomyContentsAdminFilterViewModel();
-                await updater.TryUpdateModelAsync(viewModel, "Taxonomy" + contentItemId);
+                await context.Updater.TryUpdateModelAsync(viewModel, "Taxonomy" + contentItemId);
 
                 if (!string.IsNullOrEmpty(viewModel.SelectedContentItemId))
                 {
@@ -129,7 +128,7 @@ namespace OrchardCore.Taxonomies.Drivers
                 }
             }
 
-            return await EditAsync(model, updater);
+            return await EditAsync(model, context);
         }
 
         private static void PopulateTermEntries(List<FilterTermEntry> termEntries, IEnumerable<ContentItem> contentItems, int level)

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TermPartContentDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TermPartContentDriver.cs
@@ -34,12 +34,12 @@ namespace OrchardCore.Taxonomies.Drivers
             _contentManager = contentManager;
         }
 
-        public override Task<IDisplayResult> DisplayAsync(ContentItem model, BuildDisplayContext context)
+        public override IDisplayResult Display(ContentItem model, BuildDisplayContext context)
         {
             var part = model.As<TermPart>();
             if (part != null)
             {
-                return Task.FromResult<IDisplayResult>(Initialize<TermPartViewModel>("TermPart", async m =>
+                return Initialize<TermPartViewModel>("TermPart", async m =>
                 {
                     var pager = await GetPagerAsync(context.Updater, _pagerOptions.GetPageSize());
                     m.TaxonomyContentItemId = part.TaxonomyContentItemId;
@@ -47,10 +47,10 @@ namespace OrchardCore.Taxonomies.Drivers
                     m.ContentItems = (await QueryTermItemsAsync(part, pager)).ToArray();
                     m.Pager = await context.New.PagerSlim(pager);
                 })
-                .Location("Detail", "Content:5"));
+                .Location("Detail", "Content:5");
             }
 
-            return Task.FromResult<IDisplayResult>(null);
+            return null;
         }
 
         private async Task<IEnumerable<ContentItem>> QueryTermItemsAsync(TermPart termPart, PagerSlim pager)

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/TwoFactorMethodDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/TwoFactorMethodDisplayDriver.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Users.Models;
@@ -7,11 +6,11 @@ namespace OrchardCore.Users.Drivers;
 
 public class TwoFactorMethodDisplayDriver : DisplayDriver<TwoFactorMethod>
 {
-    public override Task<IDisplayResult> DisplayAsync(TwoFactorMethod model, BuildDisplayContext context)
+    public override IDisplayResult Display(TwoFactorMethod model, BuildDisplayContext context)
     {
         if (string.IsNullOrEmpty(model.Provider))
         {
-            return Task.FromResult<IDisplayResult>(null);
+            return null;
         }
 
         var icon = Initialize<TwoFactorMethod>($"TwoFactorMethod_{model.Provider}_Icon", vm =>
@@ -32,6 +31,6 @@ public class TwoFactorMethodDisplayDriver : DisplayDriver<TwoFactorMethod>
             vm.IsEnabled = model.IsEnabled;
         }).Location("SummaryAdmin", "Actions");
 
-        return Task.FromResult<IDisplayResult>(Combine(icon, content, actions));
+        return Combine(icon, content, actions);
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriver.cs
@@ -72,12 +72,17 @@ namespace OrchardCore.DisplayManagement.Handlers
 
         public virtual Task<IDisplayResult> DisplayAsync(TModel model, TDisplayContext context)
         {
-            return DisplayAsync(model, context.Updater);
+            return Task.FromResult(Display(model, context));
         }
 
         public virtual Task<IDisplayResult> DisplayAsync(TModel model, IUpdateModel updater)
         {
             return Task.FromResult(Display(model, updater));
+        }
+
+        public virtual IDisplayResult Display(TModel model, TDisplayContext context)
+        {
+            return Display(model, context.Updater);
         }
 
         public virtual IDisplayResult Display(TModel model, IUpdateModel updater)
@@ -92,7 +97,7 @@ namespace OrchardCore.DisplayManagement.Handlers
 
         public virtual Task<IDisplayResult> EditAsync(TModel model, TEditorContext context)
         {
-            return EditAsync(model, context.Updater);
+            return Task.FromResult(Edit(model, context));
         }
 
         public virtual Task<IDisplayResult> EditAsync(TModel model, IUpdateModel updater)
@@ -168,46 +173,46 @@ namespace OrchardCore.DisplayManagement.Handlers
             return true;
         }
 
-        Task<IDisplayResult> IDisplayDriver<TModel, TDisplayContext, TEditorContext, TUpdateContext>.BuildDisplayAsync(TModel model, TDisplayContext context)
+        async Task<IDisplayResult> IDisplayDriver<TModel, TDisplayContext, TEditorContext, TUpdateContext>.BuildDisplayAsync(TModel model, TDisplayContext context)
         {
             var concrete = model as TConcrete;
 
-            if (concrete == null || !CanHandleModel(concrete))
+            if (concrete == null || !await CanHandleModelAsync(concrete))
             {
-                return Task.FromResult<IDisplayResult>(null);
+                return null;
             }
 
             BuildPrefix(concrete, context.HtmlFieldPrefix);
 
-            return DisplayAsync(concrete, context);
+            return await DisplayAsync(concrete, context);
         }
 
-        Task<IDisplayResult> IDisplayDriver<TModel, TDisplayContext, TEditorContext, TUpdateContext>.BuildEditorAsync(TModel model, TEditorContext context)
+        async Task<IDisplayResult> IDisplayDriver<TModel, TDisplayContext, TEditorContext, TUpdateContext>.BuildEditorAsync(TModel model, TEditorContext context)
         {
             var concrete = model as TConcrete;
 
-            if (concrete == null || !CanHandleModel(concrete))
+            if (concrete == null || !await CanHandleModelAsync(concrete))
             {
-                return Task.FromResult<IDisplayResult>(null);
+                return null;
             }
 
             BuildPrefix(concrete, context.HtmlFieldPrefix);
 
-            return EditAsync(concrete, context);
+            return await EditAsync(concrete, context);
         }
 
-        Task<IDisplayResult> IDisplayDriver<TModel, TDisplayContext, TEditorContext, TUpdateContext>.UpdateEditorAsync(TModel model, TUpdateContext context)
+        async Task<IDisplayResult> IDisplayDriver<TModel, TDisplayContext, TEditorContext, TUpdateContext>.UpdateEditorAsync(TModel model, TUpdateContext context)
         {
             var concrete = model as TConcrete;
 
-            if (concrete == null || !CanHandleModel(concrete))
+            if (concrete == null || !await CanHandleModelAsync(concrete))
             {
-                return Task.FromResult<IDisplayResult>(null);
+                return null;
             }
 
             BuildPrefix(concrete, context.HtmlFieldPrefix);
 
-            return UpdateAsync(concrete, context);
+            return await UpdateAsync(concrete, context);
         }
     }
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriver.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Handlers/DisplayDriver.cs
@@ -75,17 +75,7 @@ namespace OrchardCore.DisplayManagement.Handlers
             return Task.FromResult(Display(model, context));
         }
 
-        public virtual Task<IDisplayResult> DisplayAsync(TModel model, IUpdateModel updater)
-        {
-            return Task.FromResult(Display(model, updater));
-        }
-
         public virtual IDisplayResult Display(TModel model, TDisplayContext context)
-        {
-            return Display(model, context.Updater);
-        }
-
-        public virtual IDisplayResult Display(TModel model, IUpdateModel updater)
         {
             return Display(model);
         }
@@ -100,19 +90,14 @@ namespace OrchardCore.DisplayManagement.Handlers
             return Task.FromResult(Edit(model, context));
         }
 
-        public virtual Task<IDisplayResult> EditAsync(TModel model, IUpdateModel updater)
+        public virtual IDisplayResult Edit(TModel model, TEditorContext context)
         {
-            return Task.FromResult(Edit(model, updater));
+            return Edit(model, context.Updater);
         }
 
         public virtual IDisplayResult Edit(TModel model, IUpdateModel updater)
         {
             return Edit(model);
-        }
-
-        public virtual IDisplayResult Edit(TModel model, TEditorContext context)
-        {
-            return Edit(model, context.Updater);
         }
 
         public virtual IDisplayResult Edit(TModel model)
@@ -132,7 +117,7 @@ namespace OrchardCore.DisplayManagement.Handlers
 
         public virtual Task<IDisplayResult> UpdateAsync(TModel model, IUpdateModel updater)
         {
-            return EditAsync(model, updater);
+            return Task.FromResult(Edit(model, updater));
         }
 
         protected virtual void BuildPrefix(TModel model, string htmlFieldPrefix)

--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -277,7 +277,7 @@ In addition to the above changes, the following changes were made:
 - The `IDisplayResult Display(TModel model, TDisplayContext context)` method was added.
 - The `Task<bool> CanHandleModelAsync(TModel model)` method was added.
 - The `Task<IDisplayResult> DisplayAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `DisplayAsync(TModel model, TDisplayContext context)` and access the `IUpdateModel` in `context.Updater`.
-- The `Task<IDisplayResult> EditAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `EditAsync(TModel model, TEditorContext context)`.
+- The `Task<IDisplayResult> EditAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `EditAsync(TModel model, TEditorContext context)` and access the `IUpdateModel` in `context.Updater`.
 
 ### GraphQL Module
 

--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -271,6 +271,14 @@ Here are the updated signatures:
 
 These adjustments ensure compatibility and adherence to the latest conventions within the `SectionDisplayDriver` class.
 
+In addition to the above changes, the following changes were made:
+
+- The `IDisplayResult Edit(TModel model, TEditorContext context)` method was added.
+- The `IDisplayResult Display(TModel model, TDisplayContext context)` method was added.
+- The `Task<bool> CanHandleModelAsync(TModel model)` method was added.
+- The `Task<IDisplayResult> DisplayAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `DisplayAsync(TModel model, TDisplayContext context)`.
+- The `Task<IDisplayResult> EditAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `EditAsync(TModel model, TEditorContext context)`.
+
 ### GraphQL Module
 
 The GraphQL schema may change because fields are now always added to the correct part. Previously, additional fields may have been added to the parent content item type directly. 
@@ -638,11 +646,3 @@ Many type commonly used by modules can be `sealed`, which improves runtime perfo
 
 !!! note
     Do not seal classes that are used to create shapes like view-models. Sealing these classes can break your code at runtime, as these classes need to be unsealed to allow for proxy creation.
-
-### Display Management
-
-The following three methods have been added to the base DisplayDriver for your convenience:
-
-- `public virtual IDisplayResult Edit(TModel model, TEditorContext context)`
-- `public virtual IDisplayResult Display(TModel model, TDisplayContext context)`
-- `public virtual Task<bool> CanHandleModelAsync(TModel model)`

--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -638,3 +638,11 @@ Many type commonly used by modules can be `sealed`, which improves runtime perfo
 
 !!! note
     Do not seal classes that are used to create shapes like view-models. Sealing these classes can break your code at runtime, as these classes need to be unsealed to allow for proxy creation.
+
+### Display Management
+
+The following three methods have been added to the base DisplayDriver for your convenience:
+
+- `public virtual IDisplayResult Edit(TModel model, TEditorContext context)`
+- `public virtual IDisplayResult Display(TModel model, TDisplayContext context)`
+- `public virtual Task<bool> CanHandleModelAsync(TModel model)`

--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -276,7 +276,7 @@ In addition to the above changes, the following changes were made:
 - The `IDisplayResult Edit(TModel model, TEditorContext context)` method was added.
 - The `IDisplayResult Display(TModel model, TDisplayContext context)` method was added.
 - The `Task<bool> CanHandleModelAsync(TModel model)` method was added.
-- The `Task<IDisplayResult> DisplayAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `DisplayAsync(TModel model, TDisplayContext context)`.
+- The `Task<IDisplayResult> DisplayAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `DisplayAsync(TModel model, TDisplayContext context)` and access the `IUpdateModel` in `context.Updater`.
 - The `Task<IDisplayResult> EditAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `EditAsync(TModel model, TEditorContext context)`.
 
 ### GraphQL Module


### PR DESCRIPTION
Adding a new virtual method to the `DisplayDriver`

 - `Display(TModel model, TDisplayContext context)`

Also, fix the recently added `virtual IDisplayResult Edit(TModel model, TEditorContext context)` to ensure it actually gets calls.

Here is a summary of all changes 

- The `IDisplayResult Edit(TModel model, TEditorContext context)` method was added.
- The `IDisplayResult Display(TModel model, TDisplayContext context)` method was added.
- The `Task<IDisplayResult> DisplayAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `DisplayAsync(TModel model, TDisplayContext context)`.
- The `Display(TModel model, IUpdateModel updater)` was removed. Instead, you can use `Display(TModel model, TDisplayContext context)`.
- The `Task<IDisplayResult> EditAsync(TModel model, IUpdateModel updater)` method was removed. Instead, you can use `EditAsync(TModel model, TEditorContext context)`.


### Here is invocation path before the PR

#### Edit Invocation Path

`EditAsync(TModel model, TEditorContext context)` >> `EditAsync(TModel model, IUpdateModel updater)` >> `Edit(TModel model, IUpdateModel updater)` >> `Edit(TModel model)`

#### Display Invocation Path

`DisplayAsync(TModel model, TDisplayContext context)` >> `DisplayAsync(TModel model, IUpdateModel updater)` >> `Display(TModel model, IUpdateModel updater)` >> `Display(TModel model)` 

### Here is invocation path after the PR

#### Edit Invocation Path

Note here we removed the `EditAsync(TModel model, IUpdateModel updater)`

`EditAsync(TModel model, TEditorContext context)` >> `Edit(TModel model, TEditorContext context)` >> `Edit(TModel model, IUpdateModel updater)` >> `Edit(TModel model)`


#### Display Invocation Path

Note here we replaced `DisplayAsync(TModel model, IUpdateModel updater)` and `Display(TModel model, IUpdateModel updater)` with `Display(TModel model, TDisplayContext context)`. So there is one less execution step in the chain.

`DisplayAsync(TModel model, TDisplayContext context)` >> `Display(TModel model, TDisplayContext context)` >> `Display(TModel model)`


