### PR TITLE
Use Page when listing Terms Not PageSlim

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Razor/AliasPartRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Razor/AliasPartRazorHelperExtensions.cs
@@ -22,7 +22,7 @@ public static class AliasPartRazorHelperExtensions
             return null;
         }
 
-        // Provided for backwards compatability and avoiding confusion.
+        // Provided for backwards compatibility and avoiding confusion.
         if (alias.StartsWith("alias:", StringComparison.OrdinalIgnoreCase))
         {
             alias = alias[6..];

--- a/src/OrchardCore.Modules/OrchardCore.Autoroute/Razor/AutoroutePartRazorHelperExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Autoroute/Razor/AutoroutePartRazorHelperExtensions.cs
@@ -22,7 +22,7 @@ public static class AutoroutePartRazorHelperExtensions
             return null;
         }
 
-        // Provided for backwards compatability and avoiding confusion.
+        // Provided for backwards compatibility and avoiding confusion.
         if (slug.StartsWith(AutorouteConstants.SlugPrefix, StringComparison.OrdinalIgnoreCase))
         {
             slug = slug[5..];

--- a/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TermPartContentDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Taxonomies/Drivers/TermPartContentDriver.cs
@@ -1,8 +1,9 @@
-using System.Linq.Expressions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
-using OrchardCore.ContentManagement.Records;
+using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Views;
@@ -10,124 +11,77 @@ using OrchardCore.Navigation;
 using OrchardCore.Taxonomies.Core;
 using OrchardCore.Taxonomies.Models;
 using OrchardCore.Taxonomies.ViewModels;
-using YesSql;
 
 namespace OrchardCore.Taxonomies.Drivers;
 
 public sealed class TermPartContentDriver : ContentDisplayDriver
 {
-    private readonly ISession _session;
     private readonly IContentsTaxonomyListQueryService _contentsTaxonomyListQueryService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly PagerOptions _pagerOptions;
     private readonly IContentManager _contentManager;
 
     public TermPartContentDriver(
-        ISession session,
         IOptions<PagerOptions> pagerOptions,
+        IHttpContextAccessor httpContextAccessor,
         IContentsTaxonomyListQueryService contentsTaxonomyListQueryService,
         IContentManager contentManager)
     {
-        _session = session;
         _contentsTaxonomyListQueryService = contentsTaxonomyListQueryService;
+        _httpContextAccessor = httpContextAccessor;
         _pagerOptions = pagerOptions.Value;
         _contentManager = contentManager;
     }
 
     public override IDisplayResult Display(ContentItem model, BuildDisplayContext context)
     {
-        var part = model.As<TermPart>();
-        if (part != null)
+        if (!model.TryGet<TermPart>(out var part))
         {
-            return Initialize<TermPartViewModel>("TermPart", async m =>
-            {
-                var pager = await GetPagerAsync(context.Updater, _pagerOptions.GetPageSize());
-                m.TaxonomyContentItemId = part.TaxonomyContentItemId;
-                m.ContentItem = part.ContentItem;
-                m.ContentItems = (await QueryTermItemsAsync(part, pager)).ToArray();
-                m.Pager = await context.New.PagerSlim(pager);
-            }).Location(OrchardCoreConstants.DisplayType.Detail, "Content:5");
+            return null;
         }
 
-        return null;
+        return Initialize<TermPartViewModel>("TermPart", async m =>
+        {
+            var pager = await GetPagerAsync(context.Updater, _pagerOptions.GetPageSize());
+
+            var (totalItemCount, containedItems) = await QueryTermItemsAsync(part, pager);
+            m.TaxonomyContentItemId = part.TaxonomyContentItemId;
+            m.ContentItem = part.ContentItem;
+            m.ContentItems = containedItems;
+
+            var routeValues = new RouteValueDictionary
+            {
+                ["contentItemId"] = part.ContentItem.ContentItemId,
+            };
+
+            if (_httpContextAccessor.HttpContext?.Request?.RouteValues is not null && _httpContextAccessor.HttpContext.Request.RouteValues.TryGetValue("jsonPath", out var jsonPath))
+            {
+                routeValues["jsonPath"] = jsonPath;
+            }
+
+            m.Pager = await context.ShapeFactory.PagerAsync(pager, totalItemCount, routeValues);
+        }).Location(OrchardCoreConstants.DisplayType.Detail, "Content:5");
     }
 
-    private async Task<IEnumerable<ContentItem>> QueryTermItemsAsync(TermPart termPart, PagerSlim pager)
+    private async Task<(int, IEnumerable<ContentItem>)> QueryTermItemsAsync(TermPart termPart, Pager pager)
     {
         var query = await _contentsTaxonomyListQueryService.QueryAsync(termPart, pager);
 
         var containedItems = await query.ListAsync();
 
-        if (!containedItems.Any())
-        {
-            return containedItems;
-        }
+        await _contentManager.LoadAsync(containedItems);
 
-        if (pager.Before != null)
-        {
-            containedItems = containedItems.Reverse();
-
-            // There is always an After as we clicked on Before.
-            pager.Before = null;
-            pager.After = containedItems.Last().CreatedUtc.Value.Ticks.ToString();
-
-            if (containedItems.Count() == pager.PageSize + 1)
-            {
-                containedItems = containedItems.Skip(1);
-                pager.Before = containedItems.First().CreatedUtc.Value.Ticks.ToString();
-            }
-
-            return await _contentManager.LoadAsync(containedItems);
-        }
-
-        if (pager.After != null)
-        {
-            // There is always a Before page as we clicked on After.
-            pager.Before = containedItems.First().CreatedUtc.Value.Ticks.ToString();
-            pager.After = null;
-
-            if (containedItems.Count() == pager.PageSize + 1)
-            {
-                containedItems = containedItems.Take(pager.PageSize);
-                pager.After = containedItems.Last().CreatedUtc.Value.Ticks.ToString();
-            }
-
-            return await _contentManager.LoadAsync(containedItems);
-        }
-
-        pager.Before = null;
-        pager.After = null;
-
-        if (containedItems.Count() == pager.PageSize + 1)
-        {
-            containedItems = containedItems.Take(pager.PageSize);
-            pager.After = containedItems.Last().CreatedUtc.Value.Ticks.ToString();
-        }
-
-        return await _contentManager.LoadAsync(containedItems);
+        return (await query.CountAsync(), containedItems);
     }
 
-    private static async Task<PagerSlim> GetPagerAsync(IUpdateModel updater, int pageSize)
+    private static async Task<Pager> GetPagerAsync(IUpdateModel updater, int pageSize)
     {
-        var pagerParameters = new PagerSlimParameters();
+        var pagerParameters = new PagerParameters();
+
         await updater.TryUpdateModelAsync(pagerParameters);
 
-        var pager = new PagerSlim(pagerParameters, pageSize);
+        var pager = new Pager(pagerParameters, pageSize);
 
         return pager;
-    }
-
-    private static Expression<Func<ContentItemIndex, bool>> CreateContentIndexFilter(DateTime? before, DateTime? after)
-    {
-        if (before != null)
-        {
-            return x => x.Published && x.CreatedUtc > before;
-        }
-
-        if (after != null)
-        {
-            return x => x.Published && x.CreatedUtc < after;
-        }
-
-        return x => x.Published;
     }
 }

--- a/src/OrchardCore/OrchardCore.Taxonomies.Core/DefaultContentsTaxonomyListQueryService.cs
+++ b/src/OrchardCore/OrchardCore.Taxonomies.Core/DefaultContentsTaxonomyListQueryService.cs
@@ -1,4 +1,3 @@
-using System.Linq.Expressions;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Records;
@@ -26,50 +25,17 @@ public sealed class DefaultContentsTaxonomyListQueryService : IContentsTaxonomyL
         _logger = logger;
     }
 
