### PR TITLE
Fixes duplicated IDs on hidden input fields of the flows editor and cleanup FlowPart

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Controllers/AdminController.cs
@@ -81,13 +81,10 @@ public sealed class AdminController : Controller
             // Input hidden
             // Prefixes
             PrefixValue: prefix,
-            PrefixesId: prefixesName.Replace('.', '_'),
             PrefixesName: prefixesName,
             // ContentTypes
-            ContentTypesId: contentTypesName.Replace('.', '_'),
             ContentTypesName: contentTypesName,
             // ContentItems
-            ContentItemsId: contentItemsName.Replace('.', '_'),
             ContentItemsName: contentItemsName
         );
         // Only Add ColumnSize Property if Part has FlowMetadata

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -55,6 +55,9 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
     }
 
     public override IDisplayResult Edit(FlowPart flowPart, BuildPartEditorContext context)
+        => EditInternal(flowPart, context, null);
+
+    private ShapeResult EditInternal(FlowPart flowPart, BuildPartEditorContext context, string[] prefixes)
     {
         return Initialize<FlowPartEditViewModel>(GetEditorShapeType(context), async model =>
         {
@@ -87,7 +90,7 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
             model.FlowPart = flowPart;
             model.Updater = context.Updater;
             model.ContainedContentTypeDefinitions = containedContentTypes;
-            model.Prefixes = flowPart.Prefixes;
+            model.Prefixes = prefixes;
         });
     }
 
@@ -123,9 +126,8 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
         }
 
         part.Widgets = contentItems;
-        part.Prefixes = model.Prefixes;
 
-        return Edit(part, context);
+        return EditInternal(part, context, model.Prefixes);
     }
 
     private async Task<IEnumerable<ContentTypeDefinition>> GetContainedContentTypesAsync(ContentTypePartDefinition typePartDefinition)

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Models/FlowPart.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Models/FlowPart.cs
@@ -8,8 +8,4 @@ public class FlowPart : ContentPart
 {
     [BindNever]
     public List<ContentItem> Widgets { get; set; } = [];
-
-    [BindNever]
-    [JsonIgnore]
-    public string[] Prefixes { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -199,6 +199,7 @@
                                     if ($(this).attr('id') !== undefined) {
                                         $(this).attr('id', $(this).attr('id').replace(sourceGuid, ''));
                                     }
+
                                     $(this).attr('name', $(this).attr('name').replace(sourceNameGuid, ''));
                                 });
                             }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -28,34 +28,31 @@
 
                 //Create a Card Shape
                 dynamic contentCard = await New.ContentCard(
-                    //For Updater
-                    CollectionShape: Model,
-                    //Shape Specific
-                    CollectionShapeType: nameof(FlowPart),
-                    ContentItem: widget,
-                    BuildEditor: true,
-                    ParentContentType: parentContentType,
-                    ContainedContentTypes: Model.ContainedContentTypeDefinitions,
-                    CollectionPartName: partName,
-                    //FlowPart Card Specific - For Frame
-                    ColumnSize: colSize,
-                    //Card Specific Properties
-                    TargetId: widgetTemplatePlaceholderId,
-                    Inline: false,
-                    CanMove: true,
-                    CanDelete: true,
-                    //Input hidden
-                    //Prefixes
-                    HtmlFieldPrefix: htmlFieldPrefix,
-                    PrefixValue: Model.Prefixes != null && Model.Prefixes.Length > index ? Model.Prefixes[index++] : htmlFieldPrefix + '-' + (index++).ToString(),
-                    PrefixesId: Html.IdFor(x => x.Prefixes),
-                    PrefixesName: Html.NameFor(x => x.Prefixes),
-                    //Content Types
-                    ContentTypesId: Html.IdFor(x => x.ContentTypes),
-                    ContentTypesName: Html.NameFor(x => x.ContentTypes),
-                    //Content Items
-                    ContentItemsId: Html.IdFor(x => x.ContentItems),
-                    ContentItemsName: Html.NameFor(x => x.ContentItems)
+                //For Updater
+                CollectionShape: Model,
+                //Shape Specific
+                CollectionShapeType: nameof(FlowPart),
+                ContentItem: widget,
+                BuildEditor: true,
+                ParentContentType: parentContentType,
+                ContainedContentTypes: Model.ContainedContentTypeDefinitions,
+                CollectionPartName: partName,
+                //FlowPart Card Specific - For Frame
+                ColumnSize: colSize,
+                //Card Specific Properties
+                TargetId: widgetTemplatePlaceholderId,
+                Inline: false,
+                CanMove: true,
+                CanDelete: true,
+                //Input hidden
+                //Prefixes
+                HtmlFieldPrefix: htmlFieldPrefix,
+                PrefixValue: Model.Prefixes != null && Model.Prefixes.Length > index ? Model.Prefixes[index++] : htmlFieldPrefix + '-' + (index++).ToString(),
+                PrefixesName: Html.NameFor(x => x.Prefixes),
+                //Content Types
+                ContentTypesName: Html.NameFor(x => x.ContentTypes),
+                //Content Items
+                ContentItemsName: Html.NameFor(x => x.ContentItems)
                 );
                 @await DisplayAsync(contentCard)
             }
