### PR TITLE
Add OAuth 2.0 Pushed Authorization Requests support in the OpenID module

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Configuration/OpenIdServerConfiguration.cs
@@ -105,6 +105,12 @@ public sealed class OpenIdServerConfiguration : IConfigureOptions<Authentication
                 settings.IntrospectionEndpointPath.ToUriComponent()[1..], UriKind.Relative));
         }
 
+        if (settings.PushedAuthorizationEndpointPath.HasValue)
+        {
+            options.PushedAuthorizationEndpointUris.Add(new Uri(
+                settings.PushedAuthorizationEndpointPath.ToUriComponent()[1..], UriKind.Relative));
+        }
+
         if (settings.RevocationEndpointPath.HasValue)
         {
             options.RevocationEndpointUris.Add(new Uri(
@@ -173,6 +179,7 @@ public sealed class OpenIdServerConfiguration : IConfigureOptions<Authentication
         }
 
         options.RequireProofKeyForCodeExchange = settings.RequireProofKeyForCodeExchange;
+        options.RequirePushedAuthorizationRequests = settings.RequirePushedAuthorizationRequests;
 
         options.Scopes.Add(Scopes.Email);
         options.Scopes.Add(Scopes.Phone);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -180,7 +180,8 @@ public sealed class ApplicationController : Controller
             Roles = model.RoleEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
             Scopes = model.ScopeEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
             Type = model.Type,
-            RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange
+            RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange,
+            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests
         };
 
         await _applicationManager.UpdateDescriptorFromSettings(settings);
@@ -243,7 +244,8 @@ public sealed class ApplicationController : Controller
             PostLogoutRedirectUris = string.Join(" ", await _applicationManager.GetPostLogoutRedirectUrisAsync(application)),
             RedirectUris = string.Join(" ", await _applicationManager.GetRedirectUrisAsync(application)),
             Type = await _applicationManager.GetClientTypeAsync(application),
-            RequireProofKeyForCodeExchange = await HasRequirementAsync(OpenIddictConstants.Requirements.Features.ProofKeyForCodeExchange)
+            RequireProofKeyForCodeExchange = await HasRequirementAsync(OpenIddictConstants.Requirements.Features.ProofKeyForCodeExchange),
+            RequirePushedAuthorizationRequests = await HasRequirementAsync(OpenIddictConstants.Requirements.Features.PushedAuthorizationRequests)
         };
 
         var roleService = HttpContext.RequestServices?.GetService<IRoleService>();
@@ -347,7 +349,8 @@ public sealed class ApplicationController : Controller
             Roles = model.RoleEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
             Scopes = model.ScopeEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
             Type = model.Type,
-            RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange
+            RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange,
+            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests
         };
 
         await _applicationManager.UpdateDescriptorFromSettings(settings, application);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -181,7 +181,7 @@ public sealed class ApplicationController : Controller
             Scopes = model.ScopeEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
             Type = model.Type,
             RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange,
-            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests
+            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests,
         };
 
         await _applicationManager.UpdateDescriptorFromSettings(settings);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -245,7 +245,7 @@ public sealed class ApplicationController : Controller
             RedirectUris = string.Join(" ", await _applicationManager.GetRedirectUrisAsync(application)),
             Type = await _applicationManager.GetClientTypeAsync(application),
             RequireProofKeyForCodeExchange = await HasRequirementAsync(OpenIddictConstants.Requirements.Features.ProofKeyForCodeExchange),
-            RequirePushedAuthorizationRequests = await HasRequirementAsync(OpenIddictConstants.Requirements.Features.PushedAuthorizationRequests)
+            RequirePushedAuthorizationRequests = await HasRequirementAsync(OpenIddictConstants.Requirements.Features.PushedAuthorizationRequests),
         };
 
         var roleService = HttpContext.RequestServices?.GetService<IRoleService>();

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -350,7 +350,7 @@ public sealed class ApplicationController : Controller
             Scopes = model.ScopeEntries.Where(x => x.Selected).Select(x => x.Name).ToArray(),
             Type = model.Type,
             RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange,
-            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests
+            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests,
         };
 
         await _applicationManager.UpdateDescriptorFromSettings(settings, application);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentSource.cs
@@ -53,7 +53,7 @@ public sealed class OpenIdServerDeploymentSource
             DisableRollingRefreshTokens = settings.DisableRollingRefreshTokens,
             UseReferenceAccessTokens = settings.UseReferenceAccessTokens,
             RequireProofKeyForCodeExchange = settings.RequireProofKeyForCodeExchange,
