### PR TITLE
Add documentation about the relation ship between Linkfield and HtmlSanitizerService

### DIFF
--- a/src/docs/reference/modules/ContentFields/README.md
+++ b/src/docs/reference/modules/ContentFields/README.md
@@ -141,7 +141,19 @@ Or to render the referenced content item:
         @await Orchard.DisplayAsync(contentItem, "Detail")
     }
     ```
+### `LinkField`
 
+Field used to display a link.
+
+#### `LinkFieldViewModel`
+
+| Property | Description                             |
+|----------|-----------------------------------------|
+| Url      | A valid URI for the href                |
+| Text     | The text to display                     |
+| Target   | The target attribute for the anchor tag, [Target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target) |
+
+!!! Note: By default the http and https are the only URIs permitted. In order to use other URIs like mailto and tel you must configure the [HTML Sanitizer](../Sanitizer/README.md). 
 ### `LocalizationSetContentPickerField`
 
 This field allows you to store the `LocalizationSet` of a `ContentItem`, when a reference shouldn't point to a specific culture of a content item.  
@@ -149,6 +161,20 @@ This simplifies getting a content item of the correct culture on the frontend.
 
 The following example uses the `localization_set` liquid filter which returns a single ContentItem
 per set based on the request culture, if no culture is specified.
+
+### Link Field Example 
+
+=== "Liquid"
+
+``` liquid
+<a href='{{Model.Url}}' Target={{Model.Target}}>{{Model.Text}}</a>
+```
+
+=== "Razor"
+
+```html
+<a href="@Model.Url" target="@Model.Target">@Model.Text</a>
+```
 
 #### LocalizationSet ContentPicker Field Example
 


### PR DESCRIPTION
The LinkField is used to create anchor tags and includes security features to sanitize the links which includes restricting the URI schemes to http and https unless the sanitizer is configured. In order to use a mailto or tel scheme you have to update the sanitizer.  
I added documentation to the Content Fields docs for the LinkField and included the associated between a LinkField and the sanitizer. 

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
