### PR TITLE
Allow ExecuteAfterEndOfRequestAsync to accept arguments

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
@@ -25,10 +25,12 @@ public static class HttpBackgroundJob
 
         // Can't be executed outside of an http context.
         var httpContextAccessor = scope.ServiceProvider.GetRequiredService<IHttpContextAccessor>();
+
         if (httpContextAccessor.HttpContext == null)
         {
             return Task.CompletedTask;
         }
+
         // Record the current logged in user.
         var userPrincipal = httpContextAccessor.HttpContext.User.Clone();
 
@@ -41,6 +43,7 @@ public static class HttpBackgroundJob
             while (httpContextAccessor.HttpContext != null)
             {
                 await Task.Delay(1_000);
+
                 if (timeoutTask.IsCompleted)
                 {
                     return;
@@ -59,12 +62,14 @@ public static class HttpBackgroundJob
 
             // Create a new 'HttpContext' to be used in the background.
             httpContextAccessor.HttpContext = shellContext.CreateHttpContext();
+
             // Restore the current user.
             httpContextAccessor.HttpContext.User = userPrincipal;
 
             // Here the 'IActionContextAccessor.ActionContext' need to be cleared, this 'AsyncLocal'
             // field is not cleared by 'AspnetCore' and still references the previous 'HttpContext'.
             var actionContextAccessor = scope.ServiceProvider.GetService<IActionContextAccessor>();
+
             if (actionContextAccessor is not null)
             {
                 // Clear the stale 'ActionContext' that may be used e.g.
@@ -76,6 +81,7 @@ public static class HttpBackgroundJob
             await ShellScope.UsingChildScopeAsync(async scope =>
             {
                 var logger = scope.ServiceProvider.GetRequiredService<ILogger<ShellScope>>();
+
                 try
                 {
                     await job(scope);
@@ -101,47 +107,35 @@ public static class HttpBackgroundJob
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync(string jobName, Func<ShellScope, Task> job)
-    {
-        return ExecuteAfterEndOfRequestInternalAsync(jobName, job);
-    }
+        => ExecuteAfterEndOfRequestInternalAsync(jobName, job);
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1>(string jobName, T1 item1, Func<ShellScope, T1, Task> job)
-    {
-        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1));
-    }
+        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1));
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1, T2>(string jobName, T1 item1, T2 item2, Func<ShellScope, T1, T2, Task> job)
-    {
-        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2));
-    }
+        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2));
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3>(string jobName, T1 item1, T2 item2, T3 item3, Func<ShellScope, T1, T2, T3, Task> job)
-    {
-        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3));
-    }
+        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3));
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3, T4>(string jobName, T1 item1, T2 item2, T3 item3, T4 item4, Func<ShellScope, T1, T2, T3, T4, Task> job)
-    {
-        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3, item4));
-    }
+        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3, item4));
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3, T4, T5>(string jobName, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, Func<ShellScope, T1, T2, T3, T4, T5, Task> job)
-    {
-        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3, item4, item5));
-    }
+        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3, item4, item5));
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
@@ -13,7 +13,7 @@ public static class HttpBackgroundJob
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
-    public static Task ExecuteAfterEndOfRequestAsync(string jobName, Func<ShellScope, Task> job)
+    private static Task ExecuteAfterEndOfRequestInternalAsync(string jobName, Func<ShellScope, Task> job)
     {
         var scope = ShellScope.Current;
 
@@ -95,5 +95,53 @@ public static class HttpBackgroundJob
         });
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
+    /// </summary>
+    public static Task ExecuteAfterEndOfRequestAsync(string jobName, Func<ShellScope, Task> job)
+    {
+        return ExecuteAfterEndOfRequestInternalAsync(jobName, job);
+    }
+
+    /// <summary>
+    /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
+    /// </summary>
+    public static Task ExecuteAfterEndOfRequestAsync<T1>(string jobName, T1 item1, Func<ShellScope, T1, Task> job)
+    {
+        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1));
+    }
+
+    /// <summary>
+    /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
+    /// </summary>
+    public static Task ExecuteAfterEndOfRequestAsync<T1, T2>(string jobName, T1 item1, T2 item2, Func<ShellScope, T1, T2, Task> job)
+    {
+        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2));
+    }
+
+    /// <summary>
+    /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
+    /// </summary>
+    public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3>(string jobName, T1 item1, T2 item2, T3 item3, Func<ShellScope, T1, T2, T3, Task> job)
+    {
+        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3));
+    }
+
+    /// <summary>
+    /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
+    /// </summary>
+    public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3, T4>(string jobName, T1 item1, T2 item2, T3 item3, T4 item4, Func<ShellScope, T1, T2, T3, T4, Task> job)
+    {
+        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3, item4));
+    }
+
+    /// <summary>
+    /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
+    /// </summary>
+    public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3, T4, T5>(string jobName, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, Func<ShellScope, T1, T2, T3, T4, T5, Task> job)
+    {
+        return ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3, item4, item5));
     }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
@@ -13,7 +13,7 @@ public static class HttpBackgroundJob
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
-    private static Task ExecuteAfterEndOfRequestInternalAsync(string jobName, Func<ShellScope, Task> job)
+    public static Task ExecuteAfterEndOfRequestAsync(string jobName, Func<ShellScope, Task> job)
     {
         var scope = ShellScope.Current;
 
@@ -106,36 +106,30 @@ public static class HttpBackgroundJob
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
-    public static Task ExecuteAfterEndOfRequestAsync(string jobName, Func<ShellScope, Task> job)
-        => ExecuteAfterEndOfRequestInternalAsync(jobName, job);
-
-    /// <summary>
-    /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
-    /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1>(string jobName, T1 item1, Func<ShellScope, T1, Task> job)
-        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1));
+        => ExecuteAfterEndOfRequestAsync(jobName, scope => job(scope, item1));
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1, T2>(string jobName, T1 item1, T2 item2, Func<ShellScope, T1, T2, Task> job)
-        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2));
+        => ExecuteAfterEndOfRequestAsync(jobName, scope => job(scope, item1, item2));
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3>(string jobName, T1 item1, T2 item2, T3 item3, Func<ShellScope, T1, T2, T3, Task> job)
-        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3));
+        => ExecuteAfterEndOfRequestAsync(jobName, scope => job(scope, item1, item2, item3));
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3, T4>(string jobName, T1 item1, T2 item2, T3 item3, T4 item4, Func<ShellScope, T1, T2, T3, T4, Task> job)
-        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3, item4));
+        => ExecuteAfterEndOfRequestAsync(jobName, scope => job(scope, item1, item2, item3, item4));
 
     /// <summary>
     /// Executes a background job in an isolated <see cref="ShellScope"/> after the current HTTP request is completed.
     /// </summary>
     public static Task ExecuteAfterEndOfRequestAsync<T1, T2, T3, T4, T5>(string jobName, T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, Func<ShellScope, T1, T2, T3, T4, T5, Task> job)
-        => ExecuteAfterEndOfRequestInternalAsync(jobName, scope => job(scope, item1, item2, item3, item4, item5));
+        => ExecuteAfterEndOfRequestAsync(jobName, scope => job(scope, item1, item2, item3, item4, item5));
 }


### PR DESCRIPTION
This will make it easier to pass object into the background task when calling it
