### PR TITLE
Refactor link target inputs to dropdowns

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Items/LinkAdminNode.Fields.TreeEdit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Items/LinkAdminNode.Fields.TreeEdit.cshtml
@@ -25,13 +25,12 @@
 
 <div class="mb-3">
     <label asp-for="Target" class="form-label">@T["Target"]</label>
-    <input asp-for="Target" list="targetOptions" class="form-control" />
-    <datalist id="targetOptions">
+	<select asp-for="Target" class="form-select">
         <option value="_self">@T["Opens the linked document in the same frame as it was clicked (this is default)."]</option>
         <option value="_blank">@T["Opens the linked document in a new window or tab."]</option>
         <option value="_parent">@T["Opens the linked document in the parent frame."]</option>
         <option value="_top">@T["Opens the linked document in the full body of the window."]</option>
-    </datalist>
+    </select>
     <span class="hint">@T["The target attribute of the A tag, see more:"] <a class="seedoc" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target">target</a></span>
 </div>
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkField.Edit.cshtml
@@ -51,13 +51,12 @@
                     @T["Target"]
                 </label>
                 <div class="@Orchard.GetEndClasses()">
-                    <input asp-for="Target" list="targetOptions" class="form-control" />
-                    <datalist id="targetOptions">
+					<select asp-for="Target" class="form-select">
                         <option value="_self">@T["Opens the linked document in the same frame as it was clicked (default)."]</option>
                         <option value="_blank">@T["Opens the linked document in a new window or tab."]</option>
                         <option value="_parent">@T["Opens the linked document in the parent frame."]</option>
                         <option value="_top">@T["Opens the linked document in the full body of the window."]</option>
-                    </datalist>
+                    </select>
                     <span class="hint">
                         @T["The target attribute of the anchor tag, see more:"]
                         <a class="seedoc" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target">

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkFieldSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LinkFieldSettings.Edit.cshtml
@@ -61,13 +61,12 @@
 <div class="row">
     <div class="mb-3 col-md-6">
         <label asp-for="DefaultTarget" class="form-label">@T["Default value of the Target"]</label>
-        <input asp-for="DefaultTarget" list="targetOptions" class="form-control" />
-        <datalist id="targetOptions">
+		<select asp-for="DefaultTarget" class="form-select">
             <option value="_self">@T["Opens the linked document in the same frame as it was clicked (default)."]</option>
             <option value="_blank">@T["Opens the linked document in a new window or tab."]</option>
             <option value="_parent">@T["Opens the linked document in the parent frame."]</option>
             <option value="_top">@T["Opens the linked document in the full body of the window."]</option>
-        </datalist>
+        </select>
         <span class="hint">@T["The default target proposed when creating a content item."]</span>
         <span asp-validation-for="DefaultTarget" class="text-danger"></span>
     </div>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/ContentTypeSettings.Edit.cshtml
@@ -66,13 +66,12 @@
 <div class="mb-3">
     <div class="w-md-75 w-xl-50">
         <label asp-for="Stereotype">@T["Stereotype"]</label>
-        <input asp-for="Stereotype" list="stereotypeOptions" type="text" class="form-control">
-        <datalist id="stereotypeOptions">
+		<select asp-for="Stereotype" id="stereotypeOptions" class="form-select">
             @foreach (var item in Model.Options.Stereotypes)
             {
                 <option value="@item.Stereotype">@item.DisplayName</option>
             }
-        </datalist>
+        </select>
     </div>
     <span class="hint">@T["(Optional) The stereotype of the content type. e.g., Widget, MenuItem, ..."]</span>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/HtmlMenuItemPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/HtmlMenuItemPart.Edit.cshtml
@@ -18,13 +18,12 @@
 <div class="@Orchard.GetWrapperClasses()">
     <label asp-for="Target" class="@Orchard.GetLabelClasses()">@T["Target"]</label>
     <div class="@Orchard.GetEndClasses()">
-        <input asp-for="Target" list="targetOptions" class="form-control" />
-        <datalist id="targetOptions">
+        <select asp-for="Target" class="form-select">
             <option value="_self">@T["Opens the linked document in the same frame as it was clicked (this is default)."]</option>
             <option value="_blank">@T["Opens the linked document in a new window or tab."]</option>
             <option value="_parent">@T["Opens the linked document in the parent frame."]</option>
             <option value="_top">@T["Opens the linked document in the full body of the window."]</option>
-        </datalist>
+        </select>
         <span class="hint">@T["The target attribute of the A tag, see more:"] <a class="seedoc" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target">target</a></span>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Views/LinkMenuItemPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Views/LinkMenuItemPart.Edit.cshtml
@@ -18,13 +18,12 @@
 <div class="@Orchard.GetWrapperClasses()">
     <label asp-for="Target" class="@Orchard.GetLabelClasses()">@T["Target"]</label>
     <div class="@Orchard.GetEndClasses()">
-        <input asp-for="Target" list="targetOptions" class="form-control" />
-        <datalist id="targetOptions">
+		<select asp-for="Target" class="form-select">
             <option value="_self">@T["Opens the linked document in the same frame as it was clicked (this is default)."]</option>
             <option value="_blank">@T["Opens the linked document in a new window or tab."]</option>
             <option value="_parent">@T["Opens the linked document in the parent frame."]</option>
             <option value="_top">@T["Opens the linked document in the full body of the window."]</option>
-        </datalist>
+        </select>
         <span class="hint">@T["The target attribute of the A tag, see more:"] <a class="seedoc" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target">target</a></span>
     </div>
 </div>


### PR DESCRIPTION
Replaced `<input>` elements with `<select>` dropdowns for the "Target" and "DefaultTarget" fields in multiple Razor view files. This change allows users to choose from predefined options (`_self`, `_blank`, `_parent`, `_top`) instead of manual input. Removed unnecessary `<datalist>` elements as part of this update.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
