### PR TITLE
Move CultureValue to OC.Localization module

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Liquid/CultureValue.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Liquid/CultureValue.cs
@@ -4,9 +4,8 @@ using Fluid;
 using Fluid.Values;
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.Liquid;
-using OrchardCore.Localization;
 
-namespace OrchardCore.DisplayManagement.Liquid.Values;
+namespace OrchardCore.Localization.Liquid;
 
 internal sealed class CultureValue : FluidValue
 {

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Startup.cs
@@ -1,3 +1,4 @@
+using Fluid;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,6 +9,7 @@ using OrchardCore.Admin.Models;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Localization.Drivers;
+using OrchardCore.Localization.Liquid;
 using OrchardCore.Localization.Models;
 using OrchardCore.Localization.Services;
 using OrchardCore.Modules;
@@ -95,5 +97,15 @@ public sealed class CulturePickerStartup : StartupBase
 
         services.Configure<RequestLocalizationOptions>(options =>
             options.AddInitialRequestCultureProvider(new AdminCookieCultureProvider(_shellSettings, _adminOptions)));
+    }
+}
+
+[RequireFeatures("OrchardCore.Liquid")]
+public sealed class LocalizationLiquidStartup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.Configure<TemplateOptions>(options
+            => options.Scope.SetValue("Culture", new CultureValue()));
     }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using Fluid;
 using Fluid.Values;
 using Microsoft.AspNetCore.Html;
@@ -13,12 +12,10 @@ using OrchardCore.DisplayManagement.Liquid;
 using OrchardCore.DisplayManagement.Liquid.Filters;
 using OrchardCore.DisplayManagement.Liquid.TagHelpers;
 using OrchardCore.DisplayManagement.Liquid.Tags;
-using OrchardCore.DisplayManagement.Liquid.Values;
 using OrchardCore.DisplayManagement.Razor;
 using OrchardCore.DisplayManagement.Shapes;
 using OrchardCore.DisplayManagement.Zones;
 using OrchardCore.Liquid;
-using OrchardCore.Localization;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -68,8 +65,6 @@ public static class OrchardCoreBuilderExtensions
                 o.MemberAccessStrategy.Register<Shape>("*", new ShapeAccessor());
                 o.MemberAccessStrategy.Register<ZoneHolding>("*", new ShapeAccessor());
                 o.MemberAccessStrategy.Register<ShapeMetadata>();
-
-                o.Scope.SetValue("Culture", new CultureValue());
 
                 o.Scope.SetValue("Environment", new ObjectValue(new LiquidEnvironmentAccessor()));
                 o.MemberAccessStrategy.Register<LiquidEnvironmentAccessor, FluidValue>((obj, name, ctx) =>


### PR DESCRIPTION
To keep things clear and consistent it would be nice to move the `CultureValue` into the `OC.Localization` module, this way the fluid value will show up once the Liquid module is enabled