### PR TITLE
Configure Renovate to update .NET framework-specific packages in a .NET framework-aware way (Lombiq Technologies: OCORE-218)

### DIFF
--- a/.github/ISSUE_TEMPLATE/target_frameworks.md
+++ b/.github/ISSUE_TEMPLATE/target_frameworks.md
@@ -17,3 +17,18 @@ Use the minimal SDK version required, the `rollForward` rule will pick the lates
 - [ ] Update docker file base images.
 - [ ] Update documentation pages specifying a TFM (search for `<TargetFramework>`).
 - [ ] Add a note about the supported .NET versions to the upcoming release notes.
+- [ ] When dual-targeting framework versions, configure Renovate in the `renovate.json5` file (in the repository root) to update packages targeting the older framework only up to their compatible versions. An example package rule for the `packageRules` section that will update the <9.0.0 (i.e. 8.x) version of the matching packages only up to 8.x:
+  ```json5
+  {
+      // The .NET 8 versions of these packages need to stay on 8.x. We maintain a separate reference to the 
+      // .NET 9 versions in Directory.Packages.props, only active when building for .NET 9.
+      matchPackageNames: [
+          '/^Microsoft\\.AspNetCore.*$/',
+          '/^Microsoft\\.Extensions.*$/',
+          'Serilog.AspNetCore',
+          'System.Text.Json',
+      ],
+      allowedVersions: '<9.0.0',
+      matchCurrentVersion: '<9.0.0',
+  }
+  ```

--- a/.github/ISSUE_TEMPLATE/target_frameworks.md
+++ b/.github/ISSUE_TEMPLATE/target_frameworks.md
@@ -21,7 +21,7 @@ Use the minimal SDK version required, the `rollForward` rule will pick the lates
   ```json5
   {
       // The .NET 8 versions of these packages need to stay on 8.x. We maintain a separate reference to the 
-      // .NET 9 versions in Directory.Packages.props, only active when building for .NET 9.
+      // .NET 9 versions in Directory.Packages.props, which is only active when building for .NET 9.
       matchPackageNames: [
           '/^Microsoft\\.AspNetCore.*$/',
           '/^Microsoft\\.Extensions.*$/',

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,9 +9,19 @@
     // See https://docs.renovatebot.com/configuration-options/#configmigration.
     configMigration: true,
     packageRules: [
+        // Disable certain updates.
         {
+            // The .NET 8 version of Serilog.AspNetCore (8.x) needs to stay on 8.x. We maintain a separate reference to
+            // the 9.x version in Directory.Packages.props, only active when building for .NET 9.
             matchPackageNames: [
-                // See the corresponding comment in Directory.Packages.props.
+                'Serilog.AspNetCore',
+            ],
+            allowedVersions: '<9.0.0',
+            matchCurrentVersion: '<9.0.0',
+        },
+        {
+            // See the corresponding comment in Directory.Packages.props.
+            matchPackageNames: [
                 'System.Drawing.Common',
             ],
             enabled: false,
@@ -85,5 +95,5 @@
     schedule: [
         'before 5am on Sunday',
     ],
-    labels: ['dependencies'],
+    addLabels: ['dependencies'],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,10 +11,13 @@
     packageRules: [
         // Disable certain updates.
         {
-            // The .NET 8 version of Serilog.AspNetCore (8.x) needs to stay on 8.x. We maintain a separate reference to
-            // the 9.x version in Directory.Packages.props, only active when building for .NET 9.
+            // The .NET 8 versions of these packages need to stay on 8.x. We maintain a separate reference to the 
+            // .NET 9 versions in Directory.Packages.props, only active when building for .NET 9.
             matchPackageNames: [
+                '/^Microsoft\\.AspNetCore.*$/',
+                '/^Microsoft\\.Extensions.*$/',
                 'Serilog.AspNetCore',
+                'System.Text.Json',
             ],
             allowedVersions: '<9.0.0',
             matchCurrentVersion: '<9.0.0',


### PR DESCRIPTION
This is to prevent Renovate trying to update e.g. `Serilog.AspNetCore` 8.x to 9.x also when targeting .NET 8. The .NET 9 version will be updated to the latest.