### PR TITLE
Fix Publish Content Task

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/PublishContentTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Activities/PublishContentTask.cs
@@ -33,7 +33,7 @@ public class PublishContentTask : ContentTask
         var content = (await GetContentAsync(workflowContext))
             ?? throw new InvalidOperationException($"The '{nameof(PublishContentTask)}' failed to retrieve the content item.");
 
-        if (string.Equals(InlineEvent.ContentItemId, content.ContentItem.ContentItemId, StringComparison.OrdinalIgnoreCase))
+        if (!content.HasDraft())
         {
             return Outcomes("Noop");
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -567,6 +567,7 @@ public class DefaultContentManager : IContentManager
         if (options.IsDraft)
         {
             contentItem.Published = false;
+            contentItem.Latest = true;
         }
 
         // Build a context with the initialized instance to create


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/16939

Updated the condition in the Publish Content Task. The condition for the Noop behavior is related to the properties of the content item, not the workflow. The workflow should publish content when the workflow is scheduled, restarted or triggered by a user event. To publish a content item, it must have a draft

Updated the default properties for a content item when it is created. When a content item is created, it is the latest version of the content item by default.