### PR TITLE
Skip processing of media root path by MediaFileStoreResolverMiddleware

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaFileStoreResolverMiddleware.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OrchardCore.FileStorage;
 using OrchardCore.Routing;
 
 namespace OrchardCore.Media.Services;
@@ -50,12 +51,13 @@ public class MediaFileStoreResolverMiddleware
         }
 
         var validatePath = context.Request.Path.StartsWithNormalizedSegments(_assetsRequestPath, StringComparison.OrdinalIgnoreCase, out var subPath);
-        if (!validatePath)
+        if (!validatePath || string.IsNullOrEmpty(_mediaFileStore.NormalizePath(subPath)))
         {
             _logger.LogDebug("Request path {Path} does not match the assets request path {RequestPath}", subPath, _assetsRequestPath);
             await _next(context);
             return;
         }
+
 
         // subPath.Value returns an unescaped path value, subPath returns an escaped path value.
         var subPathValue = subPath.Value;


### PR DESCRIPTION
When someone requests root media path like  /media or /media/ with OrchardCore.Media.AmazonS3 module enabled then floowing error message writes to log "Error retrieving file from media file store for request path /". 
This does not look like exceptional situation so I added a code to skip this handling.
