### PR TITLE
Do not use statics in SiteContext

### DIFF
--- a/src/OrchardCore/OrchardCore/Locking/LocalLock.cs
+++ b/src/OrchardCore/OrchardCore/Locking/LocalLock.cs
@@ -160,7 +160,11 @@ public sealed class LocalLock : IDistributedLock, ILocalLock, IDisposable
 
     public void Dispose()
     {
-        var semaphores = _semaphores.Values.ToArray();
+        Semaphore[] semaphores;
+        lock (_semaphores)
+        {
+            semaphores = _semaphores.Values.ToArray();
+        }
 
         foreach (var semaphore in semaphores)
         {

--- a/test/OrchardCore.Benchmarks/ShapeDescriptorIndexBenchmark.cs
+++ b/test/OrchardCore.Benchmarks/ShapeDescriptorIndexBenchmark.cs
@@ -16,13 +16,14 @@ namespace OrchardCore.Benchmarks;
 public class ShapeDescriptorIndexBenchmark
 {
     private readonly ConcurrentDictionary<string, FeatureShapeDescriptor> _shapeDescriptors = new();
+    private BlogContext _context;
 
     [GlobalSetup]
     public async Task SetupAsync()
     {
-        using var content = new BlogContext();
-        await content.InitializeAsync();
-        await content.UsingTenantScopeAsync(async scope =>
+        _context = new BlogContext();
+        await _context.InitializeAsync();
+        await _context.UsingTenantScopeAsync(async scope =>
         {
             var bindingStrategies = scope.ServiceProvider.GetRequiredService<IEnumerable<IShapeTableProvider>>();
             var typeFeatureProvider = scope.ServiceProvider.GetRequiredService<ITypeFeatureProvider>();

--- a/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/ContentApiController/BlogPostApiControllerTests.cs
@@ -14,7 +14,7 @@ public class BlogPostApiControllerTests
     [Fact]
     public async Task ShouldCreateDraftOfExistingContentItem()
     {
-        using var context = new BlogPostApiControllerContext();
+        await using var context = new BlogPostApiControllerContext();
 
         await context.InitializeAsync();
 
@@ -33,7 +33,7 @@ public class BlogPostApiControllerTests
     [Fact]
     public async Task ShouldCreateAndPublishExistingContentItem()
     {
-        using var context = new BlogPostApiControllerContext();
+        await using var context = new BlogPostApiControllerContext();
 
         // Setup
         await context.InitializeAsync();
@@ -53,7 +53,7 @@ public class BlogPostApiControllerTests
     [Fact]
     public async Task ShouldOnlyCreateTwoContentItemRecordsForExistingContentItem()
     {
-        using var context = new BlogPostApiControllerContext();
+        await using var context = new BlogPostApiControllerContext();
 
         // Setup
         await context.InitializeAsync();
@@ -78,7 +78,7 @@ public class BlogPostApiControllerTests
     [Fact]
     public async Task ShouldCreateDraftOfNewContentItem()
     {
-        using var context = new BlogPostApiControllerContext();
+        await using var context = new BlogPostApiControllerContext();
 
         // Setup
         var displayText = "some other blog post";
@@ -134,7 +134,7 @@ public class BlogPostApiControllerTests
     [Fact]
     public async Task ShouldCreateAndPublishNewContentItem()
     {
-        using var context = new BlogPostApiControllerContext();
+        await using var context = new BlogPostApiControllerContext();
 
         // Setup
         var displayText = "some other blog post";
@@ -191,7 +191,7 @@ public class BlogPostApiControllerTests
     [Fact]
     public async Task ShouldFailValidationWhenAutoroutePathIsNotUnique()
     {
-        using var context = new BlogPostApiControllerContext();
+        await using var context = new BlogPostApiControllerContext();
 
         // Setup
         await context.InitializeAsync();
@@ -253,7 +253,7 @@ public class BlogPostApiControllerTests
     [Fact]
     public async Task ShouldGenerateUniqueAutoroutePath()
     {
-        using var context = new BlogPostApiControllerContext();
+        await using var context = new BlogPostApiControllerContext();
 
         // Setup
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostContentStepIdempotentTests.cs
@@ -10,7 +10,7 @@ public class BlogPostContentStepIdempotentTests
     [Fact]
     public async Task ShouldProduceSameOutcomeForNewContentOnMultipleExecutions()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();
@@ -50,7 +50,7 @@ public class BlogPostContentStepIdempotentTests
     [Fact]
     public async Task ShouldProduceSameOutcomeForExistingContentItemVersionOnMultipleExecutions()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostCreateDeploymentPlanTests.cs
@@ -12,7 +12,7 @@ public class BlogPostCreateDeploymentPlanTests
     [Fact]
     public async Task ShouldCreateNewPublishedContentItemVersion()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();
@@ -49,7 +49,7 @@ public class BlogPostCreateDeploymentPlanTests
     [Fact]
     public async Task ShouldDiscardDraftThenCreateNewPublishedContentItemVersion()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();
@@ -92,7 +92,7 @@ public class BlogPostCreateDeploymentPlanTests
     [Fact]
     public async Task ShouldDiscardDraftThenCreateNewDraftContentItemVersion()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();
@@ -137,7 +137,7 @@ public class BlogPostCreateDeploymentPlanTests
     [Fact]
     public async Task ShouldCreateNewPublishedContentItem()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();
@@ -167,7 +167,7 @@ public class BlogPostCreateDeploymentPlanTests
     [Fact]
     public async Task ShouldIgnoreDuplicateContentItems()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/BlogPostUpdateDeploymentPlanTests.cs
@@ -10,7 +10,7 @@ public class BlogPostUpdateDeploymentPlanTests
     [Fact]
     public async Task ShouldUpdateExistingContentItemVersion()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();
@@ -39,7 +39,7 @@ public class BlogPostUpdateDeploymentPlanTests
     [Fact]
     public async Task ShouldDiscardDraftThenUpdateExistingContentItemVersion()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();
@@ -77,7 +77,7 @@ public class BlogPostUpdateDeploymentPlanTests
     [Fact]
     public async Task ShouldUpdateDraftThenPublishExistingContentItemVersion()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/ContentStepLuceneQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/ContentManagement/DeploymentPlans/ContentStepLuceneQueryTests.cs
@@ -10,7 +10,7 @@ public class ContentStepLuceneQueryTests
     [Fact]
     public async Task ShouldUpdateLuceneIndexesOnImport()
     {
-        using var context = new BlogPostDeploymentContext();
+        await using var context = new BlogPostDeploymentContext();
 
         // Setup
         await context.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/Context/AgencyContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/AgencyContext.cs
@@ -2,10 +2,6 @@ namespace OrchardCore.Tests.Apis.Context;
 
 public class AgencyContext : SiteContext
 {
-    static AgencyContext()
-    {
-    }
-
     public AgencyContext()
     {
         this.WithRecipe("Agency");

--- a/test/OrchardCore.Tests/Apis/Context/BlogContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogContext.cs
@@ -10,10 +10,6 @@ public class BlogContext : SiteContext
 
     public string BlogContentItemId { get; private set; }
 
-    static BlogContext()
-    {
-    }
-
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/Context/BlogPostApiControllerContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogPostApiControllerContext.cs
@@ -10,10 +10,6 @@ public class BlogPostApiControllerContext : SiteContext
     public string CategoriesTaxonomyContentItemId { get; private set; }
     public string TagsTaxonomyContentItemId { get; private set; }
 
-    static BlogPostApiControllerContext()
-    {
-    }
-
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/Context/BlogPostDeploymentContext.cs
+++ b/test/OrchardCore.Tests/Apis/Context/BlogPostDeploymentContext.cs
@@ -14,10 +14,6 @@ public class BlogPostDeploymentContext : SiteContext
     public ContentItem OriginalBlogPost { get; private set; }
     public string OriginalBlogPostVersionId { get; private set; }
 
-    static BlogPostDeploymentContext()
-    {
-    }
-
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();

--- a/test/OrchardCore.Tests/Apis/Context/MvcTestFixture.cs
+++ b/test/OrchardCore.Tests/Apis/Context/MvcTestFixture.cs
@@ -3,16 +3,13 @@ namespace OrchardCore.Tests.Apis.Context;
 public class OrchardTestFixture<TStartup> : WebApplicationFactory<TStartup>
     where TStartup : class
 {
+    public string ContentRoot { get; } = Guid.NewGuid().ToString("N");
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        var shellsApplicationDataPath = Path.Combine(Directory.GetCurrentDirectory(), "App_Data");
-
-        if (Directory.Exists(shellsApplicationDataPath))
-        {
-            Directory.Delete(shellsApplicationDataPath, true);
-        }
-
-        builder.UseContentRoot(Directory.GetCurrentDirectory());
+        var contentRoot = Path.Combine(Directory.GetCurrentDirectory(), ContentRoot);
+        builder.UseContentRoot(contentRoot);
+        builder.UseWebRoot(Path.Combine(contentRoot, "wwwroot"));
     }
 
     protected override IWebHostBuilder CreateWebHostBuilder()

--- a/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Blog/BlogPostTests.cs
@@ -15,7 +15,7 @@ public class BlogPostTests
 
     public async Task ShouldListAllBlogs()
     {
-        using var context = new BlogContext();
+        await using var context = new BlogContext();
         await context.InitializeAsync();
 
         var result = await context
@@ -34,7 +34,7 @@ public class BlogPostTests
     [Fact]
     public async Task ShouldQueryByBlogPostAutoroutePart()
     {
-        using var context = new BlogContext();
+        await using var context = new BlogContext();
         await context.InitializeAsync();
 
         var blogPostContentItemId1 = await context
@@ -95,7 +95,7 @@ public class BlogPostTests
     [Fact]
     public async Task WhenThePartHasTheSameNameAsTheContentTypeShouldCollapseFieldsToContentType()
     {
-        using var context = new BlogContext();
+        await using var context = new BlogContext();
         await context.InitializeAsync();
 
         var result = await context
@@ -114,7 +114,7 @@ public class BlogPostTests
     [Fact]
     public async Task WhenCreatingABlogPostShouldBeAbleToPopulateField()
     {
-        using var context = new BlogContext();
+        await using var context = new BlogContext();
         await context.InitializeAsync();
 
         var blogPostContentItemId = await context
@@ -164,7 +164,7 @@ public class BlogPostTests
     [Fact]
     public async Task ShouldQueryByStatus()
     {
-        using var context = new BlogContext();
+        await using var context = new BlogContext();
         await context.InitializeAsync();
 
         var draft = await context
@@ -202,7 +202,7 @@ public class BlogPostTests
     [Fact]
     public async Task ShouldNotBeAbleToExecuteAnyQueriesWithoutPermission()
     {
-        using var context = new SiteContext()
+        await using var context = new SiteContext()
             .WithPermissionsContext(new PermissionsContext { UsePermissionsContext = true });
 
         await context.InitializeAsync();
@@ -214,7 +214,7 @@ public class BlogPostTests
     [Fact]
     public async Task ShouldReturnBlogsWithViewBlogContentPermission()
     {
-        using var context = new SiteContext()
+        await using var context = new SiteContext()
             .WithPermissionsContext(new PermissionsContext
             {
                 UsePermissionsContext = true,
@@ -239,7 +239,7 @@ public class BlogPostTests
     [Fact]
     public async Task ShouldNotReturnBlogsWithViewOwnBlogContentPermission()
     {
-        using var context = new SiteContext()
+        await using var context = new SiteContext()
             .WithPermissionsContext(new PermissionsContext
             {
                 UsePermissionsContext = true,
@@ -264,7 +264,7 @@ public class BlogPostTests
     [Fact]
     public async Task ShouldNotReturnBlogsWithoutViewBlogContentPermission()
     {
-        using var context = new SiteContext()
+        await using var context = new SiteContext()
             .WithPermissionsContext(new PermissionsContext
             {
                 UsePermissionsContext = true,
@@ -288,7 +288,7 @@ public class BlogPostTests
     [Fact]
     public async Task ShouldQueryContainedPart()
     {
-        using var context = new BlogContext();
+        await using var context = new BlogContext();
         await context.InitializeAsync();
 
         var result = await context

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentManagement/DynamicContentTypeQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentManagement/DynamicContentTypeQueryTests.cs
@@ -5,7 +5,7 @@ public class DynamicContentTypeQueryTests
     [Fact]
     public async Task ShouldQueryContentFields()
     {
-        using var context = new DynamicContentTypeContext();
+        await using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
 
         var result = await context
@@ -30,7 +30,7 @@ public class DynamicContentTypeQueryTests
     [Fact]
     public async Task ShouldQueryCollapsedContentFields()
     {
-        using var context = new DynamicContentTypeContext();
+        await using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
 
         var result = await context
@@ -55,7 +55,7 @@ public class DynamicContentTypeQueryTests
     [Fact]
     public async Task ShouldQueryCollapsedContentFieldsWithPreventCollision()
     {
-        using var context = new DynamicContentTypeContext();
+        await using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
 
         var result = await context
@@ -80,7 +80,7 @@ public class DynamicContentTypeQueryTests
     [Fact]
     public async Task ShouldQueryMultipleContentFields()
     {
-        using var context = new DynamicContentTypeContext();
+        await using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
 
         var result = await context
@@ -113,7 +113,7 @@ public class DynamicContentTypeQueryTests
     [Fact]
     public async Task ShouldOrderByCreatedUtc()
     {
-        using var context = new DynamicContentTypeContext();
+        await using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
 
         var resultAsc = await context
@@ -141,7 +141,7 @@ public class DynamicContentTypeQueryTests
     [Fact]
     public async Task ShouldQuerySimilarNamedContentFields()
     {
-        using var context = new DynamicContentTypeContext();
+        await using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
 
         var numberResult = await context
@@ -172,7 +172,7 @@ public class DynamicContentTypeQueryTests
     [Fact]
     public async Task ShouldDistinquishMultipleNamedContentFields()
     {
-        using var context = new DynamicContentTypeContext();
+        await using var context = new DynamicContentTypeContext();
         await context.InitializeAsync();
 
         // Make sure values of field2 are not included by querying field1

--- a/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/Queries/RecentBlogPostsQueryTests.cs
@@ -9,7 +9,7 @@ public class RecentBlogPostsQueryTests
     [Fact]
     public async Task ShouldListBlogPostWhenCallingAQuery()
     {
-        using var context = new BlogContext();
+        await using var context = new BlogContext();
         await context.InitializeAsync();
 
         var blogPostContentItemId = await context

--- a/test/OrchardCore.Tests/Apis/Lucene/LuceneContext.cs
+++ b/test/OrchardCore.Tests/Apis/Lucene/LuceneContext.cs
@@ -4,10 +4,6 @@ namespace OrchardCore.Tests.Apis.Lucene;
 
 public class LuceneContext : SiteContext
 {
-    static LuceneContext()
-    {
-    }
-
     public LuceneContext()
     {
         this.WithRecipe("luceneQueryTest");

--- a/test/OrchardCore.Tests/Apis/Lucene/LuceneQueryTests.cs
+++ b/test/OrchardCore.Tests/Apis/Lucene/LuceneQueryTests.cs
@@ -12,7 +12,7 @@ public class LuceneQueryTests
     [Fact]
     public async Task BoostingTitleShouldHaveTitlesContainingOrchardAppearFirst()
     {
-        using var context = new LuceneContext();
+        await using var context = new LuceneContext();
         await context.InitializeAsync();
 
         // Act
@@ -48,7 +48,7 @@ public class LuceneQueryTests
     [Fact]
     public async Task BoostingBodyShouldHaveTitlesNotContainingOrchardAppearFirst()
     {
-        using var context = new LuceneContext();
+        await using var context = new LuceneContext();
         await context.InitializeAsync();
 
         // Act
@@ -83,7 +83,7 @@ public class LuceneQueryTests
     [Fact]
     public async Task SimpleQueryWildcardHasResults()
     {
-        using var context = new LuceneContext();
+        await using var context = new LuceneContext();
         await context.InitializeAsync();
 
         // Act
@@ -122,7 +122,7 @@ public class LuceneQueryTests
     [Fact]
     public async Task TwoWildcardQueriesWithBoostHasResults()
     {
-        using (var context = new LuceneContext())
+        await using (var context = new LuceneContext())
         {
             await context.InitializeAsync();
 
@@ -177,7 +177,7 @@ public class LuceneQueryTests
     [Fact]
     public async Task LuceneQueryTemplateWithSpecialCharactersShouldNotThrowError()
     {
-        using var context = new LuceneContext();
+        await using var context = new LuceneContext();
         await context.InitializeAsync();
 
         // Act

--- a/test/OrchardCore.Tests/Data/JsonDynamicTests.cs
+++ b/test/OrchardCore.Tests/Data/JsonDynamicTests.cs
@@ -936,7 +936,7 @@ public class JsonDynamicTests
     public async Task SerializingJsonDynamicValueInScripting()
     {
         // Arrange
-        using var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(scope =>
         {

--- a/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
@@ -12,7 +12,7 @@ public class LiquidTests
     [Fact]
     public async Task ComparingTextField_ReturnsCorrectValue()
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {
@@ -45,7 +45,7 @@ public class LiquidTests
     [Fact]
     public async Task ComparingDateTimeField_ReturnsCorrectValue()
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {
@@ -80,7 +80,7 @@ public class LiquidTests
     [Fact]
     public async Task ComparingNumericField_ReturnsCorrectValue()
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {
@@ -113,7 +113,7 @@ public class LiquidTests
     [Fact]
     public async Task SortingContentItems_ShouldSortTheArrayOnIntegerField()
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {
@@ -139,7 +139,7 @@ public class LiquidTests
     [Fact]
     public async Task FilteringContentItems_ShouldFilterTheArrayOnBooleanField()
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {
@@ -165,7 +165,7 @@ public class LiquidTests
     [Fact]
     public async Task FilteringAndSortingContentItems_ShouldFilterAndSortTheArrayOnContentFields()
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {

--- a/test/OrchardCore.Tests/Localization/LocalizationManagerTests.cs
+++ b/test/OrchardCore.Tests/Localization/LocalizationManagerTests.cs
@@ -81,7 +81,7 @@ public class LocalizationManagerTests
     [InlineData("zh-CN", "你好！")]
     public async Task TestLocalizationRule(string culture, string expected)
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
 
         var recipeSteps = new JsonArray

--- a/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdAuthenticationTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.OpenId/OpenIdAuthenticationTests.cs
@@ -18,7 +18,7 @@ public class OpenIdAuthenticationTests
     [Fact]
     public async Task OpenId_CodeFlow_CanExchangeAuthorizationCodeForAccessTokenOnlyOnce()
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
 
         await context.InitializeAsync();
 
@@ -175,7 +175,7 @@ public class OpenIdAuthenticationTests
     [Fact]
     public async Task OpenId_CodeFlowWithPushedAuthorizationRequests_CanExchangeAuthorizationCodeForAccessTokenOnlyOnce()
     {
-        var context = new SiteContext();
+        await using var context = new SiteContext();
 
         await context.InitializeAsync();
 

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Tenants/Services/TenantValidatorTests.cs
@@ -9,10 +9,6 @@ namespace OrchardCore.Modules.Tenants.Services.Tests;
 
 public class TenantValidatorTests : SiteContext
 {
-    static TenantValidatorTests()
-    {
-    }
-
     [Theory]
     [InlineData("Tenant1", "tenant1", "", "Feature Profile", new[] { "A tenant with the same name already exists." })]
     [InlineData("tEnAnT1", "tenant1", "", "Feature Profile", new[] { "A tenant with the same name already exists." })]
@@ -98,7 +94,7 @@ public class TenantValidatorTests : SiteContext
         }
     }
 
-    private static TenantValidator CreateTenantValidator(bool defaultTenant = true)
+    private TenantValidator CreateTenantValidator(bool defaultTenant = true)
     {
         var featureProfilesServiceMock = new Mock<IFeatureProfilesService>();
         featureProfilesServiceMock.Setup(fp => fp.GetFeatureProfilesAsync())
@@ -133,7 +129,7 @@ public class TenantValidatorTests : SiteContext
             );
     }
 
-    private static async Task SeedTenantsAsync()
+    private async Task SeedTenantsAsync()
     {
         await ShellHost.GetOrCreateShellContextAsync(new ShellSettings { Name = "Tenant1", RequestUrlPrefix = "tenant1" }.AsUninitialized());
         await ShellHost.GetOrCreateShellContextAsync(new ShellSettings { Name = "Tenant2", RequestUrlPrefix = string.Empty, RequestUrlHost = "example2.com" }.AsUninitialized());

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/AccountControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/AccountControllerTests.cs
@@ -17,7 +17,7 @@ public class AccountControllerTests
     public async Task ExternalLoginSignIn_Test()
     {
         // Arrange
-        var context = await GetSiteContextAsync(new RegistrationSettings(), true, true, true);
+        await using var context = await GetSiteContextAsync(new RegistrationSettings(), true, true, true);
 
         // Act
         var model = new RegisterViewModel()
@@ -165,7 +165,7 @@ public class AccountControllerTests
     public async Task Register_WhenAllowed_RegisterUser()
     {
         // Arrange
-        var context = await GetSiteContextAsync(new RegistrationSettings());
+        await using var context = await GetSiteContextAsync(new RegistrationSettings());
 
         var responseFromGet = await context.Client.GetAsync("Register", TestContext.Current.CancellationToken);
 
@@ -201,7 +201,7 @@ public class AccountControllerTests
     public async Task Register_WhenNotAllowed_ReturnNotFound()
     {
         // Arrange
-        var context = await GetSiteContextAsync(new RegistrationSettings(), false);
+        await using var context = await GetSiteContextAsync(new RegistrationSettings(), false);
 
         // Act
         var response = await context.Client.GetAsync("Register", TestContext.Current.CancellationToken);
@@ -214,7 +214,7 @@ public class AccountControllerTests
     public async Task Register_WhenFeatureIsNotEnable_ReturnNotFound()
     {
         // Arrange
-        var context = await GetSiteContextAsync(new RegistrationSettings(), enableRegistrationFeature: false);
+        await using var context = await GetSiteContextAsync(new RegistrationSettings(), enableRegistrationFeature: false);
 
         // Act
         var response = await context.Client.GetAsync("Register", TestContext.Current.CancellationToken);
@@ -227,7 +227,7 @@ public class AccountControllerTests
     public async Task Register_WhenRequireUniqueEmailIsTrue_PreventRegisteringMultipleUsersWithTheSameEmails()
     {
         // Arrange
-        var context = await GetSiteContextAsync(new RegistrationSettings());
+        await using var context = await GetSiteContextAsync(new RegistrationSettings());
 
         var responseFromGet = await context.Client.GetAsync("Register", TestContext.Current.CancellationToken);
 
@@ -271,7 +271,7 @@ public class AccountControllerTests
     public async Task Register_WhenRequireUniqueEmailIsFalse_AllowRegisteringMultipleUsersWithTheSameEmails()
     {
         // Arrange
-        var context = await GetSiteContextAsync(new RegistrationSettings(), enableRegistrationFeature: true, requireUniqueEmail: false);
+        await using var context = await GetSiteContextAsync(new RegistrationSettings(), enableRegistrationFeature: true, requireUniqueEmail: false);
 
         // Register First User
         var responseFromGet = await context.Client.GetAsync("Register", TestContext.Current.CancellationToken);
@@ -317,7 +317,7 @@ public class AccountControllerTests
     public async Task Register_WhenModeration_RedirectToRegistrationPending()
     {
         // Arrange
-        var context = await GetSiteContextAsync(new RegistrationSettings()
+        await using var context = await GetSiteContextAsync(new RegistrationSettings()
         {
             UsersAreModerated = true,
         });
@@ -357,7 +357,7 @@ public class AccountControllerTests
     public async Task Register_WhenRequireEmailConfirmation_RedirectToConfirmEmailSent()
     {
         // Arrange
-        var context = await GetSiteContextAsync(new RegistrationSettings
+        await using var context = await GetSiteContextAsync(new RegistrationSettings
         {
             UsersMustValidateEmail = true,
         }, true, true, false);

--- a/test/OrchardCore.Tests/Recipes/RecipeExecutorTests.cs
+++ b/test/OrchardCore.Tests/Recipes/RecipeExecutorTests.cs
@@ -59,7 +59,7 @@ public class RecipeExecutorTests
     [Fact]
     public async Task ContentDefinitionStep_WhenPartNameIsMissing_RecipeExecutionException()
     {
-        using var context = new BlogContext();
+        await using var context = new BlogContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {

--- a/test/OrchardCore.Tests/Scripting/ScriptFunctionsTest.cs
+++ b/test/OrchardCore.Tests/Scripting/ScriptFunctionsTest.cs
@@ -8,7 +8,7 @@ public class ScriptFunctionsTest
     [Fact]
     public async Task TheScriptingEngineShouldBeAbleToHandleJsonObject()
     {
-        using var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(scope =>
         {

--- a/test/OrchardCore.Tests/Serializers/JsonSerializerTests.cs
+++ b/test/OrchardCore.Tests/Serializers/JsonSerializerTests.cs
@@ -53,7 +53,7 @@ public class JsonSerializerTests
     [Fact]
     public async Task DefaultContentSerializer_SerializeAndDeserialize_UserWithUserLoginInfo()
     {
-        using var context = new SiteContext();
+        await using var context = new SiteContext();
         await context.InitializeAsync();
         await context.UsingTenantScopeAsync(async scope =>
         {

--- a/test/OrchardCore.Tests/Shell/ShellHostTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellHostTests.cs
@@ -12,7 +12,7 @@ public class ShellHostTests : SiteContext
     [Theory]
     [InlineData("Tenant1", "tenant1", "tEnAnT1")]
     [InlineData(ShellSettings.DefaultShellName, "", "dEfAuLt")]
-    public static async Task CanGetShellByCaseInsensitiveName(string name, string urlPrefix, string searchName)
+    public async Task CanGetShellByCaseInsensitiveName(string name, string urlPrefix, string searchName)
     {
         await ShellHost.InitializeAsync();
 

--- a/test/OrchardCore.Tests/Shell/ShellScopeTests.cs
+++ b/test/OrchardCore.Tests/Shell/ShellScopeTests.cs
@@ -9,7 +9,7 @@ public class ShellScopeTests
     [Fact]
     public static async Task ShellScopeConcurrencyTest()
     {
-        var context = new SiteContext()
+        await using var context = new SiteContext()
             .WithRecipe("SaaS");
         await context.InitializeAsync();
 


### PR DESCRIPTION
@MikeAlhayek Here's a summary of the changes I made to improve the unit tests:

While investigating some flaky tests, I encountered a significant issue with memory usage. The root cause was the static `ShellHost` in `SiteContext`, which retains parts of every test tenant in memory. To reproduce certain issues, I had to run some tests thousands of times, which led to excessive memory consumption. At one point exceeding 22GB of RAM and significantly slowed down test execution.

This PR documents the work I started to address that problem. However, it's still a work in progress and not intended for merging. Notably, directory cleanup is not yet reliable, which will likely cause issues if the tests are run repeatedly.

I’m not planning to continue this work at the moment, but I wanted to share the current state for reference.

