### PR TITLE
Fix registration settings tab being "Content" (Lombiq Technologies: OCORE-229)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RegistrationSettingsDisplayDriver.cs
@@ -46,7 +46,7 @@ public sealed class RegistrationSettingsDisplayDriver : SiteDisplayDriver<Regist
             model.UsersMustValidateEmail = settings.UsersMustValidateEmail;
             model.UsersAreModerated = settings.UsersAreModerated;
             model.UseSiteTheme = settings.UseSiteTheme;
-        }).Location("Content:5")
+        }).Location("Content:5#General")
         .OnGroup(SettingsGroupId);
     }
 


### PR DESCRIPTION
Renamed it to "General", like the others:

![image](https://github.com/user-attachments/assets/81839bd9-f4b3-4889-aa08-bf54b6a991d4)
