### PR TITLE
Use ReadCommitted as the default data isolation level while providing an option for configurability

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -29,7 +29,8 @@
     //"OrchardCore_YesSql": {
     //  "CommandsPageSize": 500,
     //  "QueryGatingEnabled": true,
-    //  "EnableThreadSafetyChecks": false
+    //  "EnableThreadSafetyChecks": false,
+    //  "IsolationLevel": "ReadCommitted"
     //},
     // See https://docs.orchardcore.net/en/latest/reference/modules/DataProtection.Azure/#configuration to configure data protection key storage in Azure Blob Storage.
     //"OrchardCore_DataProtection_Azure": {

--- a/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/YesSqlOptions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql.Abstractions/YesSqlOptions.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using YesSql;
 
 namespace OrchardCore.Data.YesSql;
@@ -17,4 +18,6 @@ public class YesSqlOptions
     public IContentSerializer ContentSerializer { get; set; }
 
     public bool EnableThreadSafetyChecks { get; set; }
+
+    public IsolationLevel IsolationLevel { get; set; } = IsolationLevel.ReadCommitted;
 }

--- a/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Data.YesSql/OrchardCoreBuilderExtensions.cs
@@ -73,7 +73,7 @@ public static class OrchardCoreBuilderExtensions
                 {
                     case DatabaseProviderValue.SqlConnection:
                         storeConfiguration
-                            .UseSqlServer(shellSettings["ConnectionString"], IsolationLevel.ReadUncommitted, shellSettings["Schema"])
+                            .UseSqlServer(shellSettings["ConnectionString"], yesSqlOptions.IsolationLevel, shellSettings["Schema"])
                             .UseBlockIdGenerator();
                         break;
                     case DatabaseProviderValue.Sqlite:
@@ -86,17 +86,17 @@ public static class OrchardCoreBuilderExtensions
                         var connectionString = SqliteHelper.GetConnectionString(sqliteOptions, databaseFolder, shellSettings);
 
                         storeConfiguration
-                            .UseSqLite(connectionString, IsolationLevel.ReadUncommitted)
+                            .UseSqLite(connectionString, yesSqlOptions.IsolationLevel)
                             .UseDefaultIdGenerator();
                         break;
                     case DatabaseProviderValue.MySql:
                         storeConfiguration
-                            .UseMySql(shellSettings["ConnectionString"], IsolationLevel.ReadUncommitted, shellSettings["Schema"])
+                            .UseMySql(shellSettings["ConnectionString"], yesSqlOptions.IsolationLevel, shellSettings["Schema"])
                             .UseBlockIdGenerator();
                         break;
                     case DatabaseProviderValue.Postgres:
                         storeConfiguration
-                            .UsePostgreSql(shellSettings["ConnectionString"], IsolationLevel.ReadUncommitted, shellSettings["Schema"])
+                            .UsePostgreSql(shellSettings["ConnectionString"], yesSqlOptions.IsolationLevel, shellSettings["Schema"])
                             .UseBlockIdGenerator();
                         break;
                     default:
@@ -192,6 +192,7 @@ public static class OrchardCoreBuilderExtensions
             IdentityColumnSize = Enum.Parse<IdentityColumnSize>(databaseTableOptions.IdentityColumnSize),
             Logger = loggerFactory.CreateLogger("YesSql"),
             ContentSerializer = new DefaultContentJsonSerializer(serializerOptions.Value.SerializerOptions),
+            IsolationLevel = yesSqlOptions.IsolationLevel,
         };
 
         if (yesSqlOptions.IdGenerator != null)

--- a/src/docs/reference/modules/Data/README.md
+++ b/src/docs/reference/modules/Data/README.md
@@ -37,6 +37,7 @@ OrchardCore uses the `YesSql` library to interact with the configured database p
 | `VersionAccessorFactory`    | You can provide your own version accessor factory.                                                                                            |
 | `ContentSerializer`         | You can provide your own content serializer.                                                                                                  |
 | `EnableThreadSafetyChecks`  | Gets or sets the `EnableThreadSafetyChecks` option in YesSql, which aids in diagnosing concurrency or race condition issues.                  |
+| `IsolationLevel`            | Gets or sets the transaction isolation level to use by default. The default value is `ReadCommitted`.                                         |
 
 For example, you can change the default command-page-size from `500` to `1000` by adding the following code to your startup code.
 

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -6,6 +6,10 @@ Before upgrading from version 2 to v3, it is important to first compile your pro
 
 ## Breaking Changes
 
+### YesSql Changes
+
+Previously, we configured YesSql with the `ReadUncommitted` isolation level. We have now set `ReadCommitted` as the default and made it configurable through settings.
+
 ### Email Module
 
 Previously, emails sent from Orchard Core could have either a plain text body, or an HTML body, but not both. Now, they can have both. This also brings some code-level API changes, see below.


### PR DESCRIPTION
This pull request introduces changes to support configurable transaction isolation levels in the YesSql integration within OrchardCore. The main updates include adding a new configuration option for isolation levels and ensuring that this option is utilized across various database providers.

Key changes include:

### Configuration Enhancements:
* Added `IsolationLevel` configuration option to `appsettings.json` to allow setting the transaction isolation level.

### Codebase Updates:
* Introduced `IsolationLevel` property to `YesSqlOptions` class with a default value of `ReadCommitted`.
* Modified `OrchardCoreBuilderExtensions.cs` to use the configured `IsolationLevel` for SQL Server, SQLite, MySQL, and PostgreSQL database providers. [[1]](diffhunk://#diff-b499711d6aba6467e68b5d1377792bdadf5074011067c7ecedfd8e166458ec70L76-R76) [[2]](diffhunk://#diff-b499711d6aba6467e68b5d1377792bdadf5074011067c7ecedfd8e166458ec70L89-R99) [[3]](diffhunk://#diff-b499711d6aba6467e68b5d1377792bdadf5074011067c7ecedfd8e166458ec70R195)

### Documentation:
* Updated the documentation to include the new `IsolationLevel` option in the list of configurable settings for YesSql.