### PR TITLE
Show ThemeToggler on supported themes only

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Themes/Drivers/ToggleThemeNavbarDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Drivers/ToggleThemeNavbarDisplayDriver.cs
@@ -18,7 +18,6 @@ public sealed class ToggleThemeNavbarDisplayDriver : DisplayDriver<Navbar>
     {
         return View("ToggleTheme", model)
             .RenderWhen(async () => (await _siteService.GetSettingsAsync<AdminSettings>()).DisplayThemeToggler)
-            .Location("Detail", "Content:10")
             .Location("DetailAdmin", "Content:10");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Startup.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using OrchardCore.Admin.Models;
 using OrchardCore.Deployment;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Theming;
@@ -31,7 +30,6 @@ public sealed class Startup : StartupBase
         services.AddScoped<IThemeService, ThemeService>();
         services.AddScoped<ThemeTogglerService>();
         services.AddDeployment<ThemesDeploymentSource, ThemesDeploymentStep, ThemesDeploymentStepDriver>();
-        services.AddDisplayDriver<Navbar, ToggleThemeNavbarDisplayDriver>();
         services.AddDisplayDriver<ThemeEntry, ThemeEntryDisplayDriver>();
     }
 }

--- a/src/OrchardCore.Themes/TheAdmin/Drivers/ToggleThemeNavbarDisplayDriver.cs
+++ b/src/OrchardCore.Themes/TheAdmin/Drivers/ToggleThemeNavbarDisplayDriver.cs
@@ -1,23 +1,28 @@
+using OrchardCore.Admin;
 using OrchardCore.Admin.Models;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Settings;
 
-namespace OrchardCore.Themes.Drivers;
+namespace OrchardCore.Themes.TheAdmin.Drivers;
 
 public sealed class ToggleThemeNavbarDisplayDriver : DisplayDriver<Navbar>
 {
     private readonly ISiteService _siteService;
+    private readonly IAdminThemeService _adminThemeService;
 
-    public ToggleThemeNavbarDisplayDriver(ISiteService siteService)
+    public ToggleThemeNavbarDisplayDriver(
+        ISiteService siteService,
+        IAdminThemeService adminThemeService)
     {
         _siteService = siteService;
+        _adminThemeService = adminThemeService;
     }
 
     public override IDisplayResult Display(Navbar model, BuildDisplayContext context)
     {
         return View("ToggleTheme", model)
-            .RenderWhen(async () => (await _siteService.GetSettingsAsync<AdminSettings>()).DisplayThemeToggler)
+            .RenderWhen(async () => (await _siteService.GetSettingsAsync<AdminSettings>()).DisplayThemeToggler && await _adminThemeService.GetAdminThemeNameAsync() == "TheAdmin")
             .Location("DetailAdmin", "Content:10");
     }
 }

--- a/src/OrchardCore.Themes/TheAdmin/Drivers/ToggleThemeNavbarDisplayDriver.cs
+++ b/src/OrchardCore.Themes/TheAdmin/Drivers/ToggleThemeNavbarDisplayDriver.cs
@@ -1,4 +1,3 @@
-using OrchardCore.Admin;
 using OrchardCore.Admin.Models;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
@@ -9,20 +8,16 @@ namespace OrchardCore.Themes.TheAdmin.Drivers;
 public sealed class ToggleThemeNavbarDisplayDriver : DisplayDriver<Navbar>
 {
     private readonly ISiteService _siteService;
-    private readonly IAdminThemeService _adminThemeService;
 
-    public ToggleThemeNavbarDisplayDriver(
-        ISiteService siteService,
-        IAdminThemeService adminThemeService)
+    public ToggleThemeNavbarDisplayDriver(ISiteService siteService)
     {
         _siteService = siteService;
-        _adminThemeService = adminThemeService;
     }
 
     public override IDisplayResult Display(Navbar model, BuildDisplayContext context)
     {
         return View("ToggleTheme", model)
-            .RenderWhen(async () => (await _siteService.GetSettingsAsync<AdminSettings>()).DisplayThemeToggler && await _adminThemeService.GetAdminThemeNameAsync() == "TheAdmin")
+            .RenderWhen(async () => (await _siteService.GetSettingsAsync<AdminSettings>()).DisplayThemeToggler)
             .Location("DetailAdmin", "Content:10");
     }
 }

--- a/src/OrchardCore.Themes/TheAdmin/Startup.cs
+++ b/src/OrchardCore.Themes/TheAdmin/Startup.cs
@@ -1,7 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Admin.Models;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Html;
 using OrchardCore.Environment.Shell.Configuration;
 using OrchardCore.Modules;
+using OrchardCore.Themes.TheAdmin.Drivers;
 
 namespace OrchardCore.Themes.TheAdmin;
 
@@ -16,6 +19,7 @@ public sealed class Startup : StartupBase
 
     public override void ConfigureServices(IServiceCollection services)
     {
+        services.AddDisplayDriver<Navbar, ToggleThemeNavbarDisplayDriver>();
         services.AddResourceConfiguration<ResourceManagementOptionsConfiguration>();
         services.Configure<TheAdminThemeOptions>(_configuration.GetSection("TheAdminTheme:StyleSettings"));
     }

--- a/src/OrchardCore.Themes/TheTheme/Drivers/ToggleThemeNavbarDisplayDriver.cs
+++ b/src/OrchardCore.Themes/TheTheme/Drivers/ToggleThemeNavbarDisplayDriver.cs
@@ -1,0 +1,23 @@
+using OrchardCore.Admin.Models;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Themes.Services;
+
+namespace TheTheme.Drivers;
+
+public sealed class ToggleThemeNavbarDisplayDriver : DisplayDriver<Navbar>
+{
+    private readonly ISiteThemeService _siteThemeService;
+
+    public ToggleThemeNavbarDisplayDriver(ISiteThemeService siteThemeService)
+    {
+        _siteThemeService = siteThemeService;
+    }
+
+    public override IDisplayResult Display(Navbar model, BuildDisplayContext context)
+    {
+        return View("ToggleTheme", model)
+            .RenderWhen(async () => await _siteThemeService.GetSiteThemeNameAsync() == "TheTheme")
+            .Location("Detail", "Content:10");
+    }
+}

--- a/src/OrchardCore.Themes/TheTheme/Startup.cs
+++ b/src/OrchardCore.Themes/TheTheme/Startup.cs
@@ -1,11 +1,15 @@
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Admin.Models;
+using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
+using TheTheme.Drivers;
 
 namespace OrchardCore.Themes.TheTheme;
 
 public sealed class Startup : StartupBase
 {
-    public override void ConfigureServices(IServiceCollection serviceCollection)
+    public override void ConfigureServices(IServiceCollection services)
     {
+        services.AddDisplayDriver<Navbar, ToggleThemeNavbarDisplayDriver>();
     }
 }


### PR DESCRIPTION
The Theme toggler (Dark/Auto/Light) should be explicitly added to themes that support it. By default it should not be added to every frontend theme.