### PR TITLE
Fixed ContainedPartIndex behavior for DisplayText over 255 chars long

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ContainedPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ContainedPartIndex.cs
@@ -50,12 +50,15 @@ public class ContainedPartIndexProvider : IndexProvider<ContentItem>
                     Order = containedPart.Order,
                     Published = contentItem.Published,
                     Latest = contentItem.Latest,
-                    DisplayText = contentItem.DisplayText,
                 };
 
                 if (containedPartIndex.DisplayText?.Length > ContainedPartIndex.MaxDisplayTextSize)
                 {
                     containedPartIndex.DisplayText = contentItem.DisplayText[..ContainedPartIndex.MaxDisplayTextSize];
+                } 
+                else 
+                {
+                    containedPartIndex.DisplayText = contentItem.DisplayText;
                 }
 
                 return containedPartIndex;

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ContainedPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ContainedPartIndex.cs
@@ -6,6 +6,8 @@ namespace OrchardCore.Lists.Indexes;
 
 public class ContainedPartIndex : MapIndex
 {
+    public const int MaxDisplayTextSize = 255;
+
     public string ListContentItemId { get; set; }
 
     public int Order { get; set; }
@@ -40,7 +42,7 @@ public class ContainedPartIndexProvider : IndexProvider<ContentItem>
                     return null;
                 }
 
-                return new ContainedPartIndex
+                var containedPartIndex = new ContainedPartIndex
                 {
                     ContentItemId = contentItem.ContentItemId,
                     ListContentType = containedPart.ListContentType,
@@ -50,6 +52,13 @@ public class ContainedPartIndexProvider : IndexProvider<ContentItem>
                     Latest = contentItem.Latest,
                     DisplayText = contentItem.DisplayText,
                 };
+
+                if (containedPartIndex.DisplayText?.Length > ContainedPartIndex.MaxDisplayTextSize)
+                {
+                    containedPartIndex.DisplayText = contentItem.DisplayText[..ContainedPartIndex.MaxDisplayTextSize];
+                }
+
+                return containedPartIndex;
             });
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Migrations.cs
@@ -25,7 +25,7 @@ public sealed class Migrations : DataMigration
         await SchemaBuilder.CreateMapIndexTableAsync<ContainedPartIndex>(table => table
             .Column<string>("ContentItemId", column => column.WithLength(26))
             .Column<string>("ListContentItemId", column => column.WithLength(26))
-            .Column<string>("DisplayText")
+            .Column<string>("DisplayText", column => column.WithLength(ContainedPartIndex.MaxDisplayTextSize))
             .Column<int>("Order")
             .Column<string>("ListContentType")
             .Column<bool>("Published")
@@ -84,7 +84,7 @@ public sealed class Migrations : DataMigration
         );
 
         await SchemaBuilder.AlterIndexTableAsync<ContainedPartIndex>(table => table
-            .AddColumn<string>("DisplayText")
+            .AddColumn<string>("DisplayText", column => column.WithLength(ContainedPartIndex.MaxDisplayTextSize))
         );
 
         await SchemaBuilder.AlterIndexTableAsync<ContainedPartIndex>(table => table


### PR DESCRIPTION
Hi! Currently there is an issue when adding content items with long DisplayText (over 255 chars) as a child list item. Postgres database allowes only 255 chars for ContainedPartIndex.DisplayText column. So this fix truncates long DisplayText to 255 chars, similart to ContentItemIndex behavior