### PR TITLE
Fix PDF FileStream reading bug

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media.Indexing.Pdf/Services/PdfMediaFileTextProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Indexing.Pdf/Services/PdfMediaFileTextProvider.cs
@@ -16,7 +16,7 @@ public class PdfMediaFileTextProvider : IMediaFileTextProvider
         {
             if (!fileStream.CanSeek)
             {
-                seekableStream = new FileStream(Path.GetTempFileName(), FileMode.OpenOrCreate, FileAccess.Write, FileShare.None, 4096, FileOptions.DeleteOnClose);
+                seekableStream = new FileStream(Path.GetTempFileName(), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose);
 
                 await fileStream.CopyToAsync(seekableStream);
 


### PR DESCRIPTION
Fixes #[17291](https://github.com/OrchardCMS/OrchardCore/issues/17291) by specifying that both `Read` and `Write` access are needed on the `FileStream` used for reading PDF files.  This bug was observed when indexing PDFs stored in Azure Blog Storage.