### PR TITLE
Add elasticsearch _score and highlights to ElasticsearchQueryResult

### DIFF
--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Abstractions/ElasticTopDocs.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Abstractions/ElasticTopDocs.cs
@@ -1,8 +1,11 @@
+using Nest;
+
 namespace OrchardCore.Search.Elasticsearch;
 
 public class ElasticTopDocs
 {
     public List<Dictionary<string, object>> TopDocs { get; set; }
     public List<Dictionary<string, object>> Fields { get; set; }
+    public IReadOnlyCollection<IHit<Dictionary<string, object>>> Hits { get; set; }
     public long Count { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQueryService.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQueryService.cs
@@ -47,7 +47,7 @@ public class ElasticQueryService : IElasticQueryService
                 Fields = deserializedSearchRequest.Fields,
                 Sort = deserializedSearchRequest.Sort,
                 Source = deserializedSearchRequest.Source,
-                Highlight = deserializedSearchRequest.Highlight
+                Highlight = deserializedSearchRequest.Highlight,
             };
 
             var searchResponse = await _elasticClient.SearchAsync<Dictionary<string, object>>(searchRequest);

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQueryService.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQueryService.cs
@@ -47,6 +47,7 @@ public class ElasticQueryService : IElasticQueryService
                 Fields = deserializedSearchRequest.Fields,
                 Sort = deserializedSearchRequest.Sort,
                 Source = deserializedSearchRequest.Source,
+                Highlight = deserializedSearchRequest.Highlight
             };
 
             var searchResponse = await _elasticClient.SearchAsync<Dictionary<string, object>>(searchRequest);
@@ -72,6 +73,7 @@ public class ElasticQueryService : IElasticQueryService
                 elasticTopDocs.Count = searchResponse.Total;
                 elasticTopDocs.TopDocs = new List<Dictionary<string, object>>(searchResponse.Documents);
                 elasticTopDocs.Fields = hits;
+                elasticTopDocs.Hits = searchResponse.Hits;
             }
             else
             {

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQuerySource.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQuerySource.cs
@@ -1,4 +1,5 @@
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Fluid;
 using Fluid.Values;
@@ -23,6 +24,8 @@ public sealed class ElasticQuerySource : IQuerySource
     private readonly ISession _session;
     private readonly JavaScriptEncoder _javaScriptEncoder;
     private readonly TemplateOptions _templateOptions;
+
+    private readonly JsonSerializerOptions options = new JsonSerializerOptions() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
 
     public ElasticQuerySource(
         IElasticQueryService queryService,
@@ -78,10 +81,17 @@ public sealed class ElasticQuerySource : IQuerySource
         {
             var results = new List<JsonObject>();
 
-            foreach (var document in docs.TopDocs)
+            foreach (var document in docs.Hits)
             {
-                results.Add(new JsonObject(document.Select(x =>
-                    KeyValuePair.Create(x.Key, (JsonNode)JsonValue.Create(x.Value.ToString())))));
+                var keyValuePairs = document.Source.Select(x =>
+                    KeyValuePair.Create(x.Key, (JsonNode)JsonValue.Create(x.Value.ToString()))).ToList();
+
+                keyValuePairs.Add(KeyValuePair.Create("_score", (JsonNode)JsonValue.Create(document.Score.Value.ToString())));
+
+                var highlights = JsonSerializer.Serialize(document.Highlight, options);
+                keyValuePairs.Add(KeyValuePair.Create("Highlight", (JsonNode)JsonValue.Create(highlights)));
+
+                results.Add(new JsonObject(keyValuePairs));
             }
 
             elasticQueryResults.Items = results;

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQuerySource.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQuerySource.cs
@@ -87,7 +87,7 @@ public sealed class ElasticQuerySource : IQuerySource
 
                 keyValuePairs.Add(KeyValuePair.Create("_score", (JsonNode)JsonValue.Create(document.Score.Value.ToString())));
 
-                var highlights = JsonSerializer.Serialize(document.Highlight, options);
+                var highlights = JsonSerializer.Serialize(document.Highlight, JOptions.UnsafeRelaxedJsonEscaping);
                 keyValuePairs.Add(KeyValuePair.Create("Highlight", (JsonNode)JsonValue.Create(highlights)));
 
                 results.Add(new JsonObject(keyValuePairs));

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQuerySource.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQuerySource.cs
@@ -25,7 +25,6 @@ public sealed class ElasticQuerySource : IQuerySource
     private readonly JavaScriptEncoder _javaScriptEncoder;
     private readonly TemplateOptions _templateOptions;
 
-    private readonly JsonSerializerOptions options = new JsonSerializerOptions() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
 
     public ElasticQuerySource(
         IElasticQueryService queryService,


### PR DESCRIPTION
I have a task to get low level elasticsearch information such as _score of a hit and highlights. And for now it is impossible to get it.

So this fix:

1. Added support of highlights in the queries
2. Added return of elasticsearch _score and highlights in graphQL using object return scheme