### PR TITLE
Fix an InvalidOperationException when adding a before-dispose callback to a shell scope

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Scope/ShellScope.cs
@@ -514,9 +514,9 @@ public sealed class ShellScope : IServiceScope, IAsyncDisposable
     /// </summary>
     private async Task TerminateShellInternalAsync()
     {
-        _state |= ShellScopeStates.IsTerminating;
         if (_state.HasFlag(ShellScopeStates.ServiceScopeOnly))
         {
+            _state |= ShellScopeStates.IsTerminating;
             return;
         }
 
@@ -535,6 +535,8 @@ public sealed class ShellScope : IServiceScope, IAsyncDisposable
                 await tenantEvent.TerminatedAsync();
             }
         }
+
+        _state |= ShellScopeStates.IsTerminating;
     }
 
     public void Dispose()


### PR DESCRIPTION
Fixes an issue when adding before-dispose callbacks to a shell scope from within `IModularTenantEvents.TerminatingAsync` and `IModularTenantEvents.TerminatedAsync` events. 

