### PR TITLE
Cleanup and more robust behavior for ElasticsearchIndexStep

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Model/LuceneIndexSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Model/LuceneIndexSettings.cs
@@ -1,13 +1,10 @@
-using System.Text.Json.Serialization;
 using OrchardCore.Data.Documents;
+using OrchardCore.Search.Models;
 
 namespace OrchardCore.Search.Lucene.Model;
 
-public class LuceneIndexSettings
+public class LuceneIndexSettings : IndexSettingsBase
 {
-    [JsonIgnore]
-    public string IndexName { get; set; }
-
     public string AnalyzerName { get; set; }
 
     public bool IndexLatest { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Recipes/LuceneIndexStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Recipes/LuceneIndexStep.cs
@@ -25,19 +25,13 @@ public sealed class LuceneIndexStep : NamedRecipeStepHandler
 
     protected override async Task HandleAsync(RecipeExecutionContext context)
     {
-        if (context.Step["Indices"] is not JsonArray jsonArray)
-        {
-            return;
-        }
+        var settings = context.GetIndexSettings<LuceneIndexSettings>();
 
-        foreach (var index in jsonArray)
+        foreach (var setting in settings)
         {
-            var luceneIndexSettings = index.ToObject<Dictionary<string, LuceneIndexSettings>>().FirstOrDefault();
-
-            if (!_luceneIndexManager.Exists(luceneIndexSettings.Key))
+            if (!_luceneIndexManager.Exists(setting.IndexName))
             {
-                luceneIndexSettings.Value.IndexName = luceneIndexSettings.Key;
-                await _luceneIndexingService.CreateIndexAsync(luceneIndexSettings.Value);
+                await _luceneIndexingService.CreateIndexAsync(setting);
             }
         }
     }

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/Extensions/RecipeExecutionContextExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/Extensions/RecipeExecutionContextExtensions.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Nodes;
+using OrchardCore.Search.Models;
+
+namespace OrchardCore.Recipes.Models;
+
+public static class RecipeExecutionContextExtensions
+{
+    /// <summary>
+    /// Converts the <paramref name="context"/> into <see cref="IndexRecipeStep{T}"/> and returns all the indexes with
+    /// the name property correctly set.
+    /// </summary>
+    public static IEnumerable<T> GetIndexSettings<T>(this RecipeExecutionContext context)
+        where T : IndexSettingsBase =>
+        context
+            .Step
+            .ToObject<IndexRecipeStep<T>>()
+            .Indexes
+            .SelectMany(indexes => indexes.Select(pair =>
+            {
+                pair.Value.IndexName = pair.Key;
+                return pair.Value;
+            }));
+}

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/Models/IndexRecipeStep.cs
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/Models/IndexRecipeStep.cs
@@ -1,0 +1,18 @@
+namespace OrchardCore.Search.Models;
+
+public class IndexRecipeStep<T>
+    where T : IndexSettingsBase
+{
+    public string Name { get; set; }
+
+    public IList<Dictionary<string, T>> Indexes { get; set; } = [];
+
+    // Some search providers like Elasticserach and Lucene use the term "Indices" for the plural of index, but the
+    // common spelling in US English is "Indexes". So both are supported to avoid unnecessary spelling problems.
+    [Obsolete($"Maintained for backwards compatibility, please use {nameof(Indexes)} instead.")]
+    public IList<Dictionary<string, T>> Indices
+    {
+        get => Indexes;
+        set => Indexes = value?.Count > 0 ? value : Indexes;
+    }
+}

--- a/src/OrchardCore/OrchardCore.Search.Abstractions/Models/IndexSettingsBase.cs
+++ b/src/OrchardCore/OrchardCore.Search.Abstractions/Models/IndexSettingsBase.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace OrchardCore.Search.Models;
+
+public abstract class IndexSettingsBase
+{
+    [JsonIgnore]
+    public string IndexName { get; set; }
+}

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Models/ElasticIndexSettings.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Models/ElasticIndexSettings.cs
@@ -1,13 +1,10 @@
-using System.Text.Json.Serialization;
 using OrchardCore.Data.Documents;
+using OrchardCore.Search.Models;
 
 namespace OrchardCore.Search.Elasticsearch.Core.Models;
 
-public class ElasticIndexSettings
+public class ElasticIndexSettings : IndexSettingsBase
 {
-    [JsonIgnore]
-    public string IndexName { get; set; }
-
     public string AnalyzerName { get; set; }
 
     public string QueryAnalyzerName { get; set; }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
@@ -53,6 +53,7 @@ public sealed class ElasticsearchIndexStep : NamedRecipeStepHandler
     private static ElasticIndexSettings WithIndexName(ElasticIndexSettings settings, string name)
     {
         settings.IndexName = name;
+
         return settings;
     }
 }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
@@ -35,7 +35,7 @@ public sealed class ElasticsearchIndexStep : NamedRecipeStepHandler
         // Get all properties of each objects inside the indexes array. The property name is treated as the index name.
         var settings = indexes
             .SelectMany(index => index.ToObject<Dictionary<string, ElasticIndexSettings>>())
-            .Select(pair => WithIndexName(pair.Value, pair.Key));
+            .Select(WithIndexName);
 
         // Create the described index only if it doesn't already exist for the current tenant prefix.
         foreach (var setting in settings)

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
@@ -47,10 +47,10 @@ public sealed class ElasticsearchIndexStep : NamedRecipeStepHandler
         }
     }
 
-    private static ElasticIndexSettings WithIndexName(ElasticIndexSettings settings, string name)
+    private static ElasticIndexSettings WithIndexName(KeyValuePair<string, ElasticIndexSettings> pair)
     {
-        settings.IndexName = name;
+        pair.Value.IndexName = pair.Key;
 
-        return settings;
+        return pair.Value;
     }
 }

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
@@ -29,8 +29,8 @@ public sealed class ElasticsearchIndexStep : NamedRecipeStepHandler
         // Elasticserach uses the term "Indices" for the plural of index, but the common spelling in US English is
         // "Indexes". So both are supported to avoid unnecessary spelling problems.
         var indexes = context.Step["Indexes"] as JsonArray ??
-                      context.Step["Indices"] as JsonArray ??
-                      [];
+                context.Step["Indices"] as JsonArray ??
+                [];
 
         // Get all properties of each objects inside the indexes array. The property name is treated as the index name.
         var settings = indexes

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Recipes/ElasticsearchIndexStep.cs
@@ -47,9 +47,6 @@ public sealed class ElasticsearchIndexStep : NamedRecipeStepHandler
         }
     }
 
-    /// <summary>
-    /// Assigns <paramref name="name"/> to <see cref="ElasticIndexSettings.IndexName"/> of <paramref name="settings"/>.
-    /// </summary>
     private static ElasticIndexSettings WithIndexName(ElasticIndexSettings settings, string name)
     {
         settings.IndexName = name;


### PR DESCRIPTION
I was trying to read the `ElasticIndexSettings` recipe step to understand how to correctly use it in my code and found it to be a bit confusing (for example, why is only the first property checked for each object?). This minor rewrite is backwards compatible and enables more compact recipes.