### PR TITLE
support .webm filetype in media extensions

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -55,7 +55,7 @@
     //  "AssetsRequestPath": "/media",
     //  "AssetsPath": "Media",
     //  "UseTokenizedQueryString": true,
-    //  "AllowedFileExtensions": [".jpg",".jpeg",".png",".gif",".ico",".svg",".webp",".pdf",".doc",".docx",".ppt",".pptx",".pps",".ppsx",".odt",".xls",".xlsx",".psd",".mp3",".m4a",".ogg",".wav",".mp4",".m4v",".mov",".wmv",".avi",".mpg",".ogv",".3gp"],
+    //  "AllowedFileExtensions": [".jpg",".jpeg",".png",".gif",".ico",".svg",".webp",".pdf",".doc",".docx",".ppt",".pptx",".pps",".ppsx",".odt",".xls",".xlsx",".psd",".mp3",".m4a",".ogg",".wav",".mp4",".m4v",".mov",".wmv",".avi",".mpg",".ogv",".3gp",".webm"],
     //  "ContentSecurityPolicy": "default-src 'self'; style-src 'unsafe-inline'",
     //  "MaxUploadChunkSize": 104857600,
     //  "TemporaryFileLifetime": "01:00:00"

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
@@ -47,6 +47,7 @@ public sealed class MediaOptionsConfiguration : IConfigureOptions<MediaOptions>
         ".mpg",
         ".ogv", // (Ogg)
         ".3gp", // (3GPP)
+        ".webm"
     ];
 
     private const int DefaultMaxBrowserCacheDays = 30;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/MediaOptionsConfiguration.cs
@@ -47,7 +47,7 @@ public sealed class MediaOptionsConfiguration : IConfigureOptions<MediaOptions>
         ".mpg",
         ".ogv", // (Ogg)
         ".3gp", // (3GPP)
-        ".webm"
+        ".webm",
     ];
 
     private const int DefaultMaxBrowserCacheDays = 30;

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -356,7 +356,7 @@ The following configuration values are used by default and can be customized:
             ".mpg",
             ".ogv", // Ogg
             ".3gp", // 3GPP
-            ".webm"
+            ".webm",
         ],
 
       // The Content Security Policy to apply to assets served from the media library.

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -356,6 +356,7 @@ The following configuration values are used by default and can be customized:
             ".mpg",
             ".ogv", // Ogg
             ".3gp", // 3GPP
+            ".webm"
         ],
 
       // The Content Security Policy to apply to assets served from the media library.


### PR DESCRIPTION
 .webm is popular and should be supported by default.