### PR TITLE
Allow the use of the site's time zone in workflow timer activities

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEvent.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
 using NCrontab;
 using OrchardCore.Modules;
+using OrchardCore.Settings;
 using OrchardCore.Workflows.Abstractions.Models;
 using OrchardCore.Workflows.Activities;
 using OrchardCore.Workflows.Models;
@@ -10,12 +12,17 @@ namespace OrchardCore.Workflows.Timers;
 public class TimerEvent : EventActivity
 {
     public static string EventName => nameof(TimerEvent);
+
     private readonly IClock _clock;
+    private readonly ISiteService _siteService;
+    private readonly ILogger _logger;
     protected readonly IStringLocalizer S;
 
-    public TimerEvent(IClock clock, IStringLocalizer<TimerEvent> localizer)
+    public TimerEvent(IClock clock, ISiteService siteService, ILogger<TimerEvent> logger, IStringLocalizer<TimerEvent> localizer)
     {
         _clock = clock;
+        _siteService = siteService;
+        _logger = logger;
         S = localizer;
     }
 
@@ -31,15 +38,21 @@ public class TimerEvent : EventActivity
         set => SetProperty(value);
     }
 
+    public bool UseLocalTime
+    {
+        get => GetProperty(() => false);
+        set => SetProperty(value);
+    }
+
     private DateTime? StartedUtc
     {
         get => GetProperty<DateTime?>();
         set => SetProperty(value);
     }
 
-    public override bool CanExecute(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+    public override async Task<bool> CanExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        return StartedUtc == null || IsExpired();
+        return StartedUtc == null || await IsExpiredAsync();
     }
 
     public override IEnumerable<Outcome> GetPossibleOutcomes(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
@@ -47,9 +60,9 @@ public class TimerEvent : EventActivity
         return Outcomes(S["Done"]);
     }
 
-    public override ActivityExecutionResult Resume(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
+    public override async Task<ActivityExecutionResult> ResumeAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
-        if (IsExpired())
+        if (await IsExpiredAsync())
         {
             workflowContext.LastResult = "TimerEvent";
             return Outcomes("Done");
@@ -58,12 +71,36 @@ public class TimerEvent : EventActivity
         return Halt();
     }
 
-    private bool IsExpired()
+    private async Task<bool> IsExpiredAsync()
     {
         StartedUtc ??= _clock.UtcNow;
         var schedule = CrontabSchedule.Parse(CronExpression);
-        var whenUtc = schedule.GetNextOccurrence(StartedUtc.Value);
 
-        return _clock.UtcNow >= whenUtc;
+        ITimeZone timeZone = null;
+
+        if (UseLocalTime && _siteService is not null)
+        {
+            try
+            {
+                timeZone = _clock.GetTimeZone((await _siteService.GetSiteSettingsAsync()).TimeZoneId);
+            }
+            catch (Exception ex) when (!ex.IsFatal())
+            {
+                _logger.LogError(ex, "Error while getting the time zone from the site settings.");
+            }
+        }
+
+        var now = _clock.UtcNow;
+        var baseTime = StartedUtc.Value;
+
+        if (timeZone is not null)
+        {
+            now = _clock.ConvertToTimeZone(now, timeZone).DateTime;
+            baseTime = _clock.ConvertToTimeZone(baseTime, timeZone).DateTime;
+        }
+
+        var nextOccurrence = schedule.GetNextOccurrence(baseTime);
+
+        return now >= nextOccurrence;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEventDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEventDisplayDriver.cs
@@ -7,10 +7,12 @@ public sealed class TimerEventDisplayDriver : ActivityDisplayDriver<TimerEvent, 
     protected override void EditActivity(TimerEvent source, TimerEventViewModel model)
     {
         model.CronExpression = source.CronExpression;
+        model.UseLocalTime = source.UseLocalTime;
     }
 
     protected override void UpdateActivity(TimerEventViewModel model, TimerEvent target)
     {
         target.CronExpression = model.CronExpression.Trim();
+        target.UseLocalTime = model.UseLocalTime;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEventViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Timers/TimerEventViewModel.cs
@@ -6,4 +6,6 @@ public class TimerEventViewModel
 {
     [Required]
     public string CronExpression { get; set; }
+
+    public bool UseLocalTime { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/TimerEvent.Fields.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Items/TimerEvent.Fields.Edit.cshtml
@@ -7,3 +7,9 @@
     <span asp-validation-for="CronExpression"></span>
     <span class="hint">@T["The CRON expression."]</span>
 </div>
+<div class="mb-3 form-check" asp-validation-class-for="UseLocalTime">
+    <input type="checkbox" asp-for="UseLocalTime" class="form-check-input" />
+    <span asp-validation-for="UseLocalTime"></span>
+    <label asp-for="UseLocalTime" class="form-check-label">@T["Use site time zone"]</label>
+    <span class="hint dashed">@T["The CRON expression uses UTC by default. Check this box to use the site's time zone instead."]</span>
+</div>


### PR DESCRIPTION
The CRON pattern in a workflow timer activity is currently always based on UTC time. This change introduces an option to use the site's time zone setting instead. The change is optional to prevent unintended behavior in existing workflows.

Fixes #14253