### PR TITLE
Fix SQL command generation in OrchardCore.Data.DbConnectionValidator'…

### DIFF
--- a/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/DbConnectionValidator.cs
@@ -174,7 +174,7 @@ public class DbConnectionValidator : IDbConnectionValidator
             sqlBuilder.WhereAnd($"Type = '{_shellDescriptorTypeColumnValue}'");
         }
 
-        return sqlBuilder.ToString();
+        return sqlBuilder.ToSqlString();
     }
 
     private static (IConnectionFactory connectionFactory, ISqlDialect sqlDialect) GetFactoryAndSqlDialect(


### PR DESCRIPTION
ToString() is returning the object type (YesSql.Sql.SqlBuilder) rather than a valid SQL command like "SELECT TOP (1) * FROM [Document]".

This happened to me when creating a new site from scratch, with SQL Server database.

I always reserve myself the right to be wrong so, please, verify.