### PR TITLE
Vue Draggable version 2 dep. on Vue 2

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -1077,7 +1077,7 @@ public sealed class ResourceManagementOptionsConfiguration
 
         manifest
             .DefineScript("vue-draggable")
-            .SetDependencies("vuejs", "Sortable")
+            .SetDependencies("vuejs:2", "Sortable")
             .SetUrl(
                 "~/OrchardCore.Resources/Vendor/vue-draggable-2.24.3/vuedraggable.umd.min.js",
                 "~/OrchardCore.Resources/Vendor/vue-draggable-2.24.3/vuedraggable.umd.js"


### PR DESCRIPTION
Vue Draggable resource needs to have a dependency on specific Vue 2 version.

![image](https://github.com/user-attachments/assets/93f43aad-8fc5-44e7-ad5e-f938fe9b968b)

Fixes #17571, #17554

