### PR TITLE
Add a base document-index to allow indexing non-content items in AzureAI search

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
@@ -14,6 +14,7 @@ using OrchardCore.Modules;
 using OrchardCore.Search.Lucene.Model;
 using OrchardCore.Search.Lucene.Services;
 using Spatial4n.Context;
+using static OrchardCore.Indexing.DocumentIndexBase;
 using Directory = System.IO.Directory;
 using LDirectory = Lucene.Net.Store.Directory;
 using LuceneLock = Lucene.Net.Store.Lock;
@@ -206,7 +207,7 @@ public class LuceneIndexManager : IDisposable
 
             switch (entry.Type)
             {
-                case DocumentIndex.Types.Boolean:
+                case Types.Boolean:
                     // Store "true"/"false" for boolean.
                     doc.Add(new StringField(entry.Name, Convert.ToString(entry.Value).ToLowerInvariant(), store));
 
@@ -216,7 +217,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case DocumentIndex.Types.DateTime:
+                case Types.DateTime:
                     if (entry.Value != null)
                     {
                         if (entry.Value is DateTimeOffset)
@@ -246,7 +247,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case DocumentIndex.Types.Integer:
+                case Types.Integer:
                     if (entry.Value != null && long.TryParse(entry.Value.ToString(), out var value))
                     {
                         doc.Add(new Int64Field(entry.Name, value, store));
@@ -263,7 +264,7 @@ public class LuceneIndexManager : IDisposable
 
                     break;
 
-                case DocumentIndex.Types.Number:
+                case Types.Number:
                     if (entry.Value != null)
                     {
                         doc.Add(new DoubleField(entry.Name, Convert.ToDouble(entry.Value), store));
@@ -279,7 +280,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case DocumentIndex.Types.Text:
+                case Types.Text:
                     if (entry.Value != null && !string.IsNullOrEmpty(Convert.ToString(entry.Value)))
                     {
                         var stringValue = Convert.ToString(entry.Value);
@@ -319,10 +320,10 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case DocumentIndex.Types.GeoPoint:
+                case Types.GeoPoint:
                     var strategy = new RecursivePrefixTreeStrategy(_grid, entry.Name);
 
-                    if (entry.Value != null && entry.Value is DocumentIndex.GeoPoint point)
+                    if (entry.Value != null && entry.Value is DocumentIndexBase.GeoPoint point)
                     {
                         var geoPoint = _ctx.MakePoint((double)point.Longitude, (double)point.Latitude);
                         foreach (var field in strategy.CreateIndexableFields(geoPoint))
@@ -422,7 +423,7 @@ public class LuceneIndexManager : IDisposable
     }
 
     /// <summary>
-    /// Releases all readers and writers. This can be used after some time of innactivity to free resources.
+    /// Releases all readers and writers. This can be used after some time of inactivity to free resources.
     /// </summary>
     public void FreeReaderWriter()
     {
@@ -456,7 +457,7 @@ public class LuceneIndexManager : IDisposable
     }
 
     /// <summary>
-    /// Releases all readers and writers. This can be used after some time of innactivity to free resources.
+    /// Releases all readers and writers. This can be used after some time of inactivity to free resources.
     /// </summary>
     public void FreeReaderWriter(string indexName)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
@@ -14,7 +14,6 @@ using OrchardCore.Modules;
 using OrchardCore.Search.Lucene.Model;
 using OrchardCore.Search.Lucene.Services;
 using Spatial4n.Context;
-using static OrchardCore.Indexing.DocumentIndexBase;
 using Directory = System.IO.Directory;
 using LDirectory = Lucene.Net.Store.Directory;
 using LuceneLock = Lucene.Net.Store.Lock;
@@ -207,7 +206,7 @@ public class LuceneIndexManager : IDisposable
 
             switch (entry.Type)
             {
-                case Types.Boolean:
+                case DocumentIndex.Types.Boolean:
                     // Store "true"/"false" for boolean.
                     doc.Add(new StringField(entry.Name, Convert.ToString(entry.Value).ToLowerInvariant(), store));
 
@@ -217,7 +216,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case Types.DateTime:
+                case DocumentIndex.Types.DateTime:
                     if (entry.Value != null)
                     {
                         if (entry.Value is DateTimeOffset)
@@ -247,7 +246,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case Types.Integer:
+                case DocumentIndex.Types.Integer:
                     if (entry.Value != null && long.TryParse(entry.Value.ToString(), out var value))
                     {
                         doc.Add(new Int64Field(entry.Name, value, store));
@@ -264,7 +263,7 @@ public class LuceneIndexManager : IDisposable
 
                     break;
 
-                case Types.Number:
+                case DocumentIndex.Types.Number:
                     if (entry.Value != null)
                     {
                         doc.Add(new DoubleField(entry.Name, Convert.ToDouble(entry.Value), store));
@@ -280,7 +279,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case Types.Text:
+                case DocumentIndex.Types.Text:
                     if (entry.Value != null && !string.IsNullOrEmpty(Convert.ToString(entry.Value)))
                     {
                         var stringValue = Convert.ToString(entry.Value);
@@ -320,7 +319,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case Types.GeoPoint:
+                case DocumentIndex.Types.GeoPoint:
                     var strategy = new RecursivePrefixTreeStrategy(_grid, entry.Name);
 
                     if (entry.Value != null && entry.Value is DocumentIndexBase.GeoPoint point)

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexManager.cs
@@ -206,7 +206,7 @@ public class LuceneIndexManager : IDisposable
 
             switch (entry.Type)
             {
-                case DocumentIndex.Types.Boolean:
+                case DocumentIndexBase.Types.Boolean:
                     // Store "true"/"false" for boolean.
                     doc.Add(new StringField(entry.Name, Convert.ToString(entry.Value).ToLowerInvariant(), store));
 
@@ -216,7 +216,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case DocumentIndex.Types.DateTime:
+                case DocumentIndexBase.Types.DateTime:
                     if (entry.Value != null)
                     {
                         if (entry.Value is DateTimeOffset)
@@ -246,7 +246,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case DocumentIndex.Types.Integer:
+                case DocumentIndexBase.Types.Integer:
                     if (entry.Value != null && long.TryParse(entry.Value.ToString(), out var value))
                     {
                         doc.Add(new Int64Field(entry.Name, value, store));
@@ -263,7 +263,7 @@ public class LuceneIndexManager : IDisposable
 
                     break;
 
-                case DocumentIndex.Types.Number:
+                case DocumentIndexBase.Types.Number:
                     if (entry.Value != null)
                     {
                         doc.Add(new DoubleField(entry.Name, Convert.ToDouble(entry.Value), store));
@@ -279,7 +279,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case DocumentIndex.Types.Text:
+                case DocumentIndexBase.Types.Text:
                     if (entry.Value != null && !string.IsNullOrEmpty(Convert.ToString(entry.Value)))
                     {
                         var stringValue = Convert.ToString(entry.Value);
@@ -319,7 +319,7 @@ public class LuceneIndexManager : IDisposable
                     }
                     break;
 
-                case DocumentIndex.Types.GeoPoint:
+                case DocumentIndexBase.Types.GeoPoint:
                     var strategy = new RecursivePrefixTreeStrategy(_grid, entry.Name);
 
                     if (entry.Value != null && entry.Value is DocumentIndexBase.GeoPoint point)

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/DocumentIndex.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/DocumentIndex.cs
@@ -1,76 +1,14 @@
-using Microsoft.AspNetCore.Html;
-
 namespace OrchardCore.Indexing;
 
-public class DocumentIndex(string contentItemId, string contentItemVersionId)
+public class DocumentIndex : DocumentIndexBase
 {
-    public List<DocumentIndexEntry> Entries { get; } = [];
+    public string ContentItemId { get; }
 
-    public void Set(string name, string value, DocumentIndexOptions options)
+    public string ContentItemVersionId { get; }
+
+    public DocumentIndex(string contentItemId, string contentItemVersionId)
     {
-        Entries.Add(new DocumentIndexEntry(name, value, Types.Text, options));
-    }
-
-    public void Set(string name, IHtmlContent value, DocumentIndexOptions options)
-    {
-        Entries.Add(new DocumentIndexEntry(name, value, Types.Text, options));
-    }
-
-    public void Set(string name, DateTimeOffset? value, DocumentIndexOptions options)
-    {
-        Entries.Add(new DocumentIndexEntry(name, value, Types.DateTime, options));
-    }
-
-    public void Set(string name, int? value, DocumentIndexOptions options)
-    {
-        Entries.Add(new DocumentIndexEntry(name, value, Types.Integer, options));
-    }
-
-    public void Set(string name, bool? value, DocumentIndexOptions options)
-    {
-        Entries.Add(new DocumentIndexEntry(name, value, Types.Boolean, options));
-    }
-
-    public void Set(string name, double? value, DocumentIndexOptions options)
-    {
-        Entries.Add(new DocumentIndexEntry(name, value, Types.Number, options));
-    }
-
-    public void Set(string name, decimal? value, DocumentIndexOptions options)
-    {
-        Entries.Add(new DocumentIndexEntry(name, value, Types.Number, options));
-    }
-
-    public void Set(string name, GeoPoint value, DocumentIndexOptions options)
-    {
-        Entries.Add(new DocumentIndexEntry(name, value, Types.GeoPoint, options));
-    }
-
-    public string ContentItemId { get; } = contentItemId;
-
-    public string ContentItemVersionId { get; } = contentItemVersionId;
-
-    public enum Types
-    {
-        Integer,
-        Text,
-        DateTime,
-        Boolean,
-        Number,
-        GeoPoint
-    }
-
-    public class GeoPoint
-    {
-        public decimal Longitude;
-        public decimal Latitude;
-    }
-
-    public class DocumentIndexEntry(string name, object value, Types type, DocumentIndexOptions options)
-    {
-        public string Name { get; } = name;
-        public object Value { get; } = value;
-        public Types Type { get; } = type;
-        public DocumentIndexOptions Options { get; } = options;
+        ContentItemId = contentItemId;
+        ContentItemVersionId = contentItemVersionId;
     }
 }

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/DocumentIndexBase.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/DocumentIndexBase.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.AspNetCore.Html;
+
+namespace OrchardCore.Indexing;
+
+public class DocumentIndexBase
+{
+    public List<DocumentIndexEntry> Entries { get; } = [];
+
+    public void Set(string name, string value, DocumentIndexOptions options)
+    {
+        Entries.Add(new DocumentIndexEntry(name, value, Types.Text, options));
+    }
+
+    public void Set(string name, IHtmlContent value, DocumentIndexOptions options)
+    {
+        Entries.Add(new DocumentIndexEntry(name, value, Types.Text, options));
+    }
+
+    public void Set(string name, DateTimeOffset? value, DocumentIndexOptions options)
+    {
+        Entries.Add(new DocumentIndexEntry(name, value, Types.DateTime, options));
+    }
+
+    public void Set(string name, int? value, DocumentIndexOptions options)
+    {
+        Entries.Add(new DocumentIndexEntry(name, value, Types.Integer, options));
+    }
+
+    public void Set(string name, bool? value, DocumentIndexOptions options)
+    {
+        Entries.Add(new DocumentIndexEntry(name, value, Types.Boolean, options));
+    }
+
+    public void Set(string name, double? value, DocumentIndexOptions options)
+    {
+        Entries.Add(new DocumentIndexEntry(name, value, Types.Number, options));
+    }
+
+    public void Set(string name, decimal? value, DocumentIndexOptions options)
+    {
+        Entries.Add(new DocumentIndexEntry(name, value, Types.Number, options));
+    }
+
+    public void Set(string name, GeoPoint value, DocumentIndexOptions options)
+    {
+        Entries.Add(new DocumentIndexEntry(name, value, Types.GeoPoint, options));
+    }
+
+    public enum Types
+    {
+        Integer,
+        Text,
+        DateTime,
+        Boolean,
+        Number,
+        GeoPoint,
+    }
+
+    public class GeoPoint
+    {
+        public decimal Longitude;
+        public decimal Latitude;
+    }
+
+    public class DocumentIndexEntry(string name, object value, Types type, DocumentIndexOptions options)
+    {
+        public string Name { get; } = name;
+        public object Value { get; } = value;
+        public Types Type { get; } = type;
+        public DocumentIndexOptions Options { get; } = options;
+    }
+}

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Models/AzureAISearchIndexMap.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Models/AzureAISearchIndexMap.cs
@@ -1,5 +1,5 @@
 using OrchardCore.Indexing;
-using static OrchardCore.Indexing.DocumentIndex;
+using static OrchardCore.Indexing.DocumentIndexBase;
 
 namespace OrchardCore.Search.AzureAI.Models;
 

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Models/SearchIndexDefinition.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Models/SearchIndexDefinition.cs
@@ -1,4 +1,4 @@
-using static OrchardCore.Indexing.DocumentIndex;
+using static OrchardCore.Indexing.DocumentIndexBase;
 
 namespace OrchardCore.Search.AzureAI.Models;
 

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
@@ -6,7 +6,7 @@ using OrchardCore.Contents.Indexing;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
 using OrchardCore.Search.AzureAI.Models;
-using static OrchardCore.Indexing.DocumentIndex;
+using static OrchardCore.Indexing.DocumentIndexBase;
 
 namespace OrchardCore.Search.AzureAI.Services;
 
@@ -130,7 +130,7 @@ public class AzureAIIndexDocumentManager
         await DeleteDocumentsAsync(indexName, contentItemIds);
     }
 
-    public async Task<bool> MergeOrUploadDocumentsAsync(string indexName, IList<DocumentIndex> indexDocuments, AzureAISearchIndexSettings indexSettings)
+    public async Task<bool> MergeOrUploadDocumentsAsync(string indexName, IList<DocumentIndexBase> indexDocuments, AzureAISearchIndexSettings indexSettings)
     {
         ArgumentException.ThrowIfNullOrEmpty(indexName);
         ArgumentNullException.ThrowIfNull(indexDocuments);
@@ -244,7 +244,7 @@ public class AzureAIIndexDocumentManager
         indexMappings.Add(indexMap);
     }
 
-    private static IEnumerable<SearchDocument> CreateSearchDocuments(IEnumerable<DocumentIndex> indexDocuments, Dictionary<string, IEnumerable<AzureAISearchIndexMap>> mappings)
+    private static IEnumerable<SearchDocument> CreateSearchDocuments(IEnumerable<DocumentIndexBase> indexDocuments, Dictionary<string, IEnumerable<AzureAISearchIndexMap>> mappings)
     {
         foreach (var indexDocument in indexDocuments)
         {
@@ -252,13 +252,15 @@ public class AzureAIIndexDocumentManager
         }
     }
 
-    private static SearchDocument CreateSearchDocument(DocumentIndex documentIndex, Dictionary<string, IEnumerable<AzureAISearchIndexMap>> mappingDictionary)
+    private static SearchDocument CreateSearchDocument(DocumentIndexBase documentIndex, Dictionary<string, IEnumerable<AzureAISearchIndexMap>> mappingDictionary)
     {
-        var doc = new SearchDocument()
+        var doc = new SearchDocument();
+
+        if (documentIndex is DocumentIndex index)
         {
-            { IndexingConstants.ContentItemIdKey, documentIndex.ContentItemId },
-            { IndexingConstants.ContentItemVersionIdKey, documentIndex.ContentItemVersionId },
-        };
+            doc.Add(IndexingConstants.ContentItemIdKey, index.ContentItemId);
+            doc.Add(IndexingConstants.ContentItemVersionIdKey, index.ContentItemVersionId);
+        }
 
         foreach (var entry in documentIndex.Entries)
         {
@@ -276,14 +278,14 @@ public class AzureAIIndexDocumentManager
 
             switch (entry.Type)
             {
-                case Types.Boolean:
+                case DocumentIndexBase.Types.Boolean:
                     if (entry.Value is bool boolValue)
                     {
                         doc.TryAdd(map.AzureFieldKey, boolValue);
                     }
                     break;
 
-                case Types.DateTime:
+                case DocumentIndexBase.Types.DateTime:
 
                     if (entry.Value is DateTimeOffset offsetValue)
                     {
@@ -296,7 +298,7 @@ public class AzureAIIndexDocumentManager
 
                     break;
 
-                case Types.Integer:
+                case DocumentIndexBase.Types.Integer:
                     if (entry.Value != null && long.TryParse(entry.Value.ToString(), out var value))
                     {
                         doc.TryAdd(map.AzureFieldKey, value);
@@ -304,21 +306,21 @@ public class AzureAIIndexDocumentManager
 
                     break;
 
-                case Types.Number:
+                case DocumentIndexBase.Types.Number:
                     if (entry.Value != null)
                     {
                         doc.TryAdd(map.AzureFieldKey, Convert.ToDouble(entry.Value));
                     }
                     break;
 
-                case Types.GeoPoint:
+                case DocumentIndexBase.Types.GeoPoint:
                     if (entry.Value != null)
                     {
                         doc.TryAdd(map.AzureFieldKey, entry.Value);
                     }
                     break;
 
-                case Types.Text:
+                case DocumentIndexBase.Types.Text:
                     if (entry.Value != null)
                     {
                         var stringValue = Convert.ToString(entry.Value);

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexDocumentManager.cs
@@ -285,7 +285,7 @@ public class AzureAIIndexDocumentManager
                     }
                     break;
 
-                case DocumentIndexBase.Types.DateTime:
+                case Types.DateTime:
 
                     if (entry.Value is DateTimeOffset offsetValue)
                     {
@@ -298,7 +298,7 @@ public class AzureAIIndexDocumentManager
 
                     break;
 
-                case DocumentIndexBase.Types.Integer:
+                case Types.Integer:
                     if (entry.Value != null && long.TryParse(entry.Value.ToString(), out var value))
                     {
                         doc.TryAdd(map.AzureFieldKey, value);
@@ -306,21 +306,21 @@ public class AzureAIIndexDocumentManager
 
                     break;
 
-                case DocumentIndexBase.Types.Number:
+                case Types.Number:
                     if (entry.Value != null)
                     {
                         doc.TryAdd(map.AzureFieldKey, Convert.ToDouble(entry.Value));
                     }
                     break;
 
-                case DocumentIndexBase.Types.GeoPoint:
+                case Types.GeoPoint:
                     if (entry.Value != null)
                     {
                         doc.TryAdd(map.AzureFieldKey, entry.Value);
                     }
                     break;
 
-                case DocumentIndexBase.Types.Text:
+                case Types.Text:
                     if (entry.Value != null)
                     {
                         var stringValue = Convert.ToString(entry.Value);

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexManager.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Modules;
 using OrchardCore.Search.AzureAI.Models;
-using static OrchardCore.Indexing.DocumentIndex;
+using static OrchardCore.Indexing.DocumentIndexBase;
 
 namespace OrchardCore.Search.AzureAI.Services;
 

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexingService.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexingService.cs
@@ -93,7 +93,7 @@ public class AzureAISearchIndexingService
             Dictionary<string, ContentItem> allLatest = null;
 
             // Group all DocumentIndex by index to batch update them.
-            var updatedDocumentsByIndex = indexSettings.ToDictionary(x => x.IndexName, b => new List<DocumentIndex>());
+            var updatedDocumentsByIndex = indexSettings.ToDictionary(x => x.IndexName, b => new List<DocumentIndexBase>());
 
             var settingsByIndex = indexSettings.ToDictionary(x => x.IndexName);
 


### PR DESCRIPTION
I need a way to create AzureAI indexes from a non-ContentItem source. We can easily allow for this if we introduce `DocumentIndexBase` which does not contain `ContentItemId` and `ContentItemVersionId`