### PR TITLE
Upgrade OpenIddict packages to 6.3.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,12 +49,12 @@
     <PackageVersion Include="NJsonSchema" Version="11.3.2" />
     <PackageVersion Include="NLog.Web.AspNetCore" Version="5.4.0" />
     <PackageVersion Include="NodaTime" Version="3.2.2" />
-    <PackageVersion Include="OpenIddict.Core" Version="6.2.1" />
-    <PackageVersion Include="OpenIddict.Server.AspNetCore" Version="6.2.1" />
-    <PackageVersion Include="OpenIddict.Server.DataProtection" Version="6.2.1" />
-    <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="6.2.1" />
-    <PackageVersion Include="OpenIddict.Validation.DataProtection" Version="6.2.1" />
-    <PackageVersion Include="OpenIddict.Validation.SystemNetHttp" Version="6.2.1" />
+    <PackageVersion Include="OpenIddict.Core" Version="6.3.0" />
+    <PackageVersion Include="OpenIddict.Server.AspNetCore" Version="6.3.0" />
+    <PackageVersion Include="OpenIddict.Server.DataProtection" Version="6.3.0" />
+    <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="6.3.0" />
+    <PackageVersion Include="OpenIddict.Validation.DataProtection" Version="6.3.0" />
+    <PackageVersion Include="OpenIddict.Validation.SystemNetHttp" Version="6.3.0" />
     <PackageVersion Include="OrchardCore.Translations.All" Version="2.1.0" />
     <PackageVersion Include="PdfPig" Version="0.1.10" />
     <PackageVersion Include="Shortcodes" Version="1.3.5" />


### PR DESCRIPTION
This is typically done automatically by the bot. But I need this update sooner.

