### PR TITLE
Add Message template to The Theme and unify font-awesome injection

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/Login.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/Login.cshtml
@@ -18,7 +18,7 @@
     var disableLocalLogin = (await SiteService.GetSettingsAsync<LoginSettings>()).DisableLocalLogin;
 }
 
-<style asp-name="font-awesome" version="6"></style>
+<script asp-name="font-awesome" at="Foot" version="6"></script>
 
 <div class="row">
     @if (!ViewContext.ModelState.IsValid)

--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -38,7 +38,7 @@
     <script asp-name="bootstrap" version="5" at="Foot"></script>
     <script asp-name="theme-manager" at="Foot"></script>
 
-    <style asp-name="font-awesome" version="6"></style>
+    <script asp-name="font-awesome" at="Foot" version="6"></script>
     <resources type="Header" />
     @await RenderSectionAsync("HeadMeta", required: false)
 </head>

--- a/src/OrchardCore.Themes/TheTheme/Views/Message.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Message.cshtml
@@ -1,0 +1,14 @@
+@{
+    string type = Model.Type.ToString().ToLowerInvariant();
+    var bsClassName = type switch
+    {
+        "information" => "alert-info",
+        "error" => "alert-danger",
+        _ => $"alert-{type}",
+    };
+}
+
+<div class="alert alert-dismissible @bsClassName fade show message-@type" role="alert">
+    @Model.Message
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+</div>


### PR DESCRIPTION
In `TheAdmin` theme we register font-awesome using javascript like this 

> <script asp-name="font-awesome" at="Foot" version="6"></script>

In `TheTheme` using the same script will reuse the same script "less resources". Also, if we define a 2FA or login layout we can simply use the same icons without causing conflict.