### PR TITLE
Revert "Add condition for User moderation and Email confirmation upon registration #17611"

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/EmailConfirmationRegistrationFormEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/EmailConfirmationRegistrationFormEvents.cs
@@ -29,6 +29,7 @@ internal sealed class EmailConfirmationRegistrationFormEvents : RegistrationForm
             return;
         }
 
+        context.CancelSignIn = true;
         await _userEmailConfirmationService.SendEmailConfirmationAsync(context.User);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/UserModerationRegistrationFormEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/UserModerationRegistrationFormEvents.cs
@@ -16,7 +16,8 @@ internal sealed class UserModerationRegistrationFormEvents : RegistrationFormEve
     public override Task RegisteringAsync(UserRegisteringContext context)
     {
         if (context.User is User user &&
-            !(_registrationOptions.UsersAreModerated && !user.IsEnabled))
+            _registrationOptions.UsersAreModerated &&
+            !user.IsEnabled)
         {
             context.CancelSignIn = true;
         }

--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -361,7 +361,7 @@ public sealed class UserService : IUserService
 
         await _registrationFormEvents.InvokeAsync((e, ctx) => e.RegisteringAsync(ctx), context, _logger);
 
-        if (!context.CancelSignIn && !_registrationOptions.UsersAreModerated && !_registrationOptions.UsersMustValidateEmail)
+        if (!context.CancelSignIn)
         {
             await _signInManager.SignInAsync(user, isPersistent: false);
         }


### PR DESCRIPTION
Revert "Add condition for User moderation and Email confirmation upon registration #17611" and implement proper fix in `EmailConfirmationRegstrationFormEvents` handler.

/cc @SzymonSel This must not be forgotten, so I quickly added a fix. 