### PR TITLE
Ensure checked boxes are preserved in OrchardCore.Forms even where th…

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Forms/Views/Items/InputPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Views/Items/InputPart.cshtml
@@ -14,7 +14,7 @@
     {
         if (Model.Value.Type == "checkbox")
         {
-            isChecked = fieldEntry.AttemptedValue == fieldValue;
+            isChecked = fieldEntry.AttemptedValue == (fieldValue ?? "on");
         }
         else
         {

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Views/Items/InputPart.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Views/Items/InputPart.cshtml
@@ -14,6 +14,12 @@
     {
         if (Model.Value.Type == "checkbox")
         {
+            // Unlike other input controls, a checkbox's value is only included in the
+            // submitted data if the checkbox is currently checked. If it is, then the
+            // value of the checkbox's value attribute is reported as the input's value, 
+            // or 'on' if no value is set.
+            // c.f. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#additional_attributes
+
             isChecked = fieldEntry.AttemptedValue == (fieldValue ?? "on");
         }
         else


### PR DESCRIPTION
Fixes #17023
 
Ensure checked boxes are preserved in OrchardCore.Forms even where there isn't a default value on the InputPart

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/guides/contributing/. -->