### PR TITLE
Update global.json to patch 100

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.203",
+      "version": "9.0.100",
       "rollForward": "latestMajor"
     }
 }


### PR DESCRIPTION
When you specify an exact SDK version in global.json, such as 9.0.203, the .NET SDK will attempt to use that exact version. If it's not available, it will apply the rollForward policy to find the next suitable version.​

To allow the SDK to use the latest patch version within a major version, you can specify a lower patch version in global.json, like 9.0.100, and rely on the default LatestPatch behavior. This way, the SDK will select the highest available patch version within the 9.0.x range.