### PR TITLE
Batch Dependabot updates per directories (Lombiq Technologies: OCORE-202)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,54 @@
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Dependabot can handle at most 150 "manifests", so for NuGet, csprojs referencing packages (see docs:
+  # https://docs.github.com/en/enterprise-cloud@latest/code-security/supply-chain-security/understanding-your-software-supply-chain/troubleshooting-the-dependency-graph#are-there-limits-which-affect-the-dependency-graph-data).
+  # We're grouping updates per directories to have smaller batches.
+  # /src/OrchardCore
+  - package-ecosystem: "nuget"
+    directory: "/src/OrchardCore"
     schedule:
       interval: "weekly"
     groups:
-       # Grouped version updates configuration
+       all-dependencies:
+          patterns:
+            - "*"
+  # /src/OrchardCore.Modules
+  - package-ecosystem: "nuget"
+    directory: "/src/OrchardCore.Modules"
+    schedule:
+      interval: "weekly"
+    groups:
+       all-dependencies:
+          patterns:
+            - "*"
+  # /src/OrchardCore.Themes
+  - package-ecosystem: "nuget"
+    directory: "/src/OrchardCore.Themes"
+    schedule:
+      interval: "weekly"
+    groups:
+       all-dependencies:
+          patterns:
+            - "*"
+  # All other folders under src/.
+  - package-ecosystem: "nuget"
+    directories: 
+      - "/src/OrchardCore.Build"
+      - "/src/OrchardCore.Cms.Web"
+      - "/src/OrchardCore.Mvc.Web"
+      - "/src/Templates**"
+    schedule:
+      interval: "weekly"
+    groups:
+       all-dependencies:
+          patterns:
+            - "*"
+  # /test
+  - package-ecosystem: "nuget"
+    directory: "/test"
+    schedule:
+      interval: "weekly"
+    groups:
        all-dependencies:
           patterns:
             - "*"


### PR DESCRIPTION
I hope this fixes #16729. This is speculative though, I'm not entirely sure, but following the logic of Dependabot's manifest limit, I think it should work. Grouping dependencies (like updating Microsoft.* ones in one group, then OpenIddict.* ones in another...) wouldn't help, I think, because the number of manifests would still be the same.