### PR TITLE
add multivalue where conditions on IDs in graphql, fix multivalue fil…

### DIFF
--- a/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Queries/WhereInputObjectGraphType.cs
+++ b/src/OrchardCore/OrchardCore.Apis.GraphQL.Abstractions/Queries/WhereInputObjectGraphType.cs
@@ -88,6 +88,10 @@ public abstract class WhereInputObjectGraphType<TSourceType> : InputObjectGraphT
             AddMultiValueFilters(graphType, fieldName, description, aliasName, contentPart, contentField);
             AddStringFilters(graphType, fieldName, description, aliasName, contentPart, contentField);
         }
+        else if (graphType == typeof(IdGraphType))
+        {
+            AddMultiValueFilters(graphType, fieldName, description, aliasName, contentPart, contentField);
+        }
         else if (graphType == typeof(DateTimeGraphType) ||
             graphType == typeof(DateGraphType) ||
             graphType == typeof(DateOnlyGraphType) ||
@@ -120,7 +124,8 @@ public abstract class WhereInputObjectGraphType<TSourceType> : InputObjectGraphT
 
     private void AddMultiValueFilters(Type graphType, string fieldName, string description, string aliasName, string contentPart, string contentField)
     {
-        AddFilterFields(graphType, MultiValueComparisonOperators, fieldName, description, aliasName, contentPart, contentField);
+        var wrappedType = typeof(ListGraphType<>).MakeGenericType(graphType);
+        AddFilterFields(wrappedType, MultiValueComparisonOperators, fieldName, description, aliasName, contentPart, contentField);
     }
 
     private void AddFilterFields(


### PR DESCRIPTION
Fixes #17653

Restores _in and _not_in filters on ID types
![image](https://github.com/user-attachments/assets/a7a28676-7b40-40ca-b9b6-d743325a58a7)

Cause by https://github.com/OrchardCMS/OrchardCore/commit/3853b973f59196c0f5c75a6c72b885679b5bbc8c#diff-08182851c6e450be93eadab38c390ba2450025dcf34165cecd3796b4e0d3fe5e

Fixes where in/not in filters, it was not possible to use array filter type - caused by unwrapping here https://github.com/OrchardCMS/OrchardCore/commit/5dc244bf64afb2056939b617885fceb7a0da3607#diff-08182851c6e450be93eadab38c390ba2450025dcf34165cecd3796b4e0d3fe5eR105