### PR TITLE
Display query errors from ElasticSearch

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/QueryApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/QueryApiController.cs
@@ -3,12 +3,14 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using OrchardCore.Infrastructure.Filters;
 
 namespace OrchardCore.Queries.Controllers;
 
 [Route("api/queries")]
 [ApiController]
 [Authorize(AuthenticationSchemes = "Api")]
+[TypeFilter(typeof(ApiExceptionHandlingFilter))]
 [IgnoreAntiforgeryToken]
 [AllowAnonymous]
 public sealed class QueryApiController : ControllerBase

--- a/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/OrchardCore.Queries.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Data.Abstractions\OrchardCore.Data.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Deployment.Abstractions\OrchardCore.Deployment.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Infrastructure\OrchardCore.Infrastructure.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Localization.Abstractions\OrchardCore.Localization.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Liquid.Abstractions\OrchardCore.Liquid.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Razor/ContentQueryOrchardRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Razor/ContentQueryOrchardRazorHelperExtensions.cs
@@ -14,33 +14,41 @@ public static class ContentQueryOrchardRazorHelperExtensions
 
     public static async Task<IEnumerable<ContentItem>> ContentQueryAsync(this IOrchardHelper orchardHelper, string queryName, IDictionary<string, object> parameters)
     {
-        var results = await orchardHelper.QueryAsync(queryName, parameters);
+
         var contentItems = new List<ContentItem>();
-
-        if (results != null)
+        try
         {
-            foreach (var result in results)
+            var results = await orchardHelper.QueryAsync(queryName, parameters);
+            if (results != null)
             {
-                if (result is not ContentItem contentItem)
+                foreach (var result in results)
                 {
-                    contentItem = null;
-
-                    if (result is JsonObject jObject)
+                    if (result is not ContentItem contentItem)
                     {
-                        contentItem = jObject.ToObject<ContentItem>();
+                        contentItem = null;
+
+                        if (result is JsonObject jObject)
+                        {
+                            contentItem = jObject.ToObject<ContentItem>();
+                        }
                     }
-                }
 
-                // If input is a 'JObject' but which not represents a 'ContentItem',
-                // a 'ContentItem' is still created but with some null properties.
-                if (contentItem?.ContentItemId == null)
-                {
-                    continue;
-                }
+                    // If input is a 'JObject' but which not represents a 'ContentItem',
+                    // a 'ContentItem' is still created but with some null properties.
+                    if (contentItem?.ContentItemId == null)
+                    {
+                        continue;
+                    }
 
-                contentItems.Add(contentItem);
+                    contentItems.Add(contentItem);
+                }
             }
         }
+        catch (Exception)
+        {
+            return contentItems;
+        }
+
 
         return contentItems;
     }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Controllers/ElasticsearchApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Controllers/ElasticsearchApiController.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Entities;
+using OrchardCore.Infrastructure.Filters;
 using OrchardCore.Queries;
 using OrchardCore.Search.Elasticsearch.Core.Services;
 using OrchardCore.Search.Elasticsearch.Models;
@@ -11,6 +12,7 @@ namespace OrchardCore.Search.Elasticsearch;
 
 [Route("api/elasticsearch")]
 [ApiController]
