### PR TITLE
Add extension method for easier `ResourceManagementOptions` registration (Lombiq Technologies: OCORE-208)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
@@ -1,6 +1,5 @@
 using Fluid;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.ContentFields.Drivers;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentFields.Handlers;
@@ -16,7 +15,6 @@ using OrchardCore.Data;
 using OrchardCore.Data.Migration;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Users;
 
 namespace OrchardCore.ContentFields;
@@ -25,7 +23,7 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.Configure<TemplateOptions>(o =>
         {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Startup.cs
@@ -23,7 +23,7 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.Configure<TemplateOptions>(o =>
         {

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Startup.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentPreview.Drivers;
@@ -9,7 +8,6 @@ using OrchardCore.ContentPreview.Models;
 using OrchardCore.ContentPreview.Settings;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
-using OrchardCore.ResourceManagement;
 
 namespace OrchardCore.ContentPreview;
 
@@ -17,7 +15,7 @@ public sealed class Startup : Modules.StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddScoped<IContentDisplayDriver, ContentPreviewDriver>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Startup.cs
@@ -15,7 +15,7 @@ public sealed class Startup : Modules.StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddScoped<IContentDisplayDriver, ContentPreviewDriver>();
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Startup.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentTypes.Deployment;
 using OrchardCore.ContentTypes.Editors;
@@ -10,7 +9,6 @@ using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
 using OrchardCore.Recipes.Events;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.ContentTypes;
@@ -37,7 +35,7 @@ public sealed class Startup : StartupBase
         services.AddRecipeExecutionStep<DeleteContentDefinitionStep>();
 
         services.AddTransient<IRecipeEventHandler, LuceneRecipeEventHandler>();
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Startup.cs
@@ -35,7 +35,7 @@ public sealed class Startup : StartupBase
         services.AddRecipeExecutionStep<DeleteContentDefinitionStep>();
 
         services.AddTransient<IRecipeEventHandler, LuceneRecipeEventHandler>();
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }
 

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Startup.cs
@@ -32,7 +32,7 @@ public sealed class Startup : StartupBase
         services.AddSiteDisplayDriver<FacebookSettingsDisplayDriver>();
         services.AddRecipeExecutionStep<FacebookSettingsStep>();
 
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
         services.AddTransient<IConfigureOptions<FacebookSettings>, FacebookSettingsConfiguration>();
 
         services.Configure<MvcOptions>((options) =>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Startup.cs
@@ -12,7 +12,6 @@ using OrchardCore.Facebook.Settings;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Facebook;

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Startup.cs
@@ -33,7 +33,7 @@ public sealed class Startup : StartupBase
         services.AddSiteDisplayDriver<FacebookSettingsDisplayDriver>();
         services.AddRecipeExecutionStep<FacebookSettingsStep>();
 
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
         services.AddTransient<IConfigureOptions<FacebookSettings>, FacebookSettingsConfiguration>();
 
         services.Configure<MvcOptions>((options) =>

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
@@ -1,6 +1,5 @@
 using Fluid;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
@@ -13,7 +12,6 @@ using OrchardCore.Flows.Settings;
 using OrchardCore.Flows.ViewModels;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 
 namespace OrchardCore.Flows;
 
@@ -48,6 +46,6 @@ public sealed class Startup : StartupBase
 
         services.AddDataMigration<Migrations>();
 
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Startup.cs
@@ -46,6 +46,6 @@ public sealed class Startup : StartupBase
 
         services.AddDataMigration<Migrations>();
 
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
@@ -78,7 +78,7 @@ public sealed class Startup : StartupBase
         .AddLiquidFilter<ShapeRenderFilter>("shape_render")
         .AddLiquidFilter<ShapeStringifyFilter>("shape_stringify");
 
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }
 

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Startup.cs
@@ -5,7 +5,6 @@ using Fluid.Values;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.Data.Migration;
@@ -20,7 +19,6 @@ using OrchardCore.Liquid.Models;
 using OrchardCore.Liquid.Services;
 using OrchardCore.Liquid.ViewModels;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 
 namespace OrchardCore.Liquid;
 
@@ -80,7 +78,7 @@ public sealed class Startup : StartupBase
         .AddLiquidFilter<ShapeRenderFilter>("shape_render")
         .AddLiquidFilter<ShapeStringifyFilter>("shape_stringify");
 
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -84,7 +84,7 @@ public sealed class Startup : StartupBase
         .AddLiquidFilter<AssetUrlFilter>("asset_url")
         .AddLiquidFilter<ResizeUrlFilter>("resize_url");
 
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddTransient<IConfigureOptions<MediaOptions>, MediaOptionsConfiguration>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -85,7 +85,7 @@ public sealed class Startup : StartupBase
         .AddLiquidFilter<AssetUrlFilter>("asset_url")
         .AddLiquidFilter<ResizeUrlFilter>("resize_url");
 
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddTransient<IConfigureOptions<MediaOptions>, MediaOptionsConfiguration>();
 

--- a/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Startup.cs
@@ -41,7 +41,6 @@ using OrchardCore.Modules;
 using OrchardCore.Modules.FileProviders;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Shortcodes;
 using SixLabors.ImageSharp.Web.Caching;

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Startup.cs
@@ -64,7 +64,7 @@ public sealed class Startup : StartupBase
 
         services.Configure<NotificationOptions>(_shellConfiguration.GetSection("OrchardCore_Notifications"));
 
-        services.AddResourceManagementOptionsConfiguration<NotificationOptionsConfiguration>();
+        services.AddResourceConfiguration<NotificationOptionsConfiguration>();
         services.AddDisplayDriver<User, UserNotificationPreferencesPartDisplayDriver>();
         services.AddDisplayDriver<Navbar, NotificationNavbarDisplayDriver>();
         services.AddScoped<INotificationEvents, CacheNotificationEventsHandler>();

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Startup.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.Admin.Models;
 using OrchardCore.Data;
 using OrchardCore.Data.Migration;
@@ -17,7 +16,6 @@ using OrchardCore.Notifications.Indexes;
 using OrchardCore.Notifications.Migrations;
 using OrchardCore.Notifications.Models;
 using OrchardCore.Notifications.Services;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Users;
 using OrchardCore.Users.Models;
@@ -66,7 +64,7 @@ public sealed class Startup : StartupBase
 
         services.Configure<NotificationOptions>(_shellConfiguration.GetSection("OrchardCore_Notifications"));
 
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, NotificationOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<NotificationOptionsConfiguration>();
         services.AddDisplayDriver<User, UserNotificationPreferencesPartDisplayDriver>();
         services.AddDisplayDriver<Navbar, NotificationNavbarDisplayDriver>();
         services.AddScoped<INotificationEvents, CacheNotificationEventsHandler>();

--- a/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/OrchardCore.Resources.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement.Liquid\OrchardCore.DisplayManagement.Liquid.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement.Core\OrchardCore.ResourceManagement.Core.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Startup.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Liquid;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Modules;
@@ -31,7 +30,7 @@ public sealed class Startup : StartupBase
             o.LiquidViewParserConfiguration.Add(parser => parser.RegisterParserBlock("styleblock", parser.ArgumentsListParser, StyleBlock.WriteToAsync));
         });
 
-        serviceCollection.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
 
         var resourceConfiguration = _shellConfiguration.GetSection("OrchardCore_Resources");
         serviceCollection.Configure<ResourceOptions>(resourceConfiguration);

--- a/src/OrchardCore.Modules/OrchardCore.Resources/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/Startup.cs
@@ -30,7 +30,7 @@ public sealed class Startup : StartupBase
             o.LiquidViewParserConfiguration.Add(parser => parser.RegisterParserBlock("styleblock", parser.ArgumentsListParser, StyleBlock.WriteToAsync));
         });
 
