### PR TITLE
Fix "The node already has a parent" error when attempting to run recipe with ContentIndexSettings property when Lucene is enabled.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Recipes/LuceneRecipeEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Recipes/LuceneRecipeEventHandler.cs
@@ -35,7 +35,7 @@ public class LuceneRecipeEventHandler : IRecipeEventHandler
                         if (partDefinition.Settings.TryGetPropertyValue("ContentIndexSettings", out var existingPartSettings) &&
                             !partDefinition.Settings.ContainsKey("LuceneContentIndexSettings"))
                         {
-                            partDefinition.Settings.Add("LuceneContentIndexSettings", existingPartSettings);
+                            partDefinition.Settings.Add("LuceneContentIndexSettings", existingPartSettings?.DeepClone());
                         }
 
                         partDefinition.Settings.Remove("ContentIndexSettings");
@@ -49,7 +49,7 @@ public class LuceneRecipeEventHandler : IRecipeEventHandler
                 {
                     if (partDefinition.Settings.TryGetPropertyValue("ContentIndexSettings", out var existingPartSettings))
                     {
-                        partDefinition.Settings["LuceneContentIndexSettings"] = existingPartSettings;
+                        partDefinition.Settings["LuceneContentIndexSettings"] = existingPartSettings?.DeepClone();
                     }
 
                     partDefinition.Settings.Remove("ContentIndexSettings");
@@ -60,7 +60,7 @@ public class LuceneRecipeEventHandler : IRecipeEventHandler
                         {
                             if (fieldDefinition.Settings.TryGetPropertyValue("ContentIndexSettings", out var existingFieldSettings))
                             {
-                                fieldDefinition.Settings["LuceneContentIndexSettings"] = existingFieldSettings;
+                                fieldDefinition.Settings["LuceneContentIndexSettings"] = existingFieldSettings?.DeepClone();
                             }
 
                             fieldDefinition.Settings.Remove("ContentIndexSettings");


### PR DESCRIPTION
Do deep clone when replacing ContentIndexSettings property with LuceneContentIndexSettings property in LuceneRecipeEventHandler.

Fix #18061 