+[TypeFilter(typeof(ApiExceptionHandlingFilter))]
 [Authorize(AuthenticationSchemes = "Api"), IgnoreAntiforgeryToken, AllowAnonymous]
 public sealed class ElasticsearchApiController : ControllerBase
 {

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/OrchardCore.Search.Elasticsearch.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/OrchardCore.Search.Elasticsearch.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Admin.Abstractions\OrchardCore.Admin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Infrastructure\OrchardCore.Infrastructure.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ContentManagement.GraphQL\OrchardCore.ContentManagement.GraphQL.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Controllers/LuceneApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Controllers/LuceneApiController.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Entities;
+using OrchardCore.Infrastructure.Filters;
 using OrchardCore.Queries;
 using OrchardCore.Search.Lucene.Model;
 
@@ -10,6 +11,7 @@ namespace OrchardCore.Search.Lucene.Controllers;
 [Route("api/lucene")]
 [ApiController]
 [Authorize(AuthenticationSchemes = "Api")]
+[TypeFilter(typeof(ApiExceptionHandlingFilter))]
 [IgnoreAntiforgeryToken]
 [AllowAnonymous]
 public sealed class LuceneApiController : ControllerBase

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/OrchardCore.Search.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/OrchardCore.Search.Lucene.csproj
@@ -27,6 +27,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Deployment.Abstractions\OrchardCore.Deployment.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Indexing.Abstractions\OrchardCore.Indexing.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Infrastructure\OrchardCore.Infrastructure.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Localization.Abstractions\OrchardCore.Localization.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Liquid.Abstractions\OrchardCore.Liquid.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />

--- a/src/OrchardCore/OrchardCore.Infrastructure/Filters/ApiExceptionHandlingFilter.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Filters/ApiExceptionHandlingFilter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http.Json;
+using Json.More;
+namespace OrchardCore.Infrastructure.Filters;
+
+public class ApiExceptionHandlingFilter : IAsyncExceptionFilter
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    public ApiExceptionHandlingFilter()
+    {
+
+    }
+
+    public async Task OnExceptionAsync(ExceptionContext context)
+    {
+        var response = new ProblemDetails
+        {
+            Type = "https://tools.ietf.org/html/rfc7231#section-6.6.1",
+            Title = "An error occurred while processing your request.",
+            Status = StatusCodes.Status500InternalServerError,
+            Detail = context.Exception.Message,
+            Instance = context.HttpContext.Request.Path
+        };
+
+        context.HttpContext.Response.StatusCode = response.Status.Value;
+        context.Result = new JsonResult(response, _jsonOptions);
+        context.ExceptionHandled = true;
+    }
+}
+

--- a/src/OrchardCore/OrchardCore.Infrastructure/Filters/ApiExceptionHandlingFilter.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Filters/ApiExceptionHandlingFilter.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Http.Json;
 using Json.More;
 namespace OrchardCore.Infrastructure.Filters;
 
-public class ApiExceptionHandlingFilter : IAsyncExceptionFilter
+public class ApiExceptionHandlingFilter : IExceptionFilter
 {
     private static readonly JsonSerializerOptions _jsonOptions = new()
     {
@@ -24,7 +24,7 @@ public class ApiExceptionHandlingFilter : IAsyncExceptionFilter
 
     }
 
-    public async Task OnExceptionAsync(ExceptionContext context)
+    public void OnException(ExceptionContext context)
     {
         var response = new ProblemDetails
         {

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQueryService.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticQueryService.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Nest;
 
@@ -81,6 +82,7 @@ public class ElasticQueryService : IElasticQueryService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error while querying elastic with exception: {Message}", ex.Message);
+            throw;
         }
 
         return elasticTopDocs;


### PR DESCRIPTION
Currently Elastic Query run does not return errors. (Cost me a chunk of time when converting from lucene to elastic)

https://github.com/OrchardCMS/OrchardCore/issues/16938

For discussion. Honestly not sure the best way to handle this.

Options:
1) Do we want to bother with this or leave it to users to try and dig into logging? (Error is logged in ES module).
2) We could just let the error hit the front end. (however one query error breaks whole page)
3) We swallow any errors on API and helpers and keep the exception bubbling up to the admin ui.
4) We use some sort of notification instead.
 
ElasticQueryService rethrows to bubble error up to admin UI and to ApiExceptionHandlingFilter.
![image](https://github.com/user-attachments/assets/d1e0c08b-d2a2-4259-9d77-1f9481a9a2ff)

New ApiExceptionHandlingFilter to return nice problem details on API exception.
![image](https://github.com/user-attachments/assets/946b4569-968d-4ee8-a565-4fe0922b4f29)

Swallow error on razor helper. Might need to do liquid filter too. Optionally could not swallow error and razor would return:
![image](https://github.com/user-attachments/assets/4cc019ec-d59d-4161-8032-7b9b24873046)