@@ -77,16 +74,16 @@
                         @foreach (var type in widgetContentTypes.OrderBy(w => w.DisplayName))
                         {
                             <a class="dropdown-item add-widget btn-sm"
-                            data-target-id="@widgetTemplatePlaceholderId"
-                            data-html-field-prefix="@htmlFieldPrefix"
-                            data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
-                            data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
-                            data-contentitems-name="@Html.NameFor(x => x.ContentItems)"
-                            data-widget-type="@type.Name"
-                            data-flowmetadata="true"
-                            data-parent-content-type="@parentContentType"
-                            data-part-name="@partName"
-                            href="javascript:;">@type.DisplayName</a>
+                               data-target-id="@widgetTemplatePlaceholderId"
+                               data-html-field-prefix="@htmlFieldPrefix"
+                               data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
+                               data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
+                               data-contentitems-name="@Html.NameFor(x => x.ContentItems)"
+                               data-widget-type="@type.Name"
+                               data-flowmetadata="true"
+                               data-parent-content-type="@parentContentType"
+                               data-part-name="@partName"
+                               href="javascript:;">@type.DisplayName</a>
                         }
                     }
                 </div>
@@ -102,7 +99,7 @@
             var contentItem = await ContentManager.NewAsync(type.Name);
             await DisplayAsync(await ContentItemDisplayManager.BuildEditorAsync(contentItem, Model.Updater, true, "", Guid.NewGuid().ToString("n")));
         }
-        
+
         <script asp-name="flowpart-edit" at="Foot"></script>
         <style asp-name="flowpart-edit" at="Head"></style>
     }
@@ -179,21 +176,27 @@
 
                                 if (source.length > 0) {
                                     inputs.each(function (index, item) {
-                                        $(this).attr('id', $(this).attr('id').replace(sourceGuid, destGuid));
+                                        if ($(this).attr('id') !== undefined) {
+                                            $(this).attr('id', $(this).attr('id').replace(sourceGuid, destGuid));
+                                        }
                                         $(this).attr('name', $(this).attr('name').replace(sourceNameGuid, destNameGuid));
                                     });
 
                                 } else {
 
                                     inputs.each(function (index, item) {
-                                        $(this).attr('id', destGuid + $(this).attr('id'));
+                                        if ($(this).attr('id') !== undefined) {
+                                            $(this).attr('id', destGuid + $(this).attr('id'));
+                                        }
                                         $(this).attr('name', destNameGuid + $(this).attr('name'));
                                     });
                                 }
                             }
                             else if (source.length > 0) {
                                 inputs.each(function (index, item) {
-                                    $(this).attr('id', $(this).attr('id').replace(sourceGuid, ''));
+                                    if ($(this).attr('id') !== undefined) {
+                                        $(this).attr('id', $(this).attr('id').replace(sourceGuid, ''));
+                                    }
                                     $(this).attr('name', $(this).attr('name').replace(sourceNameGuid, ''));
                                 });
                             }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -189,6 +189,7 @@
                                         if ($(this).attr('id') !== undefined) {
                                             $(this).attr('id', destGuid + $(this).attr('id'));
                                         }