-        serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        serviceCollection.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 
         var resourceConfiguration = _shellConfiguration.GetSection("OrchardCore_Resources");
         serviceCollection.Configure<ResourceOptions>(resourceConfiguration);

--- a/src/OrchardCore.Modules/OrchardCore.Spatial/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Spatial/Startup.cs
@@ -1,12 +1,10 @@
 using Fluid;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Spatial.Drivers;
 using OrchardCore.Spatial.Fields;
 using OrchardCore.Spatial.Handlers;
@@ -19,7 +17,7 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
 
         // Coordinate Field
         services.AddContentField<GeoPointField>()

--- a/src/OrchardCore.Modules/OrchardCore.Spatial/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Spatial/Startup.cs
@@ -17,7 +17,7 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 
         // Coordinate Field
         services.AddContentField<GeoPointField>()

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Startup.cs
@@ -17,7 +17,7 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddScoped<IShapeBindingResolver, TemplatesShapeBindingResolver>();
         services.AddScoped<PreviewTemplatesProvider>();

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Startup.cs
@@ -1,12 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Templates.Deployment;
 using OrchardCore.Templates.Recipes;
@@ -19,7 +17,7 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddScoped<IShapeBindingResolver, TemplatesShapeBindingResolver>();
         services.AddScoped<PreviewTemplatesProvider>();

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.Admin.Models;
 using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement.Handlers;
