### PR TITLE
Remove unnecessary FeatureBuilderEvents

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Extensions/Features/IFeatureBuilderEvents.cs
@@ -22,14 +22,3 @@ public class FeatureBuildingContext
     public bool IsAlwaysEnabled { get; set; }
     public bool EnabledByDependencyOnly { get; set; }
 }
-
-public abstract class FeatureBuilderEvents : IFeatureBuilderEvents
-{
-    public virtual void Building(FeatureBuildingContext context)
-    {
-    }
-
-    public virtual void Built(IFeatureInfo featureInfo)
-    {
-    }
-}


### PR DESCRIPTION
There's no need for the abstract class `FeatureBuilderEvents` while we have  `IFeatureBuilderEvents` and no implementation on it