### PR TITLE
Fix implicit HomeRoute dependency in Autoroute

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Manifest.cs
@@ -5,6 +5,10 @@ using OrchardCore.Modules.Manifest;
     Author = ManifestConstants.OrchardCoreTeam,
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
-    Dependencies = ["OrchardCore.ContentTypes", "OrchardCore.HomeRoute"],
+    Dependencies =
+    [
+        "OrchardCore.ContentTypes", 
+        "OrchardCore.HomeRoute",
+    ],
     Category = "Navigation"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Manifest.cs
@@ -5,10 +5,6 @@ using OrchardCore.Modules.Manifest;
     Author = ManifestConstants.OrchardCoreTeam,
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
-    Dependencies = [
-        "OrchardCore.ContentTypes",
-        "OrchardCore.HomeRoute",
-    ],
-
+    Dependencies = ["OrchardCore.ContentTypes", "OrchardCore.HomeRoute"],
     Category = "Navigation"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Manifest.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Manifest.cs
@@ -5,6 +5,10 @@ using OrchardCore.Modules.Manifest;
     Author = ManifestConstants.OrchardCoreTeam,
     Website = ManifestConstants.OrchardCoreWebsite,
     Version = ManifestConstants.OrchardCoreVersion,
-    Dependencies = ["OrchardCore.ContentTypes"],
+    Dependencies = [
+        "OrchardCore.ContentTypes",
+        "OrchardCore.HomeRoute",
+    ],
+
     Category = "Navigation"
 )]

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs
@@ -9,7 +9,7 @@ public static class AutoroutePartExtensions
     {
         if (autoroute.Path == "/")
         {
-            yield return new ValidationResult(S["Your permalink can't be set to the homepage, please use the homepage feature instead."], new[] { nameof(autoroute.Path) });
+            yield return new ValidationResult(S["Your permalink can't be set to the homepage, please use the homepage option instead."], new[] { nameof(autoroute.Path) });
         }
 
         if (HasInvalidCharacters(autoroute.Path))

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Models/AutoroutePartExtensions.cs
@@ -9,7 +9,7 @@ public static class AutoroutePartExtensions
     {
         if (autoroute.Path == "/")
         {
-            yield return new ValidationResult(S["Your permalink can't be set to the homepage, please use the homepage option instead."], new[] { nameof(autoroute.Path) });
+            yield return new ValidationResult(S["Your permalink can't be set to the homepage, please use the homepage feature instead."], new[] { nameof(autoroute.Path) });
         }
 
         if (HasInvalidCharacters(autoroute.Path))


### PR DESCRIPTION
Fix #17244

Changes:
- **Add HomeRoute dependency to Autoroute**
- **Update admin message wording**

The Autoroute was written such that it assumes the home route feature is enabled. This PR makes that assumption an explicit dependency.