### PR TITLE
Configure both Microsoft.AspNetCore.Http.Json.JsonOptions & Microsoft.AspNetCore.Mvc.JsonOptions using DocumentJsonSerializerOptions defaults

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Json/JsonOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Json/JsonOptionsConfigurations.cs
@@ -1,11 +1,13 @@
 using System.Text.Json;
-using Microsoft.AspNetCore.Http.Json;
+using HttpJsonOptions = Microsoft.AspNetCore.Http.Json.JsonOptions;
+using MvcJsonOptions = Microsoft.AspNetCore.Mvc.JsonOptions;
 using Microsoft.Extensions.Options;
 using OrchardCore.Json.Extensions;
 
 namespace OrchardCore.Json;
 
-internal sealed class JsonOptionsConfigurations : IConfigureOptions<JsonOptions>
+internal sealed class JsonOptionsConfigurations: IConfigureOptions<HttpJsonOptions>, IConfigureOptions<MvcJsonOptions>
+
 {
     private readonly JsonSerializerOptions _jsonSerializerOptions;
 
@@ -14,8 +16,9 @@ internal sealed class JsonOptionsConfigurations : IConfigureOptions<JsonOptions>
         _jsonSerializerOptions = jsonSerializerOptions.Value.SerializerOptions;
     }
 
-    public void Configure(JsonOptions options)
-    {
-        options.SerializerOptions.Merge(_jsonSerializerOptions);
-    }
+    public void Configure(HttpJsonOptions options)
+        => options.SerializerOptions.Merge(_jsonSerializerOptions);
+
+    public void Configure(MvcJsonOptions options)
+        => options.JsonSerializerOptions.Merge(_jsonSerializerOptions);
 }


### PR DESCRIPTION
This pull request includes changes to the `JsonOptionsConfigurations` class to support both `HttpJsonOptions` and `MvcJsonOptions` configurations.

Fixes #16831

/cc @wAsnk