-            RequirePushedAuthorizationRequests = settings.RequirePushedAuthorizationRequests
+            RequirePushedAuthorizationRequests = settings.RequirePushedAuthorizationRequests,
         };
 
         result.Steps.Add(new JsonObject

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentSource.cs
@@ -39,6 +39,7 @@ public sealed class OpenIdServerDeploymentSource
             EnableTokenEndpoint = !string.IsNullOrWhiteSpace(settings.TokenEndpointPath),
             EnableUserInfoEndpoint = !string.IsNullOrWhiteSpace(settings.UserinfoEndpointPath),
             EnableIntrospectionEndpoint = !string.IsNullOrWhiteSpace(settings.IntrospectionEndpointPath),
+            EnablePushedAuthorizationEndpoint = !string.IsNullOrWhiteSpace(settings.PushedAuthorizationEndpointPath),
             EnableRevocationEndpoint = !string.IsNullOrWhiteSpace(settings.RevocationEndpointPath),
 
             AllowAuthorizationCodeFlow = settings.AllowAuthorizationCodeFlow,
@@ -52,6 +53,7 @@ public sealed class OpenIdServerDeploymentSource
             DisableRollingRefreshTokens = settings.DisableRollingRefreshTokens,
             UseReferenceAccessTokens = settings.UseReferenceAccessTokens,
             RequireProofKeyForCodeExchange = settings.RequireProofKeyForCodeExchange,
+            RequirePushedAuthorizationRequests = settings.RequirePushedAuthorizationRequests
         };
 
         result.Steps.Add(new JsonObject

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdServerSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdServerSettingsDisplayDriver.cs
@@ -54,6 +54,7 @@ public sealed class OpenIdServerSettingsDisplayDriver : DisplayDriver<OpenIdServ
             model.EnableTokenEndpoint = settings.TokenEndpointPath.HasValue;
             model.EnableUserInfoEndpoint = settings.UserinfoEndpointPath.HasValue;
             model.EnableIntrospectionEndpoint = settings.IntrospectionEndpointPath.HasValue;
+            model.EnablePushedAuthorizationEndpoint = settings.PushedAuthorizationEndpointPath.HasValue;
             model.EnableRevocationEndpoint = settings.RevocationEndpointPath.HasValue;
 
             model.AllowAuthorizationCodeFlow = settings.AllowAuthorizationCodeFlow;
@@ -67,6 +68,7 @@ public sealed class OpenIdServerSettingsDisplayDriver : DisplayDriver<OpenIdServ
             model.DisableRollingRefreshTokens = settings.DisableRollingRefreshTokens;
             model.UseReferenceAccessTokens = settings.UseReferenceAccessTokens;
             model.RequireProofKeyForCodeExchange = settings.RequireProofKeyForCodeExchange;
+            model.RequirePushedAuthorizationRequests = settings.RequirePushedAuthorizationRequests;
 
             foreach (var (certificate, location, name) in await _serverService.GetAvailableCertificatesAsync())
             {
@@ -120,6 +122,8 @@ public sealed class OpenIdServerSettingsDisplayDriver : DisplayDriver<OpenIdServ
             new PathString("/connect/userinfo") : PathString.Empty;
         settings.IntrospectionEndpointPath = model.EnableIntrospectionEndpoint ?
             new PathString("/connect/introspect") : PathString.Empty;
+        settings.PushedAuthorizationEndpointPath = model.EnablePushedAuthorizationEndpoint ?
+            new PathString("/connect/par") : PathString.Empty;
         settings.RevocationEndpointPath = model.EnableRevocationEndpoint ?
             new PathString("/connect/revoke") : PathString.Empty;
 
@@ -134,6 +138,7 @@ public sealed class OpenIdServerSettingsDisplayDriver : DisplayDriver<OpenIdServ
         settings.DisableRollingRefreshTokens = model.DisableRollingRefreshTokens;
         settings.UseReferenceAccessTokens = model.UseReferenceAccessTokens;
         settings.RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange;
+        settings.RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests;
 
         return await EditAsync(settings, context);
     }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Migrations/PushedAuthorizationRequestsMigration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Migrations/PushedAuthorizationRequestsMigration.cs
@@ -1,0 +1,106 @@
+#nullable enable
+
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using OpenIddict.Abstractions;
+using OrchardCore.Data.Migration;
+using OrchardCore.Environment.Shell.Scope;
+using OrchardCore.OpenId.Abstractions.Descriptors;
+using OrchardCore.OpenId.Abstractions.Managers;
+using OrchardCore.OpenId.Settings;
+using OrchardCore.Settings;
+
+namespace OrchardCore.OpenId.Migrations;
+
+public sealed class PushedAuthorizationRequestsMigration : DataMigration
+{
+#pragma warning disable CA1822 // Mark members as static
+    public int Create()
+#pragma warning restore CA1822 // Mark members as static
+    {
+        // Note: this migration is responsible for enabling the pushed authorization endpoint in the server settings and
+        // automatically granting existing applications the right to use it they are allowed to use the authorization endpoint.
+
+        ShellScope.AddDeferredTask(async scope =>
+        {
+            var manager = scope.ServiceProvider.GetRequiredService<IOpenIdApplicationManager>();
+            var service = scope.ServiceProvider.GetRequiredService<ISiteService>();
+
+            List<Exception>? exceptions = null;
+
+            // Note: for performance reasons, the maximum number of applications that can
+            // be updated by this migration is 100 per batch operation and 100K in total.
+            for (var index = 0; index < 1_000; index++)
+            {
+                List<object> applications = [];
+
+                // Note: the applications are deliberately buffered to ensure we don't actively update
+                // application entries while the applications table is still being read at the same time.
+                await foreach (var application in manager.ListAsync(100, index * 100))
+                {
+                    applications.Add(application);
+                }
+
+                foreach (var application in applications)
+                {
+                    // If the pushed authorization endpoint permission was already
+                    // granted (manually or automatically), there's nothing left to do.
+                    if (await manager.HasPermissionAsync(application, OpenIddictConstants.Permissions.Endpoints.PushedAuthorization))
+                    {
+                        continue;
+                    }
+
+                    // If the application wasn't granted the authorization endpoint permission,
+                    // do not automatically allow it to use the pushed authorization endpoint.
+                    if (!await manager.HasPermissionAsync(application, OpenIddictConstants.Permissions.Endpoints.Authorization))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var descriptor = new OpenIdApplicationDescriptor();
+                        await manager.PopulateAsync(descriptor, application);
+
+                        descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.PushedAuthorization);
+                        await manager.PopulateAsync(application, descriptor);
+                        await manager.UpdateAsync(application);
+                    }
+
+                    catch (Exception exception)
+                    {
+                        exceptions ??= [];
+                        exceptions.Add(exception);
+                    }
+                }
+
+                if (applications.Count is < 100)
+                {
+                    break;
+                }
+            }
+
+            // If the server feature was explicitly configured (e.g using a recipe or via the GUI), update
+            // the server settings stored in the database to enable the pushed authorization endpoint.
+            var container = await service.LoadSiteSettingsAsync();
+            if (container.Properties.TryGetPropertyValue(nameof(OpenIdServerSettings), out var node) &&
+                node.ToObject<OpenIdServerSettings>(JOptions.Default) is OpenIdServerSettings settings &&
+                !settings.PushedAuthorizationEndpointPath.HasValue)
+            {
+                settings.PushedAuthorizationEndpointPath = new PathString("/connect/par");
+
+                container.Properties[nameof(OpenIdServerSettings)] = JObject.FromObject(settings, JOptions.Default);
+                await service.UpdateSiteSettingsAsync(container);
+            }
+
+            if (exceptions is { Count: > 0 })
+            {
+                throw new AggregateException(exceptions);
+            }
+        });
+
+        return 1;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/OpenIdApplicationSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/OpenIdApplicationSettings.cs
@@ -25,6 +25,7 @@ public class OpenIdApplicationSettings
     public bool AllowIntrospectionEndpoint { get; set; }
     public bool AllowRevocationEndpoint { get; set; }
     public bool RequireProofKeyForCodeExchange { get; set; }
+    public bool RequirePushedAuthorizationRequests { get; set; }
 }
 
 internal static class OpenIdApplicationExtensions
