### PR TITLE
Adapting to OrchardCore.Benchmarks namespace change

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -65,9 +65,9 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
-    <PackageVersion Include="xunit.v3" Version="1.0.0" />
-    <PackageVersion Include="xunit.analyzers" Version="1.18.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="xunit.v3" Version="1.1.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.20.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="YesSql" Version="5.2.0" />
     <PackageVersion Include="YesSql.Abstractions" Version="5.2.0" />
     <PackageVersion Include="YesSql.Core" Version="5.2.0" />

--- a/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
+++ b/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
@@ -12,7 +12,7 @@
     <NoWarn>$(NoWarn);CA1707;EnableGenerateDocumentationFile</NoWarn>
     <!-- Without this, we get an "error CS0017: Program has more than one entry point defined." due to
     BenchmarkDotNet's auto-generated entry point. -->
-    <StartupObject>OrchardCore.Benchmark.Program</StartupObject>
+    <StartupObject>OrchardCore.Benchmarks.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
+++ b/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(DefaultTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(CommonTargetFrameworks)</TargetFrameworks>
     <RootNamespace>OrchardCore.Benchmark</RootNamespace>
     <IsPackable>false</IsPackable>
     <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>

--- a/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
+++ b/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(CommonTargetFrameworks)</TargetFrameworks>
@@ -10,6 +10,9 @@
     <OutputType>Exe</OutputType>
     <!-- Remove the underscores from member name -->
     <NoWarn>$(NoWarn);CA1707;EnableGenerateDocumentationFile</NoWarn>
+    <!-- Without this, we get an "error CS0017: Program has more than one entry point defined." due to
+    BenchmarkDotNet's auto-generated entry point. -->
+    <StartupObject>OrchardCore.Benchmark.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
+++ b/test/OrchardCore.Benchmarks/OrchardCore.Benchmarks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(CommonTargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultTargetFramework)</TargetFrameworks>
     <RootNamespace>OrchardCore.Benchmark</RootNamespace>
     <IsPackable>false</IsPackable>
     <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>


### PR DESCRIPTION
Following up on https://github.com/OrchardCMS/OrchardCore/pull/17584.