### PR TITLE
Fix DisplayText truncating in ContainedPartIndex

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ContainedPartIndex.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Indexes/ContainedPartIndex.cs
@@ -52,7 +52,7 @@ public class ContainedPartIndexProvider : IndexProvider<ContentItem>
                     Latest = contentItem.Latest,
                 };
 
-                if (containedPartIndex.DisplayText?.Length > ContainedPartIndex.MaxDisplayTextSize)
+                if (contentItem.DisplayText?.Length > ContainedPartIndex.MaxDisplayTextSize)
                 {
                     containedPartIndex.DisplayText = contentItem.DisplayText[..ContainedPartIndex.MaxDisplayTextSize];
                 }


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
`containedPartIndex.DisplayText` is always null, so `contentItem.DisplayText` should be analyzed.