### PR TITLE
Fix Elasticsearch indexing InvalidOperationException with new index (Lombiq Technologies: OCORE-232)

### DIFF
--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticsearchIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticsearchIndexManager.cs
@@ -390,11 +390,9 @@ public sealed class ElasticsearchIndexManager
         var mappings = await GetIndexMappings(indexName);
 
         var jsonDocument = JsonDocument.Parse(mappings);
-        jsonDocument.RootElement.TryGetProperty("_meta", out var meta);
-        meta.TryGetProperty(_lastTaskId, out var lastTaskId);
-        lastTaskId.TryGetInt64(out var longValue);
-
-        return longValue;
+        return jsonDocument.RootElement.TryGetProperty("_meta", out var meta) && meta.TryGetProperty(_lastTaskId, out var lastTaskId)
+            ? lastTaskId.GetInt64()
+            : 0;
     }
 
     /// <summary>


### PR DESCRIPTION
Starting with a fresh index, you get the below exception with the latest `main`. This fixes that.

```
2025-05-21 00:45:16.5538|Default|00-7a03aa023a064402bac42235a4298658-1cde57f16f911af1-00||OrchardCore.Environment.Shell.Scope.ShellScope|ERROR|Error while executing the background job 'elastic-initialize' after the end of the request on tenant 'Default'. System.InvalidOperationException: Operation is not valid due to the current state of the object.
   at System.Text.Json.JsonElement.TryGetProperty(String propertyName, JsonElement& value)
   at OrchardCore.Search.Elasticsearch.Core.Services.ElasticsearchIndexManager.GetLastTaskId(String indexName) in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexManager.cs:line 394
   at OrchardCore.Search.Elasticsearch.Core.Services.ElasticsearchIndexingService.ProcessContentItemsAsync(String[] indexNames) in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexingService.cs:line 85
   at OrchardCore.Search.Elasticsearch.ElasticsearchIndexInitializerService.<>c.<<ActivatedAsync>b__6_0>d.MoveNext() in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexInitializerService.cs:line 66
--- End of stack trace from previous location ---
   at OrchardCore.BackgroundJobs.HttpBackgroundJob.<>c__DisplayClass0_0.<<ExecuteAfterEndOfRequestAsync>b__1>d.MoveNext() in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Abstractions\BackgroundJobs\HttpBackgroundJob.cs:line 87    at System.Text.Json.JsonElement.TryGetProperty(String propertyName, JsonElement& value)
   at OrchardCore.Search.Elasticsearch.Core.Services.ElasticsearchIndexManager.GetLastTaskId(String indexName) in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexManager.cs:line 394
   at OrchardCore.Search.Elasticsearch.Core.Services.ElasticsearchIndexingService.ProcessContentItemsAsync(String[] indexNames) in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexingService.cs:line 85
   at OrchardCore.Search.Elasticsearch.ElasticsearchIndexInitializerService.<>c.<<ActivatedAsync>b__6_0>d.MoveNext() in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexInitializerService.cs:line 66
--- End of stack trace from previous location ---
   at OrchardCore.BackgroundJobs.HttpBackgroundJob.<>c__DisplayClass0_0.<<ExecuteAfterEndOfRequestAsync>b__1>d.MoveNext() in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Abstractions\BackgroundJobs\HttpBackgroundJob.cs:line 87
2025-05-21 00:45:16.6523|Default|00-fc2a7e79d856fa09626c3721ec6d1042-a484fcfc0db00d0f-00||OrchardCore.Environment.Shell.Scope.ShellScope|ERROR|Error while executing the background job 'elastic-index-rebuild' after the end of the request on tenant 'Default'. System.InvalidOperationException: Operation is not valid due to the current state of the object.
   at System.Text.Json.JsonElement.TryGetProperty(String propertyName, JsonElement& value)
   at OrchardCore.Search.Elasticsearch.Core.Services.ElasticsearchIndexManager.GetLastTaskId(String indexName) in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexManager.cs:line 394
   at OrchardCore.Search.Elasticsearch.Core.Services.ElasticsearchIndexingService.ProcessContentItemsAsync(String[] indexNames) in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexingService.cs:line 85
   at OrchardCore.Search.Elasticsearch.Core.Recipes.ElasticsearchIndexRebuildStep.<>c__DisplayClass1_0.<<HandleAsync>b__0>d.MoveNext() in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Recipes\ElasticsearchIndexRebuildStep.cs:line 56
--- End of stack trace from previous location ---
   at OrchardCore.BackgroundJobs.HttpBackgroundJob.<>c__DisplayClass0_0.<<ExecuteAfterEndOfRequestAsync>b__1>d.MoveNext() in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Abstractions\BackgroundJobs\HttpBackgroundJob.cs:line 87    at System.Text.Json.JsonElement.TryGetProperty(String propertyName, JsonElement& value)
   at OrchardCore.Search.Elasticsearch.Core.Services.ElasticsearchIndexManager.GetLastTaskId(String indexName) in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexManager.cs:line 394
   at OrchardCore.Search.Elasticsearch.Core.Services.ElasticsearchIndexingService.ProcessContentItemsAsync(String[] indexNames) in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Services\ElasticsearchIndexingService.cs:line 85
   at OrchardCore.Search.Elasticsearch.Core.Recipes.ElasticsearchIndexRebuildStep.<>c__DisplayClass1_0.<<HandleAsync>b__0>d.MoveNext() in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Search.Elasticsearch.Core\Recipes\ElasticsearchIndexRebuildStep.cs:line 56
--- End of stack trace from previous location ---
   at OrchardCore.BackgroundJobs.HttpBackgroundJob.<>c__DisplayClass0_0.<<ExecuteAfterEndOfRequestAsync>b__1>d.MoveNext() in E:\Projects\OrchardForks\OrchardCore10\src\OrchardCore\OrchardCore.Abstractions\BackgroundJobs\HttpBackgroundJob.cs:line 87
```