### PR TITLE
Fix that the sitemap document is updated even if it doesn't need to, potentially causing `ConcurrencyException`s (Lombiq Technologies: OCORE-228)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceUpdateHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceUpdateHandler.cs
@@ -32,7 +32,6 @@ public class ContentTypesSitemapSourceUpdateHandler : ISitemapSourceUpdateHandle
         }
 
         var contentTypeName = contentItem.ContentType;
-
         var sitemapNeedsUpdate = false;
 
         foreach (var sitemap in sitemaps)

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceUpdateHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Sitemaps/ContentTypesSitemapSourceUpdateHandler.cs
@@ -33,6 +33,8 @@ public class ContentTypesSitemapSourceUpdateHandler : ISitemapSourceUpdateHandle
 
         var contentTypeName = contentItem.ContentType;
 
+        var sitemapNeedsUpdate = false;
+
         foreach (var sitemap in sitemaps)
         {
             // Do not break out of this loop, as it must check each sitemap.
@@ -47,21 +49,27 @@ public class ContentTypesSitemapSourceUpdateHandler : ISitemapSourceUpdateHandle
                 if (source.IndexAll)
                 {
                     sitemap.Identifier = IdGenerator.GenerateId();
+                    sitemapNeedsUpdate = true;
                     break;
                 }
                 else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName, StringComparison.Ordinal))
                 {
                     sitemap.Identifier = IdGenerator.GenerateId();
+                    sitemapNeedsUpdate = true;
                     break;
                 }
                 else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName, StringComparison.Ordinal)))
                 {
                     sitemap.Identifier = IdGenerator.GenerateId();
+                    sitemapNeedsUpdate = true;
                     break;
                 }
             }
         }
 
-        await _sitemapManager.UpdateSitemapAsync();
+        if (sitemapNeedsUpdate)
+        {
+            await _sitemapManager.UpdateSitemapAsync();
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/CustomPathSitemapSourceUpdateHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/CustomPathSitemapSourceUpdateHandler.cs
@@ -21,6 +21,8 @@ public class CustomPathSitemapSourceUpdateHandler : ISitemapSourceUpdateHandler
             return;
         }
 
+        var sitemapNeedsUpdate = false;
+
         foreach (var sitemap in sitemaps)
         {
             // Do not break out of this loop, as it must check each sitemap.
@@ -33,9 +35,13 @@ public class CustomPathSitemapSourceUpdateHandler : ISitemapSourceUpdateHandler
                 }
 
                 sitemap.Identifier = IdGenerator.GenerateId();
+                sitemapNeedsUpdate = true;
             }
         }
 
-        await _sitemapManager.UpdateSitemapAsync();
+        if (sitemapNeedsUpdate)
+        {
+            await _sitemapManager.UpdateSitemapAsync();
+        }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/SitemapIndexTypeUpdateHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/SitemapIndexTypeUpdateHandler.cs
@@ -35,6 +35,7 @@ public class SitemapIndexTypeUpdateHandler : ISitemapTypeUpdateHandler
         }
 
         var contentTypeName = contentItem.ContentType;
+        var sitemapNeedsUpdate = false;
 
         foreach (var sitemap in sitemaps)
         {
@@ -48,21 +49,27 @@ public class SitemapIndexTypeUpdateHandler : ISitemapTypeUpdateHandler
                 if (source.IndexAll)
                 {
                     sitemap.Identifier = IdGenerator.GenerateId();
+                    sitemapNeedsUpdate = true;
                     break;
                 }
                 else if (source.LimitItems && string.Equals(source.LimitedContentType.ContentTypeName, contentTypeName, StringComparison.Ordinal))
                 {
                     sitemap.Identifier = IdGenerator.GenerateId();
+                    sitemapNeedsUpdate = true;
                     break;
                 }
                 else if (source.ContentTypes.Any(ct => string.Equals(ct.ContentTypeName, contentTypeName, StringComparison.Ordinal)))
                 {
                     sitemap.Identifier = IdGenerator.GenerateId();
+                    sitemapNeedsUpdate = true;
                     break;
                 }
             }
         }
 
-        await _sitemapManager.UpdateSitemapAsync();
+        if (sitemapNeedsUpdate)
+        {
+            await _sitemapManager.UpdateSitemapAsync();
+        }
     }
 }


### PR DESCRIPTION
The sitemap document is updated on every content item publish, in all `ISitemapSourceUpdateHandler`s, even if it doesn't need to. This can cause `ConcurrencyException`s, despite the lock here:

https://github.com/OrchardCMS/OrchardCore/blob/a4361001c796cc92a544515ac9c7cdbcb2dee5b9/src/OrchardCore.Modules/OrchardCore.Sitemaps/Handlers/DefaultSitemapUpdateHandler.cs#L18

Additionally, these updates are just unnecessary calls to the DB.

I'm not particularly fond of the repeated checks, but I don't have a better idea.