### PR TITLE
Remove erroneous warning

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADSettingsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADSettingsConfiguration.cs
@@ -9,14 +9,10 @@ namespace OrchardCore.Microsoft.Authentication.Configuration;
 public sealed class AzureADSettingsConfiguration : IConfigureOptions<AzureADSettings>
 {
     private readonly IAzureADService _azureADService;
-    private readonly ILogger _logger;
 
-    public AzureADSettingsConfiguration(
-        IAzureADService azureADService,
-        ILogger<AzureADSettingsConfiguration> logger)
+    public AzureADSettingsConfiguration(IAzureADService azureADService)
     {
         _azureADService = azureADService;
-        _logger = logger;
     }
 
     public void Configure(AzureADSettings options)

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADSettingsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADSettingsConfiguration.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using OrchardCore.Environment.Shell;
 using OrchardCore.Microsoft.Authentication.Services;
 using OrchardCore.Microsoft.Authentication.Settings;
 
@@ -10,16 +9,13 @@ namespace OrchardCore.Microsoft.Authentication.Configuration;
 public sealed class AzureADSettingsConfiguration : IConfigureOptions<AzureADSettings>
 {
     private readonly IAzureADService _azureADService;
-    private readonly ShellSettings _shellSettings;
     private readonly ILogger _logger;
 
     public AzureADSettingsConfiguration(
         IAzureADService azureADService,
-        ShellSettings shellSettings,
         ILogger<AzureADSettingsConfiguration> logger)
     {
         _azureADService = azureADService;
-        _shellSettings = shellSettings;
         _logger = logger;
     }
 
@@ -45,11 +41,6 @@ public sealed class AzureADSettingsConfiguration : IConfigureOptions<AzureADSett
 
         if (_azureADService.ValidateSettings(settings).Any(result => result != ValidationResult.Success))
         {
-            if (_shellSettings.IsRunning())
-            {
-                _logger.LogWarning("The AzureAD Authentication is not correctly configured.");
-            }
-
             return null;
         }
 


### PR DESCRIPTION
Fix #14050. There is already a correct warning for no configuration [here](https://github.com/OrchardCMS/OrchardCore/blob/f59c1be09e4da1e45c99b147d14ff5b283eab9a0/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Configuration/AzureADOptionsConfiguration.cs#L36-L43).