### PR TITLE
Redirect to the deployment plan steps after creating plan (Lombiq Technologies: OCORE-210)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
@@ -233,7 +233,7 @@ public sealed class DeploymentPlanController : Controller
 
             await _session.SaveAsync(deploymentPlan);
 
-            return RedirectToAction(nameof(Index));
+            return RedirectToAction(nameof(Display), new { id = deploymentPlan.Id });
         }
 
         // If we got this far, something failed, redisplay form


### PR DESCRIPTION
Previously, when you created a deployment plan, you were redirected back to the deployment plan list. Now, you're redirected to the plan's step editor, which is a more logical destination (since most possibly you create the plan so then you actually do something with it).

In the same vein as https://github.com/OrchardCMS/OrchardCore/issues/17110.