### PR TITLE
Updating release instructions (Lombiq Technologies: OCORE-223)

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -59,11 +59,11 @@ assignees: ''
 - [ ] Create a pull request from the release branch (e.g., `release/2.1.x`) into `main`.
 - [ ] Resolve any merge conflicts using external tools (e.g., Fork) to avoid auto-merging `main` into the release branch. **Important**: DO NOT resolve conflicts using GitHub's interface; that will automatically merge `main` into the release branch, which must be avoided.
 - [ ] Merge the PR if all checks pass. If there are merge conflicts, then you'll need to merge to `main` manually using the following steps:
-  - Fetch the latest changes from the Git repository.
-  - Checkout the `main` branch.
-  - Merge the release branch (e.g., `release/2.1`) into `main` with a merge commit (NOT a squash merge).
-  - Resolve any conflicts.
-  - Push the changes to `main`. This action requires a user with the ability to force-push into `main`, as it is protected by default.
+  1. Fetch the latest changes from the Git repository.
+  2. Checkout the `main` branch.
+  3. Merge the release branch (e.g., `release/2.1.x`) into `main` with a merge commit (NOT a squash merge).
+  4. Resolve any conflicts.
+  5. Push the changes to `main`. This action requires a user with the ability to force-push into `main`, as it is protected by default.
 
 ## Step 6: Housekeeping
 

--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -11,67 +11,70 @@ assignees: ''
 
 ## Step 1: Backporting Pull Requests
 
-1. **Identify Pull Requests**: Review any pull requests (PRs) that need to be backported to the release branch.
-2. **Backporting Process**: For PRs merged into the `main` branch that need to be applied to the release branch (e.g., `release/2.1`), comment on the merged PR with `/backport to release/2.1`. This comment will trigger a GitHub Action to create a new PR with the same changes for the `release/2.1` branch.
-3. **Merge PRs**: Once all necessary PRs are created, merge them into the `release/2.1` branch.
+1. **Identify Pull Requests**: Review any pull requests (PRs) that need to be backported to the release branch. These should be PRs that contain strictly bug fixes and nothing else.
+2. **Backport Pull Requests**: For PRs merged into the `main` branch that need to be applied to the release branch (e.g., `release/2.1.x`), comment on the merged PR with `/backport to release/2.1.x`. This comment will trigger a GitHub Action to create a new PR with the same changes for the `release/2.1.x` branch.
+3. **Merge PRs**: Once all necessary PRs are created, merge them into the `release/2.1.x` branch.
 
 ## Step 2: Code and Documentation Updates
 
