### PR TITLE
Add Search Highlights

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search/Controllers/SearchController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Controllers/SearchController.cs
@@ -199,6 +199,7 @@ public sealed class SearchController : Controller
                 ContentItems = containedItems.OrderBy(x => searchResult.ContentItemIds.IndexOf(x.ContentItemId))
                 .Take(pager.PageSize)
                 .ToList(),
+                Highlights = searchResult.Highlights,
             },
             Pager = await _shapeFactory.PagerSlimAsync(pager, new Dictionary<string, string>()
             {

--- a/src/OrchardCore.Modules/OrchardCore.Search/Views/Search-Results.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Views/Search-Results.cshtml
@@ -1,13 +1,26 @@
+@using OrchardCore.ContentManagement
 @model SearchResultsViewModel
 @inject IContentItemDisplayManager DisplayManager
+@inject IContentManager ContentManager
 
 @if (Model.ContentItems != null && Model.ContentItems.Any())
 {
     <ul class="list-group">
         @foreach (var contentItem in Model.ContentItems)
         {
+            var metadata = await ContentManager.PopulateAspectAsync<ContentItemMetadata>(contentItem);
+
             <li class="list-group-item">
-                @await DisplayAsync(await DisplayManager.BuildDisplayAsync(contentItem, null, "Summary"))
+                @if (Model.Highlights is not null && Model.Highlights.TryGetValue(contentItem.ContentItemId, out var highlights))
+                {
+                    <h2><a href="@Url.Action(null, metadata.DisplayRouteValues)">@contentItem.DisplayText</a></h2>
+
+                    @Html.Raw(string.Join(string.Empty, highlights.SelectMany(x => x.Value)))
+                }
+                else
+                {
+                    @await DisplayAsync(await DisplayManager.BuildDisplayAsync(contentItem, null, "Summary"))
+                }
             </li>
         }
     </ul>

--- a/src/OrchardCore.Modules/OrchardCore.Search/Views/Search-Results.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Views/Search-Results.cshtml
@@ -15,9 +15,17 @@
             <li class="list-group-item">
                 @if (Model.Highlights is not null && Model.Highlights.TryGetValue(contentItem.ContentItemId, out var highlights))
                 {
-                    <h2><a href="@Url.Action(null, metadata.DisplayRouteValues)">@contentItem.DisplayText</a></h2>
+                    <h2>
+                        <a href="@Url.Action(null, metadata.DisplayRouteValues)">@contentItem.DisplayText</a>
+                    </h2>
 
-                    @Html.Raw(string.Join(string.Empty, highlights.SelectMany(x => x.Value)))
+                    @foreach (var fragments in highlights.Values)
+                    {
+                        foreach (var fragment in fragments)
+                        {
+                            @Html.Raw(fragment)
+                        }
+                    }
                 }
                 else
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Search/Views/Search-Results.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Views/Search-Results.cshtml
@@ -1,5 +1,7 @@
 @using OrchardCore.ContentManagement
+
 @model SearchResultsViewModel
+
 @inject IContentItemDisplayManager DisplayManager
 @inject IContentManager ContentManager
 

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Search-Results.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Search-Results.liquid
@@ -2,10 +2,23 @@
     <ul class="list-group">
         {% for item in Model.ContentItems %}
             <li class="list-group-item">
+            {% if Model.Highlights != null and Model.Highlights[item.ContentItemId] != null %}
+                {% assign highlights = Model.Highlights[item.ContentItemId] %}
+                {% for key in highlights %}
+                    {% assign content = key[1] %}
+                    {% if content != null %}
+                        <h2><a href="{{ item | display_url }}">{{ item | display_text }}</a></h2>
+                        {% for value in content %}
+                            {{ value | raw }}
+                        {% endfor %}
+                    {% endif %}
+                {% endfor %}
+            {% else %}
                 {{ item | shape_build_display: "Summary" | shape_render }}
+            {% endif %}
             </li>
         {% endfor %}
     </ul>
 {% else %}
-    <p class="alert alert-warning">{{"There are no such results." | t }}</p>
+    <p class="alert alert-warning">{{ "There are no such results." | t }}</p>
 {% endif %}

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/SearchResult.cs
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/SearchResult.cs
@@ -4,6 +4,8 @@ public class SearchResult
 {
     public IList<string> ContentItemIds { get; set; }
 
+    public Dictionary<string, IReadOnlyDictionary<string, IReadOnlyCollection<string>>> Highlights { get; set; }
+
     public bool Latest { get; set; }
 
     public bool Success { get; set; }

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/ViewModels/SearchResultsViewModel.cs
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/ViewModels/SearchResultsViewModel.cs
@@ -19,5 +19,8 @@ public class SearchResultsViewModel : ShapeViewModel
     [BindNever]
     public IEnumerable<ContentItem> ContentItems { get; set; }
 
+    [BindNever]
+    public Dictionary<string, IReadOnlyDictionary<string, IReadOnlyCollection<string>>> Highlights { get; set; }
+
     public string Index { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticsearchIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticsearchIndexManager.cs
@@ -699,7 +699,7 @@ public sealed class ElasticsearchIndexManager
                 elasticTopDocs.TopDocs.Add(new ElasticsearchRecord(document)
                 {
                     Score = hit.Score,
-                    Highlights = hit?.Highlight
+                    Highlights = hit.Highlight,
                 });
 
                 continue;
@@ -713,7 +713,7 @@ public sealed class ElasticsearchIndexManager
             elasticTopDocs.TopDocs.Add(new ElasticsearchRecord(topDoc)
             {
                 Score = hit.Score,
-                Highlights = hit.Highlight
+                Highlights = hit.Highlight,
             });
         }
 

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticsearchService.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticsearchService.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Encodings.Web;
 using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Core.Search;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 using Fluid.Values;
 using Microsoft.Extensions.Logging;
@@ -90,6 +91,7 @@ public class ElasticsearchService : ISearchService
         {
             var searchType = searchSettings.GetSearchType();
             Query query = null;
+            Highlight highlight = null;
 
             if (searchType == ElasticSettings.CustomSearchType && !string.IsNullOrWhiteSpace(searchSettings.DefaultQuery))
             {
@@ -106,6 +108,7 @@ public class ElasticsearchService : ISearchService
                     var searchRequest = await _elasticClient.RequestResponseSerializer.DeserializeAsync<SearchRequest>(stream);
 
                     query = searchRequest.Query;
+                    highlight = searchRequest.Highlight;
                 }
                 catch { }
             }
@@ -130,10 +133,10 @@ public class ElasticsearchService : ISearchService
             {
                 From = start,
                 Size = pageSize,
+                Highlight = highlight,
             };
 
-            result.ContentItemIds = await _elasticsQueryService.GetContentItemIdsAsync(searchContext);
-
+            await _elasticsQueryService.PopulateResultAsync(searchContext, result);
             result.Success = true;
         }
         catch (Exception e)

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -64,6 +64,44 @@ Additionally, the `OrchardCore.Search.Elasticsearch.Abstractions` project has be
 
 The method `ExecuteQueryAsync(string indexName, Query query, List<SortOptions> sort, int from, int size)` has been removed from the `ElasticsearchQueryService` class. In its place, we have introduced the new method `GetContentItemIdsAsync(ElasticsearchSearchContext request)`, which streamlines the query execution process by encapsulating the necessary parameters within a single context object.
 
+### Search Highlights
+
+The latest update introduces support for **Search Highlights** in Elasticsearch queries. When highlights are enabled, Elasticsearch will return relevant text segments that match the search term, allowing for a more contextual and user-friendly search result display.
+
+#### Example Elasticsearch Query
+
+Here's an example of how to configure the Elasticsearch query to include highlights:
+
+```json
+{
+  "query": {
+    "multi_match": {
+      "fields": [
+        "Content.ContentItem.FullText"
+      ],
+      "query": "{{ term }}",
+      "fuzziness": "AUTO"
+    }
+  },
+  "highlight": {
+    "pre_tags": [
+      "<span style='background-color: #FFF3CD;'>"
+    ],
+    "post_tags": [
+      "</span>"
+    ],
+    "fields": {
+      "Content.ContentItem.FullText": {
+        "fragment_size": 150,
+        "number_of_fragments": 3
+      }
+    }
+  }
+}
+```
+
+With this feature, Elasticsearch will return highlighted fragments wrapped in custom HTML tags, which can then be displayed in the Search module or other components. This enables the presentation of more relevant content that directly matches the search term.
+
 ### Azure Search AI Module  
 
 #### Enhanced Multi-Source Indexing  
@@ -257,6 +295,10 @@ This change streamlines the email confirmation process by moving it out of the u
 
 !!! note
     The **Confirm email** option will only be visible if the user has not yet been confirmed.
+
+### Search Module
+
+The Search Module now supports **Highlights**. If the search service provider supports Highlights, they will be rendered by default. If Highlights are unavailable, the module will fall back to displaying the `ContentItem` in a summary view.
 
 ### ReCaptcha Module
 

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -301,7 +301,7 @@ This change streamlines the email confirmation process by moving it out of the u
 
 ### Search Module
 
-The Search Module now supports **Highlights**. If the search service provider supports Highlights, they will be rendered by default. If Highlights are unavailable, the module will fall back to displaying the `ContentItem` in a **Summary** display mode.
+The Search Module now supports **Highlights**. If the search service provider supports Highlights, they will be rendered by default. If Highlights are unavailable, the module will fall back to displaying the `ContentItem` in a **Summary** display type.
 
 ### ReCaptcha Module
 

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -102,6 +102,9 @@ Here's an example of how to configure the Elasticsearch query to include highlig
 
 With this feature, Elasticsearch will return highlighted fragments wrapped in custom HTML tags, which can then be displayed in the Search module or other components. This enables the presentation of more relevant content that directly matches the search term.
 
+!!! note
+    Highlights request only work when the content item is stored in Elasticsearch service.
+
 ### Azure Search AI Module  
 
 #### Enhanced Multi-Source Indexing  
@@ -298,7 +301,7 @@ This change streamlines the email confirmation process by moving it out of the u
 
 ### Search Module
 
-The Search Module now supports **Highlights**. If the search service provider supports Highlights, they will be rendered by default. If Highlights are unavailable, the module will fall back to displaying the `ContentItem` in a summary view.
+The Search Module now supports **Highlights**. If the search service provider supports Highlights, they will be rendered by default. If Highlights are unavailable, the module will fall back to displaying the `ContentItem` in a **Summary** display mode.
 
 ### ReCaptcha Module
 


### PR DESCRIPTION
### Description

This PR enhances the display of search results by integrating support for `Highlights`, which is a feature provided by search services like Elasticsearch. When highlights are available, they will be displayed as the key segments of the found text, offering a more contextual preview. If no highlights are returned, the contentitem will be shown in Summary display type as we do today.

### Example Elasticsearch Query

The following example demonstrates how Elasticsearch can be configured to return highlighted text within search results:

```json
{
  "query": {
    "multi_match": {
      "fields": [
        "Content.ContentItem.DisplayText.keyword",
        "Content.BodyAspect.Body"
      ],
      "query": "{{ term }}",
      "fuzziness": "AUTO"
    }
  },
  "highlight": {
    "pre_tags": [
      "<span style='background-color: #FFF3CD;'>"
    ],
    "post_tags": [
      "</span>"
    ],
    "fields": {
      "Content.BodyAspect.Body": {
        "fragment_size": 250,
        "number_of_fragments": 1
      }
    }
  }
}
```

In this query, the `highlight` section specifies how matched terms will be wrapped in HTML tags with a yellow background, and it limits the highlighted fragments to 3 with a maximum size of 150 characters each.

#### Here is a search result without Highlights:

![image](https://github.com/user-attachments/assets/8534a5d2-9e09-4828-9670-4094b9056461)

#### Here is a search result with Highlights:

![image](https://github.com/user-attachments/assets/fa30e609-7f4a-485f-8aac-40ae225e4bb9)


