### PR TITLE
Fix widget expansion behavior in Flow Part while editing ContentItem

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/ContentCard-FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/ContentCard-FlowPart.Edit.cshtml
@@ -12,7 +12,7 @@
     var editorId = "contentEditor_" + Model.PrefixValue;
 }
 
-<div class="widget widget-editor card my-1@(Model.Inline ? " collapsed" : string.Empty)">
+<div class="widget widget-editor card my-1@(!Model.Inline ? " collapsed" : string.Empty)">
     <div class="widget-editor-header card-header text-muted py-1 ps-2 pe-1">
         @if (Model.CanMove != false)
         {


### PR DESCRIPTION
This pull request addresses an unintended behavior where widgets inside flow parts expand by default when the flow part is expanded. The issue was caused by a change made in commit [1107fc1](https://github.com/OrchardCMS/OrchardCore/commit/1107fc1e0aeb9be1b7d82d9dd86ddc1ed75ceacd#diff-ed7b829dc6a985d594f8b6c6833a3f21b401c5c923345be3ef3eaafeaa88a660L15), which aimed to remove extra spacing around editing contents, flow, and bag parts.

The specific change that led to this unintended behavior was related to the modification of the collapsed class logic for widgets:

`<div class="widget widget-editor card my-1 @(Model.Inline != true ? "collapsed" : "")">
`

This logic was altered in the commit to:

`<div class="widget widget-editor card my-1 @(Model.Inline ? " collapsed" : String.Empty)">
`

This change caused widgets to expand by default when the flow part was expanded.

**Fix:**

I have corrected the behavior by updating the widget class assignment logic. The widget expansion now correctly follows the intended behavior.


