### PR TITLE
Workflow pruning task

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Permissions.cs
@@ -8,11 +8,13 @@ public sealed class Permissions : IPermissionProvider
 {
     public static readonly Permission ManageWorkflows = new("ManageWorkflows", "Manage workflows", isSecurityCritical: true);
     public static readonly Permission ExecuteWorkflows = new("ExecuteWorkflows", "Execute workflows", isSecurityCritical: true);
+    public static readonly Permission ManageWorkflowSettings = new(nameof(ManageWorkflowSettings), "Manage workflow settings", [ManageWorkflows] );
 
     private readonly IEnumerable<Permission> _allPermissions =
     [
         ManageWorkflows,
         ExecuteWorkflows,
+        ManageWorkflowSettings
     ];
 
     public Task<IEnumerable<Permission>> GetPermissionsAsync()

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Permissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Permissions.cs
@@ -8,13 +8,13 @@ public sealed class Permissions : IPermissionProvider
 {
     public static readonly Permission ManageWorkflows = new("ManageWorkflows", "Manage workflows", isSecurityCritical: true);
     public static readonly Permission ExecuteWorkflows = new("ExecuteWorkflows", "Execute workflows", isSecurityCritical: true);
-    public static readonly Permission ManageWorkflowSettings = new(nameof(ManageWorkflowSettings), "Manage workflow settings", [ManageWorkflows] );
+    public static readonly Permission ManageWorkflowSettings = new("ManageWorkflowSettings", "Manage workflow settings", [ManageWorkflows] );
 
     private readonly IEnumerable<Permission> _allPermissions =
     [
         ManageWorkflows,
         ExecuteWorkflows,
-        ManageWorkflowSettings
+        ManageWorkflowSettings,
     ];
 
     public Task<IEnumerable<Permission>> GetPermissionsAsync()

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
@@ -19,7 +19,8 @@
 
     <div class="mb-3" asp-validation-class-for="LastRunUtc">
         <label asp-for="LastRunUtc">@T["Last run"]</label>
-        <div class="form-control">@(Model.LastRunUtc.HasValue ? await DisplayAsync(await New.DateTime(Utc: Model.LastRunUtc.Value, Format: "g")) : T["Never"])</div>
+        <div class="form-control">@(Model.LastRunUtc.HasValue ? await DisplayAsync(await New.DateTime(Utc:
+            Model.LastRunUtc.Value, Format: "g")) : T["Never"])</div>
         <span class="hint">@T["The last time the background pruning task was run."]</span>
     </div>
 
@@ -28,12 +29,8 @@
         {
             <div class="col-xs-12">
                 <div class="form-check">
-                    <input type="checkbox"
-                           class="form-check-input workflow-status"
-                           id="@Html.IdFor(m => m.Statuses[i])"
-                           name="@Html.NameFor(x => x.Statuses)"
-                           checked="@status[i].IsSelected"
-                           value="@status[i].Value">
+                    <input type="checkbox" class="form-check-input workflow-status" id="@Html.IdFor(m => m.Statuses[i])"
+                        name="@Html.NameFor(x => x.Statuses)" checked="@status[i].IsSelected" value="@status[i].Value">
                     <label class="form-check-label" for="@Html.IdFor(m => m.Statuses[i])">@T[status[i].Value]</label>
                 </div>
             </div>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
@@ -18,7 +18,7 @@
     </div>
 
     <div class="mb-3" asp-validation-class-for="LastRunUtc">
-        <label asp-for="LastRunUtc">@T["Last run"]</label>
+        <label asp-for="LastRunUtc" class="control-label">@T["Last run"]</label>
         <div class="form-control">@(Model.LastRunUtc.HasValue ? await DisplayAsync(await New.DateTime(Utc:
             Model.LastRunUtc.Value, Format: "g")) : T["Never"])</div>
         <span class="hint">@T["The last time the background pruning task was run."]</span>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
@@ -1,3 +1,4 @@
+@using OrchardCore.Workflows.WorkflowPruning.Services
 @using OrchardCore.Workflows.WorkflowPruning.ViewModels
 @model WorkflowPruningViewModel
 @{
@@ -19,8 +20,10 @@
 
     <div class="mb-3" asp-validation-class-for="LastRunUtc">
         <label asp-for="LastRunUtc" class="control-label">@T["Last run"]</label>
-        <div class="form-control">@(Model.LastRunUtc.HasValue ? await DisplayAsync(await New.DateTime(Utc:
-            Model.LastRunUtc.Value, Format: "g")) : T["Never"])</div>
+        <div class="form-control">
+            @(Model.LastRunUtc.HasValue ? await DisplayAsync(await New.DateTime(Utc:
+                Model.LastRunUtc.Value, Format: "g")) : T["Never"])
+        </div>
         <span class="hint">@T["The last time the background pruning task was run."]</span>
     </div>
 
@@ -30,7 +33,7 @@
             <div class="col-xs-12">
                 <div class="form-check">
                     <input type="checkbox" class="form-check-input workflow-status" id="@Html.IdFor(m => m.Statuses[i])"
-                        name="@Html.NameFor(x => x.Statuses)" checked="@status[i].IsSelected" value="@status[i].Value">
+                           name="@Html.NameFor(x => x.Statuses)" checked="@status[i].IsSelected" value="@status[i].Value">
                     <label class="form-check-label" for="@Html.IdFor(m => m.Statuses[i])">@T[status[i].Value]</label>
                 </div>
             </div>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
@@ -1,7 +1,7 @@
 @using OrchardCore.Workflows.WorkflowPruning.ViewModels
 @model WorkflowPruningViewModel
 @{
-    var status = WorkflowStatusBuiler.Build(Model.Statuses);
+    var status = WorkflowStatusBuilder.Build(Model.Statuses);
 }
 
 <section>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
@@ -1,0 +1,42 @@
+@using OrchardCore.Workflows.WorkflowPruning.ViewModels
+@model WorkflowPruningViewModel
+@{
+    var status = WorkflowStatusBuiler.Build(Model.Statuses);
+}
+
+<section>
+    <div class="form-check">
+        <input type="checkbox" class="form-check-input" asp-for="Disabled" checked="@Model.Disabled" />
+        <label class="form-check-label" asp-for="Disabled">@T["Disable"]</label>
+        <span class="hint dashed">@T["Whether the task is disabled."]</span>
+    </div>
+
+    <div class="mb-3" asp-validation-class-for="RetentionDays">
+        <label asp-for="RetentionDays">@T["Retention period"]</label>
+        <input asp-for="RetentionDays" type="number" class="form-control" />
+        <span class="hint">@T["The number of days a workflow instance is retained."]</span>
+    </div>
+
+    <div class="mb-3" asp-validation-class-for="LastRunUtc">
+        <label asp-for="LastRunUtc">@T["Last run"]</label>
+        <div class="form-control">@(Model.LastRunUtc.HasValue ? await DisplayAsync(await New.DateTime(Utc: Model.LastRunUtc.Value, Format: "g")) : T["Never"])</div>
+        <span class="hint">@T["The last time the background pruning task was run."]</span>
+    </div>
+
+    <div class="row">
+        @for (var i = 0; i < status.Length; i++)
+        {
+            <div class="col-xs-12">
+                <div class="form-check">
+                    <input type="checkbox"
+                           class="form-check-input workflow-status"
+                           id="@Html.IdFor(m => m.Statuses[i])"
+                           name="@Html.NameFor(x => x.Statuses)"
+                           checked="@status[i].IsSelected"
+                           value="@status[i].Value">
+                    <label class="form-check-label" for="@Html.IdFor(m => m.Statuses[i])">@T[status[i].Value]</label>
+                </div>
+            </div>
+        }
+    </div>
+</section>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowPruning.Fields.Edit.cshtml
@@ -12,7 +12,7 @@
     </div>
 
     <div class="mb-3" asp-validation-class-for="RetentionDays">
-        <label asp-for="RetentionDays">@T["Retention period"]</label>
+        <label asp-for="RetentionDays" class="control-label">@T["Retention period"]</label>
         <input asp-for="RetentionDays" type="number" class="form-control" />
         <span class="hint">@T["The number of days a workflow instance is retained."]</span>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/AdminMenu.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Navigation;
 using OrchardCore.Workflows.WorkflowPruning.Drivers;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/AdminMenu.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Navigation;
+using OrchardCore.Workflows.WorkflowPruning.Drivers;
+
+namespace OrchardCore.Workflows.WorkflowPruning;
+
+public class AdminMenu : INavigationProvider
+{
+    private readonly IStringLocalizer S;
+
+    public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
+    {
+        S = stringLocalizer;
+    }
+
+    public Task BuildNavigationAsync(string name, NavigationBuilder builder)
+    {
+        if (!string.Equals(name, "admin", StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.CompletedTask;
+        }
+
+        builder.Add(
+            S["Configuration"],
+            configuration =>
+                configuration.Add(
+                    S["Settings"],
+                    settings =>
+                        settings.Add(
+                            S["Workflow Pruning"],
+                            S["Workflow Pruning"],
+                            pruning =>
+                                pruning
+                                    .Action(
+                                        "Index",
+                                        "Admin",
+                                        new
+                                        {
+                                            area = "OrchardCore.Settings",
+                                            groupid = WorkflowPruningDisplayDriver.GroupId
+                                        }
+                                    )
+                                    .Permission(Permissions.ManageWorkflowSettings)
+                                    .LocalNav()
+                        )
+                )
+        );
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/AdminMenu.cs
@@ -12,7 +12,6 @@ public sealed class AdminMenu : INavigationProvider
     private static readonly RouteValueDictionary _routeValues = new()
     {
         { "area", "OrchardCore.Settings" },
-        // Since features admin accepts tenant, always pass empty string to create valid link for current tenant.
         { "groupId", WorkflowPruningDisplayDriver.GroupId },
     };
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Drivers/WorkflowPruningDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Drivers/WorkflowPruningDisplayDriver.cs
@@ -1,0 +1,89 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using OrchardCore.DisplayManagement.Entities;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Settings;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.WorkflowPruning.Models;
+using OrchardCore.Workflows.WorkflowPruning.ViewModels;
+
+namespace OrchardCore.Workflows.WorkflowPruning.Drivers;
+
+public class WorkflowPruningDisplayDriver
+ : SiteDisplayDriver< WorkflowPruningSettings>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IAuthorizationService _authorizationService;
+
+    public WorkflowPruningDisplayDriver(
+        IAuthorizationService authorizationService,
+        IHttpContextAccessor httpContextAccessor
+    )
+    {
+        _authorizationService = authorizationService;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public const string GroupId = "WorkflowPruningSettings";
+
+    protected override string SettingsGroupId => GroupId;
+
+    public override IDisplayResult Edit(ISite model, WorkflowPruningSettings section, BuildEditorContext context)
+    {
+        return Initialize<WorkflowPruningViewModel>(
+                "WorkflowPruning_Fields_Edit",
+                model =>
+                {
+                    model.RetentionDays = section.RetentionDays;
+                    model.LastRunUtc = section.LastRunUtc;
+                    model.Disabled = section.Disabled;
+                    model.Statuses =
+                        section.Statuses
+                        ?? new WorkflowStatus[]
+                        {
+                        WorkflowStatus.Idle,
+                        WorkflowStatus.Starting,
+                        WorkflowStatus.Resuming,
+                        WorkflowStatus.Executing,
+                        WorkflowStatus.Halted,
+                        WorkflowStatus.Finished,
+                        WorkflowStatus.Faulted,
+                        WorkflowStatus.Aborted
+                        };
+                }
+            )
+            .Location("Content:5")
+            .OnGroup(GroupId);
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(
+        ISite model,
+        WorkflowPruningSettings section,
+        UpdateEditorContext context
+    )
+    {
+        if (
+            !await _authorizationService.AuthorizeAsync(
+                _httpContextAccessor.HttpContext?.User,
+                Permissions.ManageWorkflowSettings
+            )
+        )
+        {
+            return null;
+        }
+
+        if (context.GroupId == GroupId)
+        {
+            var viewModel = new WorkflowPruningViewModel();
+            await context.Updater.TryUpdateModelAsync(viewModel, Prefix);
+
+            section.RetentionDays = viewModel.RetentionDays;
+            section.Disabled = viewModel.Disabled;
+            section.Statuses = viewModel.Statuses;
+        }
+
+        return await EditAsync(model, section, context);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Models/WorkflowPruningSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Models/WorkflowPruningSettings.cs
@@ -1,0 +1,14 @@
+using System;
+using OrchardCore.Entities;
+using OrchardCore.Workflows.Models;
+
+namespace OrchardCore.Workflows.WorkflowPruning.Models;
+
+public class WorkflowPruningSettings : Entity
+{
+    public int RetentionDays { get; set; } = 90;
+    public DateTime? LastRunUtc { get; set; }
+    public bool Disabled { get; set; }
+
+    public WorkflowStatus[] Statuses { get; set; }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Models/WorkflowPruningSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Models/WorkflowPruningSettings.cs
@@ -7,7 +7,10 @@ namespace OrchardCore.Workflows.WorkflowPruning.Models;
 public class WorkflowPruningSettings : Entity
 {
     public int RetentionDays { get; set; } = 90;
+
     public DateTime? LastRunUtc { get; set; }
+
     public bool Disabled { get; set; }
+    
     public WorkflowStatus[] Statuses { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Models/WorkflowPruningSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Models/WorkflowPruningSettings.cs
@@ -9,6 +9,5 @@ public class WorkflowPruningSettings : Entity
     public int RetentionDays { get; set; } = 90;
     public DateTime? LastRunUtc { get; set; }
     public bool Disabled { get; set; }
-
     public WorkflowStatus[] Statuses { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningBackgroundTask.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OrchardCore.BackgroundTasks;
+using OrchardCore.Entities;
+using OrchardCore.Modules;
+using OrchardCore.Settings;
+using OrchardCore.Workflows.WorkflowPruning.Models;
+
+namespace OrchardCore.Workflows.WorkflowPruning.Services;
+
+[BackgroundTask(
+    Schedule = "0 0 * * *",
+    Title = "Workflow Pruning Background Task",
+    Description = "Regularly prunes old workflow instances.",
+    LockTimeout = 3_000,
+    LockExpiration = 30_000
+)]
+public class WorkflowPruningBackgroundTask : IBackgroundTask
+{
+    public async Task DoWorkAsync(IServiceProvider serviceProvider, CancellationToken cancellationToken)
+    {
+        var siteService = serviceProvider.GetRequiredService<ISiteService>();
+
+        var workflowPruningSettings = (await siteService.GetSiteSettingsAsync()).As<WorkflowPruningSettings>();
+        if (workflowPruningSettings.Disabled)
+        {
+            return;
+        }
+
+        var logger = serviceProvider.GetRequiredService<ILogger<WorkflowPruningBackgroundTask>>();
+
+        try
+        {
+            var clock = serviceProvider.GetRequiredService<IClock>();
+            var workflowCleanUpManager = serviceProvider.GetRequiredService<IWorkflowPruningManager>();
+
+            logger.LogDebug("Starting pruning Workflow instances.");
+            var prunedQty = await workflowCleanUpManager.PruneWorkflowInstancesAsync(
+                TimeSpan.FromDays(workflowPruningSettings.RetentionDays)
+            );
+            logger.LogDebug("Pruned {PrunedCount} workflow instances.", prunedQty);
+
+            workflowPruningSettings.LastRunUtc = clock.UtcNow;
+
+            var siteSettings = await siteService.LoadSiteSettingsAsync();
+            siteSettings.Alter<WorkflowPruningSettings>(
+                nameof(WorkflowPruningSettings),
+                settings =>
+                {
+                    settings.LastRunUtc = clock.UtcNow;
+                }
+            );
+
+            await siteService.UpdateSiteSettingsAsync(siteSettings);
+        }
+        catch (Exception ex) when (!ex.IsFatal())
+        {
+            logger.LogError(ex, "Error while pruning workflow instances.");
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningBackgroundTask.cs
@@ -24,7 +24,7 @@ public class WorkflowPruningBackgroundTask : IBackgroundTask
     {
         var siteService = serviceProvider.GetRequiredService<ISiteService>();
 
-        var workflowPruningSettings = (await siteService.GetSiteSettingsAsync()).As<WorkflowPruningSettings>();
+        var workflowPruningSettings = await siteService.GetSiteSettingsAsync<WorkflowPruningSettings>();
         if (workflowPruningSettings.Disabled)
         {
             return;
@@ -46,13 +46,10 @@ public class WorkflowPruningBackgroundTask : IBackgroundTask
             workflowPruningSettings.LastRunUtc = clock.UtcNow;
 
             var siteSettings = await siteService.LoadSiteSettingsAsync();
-            siteSettings.Alter<WorkflowPruningSettings>(
-                nameof(WorkflowPruningSettings),
-                settings =>
-                {
-                    settings.LastRunUtc = clock.UtcNow;
-                }
-            );
+            siteSettings.Alter<WorkflowPruningSettings>(settings =>
+            {
+                settings.LastRunUtc = clock.UtcNow;
+            });
 
             await siteService.UpdateSiteSettingsAsync(siteSettings);
         }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningBackgroundTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningBackgroundTask.cs
@@ -24,7 +24,7 @@ public class WorkflowPruningBackgroundTask : IBackgroundTask
     {
         var siteService = serviceProvider.GetRequiredService<ISiteService>();
 
-        var workflowPruningSettings = await siteService.GetSiteSettingsAsync<WorkflowPruningSettings>();
+        var workflowPruningSettings = await siteService.GetSettingsAsync<WorkflowPruningSettings>();
         if (workflowPruningSettings.Disabled)
         {
             return;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
@@ -28,19 +28,19 @@ public class WorkflowPruningManager
     public async Task<int> PruneWorkflowInstancesAsync(TimeSpan retentionPeriod)
     {
         var dateThreshold = _clock.UtcNow.AddDays(1) - retentionPeriod;
-        var settings =  (await _siteService.GetSiteSettingsAsync()).As<WorkflowPruningSettings>();
+        var settings =  await _siteService.GetSiteSettingsAsync<WorkflowPruningSettings>();
 
         settings.Statuses ??=
-            [
-                WorkflowStatus.Idle,
-                WorkflowStatus.Starting,
-                WorkflowStatus.Resuming,
-                WorkflowStatus.Executing,
-                WorkflowStatus.Halted,
-                WorkflowStatus.Finished,
-                WorkflowStatus.Faulted,
-                WorkflowStatus.Aborted
-            ];
+        [
+            WorkflowStatus.Idle,
+            WorkflowStatus.Starting,
+            WorkflowStatus.Resuming,
+            WorkflowStatus.Executing,
+            WorkflowStatus.Halted,
+            WorkflowStatus.Finished,
+            WorkflowStatus.Faulted,
+            WorkflowStatus.Aborted
+        ];
 
         if (settings.Statuses.Length <= 0)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using OrchardCore.Modules;
+using OrchardCore.Settings;
+using OrchardCore.Workflows.Indexes;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.WorkflowPruning.Models;
+using YesSql;
+using YesSql.Services;
+
+namespace OrchardCore.Workflows.WorkflowPruning.Services;
+
+public class WorkflowPruningManager
+    : IWorkflowPruningManager
+{
+    private readonly ISiteService _siteService;
+    private readonly ISession _session;
+    private readonly IClock _clock;
+
+    public WorkflowPruningManager(ISiteService siteService, ISession session, IClock clock)
+    {
+        _siteService = siteService;
+        _session = session;
+        _clock = clock;
+    }
+
+    public async Task<int> PruneWorkflowInstancesAsync(TimeSpan retentionPeriod)
+    {
+        var dateThreshold = _clock.UtcNow.AddDays(1) - retentionPeriod;
+        var settings =  (await _siteService.GetSiteSettingsAsync()).As<WorkflowPruningSettings>();
+
+        if (settings.Statuses?.Length is not > 0)
+        {
+            return 0;
+        }
+
+        var statuses = settings.Statuses.Select(x => (int)x).ToArray();
+        var workflowInstances = await _session
+            .Query<Workflow, WorkflowIndex>(x => x.WorkflowStatus.IsIn(statuses) && x.CreatedUtc <= dateThreshold)
+            .ListAsync();
+
+        var total = 0;
+        foreach (var item in workflowInstances)
+        {
+            _session.Delete(item);
+            total++;
+        }
+
+        return total;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
@@ -30,7 +30,19 @@ public class WorkflowPruningManager
         var dateThreshold = _clock.UtcNow.AddDays(1) - retentionPeriod;
         var settings =  (await _siteService.GetSiteSettingsAsync()).As<WorkflowPruningSettings>();
 
-        if (settings.Statuses?.Length is not > 0)
+        settings.Statuses ??=
+            [
+                WorkflowStatus.Idle,
+                WorkflowStatus.Starting,
+                WorkflowStatus.Resuming,
+                WorkflowStatus.Executing,
+                WorkflowStatus.Halted,
+                WorkflowStatus.Finished,
+                WorkflowStatus.Faulted,
+                WorkflowStatus.Aborted
+            ];
+
+        if (settings.Statuses.Length <= 0)
         {
             return 0;
         }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
@@ -27,7 +27,7 @@ public class WorkflowPruningManager : IWorkflowPruningManager
     public async Task<int> PruneWorkflowInstancesAsync(TimeSpan retentionPeriod)
     {
         var dateThreshold = _clock.UtcNow.AddDays(1) - retentionPeriod;
-        var settings =  await _siteService.GetSiteSettingsAsync<WorkflowPruningSettings>();
+        var settings = await _siteService.GetSettingsAsync<WorkflowPruningSettings>();
 
         settings.Statuses ??=
         [

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowPruningManager.cs
@@ -11,8 +11,7 @@ using YesSql.Services;
 
 namespace OrchardCore.Workflows.WorkflowPruning.Services;
 
-public class WorkflowPruningManager
-    : IWorkflowPruningManager
+public class WorkflowPruningManager : IWorkflowPruningManager
 {
     private readonly ISiteService _siteService;
     private readonly ISession _session;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowStatusBuilder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Services/WorkflowStatusBuilder.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Linq;
+using OrchardCore.Workflows.Models;
+
+namespace OrchardCore.Workflows.WorkflowPruning.Services;
+
+internal sealed class WorkflowStatusBuilder
+{
+    public bool IsSelected { get; set; }
+
+    public string Value { get; set; }
+
+    public static WorkflowStatusBuilder[] Build(WorkflowStatus[] selectedStatuses) =>
+        Enum.GetValues(typeof(WorkflowStatus))
+            .Cast<WorkflowStatus>()
+            .Select(x => new WorkflowStatusBuilder
+            {
+                IsSelected = selectedStatuses?.Contains(x) ?? false,
+                Value = x.ToString()
+            })
+            .OrderBy(x => x.Value)
+            .ToArray();
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Startup.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.BackgroundTasks;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.Modules;
+using OrchardCore.Navigation;
+using OrchardCore.Security.Permissions;
+using OrchardCore.Settings;
+using OrchardCore.Workflows.WorkflowPruning.Drivers;
+using OrchardCore.Workflows.WorkflowPruning.Services;
+
+namespace OrchardCore.Workflows.WorkflowPruning;
+
+[Feature("OrchardCore.Workflows")]
+public class Startup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IPermissionProvider, Permissions>();
+        services.AddScoped<IWorkflowPruningManager, WorkflowPruningManager>();
+        services.AddSingleton<IBackgroundTask, WorkflowPruningBackgroundTask>();
+        services.AddScoped<IDisplayDriver<ISite>, WorkflowPruningDisplayDriver>();
+        services.AddScoped<INavigationProvider, AdminMenu>();
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/Startup.cs
@@ -11,7 +11,7 @@ using OrchardCore.Workflows.WorkflowPruning.Services;
 namespace OrchardCore.Workflows.WorkflowPruning;
 
 [Feature("OrchardCore.Workflows")]
-public class Startup : StartupBase
+public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/ViewModels/WorkflowPruningViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/ViewModels/WorkflowPruningViewModel.cs
@@ -7,20 +7,24 @@ namespace OrchardCore.Workflows.WorkflowPruning.ViewModels;
 public class WorkflowPruningViewModel
 {
     public DateTime? LastRunUtc { get; set; }
+
     public bool Disabled { get; set; }
+
     public int RetentionDays { get; set; }
+    
     public WorkflowStatus[] Statuses { get; set; }
 }
 
-public class WorkflowStatusBuiler
+public sealed class WorkflowStatusBuilder
 {
     public bool IsSelected { get; set; }
+
     public string Value { get; set; }
 
-    public static WorkflowStatusBuiler[] Build(WorkflowStatus[] selectedStatuses) =>
+    public static WorkflowStatusBuilder[] Build(WorkflowStatus[] selectedStatuses) =>
         Enum.GetValues(typeof(WorkflowStatus))
             .Cast<WorkflowStatus>()
-            .Select(x => new WorkflowStatusBuiler
+            .Select(x => new WorkflowStatusBuilder
             {
                 IsSelected = selectedStatuses?.Contains(x) ?? false,
                 Value = x.ToString()

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/ViewModels/WorkflowPruningViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/ViewModels/WorkflowPruningViewModel.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Linq;
+using OrchardCore.Workflows.Models;
+
+namespace OrchardCore.Workflows.WorkflowPruning.ViewModels;
+
+public class WorkflowPruningViewModel
+{
+    public DateTime? LastRunUtc { get; set; }
+    public bool Disabled { get; set; }
+    public int RetentionDays { get; set; }
+    public WorkflowStatus[] Statuses { get; set; }
+}
+
+public class WorkflowStatusBuiler
+{
+    public bool IsSelected { get; set; }
+    public string Value { get; set; }
+
+    public static WorkflowStatusBuiler[] Build(WorkflowStatus[] selectedStatuses) =>
+        Enum.GetValues(typeof(WorkflowStatus))
+            .Cast<WorkflowStatus>()
+            .Select(x => new WorkflowStatusBuiler
+            {
+                IsSelected = selectedStatuses?.Contains(x) ?? false,
+                Value = x.ToString()
+            })
+            .OrderBy(x => x.Value)
+            .ToArray();
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/ViewModels/WorkflowPruningViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/WorkflowPruning/ViewModels/WorkflowPruningViewModel.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using OrchardCore.Workflows.Models;
 
 namespace OrchardCore.Workflows.WorkflowPruning.ViewModels;
@@ -11,24 +10,6 @@ public class WorkflowPruningViewModel
     public bool Disabled { get; set; }
 
     public int RetentionDays { get; set; }
-    
+
     public WorkflowStatus[] Statuses { get; set; }
-}
-
-public sealed class WorkflowStatusBuilder
-{
-    public bool IsSelected { get; set; }
-
-    public string Value { get; set; }
-
-    public static WorkflowStatusBuilder[] Build(WorkflowStatus[] selectedStatuses) =>
-        Enum.GetValues(typeof(WorkflowStatus))
-            .Cast<WorkflowStatus>()
-            .Select(x => new WorkflowStatusBuilder
-            {
-                IsSelected = selectedStatuses?.Contains(x) ?? false,
-                Value = x.ToString()
-            })
-            .OrderBy(x => x.Value)
-            .ToArray();
 }

--- a/src/OrchardCore/OrchardCore.Workflows.Abstractions/WorkflowPruning/Services/IWorkflowPruningManager.cs
+++ b/src/OrchardCore/OrchardCore.Workflows.Abstractions/WorkflowPruning/Services/IWorkflowPruningManager.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Threading.Tasks;
+
+namespace OrchardCore.Workflows.WorkflowPruning.Services;
+
+public interface IWorkflowPruningManager
+{
+    Task<int> PruneWorkflowInstancesAsync(TimeSpan retentionPeriod);
+}


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->

Fixes #11609 

One of our guys, Jose, added this feature to our project some time ago, but left before he was able to contribute it back, so doing so on his behalf.

It is similar to the audit trail settings, however you can select a range of workflow statuses to prune.

![image](https://github.com/user-attachments/assets/27ef4f0a-11ee-491a-bf14-158febd1bf75)

Currently its part of the main workflows feature, and by default will be on, but on a site where the statuses have not been set, it will set them to all at 90 days when the background task runs.

Will let the community decide what behaviour they want there. 

Perhaps it would be better to make it a feature.