@@ -113,10 +114,12 @@ internal static class OpenIdApplicationExtensions
         if (model.AllowAuthorizationCodeFlow || model.AllowHybridFlow || model.AllowImplicitFlow)
         {
             descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.Authorization);
+            descriptor.Permissions.Add(OpenIddictConstants.Permissions.Endpoints.PushedAuthorization);
         }
         else
         {
             descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.Authorization);
+            descriptor.Permissions.Remove(OpenIddictConstants.Permissions.Endpoints.PushedAuthorization);
         }
 
         if (model.AllowAuthorizationCodeFlow || model.AllowHybridFlow ||
@@ -207,6 +210,15 @@ internal static class OpenIdApplicationExtensions
         else
         {
             descriptor.Requirements.Remove(OpenIddictConstants.Requirements.Features.ProofKeyForCodeExchange);
+        }
+
+        if (model.RequirePushedAuthorizationRequests)
+        {
+            descriptor.Requirements.Add(OpenIddictConstants.Requirements.Features.PushedAuthorizationRequests);
+        }
+        else
+        {
+            descriptor.Requirements.Remove(OpenIddictConstants.Requirements.Features.PushedAuthorizationRequests);
         }
 
         descriptor.Roles.Clear();

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -44,7 +44,7 @@ public sealed class OpenIdApplicationStep : NamedRecipeStepHandler
             Scopes = model.ScopeEntries.Select(x => x.Name).ToArray(),
             Type = model.Type,
             RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange,
-            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests
+            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests,
         };
 
         await _applicationManager.UpdateDescriptorFromSettings(settings, app);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStep.cs
@@ -44,6 +44,7 @@ public sealed class OpenIdApplicationStep : NamedRecipeStepHandler
             Scopes = model.ScopeEntries.Select(x => x.Name).ToArray(),
             Type = model.Type,
             RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange,
+            RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests
         };
 
         await _applicationManager.UpdateDescriptorFromSettings(settings, app);

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStepModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdApplicationStepModel.cs
@@ -21,6 +21,7 @@ public class OpenIdApplicationStepModel
     public bool AllowIntrospectionEndpoint { get; set; }
     public bool AllowRevocationEndpoint { get; set; }
     public bool RequireProofKeyForCodeExchange { get; set; }
+    public bool RequirePushedAuthorizationRequests { get; set; }
 
     public class RoleEntry
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdServerSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdServerSettingsStep.cs
@@ -46,6 +46,8 @@ public sealed class OpenIdServerSettingsStep : NamedRecipeStepHandler
             new PathString("/connect/userinfo") : PathString.Empty;
         settings.IntrospectionEndpointPath = model.EnableIntrospectionEndpoint ?
             new PathString("/connect/introspect") : PathString.Empty;
