### PR TITLE
IStringLocalizer, IHtmlStringLocalizer fields should be private

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Admin/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", AdminSiteSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/AdminMenu.cs
@@ -7,8 +7,7 @@ namespace OrchardCore.AdminMenu;
 public sealed class AdminMenu : AdminNavigationProvider
 {
     private readonly AdminMenuNavigationProvidersCoordinator _adminMenuNavigationProviderCoordinator;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(
         AdminMenuNavigationProvidersCoordinator adminMenuNavigationProviderCoordinator,

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Drivers/AliasPartDisplayDriver.cs
@@ -13,8 +13,7 @@ namespace OrchardCore.Alias.Drivers;
 public sealed class AliasPartDisplayDriver : ContentPartDisplayDriver<AliasPart>
 {
     private readonly ISession _session;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AliasPartDisplayDriver(
         ISession session,

--- a/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Apis.GraphQL/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Apis.GraphQL;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Controllers/AdminController.cs
@@ -26,8 +26,6 @@ public sealed class AdminController : Controller
     private readonly IDisplayManager<AuditTrailEvent> _displayManager;
     private readonly IDisplayManager<AuditTrailIndexOptions> _auditTrailOptionsDisplayManager;
 
-    internal readonly IStringLocalizer S;
-
     public AdminController(
         IOptions<PagerOptions> pagerOptions,
         IShapeFactory shapeFactory,
@@ -36,8 +34,7 @@ public sealed class AdminController : Controller
         IAuthorizationService authorizationService,
         IAuditTrailAdminListQueryService auditTrailAdminListQueryService,
         IDisplayManager<AuditTrailEvent> displayManager,
-        IDisplayManager<AuditTrailIndexOptions> auditTrailOptionsDisplayManager,
-        IStringLocalizer<AdminController> stringLocalizer)
+        IDisplayManager<AuditTrailIndexOptions> auditTrailOptionsDisplayManager)
     {
         _pagerOptions = pagerOptions.Value;
         _shapeFactory = shapeFactory;
@@ -47,7 +44,6 @@ public sealed class AdminController : Controller
         _auditTrailAdminListQueryService = auditTrailAdminListQueryService;
         _displayManager = displayManager;
         _auditTrailOptionsDisplayManager = auditTrailOptionsDisplayManager;
-        S = stringLocalizer;
     }
 
     [Admin("AuditTrail/{correlationId?}", "AuditTrailIndex")]

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Navigation/AuditTrailAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Navigation/AuditTrailAdminMenu.cs
@@ -20,7 +20,7 @@ public sealed class AuditTrailAdminMenu : AdminNavigationProvider
         { "groupId", AuditTrailSettingsGroup.Id },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AuditTrailAdminMenu(IStringLocalizer<AuditTrailAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Drivers/AutoroutePartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Drivers/AutoroutePartDisplayDriver.cs
@@ -23,8 +23,7 @@ public sealed class AutoroutePartDisplayDriver : ContentPartDisplayDriver<Autoro
     private readonly IAuthorizationService _authorizationService;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly YesSql.ISession _session;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AutoroutePartDisplayDriver(
         IOptions<AutorouteOptions> options,

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.BackgroundTasks;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Controllers/BackgroundTaskController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.BackgroundTasks/Controllers/BackgroundTaskController.cs
@@ -28,9 +28,8 @@ public sealed class BackgroundTaskController : Controller
     private readonly PagerOptions _pagerOptions;
     private readonly INotifier _notifier;
     private readonly IShapeFactory _shapeFactory;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public BackgroundTaskController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/ContentPickerFieldDisplayDriver.cs
@@ -25,8 +25,7 @@ public sealed class ContentPickerFieldDisplayDriver : ContentFieldDisplayDriver<
     private readonly ILiquidTemplateManager _templateManager;
     private readonly IAuthorizationService _authorizationService;
     private readonly IHttpContextAccessor _httpContextAccessor;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ContentPickerFieldDisplayDriver(
         IContentManager contentManager,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/LocalizationSetContentPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/LocalizationSetContentPickerFieldDisplayDriver.cs
@@ -18,8 +18,7 @@ public sealed class LocalizationSetContentPickerFieldDisplayDriver : ContentFiel
 {
     private readonly IContentManager _contentManager;
     private readonly IContentLocalizationManager _contentLocalizationManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public LocalizationSetContentPickerFieldDisplayDriver(
         IContentManager contentManager,

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/TextFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/TextFieldDisplayDriver.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.ContentFields.Drivers;
 
 public sealed class TextFieldDisplayDriver : ContentFieldDisplayDriver<TextField>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public TextFieldDisplayDriver(IStringLocalizer<TextFieldDisplayDriver> localizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/TimeFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/TimeFieldDisplayDriver.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.ContentFields.Drivers;
 
 public sealed class TimeFieldDisplayDriver : ContentFieldDisplayDriver<TimeField>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public TimeFieldDisplayDriver(IStringLocalizer<TimeFieldDisplayDriver> localizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/UserPickerFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Drivers/UserPickerFieldDisplayDriver.cs
@@ -17,8 +17,7 @@ namespace OrchardCore.ContentFields.Drivers;
 public sealed class UserPickerFieldDisplayDriver : ContentFieldDisplayDriver<UserPickerField>
 {
     private readonly ISession _session;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public UserPickerFieldDisplayDriver(
         ISession session,

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/AdminMenu.cs
@@ -19,7 +19,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", ContentCulturePickerSettingsDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/AdminController.cs
@@ -16,8 +16,7 @@ public sealed class AdminController : Controller
     private readonly IContentLocalizationManager _contentLocalizationManager;
     private readonly INotifier _notifier;
     private readonly IAuthorizationService _authorizationService;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IContentManager contentManager,

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Drivers/LocalizationContentsAdminListDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Drivers/LocalizationContentsAdminListDisplayDriver.cs
@@ -11,8 +11,7 @@ namespace OrchardCore.ContentLocalization.Drivers;
 public sealed class LocalizationContentsAdminListDisplayDriver : DisplayDriver<ContentOptionsViewModel>
 {
     private readonly ILocalizationService _localizationService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public LocalizationContentsAdminListDisplayDriver(
         ILocalizationService localizationService,

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/AdminMenu.cs
@@ -10,7 +10,7 @@ public sealed class AdminMenu : AdminNavigationProvider
 {
     private static readonly string _adminControllerName = typeof(AdminController).ControllerName();
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -27,9 +27,8 @@ public sealed class AdminController : Controller
     private readonly IContentDefinitionDisplayManager _contentDefinitionDisplayManager;
     private readonly INotifier _notifier;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     public AdminController(
         IContentDefinitionDisplayManager contentDefinitionDisplayManager,

--- a/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/AdminMenu.cs
@@ -35,8 +35,7 @@ public sealed class AdminMenu : AdminNavigationProvider
     private readonly LinkGenerator _linkGenerator;
     private readonly IAuthorizationService _authorizationService;
     private readonly ISiteService _siteService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(
         IContentDefinitionManager contentDefinitionManager,

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -38,9 +38,8 @@ public sealed class AdminController : Controller, IUpdateModel
     private readonly IDisplayManager<ContentOptionsViewModel> _contentOptionsDisplayManager;
     private readonly ISession _session;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     public AdminController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Cors/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Cors/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Cors;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> localizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Cors/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Cors/Controllers/AdminController.cs
@@ -19,8 +19,7 @@ public sealed class AdminController : Controller
     private readonly IAuthorizationService _authorizationService;
     private readonly CorsService _corsService;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IShellHost shellHost,

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/AdminMenu.cs
@@ -12,8 +12,7 @@ public sealed class AdminMenu : AdminNavigationProvider
     private static readonly ConcurrentDictionary<string, RouteValueDictionary> _routeValues = [];
 
     private readonly CustomSettingsService _customSettingsService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(
         IStringLocalizer<AdminMenu> localizer,

--- a/src/OrchardCore.Modules/OrchardCore.Demo/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Demo/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Demo;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Deployment.Remote;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> localizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/ExportRemoteInstanceController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/ExportRemoteInstanceController.cs
@@ -23,8 +23,7 @@ public sealed class ExportRemoteInstanceController : Controller
     private readonly RemoteInstanceService _service;
     private readonly INotifier _notifier;
     private readonly IHttpClientFactory _httpClientFactory;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public ExportRemoteInstanceController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/ImportRemoteInstanceController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/ImportRemoteInstanceController.cs
@@ -22,9 +22,7 @@ public sealed class ImportRemoteInstanceController : Controller
     private readonly INotifier _notifier;
     private readonly ILogger _logger;
     private readonly IDataProtector _dataProtector;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public ImportRemoteInstanceController(
         IDataProtectionProvider dataProtectionProvider,
@@ -32,7 +30,6 @@ public sealed class ImportRemoteInstanceController : Controller
         IDeploymentManager deploymentManager,
         INotifier notifier,
         IHtmlLocalizer<ImportRemoteInstanceController> htmlLocalizer,
-        IStringLocalizer<ImportRemoteInstanceController> stringLocalizer,
         ILogger<ImportRemoteInstanceController> logger)
     {
         _deploymentManager = deploymentManager;
@@ -40,7 +37,6 @@ public sealed class ImportRemoteInstanceController : Controller
         _logger = logger;
         _remoteClientService = remoteClientService;
         H = htmlLocalizer;
-        S = stringLocalizer;
         _dataProtector = dataProtectionProvider.CreateProtector("OrchardCore.Deployment").ToTimeLimitedDataProtector();
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/RemoteInstanceController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Controllers/RemoteInstanceController.cs
@@ -25,9 +25,8 @@ public sealed class RemoteInstanceController : Controller
     private readonly IShapeFactory _shapeFactory;
     private readonly INotifier _notifier;
     private readonly RemoteInstanceService _service;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public RemoteInstanceController(
         RemoteInstanceService service,

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Deployment;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
@@ -31,9 +31,8 @@ public sealed class DeploymentPlanController : Controller
     private readonly INotifier _notifier;
     private readonly IUpdateModelAccessor _updateModelAccessor;
     private readonly IShapeFactory _shapeFactory;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public DeploymentPlanController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/StepController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/StepController.cs
@@ -19,8 +19,7 @@ public sealed class StepController : Controller
     private readonly ISession _session;
     private readonly INotifier _notifier;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public StepController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Email.Azure/Drivers/AzureEmailSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Azure/Drivers/AzureEmailSettingsDisplayDriver.cs
@@ -26,8 +26,7 @@ public sealed class AzureEmailSettingsDisplayDriver : SiteDisplayDriver<AzureEma
     private readonly IAuthorizationService _authorizationService;
     private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly IEmailAddressValidator _emailValidator;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AzureEmailSettingsDisplayDriver(
         IShellReleaseManager shellReleaseManager,

--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Drivers/SmtpSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Drivers/SmtpSettingsDisplayDriver.cs
@@ -27,8 +27,7 @@ public sealed class SmtpSettingsDisplayDriver : SiteDisplayDriver<SmtpSettings>
     private readonly SmtpOptions _smtpOptions;
     private readonly IAuthorizationService _authorizationService;
     private readonly IEmailAddressValidator _emailValidator;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => EmailSettings.GroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/AdminMenu.cs
@@ -15,7 +15,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", EmailSettings.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
@@ -19,9 +19,8 @@ public sealed class AdminController : Controller
     private readonly EmailProviderOptions _providerOptions;
     private readonly IEmailService _emailService;
     private readonly IEmailProviderResolver _emailProviderResolver;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     public AdminController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Email/Drivers/EmailSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Drivers/EmailSettingsDisplayDriver.cs
@@ -23,8 +23,6 @@ public sealed class EmailSettingsDisplayDriver : SiteDisplayDriver<EmailSettings
     private readonly IShellReleaseManager _shellReleaseManager;
     private readonly EmailProviderOptions _emailProviders;
 
-    internal readonly IStringLocalizer S;
-
     protected override string SettingsGroupId
         => EmailSettings.GroupId;
 
@@ -34,8 +32,7 @@ public sealed class EmailSettingsDisplayDriver : SiteDisplayDriver<EmailSettings
         IOptions<EmailProviderOptions> emailProviders,
         IOptions<EmailOptions> emailOptions,
         IEmailProviderResolver emailProviderResolver,
-        IShellReleaseManager shellReleaseManager,
-        IStringLocalizer<EmailSettingsDisplayDriver> stringLocalizer)
+        IShellReleaseManager shellReleaseManager)
     {
         _httpContextAccessor = httpContextAccessor;
         _authorizationService = authorizationService;
@@ -43,7 +40,6 @@ public sealed class EmailSettingsDisplayDriver : SiteDisplayDriver<EmailSettings
         _emailProviderResolver = emailProviderResolver;
         _emailProviders = emailProviders.Value;
         _shellReleaseManager = shellReleaseManager;
-        S = stringLocalizer;
     }
     public override async Task<IDisplayResult> EditAsync(ISite site, EmailSettings settings, BuildEditorContext context)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenu.cs
@@ -12,7 +12,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", FacebookConstants.Features.Core },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenuLogin.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenuLogin.cs
@@ -12,7 +12,7 @@ public sealed class AdminMenuLogin : AdminNavigationProvider
         { "groupId", FacebookConstants.Features.Login },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenuLogin(IStringLocalizer<AdminMenuLogin> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenuPixel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/AdminMenuPixel.cs
@@ -12,7 +12,7 @@ public sealed class AdminMenuPixel : AdminNavigationProvider
         { "groupId", FacebookConstants.PixelSettingsGroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenuPixel(
         IStringLocalizer<AdminMenuLogin> stringLocalizer)

--- a/src/OrchardCore.Modules/OrchardCore.Features/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "tenant", string.Empty },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -24,9 +24,8 @@ public sealed class AdminController : Controller
     private readonly IShellFeaturesManager _shellFeaturesManager;
     private readonly AdminOptions _adminOptions;
     private readonly INotifier _notifier;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
@@ -28,8 +28,7 @@ public sealed class BagPartDisplayDriver : ContentPartDisplayDriver<BagPart>
     private readonly ILogger _logger;
     private readonly INotifier _notifier;
     private readonly IAuthorizationService _authorizationService;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public BagPartDisplayDriver(
         IContentManager contentManager,

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -22,8 +22,7 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
     private readonly IServiceProvider _serviceProvider;
     private readonly INotifier _notifier;
     private readonly ILogger _logger;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public FlowPartDisplayDriver(
         IContentDefinitionManager contentDefinitionManager,

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormInputElementPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/FormInputElementPartDisplayDriver.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.Forms.Drivers;
 
 public sealed class FormInputElementPartDisplayDriver : ContentPartDisplayDriver<FormInputElementPart>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public FormInputElementPartDisplayDriver(IStringLocalizer<FormInputElementPartDisplayDriver> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/SelectPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Drivers/SelectPartDisplayDriver.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Forms.Drivers;
 
 public sealed class SelectPartDisplayDriver : ContentPartDisplayDriver<SelectPart>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public SelectPartDisplayDriver(IStringLocalizer<SelectPartDisplayDriver> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.GitHub/AdminMenuGitHubLogin.cs
+++ b/src/OrchardCore.Modules/OrchardCore.GitHub/AdminMenuGitHubLogin.cs
@@ -12,7 +12,7 @@ public sealed class AdminMenuGitHubLogin : AdminNavigationProvider
         { "groupId", GitHubConstants.Features.GitHubAuthentication },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenuGitHubLogin(IStringLocalizer<AdminMenuGitHubLogin> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Google/GoogleAnalyticsAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/GoogleAnalyticsAdminMenu.cs
@@ -12,7 +12,7 @@ public sealed class GoogleAnalyticsAdminMenu : AdminNavigationProvider
         { "groupId", GoogleConstants.Features.GoogleAnalytics },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public GoogleAnalyticsAdminMenu(IStringLocalizer<GoogleAnalyticsAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Google/GoogleAuthenticationAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/GoogleAuthenticationAdminMenu.cs
@@ -12,7 +12,7 @@ public sealed class GoogleAuthenticationAdminMenu : AdminNavigationProvider
         { "groupId", GoogleConstants.Features.GoogleAuthentication },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public GoogleAuthenticationAdminMenu(IStringLocalizer<GoogleAuthenticationAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Google/GoogleTagManagerAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Google/GoogleTagManagerAdminMenu.cs
@@ -12,7 +12,7 @@ public sealed class GoogleTagManagerAdminMenu : AdminNavigationProvider
         { "groupId", GoogleConstants.Features.GoogleTagManager },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public GoogleTagManagerAdminMenu(IStringLocalizer<GoogleTagManagerAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Html/Drivers/HtmlBodyPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Html/Drivers/HtmlBodyPartDisplayDriver.cs
@@ -22,8 +22,7 @@ public sealed class HtmlBodyPartDisplayDriver : ContentPartDisplayDriver<HtmlBod
     private readonly IHtmlSanitizerService _htmlSanitizerService;
     private readonly HtmlEncoder _htmlEncoder;
     private readonly IShortcodeService _shortcodeService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public HtmlBodyPartDisplayDriver(ILiquidTemplateManager liquidTemplateManager,
         IHtmlSanitizerService htmlSanitizerService,

--- a/src/OrchardCore.Modules/OrchardCore.Https/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Https/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", HttpsSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Https/Drivers/HttpsSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Https/Drivers/HttpsSettingsDisplayDriver.cs
@@ -20,8 +20,7 @@ public sealed class HttpsSettingsDisplayDriver : SiteDisplayDriver<HttpsSettings
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public HttpsSettingsDisplayDriver(
         IShellReleaseManager shellReleaseManager,

--- a/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", LayerSiteSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/AdminController.cs
@@ -41,9 +41,8 @@ public sealed class AdminController : Controller
     private readonly IEnumerable<IConditionFactory> _conditionFactories;
     private readonly INotifier _notifier;
     private readonly ILogger _logger;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IContentDefinitionManager contentDefinitionManager,

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/LayerRuleController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Controllers/LayerRuleController.cs
@@ -22,8 +22,7 @@ public sealed class LayerRuleController : Controller
     private readonly IConditionIdGenerator _conditionIdGenerator;
     private readonly INotifier _notifier;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public LayerRuleController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerMetadataWelder.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Drivers/LayerMetadataWelder.cs
@@ -13,8 +13,7 @@ namespace OrchardCore.Layers.Drivers;
 public sealed class LayerMetadataWelder : ContentDisplayDriver
 {
     private readonly ILayerService _layerService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public LayerMetadataWelder(
         ILayerService layerService,

--- a/src/OrchardCore.Modules/OrchardCore.Liquid/Drivers/LiquidPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/Drivers/LiquidPartDisplayDriver.cs
@@ -11,8 +11,7 @@ namespace OrchardCore.Liquid.Drivers;
 public sealed class LiquidPartDisplayDriver : ContentPartDisplayDriver<LiquidPart>
 {
     private readonly ILiquidTemplateManager _liquidTemplateManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public LiquidPartDisplayDriver(
         ILiquidTemplateManager liquidTemplateManager,

--- a/src/OrchardCore.Modules/OrchardCore.Localization/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/AdminMenu.cs
@@ -16,7 +16,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", LocalizationSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     /// <summary>
     /// Creates a new instance of the <see cref="AdminMenu"/>.

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Drivers/LocalizationSettingsDisplayDriver.cs
@@ -27,9 +27,8 @@ public sealed class LocalizationSettingsDisplayDriver : SiteDisplayDriver<Locali
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
     private readonly CultureOptions _cultureOptions;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => GroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Drivers/MarkdownBodyPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Drivers/MarkdownBodyPartDisplayDriver.cs
@@ -24,8 +24,7 @@ public sealed class MarkdownBodyPartDisplayDriver : ContentPartDisplayDriver<Mar
     private readonly IHtmlSanitizerService _htmlSanitizerService;
     private readonly IShortcodeService _shortcodeService;
     private readonly IMarkdownService _markdownService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public MarkdownBodyPartDisplayDriver(ILiquidTemplateManager liquidTemplateManager,
         HtmlEncoder htmlEncoder,

--- a/src/OrchardCore.Modules/OrchardCore.Markdown/Drivers/MarkdownFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Markdown/Drivers/MarkdownFieldDisplayDriver.cs
@@ -24,8 +24,7 @@ public sealed class MarkdownFieldDisplayDriver : ContentFieldDisplayDriver<Markd
     private readonly IHtmlSanitizerService _htmlSanitizerService;
     private readonly IShortcodeService _shortcodeService;
     private readonly IMarkdownService _markdownService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public MarkdownFieldDisplayDriver(ILiquidTemplateManager liquidTemplateManager,
         HtmlEncoder htmlEncoder,

--- a/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Media.AmazonS3;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.AmazonS3/Controllers/AdminController.cs
@@ -13,8 +13,7 @@ public sealed class AdminController : Controller
     private readonly IAuthorizationService _authorizationService;
     private readonly AwsStorageOptions _options;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Media.Azure/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media.Azure/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Media.Azure;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Media;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -31,8 +31,7 @@ public sealed class AdminController : Controller
     private readonly IFileVersionProvider _fileVersionProvider;
     private readonly IServiceProvider _serviceProvider;
     private readonly AttachedMediaFieldFileService _attachedMediaFieldFileService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminController(
         IMediaFileStore mediaFileStore,

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaCacheController.cs
@@ -16,8 +16,7 @@ public sealed class MediaCacheController : Controller
     private readonly IAuthorizationService _authorizationService;
     private readonly IMediaFileStoreCache _mediaFileStoreCache;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public MediaCacheController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/MediaProfilesController.cs
@@ -29,9 +29,8 @@ public sealed class MediaProfilesController : Controller
     private readonly PagerOptions _pagerOptions;
     private readonly INotifier _notifier;
     private readonly IShapeFactory _shapeFactory;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public MediaProfilesController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Media/Drivers/MediaFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Drivers/MediaFieldDisplayDriver.cs
@@ -17,8 +17,7 @@ public sealed class MediaFieldDisplayDriver : ContentFieldDisplayDriver<MediaFie
 {
     private readonly AttachedMediaFieldFileService _attachedMediaFieldFileService;
     private readonly ILogger _logger;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public MediaFieldDisplayDriver(AttachedMediaFieldFileService attachedMediaFieldFileService,
         IStringLocalizer<MediaFieldDisplayDriver> localizer,

--- a/src/OrchardCore.Modules/OrchardCore.Media/MediaCacheAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/MediaCacheAdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Media;
 
 public sealed class MediaCacheAdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public MediaCacheAdminMenu(IStringLocalizer<MediaCacheAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Menu/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/AdminMenu.cs
@@ -14,7 +14,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "Options.CanCreateSelectedContentType", true },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Controllers/AdminController.cs
@@ -23,8 +23,7 @@ public sealed class AdminController : Controller
     private readonly IContentDefinitionManager _contentDefinitionManager;
     private readonly INotifier _notifier;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IContentManager contentManager,

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/HtmlMenuItemPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/HtmlMenuItemPartDisplayDriver.cs
@@ -18,8 +18,7 @@ public sealed class HtmlMenuItemPartDisplayDriver : ContentPartDisplayDriver<Htm
     private readonly IActionContextAccessor _actionContextAccessor;
     private readonly IHtmlSanitizerService _htmlSanitizerService;
     private readonly HtmlEncoder _htmlencoder;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public HtmlMenuItemPartDisplayDriver(
         IUrlHelperFactory urlHelperFactory,

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/LinkMenuItemPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/LinkMenuItemPartDisplayDriver.cs
@@ -17,8 +17,7 @@ public sealed class LinkMenuItemPartDisplayDriver : ContentPartDisplayDriver<Lin
     private readonly IActionContextAccessor _actionContextAccessor;
     private readonly IHtmlSanitizerService _htmlSanitizerService;
     private readonly HtmlEncoder _htmlEncoder;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public LinkMenuItemPartDisplayDriver(
         IUrlHelperFactory urlHelperFactory,

--- a/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/MenuPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Menu/Drivers/MenuPartDisplayDriver.cs
@@ -19,8 +19,7 @@ public sealed class MenuPartDisplayDriver : ContentPartDisplayDriver<MenuPart>
     private readonly IContentDefinitionManager _contentDefinitionManager;
     private readonly INotifier _notifier;
     private readonly ILogger _logger;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public MenuPartDisplayDriver(
         IContentDefinitionManager contentDefinitionManager,

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenuAAD.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenuAAD.cs
@@ -12,7 +12,7 @@ public sealed class AdminMenuAAD : AdminNavigationProvider
         { "groupId", MicrosoftAuthenticationConstants.Features.AAD },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenuAAD(IStringLocalizer<AdminMenuAAD> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenuMicrosoftAccount.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/AdminMenuMicrosoftAccount.cs
@@ -12,7 +12,7 @@ public sealed class AdminMenuMicrosoftAccount : AdminNavigationProvider
         { "groupId", MicrosoftAuthenticationConstants.Features.MicrosoftAccount },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenuMicrosoftAccount(IStringLocalizer<AdminMenuMicrosoftAccount> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Controllers/AdminController.cs
@@ -37,9 +37,8 @@ public sealed class AdminController : Controller, IUpdateModel
     private readonly IShapeFactory _shapeFactory;
     private readonly PagerOptions _pagerOptions;
     private readonly IClock _clock;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ClientAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ClientAdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class ClientAdminMenu : AdminNavigationProvider
     };
 
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ClientAdminMenu(IStringLocalizer<ClientAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ApplicationController.cs
@@ -31,9 +31,8 @@ public sealed class ApplicationController : Controller
     private readonly IOpenIdScopeManager _scopeManager;
     private readonly INotifier _notifier;
     private readonly ShellDescriptor _shellDescriptor;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public ApplicationController(
         IShapeFactory shapeFactory,

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ScopeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ScopeController.cs
@@ -22,8 +22,7 @@ public sealed class ScopeController : Controller
     private readonly IOpenIdScopeManager _scopeManager;
     private readonly IShapeFactory _shapeFactory;
     private readonly PagerOptions _pagerOptions;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ScopeController(
         IOpenIdScopeManager scopeManager,

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ServerConfigurationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ServerConfigurationController.cs
@@ -23,8 +23,7 @@ public sealed class ServerConfigurationController : Controller
     private readonly IShellHost _shellHost;
     private readonly ShellSettings _shellSettings;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public ServerConfigurationController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ValidationConfigurationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Controllers/ValidationConfigurationController.cs
@@ -23,8 +23,7 @@ public sealed class ValidationConfigurationController : Controller
     private readonly IShellHost _shellHost;
     private readonly ShellSettings _shellSettings;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public ValidationConfigurationController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdClientSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdClientSettingsDisplayDriver.cs
@@ -26,8 +26,7 @@ public sealed class OpenIdClientSettingsDisplayDriver : SiteDisplayDriver<OpenId
     private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IOpenIdClientService _clientService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => "OrchardCore.OpenId.Client";

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Drivers/OpenIdValidationSettingsDisplayDriver.cs
@@ -15,8 +15,7 @@ public sealed class OpenIdValidationSettingsDisplayDriver : DisplayDriver<OpenId
     private readonly IShellHost _shellHost;
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public OpenIdValidationSettingsDisplayDriver(
         IShellHost shellHost,

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ManagementAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ManagementAdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.OpenId;
 
 public sealed class ManagementAdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ManagementAdminMenu(IStringLocalizer<ManagementAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ServerAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ServerAdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.OpenId;
 
 public sealed class ServerAdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ServerAdminMenu(IStringLocalizer<ClientAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/ValidationAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/ValidationAdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.OpenId;
 
 public sealed class ValidationAdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ValidationAdminMenu(IStringLocalizer<ValidationAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Placements/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Placements;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Controllers/AdminController.cs
@@ -30,9 +30,8 @@ public sealed class AdminController : Controller
     private readonly INotifier _notifier;
     private readonly IShapeFactory _shapeFactory;
     private readonly PagerOptions _pagerOptions;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     public AdminController(
         ILogger<AdminController> logger,

--- a/src/OrchardCore.Modules/OrchardCore.Queries/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Queries;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Controllers/AdminController.cs
@@ -30,9 +30,8 @@ public sealed class AdminController : Controller
     private readonly IDisplayManager<Query> _displayManager;
     private readonly IUpdateModelAccessor _updateModelAccessor;
     private readonly IShapeFactory _shapeFactory;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IDisplayManager<Query> displayManager,

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Drivers/QueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Drivers/QueryDisplayDriver.cs
@@ -10,8 +10,7 @@ namespace OrchardCore.Queries.Drivers;
 public sealed class QueryDisplayDriver : DisplayDriver<Query>
 {
     private readonly IQueryManager _queryManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public QueryDisplayDriver(
         IQueryManager queryManager,

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Sql/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Sql/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Queries.Sql;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", ReCaptchaSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Recipes;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Recipes/Controllers/AdminController.cs
@@ -26,9 +26,7 @@ public sealed class AdminController : Controller
     private readonly IEnumerable<IRecipeEnvironmentProvider> _environmentProviders;
     private readonly INotifier _notifier;
     private readonly ILogger _logger;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IShellHost shellHost,
@@ -40,8 +38,7 @@ public sealed class AdminController : Controller
         IEnumerable<IRecipeEnvironmentProvider> environmentProviders,
         INotifier notifier,
         ILogger<AdminController> logger,
-        IHtmlLocalizer<AdminController> htmlLocalizer,
-        IStringLocalizer<AdminController> stringLocalizer)
+        IHtmlLocalizer<AdminController> htmlLocalizer)
     {
         _shellHost = shellHost;
         _shellSettings = shellSettings;
@@ -53,7 +50,6 @@ public sealed class AdminController : Controller
         _notifier = notifier;
         _logger = logger;
         H = htmlLocalizer;
-        S = stringLocalizer;
     }
 
     [Admin("Recipes", "Recipes")]

--- a/src/OrchardCore.Modules/OrchardCore.ReverseProxy/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReverseProxy/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", ReverseProxySettingsDisplayDriver.GroupId},
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Roles/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Roles;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
@@ -28,9 +28,8 @@ public sealed class AdminController : Controller
     private readonly IShellFeaturesManager _shellFeaturesManager;
     private readonly IRoleService _roleService;
     private readonly INotifier _notifier;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IDocumentStore documentStore,

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Drivers/JavascriptConditionDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Drivers/JavascriptConditionDisplayDriver.cs
@@ -16,9 +16,8 @@ public sealed class JavascriptConditionDisplayDriver : DisplayDriver<Condition, 
 {
     private readonly INotifier _notifier;
     private readonly JavascriptConditionEvaluator _evaluator;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     public JavascriptConditionDisplayDriver(
         IHtmlLocalizer<JavascriptConditionDisplayDriver> htmlLocalizer,

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Controllers/AdminController.cs
@@ -34,9 +34,8 @@ public sealed class AdminController : Controller
     private readonly IDisplayManager<AzureAISearchIndexSettings> _displayManager;
     private readonly AzureAISearchOptions _azureAISearchOptions;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         ISiteService siteService,

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/AzureAISearchDefaultSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/AzureAISearchDefaultSettingsDisplayDriver.cs
@@ -25,8 +25,7 @@ public sealed class AzureAISearchDefaultSettingsDisplayDriver : SiteDisplayDrive
     private readonly AzureAISearchDefaultOptions _searchOptions;
     private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly IShellReleaseManager _shellReleaseManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => GroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/AzureAISearchSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/AzureAISearchSettingsDisplayDriver.cs
@@ -22,8 +22,7 @@ public sealed class AzureAISearchSettingsDisplayDriver : SiteDisplayDriver<Azure
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
     private readonly IShellReleaseManager _shellReleaseManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => SearchConstants.SearchSettingsGroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/ContentAzureAISearchIndexSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Drivers/ContentAzureAISearchIndexSettingsDisplayDriver.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Search.AzureAI.Drivers;
 
 internal sealed class ContentAzureAISearchIndexSettingsDisplayDriver : DisplayDriver<AzureAISearchIndexSettings>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ContentAzureAISearchIndexSettingsDisplayDriver(IStringLocalizer<ContentAzureAISearchIndexSettingsDisplayDriver> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Controllers/AdminController.cs
@@ -48,9 +48,8 @@ public sealed class AdminController : Controller
     private readonly ElasticsearchQueryService _elasticQueryService;
     private readonly ElasticsearchConnectionOptions _elasticConnectionOptions;
     private readonly ILocalizationService _localizationService;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         ISiteService siteService,

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticSettingsDisplayDriver.cs
@@ -26,8 +26,7 @@ public sealed class ElasticSettingsDisplayDriver : SiteDisplayDriver<ElasticSett
     private readonly IAuthorizationService _authorizationService;
     private readonly ElasticsearchConnectionOptions _elasticConnectionOptions;
     private readonly ElasticsearchClient _elasticClient;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => SearchConstants.SearchSettingsGroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticsearchQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Drivers/ElasticsearchQueryDisplayDriver.cs
@@ -13,8 +13,7 @@ namespace OrchardCore.Search.Elasticsearch.Drivers;
 public sealed class ElasticsearchQueryDisplayDriver : DisplayDriver<Query>
 {
     private readonly ElasticsearchIndexSettingsService _elasticIndexSettingsService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ElasticsearchQueryDisplayDriver(
         IStringLocalizer<ElasticsearchQueryDisplayDriver> stringLocalizer,

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Controllers/AdminController.cs
@@ -48,9 +48,8 @@ public sealed class AdminController : Controller
     private readonly ILogger _logger;
     private readonly IOptions<TemplateOptions> _templateOptions;
     private readonly ILocalizationService _localizationService;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IContentDefinitionManager contentDefinitionManager,

--- a/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Drivers/LuceneQueryDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Lucene/Drivers/LuceneQueryDisplayDriver.cs
@@ -12,8 +12,7 @@ namespace OrchardCore.Search.Lucene.Drivers;
 public sealed class LuceneQueryDisplayDriver : DisplayDriver<Query>
 {
     private readonly LuceneIndexSettingsService _luceneIndexSettingsService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public LuceneQueryDisplayDriver(
         IStringLocalizer<LuceneQueryDisplayDriver> stringLocalizer,

--- a/src/OrchardCore.Modules/OrchardCore.Search/Controllers/SearchController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Controllers/SearchController.cs
@@ -28,8 +28,7 @@ public sealed class SearchController : Controller
     private readonly IEnumerable<ISearchHandler> _searchHandlers;
     private readonly IShapeFactory _shapeFactory;
     private readonly ILogger _logger;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public SearchController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Security/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Security/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", SecuritySettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Seo/Drivers/RobotsSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/Drivers/RobotsSettingsDisplayDriver.cs
@@ -16,8 +16,7 @@ public sealed class RobotsSettingsDisplayDriver : SiteDisplayDriver<RobotsSettin
     private readonly IAuthorizationService _authorizationService;
     private readonly IStaticFileProvider _staticFileProvider;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     protected override string SettingsGroupId
         => SeoConstants.RobotsSettingsGroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Seo/Drivers/SeoMetaPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Seo/Drivers/SeoMetaPartDisplayDriver.cs
@@ -12,7 +12,7 @@ namespace OrchardCore.Seo.Drivers;
 
 public sealed class SeoMetaPartDisplayDriver : ContentPartDisplayDriver<SeoMetaPart>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public SeoMetaPartDisplayDriver(IStringLocalizer<SeoMetaPartDisplayDriver> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", DefaultSiteSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DefaultSiteSettingsDisplayDriver.cs
@@ -12,8 +12,7 @@ public sealed class DefaultSiteSettingsDisplayDriver : DisplayDriver<ISite>
     public const string GroupId = "general";
 
     private readonly IShellReleaseManager _shellReleaseManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public DefaultSiteSettingsDisplayDriver(
         IShellReleaseManager shellReleaseManager,

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Controllers/AdminController.cs
@@ -33,9 +33,8 @@ public sealed class AdminController : Controller
     private readonly INotifier _notifier;
     private readonly IShapeFactory _shapeFactory;
     private readonly IHtmlSanitizerService _htmlSanitizerService;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Controllers/AdminController.cs
@@ -32,9 +32,8 @@ public sealed class AdminController : Controller
     private readonly IUpdateModelAccessor _updateModelAccessor;
     private readonly INotifier _notifier;
     private readonly IShapeFactory _shapeFactory;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         ISitemapHelperService sitemapService,

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Controllers/SitemapCacheController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Controllers/SitemapCacheController.cs
@@ -14,8 +14,7 @@ public sealed class SitemapCacheController : Controller
     private readonly IAuthorizationService _authorizationService;
     private readonly ISitemapCacheProvider _sitemapCacheProvider;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public SitemapCacheController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Drivers/CustomPathSitemapSourceDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Drivers/CustomPathSitemapSourceDriver.cs
@@ -9,7 +9,7 @@ namespace OrchardCore.Sitemaps.Drivers;
 
 public sealed class CustomPathSitemapSourceDriver : DisplayDriver<SitemapSource, CustomPathSitemapSource>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public CustomPathSitemapSourceDriver(IStringLocalizer<CustomPathSitemapSourceDriver> localizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Sms.Azure/Drivers/AzureSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms.Azure/Drivers/AzureSettingsDisplayDriver.cs
@@ -26,9 +26,8 @@ public sealed class AzureSettingsDisplayDriver : SiteDisplayDriver<AzureSmsSetti
     private readonly IPhoneFormatValidator _phoneFormatValidator;
     private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => SmsSettings.GroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Sms/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms/AdminMenu.cs
@@ -14,7 +14,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", SmsSettings.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Sms/Drivers/SmsSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms/Drivers/SmsSettingsDisplayDriver.cs
@@ -18,8 +18,6 @@ public sealed class SmsSettingsDisplayDriver : SiteDisplayDriver<SmsSettings>
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
 
-    internal readonly IStringLocalizer S;
-
     private readonly SmsProviderOptions _smsProviderOptions;
 
     protected override string SettingsGroupId
@@ -29,14 +27,12 @@ public sealed class SmsSettingsDisplayDriver : SiteDisplayDriver<SmsSettings>
         IShellReleaseManager shellReleaseManager,
         IHttpContextAccessor httpContextAccessor,
         IAuthorizationService authorizationService,
-        IOptions<SmsProviderOptions> smsProviders,
-        IStringLocalizer<SmsSettingsDisplayDriver> stringLocalizer)
+        IOptions<SmsProviderOptions> smsProviders)
     {
         _shellReleaseManager = shellReleaseManager;
         _httpContextAccessor = httpContextAccessor;
         _authorizationService = authorizationService;
         _smsProviderOptions = smsProviders.Value;
-        S = stringLocalizer;
     }
 
     public override IDisplayResult Edit(ISite site, SmsSettings settings, BuildEditorContext context)

--- a/src/OrchardCore.Modules/OrchardCore.Sms/Drivers/SmsTaskDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms/Drivers/SmsTaskDisplayDriver.cs
@@ -15,8 +15,7 @@ public sealed class SmsTaskDisplayDriver : ActivityDisplayDriver<SmsTask, SmsTas
 {
     private readonly IPhoneFormatValidator _phoneFormatValidator;
     private readonly ILiquidTemplateManager _liquidTemplateManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public SmsTaskDisplayDriver(
         IPhoneFormatValidator phoneFormatValidator,

--- a/src/OrchardCore.Modules/OrchardCore.Sms/Drivers/TwilioSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sms/Drivers/TwilioSettingsDisplayDriver.cs
@@ -26,9 +26,8 @@ public sealed class TwilioSettingsDisplayDriver : SiteDisplayDriver<TwilioSettin
     private readonly IPhoneFormatValidator _phoneFormatValidator;
     private readonly IDataProtectionProvider _dataProtectionProvider;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => SmsSettings.GroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Spatial/Drivers/GeoPointFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Spatial/Drivers/GeoPointFieldDisplayDriver.cs
@@ -14,7 +14,7 @@ namespace OrchardCore.Spatial.Drivers;
 
 public sealed class GeoPointFieldDisplayDriver : ContentFieldDisplayDriver<GeoPointField>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public GeoPointFieldDisplayDriver(IStringLocalizer<GeoPointFieldDisplayDriver> localizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Controllers/AdminController.cs
@@ -25,8 +25,7 @@ public sealed class AdminController : Controller
     private readonly ISession _session;
     private readonly INotifier _notifier;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         ISession session,

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyContentsAdminListDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyContentsAdminListDisplayDriver.cs
@@ -23,8 +23,7 @@ public sealed class TaxonomyContentsAdminListDisplayDriver : DisplayDriver<Conte
     private readonly ISiteService _siteService;
     private readonly IContentManager _contentManager;
     private readonly IContentDefinitionManager _contentDefinitionManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public TaxonomyContentsAdminListDisplayDriver(
         ISiteService siteService,

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldDisplayDriver.cs
@@ -14,8 +14,7 @@ namespace OrchardCore.Taxonomies.Drivers;
 public sealed class TaxonomyFieldDisplayDriver : ContentFieldDisplayDriver<TaxonomyField>
 {
     private readonly IContentManager _contentManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public TaxonomyFieldDisplayDriver(
         IContentManager contentManager,

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldTagsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyFieldTagsDisplayDriver.cs
@@ -16,8 +16,7 @@ namespace OrchardCore.Taxonomies.Drivers;
 public sealed class TaxonomyFieldTagsDisplayDriver : ContentFieldDisplayDriver<TaxonomyField>
 {
     private readonly IContentManager _contentManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public TaxonomyFieldTagsDisplayDriver(
         IContentManager contentManager,

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TaxonomyPartDisplayDriver.cs
@@ -13,7 +13,7 @@ namespace OrchardCore.Taxonomies.Drivers;
 
 public sealed class TaxonomyPartDisplayDriver : ContentPartDisplayDriver<TaxonomyPart>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public TaxonomyPartDisplayDriver(IStringLocalizer<TaxonomyPartDisplayDriver> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/TemplateController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Controllers/TemplateController.cs
@@ -27,9 +27,8 @@ public sealed class TemplateController : Controller
     private readonly IShapeFactory _shapeFactory;
     private readonly PagerOptions _pagerOptions;
     private readonly INotifier _notifier;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public TemplateController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/AdminMenu.cs
@@ -8,7 +8,7 @@ public sealed class AdminMenu : AdminNavigationProvider
 {
     private readonly ShellSettings _shellSettings;
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(
         ShellSettings shellSettings,

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/FeatureProfilesController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Controllers/FeatureProfilesController.cs
@@ -30,9 +30,8 @@ public sealed class FeatureProfilesController : Controller
     private readonly INotifier _notifier;
     private readonly PagerOptions _pagerOptions;
     private readonly IShapeFactory _shapeFactory;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public FeatureProfilesController(
         IAuthorizationService authorizationService,

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/FeatureProfilesAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/FeatureProfilesAdminMenu.cs
@@ -7,8 +7,7 @@ namespace OrchardCore.Tenants;
 public sealed class FeatureProfilesAdminMenu : AdminNavigationProvider
 {
     private readonly ShellSettings _shellSettings;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public FeatureProfilesAdminMenu(
         ShellSettings shellSettings,

--- a/src/OrchardCore.Modules/OrchardCore.Themes/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Themes;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Controllers/AdminController.cs
@@ -20,8 +20,7 @@ public sealed class AdminController : Controller
     private readonly IShellFeaturesManager _shellFeaturesManager;
     private readonly IAuthorizationService _authorizationService;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         ISiteThemeService siteThemeService,

--- a/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplayDriver.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Title.Drivers;
 
 public sealed class TitlePartDisplayDriver : ContentPartDisplayDriver<TitlePart>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public TitlePartDisplayDriver(IStringLocalizer<TitlePartDisplayDriver> localizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenu.cs
@@ -12,7 +12,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", TwitterConstants.Features.Twitter },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenuSignin.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Twitter/AdminMenuSignin.cs
@@ -12,7 +12,7 @@ public sealed class AdminMenuSignIn : AdminNavigationProvider
         { "groupId", TwitterConstants.Features.Signin },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenuSignIn(IStringLocalizer<AdminMenuSignIn> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.UrlRewriting;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Controllers/AdminController.cs
@@ -26,9 +26,8 @@ public sealed class AdminController : Controller
     private readonly IShellReleaseManager _shellReleaseManager;
     private readonly IEnumerable<IUrlRewriteRuleSource> _urlRewritingRuleSources;
     private readonly IRewriteRulesManager _rewriteRulesManager;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public AdminController(
         IDisplayManager<RewriteRule> rewriteRuleDisplayManager,

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Drivers/RewriteRulesDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Drivers/RewriteRulesDisplayDriver.cs
@@ -11,8 +11,7 @@ namespace OrchardCore.UrlRewriting.Drivers;
 public sealed class RewriteRulesDisplayDriver : DisplayDriver<RewriteRule>
 {
     private readonly IShellReleaseManager _shellReleaseManager;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public RewriteRulesDisplayDriver(
         IShellReleaseManager shellReleaseManager,

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Drivers/UrlRedirectRuleDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Drivers/UrlRedirectRuleDisplayDriver.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.UrlRewriting.Drivers;
 
 public sealed class UrlRedirectRuleDisplayDriver : DisplayDriver<RewriteRule>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public UrlRedirectRuleDisplayDriver(IStringLocalizer<UrlRedirectRuleDisplayDriver> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Drivers/UrlRewriteRuleDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Drivers/UrlRewriteRuleDisplayDriver.cs
@@ -11,7 +11,7 @@ namespace OrchardCore.UrlRewriting.Drivers;
 
 public sealed class UrlRewriteRuleDisplayDriver : DisplayDriver<RewriteRule>
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public UrlRewriteRuleDisplayDriver(IStringLocalizer<UrlRewriteRuleDisplayDriver> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/AdminMenu.cs
@@ -14,7 +14,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", LoginSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/ChangeEmailAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/ChangeEmailAdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class ChangeEmailAdminMenu : AdminNavigationProvider
         { "groupId", ChangeEmailSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ChangeEmailAdminMenu(IStringLocalizer<ChangeEmailAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
@@ -32,9 +32,8 @@ public sealed class AccountController : AccountBaseController
     private readonly IDisplayManager<LoginForm> _loginFormDisplayManager;
     private readonly IUpdateModelAccessor _updateModelAccessor;
     private readonly INotifier _notifier;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     public AccountController(
         IUserService userService,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ChangeEmailController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ChangeEmailController.cs
@@ -16,8 +16,7 @@ public sealed class ChangeEmailController : Controller
     private readonly IUserService _userService;
     private readonly UserManager<IUser> _userManager;
     private readonly ISiteService _siteService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ChangeEmailController(
         IUserService userService,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/EmailConfirmationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/EmailConfirmationController.cs
@@ -22,9 +22,8 @@ public sealed class EmailConfirmationController : Controller
     private readonly IEnumerable<IUserEventHandler> _userEventHandlers;
     private readonly UserEmailService _userEmailService;
     private readonly ILogger _logger;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     public EmailConfirmationController(
         UserManager<IUser> userManager,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/RegistrationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/RegistrationController.cs
@@ -19,23 +19,16 @@ public sealed class RegistrationController : Controller
     private readonly IEnumerable<ILoginFormEvent> _loginFormEvents;
     private readonly IUserService _userService;
 
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
-
     public RegistrationController(
         IDisplayManager<RegisterUserForm> registerUserDisplayManager,
         IUpdateModelAccessor updateModelAccessor,
         IEnumerable<ILoginFormEvent> loginFormEvents,
-        IUserService userService,
-        IHtmlLocalizer<RegistrationController> htmlLocalizer,
-        IStringLocalizer<RegistrationController> stringLocalizer)
+        IUserService userService)
     {
         _registerUserDisplayManager = registerUserDisplayManager;
         _updateModelAccessor = updateModelAccessor;
         _loginFormEvents = loginFormEvents;
         _userService = userService;
-        H = htmlLocalizer;
-        S = stringLocalizer;
     }
 
     [AllowAnonymous]

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegisterUserFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegisterUserFormDisplayDriver.cs
@@ -13,8 +13,7 @@ public sealed class RegisterUserFormDisplayDriver : DisplayDriver<RegisterUserFo
 {
     private readonly UserManager<IUser> _userManager;
     private readonly IdentityOptions _identityOptions;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public RegisterUserFormDisplayDriver(
         UserManager<IUser> userManager,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RoleLoginSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RoleLoginSettingsDisplayDriver.cs
@@ -18,8 +18,7 @@ public sealed class RoleLoginSettingsDisplayDriver : SiteDisplayDriver<RoleLogin
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
     private readonly IRoleService _roleService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => LoginSettingsDisplayDriver.GroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/TwoFactorLoginSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/TwoFactorLoginSettingsDisplayDriver.cs
@@ -14,8 +14,7 @@ public sealed class TwoFactorLoginSettingsDisplayDriver : SiteDisplayDriver<TwoF
 {
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly IAuthorizationService _authorizationService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     protected override string SettingsGroupId
         => LoginSettingsDisplayDriver.GroupId;

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserDisplayDriver.cs
@@ -24,9 +24,8 @@ public sealed class UserDisplayDriver : DisplayDriver<User>
     private readonly IAuthorizationService _authorizationService;
     private readonly IEnumerable<IUserEventHandler> _userEventHandlers;
     private readonly ILogger _logger;
-
-    internal readonly IHtmlLocalizer H;
-    internal readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
 
     public UserDisplayDriver(
         UserManager<IUser> userManager,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserInformationDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserInformationDisplayDriver.cs
@@ -18,8 +18,7 @@ public sealed class UserInformationDisplayDriver : DisplayDriver<User>
     private readonly IAuthorizationService _authorizationService;
     private readonly IPhoneFormatValidator _phoneFormatValidator;
     private readonly ISiteService _siteService;
-
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public UserInformationDisplayDriver(
         IHttpContextAccessor httpContextAccessor,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserRoleDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserRoleDisplayDriver.cs
@@ -20,8 +20,7 @@ public sealed class UserRoleDisplayDriver : DisplayDriver<User>
     private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly INotifier _notifier;
     private readonly IAuthorizationService _authorizationService;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public UserRoleDisplayDriver(
         UserManager<IUser> userManager,

--- a/src/OrchardCore.Modules/OrchardCore.Users/RegistrationAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/RegistrationAdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class RegistrationAdminMenu : AdminNavigationProvider
         { "groupId", RegistrationSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public RegistrationAdminMenu(IStringLocalizer<RegistrationAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/ResetPasswordAdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/ResetPasswordAdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class ResetPasswordAdminMenu : AdminNavigationProvider
         { "groupId", ResetPasswordSettingsDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public ResetPasswordAdminMenu(IStringLocalizer<ResetPasswordAdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/AdminMenu.cs
@@ -5,7 +5,7 @@ namespace OrchardCore.Workflows;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/ActivityController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/ActivityController.cs
@@ -22,8 +22,7 @@ public sealed class ActivityController : Controller
     private readonly IActivityDisplayManager _activityDisplayManager;
     private readonly INotifier _notifier;
     private readonly IUpdateModelAccessor _updateModelAccessor;
-
-    internal readonly IHtmlLocalizer H;
+    private readonly IHtmlLocalizer H;
 
     public ActivityController
     (

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Controllers/WorkflowTypeController.cs
@@ -47,9 +47,8 @@ public sealed class WorkflowTypeController : Controller
     private readonly IUpdateModelAccessor _updateModelAccessor;
     private readonly IShapeFactory _shapeFactory;
     private readonly JsonSerializerOptions _documentJsonSerializerOptions;
-
-    internal readonly IStringLocalizer S;
-    internal readonly IHtmlLocalizer H;
+    private readonly IStringLocalizer S;
+    private readonly IHtmlLocalizer H;
 
     public WorkflowTypeController
     (

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Trimming/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Trimming/AdminMenu.cs
@@ -13,7 +13,7 @@ public sealed class AdminMenu : AdminNavigationProvider
         { "groupId", WorkflowTrimmingDisplayDriver.GroupId },
     };
 
-    internal readonly IStringLocalizer S;
+    private readonly IStringLocalizer S;
 
     public AdminMenu(IStringLocalizer<AdminMenu> stringLocalizer)
     {


### PR DESCRIPTION
While we sealed almost all the types, `internal` localizers do not make sense nowadays