### PR TITLE
Do not close underlying stream in GraphQLMiddleware

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/GraphQLMiddleware.cs
@@ -91,7 +91,7 @@ public class GraphQLMiddleware : IMiddleware
 
                 if (mediaType.IsSubsetOf(_jsonMediaType) || mediaType.IsSubsetOf(_graphQlMediaType))
                 {
-                    using var sr = new StreamReader(context.Request.Body);
+                    using var sr = new StreamReader(context.Request.Body, leaveOpen: true);
                     if (mediaType.IsSubsetOf(_graphQlMediaType))
                     {
                         request = new GraphQLNamedQueryRequest


### PR DESCRIPTION
In case if application uses HTTP logging, it cannot read and log request body because GraphQLMiddleware disposes Request.Body stream.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
