### PR TITLE
Introducing Orchard Core Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Orchard Core consists of two distinct projects:
 
 [![BSD-3-Clause License](https://img.shields.io/badge/license-BSD--3--Clause-blue.svg)](LICENSE)
 [![Documentation](https://readthedocs.org/projects/orchardcore/badge/)](https://docs.orchardcore.net/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Orchard%20Core%20Guru-006BFF)](https://gurubase.io/g/orchard-core)
 [![Crowdin](https://badges.crowdin.net/orchard-core/localized.svg)](https://crowdin.com/project/orchard-core)
 [![Discord](https://img.shields.io/discord/551136772243980291?color=%237289DA&label=OrchardCore&logo=discord&logoColor=white&style=flat-square)](https://orchardcore.net/discord)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Orchard%20Core%20Guru-006BFF)](https://gurubase.io/g/orchard-core)
 
 ## Build Status
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Orchard Core consists of two distinct projects:
 [![Documentation](https://readthedocs.org/projects/orchardcore/badge/)](https://docs.orchardcore.net/)
 [![Crowdin](https://badges.crowdin.net/orchard-core/localized.svg)](https://crowdin.com/project/orchard-core)
 [![Discord](https://img.shields.io/discord/551136772243980291?color=%237289DA&label=OrchardCore&logo=discord&logoColor=white&style=flat-square)](https://orchardcore.net/discord)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Orchard%20Core%20Guru-006BFF)](https://gurubase.io/g/orchard-core)
 
 ## Build Status
 

--- a/src/docs/resources/tutorials/README.md
+++ b/src/docs/resources/tutorials/README.md
@@ -15,4 +15,4 @@ If you want to learn or improve your knowledge about Orchard Core, you can follo
 
 ## Gurubase
 
-You can also ask the [Orchard Core Guru on Gurubase](https://gurubase.io/g/orchard-core) for help. It is Orchard Core-focused AI to answer your questions.
+You can also ask the [Orchard Core Guru on Gurubase](https://gurubase.io/g/orchard-core) for help. It is an Orchard Core-focused AI to answer your questions.

--- a/src/docs/resources/tutorials/README.md
+++ b/src/docs/resources/tutorials/README.md
@@ -1,6 +1,7 @@
 # Tutorials
 
 If you want to learn or improve your knowledge about Orchard Core, you can follow some tutorials.
+You can also [Ask Orchard Core Guru](https://gurubase.io/g/orchard-core) for help. It is Orchard Core focused AI to answer your questions.
 
 ## Lombiq
 

--- a/src/docs/resources/tutorials/README.md
+++ b/src/docs/resources/tutorials/README.md
@@ -1,7 +1,6 @@
 # Tutorials
 
 If you want to learn or improve your knowledge about Orchard Core, you can follow some tutorials.
-You can also [Ask Orchard Core Guru](https://gurubase.io/g/orchard-core) for help. It is Orchard Core focused AI to answer your questions.
 
 ## Lombiq
 
@@ -13,3 +12,7 @@ You can also [Ask Orchard Core Guru](https://gurubase.io/g/orchard-core) for hel
 
 !!! warning
     The Orchard Core Training Demo module assumes that you have a good understanding of basic Orchard Core concepts, and that you can get around the Orchard admin area. You should also be familiar with how to use Visual Studio and write C#, as well as the concepts of ASP.NET Core MVC.
+
+## Gurubase
+
+You can also ask the [Orchard Core Guru on Gurubase](https://gurubase.io/g/orchard-core) for help. It is Orchard Core-focused AI to answer your questions.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Orchard Core Guru](https://gurubase.io/g/orchard-core) to Gurubase. Orchard Core Guru uses the data from this repo and data from the [docs](https://docs.orchardcore.net/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Orchard Core Guru", which highlights that Orchard Core now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Orchard Core Guru in Gurubase, just let me know that's totally fine.