@@ -7,7 +6,6 @@ using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Themes.Deployment;
 using OrchardCore.Themes.Drivers;
@@ -24,7 +22,7 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
         services.AddRecipeExecutionStep<ThemesStep>();
         services.AddPermissionProvider<Permissions>();
         services.AddScoped<IThemeSelector, SiteThemeSelector>();

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
@@ -22,7 +22,7 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
         services.AddRecipeExecutionStep<ThemesStep>();
         services.AddPermissionProvider<Permissions>();
         services.AddScoped<IThemeSelector, SiteThemeSelector>();

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Startup.cs
@@ -26,7 +26,7 @@ public sealed class Startup : StartupBase
         services.AddUrlRewritingServices()
             .AddNavigationProvider<AdminMenu>()
             .AddPermissionProvider<UrlRewritingPermissionProvider>()
-            .AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>()
+            .AddResourceConfiguration<ResourceManagementOptionsConfiguration>()
             .AddDisplayDriver<RewriteRule, RewriteRulesDisplayDriver>();
 
         // Add Apache Mod Redirect Rule.

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Startup.cs
@@ -1,12 +1,10 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security.Permissions;
 using OrchardCore.UrlRewriting.Drivers;
 using OrchardCore.UrlRewriting.Endpoints.Rules;
@@ -28,7 +26,7 @@ public sealed class Startup : StartupBase
         services.AddUrlRewritingServices()
             .AddNavigationProvider<AdminMenu>()
             .AddPermissionProvider<UrlRewritingPermissionProvider>()
-            .AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>()
+            .AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>()
             .AddDisplayDriver<RewriteRule, RewriteRulesDisplayDriver>();
 
         // Add Apache Mod Redirect Rule.

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -30,7 +30,6 @@ using OrchardCore.Mvc.Core.Utilities;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
 using OrchardCore.Recipes.Services;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Settings.Deployment;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -154,7 +154,7 @@ public sealed class Startup : StartupBase
         });
 
         services.AddTransient<IUsersAdminListFilterProvider, DefaultUsersAdminListFilterProvider>();
-        services.AddResourceManagementOptionsConfiguration<UserOptionsConfiguration>();
+        services.AddResourceConfiguration<UserOptionsConfiguration>();
         services.AddDisplayDriver<Navbar, UserMenuNavbarDisplayDriver>();
         services.AddDisplayDriver<UserMenu, UserMenuDisplayDriver>();
         services.AddShapeTableProvider<UserMenuShapeTableProvider>();

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -155,7 +155,7 @@ public sealed class Startup : StartupBase
         });
 
         services.AddTransient<IUsersAdminListFilterProvider, DefaultUsersAdminListFilterProvider>();
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, UserOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<UserOptionsConfiguration>();
         services.AddDisplayDriver<Navbar, UserMenuNavbarDisplayDriver>();
         services.AddDisplayDriver<UserMenu, UserMenuDisplayDriver>();
         services.AddShapeTableProvider<UserMenuShapeTableProvider>();

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Startup.cs
@@ -1,12 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Widgets.Drivers;
 using OrchardCore.Widgets.Models;
 using OrchardCore.Widgets.Services;
@@ -29,6 +27,6 @@ public sealed class Startup : StartupBase
         services.AddScoped<IContentTypePartDefinitionDisplayDriver, WidgetsListPartSettingsDisplayDriver>();
         services.AddContentPart<WidgetMetadata>();
         services.AddDataMigration<Migrations>();
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Startup.cs
@@ -27,6 +27,6 @@ public sealed class Startup : StartupBase
         services.AddScoped<IContentTypePartDefinitionDisplayDriver, WidgetsListPartSettingsDisplayDriver>();
         services.AddContentPart<WidgetMetadata>();
         services.AddDataMigration<Migrations>();
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
@@ -1,6 +1,5 @@
 using Fluid;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.Data;
 using OrchardCore.Data.Migration;
 using OrchardCore.Deployment;
