### PR TITLE
Set ContentType in Facebook script Middleware

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Facebook/ScriptsMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/ScriptsMiddleware.cs
@@ -52,6 +52,7 @@ public class ScriptsMiddleware
             if (script != null)
             {
                 var bytes = Encoding.UTF8.GetBytes(script);
+                httpContext.Response.ContentType = "text/javascript";
                 await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(script).AsMemory(0, bytes.Length), httpContext.RequestAborted);
 
                 return;


### PR DESCRIPTION
Set ContentType to "text/javascript" when returning facebook scripts

Fixes #17286
