### PR TITLE
Disable tabs in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,8 +105,7 @@ nav:
       - Recipes and Starter Themes: getting-started/starter-recipes.md
       - Code Generation Templates: getting-started/templates/README.md
       - Create a Theme: getting-started/theme.md
-  - Glossary:
-      - Terms and Concepts: glossary/README.md
+  - Glossary: glossary/README.md
   - How-to guides:
       - Follow the Guides: guides/README.md
       - Create a modular application: guides/create-modular-application-mvc/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,6 @@ theme:
     - header.autohide
     - navigation.footer
     - navigation.instant
-    - navigation.tabs
     - navigation.top
   palette:
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
## What
Uses sidebar navigation instead of tabs:

_Before:_
![image](https://github.com/user-attachments/assets/99eeebde-c5b3-454f-9314-41e96a19ac38)



_After:_
![image](https://github.com/user-attachments/assets/ec364a7b-943a-4824-95c6-103494970ffd)



## Why
- Easier to use
    - Faster than clicking through the tab and loading a page just to see the sub-sections
    - After reading an article, you don't need to scroll back to the top to navigate to a different section
- Consistent with smaller screen sizes. With tabs enabled, when there is not enough space to display tabs, or when using mobile, outline navigation is used.
- Encourages linear traversal as part of  #17204