### PR TITLE
Revert "Upgrade Elasticsearch to v9"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,10 @@
 <Project>
+
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageVersion Include="AngleSharp" Version="1.3.0" />
     <PackageVersion Include="AWSSDK.S3" Version="3.7.416.28" />
@@ -17,7 +19,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="Castle.Core" Version="5.2.1" />
     <PackageVersion Include="DocumentFormat.OpenXml" Version="3.3.0" />
-    <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="9.0.3" />
+    <PackageVersion Include="Elastic.Clients.Elasticsearch" Version="8.17.4" />
     <PackageVersion Include="Fluid.Core" Version="2.24.0" />
     <PackageVersion Include="GraphQL" Version="8.5.0" />
     <PackageVersion Include="GraphQL.DataLoader" Version="8.5.0" />
@@ -73,6 +75,7 @@
     <PackageVersion Include="YesSql.Filters.Query" Version="5.3.0" />
     <PackageVersion Include="ZString" Version="2.6.0" />
   </ItemGroup>
+
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <GlobalPackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="4.14.0" />
@@ -109,15 +112,18 @@
     <PackageVersion Include="System.Runtime.Caching" Version="8.0.1" />
     <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <!-- Several transitive dependencies on 8.0.4 and lower which is vulnerable -->
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <!-- Several transitive dependencies on 8.0.0 which has known vulnerabilities -->
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
   </ItemGroup>
+
   <!-- These versions are used for the NuGet packages that are dependent on the current TFM -->
   <!-- There may be no TFM in an evaluation phase so we can't use a conditional 'Property' -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
@@ -133,11 +139,14 @@
     <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="9.0.5" />
+    
     <!-- dotnet/extensions repository -->
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.5.0" />
+
     <!-- Serilog.AspNetCore -->
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
   </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="8.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.16" />
@@ -151,9 +160,12 @@
     <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="8.0.16" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.16" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.16" />
+    
     <!-- dotnet/extensions repository -->
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+    
     <!-- Serilog.AspNetCore -->
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
   </ItemGroup>
+
 </Project>

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/ElasticsearchConstants.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/ElasticsearchConstants.cs
@@ -12,6 +12,8 @@ public static class ElasticsearchConstants
 
     public const string PatternAnalyzer = "pattern";
 
