### PR TITLE
Fix wrong autocomplete=new-password on the current password field.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/ChangePassword.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/ChangePassword.cshtml
@@ -11,7 +11,7 @@
     <div class="mb-3">
         <label asp-for="CurrentPassword" class="col-md-4 form-label">@T["Current password"]</label>
         <div class="col-md-8">
-            <input asp-for="CurrentPassword" class="form-control" autofocus autocomplete="new-password" />
+            <input asp-for="CurrentPassword" class="form-control" autofocus />
             <span asp-validation-for="CurrentPassword" class="text-danger"></span>
         </div>
     </div>
@@ -26,7 +26,7 @@
     <div class="mb-3">
         <label asp-for="PasswordConfirmation" class="col-md-4 form-label">@T["New password confirmation"]</label>
         <div class="col-md-8">
-            <input asp-for="PasswordConfirmation" class="form-control" />
+            <input asp-for="PasswordConfirmation" class="form-control" autocomplete="new-password" />
             <span asp-validation-for="PasswordConfirmation" class="text-danger"></span>
         </div>
     </div>


### PR DESCRIPTION
This `autocomplete` was supposed to go on the password confirmation, not current password. Correct?

/cc @MikeAlhayek @Piedone 