### PR TITLE
Move GetRoleNamesAsync() to extension method

### DIFF
--- a/src/OrchardCore/OrchardCore.Roles.Core/Extensions/RoleServiceExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Core/Extensions/RoleServiceExtensions.cs
@@ -1,0 +1,15 @@
+using OrchardCore.Security.Services;
+
+namespace OrchardCore.Roles.Extensions;
+
+public static class RoleServiceExtensions
+{
+    public static async Task<IEnumerable<string>> GetRoleNamesAsync(this IRoleService roleService)
+    {
+        ArgumentNullException.ThrowIfNull(roleService);
+
+        var roles = await roleService.GetRolesAsync();
+
+        return roles.Select(role => role.RoleName);
+    }
+}

--- a/src/OrchardCore/OrchardCore.Roles.Core/Services/RoleService.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Core/Services/RoleService.cs
@@ -39,10 +39,9 @@ public class RoleService : IRoleService
         return Task.FromResult<IEnumerable<IRole>>(_roleManager.Roles);
     }
 
+    [Obsolete("This method is deprecated and will be removed in a future version. Use GetRolesAsync() instead.")]
     public Task<IEnumerable<string>> GetRoleNamesAsync()
-    {
-        return Task.FromResult<IEnumerable<string>>(_roleManager.Roles.Select(a => a.RoleName));
-    }
+        => RoleServiceExtensions.GetRoleNamesAsync(this);
 
     public Task<IEnumerable<string>> GetNormalizedRoleNamesAsync()
     {


### PR DESCRIPTION
It seems the `GetRoleNamesAsync()` has been added to `RoleService` accidently; this PR moved it to an extension method. No breaking changes