### PR TITLE
Added documentation for fields with alternate display modes.

### DIFF
--- a/src/docs/reference/modules/Placement/README.md
+++ b/src/docs/reference/modules/Placement/README.md
@@ -94,6 +94,24 @@ It is built using the `Part` it's contained in, and the name of the `Field`.
 For instance, if a field named `MyField` would be added to an `Article` content type, its differentiator would be `Article-MyField`.  
 If a field named `City` was added to an `Address` part then its differentiator would be `Address-City`.
 
+### Field Display Models
+
+The placement rules are stricter for non-standard display modes.
+
+1. The Shape must include the display type. For example `TextField_Display`.
+2. You must use the full differentiator. `[ContentPart]-[ContentField]_[DisplayType]__[DisplayMode]`. For a field named MyField on the Content Type Blog the differentiator is `Blog-MyField-TextField_Display__Header`.
+
+```json
+{
+  "TextField_Display"" [
+    {
+      "place": Content:1",
+      "differentiator": "Blog-MyField-TextField_Display__Header"
+    }
+  ]
+}
+```
+
 ## Shape differentiators
 
 You can find information about shape differentiators in the [Templates documentation](../../modules/Templates/README.md#content-field-differentiator)

--- a/src/docs/reference/modules/Placement/README.md
+++ b/src/docs/reference/modules/Placement/README.md
@@ -103,9 +103,9 @@ The placement rules are stricter for non-standard display modes.
 
 ```json
 {
-  "TextField_Display"" [
+  "TextField_Display": [
     {
-      "place": Content:1",
+      "place": "Content:1",
       "differentiator": "Blog-MyField-TextField_Display__Header"
     }
   ]

--- a/src/docs/reference/modules/Placement/README.md
+++ b/src/docs/reference/modules/Placement/README.md
@@ -94,7 +94,7 @@ It is built using the `Part` it's contained in, and the name of the `Field`.
 For instance, if a field named `MyField` would be added to an `Article` content type, its differentiator would be `Article-MyField`.  
 If a field named `City` was added to an `Address` part then its differentiator would be `Address-City`.
 
-### Field Display Models
+### Field Display Modes
 
 The placement rules are stricter for non-standard display modes.
 


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

The requirements for using the placement module or the placement.json file is stricter when using a content field with a display mode other than standard. I updated the documentation to include the rules as I understand them. 

Fix #17328