### PR TITLE
Add new tests and helper methods to LiquidTests for 'sort' and 'where' filters

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
@@ -1,3 +1,7 @@
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json;
+using System;
 using System.Text.Json.Dynamic;
 using System.Text.Json.Nodes;
 using Fluid;
@@ -49,6 +53,9 @@ public sealed class Startup : StartupBase
             // When a property of a 'JsonObject' value is accessed, try to look into its properties.
             options.MemberAccessStrategy.Register<JsonObject, object>((source, name) => source[name]);
 
+            // When a property of a 'JsonDynamicObject' value is accessed, try to look into its properties.
+            options.MemberAccessStrategy.Register<JsonDynamicObject, object>((json, name) => json[name]);
+
             // Convert JToken to FluidValue
             options.ValueConverters.Add(x =>
             {
@@ -57,8 +64,10 @@ public sealed class Startup : StartupBase
                     JsonObject o => new ObjectValue(o),
                     JsonDynamicObject o => new ObjectValue((JsonObject)o),
                     JsonValue o => o.GetObjectValue(),
+                    JsonDynamicValue o => ((JsonValue)(o.Node)).GetObjectValue(),
                     DateTime d => new ObjectValue(d),
                     _ => null
+
                 };
             });
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TemplateOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TemplateOptionsConfigurations.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json.Dynamic;
 using Fluid;
 using Fluid.Values;
 using Microsoft.AspNetCore.Html;
@@ -37,6 +38,7 @@ public class TemplateOptionsConfigurations : IConfigureOptions<TemplateOptions>
         options.MemberAccessStrategy.Register<ZoneHolding>("*", new ShapeAccessor());
         options.MemberAccessStrategy.Register<ShapeMetadata>();
         options.MemberAccessStrategy.Register<CultureInfo>();
+        options.MemberAccessStrategy.Register<JsonDynamicObject, object>((json, name) => json[name]);
 
         options.Scope.SetValue("Culture", new CultureValue());
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TemplateOptionsConfigurations.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/TemplateOptionsConfigurations.cs
@@ -38,7 +38,6 @@ public class TemplateOptionsConfigurations : IConfigureOptions<TemplateOptions>
         options.MemberAccessStrategy.Register<ZoneHolding>("*", new ShapeAccessor());
         options.MemberAccessStrategy.Register<ShapeMetadata>();
         options.MemberAccessStrategy.Register<CultureInfo>();
-        options.MemberAccessStrategy.Register<JsonDynamicObject, object>((json, name) => json[name]);
 
         options.Scope.SetValue("Culture", new CultureValue());
 

--- a/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
@@ -117,12 +117,11 @@ public class LiquidTests
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {
-            var template =
-"""
-unsorted:{% for action in Model %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
-{% assign hotActions = Model | sort: "Content.HotActionsPart.Order.Value" %}
-sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
-""";
+            var template = """
+                unsorted:{% for action in Model %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
+                {% assign hotActions = Model | sort: "Content.HotActionsPart.Order.Value" %}
+                sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
+                """;
 
             var json = JConvert.SerializeObject(FakeContentItems);
 
@@ -144,12 +143,11 @@ sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.Order.Valu
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {
-            var template =
-"""
-total:{{Model | size}}
-{% assign hotActions = Model | where: "Content.HotActionsPart.AddtoHotActionsMenu.Value", true %}
-filtered:{{ hotActions | size }}
-""";
+            var template = """
+                total:{{Model | size}}
+                {% assign hotActions = Model | where: "Content.HotActionsPart.AddtoHotActionsMenu.Value", true %}
+                filtered:{{ hotActions | size }}
+                """;
 
             var json = JConvert.SerializeObject(FakeContentItems);
 
@@ -171,12 +169,11 @@ filtered:{{ hotActions | size }}
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {
-            var template =
-"""
-original:{% for action in Model%}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
-{% assign hotActions = Model | where: "Content.HotActionsPart.AddtoHotActionsMenu.Value", True %}
-filtered_sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
-""";
+            var template = """
+                original:{% for action in Model%}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
+                {% assign hotActions = Model | where: "Content.HotActionsPart.AddtoHotActionsMenu.Value", true | sort: "Content.HotActionsPart.Order.Value" %}
+                filtered_sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
+                """;
 
             var json = JConvert.SerializeObject(FakeContentItems);
 

--- a/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
@@ -133,7 +133,7 @@ sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.Order.Valu
                 NullEncoder.Default,
                 testModel);
 
-            Assert.Equal("unsorted:302040605010\r\n\r\nsorted:102030405060", result);
+            Assert.Equal("unsorted:302040605010sorted:102030405060", result.ReplaceLineEndings(""));
         });
     }
 
@@ -159,8 +159,8 @@ filtered:{{ hotActions | size }}
             var result = await liquidTemplateManager.RenderStringAsync(template,
                 NullEncoder.Default,
                 testModel);
-            
-            Assert.Equal("total:6\r\n\r\nfiltered:5", result);
+
+            Assert.Equal("total:6filtered:5", result.ReplaceLineEndings(""));
         });
     }
 
