### PR TITLE
Seek stream from Base64.DecodedToStream to begin

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Base64.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Base64.cs
@@ -52,6 +52,7 @@ public static class Base64
 
         memoryStream.Advance(bytesWritten);
         memoryStream.Seek(0, SeekOrigin.Begin);
+        
         return memoryStream;
     }
 

--- a/src/OrchardCore/OrchardCore.Abstractions/Base64.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Base64.cs
@@ -51,7 +51,7 @@ public static class Base64
         }
 
         memoryStream.Advance(bytesWritten);
-
+        memoryStream.Seek(0, SeekOrigin.Begin);
         return memoryStream;
     }
 

--- a/src/OrchardCore/OrchardCore.Infrastructure/Scripting/CommonGeneratorMethods.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Scripting/CommonGeneratorMethods.cs
@@ -42,7 +42,6 @@ public class CommonGeneratorMethods : IGlobalMethodProvider
         Method = serviceProvider => (Func<string, string>)(encoded =>
         {
             var compressedStream = Base64.DecodedToStream(encoded);
-            compressedStream.Seek(0, SeekOrigin.Begin);
 
             using var gZip = new GZipStream(compressedStream, CompressionMode.Decompress, leaveOpen: true);
 

--- a/test/OrchardCore.Tests/Abstractions/Base64Tests.cs
+++ b/test/OrchardCore.Tests/Abstractions/Base64Tests.cs
@@ -7,8 +7,22 @@ public class Base64Tests
     [InlineData("SGVsbA==", "Hell")]
     [InlineData("SGVsbG8=", "Hello")]
     [InlineData("", "")]
-    public void MergeArrayShouldRespectJsonMergeSettings(string source, string expected)
+    public void DecodeToStringTest(string source, string expected)
     {
         Assert.Equal(expected, Base64.FromUTF8Base64String(source));
+    }
+
+    [Theory]
+    [InlineData("YTw+OmE/", "a<>:a?")]
+    [InlineData("SGVsbA==", "Hell")]
+    [InlineData("SGVsbG8=", "Hello")]
+    [InlineData("", "")]
+    public void DecodeToStreamTest(string source, string expected)
+    {
+        using var stream = Base64.DecodedToStream(source);
+        using var sr = new StreamReader(stream);
+        {
+            Assert.Equal(expected, sr.ReadToEnd());
+        }
     }
 }


### PR DESCRIPTION
Base64.DecodedToStream returns stream that does not ready for use.
As a result MediaStep writes empty files when setup as Base64 string.