### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,5 @@
+# .git-blame-ignore-revs
+# Define formatting rules (#16567)
+657342d05a221dfaba1fdf46813c0161dd12d4ec
+# Convert to file-scope namespaces (#16539)
 05730cfeb221680240feb3d9edca563bc388a1ef

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,7 @@
 # .git-blame-ignore-revs
+
 # Define formatting rules (#16567)
 657342d05a221dfaba1fdf46813c0161dd12d4ec
+
 # Convert to file-scope namespaces (#16539)
 05730cfeb221680240feb3d9edca563bc388a1ef

--- a/.github/.git-blame-ignore-revs
+++ b/.github/.git-blame-ignore-revs
@@ -1,5 +1,0 @@
-# .git-blame-ignore-revs
-# Use file scoped namespaces (#38076)
-a450cb69b5e4549f5515cdb057a68771f56cefd7
-# Define formatting rules (#16567)
-657342d05a221dfaba1fdf46813c0161dd12d4ec

--- a/.github/.git-blame-ignore-revs
+++ b/.github/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# .git-blame-ignore-revs
+# Use file scoped namespaces (#38076)
+a450cb69b5e4549f5515cdb057a68771f56cefd7
+# Define formatting rules (#16567)
+657342d05a221dfaba1fdf46813c0161dd12d4ec


### PR DESCRIPTION
Prevent recent refactorings from appearing in the blame history