@@ -10,7 +9,6 @@ using OrchardCore.Liquid;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
 using OrchardCore.Recipes;
-using OrchardCore.ResourceManagement;
 using OrchardCore.Security.Permissions;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Deployment;
@@ -85,7 +83,7 @@ public sealed class Startup : StartupBase
         services.AddActivity<LogTask, LogTaskDisplayDriver>();
 
         services.AddRecipeExecutionStep<WorkflowTypeStep>();
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddTrimmingServices(_shellConfiguration);
     }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
@@ -83,7 +83,7 @@ public sealed class Startup : StartupBase
         services.AddActivity<LogTask, LogTaskDisplayDriver>();
 
         services.AddRecipeExecutionStep<WorkflowTypeStep>();
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 
         services.AddTrimmingServices(_shellConfiguration);
     }

--- a/src/OrchardCore.Themes/TheAdmin/Startup.cs
+++ b/src/OrchardCore.Themes/TheAdmin/Startup.cs
@@ -16,7 +16,7 @@ public sealed class Startup : StartupBase
 
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
         services.Configure<TheAdminThemeOptions>(_configuration.GetSection("TheAdminTheme:StyleSettings"));
     }
 }

--- a/src/OrchardCore.Themes/TheAdmin/Startup.cs
+++ b/src/OrchardCore.Themes/TheAdmin/Startup.cs
@@ -1,9 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Html;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 
 namespace OrchardCore.Themes.TheAdmin;
 
@@ -18,7 +16,7 @@ public sealed class Startup : StartupBase
 
     public override void ConfigureServices(IServiceCollection services)
     {
-        services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
         services.Configure<TheAdminThemeOptions>(_configuration.GetSection("TheAdminTheme:StyleSettings"));
     }
 }

--- a/src/OrchardCore.Themes/TheAgencyTheme/Startup.cs
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Startup.cs
@@ -1,7 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 
 namespace OrchardCore.Themes.TheAgencyTheme;
 
@@ -9,6 +7,6 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Themes/TheAgencyTheme/Startup.cs
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Startup.cs
@@ -7,6 +7,6 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        serviceCollection.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
+++ b/src/OrchardCore.Themes/TheAgencyTheme/TheAgencyTheme.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement.Abstractions\OrchardCore.ResourceManagement.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Themes/TheBlogTheme/Startup.cs
+++ b/src/OrchardCore.Themes/TheBlogTheme/Startup.cs
@@ -7,6 +7,6 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        serviceCollection.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Themes/TheBlogTheme/Startup.cs
+++ b/src/OrchardCore.Themes/TheBlogTheme/Startup.cs
@@ -1,7 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 
 namespace OrchardCore.Themes.TheBlogTheme;
 
@@ -9,6 +7,6 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Themes/TheComingSoonTheme/Startup.cs
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/Startup.cs
@@ -7,6 +7,6 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+        serviceCollection.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Themes/TheComingSoonTheme/Startup.cs
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/Startup.cs
@@ -1,7 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using OrchardCore.Modules;
-using OrchardCore.ResourceManagement;
 
 namespace OrchardCore.Themes.TheComingSoonTheme;
 
@@ -9,6 +7,6 @@ public sealed class Startup : StartupBase
 {
     public override void ConfigureServices(IServiceCollection serviceCollection)
     {
-        serviceCollection.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+        serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
     }
 }

--- a/src/OrchardCore.Themes/TheComingSoonTheme/TheComingSoonTheme.csproj
+++ b/src/OrchardCore.Themes/TheComingSoonTheme/TheComingSoonTheme.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Theme.Targets\OrchardCore.Theme.Targets.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.DisplayManagement\OrchardCore.DisplayManagement.csproj" />
-    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement.Abstractions\OrchardCore.ResourceManagement.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs
@@ -20,7 +20,7 @@ public static class ServiceCollectionExtensions
     /// Adds a service implementing <see cref="IConfigureOptions{ResourceManagementOptions}"/> to the service collection.
     /// </summary>
     /// <typeparam name="T">