+        settings.PushedAuthorizationEndpointPath = model.EnablePushedAuthorizationEndpoint ?
+            new PathString("/connect/par") : PathString.Empty;
         settings.RevocationEndpointPath = model.EnableRevocationEndpoint ?
             new PathString("/connect/revoke") : PathString.Empty;
 
@@ -60,6 +62,7 @@ public sealed class OpenIdServerSettingsStep : NamedRecipeStepHandler
         settings.DisableRollingRefreshTokens = model.DisableRollingRefreshTokens;
         settings.UseReferenceAccessTokens = model.UseReferenceAccessTokens;
         settings.RequireProofKeyForCodeExchange = model.RequireProofKeyForCodeExchange;
+        settings.RequirePushedAuthorizationRequests = model.RequirePushedAuthorizationRequests;
 
         await _serverService.UpdateSettingsAsync(settings);
     }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdServerSettingsStepModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdServerSettingsStepModel.cs
@@ -20,6 +20,7 @@ public class OpenIdServerSettingsStepModel
     public bool EnableLogoutEndpoint { get; set; }
     public bool EnableUserInfoEndpoint { get; set; }
     public bool EnableIntrospectionEndpoint { get; set; }
+    public bool EnablePushedAuthorizationEndpoint { get; set; }
     public bool EnableRevocationEndpoint { get; set; }
     public bool AllowPasswordFlow { get; set; }
     public bool AllowClientCredentialsFlow { get; set; }
@@ -29,6 +30,7 @@ public class OpenIdServerSettingsStepModel
     public bool AllowImplicitFlow { get; set; }
     public bool DisableRollingRefreshTokens { get; set; }
     public bool RequireProofKeyForCodeExchange { get; set; }
+    public bool RequirePushedAuthorizationRequests { get; set; }
 
     public bool UseReferenceAccessTokens { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
@@ -65,19 +65,21 @@ public class OpenIdServerService : IOpenIdServerService
             return settings.ToObject<OpenIdServerSettings>(JOptions.Default);
         }
 
-        // If the OpenID server settings haven't been populated yet, the authorization,
-        // logout, token, userinfo, introspection and revocation endpoints are assumed to be enabled by default.
-        // In this case, only the authorization code and refresh token flows are used.
+        // If the OpenID server settings haven't been populated yet, the
+        // commonly-used endpoints are assumed to be enabled by default.
+        //
+        // In this case, only the authorization code and refresh token flows are enabled by default.
         return new OpenIdServerSettings
         {
             AllowAuthorizationCodeFlow = true,
             AllowRefreshTokenFlow = true,
             AuthorizationEndpointPath = "/connect/authorize",
-            LogoutEndpointPath = "/connect/logout",
-            TokenEndpointPath = "/connect/token",
-            UserinfoEndpointPath = "/connect/userinfo",
             IntrospectionEndpointPath = "/connect/introspect",
-            RevocationEndpointPath = "/connect/revoke"
+            LogoutEndpointPath = "/connect/logout",
+            PushedAuthorizationEndpointPath = "/connect/par",
+            RevocationEndpointPath = "/connect/revoke",
+            TokenEndpointPath = "/connect/token",
+            UserinfoEndpointPath = "/connect/userinfo"
         };
     }
 
@@ -224,6 +226,22 @@ public class OpenIdServerService : IOpenIdServerService
             results.Add(new ValidationResult(S["Access token encryption can only be disabled when using JWT tokens."], new[]
             {
                 nameof(settings.DisableAccessTokenEncryption)
+            }));
+        }
+
+        if (settings.PushedAuthorizationEndpointPath.HasValue && !settings.AuthorizationEndpointPath.HasValue)
+        {
+            results.Add(new ValidationResult(S["The pushed authorization endpoint can only be enabled when the authorization endpoint is enabled."], new[]
+            {
+                nameof(settings.PushedAuthorizationEndpointPath)
+            }));
+        }
+
+        if (settings.RequirePushedAuthorizationRequests && !settings.PushedAuthorizationEndpointPath.HasValue)
+        {
+            results.Add(new ValidationResult(S["The pushed authorization endpoint must be enabled when enforcing pushed authorization requests."], new[]
+            {
+                nameof(settings.RequirePushedAuthorizationRequests)
             }));
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Services/OpenIdServerService.cs
@@ -79,7 +79,7 @@ public class OpenIdServerService : IOpenIdServerService
             PushedAuthorizationEndpointPath = "/connect/par",
             RevocationEndpointPath = "/connect/revoke",
             TokenEndpointPath = "/connect/token",
-            UserinfoEndpointPath = "/connect/userinfo"
+            UserinfoEndpointPath = "/connect/userinfo",
         };
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdServerSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Settings/OpenIdServerSettings.cs
@@ -26,6 +26,8 @@ public class OpenIdServerSettings
 
     public PathString IntrospectionEndpointPath { get; set; }
 
+    public PathString PushedAuthorizationEndpointPath { get; set; }
+
     public PathString RevocationEndpointPath { get; set; }
 
     public bool AllowPasswordFlow { get; set; }
@@ -40,6 +42,8 @@ public class OpenIdServerSettings
     public bool UseReferenceAccessTokens { get; set; }
 
     public bool RequireProofKeyForCodeExchange { get; set; }
