### PR TITLE
Allow setting Absolute and Sliding Expiration at the same time

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Drivers/NotificationNavbarDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Drivers/NotificationNavbarDisplayDriver.cs
@@ -51,8 +51,7 @@ public sealed class NotificationNavbarDisplayDriver : DisplayDriver<Navbar>
                 model.MaxVisibleNotifications = _notificationOptions.TotalUnreadNotifications;
                 model.TotalUnread = notifications.Count;
 
-            })
-            .Location("Detail", "Content:9")
+            }).Location("Detail", "Content:9")
             .Location("DetailAdmin", "Content:9");
 
         if (_notificationOptions.AbsoluteCacheExpirationSeconds > 0 || _notificationOptions.SlidingCacheExpirationSeconds > 0)
@@ -69,7 +68,8 @@ public sealed class NotificationNavbarDisplayDriver : DisplayDriver<Navbar>
                     {
                         context.WithExpiryAfter(TimeSpan.FromSeconds(_notificationOptions.AbsoluteCacheExpirationSeconds));
                     }
-                    else if (_notificationOptions.SlidingCacheExpirationSeconds > 0)
+
+                    if (_notificationOptions.SlidingCacheExpirationSeconds > 0)
                     {
                         context.WithExpirySliding(TimeSpan.FromSeconds(_notificationOptions.SlidingCacheExpirationSeconds));
                     }

--- a/src/OrchardCore/OrchardCore.Notifications.Core/Models/NotificationOptions.cs
+++ b/src/OrchardCore/OrchardCore.Notifications.Core/Models/NotificationOptions.cs
@@ -13,16 +13,13 @@ public class NotificationOptions
     public bool DisableNotificationHtmlBodySanitizer { get; set; }
 
     /// <summary>
-    /// Specifies the cache duration in seconds for the top-unread notification.
-    /// A value of 0 disables the max-cache expiration.
-    /// If both this property and <see cref="SlidingCacheExpirationSeconds"/> are set to 0, caching will be disabled.
+    /// Gets or sets an absolute expiration time, relative to now.
     /// </summary>
     public int AbsoluteCacheExpirationSeconds { get; set; }
 
     /// <summary>
-    /// Specifies the sliding cache duration in seconds for the top-unread notification.
-    /// A value of 0 disables sliding-caching expiration.
-    /// If both this property and <see cref="AbsoluteCacheExpirationSeconds"/> are set to 0, caching will be disabled.
+    /// Gets or sets how long a cache entry can be inactive (e.g. not accessed) before it will be removed.
+    /// This will not extend the entry lifetime beyond the absolute expiration (if set in <see cref="AbsoluteCacheExpirationSeconds" />).
     /// </summary>
     public int SlidingCacheExpirationSeconds { get; set; } = 1800;
 }

--- a/src/docs/reference/modules/Notifications/README.md
+++ b/src/docs/reference/modules/Notifications/README.md
@@ -20,7 +20,7 @@ Available Options and Their Definitions:
 | `TotalUnreadNotifications`               | Specifies the maximum number of unread notifications displayed in the navigation bar. Default is 10.                                                                 |
 | `DisableNotificationHtmlBodySanitizer`   | Allows you to disable the default sanitization of the `HtmlBody` in notifications generated from workflows.                                                          |
 | `AbsoluteCacheExpirationSeconds`         | Specifies the absolute maximum duration, in seconds, for which the top unread user notifications are cached when caching is enabled. A value of 0 does not disable caching but indicates that there is no fixed expiration time for the cache. You can set this value to define a maximum lifespan for the cached data before it is invalidated. |
-| `SlidingCacheExpirationSeconds`          | Defines the sliding cache duration, in seconds, for unread user notifications when caching is enabled. By default, the cache is refreshed and extended for up to 1800 seconds (30 minutes) after each user activity. To disable sliding expiration, you can set this value to 0. |
+| `SlidingCacheExpirationSeconds`          | Gets or sets how long a cache entry can be inactive (e.g. not accessed) before it will be removed. This will not extend the entry lifetime beyond the absolute expiration (if set). To disable sliding expiration, you can set this value to 0. |
 
 ## Notification Methods
 


### PR DESCRIPTION
Allow setting AbsoluteCacheExpirationSeconds and SlidingCacheExpirationSeconds at the same time
