### PR TITLE
Obsolete ILocalClock.LocalNowAsync

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListQueryService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Services/DefaultAuditTrailAdminListQueryService.cs
@@ -87,7 +87,7 @@ public class DefaultAuditTrailAdminListQueryService : IAuditTrailAdminListQueryS
             }
         }
 
-        var localNow = await _localClock.LocalNowAsync;
+        var localNow = await _localClock.GetLocalNowAsync();
         var startOfWeek = CultureInfo.CurrentUICulture.DateTimeFormat.FirstDayOfWeek;
 
         options.AuditTrailDates =

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/LocalTimeZoneFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/LocalTimeZoneFilter.cs
@@ -24,7 +24,7 @@ public class LocalTimeZoneFilter : ILiquidFilter
 
             if (stringValue == "now" || stringValue == "today")
             {
-                value = await _localClock.LocalNowAsync;
+                value = await _localClock.GetLocalNowAsync();
             }
             else
             {

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/UtcTimeZoneFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Filters/UtcTimeZoneFilter.cs
@@ -24,7 +24,7 @@ public class UtcTimeZoneFilter : ILiquidFilter
 
             if (stringValue == "now" || stringValue == "today")
             {
-                value = await _localClock.LocalNowAsync;
+                value = await _localClock.GetLocalNowAsync();
             }
             else
             {

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/ILocalClock.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/ILocalClock.cs
@@ -5,14 +5,14 @@ namespace OrchardCore.Modules;
 /// </summary>
 public interface ILocalClock
 {
-    [Obsolete("This property has been deprecated and will be removed in a future version. Please use GetLocalNowAsync() instead.", error: true)]
-    Task<DateTimeOffset> LocalNowAsync => GetLocalNowAsync();
+    [Obsolete("This property has been deprecated and will be removed in a future version. Please use GetLocalNowAsync() instead.")]
+    Task<DateTimeOffset> LocalNowAsync { get; }
 
     /// <summary>
     /// Gets the time for the local time zone.
     /// </summary>
 
-    Task<DateTimeOffset> GetLocalNowAsync();
+    Task<DateTimeOffset> GetLocalNowAsync() => LocalNowAsync;
 
     /// <summary>
     /// Returns the local time zone.

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/ILocalClock.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/ILocalClock.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Modules;
 /// </summary>
 public interface ILocalClock
 {
-    [Obsolete("This property has been deprecated, please use GetLocalNowAsync() instead.", error: true)]
+    [Obsolete("This property has been deprecated and will be removed in a future version. Please use GetLocalNowAsync() instead.", error: true)]
     Task<DateTimeOffset> LocalNowAsync => GetLocalNowAsync();
 
     /// <summary>

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/ILocalClock.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/ILocalClock.cs
@@ -12,7 +12,10 @@ public interface ILocalClock
     /// Gets the time for the local time zone.
     /// </summary>
 
-    Task<DateTimeOffset> GetLocalNowAsync() => LocalNowAsync;
+#pragma warning disable CS0618 // Type or member is obsolete
+    Task<DateTimeOffset> GetLocalNowAsync()
+        => LocalNowAsync;
+#pragma warning restore CS0618 // Type or member is obsolete
 
     /// <summary>
     /// Returns the local time zone.

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/ILocalClock.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Services/ILocalClock.cs
@@ -5,10 +5,14 @@ namespace OrchardCore.Modules;
 /// </summary>
 public interface ILocalClock
 {
+    [Obsolete("This property has been deprecated, please use GetLocalNowAsync() instead.", error: true)]
+    Task<DateTimeOffset> LocalNowAsync => GetLocalNowAsync();
+
     /// <summary>
     /// Gets the time for the local time zone.
     /// </summary>
-    Task<DateTimeOffset> LocalNowAsync { get; }
+
+    Task<DateTimeOffset> GetLocalNowAsync();
 
     /// <summary>
     /// Returns the local time zone.

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -244,7 +244,7 @@ public static class LiquidTemplateContextExtensions
             }
 
             // Configure Fluid with the local date and time
-            var now = await localClock.LocalNowAsync;
+            var now = await localClock.GetLocalNowAsync();
 
             context.Now = () => now;
 

--- a/src/OrchardCore/OrchardCore/Modules/Services/LocalClock.cs
+++ b/src/OrchardCore/OrchardCore/Modules/Services/LocalClock.cs
@@ -17,18 +17,8 @@ public class LocalClock : ILocalClock
         _calendarManager = calendarManager;
     }
 
-    public Task<DateTimeOffset> LocalNowAsync
-    {
-        get
-        {
-            return GetLocalNowAsync();
-        }
-    }
-
-    private async Task<DateTimeOffset> GetLocalNowAsync()
-    {
-        return _clock.ConvertToTimeZone(_clock.UtcNow, await GetLocalTimeZoneAsync());
-    }
+    public async Task<DateTimeOffset> GetLocalNowAsync()
+        => _clock.ConvertToTimeZone(_clock.UtcNow, await GetLocalTimeZoneAsync());
 
     // Caching the result per request.
     public async Task<ITimeZone> GetLocalTimeZoneAsync() => _timeZone ??= await LoadLocalTimeZoneAsync();


### PR DESCRIPTION
Fixes #16751

I'm not sure why we added an `async` property which was the first time I saw it in my life. @rjpowers10 could you please try to reproduce in this PR