### PR TITLE
Improve handling of publish/unpublish operations

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -469,13 +469,23 @@ public sealed class AdminController : Controller, IUpdateModel
 
         return await EditPOST(contentItemId, returnUrl, stayOnSamePage, async contentItem =>
         {
-            await _contentManager.PublishAsync(contentItem);
+            var published = await _contentManager.PublishAsync(contentItem);
 
             var typeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
 
-            await _notifier.SuccessAsync(string.IsNullOrWhiteSpace(typeDefinition?.DisplayName)
+            if (published)
+            {
+                await _notifier.SuccessAsync(string.IsNullOrWhiteSpace(typeDefinition?.DisplayName)
                 ? H["Your content has been published."]
                 : H["Your {0} has been published.", typeDefinition.DisplayName]);
+            }
+            else
+            {
+                await _notifier.ErrorAsync(string.IsNullOrWhiteSpace(typeDefinition?.DisplayName)
+                ? H["Your content could not be published."]
+                : H["Your {0} could not be published.", typeDefinition.DisplayName]);
+
+            }
         });
     }
 
@@ -585,17 +595,32 @@ public sealed class AdminController : Controller, IUpdateModel
             return Forbid();
         }
 
-        await _contentManager.PublishAsync(contentItem);
+        var published = await _contentManager.PublishAsync(contentItem);
 
         var typeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
 
-        if (string.IsNullOrEmpty(typeDefinition?.DisplayName))
+        if (published)
         {
-            await _notifier.SuccessAsync(H["That content has been published."]);
+            if (string.IsNullOrEmpty(typeDefinition?.DisplayName))
+            {
+                await _notifier.SuccessAsync(H["That content has been published."]);
+            }
+            else
+            {
+                await _notifier.SuccessAsync(H["That {0} has been published.", typeDefinition.DisplayName]);
+            }
         }
         else
         {
-            await _notifier.SuccessAsync(H["That {0} has been published.", typeDefinition.DisplayName]);
+            if (string.IsNullOrEmpty(typeDefinition?.DisplayName))
+            {
+                await _notifier.ErrorAsync(H["That content could not be published."]);
+            }
+            else
+            {
+                await _notifier.ErrorAsync(H["That {0} could not be published.", typeDefinition.DisplayName]);
+            }
+
         }
 
         return Url.IsLocalUrl(returnUrl)
@@ -618,17 +643,32 @@ public sealed class AdminController : Controller, IUpdateModel
             return Forbid();
         }
 
-        await _contentManager.UnpublishAsync(contentItem);
+        var unpublished = await _contentManager.UnpublishAsync(contentItem);
 
         var typeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
 
-        if (string.IsNullOrEmpty(typeDefinition?.DisplayName))
+        if (unpublished)
         {
-            await _notifier.SuccessAsync(H["The content has been unpublished."]);
+            if (string.IsNullOrEmpty(typeDefinition?.DisplayName))
+            {
+                await _notifier.SuccessAsync(H["The content has been unpublished."]);
+            }
+            else
+            {
+                await _notifier.SuccessAsync(H["The {0} has been unpublished.", typeDefinition.DisplayName]);
+            }
         }
         else
         {
-            await _notifier.SuccessAsync(H["The {0} has been unpublished.", typeDefinition.DisplayName]);
+            if (string.IsNullOrEmpty(typeDefinition?.DisplayName))
+            {
+                await _notifier.ErrorAsync(H["The content could not be unpublished."]);
+            }
+            else
+            {
+                await _notifier.ErrorAsync(H["The {0} could not be unpublished.", typeDefinition.DisplayName]);
+            }
+
         }
 
         return Url.IsLocalUrl(returnUrl)

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs
@@ -120,9 +120,9 @@ public interface IContentManager
     /// <param name="contentItem"></param>
     Task SaveDraftAsync(ContentItem contentItem);
 
-    Task PublishAsync(ContentItem contentItem);
+    Task<bool> PublishAsync(ContentItem contentItem);
 
-    Task UnpublishAsync(ContentItem contentItem);
+    Task<bool> UnpublishAsync(ContentItem contentItem);
 
     Task<TAspect> PopulateAspectAsync<TAspect>(IContent content, TAspect aspect);
 


### PR DESCRIPTION
This pull request introduces changes to the content publishing and unpublishing functionality in the `OrchardCore.Contents` module. The key changes involve updating the methods to return a boolean indicating success or failure and adding user notifications based on the outcome.

### Updates to Publishing and Unpublishing Methods:

* [`src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs`](diffhunk://#diff-dbf2e5525d7b715b1f1c76eab994aad3ddac64134a5dc985291b665271b9d1d2L472-R488): Updated `EditAndPublishPOST`, `Publish`, and `Unpublish` methods to check the result of `PublishAsync` and `UnpublishAsync` and provide success or error notifications accordingly. [[1]](diffhunk://#diff-dbf2e5525d7b715b1f1c76eab994aad3ddac64134a5dc985291b665271b9d1d2L472-R488) [[2]](diffhunk://#diff-dbf2e5525d7b715b1f1c76eab994aad3ddac64134a5dc985291b665271b9d1d2L588-R603) [[3]](diffhunk://#diff-dbf2e5525d7b715b1f1c76eab994aad3ddac64134a5dc985291b665271b9d1d2R612-R624) [[4]](diffhunk://#diff-dbf2e5525d7b715b1f1c76eab994aad3ddac64134a5dc985291b665271b9d1d2L621-R651) [[5]](diffhunk://#diff-dbf2e5525d7b715b1f1c76eab994aad3ddac64134a5dc985291b665271b9d1d2R660-R672)

### Interface and Implementation Changes:

* [`src/OrchardCore/OrchardCore.ContentManagement.Abstractions/IContentManager.cs`](diffhunk://#diff-245a0379168aad68fd3ed665c6f7dc7ca61e6366793d8213883fe0b090a53910L123-R125): Modified the `PublishAsync` and `UnpublishAsync` methods in the `IContentManager` interface to return a `Task<bool>` indicating the operation's success.
* [`src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs`](diffhunk://#diff-1b5c6b4526dcd0cee3955493a415917e9192319f76dac2bd880d5845deeb82b2L364-R370): Updated the `PublishAsync` and `UnpublishAsync` methods to return a boolean result and handle cancellation scenarios. [[1]](diffhunk://#diff-1b5c6b4526dcd0cee3955493a415917e9192319f76dac2bd880d5845deeb82b2L364-R370) [[2]](diffhunk://#diff-1b5c6b4526dcd0cee3955493a415917e9192319f76dac2bd880d5845deeb82b2L388-R388) [[3]](diffhunk://#diff-1b5c6b4526dcd0cee3955493a415917e9192319f76dac2bd880d5845deeb82b2R401-R405) [[4]](diffhunk://#diff-1b5c6b4526dcd0cee3955493a415917e9192319f76dac2bd880d5845deeb82b2L428-R430) [[5]](diffhunk://#diff-1b5c6b4526dcd0cee3955493a415917e9192319f76dac2bd880d5845deeb82b2R443-R454)

closes #17440