-### Create Pull Request:
-
-  - [ ] From the release branch (e.g., `release/2.1`), create a new temporary branch for your release (e.g., `release-notes/2.1.1`).
-  - [ ] Update version references in the documentation. Refer to [this PR](https://github.com/OrchardCMS/OrchardCore/pull/17065/files) for an example. Version Updates Checklist:
-     - **Update `OrchardCore.Commons.props`**: Set `<VersionSuffix></VersionSuffix>` to the new version you're preparing for release.
-     - **Update Module Versions**: Modify `src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ManifestConstants.cs` to reflect the new version.
-     - **Release Notes**: Finalize the release notes in the documentation, including:
-       - Highlights and goals of the release.
-       - Prerequisites for running the new version.
-       - Upgrade steps and any breaking changes.
-     - **Update Documentation Navigation**: Add the release notes page to `mkdocs.yml` navigation and remove it from `not_in_nav`.
-     - **Version Mentions**: Update all references to the new version throughout the documentation, including:
-       - [Status in the root README](https://docs.orchardcore.net/en/latest/#status)
-       - CLI templates and commands.
-       - Relevant guides, such as the [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/) guide.
-  - [ ] Create a **Documentation PR** titled "Release with the new version number" (e.g., `Release 2.1.1`) from the documentation branch (e.g., `release-notes/2.1.1`) into the release branch (e.g., `release/2.1`)
-  - [ ] Merge the Documentation PR.
-  - [ ] In GitHub, manually run the `Preview - CI` workflow on your branch (NOT `main`). This will release a new preview version on CloudSmith for testing.
+- [ ] From the release branch (e.g., `release/2.1.x`), create a new temporary branch for the version (e.g., `release/2.1.1`).
+- [ ] Update version references in the documentation and code. Refer to [this PR](https://github.com/OrchardCMS/OrchardCore/pull/17065/files) for an example. The easiest is to start with a search & replace on the previous version. Version Updates Checklist:
+  - **Update `OrchardCore.Commons.props`**: Set `<VersionSuffix></VersionSuffix>` to the new version you're preparing for release.
+  - **Update Module Versions**: Modify `src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ManifestConstants.cs` to reflect the new version.
+  - **Release Notes**: Finalize the release notes in the documentation, including:
+      - Highlights and goals of the release.
+      - Prerequisites for running the new version.
+      - Upgrade steps and any breaking changes.
+  - **Update Documentation Navigation**: Add the release notes page to `mkdocs.yml` navigation and remove it from `not_in_nav`.
+  - **Version Mentions**: Update all references to the new version throughout the documentation, including:
+    - [Status in the root README](https://docs.orchardcore.net/en/latest/#status)
+    - CLI templates and commands.
+    - Relevant guides, such as the [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/) guide.
+- [ ] Create a **version PR** titled `Release <version number` (e.g., `Release 2.1.1`) from the version branch (e.g., `release/2.1.1`) into the release branch (e.g., `release/2.1.x`)
+- [ ] In GitHub, manually run the `Preview - CI` workflow on your branch (NOT `main`). This will release a new preview version on Cloudsmith for testing.
 
 ## Step 3: Validation
 
-1. **Check Functionality**: Update [`OrchardCore.Samples`](https://github.com/OrchardCMS/OrchardCore.Samples) to the latest preview version generated in the previous step. Ensure the samples work as expected.
-2. **Test Guides**: Test the following guides with NuGet packages from the CloudSmith feed:
-   - [Creating a modular ASP.NET Core application](https://docs.orchardcore.net/en/latest/guides/create-modular-application-mvc/)
-   - [Creating an Orchard Core CMS website](https://docs.orchardcore.net/en/latest/guides/create-cms-application/)
-   - [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/)
+- [ ] **Check Functionality**: Update [`OrchardCore.Samples`](https://github.com/OrchardCMS/OrchardCore.Samples) to the latest preview version generated in the previous step (just change the `OrchardCoreVersion` property in the root `Directory.Build.props` file). Ensure the samples work as expected.
+- [ ] **Test Guides**: Test the following guides with NuGet packages from the Cloudsmith feed:
+  - [Creating a modular ASP.NET Core application](https://docs.orchardcore.net/en/latest/guides/create-modular-application-mvc/)
+  - [Creating an Orchard Core CMS website](https://docs.orchardcore.net/en/latest/guides/create-cms-application/)
+  - [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/)
+- [ ] If everything looks good and all checks pass, merge the version PR.
 
-## Step 4: Create New Release
+## Step 4: Creating the New Release
 
 1. Navigate to the [GitHub Releases page](https://github.com/OrchardCMS/OrchardCore/releases/new).
 2. In the "**Choose a tag**" menu, enter the new version number, including `v` (e.g., `v2.1.1`), and select "**+ Create tag: v... on publish**."
-3. Change the target branch from `main` to your target branch (e.g., `release/2.1`).
+3. Change the target branch from `main` to the release branch (e.g., `release/2.1.x`).
 4. Enter the version number in the Title field (e.g., `2.1.1`).
 5. Click **Generate release notes** to auto-generate release notes.
-6. Ensure the "Set as the latest release" checkbox is checked, then click **Publish release**.
+6. Add a link to the release notes on the docs site: `Check out the full release notes [here](https://docs.orchardcore.net/en/latest/releases/2.1.1/).`
+7. Ensure the "Set as the latest release" checkbox is checked, then click **Publish release**.
 
-## Step 5: Align Branches
+## Step 5: Aligning Branches
 
-1. **Merge to Main**: After releasing the new version, merge the release branch into the main branch to ensure `main` contains all administrative changes.
-   - Create a pull request from the release branch into `main`.
-   - **Important**: DO NOT resolve conflicts using GitHub's interface; use external tools (e.g., Fork) to manage conflicts and avoid auto-merging `main` into the release branch. Resolving conflicts using GitHub's interface will automatically merge `main` into the release branch, which must be avoided.
-   - Once conflicts are resolved, merge the PR into `main` using the following steps:
-     - Fetch the latest changes from the Git repository.
-     - Checkout the `main` branch.
-     - Merge the release branch (e.g., `release/2.1`) into `main`.
-     - Resolve any conflicts.
-     - Force push the changes to `main`. This action requires a user with the ability to force-push into `main`, as it is protected by default.
+**Merge to `main`**: After releasing the new version, merge the release branch into the main branch to ensure `main` contains all administrative changes.
+
+- [ ] Create a pull request from the release branch (e.g., `release/2.1.x`) into `main`.
+- [ ] Resolve any merge conflicts using external tools (e.g., Fork) to avoid auto-merging `main` into the release branch. **Important**: DO NOT resolve conflicts using GitHub's interface; that will automatically merge `main` into the release branch, which must be avoided.
+- [ ] Merge the PR if all checks pass. If there are merge conflicts, then you'll need to merge to `main` manually using the following steps:
+  - Fetch the latest changes from the Git repository.
+  - Checkout the `main` branch.
+  - Merge the release branch (e.g., `release/2.1`) into `main` with a merge commit (NOT a squash merge).
+  - Resolve any conflicts.
+  - Push the changes to `main`. This action requires a user with the ability to force-push into `main`, as it is protected by default.
 
 ## Step 6: Housekeeping
 
-- [ ] Assign the milestone for the release version to this issue.
-- [ ] Close any remaining issues for this version or assign them to the next release.
+- [ ] Assign the milestone for the release version to this issue. Create one if it doesn't exist.
+- [ ] Assign the milestone to the issues that were released in the version.
+- [ ] Close the milestone.
+- [ ] Update [`OrchardCore.Samples`](https://github.com/OrchardCMS/OrchardCore.Samples) to the new released version (just change the `OrchardCoreVersion` property in the root `Directory.Build.props` file).
 
-## Step 7: Publicize the Release
+## Step 7: Publicizing the Release
 
-- [ ] Post about the release on X (formerly Twitter) via the Orchard Core X (Twitter) repo.
+- [ ] Post about the release on X (formerly Twitter) via the [Orchard Core X (Twitter) repo](https://github.com/OrchardCMS/Orchard-Core-X-Twitter).
 - [ ] Post in the [Orchard Core LinkedIn group](https://www.linkedin.com/groups/13605669/).
-- [ ] Share on the [Orchard Core Facebook page](https://www.facebook.com/OrchardCore/).
+- [ ] Post to the [Orchard Core Facebook page](https://www.facebook.com/OrchardCore/).
+- [ ] Send a message to the `#announcements` channel on Discord.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -17,32 +17,36 @@ assignees: ''
 
 ## Step 2: Code and Documentation Updates
 
-- [ ] **Create Release Branch**: Create a new release branch named `release/<version-name-with-out-patch-number>` (e.g., `release/3.0`) from the `main` branch. This branch will serve as the foundation for upcoming patch releases and facilitate versioned updates.
-- [ ] **Check CI Workflow**: Verify that the [release_ci](https://github.com/OrchardCMS/OrchardCore/blob/main/.github/workflows/release_ci.yml) workflow is using the correct .NET version for the release.
-- [ ] **Update Documentation**: Open a new pull request for the following updates:
+- [ ] **Create Release Branch**: Create a new release branch named `release/<version-name-with-patch-placeholder>` (e.g., `release/3.0.x`) from the `main` branch. This branch will serve as the foundation for upcoming patch releases and facilitate versioned updates.
+- [ ] From the release branch (e.g., `release/3.0.x`), create a new temporary branch for the version (e.g., `release/3.0.0`).
+- [ ] Update version references in the documentation and code. Refer to [this PR](https://github.com/OrchardCMS/OrchardCore/pull/17065/files) for an example. The easiest is to start with a search & replace on the previous version. Version Updates Checklist:
   - **Update `OrchardCore.Commons.props`**: Set `<VersionSuffix></VersionSuffix>` to the new version you're preparing for release.
   - **Update Module Versions**: Modify `src/OrchardCore/OrchardCore.Abstractions/Modules/Manifest/ManifestConstants.cs` to reflect the new version.
-  - **Release Notes**: Finalize release notes in the documentation, including:
-    - Key highlights and goals of the release.
-    - Prerequisites for running the new version.
-    - Upgrade steps and any breaking changes.
+  - **Release Notes**: Finalize the release notes in the documentation, including:
+      - Highlights and goals of the release.
+      - Prerequisites for running the new version.
+      - Upgrade steps and any breaking changes.
   - **Update Documentation Navigation**: Add the release notes page to `mkdocs.yml` navigation and remove it from `not_in_nav`.
   - **Version Mentions**: Update all references to the new version throughout the documentation, including:
-    - [Status in the root README](https://docs.orchardcore.net/en/latest/#status).
+    - [Status in the root README](https://docs.orchardcore.net/en/latest/#status)
     - CLI templates and commands.
     - Relevant guides, such as the [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/) guide.
+- [ ] **Check CI Workflow**: Verify that the [release_ci](https://github.com/OrchardCMS/OrchardCore/blob/main/.github/workflows/release_ci.yml) workflow is using the correct .NET version for the release, and change it in the version branch if necessary.
+- [ ] Create a **version PR** titled `Release <version number` (e.g., `Release 3.0.0) from the version branch (e.g., `release/3.0.0`) into the release branch (e.g., `release/3.0.x`)
+- [ ] In GitHub, manually run the `Preview - CI` workflow on your branch (NOT `main`). This will release a new preview version on Cloudsmith for testing.
 
 ## Step 3: Translation Updates
 
-- [ ] **Update Translations**: After finalizing code changes, update translations in the [Translations project](https://github.com/OrchardCMS/OrchardCore.Translations):
-  - Update .po files using [PoExtractor](https://github.com/lukaskabrt/PoExtractor) to refresh translations on [Crowdin](https://crowdin.com/project/orchard-core).
-  - Publish the new version on NuGet.
-  - Update the `OrchardCore.Translations.All` package reference in the main repository's `./Dependencies.Packages.props` file.
+**Update Translations**: After finalizing code changes, update translations in the [Translations project](https://github.com/OrchardCMS/OrchardCore.Translations):
+
+- [ ] Update .po files using [PoExtractor](https://github.com/lukaskabrt/PoExtractor) to refresh translations on [Crowdin](https://crowdin.com/project/orchard-core).
+- [ ] Publish the new version on NuGet.
+- [ ] Update the `OrchardCore.Translations.All` package reference in the main repository's `./Dependencies.Packages.props` file.
 
 ## Step 4: Validation
 
-- [ ] **Test Samples**: Ensure that [`OrchardCore.Samples`](https://github.com/OrchardCMS/OrchardCore.Samples) functions correctly by using the preview packages generated for the release.
-- [ ] **Validate Guides**: Test the following guides using the latest NuGet packages from the Cloudsmith feed:
+- [ ] **Check Functionality**: Update [`OrchardCore.Samples`](https://github.com/OrchardCMS/OrchardCore.Samples) to the latest preview version generated in the previous step (just change the `OrchardCoreVersion` property in the root `Directory.Build.props` file). Ensure the samples work as expected.
+- [ ] **Test Guides**: Test the following guides with NuGet packages from the Cloudsmith feed:
   - [Creating a modular ASP.NET Core application](https://docs.orchardcore.net/en/latest/guides/create-modular-application-mvc/)
   - [Creating an Orchard Core CMS website](https://docs.orchardcore.net/en/latest/guides/create-cms-application/)
   - [Creating a new decoupled CMS Website](https://docs.orchardcore.net/en/latest/guides/decoupled-cms/)
@@ -50,25 +54,42 @@ assignees: ''
   - Orchard's [Red Hat Ecosystem Catalog profile](https://catalog.redhat.com/software/applications/detail/223797) for the last certified version.
   - [Red Hat Customer Portal](https://access.redhat.com/articles/3078) for the latest version details.
   - [Certification guide](https://docs.orchardcore.net/en/latest/topics/red-hat-ecosystem-catalog-certification/) for certification steps.
+- [ ] If everything looks good and all checks pass, merge the version PR.
 
 ## Step 5: Creating the New Release
 
 1. Navigate to the [GitHub Releases page](https://github.com/OrchardCMS/OrchardCore/releases/new).
 2. In the "**Choose a tag**" menu, enter the new version number (e.g., `v3.0.0`) and select "**+ Create tag: v... on publish**."
-3. Change the target branch from `main` to your release branch (e.g., `release/3.0`).
+3. Change the target branch from `main` to your release branch (e.g., `release/3.0.x`).
 4. Enter the version number in the Title field (e.g., `3.0.0`).
 5. Click **Generate release notes** to automatically create release notes based on the changes.
-6. Ensure the "Set as the latest release" checkbox is checked, then click **Publish release**.
+6. Add a link to the release notes on the docs site: `Check out the full release notes [here](https://docs.orchardcore.net/en/latest/releases/3.0.0/).`
+7. Ensure the "Set as the latest release" checkbox is checked, then click **Publish release**.
 
-## Step 6: Post-Release Tasks
+## Step 6: Aligning Branches
+
+**Merge to `main`**: After releasing the new version, merge the release branch into the main branch to ensure `main` contains all administrative changes.
+
+- [ ] Create a pull request from the release branch (e.g., `release/3.0.x`) into `main`.
+- [ ] Resolve any merge conflicts using external tools (e.g., Fork) to avoid auto-merging `main` into the release branch. **Important**: DO NOT resolve conflicts using GitHub's interface; that will automatically merge `main` into the release branch, which must be avoided.
+- [ ] Merge the PR if all checks pass. If there are merge conflicts, then you'll need to merge to `main` manually using the following steps:
+  - Fetch the latest changes from the Git repository.
+  - Checkout the `main` branch.
+  - Merge the release branch (e.g., `release/3.0.x`) into `main` with a merge commit (NOT a squash merge).
+  - Resolve any conflicts.
+  - Push the changes to `main`. This action requires a user with the ability to force-push into `main`, as it is protected by default.
+
+## Step 7: Post-Release Tasks
 
 - [ ] **Create New Milestone**: Set up a new milestone for the next release and close the previous one.
 - [ ] **Prepare Documentation for Next Version**: Create a new release notes file for the next version in the `OrchardCore.Docs` project (e.g., `/releases/4.0.0.md`). Exclude it from navigation and validation under `not_in_nav` in `mkdocs.yml`.
 - [ ] **Update Commons.props for Next Release**: Modify `OrchardCore.Commons.props` with the next release number and set `<VersionSuffix>preview</VersionSuffix>` for preview builds.
-- [ ] **Reassign Issues**: Reassign all closed issues from the current version milestone to the upcoming version milestone.
+- [ ] **Reassign Issues**: Reassign all still open, postponed issues from the current version milestone to the upcoming version milestone.
+- [ ] Update [`OrchardCore.Samples`](https://github.com/OrchardCMS/OrchardCore.Samples) to the new released version (just change the `OrchardCoreVersion` property in the root `Directory.Build.props` file).
 
-## Step 7: Publicize the Release
+## Step 8: Publicizing the Release
 
-- [ ] Post about the release on X (formerly Twitter) via the Orchard Core X (Twitter) repo.
+- [ ] Post about the release on X (formerly Twitter) via the [Orchard Core X (Twitter) repo](https://github.com/OrchardCMS/Orchard-Core-X-Twitter).
 - [ ] Post in the [Orchard Core LinkedIn group](https://www.linkedin.com/groups/13605669/).
-- [ ] Share on the [Orchard Core Facebook page](https://www.facebook.com/OrchardCore/).
+- [ ] Post to the [Orchard Core Facebook page](https://www.facebook.com/OrchardCore/).
+- [ ] Send a message to the `#announcements` channel on Discord.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -73,11 +73,11 @@ assignees: ''
 - [ ] Create a pull request from the release branch (e.g., `release/3.0.x`) into `main`.
 - [ ] Resolve any merge conflicts using external tools (e.g., Fork) to avoid auto-merging `main` into the release branch. **Important**: DO NOT resolve conflicts using GitHub's interface; that will automatically merge `main` into the release branch, which must be avoided.
 - [ ] Merge the PR if all checks pass. If there are merge conflicts, then you'll need to merge to `main` manually using the following steps:
-  - Fetch the latest changes from the Git repository.
-  - Checkout the `main` branch.
-  - Merge the release branch (e.g., `release/3.0.x`) into `main` with a merge commit (NOT a squash merge).
-  - Resolve any conflicts.
-  - Push the changes to `main`. This action requires a user with the ability to force-push into `main`, as it is protected by default.
+  1. Fetch the latest changes from the Git repository.
+  2. Checkout the `main` branch.
+  3. Merge the release branch (e.g., `release/3.0.x`) into `main` with a merge commit (NOT a squash merge).
+  4. Resolve any conflicts.
+  5. Push the changes to `main`. This action requires a user with the ability to force-push into `main`, as it is protected by default.
 
 ## Step 7: Post-Release Tasks
 


### PR DESCRIPTION
Summary:

- Aligned the instructions with what we've actually been doing.
- Whitespace fixes.
- I'd name the release branches as `2.1.x` instead of `2.1` to signify that it's not only for `2.1.0`.
- Unified the same steps across the patch and other instructions.

The https://github.com/OrchardCMS/OrchardCore/issues/17496 issue shows most of this in action, but I adjusted the template even after that.