### PR TITLE
Fixing that the Agency landing page should render Milestone.HtmlBodyPart.Html correctly

### DIFF
--- a/src/OrchardCore.Themes/TheAgencyTheme/Recipes/Snippets/landingpage.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Recipes/Snippets/landingpage.liquid
@@ -83,7 +83,7 @@
                         <h4 class="subheading">{{ milestone.DisplayText }}</h4>
                     </div>
                     <div class="timeline-body">
-                        <p class="text-muted">{{ milestone.HtmlBodyPart.Html }}</p>
+                        <p class="text-muted">{{ milestone.HtmlBodyPart.Html | raw }}</p>
                     </div>
                 </div>
             </li>


### PR DESCRIPTION
My greatest OS contribution to date!

It's a tiny fix (that brings this section of the Agency Landing Page in line with other parts of it) so that the Milestone items' HTML is actually rendered.