-    public async Task<IQuery<ContentItem>> QueryAsync(TermPart termPart, PagerSlim pager)
+    public async Task<IQuery<ContentItem>> QueryAsync(TermPart termPart, Pager pager)
     {
         IQuery<ContentItem> query = _session.Query<ContentItem>()
             .With<TaxonomyIndex>(x => x.TermContentItemId == termPart.ContentItem.ContentItemId);
 
         await _contentTaxonomyListFilters.InvokeAsync((filter, q, part) => filter.FilterAsync(q, part), query, termPart, _logger);
 
-        if (pager.Before != null)
-        {
-            var beforeValue = new DateTime(long.Parse(pager.Before));
-
-            query = query
-                .With(CreateContentIndexFilter(beforeValue, null))
-                .ThenBy(x => x.CreatedUtc);
-        }
-        else if (pager.After != null)
-        {
-            var afterValue = new DateTime(long.Parse(pager.After));
-            query = query.With(CreateContentIndexFilter(null, afterValue))
-                .ThenByDescending(x => x.CreatedUtc);
-        }
-        else
-        {
-            query = query.With(CreateContentIndexFilter(null, null))
-                .ThenByDescending(x => x.CreatedUtc);
-        }
-
-        return query.With<TaxonomyIndex>()
+        return query
+            .With<ContentItemIndex>()
+            .ThenByDescending(x => x.CreatedUtc)
             .ThenBy(x => x.Id)
             .Take(pager.PageSize + 1);
-    }
-
-    private static Expression<Func<ContentItemIndex, bool>> CreateContentIndexFilter(DateTime? before, DateTime? after)
-    {
-        if (before != null)
-        {
-            return x => x.Published && x.CreatedUtc > before;
-        }
-
-        if (after != null)
-        {
-            return x => x.Published && x.CreatedUtc < after;
-        }
-
-        return x => x.Published;
     }
 }

