### PR TITLE
Fix required tenant in OpenId Validation settings UI

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
@@ -70,9 +70,9 @@ public sealed class OpenIdValidationSettingsDisplayDriver : DisplayDriver<OpenId
         settings.DisableTokenTypeValidation = model.DisableTokenTypeValidation;
         settings.Tenant = model.Tenant;
 
-        if (string.IsNullOrWhiteSpace(model.Tenant))
+        if (string.IsNullOrEmpty(model.Tenant))
         {
-            if (string.IsNullOrWhiteSpace(model.Authority))
+            if (string.IsNullOrEmpty(model.Authority))
             {
                 context.Updater.ModelState.AddModelError(Prefix, nameof(model.Tenant), S["A tenant or authority value is required."]);
             }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
@@ -64,22 +64,22 @@ public sealed class OpenIdValidationSettingsDisplayDriver : DisplayDriver<OpenId
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        settings.Authority = !string.IsNullOrEmpty(model.Authority) ? new Uri(model.Authority, UriKind.Absolute) : null;
+        var hasAuthority = !string.IsNullOrEmpty(model.Authority);
+
+        settings.Authority = hasAuthority ? new Uri(model.Authority, UriKind.Absolute) : null;
         settings.MetadataAddress = !string.IsNullOrEmpty(model.MetadataAddress) ? new Uri(model.MetadataAddress, UriKind.Absolute) : null;
         settings.Audience = model.Audience?.Trim();
         settings.DisableTokenTypeValidation = model.DisableTokenTypeValidation;
         settings.Tenant = model.Tenant;
 
-        if (string.IsNullOrEmpty(model.Tenant))
-        {
-            if (string.IsNullOrEmpty(model.Authority))
-            {
-                context.Updater.ModelState.AddModelError(Prefix, nameof(model.Tenant), S["A tenant or authority value is required."]);
-            }
-        }
-        else if (!_shellHost.TryGetShellContext(model.Tenant, out var shellContext) || !shellContext.Settings.IsRunning())
+        if (!string.IsNullOrEmpty(model.Tenant) && 
+        (!_shellHost.TryGetShellContext(model.Tenant, out var shellContext) || !shellContext.Settings.IsRunning()))
         {
             context.Updater.ModelState.AddModelError(Prefix, nameof(model.Tenant), S["Invalid tenant value."]);
+        } 
+        else if (!hasAuthority)
+        {
+            context.Updater.ModelState.AddModelError(Prefix, nameof(model.Authority), S["A tenant or authority value is required."]);
         }
 
         return await EditAsync(settings, context);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
@@ -72,7 +72,10 @@ public sealed class OpenIdValidationSettingsDisplayDriver : DisplayDriver<OpenId
 
         if (string.IsNullOrWhiteSpace(model.Tenant))
         {
-            context.Updater.ModelState.AddModelError(Prefix, nameof(model.Tenant), S["tenant is a required value"]);
+            if (string.IsNullOrWhiteSpace(model.Authority))
+            {
+                context.Updater.ModelState.AddModelError(Prefix, nameof(model.Tenant), S["A tenant or authority value is required."]);
+            }
         }
         else if (!_shellHost.TryGetShellContext(model.Tenant, out var shellContext) || !shellContext.Settings.IsRunning())
         {


### PR DESCRIPTION
Fix #17233. Now one of tenant or authority is required. Tenant can be empty when an external authority validates tokens.
Error is displayed on save only if both tenant and authority fields are not filled out