### PR TITLE
Make solution build on net10.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,14 +122,14 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'" >
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
   </ItemGroup>
 
   <!-- These versions are used for the NuGet packages that are dependent on the current TFM -->
   <!-- There may be no TFM in an evaluation phase so we can't use a conditional 'Property' -->
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="9.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.3" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="9.0.3" />

--- a/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
+++ b/src/OrchardCore.Cms.Web/OrchardCore.Cms.Web.csproj
@@ -14,7 +14,9 @@
          git. See an example use-case at https://docs.orchardcore.net/en/latest/reference/modules/AutoSetup/. -->
     <UserSecretsId>2cfccf50-2ae4-4017-bbd7-a0e453cbf713</UserSecretsId>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Disable XML comment warning on single file Program -->
   </PropertyGroup>
+
   <!-- For Unit Tests-->
   <ItemGroup>
     <InternalsVisibleTo Include="OrchardCore.Tests" />

--- a/src/OrchardCore.Modules/OrchardCore.Media/Deployment/MediaDeploymentStepDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Deployment/MediaDeploymentStepDriver.cs
@@ -30,7 +30,7 @@ public sealed class MediaDeploymentStepDriver : DisplayDriver<DeploymentStep, Me
             model.IncludeAll = step.IncludeAll;
             model.FilePaths = step.FilePaths;
             model.DirectoryPaths = step.DirectoryPaths;
-            model.Entries = await GetMediaStoreEntries();
+            model.Entries = await GetMediaStoreEntries().ToListAsync();
         }).Location("Content");
     }
 
@@ -55,25 +55,22 @@ public sealed class MediaDeploymentStepDriver : DisplayDriver<DeploymentStep, Me
         return Edit(step, context);
     }
 
-    private async Task<IList<MediaStoreEntryViewModel>> GetMediaStoreEntries(string path = null, MediaStoreEntryViewModel parent = null)
+    private async IAsyncEnumerable<MediaStoreEntryViewModel> GetMediaStoreEntries(string path = null, MediaStoreEntryViewModel parent = null)
     {
-        var mediaStoreEntries = await _mediaFileStore.GetDirectoryContentAsync(path)
-            .SelectAwait(async e =>
+        await foreach (var e in _mediaFileStore.GetDirectoryContentAsync(path))
+        {
+            var mediaStoreEntry = new MediaStoreEntryViewModel
             {
-                var mediaStoreEntry = new MediaStoreEntryViewModel
-                {
-                    Name = e.Name,
-                    Path = e.Path,
-                    Parent = parent
-                };
+                Name = e.Name,
+                Path = e.Path,
+                Parent = parent
+            };
 
-                mediaStoreEntry.Entries = e.IsDirectory
-                    ? await GetMediaStoreEntries(e.Path, mediaStoreEntry)
-                    : [];
+            mediaStoreEntry.Entries = e.IsDirectory
+                ? await GetMediaStoreEntries(e.Path, mediaStoreEntry).ToListAsync()
+                : [];
 
-                return mediaStoreEntry;
-            }).ToListAsync();
-
-        return mediaStoreEntries;
+            yield return mediaStoreEntry;
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Media/OrchardCore.Media.csproj
@@ -43,8 +43,11 @@
   <ItemGroup>
     <PackageReference Include="Shortcodes" />
     <PackageReference Include="SixLabors.ImageSharp.Web" />
-    <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="System.IO.Hashing" />
+  </ItemGroup>
+
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 
 </Project>

--- a/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
+++ b/src/OrchardCore.Mvc.Web/OrchardCore.Mvc.Web.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Disable XML comment warning on single file Program -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceProviderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceProviderExtensions.cs
@@ -22,6 +22,7 @@ public static class ServiceProviderExtensions
         return (TResult)ActivatorUtilities.CreateInstance(provider, type);
     }
 
+#if !NET10_0_OR_GREATER
     /// <summary>
     /// Gets the service object of the specified type with the specified key.
     /// </summary>
@@ -35,4 +36,6 @@ public static class ServiceProviderExtensions
 
         throw new InvalidOperationException("This service provider doesn't support keyed services.");
     }
+#endif
+
 }

--- a/src/OrchardCore/OrchardCore.FileStorage.FileSystem/OrchardCore.FileStorage.FileSystem.csproj
+++ b/src/OrchardCore/OrchardCore.FileStorage.FileSystem/OrchardCore.FileStorage.FileSystem.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\OrchardCore.FileStorage.Abstractions\OrchardCore.FileStorage.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <PackageReference Include="System.Linq.Async" />
   </ItemGroup>
 

--- a/test/OrchardCore.Abstractions.Tests/OrchardCore.Abstractions.Tests.csproj
+++ b/test/OrchardCore.Abstractions.Tests/OrchardCore.Abstractions.Tests.csproj
@@ -17,13 +17,16 @@
     <PackageReference Include="Lorem.Universal.NET" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.analyzers" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="System.Linq.Async" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\OrchardCore.Tests.Features\Examples.Features.AssyAttrib\Examples.Features.AssyAttrib.csproj" />
     <ProjectReference Include="..\OrchardCore.Tests.Modules\Examples.Modules.AssyAttrib.Alpha\Examples.Modules.AssyAttrib.Alpha.csproj" />

--- a/test/OrchardCore.Tests/OrchardCore.Tests.csproj
+++ b/test/OrchardCore.Tests/OrchardCore.Tests.csproj
@@ -68,13 +68,16 @@
     <PackageReference Include="AngleSharp" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.analyzers" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+    <PackageReference Include="System.Linq.Async" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>


### PR DESCRIPTION
Ensuring Orchard Core build just fine on .net10.0

- System.Linq.Async has been added to the runtime, with some slight differences (SelectAwait)
- A new extension method we have was also added in the runtime and is conflicting