### PR TITLE
Fix that Renovate tries to update AspNet.Security.OAuth.GitHub to an incompatible version for .NET 8 (Lombiq Technologies: OCORE-231)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,6 +28,7 @@
             // The .NET 8 versions of these packages need to stay on 8.x. We maintain a separate reference to the 
             // .NET 9 versions in Directory.Packages.props, only active when building for .NET 9.
             matchPackageNames: [
+                'AspNet.Security.OAuth.GitHub',
                 '/^Microsoft\\.AspNetCore.*$/',
                 '/^Microsoft\\.Extensions.*$/',
                 'Serilog.AspNetCore',


### PR DESCRIPTION
Renovate tried to update the .NET 8 version to a .NET 9-only one: https://github.com/OrchardCMS/OrchardCore/pull/17886. Fixing that.

Merging this should cause https://github.com/OrchardCMS/OrchardCore/pull/17886 to be closed by Renovate in a few minutes.