--- a/src/OrchardCore/OrchardCore.Taxonomies.Core/IContentsTaxonomyListQueryService.cs
+++ b/src/OrchardCore/OrchardCore.Taxonomies.Core/IContentsTaxonomyListQueryService.cs
@@ -7,5 +7,5 @@ namespace OrchardCore.Taxonomies.Core;
 
 public interface IContentsTaxonomyListQueryService
 {
-    Task<IQuery<ContentItem>> QueryAsync(TermPart termPart, PagerSlim pager);
+    Task<IQuery<ContentItem>> QueryAsync(TermPart termPart, Pager pager);
 }

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -142,6 +142,12 @@ There are lots of binary breaking changes in the Azure Search AI module most won
 
 - The permission `AzureAISearchPermissions.ManageAzureAISearchIndexes` was removed and the `AzureAISearchPermissions.ManageAzureAISearchISettings` was added.
 
+### Taxonomies Module
+
+Prior to this release, listing Taxonomies on the frontend used a slim pager (a pager with only "Next" and "Previous" buttons). With this release, the pager has been upgraded to a full-featured pager, allowing users to navigate through multiple pages directly.
+
+Additionally, a new interface, `IContentsTaxonomyListFilter`, has been introduced. This interface allows developers to customize or modify the query used when retrieving taxonomies, providing greater flexibility and control over taxonomy listings.
+
 ### Users Module
 
 The user registration and login functionalities have been refactored for better extensibility:

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -144,7 +144,9 @@ There are lots of binary breaking changes in the Azure Search AI module most won
 
 ### Taxonomies Module
 
-Prior to this release, listing Taxonomies on the frontend used a slim pager (a pager with only "Next" and "Previous" buttons). With this release, the pager has been upgraded to a full-featured pager, allowing users to navigate through multiple pages directly.
+In previous releases, taxonomy listings on the frontend used a simplified pager with only **Next** and **Previous** buttons. As of this release, the pager has been upgraded to a **full-featured pagination control**, allowing users to jump directly to specific pages.
+
+If your project overrides the `TermPart` view and modifies the `Model.Shape`, ensure your customization is compatible with the new shape type introduced by this change.
 
 Additionally, a new interface, `IContentsTaxonomyListFilter`, has been introduced. This interface allows developers to customize or modify the query used when retrieving taxonomies, providing greater flexibility and control over taxonomy listings.
 


### PR DESCRIPTION
This is still a draft. But we need to convert PagerSlim to Pager to give the user more options and control over the pager. For example, I have a need to show full pagination but can't because we are using PagerSlim.

I am not sure how to modify the pager in Blog theme using Liquid to keep it as-is while using Pager not PagerSlim. @sebastienros @Piedone if you guys have answer that will save me digging time.