### PR TITLE
Ensure correct feature is enabled AAD

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/MicrosoftAccountStartup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/MicrosoftAccountStartup.cs
@@ -78,6 +78,7 @@ public sealed class AzureADStartup : StartupBase
 }
 
 [RequireFeatures("OrchardCore.Deployment")]
+[Feature(MicrosoftAuthenticationConstants.Features.AAD)]
 public sealed class DeploymentStartup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)


### PR DESCRIPTION
without this dependency if you enable only microsoft authentication  and go to Configuration-Import/Export-Json Import exception occurs because AzureADDeploymentSource  cannot resolve  IAzureADService since feature is not enabled

 