### PR TITLE
Group Lucene updates together in Renovate (Lombiq Technologies: OCORE-212)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -23,6 +23,12 @@
             ],
             enabled: false,
         },
+        {
+            matchPackagePatterns: [
+                '^Lucene\\.NET.*$',
+            ],
+            groupName: 'Lucene.NET packages',
+        },
     ],
     // We only need updates once a week.
     schedule: [


### PR DESCRIPTION
This is so it doesn't try to update `Lucene.Net` and e.g. `Lucene.Net.Analysis.Common` separately, causing failing builds like https://github.com/OrchardCMS/OrchardCore/actions/runs/12218816256/job/34084745956?pr=17155.