### PR TITLE
Add a delay to make unit test reliable

### DIFF
--- a/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
@@ -26,6 +26,10 @@ public class RecentBlogPostsQueryTests
                     });
             });
 
+        // Indexing of the content item happens in the background and may not be immediate available,
+        // so we wait a bit.
+        await Task.Delay(2000, TestContext.Current.CancellationToken);
+
         var result = await context
             .GraphQLClient
             .Content


### PR DESCRIPTION
Added the same delay as in https://github.com/OrchardCMS/OrchardCore/blob/bccf787d11500c22ea0a94ab4bc662c7aa70aba6/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/ContentStepLuceneQueryTests.cs#L39 to hopefully fix the `ShouldListBlogPostWhenCallingAQuery` test.

Fixes #18007