### PR TITLE
Fix NLog internalLogFile path

### DIFF
--- a/src/OrchardCore.Cms.Web/NLog.config
+++ b/src/OrchardCore.Cms.Web/NLog.config
@@ -3,7 +3,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       autoReload="true"
       internalLogLevel="Warn"
-      internalLogFile="${var:configDir}/logs/internal-nlog.txt">
+      internalLogFile="${currentdir}/App_Data/logs/internal-nlog.txt">
 
     <extensions>
         <add assembly="NLog.Web.AspNetCore"/>


### PR DESCRIPTION
NLog doesn't support using vars like we did for the internalLogFile

The current configuration fails to work with the internalLogFile on Linux.
Documentation suggest using one of these provided vars:
https://github.com/NLog/NLog/wiki/Internal-Logging#enabling-internal-logging-using-configuration-file

This worked for me:

```
<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      autoReload="true"
      internalLogLevel="Warn"
      internalLogFile="${currentdir}/App_Data/logs/internal-nlog.txt">
```

![image](https://github.com/user-attachments/assets/03aad064-3573-4461-b1b0-a2e2a91f7c49)

Also see this : https://github.com/NLog/NLog.Web/issues/323
