### PR TITLE
Upgrade packages with vulnerability

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,7 @@
     <PackageVersion Include="MailKit" Version="4.8.0" />
     <PackageVersion Include="Markdig" Version="0.38.0" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.8.0" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="3.3.1" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="3.8.3" />
     <!--
       Important: the version of the Microsoft.IdentityModel.Protocols.OpenIdConnect package MUST
       match the IdentityModel version transitively referenced by OpenIddict to ensure we don't
@@ -47,7 +47,7 @@
  
       See https://github.com/OrchardCMS/OrchardCore/pull/16057 for more information.
     -->
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.8.0" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="MimeKit" Version="4.8.0" />


### PR DESCRIPTION
@kevinchalet is it okay to update only these 2 packages in to /release.2.1 branch? Need to address the current vulnerability issue with these two dependencies and ship 2.1.7.

Note this is based on release/2.1 branch not main.