### PR TITLE
Update README.md to include a link to the quickstart CloudFormation.

### DIFF
--- a/src/docs/reference/modules/Media.AmazonS3/README.md
+++ b/src/docs/reference/modules/Media.AmazonS3/README.md
@@ -2,6 +2,9 @@
 
 The Amazon S3 Media module enables support for storing assets in Amazon S3 Buckets.
 
+!!! note
+    For a scalable Orchard Core that is fully deployed on AWS stack with ECS, you can refer to [the quickstart CloudFormation template](https://github.com/gcl-team/Experiment.OrchardCore.Main/blob/main/Infrastructure.yml).
+
 ## Amazon S3 Media Storage (`OrchardCore.Media.AmazonS3`)
 
 The feature replaces the default App_Data file-based media store with an Amazon Media Storage Provider.

--- a/src/docs/reference/modules/Media.AmazonS3/README.md
+++ b/src/docs/reference/modules/Media.AmazonS3/README.md
@@ -2,8 +2,8 @@
 
 The Amazon S3 Media module enables support for storing assets in Amazon S3 Buckets.
 
-!!! note
-    For a scalable Orchard Core that is fully deployed on AWS stack with ECS, you can refer to [the quickstart CloudFormation template](https://github.com/gcl-team/Experiment.OrchardCore.Main/blob/main/Infrastructure.yml).
+!!! tip
+    For a scalable Orchard Core setup that is fully deployed on the AWS stack with ECS, you can refer to [the quickstart CloudFormation template](https://github.com/gcl-team/Experiment.OrchardCore.Main/blob/main/Infrastructure.yml).
 
 ## Amazon S3 Media Storage (`OrchardCore.Media.AmazonS3`)
 


### PR DESCRIPTION
Hello team,

As Orchard Core did support AWS S3 for Media, some developers feedback to me that they hope there is an easier way to setup Orchard Core on ECS with IaC (CloudFormation) so that they can spine Orchard Core up easily on ECS with all the basic services such as S3 and Aurora DB.

In this PR, I've manually added the link to [my CloudFormation template](https://github.com/gcl-team/Experiment.OrchardCore.Main/blob/main/Infrastructure.yml) under the Amazon S3 Media page.

Please let me know if this is the right place to mention the CloudFormation template or we should have another page consolidating IaC for different cloud providers.

Thank you for your time and feedback!
