### PR TITLE
Don't use Path.GetTempFileName()

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/ImportRemoteInstanceController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/ImportRemoteInstanceController.cs
@@ -69,7 +69,7 @@ public sealed class ImportRemoteInstanceController : Controller
         }
 
         // Create a temporary filename to save the archive
-        var tempArchiveName = Path.GetTempFileName() + ".zip";
+        var tempArchiveName = PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName()) + ".zip";
 
         // Create a temporary folder to extract the archive to
         var tempArchiveFolder = PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/ImportController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/ImportController.cs
@@ -64,7 +64,7 @@ public sealed class ImportController : Controller
 
         if (importedPackage != null)
         {
-            var tempArchiveName = Path.GetTempFileName() + Path.GetExtension(importedPackage.FileName);
+            var tempArchiveName = PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName()) + Path.GetExtension(importedPackage.FileName);
             var tempArchiveFolder = PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
             try

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/TenantApiController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/TenantApiController.cs
@@ -394,7 +394,7 @@ public sealed class TenantApiController : ControllerBase
                 return BadRequest(S["Either a 'recipe' file or 'RecipeName' is required."]);
             }
 
-            var tempFilename = Path.GetTempFileName();
+            var tempFilename = PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
             await System.IO.File.WriteAllTextAsync(tempFilename, model.Recipe);
 

--- a/test/OrchardCore.Tests/OrchardCore.Users/AccountControllerTests.cs
+++ b/test/OrchardCore.Tests/OrchardCore.Users/AccountControllerTests.cs
@@ -463,7 +463,7 @@ public class AccountControllerTests
                     featureIds.Add(UserConstants.Features.ExternalAuthentication);
                 }
 
-                var tempArchiveName = Path.GetTempFileName() + ".json";
+                var tempArchiveName = PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName()) + ".json";
                 var tempArchiveFolder = PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
                 var data = new JsonObject


### PR DESCRIPTION
The method `Path.GetTempFileName()` get's the full path + a name of a new temporary file. This method will create the file on desk when it is called.

Instead, `PathExtensions.Combine(Path.GetTempPath(), Path.GetRandomFileName())` will return the name only but will not create the file automatically for us.
