### PR TITLE
Temporarily downgrading GitHub Actions workflows to run on ubuntu-2204 until ubuntu-latest issues are resolved (Lombiq Technologies: OCORE-219)

### DIFF
--- a/.github/workflows/assets_validation.yml
+++ b/.github/workflows/assets_validation.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test-npm-build:
     name: Test building assets
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Rebuild packages

--- a/.github/workflows/assets_validation.yml
+++ b/.github/workflows/assets_validation.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test-npm-build:
     name: Test building assets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
     - uses: actions/checkout@v4
     - name: Rebuild packages

--- a/.github/workflows/close_stale_prs_issues.yml
+++ b/.github/workflows/close_stale_prs_issues.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   close-stale-prs-issues:
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/close_stale_prs_issues.yml
+++ b/.github/workflows/close_stale_prs_issues.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   close-stale-prs-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/comment_issue_on_triage.yml
+++ b/.github/workflows/comment_issue_on_triage.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   comment-issue-on-triage:
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
     # Despite the trigger being called "issues", this would still run for setting the milestone of PRs too.

--- a/.github/workflows/comment_issue_on_triage.yml
+++ b/.github/workflows/comment_issue_on_triage.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   comment-issue-on-triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     permissions:
       issues: write
     # Despite the trigger being called "issues", this would still run for setting the milestone of PRs too.

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   generate-community-metrics:
     name: Generate Community Metrics
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
     - name: Get Dates For Last Month
       shell: pwsh

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   generate-community-metrics:
     name: Generate Community Metrics
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
     - name: Get Dates For Last Month
       shell: pwsh

--- a/.github/workflows/contributor_map.yml
+++ b/.github/workflows/contributor_map.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-contributor-map:
     name: Update Contributor Map
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     
     steps:
       - name: Update Contributor Map

--- a/.github/workflows/contributor_map.yml
+++ b/.github/workflows/contributor_map.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-contributor-map:
     name: Update Contributor Map
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     
     steps:
       - name: Update Contributor Map

--- a/.github/workflows/docs_validation.yml
+++ b/.github/workflows/docs_validation.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   validate-building-documentation:
     name: Validating Building the Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/docs_validation.yml
+++ b/.github/workflows/docs_validation.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   validate-building-documentation:
     name: Validating Building the Documentation
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/first_time_contributor.yml
+++ b/.github/workflows/first_time_contributor.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   first-time-contributor-welcome:
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     steps:
     # We don't use the actions/first-interaction action because it can't reference the author, nor can it comment after
     # PR merge.

--- a/.github/workflows/first_time_contributor.yml
+++ b/.github/workflows/first_time_contributor.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   first-time-contributor-welcome:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     steps:
     # We don't use the actions/first-interaction action because it can't reference the author, nor can it comment after
     # PR merge.

--- a/.github/workflows/functional_all_db.yml
+++ b/.github/workflows/functional_all_db.yml
@@ -29,7 +29,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     container:
       image: cypress/included:13.17.0
     steps:
@@ -59,7 +59,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     container:
       image: cypress/included:13.17.0
     env:
@@ -90,7 +90,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     container:
       image: cypress/included:13.17.0
     services:
@@ -136,7 +136,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     container:
       image: cypress/included:13.17.0
     services:
@@ -178,7 +178,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     container:
       image: cypress/included:13.17.0
     services:

--- a/.github/workflows/functional_all_db.yml
+++ b/.github/workflows/functional_all_db.yml
@@ -29,7 +29,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     container:
       image: cypress/included:13.17.0
     steps:
@@ -59,7 +59,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     container:
       image: cypress/included:13.17.0
     env:
@@ -90,7 +90,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     container:
       image: cypress/included:13.17.0
     services:
@@ -136,7 +136,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     container:
       image: cypress/included:13.17.0
     services:
@@ -178,7 +178,7 @@ jobs:
         github.event_name == 'push' ||
         github.event.review.state == 'APPROVED' ||
         github.event.review.state == 'CHANGES_REQUESTED'
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     container:
       image: cypress/included:13.17.0
     services:

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-2204, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -38,14 +38,14 @@ jobs:
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 
     - name: Functional Tests
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-2204'
       run: |
         cd test/OrchardCore.Tests.Functional
         npm install
         npm run cms:test
         npm run mvc:test
     - uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-latest' && failure()
+      if: matrix.os == 'ubuntu-2204' && failure()
       with:
         name: Functional Test failure
         path: |

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-2204, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -38,14 +38,14 @@ jobs:
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 
     - name: Functional Tests
-      if: matrix.os == 'ubuntu-2204'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         cd test/OrchardCore.Tests.Functional
         npm install
         npm run cms:test
         npm run mvc:test
     - uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-2204' && failure()
+      if: matrix.os == 'ubuntu-22.04' && failure()
       with:
         name: Functional Test failure
         path: |

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-2204, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
     name: Build & Test
     steps:
     - uses: actions/checkout@v4
@@ -35,14 +35,14 @@ jobs:
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
     - name: Functional Tests
-      if: matrix.os == 'ubuntu-2204'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         cd test/OrchardCore.Tests.Functional
         npm install
         npm run cms:test
         npm run mvc:test
     - uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-2204' && failure()
+      if: matrix.os == 'ubuntu-22.04' && failure()
       with:
         name: functional-test-failure
         path: |

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-2204, windows-latest]
     name: Build & Test
     steps:
     - uses: actions/checkout@v4