+
                                         $(this).attr('name', destNameGuid + $(this).attr('name'));
                                     });
                                 }

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -28,31 +28,31 @@
 
                 //Create a Card Shape
                 dynamic contentCard = await New.ContentCard(
-                //For Updater
-                CollectionShape: Model,
-                //Shape Specific
-                CollectionShapeType: nameof(FlowPart),
-                ContentItem: widget,
-                BuildEditor: true,
-                ParentContentType: parentContentType,
-                ContainedContentTypes: Model.ContainedContentTypeDefinitions,
-                CollectionPartName: partName,
-                //FlowPart Card Specific - For Frame
-                ColumnSize: colSize,
-                //Card Specific Properties
-                TargetId: widgetTemplatePlaceholderId,
-                Inline: false,
-                CanMove: true,
-                CanDelete: true,
-                //Input hidden
-                //Prefixes
-                HtmlFieldPrefix: htmlFieldPrefix,
-                PrefixValue: Model.Prefixes != null && Model.Prefixes.Length > index ? Model.Prefixes[index++] : htmlFieldPrefix + '-' + (index++).ToString(),
-                PrefixesName: Html.NameFor(x => x.Prefixes),
-                //Content Types
-                ContentTypesName: Html.NameFor(x => x.ContentTypes),
-                //Content Items
-                ContentItemsName: Html.NameFor(x => x.ContentItems)
+                    //For Updater
+                    CollectionShape: Model,
+                    //Shape Specific
+                    CollectionShapeType: nameof(FlowPart),
+                    ContentItem: widget,
+                    BuildEditor: true,
+                    ParentContentType: parentContentType,
+                    ContainedContentTypes: Model.ContainedContentTypeDefinitions,
+                    CollectionPartName: partName,
+                    //FlowPart Card Specific - For Frame
+                    ColumnSize: colSize,
+                    //Card Specific Properties
+                    TargetId: widgetTemplatePlaceholderId,
+                    Inline: false,
+                    CanMove: true,
+                    CanDelete: true,
+                    //Input hidden
+                    //Prefixes
+                    HtmlFieldPrefix: htmlFieldPrefix,
+                    PrefixValue: Model.Prefixes != null && Model.Prefixes.Length > index ? Model.Prefixes[index++] : htmlFieldPrefix + '-' + (index++).ToString(),
+                    PrefixesName: Html.NameFor(x => x.Prefixes),
+                    //Content Types
+                    ContentTypesName: Html.NameFor(x => x.ContentTypes),
+                    //Content Items
+                    ContentItemsName: Html.NameFor(x => x.ContentItems)
                 );
                 @await DisplayAsync(contentCard)
             }
@@ -74,16 +74,16 @@
                         @foreach (var type in widgetContentTypes.OrderBy(w => w.DisplayName))
                         {
                             <a class="dropdown-item add-widget btn-sm"
-                               data-target-id="@widgetTemplatePlaceholderId"
-                               data-html-field-prefix="@htmlFieldPrefix"
-                               data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
-                               data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
-                               data-contentitems-name="@Html.NameFor(x => x.ContentItems)"
-                               data-widget-type="@type.Name"
-                               data-flowmetadata="true"
-                               data-parent-content-type="@parentContentType"
-                               data-part-name="@partName"
-                               href="javascript:;">@type.DisplayName</a>
+                            data-target-id="@widgetTemplatePlaceholderId"
+                            data-html-field-prefix="@htmlFieldPrefix"
+                            data-prefixes-name="@Html.NameFor(x => x.Prefixes)"
+                            data-contenttypes-name="@Html.NameFor(x => x.ContentTypes)"
+                            data-contentitems-name="@Html.NameFor(x => x.ContentItems)"
+                            data-widget-type="@type.Name"
+                            data-flowmetadata="true"
+                            data-parent-content-type="@parentContentType"
+                            data-part-name="@partName"
+                            href="javascript:;">@type.DisplayName</a>
                         }
                     }
                 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Edit.cshtml
@@ -179,6 +179,7 @@
                                         if ($(this).attr('id') !== undefined) {
                                             $(this).attr('id', $(this).attr('id').replace(sourceGuid, destGuid));
                                         }
+
                                         $(this).attr('name', $(this).attr('name').replace(sourceNameGuid, destNameGuid));
                                     });
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Views/FlowPart.Fields.Edit.cshtml
@@ -1,3 +1,3 @@
-<input type="hidden" id="@Model.CardShape.PrefixesId" name="@Model.CardShape.PrefixesName" value="@Model.CardShape.PrefixValue" />
-<input type="hidden" id="@Model.CardShape.ContentTypesId" name="@Model.CardShape.ContentTypesName" value="@Model.CardShape.ContentItem.ContentType" />
-<input type="hidden" id="@Model.CardShape.ContentItemsId" name="@Model.CardShape.ContentItemsName" value="@Model.CardShape.ContentItem.ContentItemId" />
+<input type="hidden" name="@Model.CardShape.PrefixesName" value="@Model.CardShape.PrefixValue" />
+<input type="hidden" name="@Model.CardShape.ContentTypesName" value="@Model.CardShape.ContentItem.ContentType" />
+<input type="hidden" name="@Model.CardShape.ContentItemsName" value="@Model.CardShape.ContentItem.ContentItemId" />


### PR DESCRIPTION
As a follow-up to PR #17730 this improves the previous fix, by removing an unnecessary property on the `FlowPart`.

Fixes #17731