### PR TITLE
Fix RangeQueryProvider to correctly assign nodeKind for 'lt' and 'lte

### DIFF
--- a/src/OrchardCore/OrchardCore.Search.Lucene.Core/QueryProviders/RangeQueryProvider.cs
+++ b/src/OrchardCore/OrchardCore.Search.Lucene.Core/QueryProviders/RangeQueryProvider.cs
@@ -43,11 +43,11 @@ public class RangeQueryProvider : ILuceneQueryProvider
                             break;
                         case "lt":
                             lt = element.Value;
-                            nodeKind = gt.GetValueKind();
+                            nodeKind = lt.GetValueKind();
                             break;
                         case "lte":
                             lt = element.Value;
-                            nodeKind = gt.GetValueKind();
+                            nodeKind = lt.GetValueKind();
                             includeUpper = true;
                             break;
                         case "boost":


### PR DESCRIPTION
This PR addresses an issue where using lte and lt operators in Lucene queries would result in a System.NullReferenceException. The fix involves correcting an incorrect value assignment."