### PR TITLE
Add "Create & Setup" button to the create tenant view

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
@@ -22,7 +22,7 @@
 
     <div class="mb-3">
         <button class="btn btn-primary create" type="submit" name="action" value="create">@T["Create"]</button>
-        <button class="btn btn-primary create" type="submit" name="action" value="createAndSetup">@T["Create & Setup"]</button>
+        <button class="btn btn-primary createAndSetup" type="submit" name="action" value="createAndSetup">@T["Create & Setup"]</button>
         <a class="btn btn-secondary cancel" role="button" asp-route-action="Index">@T["Cancel"]</a>
     </div>
 </form>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
@@ -22,7 +22,7 @@
 
     <div class="mb-3">
         <button class="btn btn-primary create" type="submit" name="action" value="create">@T["Create"]</button>
-        <button class="btn btn-primary createAndSetup" type="submit" name="action" value="createAndSetup">@T["Create & Setup"]</button>
+        <button class="btn btn-primary" type="submit" name="action" value="createAndSetup">@T["Create & Setup"]</button>
         <a class="btn btn-secondary cancel" role="button" asp-route-action="Index">@T["Cancel"]</a>
     </div>
 </form>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Create.cshtml
@@ -21,7 +21,8 @@
     <partial name="_TenantFeatureProfile" model="Model" />
 
     <div class="mb-3">
-        <button class="btn btn-primary create" type="submit">@T["Create"]</button>
+        <button class="btn btn-primary create" type="submit" name="action" value="create">@T["Create"]</button>
+        <button class="btn btn-primary create" type="submit" name="action" value="createAndSetup">@T["Create & Setup"]</button>
         <a class="btn btn-secondary cancel" role="button" asp-route-action="Index">@T["Cancel"]</a>
     </div>
 </form>


### PR DESCRIPTION
When creating a new tenant, it is helpful to be able to create and setup the tenant at the same time. In addition to the "Create" button, now we have "Create & Setup" button which will take you to the setup screen after a tenant was created.