### PR TITLE
Don't raise enable/disable user events when user state is not changing.

### DIFF
--- a/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Services/UserService.cs
@@ -382,6 +382,11 @@ public sealed class UserService : IUserService
 
         if (user is User u)
         {
+            if (u.IsEnabled)
+            {
+                return true;
+            }
+
             u.IsEnabled = true;
         }
 
@@ -414,6 +419,11 @@ public sealed class UserService : IUserService
 
         if (user is User u)
         {
+            if (!u.IsEnabled)
+            {
+                return true;
+            }
+
             u.IsEnabled = false;
         }
 


### PR DESCRIPTION
As a follow up to PR #17756, previously the enable/disable events where only raised if the state has actually changed. This is now only guarded by the UI, we should probably check this in the service too.

/cc @hishamco @MikeAlhayek 