### PR TITLE
Add safeguards for index names

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexingService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Services/LuceneIndexingService.cs
@@ -5,6 +5,7 @@ using OrchardCore.ContentManagement;
 using OrchardCore.Environment.Shell;
 using OrchardCore.Indexing;
 using OrchardCore.Modules;
+using OrchardCore.Mvc.Utilities;
 using OrchardCore.Search.Lucene.Model;
 using OrchardCore.Settings;
 
@@ -73,6 +74,8 @@ public class LuceneIndexingService
         }
         else
         {
+            EnsureSafeIndexName(indexName);
+
             var settings = await _luceneIndexSettingsService.GetSettingsAsync(indexName);
 
             if (settings == null)
@@ -259,6 +262,8 @@ public class LuceneIndexingService
     /// <returns></returns>
     public Task DeleteIndexAsync(string indexName)
     {
+        EnsureSafeIndexName(indexName);
+
         if (_indexManager.Exists(indexName))
         {
             _indexManager.DeleteIndex(indexName);
@@ -273,6 +278,8 @@ public class LuceneIndexingService
     /// </summary>
     public void ResetIndexAsync(string indexName)
     {
+        EnsureSafeIndexName(indexName);
+
         _indexingState.SetLastTaskId(indexName, 0);
         _indexingState.Update();
     }
@@ -282,6 +289,8 @@ public class LuceneIndexingService
     /// </summary>
     public async Task RebuildIndexAsync(string indexName)
     {
+        EnsureSafeIndexName(indexName);
+
         if (_indexManager.Exists(indexName))
         {
             _indexManager.DeleteIndex(indexName);
@@ -294,4 +303,12 @@ public class LuceneIndexingService
 
     public async Task<LuceneSettings> GetLuceneSettingsAsync()
         => await _siteService.GetSettingsAsync<LuceneSettings>() ?? new LuceneSettings();
+
+    private static void EnsureSafeIndexName(string indexName)
+    {
+        if (indexName.ToSafeName() != indexName)
+        {
+            throw new ArgumentException("Invalid chars found in index name", nameof(indexName));
+        }
+    }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Utilities/StringExtensions.cs
@@ -205,7 +205,7 @@ public static class StringExtensions
     public static string RemoveDiacritics(this string name)
     {
         var stFormD = name.Normalize(NormalizationForm.FormD);
-        var sb = new StringBuilder();
+        using var sb = ZString.CreateStringBuilder();
 
         foreach (var t in stFormD)
         {

--- a/test/OrchardCore.Tests/ContentManagement/Utilities/StringExtensionsTests.cs
+++ b/test/OrchardCore.Tests/ContentManagement/Utilities/StringExtensionsTests.cs
@@ -175,4 +175,50 @@ public class StringExtensionsTests
         // Assert
         Assert.Equal(expected, result);
     }
+
+    [Theory]
+    [InlineData("Hisham Bin Ateya", "HishamBinAteya")]
+    [InlineData("Sébastien Ros", "SebastienRos")]
+    [InlineData("Zoltán Lehóczky", "ZoltanLehoczky")]
+    public void ToSafeName_ShouldRemoveUnsafeChars(string text, string expected)
+    {
+        // Arrange & Act
+        var result = StringExtensions.ToSafeName(text);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("abc  ", "abc")]
+    [InlineData("   abc  ", "abc")]
+    [InlineData("   abc", "abc")]
+    [InlineData("", "")]
+    [InlineData(" ", "")]
+    [InlineData("  ", "")]
+    [InlineData(null, "")]
+    public void ToSafeName_ShouldStripWhiteSpaces(string text, string expected)
+    {
+        // Arrange & Act
+        var result = StringExtensions.ToSafeName(text);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("1abc", "abc")]
+    [InlineData("12abc", "abc")]
+    [InlineData("123abc", "abc")]
+    [InlineData("1abc123", "abc123")]
+    [InlineData("12abc123", "abc123")]
+    [InlineData("123abc123", "abc123")]
+    public void ToSafeName_ShouldRemoveLeadingDigits(string text, string expected)
+    {
+        // Arrange & Act
+        var result = StringExtensions.ToSafeName(text);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
 }


### PR DESCRIPTION
Wanted to be sure we could not find a way to use special chars in an index name to access other locations of the FS. From what I see in the controller it's already handled but added safeguards in the services themselves. Should be cheap for the common case where index names are already safe.

Also noticed some optimizations that could be done with .NET 8 and 9. There are more that can be done in this class, and its twin one in the abstraction project. About that I think we should have these internal so we can change them when we need without having to care about breaking external usages. It's our internal extensions, and to prevent duplication we should have a single file in a shared folder and include it in the projects that require it. External project can copy this file if they need it.