### PR TITLE
Fix Redis data protection key name

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Redis/Options/RedisKeyManagementOptionsSetup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Options/RedisKeyManagementOptionsSetup.cs
@@ -1,33 +1,79 @@
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.DataProtection.StackExchangeRedis;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
+using StackExchange.Redis;
 
 namespace OrchardCore.Redis.Options;
 
 public sealed class RedisKeyManagementOptionsSetup : IConfigureOptions<KeyManagementOptions>
 {
     private readonly IRedisService _redis;
+    private readonly ILogger _logger;
     private readonly string _tenant;
 
-    public RedisKeyManagementOptionsSetup(IRedisService redis, ShellSettings shellSettings)
+    public RedisKeyManagementOptionsSetup(IRedisService redis, ShellSettings shellSettings, ILogger<RedisKeyManagementOptionsSetup> logger)
     {
         _redis = redis;
+        _logger = logger;
         _tenant = shellSettings.Name;
     }
 
     public void Configure(KeyManagementOptions options)
     {
         var redis = _redis;
-        options.XmlRepository = new RedisXmlRepository(() =>
-        {
-            if (redis.Database == null)
-            {
-                redis.ConnectAsync().GetAwaiter().GetResult();
-            }
+        var redisKey = $"{redis.InstancePrefix}{_tenant}:DataProtection-Keys";
 
-            return redis.Database;
-        },
-        $"({redis.InstancePrefix}{_tenant}:DataProtection-Keys");
+        if (redis.Database == null)
+        {
+            redis.ConnectAsync().GetAwaiter().GetResult();
+        }
+
+        ChangeXmlRepositoryRedisKey(redisKey);
+
+        options.XmlRepository = new RedisXmlRepository(() =>
+            {
+                if (redis.Database == null)
+                {
+                    redis.ConnectAsync().GetAwaiter().GetResult();
+                    ChangeXmlRepositoryRedisKey(redisKey);
+                }
+
+                return redis.Database;
+            },
+            redisKey);
+    }
+
+    // In Orchard Core version 3, the Redis key format for each tenant has been updated.
+    // To avoid breaking data protection during upgrade and also to not impact existing nodes, we
+    // copy the old key to the new one if it doesn't exist.
+    private void ChangeXmlRepositoryRedisKey(string redisKey)
+    {
+        var database = _redis.Database;
+        if (database == null)
+        {
+            return;
+        }
+
+        var oldRedisKey = $"({_redis.InstancePrefix}{_tenant}:DataProtection-Keys";
+        try
+        {
+            if (!database.KeyExists(redisKey))
+            {
+                // Using CommandFlags.FireAndForget here is acceptable because if the old key exists, 
+                // it will be copied to the new key without waiting for the operation to complete. 
+                // If the old key does not exist, a new key will be created by the Data Protection system 
+                // when it initializes, ensuring no disruption in functionality.
+                _ = database.KeyCopy(oldRedisKey, redisKey, flags: CommandFlags.FireAndForget);
+            }
+        }
+        catch (Exception ex)
+        {
+            if (_logger.IsEnabled(LogLevel.Error))
+            {
+                _logger.LogError(ex, "Unable to copy the old Redis data protection key '{OldRedisKey}' to the new one '{NewRedisKey}'.", oldRedisKey, redisKey);
+            }
+        }
     }
 }


### PR DESCRIPTION
/cc @MikeAlhayek Maybe this way is a little bit more straight forward, compared to a migration as in #17853. What do you think?

Fixes #17814.
