### PR TITLE
Fixes an issue in the flows editor where inserting a widget caused incorrect field mapping during validation errors

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -87,6 +87,7 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
             model.FlowPart = flowPart;
             model.Updater = context.Updater;
             model.ContainedContentTypeDefinitions = containedContentTypes;
+            model.Prefixes = flowPart.Prefixes;
         });
     }
 
@@ -122,6 +123,7 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
         }
 
         part.Widgets = contentItems;
+        part.Prefixes = model.Prefixes;
 
         return Edit(part, context);
     }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Models/FlowPart.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Models/FlowPart.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using OrchardCore.ContentManagement;
 
@@ -7,4 +8,8 @@ public class FlowPart : ContentPart
 {
     [BindNever]
     public List<ContentItem> Widgets { get; set; } = [];
+
+    [BindNever]
+    [JsonIgnore]
+    public string[] Prefixes { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -47,7 +47,7 @@
                     //Input hidden
                     //Prefixes
                     HtmlFieldPrefix: htmlFieldPrefix,
-                    PrefixValue: htmlFieldPrefix + '-' + (index++).ToString(),
+                    PrefixValue: Model.Prefixes != null && Model.Prefixes.Length > index ? Model.Prefixes[index++] : htmlFieldPrefix + '-' + (index++).ToString(),
                     PrefixesId: Html.IdFor(x => x.Prefixes),
                     PrefixesName: Html.NameFor(x => x.Prefixes),
                     //Content Types


### PR DESCRIPTION
The flows editor generated HTML input names with different prefixes on the client side and server side, causing incorrect field mapping. This issue is resolved by consistently using the previously established prefixes.

Fixes #17555 