### PR TITLE
Refine Renovate config (Lombiq Technologies: OCORE-225)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,7 +13,7 @@
         // for a given dependency).
         {
             groupName: 'Non-Breaking Dependency Versions',
-            matchUpdateTypes: ['minor', 'patch', 'pin', 'pinDigest'],
+            matchUpdateTypes: ['patch', 'pin', 'pinDigest'],
             'automerge': true,
         },
         // Minor dependencies are ought to be non-breaking but can be (like

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,19 @@
     // See https://docs.renovatebot.com/configuration-options/#configmigration.
     configMigration: true,
     packageRules: [
+        // Such updates should never break, so are usually safe to automerge (unless another group below overrides it
+        // for a given dependency).
+        {
+            groupName: 'Non-Breaking Dependency Versions',
+            matchUpdateTypes: ['minor', 'patch', 'pin', 'pinDigest'],
+            'automerge': true,
+        },
+        // Minor dependencies are ought to be non-breaking but can be (like
+        // https://github.com/OrchardCMS/OrchardCore/pull/17584), so better to keep them separate.
+        {
+            groupName: 'Minor Dependency Versions',
+            matchUpdateTypes: ['minor'],
+        },
         // Disable certain updates.
         {
             // The .NET 8 versions of these packages need to stay on 8.x. We maintain a separate reference to the 


### PR DESCRIPTION
Grouping minor and patch dependency versions, and auto-merging patch ones. I opted to not group minors with patches, because the former can be more risky, breaking things.