-    /// The type of the service implementing <see cref="IConfigureOptions{ResourceManagementOptions}"/> to.
+    /// The type of the implementing of <see cref="IConfigureOptions{ResourceManagementOptions}"/> to register.
     /// </typeparam>
     public static IServiceCollection AddResourceConfiguration<T>(this IServiceCollection services)
         where T : class, IConfigureOptions<ResourceManagementOptions>

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class ServiceCollectionExtensions
     /// <typeparam name="T">
     /// The type of the service implementing <see cref="IConfigureOptions{ResourceManagementOptions}"/> to.
     /// </typeparam>
-    public static IServiceCollection AddResourceManagementOptionsConfiguration<T>(this IServiceCollection services)
+    public static IServiceCollection AddResourceConfiguration<T>(this IServiceCollection services)
         where T : class, IConfigureOptions<ResourceManagementOptions>
         => services.AddTransient<IConfigureOptions<ResourceManagementOptions>, T>();
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
 using OrchardCore.ResourceManagement;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -14,4 +15,14 @@ public static class ServiceCollectionExtensions
 
         return services;
     }
+
+    /// <summary>
+    /// Adds a service implementing <see cref="IConfigureOptions{ResourceManagementOptions}"/> to the service collection.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of the service implementing <see cref="IConfigureOptions{ResourceManagementOptions}"/> to.
+    /// </typeparam>
+    public static IServiceCollection AddResourceManagementOptionsConfiguration<T>(this IServiceCollection services)
+        where T : class, IConfigureOptions<ResourceManagementOptions>
+        => services.AddTransient<IConfigureOptions<ResourceManagementOptions>, T>();
 }

--- a/src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs
@@ -20,7 +20,7 @@ public static class ServiceCollectionExtensions
     /// Adds a service implementing <see cref="IConfigureOptions{ResourceManagementOptions}"/> to the service collection.
     /// </summary>
     /// <typeparam name="T">
-    /// The type of the implementing of <see cref="IConfigureOptions{ResourceManagementOptions}"/> to register.
+    /// The type of the implementation of <see cref="IConfigureOptions{ResourceManagementOptions}"/> to register.
     /// </typeparam>
     public static IServiceCollection AddResourceConfiguration<T>(this IServiceCollection services)
         where T : class, IConfigureOptions<ResourceManagementOptions>

--- a/src/docs/reference/modules/Resources/README.md
+++ b/src/docs/reference/modules/Resources/README.md
@@ -142,7 +142,7 @@ In this example, we define a style that depends on Bootstrap version 4. In this 
 
 !!! note "Registration"
     Make sure to register this `IConfigureOptions<ResourceManagementOptions>` in the `Startup` or your theme or module.
-    `serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();`
+    `serviceCollection.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();`
   
 ## Usage
 

--- a/src/docs/reference/modules/Resources/README.md
+++ b/src/docs/reference/modules/Resources/README.md
@@ -142,7 +142,7 @@ In this example, we define a style that depends on Bootstrap version 4. In this 
 
 !!! note "Registration"
     Make sure to register this `IConfigureOptions<ResourceManagementOptions>` in the `Startup` or your theme or module.
-    `serviceCollection.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();`
+    `serviceCollection.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();`
   
 ## Usage
 

--- a/src/docs/reference/modules/Resources/README.md
+++ b/src/docs/reference/modules/Resources/README.md
@@ -142,7 +142,7 @@ In this example, we define a style that depends on Bootstrap version 4. In this 
 
 !!! note "Registration"
     Make sure to register this `IConfigureOptions<ResourceManagementOptions>` in the `Startup` or your theme or module.
-    `serviceCollection.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();`
+    `services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();`
   
 ## Usage
 

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -112,7 +112,7 @@ Many type commonly used by classes can be `sealed`, which improves runtime perfo
 
 ### New Extension Method for Adding `IConfigureOptions<ResourceManagementOptions>` Implementations
 
