### PR TITLE
Reduce the amount of breaking changes in Azure Search AI

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.AzureAI/Controllers/AdminController.cs
@@ -278,7 +278,7 @@ public sealed class AdminController : Controller
             return NotConfigured();
         }
 
-        var settings = await _indexSettingsService.GetAsync(id);
+        var settings = await _indexSettingsService.FindByIdAsync(id);
 
         if (settings == null)
         {
@@ -305,7 +305,7 @@ public sealed class AdminController : Controller
             return BadRequest();
         }
 
-        var settings = await _indexSettingsService.GetAsync(id);
+        var settings = await _indexSettingsService.FindByIdAsync(id);
 
         if (settings == null)
         {
@@ -357,7 +357,7 @@ public sealed class AdminController : Controller
             return BadRequest();
         }
 
-        var settings = await _indexSettingsService.GetAsync(id);
+        var settings = await _indexSettingsService.FindByIdAsync(id);
 
         if (settings == null)
         {
@@ -369,13 +369,13 @@ public sealed class AdminController : Controller
         if (!exists)
         {
             // At this point we know that the index does not exists on remote server. Let's delete it locally.
-            await _indexSettingsService.DeleteAsync(id);
+            await _indexSettingsService.DeleteByIdAsync(id);
 
             await _notifier.SuccessAsync(H["Index <em>{0}</em> deleted successfully.", settings.IndexName]);
         }
         else if (await _indexManager.DeleteAsync(settings.IndexName))
         {
-            await _indexSettingsService.DeleteAsync(id);
+            await _indexSettingsService.DeleteByIdAsync(id);
 
             await _notifier.SuccessAsync(H["Index <em>{0}</em> deleted successfully.", settings.IndexName]);
         }
@@ -401,7 +401,7 @@ public sealed class AdminController : Controller
             return BadRequest();
         }
 
-        var settings = await _indexSettingsService.GetAsync(id);
+        var settings = await _indexSettingsService.FindByIdAsync(id);
 
         if (settings == null)
         {
@@ -431,7 +431,7 @@ public sealed class AdminController : Controller
             return BadRequest();
         }
 
-        var settings = await _indexSettingsService.GetAsync(id);
+        var settings = await _indexSettingsService.FindByIdAsync(id);
 
         if (settings == null)
         {

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexSettingsService.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchIndexSettingsService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -42,7 +43,7 @@ public class AzureAISearchIndexSettingsService
     public async Task<IEnumerable<AzureAISearchIndexSettings>> GetSettingsAsync()
         => (await GetDocumentAsync()).IndexSettings.Values;
 
-    public async Task<AzureAISearchIndexSettings> GetAsync(string id)
+    public async Task<AzureAISearchIndexSettings> FindByIdAsync(string id)
     {
         ArgumentException.ThrowIfNullOrEmpty(id);
 
@@ -55,6 +56,19 @@ public class AzureAISearchIndexSettingsService
 
         return null;
     }
+
+    public async Task<AzureAISearchIndexSettings> FindByNameAsync(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var document = await GetDocumentAsync();
+
+        return document.IndexSettings.Values.FirstOrDefault(x => x.IndexName == name);
+    }
+
+    [Obsolete("This method will be removed in future release. Instead use FindByIdAsync or FindByNameAsync")]
+    public Task<AzureAISearchIndexSettings> GetAsync(string name)
+        => FindByNameAsync(name);
 
     public async Task CreateAsync(AzureAISearchIndexSettings settings)
     {
@@ -112,6 +126,41 @@ public class AzureAISearchIndexSettingsService
         await _handlers.InvokeAsync((handler, ctx) => handler.SynchronizedAsync(ctx), synchronizedContext, _logger);
     }
 
+    public async Task<bool> DeleteByIdAsync(string id)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(id);
+
+        var document = await LoadDocumentAsync();
+
+        if (document.IndexSettings.Remove(id))
+        {
+            await DocumentManager.UpdateAsync(document);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public async Task<bool> DeleteByNameAsync(string name)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+
+        var document = await LoadDocumentAsync();
+
+        var index = document.IndexSettings.Values.FirstOrDefault(x => x.IndexName == name);
+
+        if (index is not null && document.IndexSettings.Remove(index.Id))
+        {
+            await DocumentManager.UpdateAsync(document);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    [Obsolete("This method will be removed in future release. Instead use DeleteByIdAsync or DeleteByNameAsync")]
     public async Task DeleteAsync(string id)
     {
         ArgumentException.ThrowIfNullOrEmpty(id);

--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchService.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAISearchService.cs
@@ -57,7 +57,7 @@ public class AzureAISearchService : ISearchService
             return result;
         }
 
-        var indexSettings = await _indexSettingsService.GetAsync(index);
+        var indexSettings = await _indexSettingsService.FindByNameAsync(index);
 
         if (indexSettings is null)
         {

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -131,9 +131,6 @@ We've introduced the `IAzureAISearchIndexSettingsHandler` interface, enabling de
 #### Key Changes  
 
 - UI routes now accept **index IDs** instead of index names.  
-- The following methods in `AzureAISearchIndexSettingsService` now use `id` instead of an index name:  
-  - `GetAsync(id)`  
-  - `DeleteAsync(id)`  
 - New methods added to `AzureAISearchIndexSettingsService`:  
   - `Task<AzureAISearchIndexSettings> NewAsync(string source, JsonNode data = null)` 
   - `Task<ValidationResultDetails> ValidateAsync(AzureAISearchIndexSettings settings)`  


### PR DESCRIPTION
### PR Description

This PR addresses a breaking change introduced in the Elasticsearch upgrade for **Orchard Core v3**. Note: this upgrade has **not yet shipped** and is still part of the v3 preview.

In that upgrade, the `GetAsync` and `DeleteAsync` methods were changed to accept an *ID* instead of a *name*, which silently broke existing behavior. Since the method signatures remained valid, this change could cause subtle bugs without any compiler warnings.

To avoid this confusing and potentially dangerous behavior, this PR restores the original `GetAsync` and `DeleteAsync` methods to accept a *name*, as they did in previous versions. These methods are now marked as `[Obsolete]` to guide developers toward the new, clearer API.

The following new methods have been introduced:

* `FindByIdAsync`
* `FindByNameAsync`
* `DeleteByIdAsync`
* `DeleteByNameAsync`

This change ensures a smoother transition by preserving backward compatibility, while clearly introducing new methods that distinguish between operations by name and by ID. It provides compiler warnings for deprecated usage, helping developers update their code intentionally.
