### PR TITLE
Improve the 'bind model state task' workflow activity

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/BindModelStateTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Workflows/Activities/BindModelStateTask.cs
@@ -42,7 +42,22 @@ public class BindModelStateTask : TaskActivity<BindModelStateTask>
 
         foreach (var item in httpContext.Request.Form)
         {
-            updater.ModelState.SetModelValue(item.Key, item.Value, item.Value);
+            // Avoid creating a new array for rawValue if there's only one value.
+            object rawValue;
+            if (item.Value.Count == 0)
+            {
+                rawValue = null;
+            }
+            else if (item.Value.Count == 1)
+            {
+                rawValue = item.Value[0];
+            }
+            else
+            {
+                rawValue = item.Value.ToArray();
+            }
+
+            updater.ModelState.SetModelValue(item.Key, rawValue, item.Value.ToString());
         }
 
         return Outcomes("Done");


### PR DESCRIPTION
When using the `BindModelStateTask` activity in a workflow, the raw value set on the `ModelState` is always of type `StringValues`, even if it contains only a single string. This behavior causes issues with input tag helpers, which fail to correctly convert the values back when redisplaying an input tag, resulting in the output `(Collection)`.

This PR updates the `BindModelStateTask` workflow activity to align with the internal model binding process. By doing so, it ensures that the model values are set correctly, preventing the conversion issues and ensuring proper display of input tags.