### PR TITLE
Simplify the Login and LoginForm views.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/Login.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/Account/Login.cshtml
@@ -1,20 +1,14 @@
 @using Microsoft.AspNetCore.Identity
-@using OrchardCore.DisplayManagement.ModelBinding
-@using OrchardCore.Entities
-@using OrchardCore.Settings
-@using OrchardCore.Users
 @using OrchardCore.Users.Models
 
 @inject SignInManager<IUser> SignInManager
-@inject UserManager<IUser> UserManager
-@inject IDisplayManager<LoginForm> LoginFormDisplayManager
-@inject IUpdateModelAccessor UpdateModelAccessor
 
 @{
     ViewLayout = "Layout__Login";
 
-    var loginProviders = (await SignInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+    var loginProviders = await SignInManager.GetExternalAuthenticationSchemesAsync();
     var disableLocalLogin = Site.As<LoginSettings>().DisableLocalLogin;
+    var hasExternalProviders = loginProviders.Any();
 }
 
 <script asp-name="font-awesome" at="Foot" version="6"></script>
@@ -29,12 +23,15 @@
 
     @if (!disableLocalLogin)
     {
-        <div class="col-md-6 @(loginProviders.Count == 0 ? "offset-md-3" : string.Empty)">
+        <div class="col-md-6 @(!hasExternalProviders ? "offset-md-3" : string.Empty)">
+            <h1 class="fs-4">@T["Log in"]</h1>
+            <hr />
+
             @await DisplayAsync(Model)
         </div>
     }
 
-    @if (loginProviders.Count > 0)
+    @if (hasExternalProviders)
     {
         <div class="col-md-6 @(disableLocalLogin ? "offset-md-3" : string.Empty)">
             <section>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/LoginForm.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/LoginForm.Edit.cshtml
@@ -1,4 +1,4 @@
-<form asp-controller="Account" asp-action="Login" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="auth-form no-multisubmit">
+<form asp-controller="Account" asp-action="Login" asp-area="OrchardCore.Users" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="auth-form no-multisubmit">
 
     @if (Model.Content != null)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/LoginForm.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/LoginForm.Edit.cshtml
@@ -1,7 +1,4 @@
-
 <form asp-controller="Account" asp-action="Login" asp-route-returnurl="@ViewData["ReturnUrl"]" method="post" class="auth-form no-multisubmit">
-    <h1 class="fs-4">@T["Log in"]</h1>
-    <hr />
 
     @if (Model.Content != null)
     {

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -102,6 +102,17 @@ will return `false` for administrators, even though they still have full access.
 {% assign isAuthorized = User | has_permission: "AccessAdminPanel" %}
 ```
 
+#### LoginForm_Edit Shape Type Modification
+
+To simplify the `LoginForm.Edit.cshtml` view, the following code has been moved to `Views/Account/Login.cshtml`:
+
+```html
+<h1 class="fs-4">@T["Log in"]</h1>
+<hr />
+```
+
+If you are overriding the `Views/Account/Login.cshtml` view, you may want to add the above code to your custom version for consistency.
+
 ### ReCaptcha
 
 In the previous implementation, the ReCaptcha module supported two modes: `AlwaysShow` and `PreventRobots`. To simplify the module and enhance integration, the `PreventRobots` mode and its related components have been removed. Going forward, **only the `AlwaysShow` mode** will be supported.


### PR DESCRIPTION
Keeping LoginForm.Edit.cshtml to minimal since the Login.cshtml is defining the structure. This allows a user to override everything they need in the Login.cshtml including removing the form headline. 

Also, remove unnecessary injections.