### PR TITLE
Fix Renovate schedule config (Lombiq Technologies: OCORE-227)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -109,9 +109,10 @@
     ],
     // With GitHub Actions, concurrency is not really an issue.
     prHourlyLimit: 0,
-    // We only need updates once a week.
+    // Between 0:00 and 6:00 UTC on Sundays. Large time window to ensure that Renovate runs at least once then:
+    // https://docs.renovatebot.com/configuration-options/#schedule.
     schedule: [
-        'before 5am on Sunday',
+        '* 0-6 * * 7',
     ],
     addLabels: ['dependencies'],
 }


### PR DESCRIPTION
I just learned that the Renovate app runs on its own schedule, every ~3 hours, and then checks if the `schedule` expression matches the current time. So, according to [the docs](https://docs.renovatebot.com/configuration-options/#schedule) we need to define a sufficiently large time window, what I did now.

Also changed the syntax from the deprecated one to cron.

This is behind some updates being left there waiting for their schedule.