### PR TITLE
fix: added IsNew and TypePartDefinition to viewmodel

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/BooleanFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/BooleanFieldDisplayDriver.cs
@@ -31,6 +31,8 @@ public sealed class BooleanFieldDisplayDriver : ContentFieldDisplayDriver<Boolea
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
@@ -63,7 +63,8 @@ public sealed class ContentPickerFieldDisplayDriver : ContentFieldDisplayDriver<
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
-
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
             model.SelectedItems = [];
             var settings = context.PartFieldDefinition.GetSettings<ContentPickerFieldSettings>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/DateFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/DateFieldDisplayDriver.cs
@@ -39,6 +39,8 @@ public sealed class DateFieldDisplayDriver : ContentFieldDisplayDriver<DateField
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/DateTimeFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/DateTimeFieldDisplayDriver.cs
@@ -47,6 +47,8 @@ public sealed class DateTimeFieldDisplayDriver : ContentFieldDisplayDriver<DateT
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/HtmlFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/HtmlFieldDisplayDriver.cs
@@ -75,6 +75,8 @@ public sealed class HtmlFieldDisplayDriver : ContentFieldDisplayDriver<HtmlField
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/LinkFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/LinkFieldDisplayDriver.cs
@@ -61,6 +61,8 @@ public sealed class LinkFieldDisplayDriver : ContentFieldDisplayDriver<LinkField
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/LocalizationSetContentPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/LocalizationSetContentPickerFieldDisplayDriver.cs
@@ -52,6 +52,8 @@ public sealed class LocalizationSetContentPickerFieldDisplayDriver : ContentFiel
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
 
             model.SelectedItems = [];
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/MultiTextFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/MultiTextFieldDisplayDriver.cs
@@ -49,6 +49,8 @@ public sealed class MultiTextFieldDisplayDriver : ContentFieldDisplayDriver<Mult
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/NumericFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/NumericFieldDisplayDriver.cs
@@ -57,6 +57,9 @@ public sealed class NumericFieldDisplayDriver : ContentFieldDisplayDriver<Numeri
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.TypePartDefinition = context.TypePartDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/TextFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/TextFieldDisplayDriver.cs
@@ -40,6 +40,8 @@ public sealed class TextFieldDisplayDriver : ContentFieldDisplayDriver<TextField
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/TimeFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/TimeFieldDisplayDriver.cs
@@ -39,6 +39,8 @@ public sealed class TimeFieldDisplayDriver : ContentFieldDisplayDriver<TimeField
             model.Field = field;
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
+            model.IsNew = context.IsNew;
+            model.TypePartDefinition = context.TypePartDefinition;
         });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/UserPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/UserPickerFieldDisplayDriver.cs
@@ -50,6 +50,7 @@ public sealed class UserPickerFieldDisplayDriver : ContentFieldDisplayDriver<Use
             model.Part = context.ContentPart;
             model.PartFieldDefinition = context.PartFieldDefinition;
             model.TypePartDefinition = context.TypePartDefinition;
+            model.IsNew = context.IsNew;
 
             if (field.UserIds.Length > 0)
             {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/YoutubeFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/YoutubeFieldDisplayDriver.cs
@@ -41,6 +41,8 @@ public sealed class YoutubeFieldDisplayDriver : ContentFieldDisplayDriver<Youtub
            model.Field = field;
            model.Part = context.ContentPart;
            model.PartFieldDefinition = context.PartFieldDefinition;
+           model.IsNew = context.IsNew;
+           model.TypePartDefinition = context.TypePartDefinition;
        });
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditBooleanFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditBooleanFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -10,4 +11,8 @@ public class EditBooleanFieldViewModel
     public BooleanField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditContentPickerFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditContentPickerFieldViewModel.cs
@@ -11,7 +11,10 @@ public class EditContentPickerFieldViewModel
     public ContentPickerField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
-
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
     [BindNever]
     public IList<VueMultiselectItemViewModel> SelectedItems { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditDateFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditDateFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -10,4 +11,8 @@ public class EditDateFieldViewModel
     public DateField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditDateTimeFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditDateTimeFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -10,4 +11,8 @@ public class EditDateTimeFieldViewModel
     public DateTimeField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditHtmlFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditHtmlFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -10,4 +11,8 @@ public class EditHtmlFieldViewModel
     public HtmlField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditLinkFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditLinkFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -12,4 +13,8 @@ public class EditLinkFieldViewModel
     public LinkField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditLocalizationSetContentPickerFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditLocalizationSetContentPickerFieldViewModel.cs
@@ -14,4 +14,9 @@ public class EditLocalizationSetContentPickerFieldViewModel
 
     [BindNever]
     public IList<VueMultiselectItemViewModel> SelectedItems { get; set; }
+
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditMultiTextFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditMultiTextFieldViewModel.cs
@@ -17,4 +17,8 @@ public class EditMultiTextFieldViewModel
 
     [BindNever]
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditNumericFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditNumericFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -10,4 +11,8 @@ public class EditNumericFieldViewModel
     public NumericField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditTextFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditTextFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -10,4 +11,8 @@ public class EditTextFieldViewModel
     public TextField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditTimeFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditTimeFieldViewModel.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -10,4 +11,8 @@ public class EditTimeFieldViewModel
     public TimeField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditUserPickerFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditUserPickerFieldViewModel.cs
@@ -23,6 +23,9 @@ public class EditUserPickerFieldViewModel
 
     [BindNever]
     public IList<VueMultiselectUserViewModel> SelectedUsers { get; set; } = [];
+
+    [BindNever]
+    public bool IsNew { get; set; }
 }
 
 public class VueMultiselectUserViewModel

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditYoutubeFieldViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/ViewModels/EditYoutubeFieldViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -14,4 +15,8 @@ public class EditYoutubeFieldViewModel
     public YoutubeField Field { get; set; }
     public ContentPart Part { get; set; }
     public ContentPartFieldDefinition PartFieldDefinition { get; set; }
+    [BindNever]
+    public ContentTypePartDefinition TypePartDefinition { get; set; }
+    [BindNever]
+    public bool IsNew { get; set; }
 }


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->
Fixes #16886 

Do note there's a precedence of passing TypePartDefintion in UserPickerFieldDisplayDriver. I realise these fields are not used, but it enables for developers to override and customize field behaviour inside content events.