### PR TITLE
Fix Asset Manager VS Code debug path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -86,7 +86,7 @@
     },
     {
       "name": "Asset Bundler Tool Debug",
-      "program": "${workspaceFolder}/.scripts/assets-build-tool/build.mjs",
+      "program": "${workspaceFolder}/.scripts/assets-manager/build.mjs",
       "request": "launch",
       "skipFiles": ["<node_internals>/**"],
       "type": "node"


### PR DESCRIPTION
Fix Asset Manager VS Code debug path
