### PR TITLE
Add a warning when using Redis for data protection.

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -110,6 +110,7 @@
     //  "Configuration": "192.168.99.100:6379,allowAdmin=true", // Redis Configuration string.
     //  "InstancePrefix": "", // Optional prefix allowing a Redis instance to be shared by different applications.
     //  "DisableCertificateVerification": false // Disable SSL/TLS certificate verification.
+    //  "AllowAdmin": false // Allow admin commands on the Redis server. May override the allowAdmin setting in the configuration string.
     //},
     // See https://docs.orchardcore.net/en/latest/reference/modules/Security/#security-settings-configuration to configure security settings.
     //"OrchardCore_Security": {

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Options/RedisKeyManagementOptionsSetup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Options/RedisKeyManagementOptionsSetup.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.DataProtection.StackExchangeRedis;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using OrchardCore.Environment.Shell;
 
@@ -8,17 +9,33 @@ namespace OrchardCore.Redis.Options;
 public sealed class RedisKeyManagementOptionsSetup : IConfigureOptions<KeyManagementOptions>
 {
     private readonly IRedisService _redis;
+    private readonly ILogger _logger;
     private readonly string _tenant;
+    private readonly bool _allowAdmin;
 
-    public RedisKeyManagementOptionsSetup(IRedisService redis, ShellSettings shellSettings)
+    public RedisKeyManagementOptionsSetup(
+        IRedisService redis,
+        IOptions<RedisOptions> options,
+        ShellSettings shellSettings,
+        ILogger<RedisKeyManagementOptionsSetup> logger)
     {
         _redis = redis;
+        _allowAdmin = options.Value.ConfigurationOptions?.AllowAdmin ?? false;
         _tenant = shellSettings.Name;
+        _logger = logger;
     }
 
     public void Configure(KeyManagementOptions options)
     {
         var redis = _redis;
+
+        if (redis.Database == null)
+        {
+            redis.ConnectAsync().GetAwaiter().GetResult();
+        }
+
+        ValidateRedisServer();
+
         options.XmlRepository = new RedisXmlRepository(() =>
         {
             if (redis.Database == null)
@@ -29,5 +46,45 @@ public sealed class RedisKeyManagementOptionsSetup : IConfigureOptions<KeyManage
             return redis.Database;
         },
         $"({redis.InstancePrefix}{_tenant}:DataProtection-Keys");
+    }
+
+    private void ValidateRedisServer()
+    {
+        if (!_logger.IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
+        if (_allowAdmin)
+        {
+            // Redis server admin commands are allowed, try to find out if persistence is enabled. Otherwise we will always warn.
+            var server = _redis.Connection?.GetServers().FirstOrDefault();
+            if (server != null)
+            {
+                try
+                {
+                    var persistenceConfig = server.Info("persistence");
+
+                    if (persistenceConfig.Any(info =>
+                        info.Any(value => (value.Key == "aof_enabled" && value.Value == "1") || (value.Key == "rdb_saves" && value.Value != "0"))))
+                    {
+                        // AOF or RDB persistence is enabled. Note that the check for RDB is not very reliable, because we are only checking if
+                        // any save occurred since the last time Redis has started. We are not checking if periodic saves are enabled.
+                        return;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (_logger.IsEnabled(LogLevel.Error))
+                    {
+                        _logger.LogError(ex, "Unable to check Redis server persistence configuration.");
+                    }
+                }
+            }
+        }
+
+        _logger.LogWarning("Redis data protection is enabled. Ensure your Redis server has a backup strategy in place to prevent data loss. " +
+            "Use either AOF (Append-Only File) or RDB (Redis Database) persistence. " +
+            "For more details, visit: https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/");
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Redis/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Startup.cs
@@ -47,6 +47,12 @@ public sealed class Startup : StartupBase
                 configurationOptions.CertificateValidation += IgnoreCertificateErrors;
             }
 
+            var allowAdmin = section.GetValue<bool?>("AllowAdmin", null);
+            if (allowAdmin.HasValue)
+            {
+                configurationOptions.AllowAdmin = allowAdmin.Value;
+            }
+
             services.Configure<RedisOptions>(options =>
             {
                 options.Configuration = configuration;


### PR DESCRIPTION
This pull request serves as an initial proposal for implementing warnings to users about the potential risks of misusing a Redis server for data protection when no persistence has been configured.

/cc @MikeAlhayek @sebastienros 