+
+    public bool RequirePushedAuthorizationRequests { get; set; }
 
     public enum TokenFormat
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Startup.cs
@@ -102,6 +102,8 @@ public sealed class ServerStartup : StartupBase
         services.TryAddSingleton<IOpenIdServerService, OpenIdServerService>();
 
         services.AddDataMigration<DefaultScopesMigration>();
+        services.AddDataMigration<PushedAuthorizationRequestsMigration>();
+
         // Note: the following services are registered using TryAddEnumerable to prevent duplicate registrations.
         services.TryAddEnumerable(new[]
         {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/CreateOpenIdApplicationViewModel.cs
@@ -46,6 +46,8 @@ public class CreateOpenIdApplicationViewModel
 
     public bool RequireProofKeyForCodeExchange { get; set; }
 
+    public bool RequirePushedAuthorizationRequests { get; set; }
+
     public class RoleEntry
     {
         public string Name { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/EditOpenIdApplicationViewModel.cs
@@ -50,6 +50,8 @@ public class EditOpenIdApplicationViewModel
 
     public bool RequireProofKeyForCodeExchange { get; set; }
 
+    public bool RequirePushedAuthorizationRequests { get; set; }
+
     public class RoleEntry
     {
         public string Name { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdServerSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ViewModels/OpenIdServerSettingsViewModel.cs
@@ -22,6 +22,7 @@ public class OpenIdServerSettingsViewModel
     public bool EnableLogoutEndpoint { get; set; }
     public bool EnableUserInfoEndpoint { get; set; }
     public bool EnableIntrospectionEndpoint { get; set; }
+    public bool EnablePushedAuthorizationEndpoint { get; set; }
     public bool EnableRevocationEndpoint { get; set; }
     public bool AllowPasswordFlow { get; set; }
     public bool AllowClientCredentialsFlow { get; set; }
@@ -32,6 +33,7 @@ public class OpenIdServerSettingsViewModel
     public bool DisableRollingRefreshTokens { get; set; }
     public bool UseReferenceAccessTokens { get; set; }
     public bool RequireProofKeyForCodeExchange { get; set; }
+    public bool RequirePushedAuthorizationRequests { get; set; }
 
     public class CertificateInfo
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Create.cshtml
@@ -142,6 +142,15 @@
                 @T["Ensure that the client application and OAuth or OIDC library being used supports PKCE before enabling this option."]
             </div>
         </div>
+        <div class="mb-3">
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" asp-for="RequirePushedAuthorizationRequests" checked="@Model.RequirePushedAuthorizationRequests">
+                <label class="form-check-label" asp-for="RequirePushedAuthorizationRequests">@T["Require Pushed Authorization Requests"]</label>
+            </div>
+            <div class="hint">
+                @T["Ensure that the client application and OAuth or OIDC library being used supports PAR before enabling this option."]
+            </div>
+        </div>
         <div class="mb-3" asp-validation-class-for="ConsentType">
             <label asp-for="ConsentType" class="form-label">@T["Consent type"]</label>
             <select asp-for="ConsentType" class="form-select">

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/Application/Edit.cshtml
@@ -156,6 +156,16 @@
             </div>
         </div>
 
+        <div class="mb-3">
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" asp-for="RequirePushedAuthorizationRequests" checked="@Model.RequirePushedAuthorizationRequests">
+                <label class="form-check-label" asp-for="RequirePushedAuthorizationRequests">@T["Require Pushed Authorization Requests"]</label>
+            </div>
+            <div class="hint">
+                @T["Ensure that the client/client library supports PAR before enabling this option."]
+            </div>
+        </div>
+
         <div class="mb-3" asp-validation-class-for="ConsentType">
             <label asp-for="ConsentType" class="form-label">@T["Consent type"]</label>
             <select asp-for="ConsentType" class="form-select">

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdServerSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Views/OpenIdServerSettings.Edit.cshtml
@@ -22,6 +22,14 @@
         </div>
     </div>
 
+    <div class="mb-3" asp-validation-class-for="EnablePushedAuthorizationEndpoint">
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" asp-for="EnablePushedAuthorizationEndpoint">
+            <label class="form-check-label" asp-for="EnablePushedAuthorizationEndpoint">@T["Enable Pushed Authorization Endpoint"]</label>
+            <span class="hint dashed">@T["Enables the endpoint:"]</span> <code>/connect/par</code>
+        </div>
+    </div>
+
     <div class="mb-3" asp-validation-class-for="EnableLogoutEndpoint">
         <div class="form-check">
             <input type="checkbox" class="form-check-input" asp-for="EnableLogoutEndpoint">
@@ -116,6 +124,19 @@
         </div>
         <div class="hint">
             @T["A global setting that enforces PKCE for all registered clients, regardless of whether the 'Require PKCE' option is enabled for individual client applications."]
+        </div>
+    </div>
+</div>
+
+<div class="mb-4">
+    <h3>@T["Pushed Authorization Requests"]</h3>
+    <div class="mb-3" asp-validation-class-for="RequirePushedAuthorizationRequests">
+        <div class="form-check">
+            <input type="checkbox" class="form-check-input" asp-for="RequirePushedAuthorizationRequests">
+            <label class="form-check-label" asp-for="RequirePushedAuthorizationRequests">@T["Require Pushed Authorization Requests"]</label>
+        </div>
+        <div class="hint">
+            @T["A global setting that enforces PAR for all registered clients, regardless of whether the 'Require PAR' option is enabled for individual client applications."]
         </div>
     </div>
 </div>

--- a/src/docs/reference/modules/OpenId/README.md
+++ b/src/docs/reference/modules/OpenId/README.md
@@ -145,7 +145,7 @@ A sample of OpenID Connect App recipe step:
       "AllowRefreshTokenFlow": false,
       "AllowImplicitFlow": false,
       "RequireProofKeyForCodeExchange": false,
-      "RequirePushedAuthorizationRequests": false
+      "RequirePushedAuthorizationRequests": false,
 }
 ```
 

--- a/src/docs/reference/modules/OpenId/README.md
+++ b/src/docs/reference/modules/OpenId/README.md
@@ -83,14 +83,18 @@ A sample of OpenID Connect Settings recipe step:
       "EncryptionCertificateThumbprint": "BC34460ABEA2D576EA68E8FFCFEEB3F45C94FB0F",
       "EnableTokenEndpoint": true,
       "EnableAuthorizationEndpoint": false,
+      "EnableIntrospectionEndpoint": false,
       "EnableLogoutEndpoint": true,
+      "EnablePushedAuthorizationEndpoint": false,
+      "EnableRevocationEndpoint": false,
       "EnableUserInfoEndpoint": true,
       "AllowPasswordFlow": true,
       "AllowClientCredentialsFlow": false,
       "AllowAuthorizationCodeFlow": false,
       "AllowRefreshTokenFlow": false,
       "AllowImplicitFlow": false,
-      "RequireProofKeyForCodeExchange" : false
+      "RequireProofKeyForCodeExchange": false,
+      "RequirePushedAuthorizationRequests": false
 }
 ```
 
@@ -140,7 +144,8 @@ A sample of OpenID Connect App recipe step:
       "AllowAuthorizationCodeFlow": false,
       "AllowRefreshTokenFlow": false,
       "AllowImplicitFlow": false,
-      "RequireProofKeyForCodeExchange": false
+      "RequireProofKeyForCodeExchange": false,
+      "RequirePushedAuthorizationRequests": false
 }
 ```
 

--- a/src/docs/reference/modules/OpenId/README.md
+++ b/src/docs/reference/modules/OpenId/README.md
@@ -94,7 +94,7 @@ A sample of OpenID Connect Settings recipe step:
       "AllowRefreshTokenFlow": false,
       "AllowImplicitFlow": false,
       "RequireProofKeyForCodeExchange": false,
-      "RequirePushedAuthorizationRequests": false
+      "RequirePushedAuthorizationRequests": false,
 }
 ```
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdApplicationStepTestsData.cs
@@ -25,6 +25,7 @@ internal sealed class OpenIdApplicationStepTestsData
                 OpenIddictConstants.Permissions.GrantTypes.RefreshToken,
                 OpenIddictConstants.Permissions.Endpoints.Authorization,
                 OpenIddictConstants.Permissions.Endpoints.EndSession,
+                OpenIddictConstants.Permissions.Endpoints.PushedAuthorization,
                 OpenIddictConstants.Permissions.Endpoints.Token,
                 OpenIddictConstants.Permissions.ResponseTypes.Code,
             });

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdAuthenticationTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdAuthenticationTests.cs
@@ -117,7 +117,7 @@ public class OpenIdAuthenticationTests
             Assert.Contains("orchauth_" + shellSettings.Name, cookies.Keys);
 
             var codeVerifier = GenerateCodeVerifier();
-            var challengeCode = GenerateCodeChallenge(codeVerifier);
+            var codeChallenge = GenerateCodeChallenge(codeVerifier);
             var requestData = new Dictionary<string, string>
             {
                 { "client_id", clientId },
@@ -125,8 +125,7 @@ public class OpenIdAuthenticationTests
                 { "redirect_uri", redirectUri },
                 { "scope", "openid offline_access" },
                 { "code_challenge_method", "S256" },
-                { "code_verifier", codeVerifier },
-                { "code_challenge", challengeCode },
+                { "code_challenge", codeChallenge },
             };
 
             var authorizeRequestMessage = HttpRequestHelper.CreatePostMessage("connect/authorize", requestData);
@@ -163,9 +162,9 @@ public class OpenIdAuthenticationTests
             var tokens = new ConcurrentBag<string>();
 
             // One one task should succeed since OpenId will only allow one access_token exchange for every authorization_code.
-            var taskOne = ExchangeCodeForTokenAsync(httpClient, cookies, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
-            var taskTwo = ExchangeCodeForTokenAsync(httpClient, cookies, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
-            var taskThree = ExchangeCodeForTokenAsync(httpClient, cookies, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
+            var taskOne = ExchangeCodeForTokenAsync(httpClient, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
+            var taskTwo = ExchangeCodeForTokenAsync(httpClient, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
+            var taskThree = ExchangeCodeForTokenAsync(httpClient, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
 
             await Task.WhenAll(taskOne, taskTwo, taskThree);
 
@@ -173,7 +172,153 @@ public class OpenIdAuthenticationTests
         });
     }
 
-    private static async Task ExchangeCodeForTokenAsync(HttpClient httpClient, IDictionary<string, string> cookies, string authorizationCode, string clientId, string redirectUri, string codeVerifier, ConcurrentBag<string> tokens)
+    [Fact]
+    public async Task OpenId_CodeFlowWithPushedAuthorizationRequests_CanExchangeAuthorizationCodeForAccessTokenOnlyOnce()
+    {
+        var context = new SiteContext();
+
+        await context.InitializeAsync();
+
+        var redirectUri = context.Client.BaseAddress.ToString() + "signin-oidc";
+
+        var clientId = "test_id";
+
+        var recipeSteps = new JsonArray
+        {
+            new JsonObject
+            {
+                {"name", "Feature"},
+                {"enable", new JsonArray(
+                    "OrchardCore.Users",
+                    "OrchardCore.OpenId.Server",
+                    "OrchardCore.OpenId.Validation",
+                    "OrchardCore.OpenId")
+                },
+            },
+            new JsonObject
+            {
+                {"name", "OpenIdApplication"},
+                {"ClientId", clientId},
+                {"DisplayName", "Test Application"},
+                {"Type", "public"},
+                {"ConsentType", "implicit"},
+                {"AllowAuthorizationCodeFlow", true},
+                {"RequireProofKeyForCodeExchange", true},
+                {"RequirePushedAuthorizationRequests", true},
+                {"AllowRefreshTokenFlow", true},
+                {"RedirectUris", redirectUri},
+            },
+        };
+
+        var recipe = new JsonObject
+        {
+            {"steps", recipeSteps},
+        };
+
+        await RecipeHelpers.RunRecipeAsync(context, recipe);
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var featureManager = scope.ServiceProvider.GetService<IShellFeaturesManager>();
+
+            Assert.True(await featureManager.IsFeatureEnabledAsync("OrchardCore.Users"));
+            Assert.True(await featureManager.IsFeatureEnabledAsync("OrchardCore.OpenId.Server"));
+            Assert.True(await featureManager.IsFeatureEnabledAsync("OrchardCore.OpenId.Validation"));
+            Assert.True(await featureManager.IsFeatureEnabledAsync("OrchardCore.OpenId"));
+
+            var httpClient = context.Client;
+
+            var session = scope.ServiceProvider.GetRequiredService<YesSql.ISession>();
+
+            var applications = await session.Query<OpenIdApplication, OpenIdApplicationIndex>(OpenIdApplication.OpenIdCollection).ListAsync();
+
+            Assert.Single(applications);
+
+            var application = applications.First();
+            Assert.True(application.ClientId == clientId);
+            Assert.Contains(redirectUri, application.RedirectUris);
+            Assert.Equal("implicit", application.ConsentType);
+            Assert.Contains(OpenIddictConstants.Permissions.GrantTypes.AuthorizationCode, application.Permissions);
+            Assert.Contains(OpenIddictConstants.Permissions.GrantTypes.RefreshToken, application.Permissions);
+            Assert.Contains(OpenIddictConstants.Permissions.Endpoints.Authorization, application.Permissions);
+            Assert.Contains(OpenIddictConstants.Permissions.Endpoints.PushedAuthorization, application.Permissions);
+            Assert.Contains(OpenIddictConstants.Permissions.Endpoints.Token, application.Permissions);
+            Assert.Contains(OpenIddictConstants.Permissions.ResponseTypes.Code, application.Permissions);
+
+            Assert.Contains(OpenIddictConstants.Requirements.Features.ProofKeyForCodeExchange, application.Requirements);
+            Assert.Contains(OpenIddictConstants.Requirements.Features.PushedAuthorizationRequests, application.Requirements);
+
+            // Visit the login page to get the AntiForgery token.
+            var loginGetRequest = await httpClient.GetAsync("Login", CancellationToken.None);
+
+            var loginFormData = new Dictionary<string, string>
+            {
+                {"__RequestVerificationToken", await AntiForgeryHelper.ExtractAntiForgeryToken(loginGetRequest) },
+                {$"{nameof(LoginForm)}.{nameof(LoginViewModel.UserName)}", "admin"},
+                {$"{nameof(LoginForm)}.{nameof(LoginViewModel.Password)}", "Password01_"},
+            };
+
+            var shellSettings = scope.ServiceProvider.GetService<ShellSettings>();
+
+            var loginPostRequest = HttpRequestHelper.CreatePostMessageWithCookies($"Login?ReturnUrl=/{shellSettings.RequestUrlPrefix}?loggedIn=true", loginFormData, loginGetRequest);
+
+            // Login
+            var loginPostResponse = await httpClient.SendAsync(loginPostRequest, CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.Redirect, loginPostResponse.StatusCode);
+
+            var loginRequestRedirectToLocation = loginPostResponse.Headers.Location?.ToString();
+
+            Assert.NotEmpty(loginRequestRedirectToLocation);
+            Assert.Contains("loggedIn=true", loginRequestRedirectToLocation);
+
+            var cookies = CookiesHelper.ExtractCookies(loginPostResponse);
+
+            Assert.Contains("orchauth_" + shellSettings.Name, cookies.Keys);
+
+            var codeVerifier = GenerateCodeVerifier();
+            var codeChallenge = GenerateCodeChallenge(codeVerifier);
+
+            var requestData = new Dictionary<string, string>
+            {
+                { "client_id", clientId },
+                { "request_uri", await GetRequestUriAsync(httpClient, clientId, redirectUri, codeChallenge) }
+            };
+
+            var authorizeRequestMessage = HttpRequestHelper.CreatePostMessage("connect/authorize", requestData);
+            CookiesHelper.AddCookiesToRequest(authorizeRequestMessage, cookies);
+
+            Assert.True(authorizeRequestMessage.Headers.Contains("Cookie"), "Cookie header is missing from request.");
+
+            var authorizeResponse = await httpClient.SendAsync(authorizeRequestMessage, CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.Redirect, authorizeResponse.StatusCode);
+
+            var finalRedirect = authorizeResponse.Headers.Location?.ToString();
+
+            Assert.NotEmpty(finalRedirect);
+            Assert.StartsWith(redirectUri, finalRedirect);
+
+            // Extract the authorization code from the query string.
+            var queryParameters = HttpUtility.ParseQueryString(new Uri(finalRedirect).Query);
+            var authorizationCode = queryParameters["code"];
+
+            Assert.NotEmpty(authorizationCode);
+
+            var tokens = new ConcurrentBag<string>();
+
+            // One one task should succeed since OpenId will only allow one access_token exchange for every authorization_code.
+            var taskOne = ExchangeCodeForTokenAsync(httpClient, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
+            var taskTwo = ExchangeCodeForTokenAsync(httpClient, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
+            var taskThree = ExchangeCodeForTokenAsync(httpClient, authorizationCode, clientId, redirectUri, codeVerifier, tokens);
+
+            await Task.WhenAll(taskOne, taskTwo, taskThree);
+
+            Assert.Single(tokens);
+        });
+    }
+
+    private static async Task ExchangeCodeForTokenAsync(HttpClient httpClient, string authorizationCode, string clientId, string redirectUri, string codeVerifier, ConcurrentBag<string> tokens)
     {
         var data = new Dictionary<string, string>()
         {
@@ -185,7 +330,6 @@ public class OpenIdAuthenticationTests
         };
 
         var request = HttpRequestHelper.CreatePostMessage("connect/token", data);
-        CookiesHelper.AddCookiesToRequest(request, cookies);
 
         var tokenResponse = await httpClient.SendAsync(request, CancellationToken.None);
 
@@ -198,6 +342,36 @@ public class OpenIdAuthenticationTests
             Assert.NotEmpty(accessToken);
 
             tokens.Add(accessToken);
+        }
+    }
+
+    private static async Task<string> GetRequestUriAsync(HttpClient httpClient, string clientId, string redirectUri, string codeChallenge)
+    {
+        var data = new Dictionary<string, string>()
+        {
+            { "client_id", clientId },
+            { "response_type", "code" },
+            { "redirect_uri", redirectUri },
+            { "scope", "openid offline_access" },
+            { "code_challenge_method", "S256" },
+            { "code_challenge", codeChallenge },
+        };
+
+        var request = HttpRequestHelper.CreatePostMessage("connect/par", data);
+
+        var response = await httpClient.SendAsync(request, CancellationToken.None);
+        if (response.IsSuccessStatusCode)
+        {
+            var result = await response.Content.ReadFromJsonAsync<JsonObject>();
+            var value = result["request_uri"]?.ToString();
+
+            Assert.NotEmpty(value);
+
+            return value;
+        }
+        else
+        {
+            throw new InvalidOperationException("An error response was returned by the pushed authorization endpoint.");
         }
     }
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdServerDeploymentSourceTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdServerDeploymentSourceTests.cs
@@ -56,6 +56,7 @@ public class OpenIdServerDeploymentSourceTests
             result.LogoutEndpointPath = "/connect/logout";
             result.UserinfoEndpointPath = "/connect/userinfo";
             result.IntrospectionEndpointPath = "/connect/introspect";
+            result.PushedAuthorizationEndpointPath = "/connect/par";
             result.RevocationEndpointPath = "/connect/revoke";
 
             result.EncryptionCertificateStoreLocation = StoreLocation.LocalMachine;
@@ -77,6 +78,7 @@ public class OpenIdServerDeploymentSourceTests
             result.DisableRollingRefreshTokens = true;
             result.UseReferenceAccessTokens = true;
             result.RequireProofKeyForCodeExchange = true;
+            result.RequirePushedAuthorizationRequests = true;
         }
 
         return result;


### PR DESCRIPTION
Fixes https://github.com/OrchardCMS/OrchardCore/issues/17594.

As recommended in the linked issue, this PR:
  - Enables the OAuth 2.0 PAR Endpoint by default as it helps make interactive flows a lot more secure for confidential clients.
  - Adds a data migration updating the server settings and all the existing applications allowed to use the authorization endpoint to also allow them to use the new PAR endpoint.
  - Updates the `UpdateDescriptorFromSettings()` extension to support handling the PAR endpoint permission.
  - Adds an option allowing to force a specific application to use PAR in the application create/edit views.
  - Adds a global option allowing to force all clients to use PAR in the server options.