### PR TITLE
Fix JS error in MarkdownField editor (Lombiq Technologies: OCORE-226)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
@@ -27,7 +27,7 @@
 <script at="Foot" depends-on="jQuery, easymde-mediatoolbar">
     $(function () {
         var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
-        var isRtl = '' + @(culture.IsRightToLeft() ? "true" : "false") + '';
+        var isRtl = '@(culture.IsRightToLeft() ? "true" : "false")';
 
         // When part is rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (markdownElement) {

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownBodyPart-Wysiwyg.Edit.cshtml
@@ -26,7 +26,7 @@
 
 <script at="Foot" depends-on="jQuery, easymde-mediatoolbar">
     $(function () {
-        var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
+        var markdownElement = document.getElementById('@Html.IdFor(m => m.Markdown)');
         var isRtl = '@(culture.IsRightToLeft() ? "true" : "false")';
 
         // When part is rendered by a flow part only the elements scripts are rendered, so the html element will not exist.

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -27,7 +27,7 @@
 <script at="Foot" depends-on="jQuery, easymde-mediatoolbar">
     $(function () {
         var markdownElement = document.getElementById('@Html.IdFor(m => m.Markdown)');
-        var isRtl = '' + @(culture.IsRightToLeft() ? "true" : "false") + '';
+        var isRtl = '@(culture.IsRightToLeft() ? "true" : "false")';
 
         // When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (markdownElement) {

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Views/MarkdownField-Wysiwyg.Edit.cshtml
@@ -26,8 +26,8 @@
 
 <script at="Foot" depends-on="jQuery, easymde-mediatoolbar">
     $(function () {
-        var markdownElement = document.getElementById("@Html.IdFor(m => m.Markdown)");
-        var isRtl = strToBool'' + @(culture.IsRightToLeft() ? "true" : "false") + '';
+        var markdownElement = document.getElementById('@Html.IdFor(m => m.Markdown)');
+        var isRtl = '' + @(culture.IsRightToLeft() ? "true" : "false") + '';
 
         // When field is rendered by a flow part only the elements scripts are rendered, so the html element will not exist.
         if (markdownElement) {


### PR DESCRIPTION
Fix the issue mentioned here: https://github.com/OrchardCMS/OrchardCore/pull/17770#discussion_r2034215889 This prevents displaying the Wysiwyg editor of MarkdownField (MarkdownBodyPart's editor doesn't have this issue).