### PR TITLE
Added a badge if user email address is not confirmed

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserFields.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserFields.cshtml
@@ -7,8 +7,8 @@
 <h5 class="float-start">@Model.User.UserName <span class="hint dashed">@Model.User.Email</span></h5>
 @if (!await UserManager.IsEmailConfirmedAsync(Model.User))
 {
-    <span class="badge text-bg-warning ms-2" title="@T["Confirmation of the email address '{0}' is pending.", Model.User.Email]">
-        <i class="fa-solid fa-envelope-open" aria-hidden="true"></i> @T["Pending"]
+    <span class="badge text-bg-warning ms-2" title="@T["The email address '{0}' has not been confirmed.", Model.User.Email]">
+        <i class="fa-solid fa-envelope-open" aria-hidden="true"></i> @T["Unconfirmed"]
     </span>
 }
 @if (!Model.User.IsEnabled)

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserFields.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserFields.cshtml
@@ -1,6 +1,16 @@
+@using Microsoft.AspNetCore.Identity
+
 @model SummaryAdminUserViewModel
 
+@inject UserManager<IUser> UserManager
+
 <h5 class="float-start">@Model.User.UserName <span class="hint dashed">@Model.User.Email</span></h5>
+@if (!await UserManager.IsEmailConfirmedAsync(Model.User))
+{
+    <span class="badge text-bg-warning ms-2" title="@T["Email not confirmed"]">
+        <i class="fa-solid fa-envelope-open" aria-hidden="true"></i> @T["Email not confirmed"]
+    </span>
+}
 @if (!Model.User.IsEnabled)
 {
     <span class="badge text-bg-danger ms-2" title="@T["Disabled"]">

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserFields.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserFields.cshtml
@@ -7,8 +7,8 @@
 <h5 class="float-start">@Model.User.UserName <span class="hint dashed">@Model.User.Email</span></h5>
 @if (!await UserManager.IsEmailConfirmedAsync(Model.User))
 {
-    <span class="badge text-bg-warning ms-2" title="@T["Email not confirmed"]">
-        <i class="fa-solid fa-envelope-open" aria-hidden="true"></i> @T["Email not confirmed"]
+    <span class="badge text-bg-warning ms-2" title="@T["Confirmation of the email address '{0}' is pending.", Model.User.Email]">
+        <i class="fa-solid fa-envelope-open" aria-hidden="true"></i> @T["Pending"]
     </span>
 }
 @if (!Model.User.IsEnabled)


### PR DESCRIPTION
After merging PR #17684 there is no more output if the user email address is confirmed or not.
I've added a simple badge to indicate the email status if it's not yet confirmed:

![image](https://github.com/user-attachments/assets/a832bd64-fa5a-4422-a33d-29e92d116979)

/cc @MikeAlhayek 
