### PR TITLE
Allow Admin to disable Two-Factor Authentication

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminTwoFactorAuthenticationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminTwoFactorAuthenticationController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using OrchardCore.Admin;
+using OrchardCore.Modules;
+using OrchardCore.Mvc.Core.Utilities;
+
+namespace OrchardCore.Users.Controllers;
+
+[Admin]
+[Feature(UserConstants.Features.TwoFactorAuthentication)]
+public sealed class AdminTwoFactorAuthenticationController : Controller
+{
+    private readonly UserManager<IUser> _userManager;
+
+    public AdminTwoFactorAuthenticationController(UserManager<IUser> userManager)
+    {
+        _userManager = userManager;
+    }
+
+    public async Task<IActionResult> Disable(string id)
+    {
+        var user = await _userManager.FindByIdAsync(id);
+
+        if (user == null)
+        {
+            return NotFound();
+        }
+
+        if (await _userManager.GetTwoFactorEnabledAsync(user))
+        {
+            await _userManager.SetTwoFactorEnabledAsync(user, false);
+        }
+
+        return RedirectToAction(nameof(AdminController.Index), typeof(AdminController).ControllerName());
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminTwoFactorAuthenticationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminTwoFactorAuthenticationController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Admin;
@@ -11,20 +12,31 @@ namespace OrchardCore.Users.Controllers;
 public sealed class AdminTwoFactorAuthenticationController : Controller
 {
     private readonly UserManager<IUser> _userManager;
+    private readonly IAuthorizationService _authorizationService;
 
-    public AdminTwoFactorAuthenticationController(UserManager<IUser> userManager)
+    public AdminTwoFactorAuthenticationController(
+        UserManager<IUser> userManager,
+        IAuthorizationService authorizationService)
     {
         _userManager = userManager;
+        _authorizationService = authorizationService;
     }
 
     public async Task<IActionResult> Disable(string id)
     {
+        if (!await _authorizationService.AuthorizeAsync(User, CommonPermissions.DisableTwoFactorAuthenticationForUsers))
+        {
+            return Forbid();
+        }
+
         var user = await _userManager.FindByIdAsync(id);
 
         if (user == null)
         {
             return NotFound();
         }
+
+
 
         if (await _userManager.GetTwoFactorEnabledAsync(user))
         {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -53,7 +53,8 @@ public sealed class UserDisplayDriver : DisplayDriver<User>
         return CombineAsync(
             Initialize<SummaryAdminUserViewModel>("UserFields", model => model.User = user).Location("SummaryAdmin", "Header:1"),
             Initialize<SummaryAdminUserViewModel>("UserInfo", model => model.User = user).Location("DetailAdmin", "Content:5"),
-            Initialize<SummaryAdminUserViewModel>("UserButtons", model => model.User = user).Location("SummaryAdmin", "Actions:1")
+            Initialize<SummaryAdminUserViewModel>("UserButtons", model => model.User = user).Location("SummaryAdmin", "Actions:1"),
+            Initialize<SummaryAdminUserViewModel>("UserActionsMenu", model => model.User = user).Location("SummaryAdmin", "ActionsMenu:5")
         );
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserRegistrationAdminDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserRegistrationAdminDisplayDriver.cs
@@ -1,0 +1,17 @@
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Users.Models;
+using OrchardCore.Users.ViewModels;
+
+namespace OrchardCore.Users.Drivers;
+
+public sealed class UserRegistrationAdminDisplayDriver : DisplayDriver<User>
+{
+    public override Task<IDisplayResult> DisplayAsync(User user, BuildDisplayContext context)
+    {
+        return CombineAsync(
+            Initialize<SummaryAdminUserViewModel>("UserSendConfirmationActionsMenu", model => model.User = user)
+            .Location("SummaryAdmin", "ActionsMenu:15")
+        );
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserTwoFactorDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserTwoFactorDisplayDriver.cs
@@ -1,0 +1,17 @@
+﻿using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Users.Models;
+using OrchardCore.Users.ViewModels;
+
+namespace OrchardCore.Users.Drivers;
+
+public sealed class UserTwoFactorDisplayDriver : DisplayDriver<User>
+{
+    public override Task<IDisplayResult> DisplayAsync(User user, BuildDisplayContext context)
+    {
+        return CombineAsync(
+            Initialize<SummaryAdminUserViewModel>("UserTwoFactorActionsMenu", model => model.User = user)
+            .Location("SummaryAdmin", "ActionsMenu:10")
+        );
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Extensions/ControllerExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Extensions/ControllerExtensions.cs
@@ -106,7 +106,7 @@ internal static class ControllerExtensions
             },
             protocol: controller.HttpContext.Request.Scheme);
 
-        await SendEmailAsync(controller, user.Email, subject, new ConfirmEmailViewModel()
+        await SendEmailAsync(controller, user.Email, subject, new ConfirmEmailViewModel
         {
             User = user,
             ConfirmEmailUrl = callbackUrl,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/TwoFactorPermissionProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/TwoFactorPermissionProvider.cs
@@ -1,0 +1,23 @@
+using OrchardCore.Security.Permissions;
+
+namespace OrchardCore.Users.Services;
+
+public sealed class TwoFactorPermissionProvider : IPermissionProvider
+{
+    private readonly IEnumerable<Permission> _allPermissions =
+    [
+        CommonPermissions.DisableTwoFactorAuthenticationForUsers,
+    ];
+
+    public Task<IEnumerable<Permission>> GetPermissionsAsync()
+        => Task.FromResult(_allPermissions);
+
+    public IEnumerable<PermissionStereotype> GetDefaultStereotypes() =>
+    [
+        new PermissionStereotype
+        {
+            Name = OrchardCoreConstants.Roles.Administrator,
+            Permissions = _allPermissions,
+        },
+    ];
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -424,6 +424,7 @@ public sealed class RegistrationStartup : StartupBase
             o.MemberAccessStrategy.Register<ConfirmEmailViewModel>();
         });
 
+        services.AddScoped<IDisplayDriver<User>, UserRegistrationAdminDisplayDriver>();
         services.AddSiteDisplayDriver<RegistrationSettingsDisplayDriver>();
         services.AddNavigationProvider<RegistrationAdminMenu>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/TwoFactorAuthenticationStartup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/TwoFactorAuthenticationStartup.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
 using OrchardCore.Mvc.Core.Utilities;
+using OrchardCore.Security.Permissions;
 using OrchardCore.Users.Controllers;
 using OrchardCore.Users.Drivers;
 using OrchardCore.Users.Endpoints.EmailAuthenticator;
@@ -37,6 +38,7 @@ public sealed class TwoFactorAuthenticationStartup : StartupBase
         services.AddScoped<IDisplayDriver<UserMenu>, TwoFactorUserMenuDisplayDriver>();
         services.AddSiteDisplayDriver<TwoFactorLoginSettingsDisplayDriver>();
         services.AddScoped<IDisplayDriver<TwoFactorMethod>, TwoFactorMethodDisplayDriver>();
+        services.AddPermissionProvider<TwoFactorPermissionProvider>();
     }
 
     public override void Configure(IApplicationBuilder app, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/OrchardCore.Modules/OrchardCore.Users/TwoFactorAuthenticationStartup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/TwoFactorAuthenticationStartup.cs
@@ -32,6 +32,7 @@ public sealed class TwoFactorAuthenticationStartup : StartupBase
             options.Filters.Add<TwoFactorAuthenticationAuthorizationFilter>();
         });
 
+        services.AddScoped<IDisplayDriver<User>, UserTwoFactorDisplayDriver>();
         services.AddScoped<IUserClaimsProvider, TwoFactorAuthenticationClaimsProvider>();
         services.AddScoped<IDisplayDriver<UserMenu>, TwoFactorUserMenuDisplayDriver>();
         services.AddSiteDisplayDriver<TwoFactorLoginSettingsDisplayDriver>();

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UserSendConfirmationActionsMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Items/UserSendConfirmationActionsMenu.cshtml
@@ -1,0 +1,19 @@
+@using Microsoft.AspNetCore.Identity
+@using OrchardCore.Users.Models
+
+@model SummaryAdminUserViewModel
+
+@inject UserManager<IUser> UserManager
+@inject IAuthorizationService AuthorizationService
+
+@if (!Model.User.EmailConfirmed &&
+Site.As<RegistrationSettings>().UsersMustValidateEmail &&
+await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditUsers, Model.User))
+{
+    <li>
+        <form method="post" class="d-inline-block" class="no-multisubmit">
+            <input name="id" type="hidden" value="@Model.User.UserId" />
+            <button asp-action="SendVerificationEmail" asp-controller="EmailConfirmation" class="dropdown-item">@T["Send verification email"]</button>
+        </form>
+    </li>
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/TemplateUserConfirmEmail.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/TemplateUserConfirmEmail.cshtml
@@ -13,7 +13,7 @@
     @T["Dear {0},", Model.User.UserName]
 </p>
 
-<p>@T["Please <a href=\"{0}\">click here</a> to confirm your account.", Model.ConfirmEmailUrl]</p>
+<p>@T["Please <a href=\"{0}\">click here</a> to confirm your account.", Html.Raw(Model.ConfirmEmailUrl)]</p>
 
 <p>@T.Plural(totalMinutes, "Please be aware that this link will expire in {0} minute.", "Please be aware that this link will expire in {0} minutes.", totalMinutes)</p>
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/User.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/User.SummaryAdmin.cshtml
@@ -25,10 +25,22 @@
         }
     </div>
 
-    @if (Model.Actions != null)
-    {
-        <div>
+    <div>
+        @if (Model.Actions != null)
+        {
             @await DisplayAsync(Model.Actions)
-        </div>
-    }
+        }
+
+        @if (Model.ActionsMenu != null && Model.ActionsMenu.HasItems)
+        {
+            <div class="btn-group" title="@T["Actions"]">
+                <button type="button" class="btn btn-sm btn-secondary dropdown-toggle actions" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    <span>@T["Actions"]</span>
+                </button>
+                <ul class="actions-menu dropdown-menu dropdown-menu-end">
+                    @await DisplayAsync(Model.ActionsMenu)
+                </ul>
+            </div>
+        }
+    </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserActionsMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserActionsMenu.cshtml
@@ -1,0 +1,32 @@
+@using Microsoft.AspNetCore.Identity
+
+@model SummaryAdminUserViewModel
+
+@inject UserManager<IUser> UserManager
+@inject IAuthorizationService AuthorizationService
+
+@{
+    var isCurrentUser = Model.User.UserName == User.Identity.Name;
+    var canEdit = await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditUsers, Model.User);
+    var isLockedOut = await UserManager.IsLockedOutAsync(Model.User);
+}
+
+@if (canEdit)
+{
+    <li>
+        <a asp-action="EditPassword" asp-route-id="@Model.User.UserId" class="dropdown-item">@T["Edit Password"]</a>
+    </li>
+    if (isLockedOut)
+    {
+        <li>
+            <a asp-action="Unlock" asp-route-id="@Model.User.UserId" class="dropdown-item" data-url-af="RemoveUrl UnsafeUrl" data-title="@T["Unlock user"]" data-message="@T["Are you sure you want to unlock this user?"]">@T["Unlock"]</a>
+        </li>
+    }
+}
+
+@if (!isCurrentUser && await AuthorizationService.AuthorizeAsync(User, CommonPermissions.DeleteUsers, Model.User))
+{
+    <li>
+        <a asp-action="Delete" asp-route-id="@Model.User.UserId" class="dropdown-item text-danger" data-url-af="RemoveUrl UnsafeUrl">@T["Delete"]</a>
+    </li>
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserActionsMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserActionsMenu.cshtml
@@ -14,7 +14,7 @@
 @if (canEdit)
 {
     <li>
-        <a asp-action="EditPassword" asp-route-id="@Model.User.UserId" class="dropdown-item">@T["Edit Password"]</a>
+        <a asp-action="EditPassword" asp-route-id="@Model.User.UserId" class="dropdown-item">@T["Change password"]</a>
     </li>
     if (isLockedOut)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserButtons.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserButtons.cshtml
@@ -1,17 +1,12 @@
 @model SummaryAdminUserViewModel
-@using OrchardCore.Entities
-@using OrchardCore.Users.Models
-@using Microsoft.AspNetCore.Identity
-@using OrchardCore.Users
-@inject UserManager<IUser> UserManager
+
 @inject IAuthorizationService AuthorizationService
+
 @{
     var isCurrentUser = Model.User.UserName == User.Identity.Name;
-    var canEdit = await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditUsers, Model.User);
-    var isLockedOut = await UserManager.IsLockedOutAsync(Model.User);
 }
 
-@if (canEdit)
+@if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditUsers, Model.User))
 {
     <a asp-action="Edit" asp-route-id="@Model.User.UserId" class="btn btn-primary btn-sm">@T["Edit"]</a>
 }
@@ -19,26 +14,4 @@
 @if (!isCurrentUser && await AuthorizationService.AuthorizeAsync(User, CommonPermissions.ViewUsers, Model.User))
 {
     <a asp-action="Display" asp-route-id="@Model.User.UserId" class="btn btn-success btn-sm">@T["View"]</a>
-}
-
-@if (canEdit)
-{
-    <a asp-action="EditPassword" asp-route-id="@Model.User.UserId" class="btn btn-secondary btn-sm">@T["Edit Password"]</a>
-    if (isLockedOut)
-    {
-        <a asp-action="Unlock" asp-route-id="@Model.User.UserId" class="btn btn-danger btn-sm" data-url-af="RemoveUrl UnsafeUrl" data-title="@T["Unlock user"]" data-message="@T["Are you sure you want to unlock this user?"]">@T["Unlock"]</a>
-    }
-}
-
-@if (!isCurrentUser && await AuthorizationService.AuthorizeAsync(User, CommonPermissions.DeleteUsers, Model.User))
-{
-    <a asp-action="Delete" asp-route-id="@Model.User.UserId" class="btn btn-danger btn-sm" data-url-af="RemoveUrl UnsafeUrl">@T["Delete"]</a>
-}
-
-@if (canEdit && !Model.User.EmailConfirmed && Site.As<RegistrationSettings>().UsersMustValidateEmail)
-{
-    <form method="post" class="d-inline-block" class="no-multisubmit">
-        <input name="id" type="hidden" value="@Model.User.UserId" />
-        <button asp-action="SendVerificationEmail" asp-controller="Registration" class="btn btn-info btn-sm">@T["Send verification email"]</button>
-    </form>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserTwoFactorActionsMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserTwoFactorActionsMenu.cshtml
@@ -6,7 +6,7 @@
 @inject UserManager<IUser> UserManager
 @inject IAuthorizationService AuthorizationService
 
-@if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditUsers, Model.User) &&
+@if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.DisableTwoFactorAuthenticationForUsers, Model.User) &&
 await UserManager.GetTwoFactorEnabledAsync(Model.User))
 {
     <li>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserTwoFactorActionsMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserTwoFactorActionsMenu.cshtml
@@ -12,7 +12,7 @@ await UserManager.GetTwoFactorEnabledAsync(Model.User))
     <li>
         <form method="post" class="d-inline-block" class="no-multisubmit">
             <input name="id" type="hidden" value="@Model.User.UserId" />
-            <button asp-action="Disable" asp-controller="AdminTwoFactorAuthentication" class="dropdown-item">@T["Disable Two Factor"]</button>
+            <button asp-action="Disable" asp-controller="AdminTwoFactorAuthentication" class="dropdown-item">@T["Disable two-factor authentication"]</button>
         </form>
     </li>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserTwoFactorActionsMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserTwoFactorActionsMenu.cshtml
@@ -1,0 +1,18 @@
+@using Microsoft.AspNetCore.Identity
+@using OrchardCore.Users.Models
+
+@model SummaryAdminUserViewModel
+
+@inject UserManager<IUser> UserManager
+@inject IAuthorizationService AuthorizationService
+
+@if (await AuthorizationService.AuthorizeAsync(User, CommonPermissions.EditUsers, Model.User) &&
+await UserManager.GetTwoFactorEnabledAsync(Model.User))
+{
+    <li>
+        <form method="post" class="d-inline-block" class="no-multisubmit">
+            <input name="id" type="hidden" value="@Model.User.UserId" />
+            <button asp-action="Disable" asp-controller="AdminTwoFactorAuthentication" class="dropdown-item">@T["Disable Two Factor"]</button>
+        </form>
+    </li>
+}

--- a/src/OrchardCore/OrchardCore.Users.Core/CommonPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/CommonPermissions.cs
@@ -23,6 +23,8 @@ public static class CommonPermissions
 
     public static readonly Permission AssignRoleToUsers = new("AssignRoleToUsers", "Assign any role to users", [EditUsers], true);
 
+    public static readonly Permission DisableTwoFactorAuthenticationForUsers = new("DisableTwoFactorAuthenticationForUsers", "Disable two-factor authentication for any user", [ManageUsers], true);
+
     public static readonly Permission EditOwnUser = new("ManageOwnUserInformation", "Edit own user information", [EditUsers]);
 
     public static Permission CreateEditUsersInRolePermission(string roleName) =>

--- a/src/docs/releases/2.1.0.md
+++ b/src/docs/releases/2.1.0.md
@@ -54,6 +54,10 @@ Also, note the following updates in `ExternalLoginSettings`:
 !!! warning
     When updating recipes to configure `LoginSettings` or `RegistrationSettings`, ensure that the settings reflect the new class structure.
 
+### Users with EditUser Permission Can Disable Two-Factor Authentication
+
+Users granted EditUser permission can now disable two-factor authentication for other users directly from the Users Admin UI.
+
 ### User Registration Feature
 
 #### User Registration Feature No Longer Required for External Authentication

--- a/src/docs/releases/2.1.0.md
+++ b/src/docs/releases/2.1.0.md
@@ -54,9 +54,9 @@ Also, note the following updates in `ExternalLoginSettings`:
 !!! warning
     When updating recipes to configure `LoginSettings` or `RegistrationSettings`, ensure that the settings reflect the new class structure.
 
-### Users with EditUser Permission Can Disable Two-Factor Authentication
+### Users With Permission Can Disable Two-Factor Authentication
 
-Users granted EditUser permission can now disable two-factor authentication for other users directly from the Users Admin UI.
+Users granted the new `DisableTwoFactorAuthenticationForUsers` permission can now disable two-factor authentication for other users directly from the Users Admin UI.
 
 ### User Registration Feature
 


### PR DESCRIPTION
Fix #13954

Adding a feature to allow user that is able to edit users to also disable their 2FA.

In the process I fixed the following existing issues: 

 - Invalid Email confirmation link being send to the emails.
 - When the Registration feature is disabled but the `RegistrationSettings.UsersMustValidateEmail` is set to true, the Users admin UI will show the "Send verification email" button next to the user.
 - When the user clicks on "Send verification email" it did not work in the past because that action in in `EmailConfirmation` not `Registration` controller.

Also, I added "Actions" button next to the user and moved the following buttons into it

- Unlock
- Delete
- Send verification email
- Disable two-factor authentication << this was added.