### PR TITLE
Fixes a threading issue in the LayerFilter.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Services/LayerFilter.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.Extensions.Caching.Memory;
 using OrchardCore.Admin;
+using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
@@ -124,18 +125,21 @@ public sealed class LayerFilter : IAsyncResultFilter
                 if (widgetDefinitions.TryGetValue(widget.ContentItem.ContentType, out var definition) &&
                     (!definition.IsSecurable() || await _authorizationService.AuthorizeAsync(context.HttpContext.User, CommonPermissions.ViewContent, widget.ContentItem)))
                 {
-                    var widgetContent = await _contentItemDisplayManager.BuildDisplayAsync(widget.ContentItem, updater);
+                    // Note: We clone the cached content item to avoid sharing the same instance across threads when rendering widgets.
+                    var contentItem = widget.ContentItem.Clone();
+
+                    var widgetContent = await _contentItemDisplayManager.BuildDisplayAsync(contentItem, updater);
 
                     widgetContent.Classes.Add("widget");
-                    widgetContent.Classes.Add("widget-" + widget.ContentItem.ContentType.HtmlClassify());
+                    widgetContent.Classes.Add("widget-" + contentItem.ContentType.HtmlClassify());
 
                     var wrapper = new WidgetWrapper
                     {
-                        Widget = widget.ContentItem,
+                        Widget = contentItem,
                         Content = widgetContent
                     };
 
-                    wrapper.Metadata.Alternates.Add("Widget_Wrapper__" + widget.ContentItem.ContentType);
+                    wrapper.Metadata.Alternates.Add("Widget_Wrapper__" + contentItem.ContentType);
                     wrapper.Metadata.Alternates.Add("Widget_Wrapper__Zone__" + widget.Zone);
 
                     var contentZone = layout.Zones[widget.Zone];

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentItemExtensions.cs
@@ -228,4 +228,29 @@ public static class ContentItemExtensions
 
         return contentItem;
     }
+
+    /// <summary>
+    /// Creates an in-memory clone of a content item.
+    /// </summary>
+    /// <param name="contentItem"></param>
+    /// <returns></returns>
+    public static ContentItem Clone(this ContentItem contentItem)
+    {
+        return new ContentItem
+        {
+            Id = contentItem.Id,
+            ContentItemId = contentItem.ContentItemId,
+            ContentItemVersionId = contentItem.ContentItemVersionId,
+            ContentType = contentItem.ContentType,
+            DisplayText = contentItem.DisplayText,
+            Owner = contentItem.Owner,
+            Author = contentItem.Author,
+            Published = contentItem.Published,
+            Latest = contentItem.Latest,
+            CreatedUtc = contentItem.CreatedUtc,
+            ModifiedUtc = contentItem.ModifiedUtc,
+            PublishedUtc = contentItem.PublishedUtc,
+            Data = contentItem.Data.Clone()
+        };
+    }
 }


### PR DESCRIPTION
Due to the non-thread-safe nature of `ContentElements`, they cannot be cached and reused across multiple concurrent requests, as is currently done by the `LayerFilter`. To avoid modifying the entire filter, I will copy the content items before constructing the display shape.

It's important to note that making `ContentElement` thread-safe is a complex task and, in my opinion, not the appropriate solution in this context. Additionally, I have not identified any other cached content items at this time.

Fixes #17532