@@ -187,7 +187,7 @@ filtered_sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.O
                 NullEncoder.Default,
                 testModel);
 
-            Assert.Equal("original:302040605010\r\n\r\nfiltered_sorted:1030405060", result);
+            Assert.Equal("original:302040605010filtered_sorted:1030405060", result.ReplaceLineEndings(""));
         });
     }
 

--- a/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
@@ -110,6 +110,106 @@ public class LiquidTests
         });
     }
 
+    [Fact]
+    public async Task SortingContentItems_ShouldSortTheArrayOnIntegerField()
+    {
+        var context = new SiteContext();
+        await context.InitializeAsync();
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var template =
+"""
+unsorted:{% for action in Model %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
+{% assign hotActions = Model | sort: "Content.HotActionsPart.Order.Value" %}
+sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
+""";
+
+            var json = JConvert.SerializeObject(FakeContentItems);
+
+            var testModel = JConvert.DeserializeObject<ContentItem[]>(json);
+
+            var liquidTemplateManager = scope.ServiceProvider.GetRequiredService<ILiquidTemplateManager>();
+            var result = await liquidTemplateManager.RenderStringAsync(template,
+                NullEncoder.Default,
+                testModel);
+
+            Assert.Equal("unsorted:302040605010\r\n\r\nsorted:102030405060", result);
+        });
+    }
+
+    [Fact]
+    public async Task FilteringContentItems_ShouldFilterTheArrayOnBooleanField()
+    {
+        var context = new SiteContext();
+        await context.InitializeAsync();
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var template =
+"""
+total:{{Model | size}}
+{% assign hotActions = Model | where: "Content.HotActionsPart.AddtoHotActionsMenu.Value", true %}
+filtered:{{ hotActions | size }}
+""";
+
+            var json = JConvert.SerializeObject(FakeContentItems);
+
+            var testModel = JConvert.DeserializeObject<ContentItem[]>(json);
+
+            var liquidTemplateManager = scope.ServiceProvider.GetRequiredService<ILiquidTemplateManager>();
+            var result = await liquidTemplateManager.RenderStringAsync(template,
+                NullEncoder.Default,
+                testModel);
+            
+            Assert.Equal("total:6\r\n\r\nfiltered:5", result);
+        });
+    }
+
+    [Fact]
+    public async Task FilteringAndSortingContentItems_ShouldFilterAndSortTheArrayOnContentFields()
+    {
+        var context = new SiteContext();
+        await context.InitializeAsync();
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var template =
+"""
+original:{% for action in Model%}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
+{% assign hotActions = Model | where: "Content.HotActionsPart.AddtoHotActionsMenu.Value", True %}
+filtered_sorted:{% for action in hotActions %}{{ action.Content.HotActionsPart.Order.Value }}{% endfor %}
+""";
+
+            var json = JConvert.SerializeObject(FakeContentItems);
+
+            var testModel = JConvert.DeserializeObject<ContentItem[]>(json);
+
+            var liquidTemplateManager = scope.ServiceProvider.GetRequiredService<ILiquidTemplateManager>();
+            var result = await liquidTemplateManager.RenderStringAsync(template,
+                NullEncoder.Default,
+                testModel);
+
+            Assert.Equal("original:302040605010\r\n\r\nfiltered_sorted:1030405060", result);
+        });
+    }
+
+
+    public static ContentItem[] FakeContentItems => new[] { "30_true", "20_false", "40_true", "60_true", "50_true", "10_true" }.Select(x => CreateFakeContentItem(decimal.Parse(x.Split('_')[0]), x.Split('_')[1] == "true")).ToArray();
+
+    public static ContentItem CreateFakeContentItem(decimal order, bool addtoHotActionsMenu)
+    {
+        var contentItem = new ContentItem();
+        contentItem.GetOrCreate<ContentPart>("HotActionsPart");
+        contentItem.Alter<ContentPart>("HotActionsPart", x =>
+        {
+            x.GetOrCreate<BooleanField>("AddtoHotActionsMenu");
+            x.Alter<BooleanField>("AddtoHotActionsMenu", f => f.Value = addtoHotActionsMenu);
+
+            x.GetOrCreate<NumericField>("Order");
+            x.Alter<NumericField>("Order", f => f.Value = order);
+
+        });
+        return contentItem;
+    }
+
     public class MyPart : ContentPart
     {
         public string Text { get; set; }
@@ -119,4 +219,5 @@ public class LiquidTests
     {
         public int Value { get; set; }
     }
+
 }


### PR DESCRIPTION
Added three new test methods to the `LiquidTests` class:
1. `SortingContentItems_ShouldSortTheArrayOnIntegerField`
2. `FilteringContentItems_ShouldFilterTheArrayOnBooleanField`
3. `FilteringAndSortingContentItems_ShouldFilterAndSortTheArrayOnContentFields`

Introduced a static property `FakeContentItems` to generate fake content items for testing.

Added a static method `CreateFakeContentItem` to create a fake content item with specified order and boolean field values.

tests for the #16922 bug

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->