+    public const string LanguageAnalyzer = "language";
+
     public const string FingerprintAnalyzer = "fingerprint";
 
     public const string CustomAnalyzer = "custom";

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Providers/ElasticsearchContentPickerResultProvider.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Providers/ElasticsearchContentPickerResultProvider.cs
@@ -57,7 +57,7 @@ public class ElasticsearchContentPickerResultProvider : IContentPickerResultProv
             if (string.IsNullOrWhiteSpace(searchContext.Query))
             {
                 searchResponse = await elasticClient.SearchAsync<JsonObject>(s => s
-                    .Indices(_elasticIndexManager.GetFullIndexName(indexName))
+                    .Index(_elasticIndexManager.GetFullIndexName(indexName))
                     .Query(q => q
                         .Bool(b => b
                             .Filter(f => f
@@ -73,7 +73,7 @@ public class ElasticsearchContentPickerResultProvider : IContentPickerResultProv
             else
             {
                 searchResponse = await elasticClient.SearchAsync<JsonObject>(s => s
-                    .Indices(_elasticIndexManager.GetFullIndexName(indexName))
+                    .Index(_elasticIndexManager.GetFullIndexName(indexName))
                     .Query(q => q
                         .Bool(b => b
                             .Filter(f => f

--- a/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticsearchIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Search.Elasticsearch.Core/Services/ElasticsearchIndexManager.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Elastic.Clients.Elasticsearch;
 using Elastic.Clients.Elasticsearch.Analysis;
+using Elastic.Clients.Elasticsearch.Fluent;
 using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Mapping;
 using Elastic.Clients.Elasticsearch.QueryDsl;
@@ -46,6 +47,7 @@ public sealed class ElasticsearchIndexManager
         { ElasticsearchConstants.KeywordAnalyzer, typeof(KeywordAnalyzer) },
         { ElasticsearchConstants.WhitespaceAnalyzer, typeof(WhitespaceAnalyzer) },
         { ElasticsearchConstants.PatternAnalyzer, typeof(PatternAnalyzer) },
+        { ElasticsearchConstants.LanguageAnalyzer, typeof(LanguageAnalyzer) },
         { ElasticsearchConstants.FingerprintAnalyzer, typeof(FingerprintAnalyzer) },
         { ElasticsearchConstants.CustomAnalyzer, typeof(CustomAnalyzer) },
         { ElasticsearchConstants.StopAnalyzer, typeof(StopAnalyzer) },
@@ -244,33 +246,33 @@ public sealed class ElasticsearchIndexManager
                     [IndexingConstants.ContentTypeKey] = new KeywordProperty(),
                 },
 
-                DynamicTemplates = [],
+                DynamicTemplates = new List<IDictionary<string, DynamicTemplate>>(),
             },
         };
 
-        var inheritedPostfix = new DynamicTemplate
+        var inheritedPostfix = DynamicTemplate.Mapping(new KeywordProperty());
+        inheritedPostfix.PathMatch = [_inheritedPostfixPattern];
+        inheritedPostfix.MatchMappingType = ["string"];
+        createIndexRequest.Mappings.DynamicTemplates.Add(new Dictionary<string, DynamicTemplate>()
         {
-            Mapping = new KeywordProperty(),
-            PathMatch = [_inheritedPostfixPattern],
-            MatchMappingType = ["string"],
-        };
+            { _inheritedPostfixPattern, inheritedPostfix },
+        });
 
-        createIndexRequest.Mappings.DynamicTemplates.Add(new KeyValuePair<string, DynamicTemplate>(_inheritedPostfixPattern, inheritedPostfix));
-
-        var idsPostfix = new DynamicTemplate
+        var idsPostfix = DynamicTemplate.Mapping(new KeywordProperty());
+        idsPostfix.PathMatch = [_idsPostfixPattern];
+        idsPostfix.MatchMappingType = ["string"];
+        createIndexRequest.Mappings.DynamicTemplates.Add(new Dictionary<string, DynamicTemplate>()
         {
-            Mapping = new KeywordProperty(),
-            PathMatch = [_idsPostfixPattern],
-            MatchMappingType = ["string"],
-        };
-        createIndexRequest.Mappings.DynamicTemplates.Add(new KeyValuePair<string, DynamicTemplate>(_idsPostfixPattern, idsPostfix));
+            { _idsPostfixPattern, idsPostfix },
+        });
 
-        var locationPostfix = new DynamicTemplate
+        var locationPostfix = DynamicTemplate.Mapping(new GeoPointProperty());
+        locationPostfix.PathMatch = [_locationPostFixPattern];
+        locationPostfix.MatchMappingType = ["object"];
+        createIndexRequest.Mappings.DynamicTemplates.Add(new Dictionary<string, DynamicTemplate>()
         {
-            Mapping = new GeoPointProperty(),
-            PathMatch = [_locationPostFixPattern],
-            MatchMappingType = ["object"],
-        };
+            { _locationPostFixPattern, locationPostfix },
+        });
 
         var response = await _elasticClient.Indices.CreateAsync(createIndexRequest);
 
@@ -279,12 +281,9 @@ public sealed class ElasticsearchIndexManager
 
     public async Task<string> GetIndexMappings(string indexName)
     {
-        var indexFullName = GetFullIndexName(indexName);
+        IndexName indexFullName = GetFullIndexName(indexName);
 
-        var response = await _elasticClient.Indices.GetMappingAsync<GetMappingResponse>((t) =>
-        {
-            t.Indices(indexFullName);
-        });
+        var response = await _elasticClient.Indices.GetMappingAsync<GetMappingResponse>(indexFullName);
 
         if (!response.IsValidResponse)
         {
@@ -300,19 +299,16 @@ public sealed class ElasticsearchIndexManager
             return null;
         }
 
-        var mappings = response.Mappings[indexFullName];
+        var mappings = response.Indices[indexFullName].Mappings;
 
         return _elasticClient.RequestResponseSerializer.SerializeToString(mappings);
     }
 
     public async Task<string> GetIndexSettings(string indexName)
     {
-        var fullName = GetFullIndexName(indexName);
+        IndexName fullName = GetFullIndexName(indexName);
 
-        var response = await _elasticClient.Indices.GetAsync<GetIndexResponse>(o =>
-        {
-            o.Indices(fullName);
-        });
+        var response = await _elasticClient.Indices.GetAsync<GetIndexResponse>(fullName);
 
         if (!response.IsValidResponse)
         {
@@ -333,12 +329,9 @@ public sealed class ElasticsearchIndexManager
 
     public async Task<string> GetIndexInfo(string indexName)
     {
-        var fullName = GetFullIndexName(indexName);
+        IndexName fullName = GetFullIndexName(indexName);
 
-        var response = await _elasticClient.Indices.GetAsync<GetIndexResponse>(o =>
-        {
-            o.Indices(fullName);
-        });
+        var response = await _elasticClient.Indices.GetAsync<GetIndexResponse>(fullName);
 
         if (!response.IsValidResponse)
         {
@@ -721,6 +714,7 @@ public sealed class ElasticsearchIndexManager
                 Highlights = hit.Highlight,
             });
         }
+
     }
 
     private static void RemoveTypeNode(JsonObject analyzerProperties)


### PR DESCRIPTION
Reverts OrchardCMS/OrchardCore#17931

As a result of the conversation (https://github.com/OrchardCMS/OrchardCore/pull/17942#issuecomment-2903626717) we should not upgrade to v9 of the library for now.

@sebastienros @Skrypt 