### PR TITLE
Update FluidTagHelper.cs

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/FluidTagHelper.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Tags/FluidTagHelper.cs
@@ -78,7 +78,6 @@ public static class FluidTagHelper
             }
         }
 
-        Interlocked.CompareExchange(ref _uniqueId, long.MaxValue, 0);
         var id = Interlocked.Increment(ref _uniqueId);
 
         var tagHelperContext = new TagHelperContext(contextAttributes, new Dictionary<object, object>(), id.ToString());


### PR DESCRIPTION
An unnecessary `Interlocked.CompareExchange` call has been removed. This call was intended to handle an overflow condition of the value, but this is already managed by the `Increment` method. Furthermore, the parameters for this call appeared to be swapped.
