### PR TITLE
Prevent maintenance workflow to run on forks

### DIFF
--- a/.github/workflows/close_stale_prs_issues.yml
+++ b/.github/workflows/close_stale_prs_issues.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   close-stale-prs-issues:
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'OrchardCMS/OrchardCore'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/comment_issue_on_triage.yml
+++ b/.github/workflows/comment_issue_on_triage.yml
@@ -9,13 +9,11 @@ on:
 
 jobs:
   comment-issue-on-triage:
-    # To enable this workflow on a fork, comment out:
-    if: github.repository == 'OrchardCMS/OrchardCore'
     runs-on: ubuntu-24.04
     permissions:
       issues: write
     # Despite the trigger being called "issues", this would still run for setting the milestone of PRs too.
-    if: github.event.issue.pull_request == null && github.event.issue.state == 'open'
+    if: github.repository == 'OrchardCMS/OrchardCore' && github.event.issue.pull_request == null && github.event.issue.state == 'open'
     steps:
       - name: Add Comment
         run: gh issue comment "$NUMBER" --body "$BODY"

--- a/.github/workflows/comment_issue_on_triage.yml
+++ b/.github/workflows/comment_issue_on_triage.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   comment-issue-on-triage:
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'OrchardCMS/OrchardCore'
     runs-on: ubuntu-24.04
     permissions:
       issues: write

--- a/.github/workflows/community_metrics.yml
+++ b/.github/workflows/community_metrics.yml
@@ -11,6 +11,8 @@ permissions:
 
 jobs:
   generate-community-metrics:
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'OrchardCMS/OrchardCore'
     name: Generate Community Metrics
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/docs_validation.yml
+++ b/.github/workflows/docs_validation.yml
@@ -19,8 +19,6 @@ concurrency:
 
 jobs:
   validate-building-documentation:
-    # To enable this workflow on a fork, comment out:
-    if: github.repository == 'OrchardCMS/OrchardCore'
     name: Validating Building the Documentation
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/docs_validation.yml
+++ b/.github/workflows/docs_validation.yml
@@ -19,6 +19,8 @@ concurrency:
 
 jobs:
   validate-building-documentation:
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'OrchardCMS/OrchardCore'
     name: Validating Building the Documentation
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/first_time_contributor.yml
+++ b/.github/workflows/first_time_contributor.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   first-time-contributor-welcome:
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'OrchardCMS/OrchardCore'
     runs-on: ubuntu-24.04
     steps:
     # We don't use the actions/first-interaction action because it can't reference the author, nor can it comment after

--- a/.github/workflows/preview_ci.yml
+++ b/.github/workflows/preview_ci.yml
@@ -9,6 +9,8 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 jobs:
   test:
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'OrchardCMS/OrchardCore'
     runs-on: ubuntu-24.04
     name: Build, Test, Deploy
     steps:

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   validate-pull-request:
+    # To enable this workflow on a fork, comment out:
+    if: github.repository == 'OrchardCMS/OrchardCore'
     name: Validate Pull Request
     runs-on: ubuntu-24.04
     timeout-minutes: 3


### PR DESCRIPTION
For example in [this issue](https://github.com/OrchardCMS/OrchardCore/issues/17913) there are 11 forks that generated a community report pointing to it. It's adding noise, and using unnecessary compute power (better for the environment).