### PR TITLE
Configure Renovate update GitHub Actions actions to full versions but still pin SHAs (Lombiq Technologies: OCORE-211)

### DIFF
--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -86,7 +86,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Create Issue
-      uses: peter-evans/create-issue-from-file@64feed10c881151d72db1df9265baf264b570b29
+      uses: peter-evans/create-issue-from-file@24452a72d85239eacf1468b0f1982a9f3fec4c94 # renovate: tag=v5.0.0
       with:
         title: Monthly community metrics report for ${{ env.LAST_MONTH }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/contributor_map.yml
+++ b/.github/workflows/contributor_map.yml
@@ -13,7 +13,6 @@ jobs:
     
     steps:
       - name: Update Contributor Map
-        # v1.1
-        uses: tunaitis/contributor-map@f34c9b1f1fcb1b9f57afe2c9f2ac1c087a49eaff
+        uses: tunaitis/contributor-map@bf97d201f9b59abe463fa4ef3b5c4478d22f606d # renovate: tag=v1.1
         with:
             output: src/docs/community/contributors/images/contributors-map.svg

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 3
     steps:
       - name: Check for Merge Conflict in PR
-        uses: eps1lon/actions-label-merge-conflict@657e437ea2533fd743739be26f0a2eeb420b306a
+        uses: eps1lon/actions-label-merge-conflict@e62d7a53ff8be8b97684bffb6cfbbf3fc1115e2e # renovate: tag=v3.0.0
         with:
             repoToken: ${{ secrets.GITHUB_TOKEN }}
             commentOnDirty: "This pull request has merge conflicts. Please resolve those before requesting a review."


### PR DESCRIPTION
See https://github.com/renovatebot/renovate/pull/10835.