@@ -35,14 +35,14 @@ jobs:
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj
     - name: Functional Tests
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-2204'
       run: |
         cd test/OrchardCore.Tests.Functional
         npm install
         npm run cms:test
         npm run mvc:test
     - uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-latest' && failure()
+      if: matrix.os == 'ubuntu-2204' && failure()
       with:
         name: functional-test-failure
         path: |

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -9,7 +9,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     name: Build, Test, Deploy
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -9,7 +9,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   test:
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     name: Build, Test, Deploy
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-2204, windows-latest]
     steps:
     - name: Get the version
       id: get_version
@@ -37,7 +37,7 @@ jobs:
       with:
         dotnet-version: '9.0.x'
     - name: Set build number 
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-2204'
       run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 15471 ))" >> $GITHUB_ENV
     - name: Build
       # NuGetAudit is intentionally not disabled here like it is for other CI builds, because we need to address any
@@ -48,35 +48,35 @@ jobs:
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 
     - name: Functional Tests
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-2204'
       run: |
         cd test/OrchardCore.Tests.Functional
         npm install
         npm run cms:test
         npm run mvc:test
     - uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-latest' && failure()
+      if: matrix.os == 'ubuntu-2204' && failure()
       with:
         name: Functional Test failure
         path: |
           test/OrchardCore.Tests.Functional/cms-tests/cypress/screenshots
           src/OrchardCore.Cms.Web/App_Data_Tests/logs
     - name: Deploy release NuGet packages
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-2204'
       run: |
         dotnet pack -c Release --no-build -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false
         dotnet nuget push './src/**/*.nupkg' -t 600 -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
     - name: Set up Docker Buildx
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-2204'
       uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-2204'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: Deploy release docker images
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-2204'
       shell: pwsh
       run: |
         Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse | Remove-Item -Recurse -Confirm:$false

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-2204, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
     steps:
     - name: Get the version
       id: get_version
@@ -37,7 +37,7 @@ jobs:
       with:
         dotnet-version: '9.0.x'
     - name: Set build number 
-      if: matrix.os == 'ubuntu-2204'
+      if: matrix.os == 'ubuntu-22.04'
       run: echo "BuildNumber=$(( $GITHUB_RUN_NUMBER + 15471 ))" >> $GITHUB_ENV
     - name: Build
       # NuGetAudit is intentionally not disabled here like it is for other CI builds, because we need to address any
@@ -48,35 +48,35 @@ jobs:
       run: |
         dotnet test -c Release --no-build ./test/OrchardCore.Tests/OrchardCore.Tests.csproj 
     - name: Functional Tests
-      if: matrix.os == 'ubuntu-2204'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         cd test/OrchardCore.Tests.Functional
         npm install
         npm run cms:test
         npm run mvc:test
     - uses: actions/upload-artifact@v4
-      if: matrix.os == 'ubuntu-2204' && failure()
+      if: matrix.os == 'ubuntu-22.04' && failure()
       with:
         name: Functional Test failure
         path: |
           test/OrchardCore.Tests.Functional/cms-tests/cypress/screenshots
           src/OrchardCore.Cms.Web/App_Data_Tests/logs
     - name: Deploy release NuGet packages
-      if: matrix.os == 'ubuntu-2204'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         dotnet pack -c Release --no-build -p:Version=${{ steps.get_version.outputs.VERSION }} -p:TreatWarningsAsErrors=false
         dotnet nuget push './src/**/*.nupkg' -t 600 -k ${{secrets.NUGET_API_KEY}} -s https://api.nuget.org/v3/index.json --skip-duplicate
     - name: Set up Docker Buildx
-      if: matrix.os == 'ubuntu-2204'
+      if: matrix.os == 'ubuntu-22.04'
       uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub
-      if: matrix.os == 'ubuntu-2204'
+      if: matrix.os == 'ubuntu-22.04'
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: Deploy release docker images
-      if: matrix.os == 'ubuntu-2204'
+      if: matrix.os == 'ubuntu-22.04'
       shell: pwsh
       run: |
         Get-ChildItem ./src/OrchardCore.Cms.Web/App_Data -Recurse | Remove-Item -Recurse -Confirm:$false

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   validate-pull-request:
     name: Validate Pull Request
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-2204
     timeout-minutes: 3
     steps:
       - name: Check for Merge Conflict in PR

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   validate-pull-request:
     name: Validate Pull Request
-    runs-on: ubuntu-2204
+    runs-on: ubuntu-22.04
     timeout-minutes: 3
     steps:
       - name: Check for Merge Conflict in PR

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -1,6 +1,6 @@
 # Orchard Core
 
-Orchard Core is an open-source, modular, multi-tenant application framework and CMS for ASP.NET Core. It's a redevelopment of [Orchard CMS](https://github.com/OrchardCMS/Orchard) on [ASP.NET Core](https://docs.microsoft.com/aspnet/core/). 
+Orchard Core is an open-source, modular, multi-tenant application framework and CMS for ASP.NET Core. It's a redevelopment of [Orchard CMS](https://github.com/OrchardCMS/Orchard) on [ASP.NET Core](https://docs.microsoft.com/aspnet/core/)?
 
 Orchard Core consists of two different targets:
 


### PR DESCRIPTION
See https://github.com/OrchardCMS/OrchardCore/issues/17311 but this is not a final fix yet.