-When adding an `IConfigureOptions<ResourceManagementOptions>` implementation, used to add static resources and commonly named `ResourceManagementOptionsConfiguration`, you previously had to do the following in `Startup` classes:
+When adding an `IConfigureOptions<ResourceManagementOptions>` implementation, used to add static resources and commonly named `ResourceManagementOptionsConfiguration`, you previously had to do the following in the `Startup` classes:
 
 ```csharp
 services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -119,7 +119,7 @@ services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceMana
 To simplify this, we introduced a new extension method to do the same in a shorter form:
 
 ```csharp
-services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 ```
 
-You can utilize this in your codebase by doing a search for the `AddTransient<IConfigureOptions<ResourceManagementOptions>, (.+)>\(\)` regex pattern and replacing it with `AddResourceManagementOptionsConfiguration<$1>()`. Projects using this have to reference the `OrchardCore.ResourceManagement` package.
+You can utilize this in your codebase by doing a search for the `AddTransient<IConfigureOptions<ResourceManagementOptions>, (.+)>\(\)` regex pattern and replacing it with `AddResourceConfiguration<$1>()`. Projects using this have to reference the `OrchardCore.ResourceManagement` package.

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -107,3 +107,19 @@ will return `false` for administrators, even though they still have full access.
 Many type commonly used by classes can be `sealed`, which improves runtime performance. While it's not mandatory, we recommend that you consider applying this improvement to your own extensions as well. We've implemented this enhancement in pull request [#16897](https://github.com/OrchardCMS/OrchardCore/pull/16897).
 
 ## Change Log
+
+### New Extension Method for Adding `IConfigureOptions<ResourceManagementOptions>` Implementations
+
+When adding an `IConfigureOptions<ResourceManagementOptions>` implementation, used to add static resources and commonly named `ResourceManagementOptionsConfiguration`, you previously had to do the following in `Startup` classes:
+
+```csharp
+services.AddTransient<IConfigureOptions<ResourceManagementOptions>, ResourceManagementOptionsConfiguration>();
+```
+
+To simplify this, we introduced a new extension method to do the same in a shorter form:
+
+```csharp
+services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
+```
+
+You can introduce this in your codebase by doing a search for the `AddTransient<IConfigureOptions<ResourceManagementOptions>, (.+)>\(\)` regex pattern and replacing it with `AddResourceManagementOptionsConfiguration<$1>()`.

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -122,4 +122,4 @@ To simplify this, we introduced a new extension method to do the same in a short
 services.AddResourceManagementOptionsConfiguration<ResourceManagementOptionsConfiguration>();
 ```
 
-You can introduce this in your codebase by doing a search for the `AddTransient<IConfigureOptions<ResourceManagementOptions>, (.+)>\(\)` regex pattern and replacing it with `AddResourceManagementOptionsConfiguration<$1>()`.
+You can utilize this in your codebase by doing a search for the `AddTransient<IConfigureOptions<ResourceManagementOptions>, (.+)>\(\)` regex pattern and replacing it with `AddResourceManagementOptionsConfiguration<$1>()`. Projects using this have to reference the `OrchardCore.ResourceManagement` package.

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -124,4 +124,4 @@ To simplify this, we introduced a new extension method to do the same in a short
 services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
 ```
 
-You can utilize this in your codebase by doing a search for the `AddTransient<IConfigureOptions<ResourceManagementOptions>, (.+)>\(\)` regex pattern and replacing it with `AddResourceConfiguration<$1>()`. Projects using this have to reference the `OrchardCore.ResourceManagement` package.
+You can utilize this in your codebase by searching the `AddTransient<IConfigureOptions<ResourceManagementOptions>, (.+)>\(\)` regex pattern and replacing it with `AddResourceConfiguration<$1>()`. Projects using this have to reference the `OrchardCore.ResourceManagement` package.

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -108,6 +108,8 @@ Many type commonly used by classes can be `sealed`, which improves runtime perfo
 
 ## Change Log
 
+## Miscellaneous
+
 ### New Extension Method for Adding `IConfigureOptions<ResourceManagementOptions>` Implementations
 
 When adding an `IConfigureOptions<ResourceManagementOptions>` implementation, used to add static resources and commonly named `ResourceManagementOptionsConfiguration`, you previously had to do the following in `Startup` classes:


### PR DESCRIPTION
Following the pattern of all the `Add*` extensions.

The implementation is in `src/OrchardCore/OrchardCore.ResourceManagement/ServiceCollectionExtensions.cs`, and the release notes are the notable changes, the rest is just search and replace.