### PR TITLE
Migrate 'IndexingTask' table to 'RecordIndexingTask' to avoid timeout

### DIFF
--- a/src/OrchardCore.Cms.Web/Program.cs
+++ b/src/OrchardCore.Cms.Web/Program.cs
@@ -6,8 +6,7 @@ builder.Host.UseNLogHost();
 
 builder.Services
     .AddOrchardCms()
-    .AddSetupFeatures("OrchardCore.AutoSetup")
-    .AddGlobalFeatures("OrchardCore.DataProtection.Azure");
+    .AddSetupFeatures("OrchardCore.AutoSetup");
 
 var app = builder.Build();
 

--- a/src/OrchardCore.Cms.Web/Program.cs
+++ b/src/OrchardCore.Cms.Web/Program.cs
@@ -6,7 +6,8 @@ builder.Host.UseNLogHost();
 
 builder.Services
     .AddOrchardCms()
-    .AddSetupFeatures("OrchardCore.AutoSetup");
+    .AddSetupFeatures("OrchardCore.AutoSetup")
+    .AddGlobalFeatures("OrchardCore.DataProtection.Azure");
 
 var app = builder.Build();
 

--- a/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/BlobOptionsSetup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataProtection.Azure/BlobOptionsSetup.cs
@@ -32,6 +32,8 @@ public class BlobOptionsSetup : IAsyncConfigureOptions<BlobOptions>
 
     public async ValueTask ConfigureAsync(BlobOptions options)
     {
+        _logger.LogDebug("Configuring BlobOptions in BlobOptionsSetup");
+
         _configuration.Bind("OrchardCore_DataProtection_Azure", options);
         await ConfigureContainerNameAsync(options);
         await ConfigureBlobNameAsync(options);
@@ -39,6 +41,8 @@ public class BlobOptionsSetup : IAsyncConfigureOptions<BlobOptions>
 
     private async ValueTask ConfigureContainerNameAsync(BlobOptions options)
     {
+        _logger.LogDebug("Configuring BlobOptions.ContainerName in BlobOptionsSetup");
+
         try
         {
             // Use Fluid directly as the service provider has not been built.
@@ -52,6 +56,11 @@ public class BlobOptionsSetup : IAsyncConfigureOptions<BlobOptions>
             // Container name must be lowercase.
             var containerName = (await template.RenderAsync(templateContext, NullEncoder.Default)).ToLower();
             options.ContainerName = containerName.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("BlobOptions.ContainerName was set to {ContainerName}", options.ContainerName);
+            }
         }
         catch (Exception e)
         {
@@ -78,9 +87,16 @@ public class BlobOptionsSetup : IAsyncConfigureOptions<BlobOptions>
 
     private async ValueTask ConfigureBlobNameAsync(BlobOptions options)
     {
+        _logger.LogDebug("Configuring BlobOptions.BlobName in BlobOptionsSetup");
+
         if (string.IsNullOrEmpty(options.BlobName))
         {
             options.BlobName = $"{_shellOptions.ShellsContainerName}/{_shellSettings.Name}/DataProtectionKeys.xml";
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("BlobOptions.BlobName was set to {BlobName}", options.BlobName);
+            }
 
             return;
         }
@@ -97,6 +113,11 @@ public class BlobOptionsSetup : IAsyncConfigureOptions<BlobOptions>
 
             var blobName = await template.RenderAsync(templateContext, NullEncoder.Default);
             options.BlobName = blobName.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug("BlobOptions.BlobName was set to {BlobName}", options.BlobName);
+            }
         }
         catch (Exception e)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/CreateIndexingTaskContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/CreateIndexingTaskContentHandler.cs
@@ -36,7 +36,7 @@ public sealed class CreateIndexingTaskContentHandler : ContentHandlerBase
             return Task.CompletedTask;
         }
 
-        return _indexingTaskManager.CreateTaskAsync(new CreateIndexingTaskContext(context.ContentItem.ContentItemId, IndexingConstants.ContentsIndexSource, IndexingTaskTypes.Delete));
+        return _indexingTaskManager.CreateTaskAsync(new CreateIndexingTaskContext(context.ContentItem.ContentItemId, IndexingConstants.ContentsIndexSource, RecordIndexingTaskTypes.Delete));
     }
 
     private Task AddUpdateTaskAsync(ContentItem contentItem)
@@ -53,6 +53,6 @@ public sealed class CreateIndexingTaskContentHandler : ContentHandlerBase
             return Task.CompletedTask;
         }
 
-        return _indexingTaskManager.CreateTaskAsync(new CreateIndexingTaskContext(contentItem.ContentItemId, IndexingConstants.ContentsIndexSource, IndexingTaskTypes.Update));
+        return _indexingTaskManager.CreateTaskAsync(new CreateIndexingTaskContext(contentItem.ContentItemId, IndexingConstants.ContentsIndexSource, RecordIndexingTaskTypes.Update));
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/DataMigrations/IndexingMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/DataMigrations/IndexingMigrations.cs
@@ -9,11 +9,11 @@ internal sealed class IndexingMigrations : DataMigration
     public async Task<int> CreateAsync()
     {
         await SchemaBuilder.CreateMapIndexTableAsync<IndexProfileIndex>(table => table
-            .Column<string>("IndexProfileId", c => c.WithLength(26))
-            .Column<string>("Name", c => c.WithLength(255))
-            .Column<string>("IndexName", c => c.WithLength(255))
-            .Column<string>("ProviderName", c => c.WithLength(50))
-            .Column<string>("Type", c => c.WithLength(50))
+            .Column<string>("IndexProfileId", column => column.WithLength(26))
+            .Column<string>("Name", column => column.WithLength(255))
+            .Column<string>("IndexName", column => column.WithLength(255))
+            .Column<string>("ProviderName", column => column.WithLength(50))
+            .Column<string>("Type", column => column.WithLength(50))
         );
 
         await SchemaBuilder.AlterIndexTableAsync<IndexProfileIndex>(table => table

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/DataMigrations/RecordIndexingTaskMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/DataMigrations/RecordIndexingTaskMigrations.cs
@@ -7,10 +7,10 @@ internal sealed class RecordIndexingTaskMigrations : DataMigration
     public async Task<int> CreateAsync()
     {
         await SchemaBuilder.CreateTableAsync("RecordIndexingTask", table => table
-           .Column<int>("Id", col => col.PrimaryKey().Identity())
-           .Column<string>("RecordId", c => c.WithLength(26))
-           .Column<string>("Category", c => c.WithLength(50))
-           .Column<DateTime>("CreatedUtc", col => col.NotNull())
+           .Column<int>("Id", column => column.PrimaryKey().Identity())
+           .Column<string>("RecordId", column => column.WithLength(26))
+           .Column<string>("Category", column => column.WithLength(50))
+           .Column<DateTime>("CreatedUtc", column => column.NotNull())
            .Column<int>("Type")
         );
 

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/DataMigrations/RecordIndexingTaskMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/DataMigrations/RecordIndexingTaskMigrations.cs
@@ -1,0 +1,23 @@
+using OrchardCore.Data.Migration;
+
+namespace OrchardCore.Indexing.DataMigrations;
+
+internal sealed class RecordIndexingTaskMigrations : DataMigration
+{
+    public async Task<int> CreateAsync()
+    {
+        await SchemaBuilder.CreateTableAsync("RecordIndexingTask", table => table
+           .Column<int>("Id", col => col.PrimaryKey().Identity())
+           .Column<string>("RecordId", c => c.WithLength(26))
+           .Column<string>("Category", c => c.WithLength(50))
+           .Column<DateTime>("CreatedUtc", col => col.NotNull())
+           .Column<int>("Type")
+        );
+
+        await SchemaBuilder.AlterTableAsync("RecordIndexingTask", table => table
+            .CreateIndex("IDX_RecordIndexingTask_RecordId_Category", "RecordId", "Category")
+        );
+
+        return 1;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/Migrations.cs
@@ -13,7 +13,7 @@ public sealed class Migrations : DataMigration
 {
     public async Task<int> CreateAsync()
     {
-        await SchemaBuilder.CreateTableAsync("igrate RecordIndexingTask", table => table
+        await SchemaBuilder.CreateTableAsync("RecordIndexingTask", table => table
            .Column<int>("Id", col => col.PrimaryKey().Identity())
            .Column<string>("RecordId", c => c.WithLength(26))
            .Column<string>("Category", c => c.WithLength(50))

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/Migrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/Migrations.cs
@@ -97,6 +97,8 @@ public sealed class Migrations : DataMigration
                     await connection.ExecuteAsync(previewTableQuery);
                 }
 
+                // At this point, the 'RecordIndexingTask' table has been populated with the data from the 'IndexingTask' table.
+                // It's safe to drop the old 'IndexingTask' table now.
                 await connection.ExecuteAsync($"drop table {indexingTaskTable}");
                 await connection.CloseAsync();
             }

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/Startup.cs
@@ -28,14 +28,19 @@ public sealed class Startup : StartupBase
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddIndexingCore();
+        services.AddDataMigration<RecordIndexingTaskMigrations>();
+
+#pragma warning disable CS0618 // Type or member is obsolete
         services.AddDataMigration<Migrations>();
+#pragma warning restore CS0618 // Type or member is obsolete
 
         services.AddNavigationProvider<AdminMenu>();
         services.AddDisplayDriver<IndexProfile, IndexProfileDisplayDriver>();
         services.AddPermissionProvider<IndexingPermissionsProvider>();
         services.AddDataMigration<PreviewIndexingMigrations>();
 
-        services.AddIndexProvider<IndexProfileIndexProvider>()
+        services
+            .AddIndexProvider<IndexProfileIndexProvider>()
             .AddDataMigration<IndexingMigrations>();
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Migrations/IndexingMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search.Elasticsearch/Migrations/IndexingMigrations.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Dapper;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using OrchardCore.Contents.Indexing;
 using OrchardCore.Data;
 using OrchardCore.Data.Migration;
@@ -22,32 +23,14 @@ namespace OrchardCore.Search.Elasticsearch.Migrations;
 internal sealed class IndexingMigrations : DataMigration
 {
     private readonly ShellSettings _shellSettings;
-    private readonly IStore _store;
-    private readonly IDbConnectionAccessor _dbConnectionAccessor;
-    private readonly IIndexProfileManager _indexProfileManager;
-    private readonly ISiteService _siteService;
-    private readonly ElasticsearchDocumentIndexManager _indexDocumentManager;
-    private readonly IIndexNameProvider _indexNameProvider;
 
-    public IndexingMigrations(
-        ShellSettings shellSettings,
-        IStore store,
-        IDbConnectionAccessor dbConnectionAccessor,
-        IIndexProfileManager indexProfileManager,
-        ISiteService siteService,
-        ElasticsearchDocumentIndexManager indexDocumentManager,
-        [FromKeyedServices(ElasticsearchConstants.ProviderName)] IIndexNameProvider indexNameProvider)
+
+    public IndexingMigrations(ShellSettings shellSettings)
     {
         _shellSettings = shellSettings;
-        _store = store;
-        _dbConnectionAccessor = dbConnectionAccessor;
-        _indexProfileManager = indexProfileManager;
-        _siteService = siteService;
-        _indexDocumentManager = indexDocumentManager;
-        _indexNameProvider = indexNameProvider;
     }
 
-    public async Task<int> CreateAsync()
+    public int Create()
     {
         var stepNumber = 1;
 
@@ -56,170 +39,186 @@ internal sealed class IndexingMigrations : DataMigration
             return stepNumber;
         }
 
-        var documentTableName = _store.Configuration.TableNameConvention.GetDocumentTable();
-        var table = $"{_store.Configuration.TablePrefix}{documentTableName}";
-        var dialect = _store.Configuration.SqlDialect;
-        var quotedTableName = dialect.QuoteForTableName(table, _store.Configuration.Schema);
-        var quotedContentColumnName = dialect.QuoteForColumnName("Content");
-        var quotedTypeColumnName = dialect.QuoteForColumnName("Type");
-
-        var sqlBuilder = new SqlBuilder(_store.Configuration.TablePrefix, _store.Configuration.SqlDialect);
-        sqlBuilder.AddSelector(quotedContentColumnName);
-        sqlBuilder.From(quotedTableName);
-        sqlBuilder.WhereAnd($" {quotedTypeColumnName} = 'OrchardCore.Search.Elasticsearch.Core.Models.ElasticIndexSettingsDocument, OrchardCore.Search.Elasticsearch.Core' ");
-        sqlBuilder.Take("1");
-
-        await using var connection = _dbConnectionAccessor.CreateConnection();
-        await connection.OpenAsync();
-        var jsonContent = await connection.QueryFirstOrDefaultAsync<string>(sqlBuilder.ToSqlString());
-
-        if (string.IsNullOrEmpty(jsonContent))
+        ShellScope.AddDeferredTask(async scope =>
         {
-            return stepNumber;
-        }
+            // This logic must be deferred to ensure that other migrations create the necessary database tables first.
 
-        var jsonObject = JsonNode.Parse(jsonContent);
+            var store = scope.ServiceProvider.GetRequiredService<IStore>();
+            var documentTableName = store.Configuration.TableNameConvention.GetDocumentTable();
+            var table = $"{store.Configuration.TablePrefix}{documentTableName}";
+            var dialect = store.Configuration.SqlDialect;
+            var quotedTableName = dialect.QuoteForTableName(table, store.Configuration.Schema);
+            var quotedContentColumnName = dialect.QuoteForColumnName("Content");
+            var quotedTypeColumnName = dialect.QuoteForColumnName("Type");
 
-        if (jsonObject["ElasticIndexSettings"] is not JsonObject indexesObject)
-        {
-            return stepNumber;
-        }
+            var sqlBuilder = new SqlBuilder(store.Configuration.TablePrefix, store.Configuration.SqlDialect);
+            sqlBuilder.AddSelector(quotedContentColumnName);
+            sqlBuilder.From(quotedTableName);
+            sqlBuilder.WhereAnd($" {quotedTypeColumnName} = 'OrchardCore.Search.Elasticsearch.Core.Models.ElasticIndexSettingsDocument, OrchardCore.Search.Elasticsearch.Core' ");
+            sqlBuilder.Take("1");
 
-        var site = await _siteService.LoadSiteSettingsAsync();
+            var dbConnectionAccessor = scope.ServiceProvider.GetRequiredService<IDbConnectionAccessor>();
+            await using var connection = dbConnectionAccessor.CreateConnection();
+            await connection.OpenAsync();
+            var jsonContent = await connection.QueryFirstOrDefaultAsync<string>(sqlBuilder.ToSqlString());
 
-        var defaultSearchProvider = site.Properties["SearchSettings"]?["ProviderName"]?.GetValue<string>();
-        var elasticSettings = site.Properties["ElasticSettings"] ?? new JsonObject();
-
-        var defaultSearchIndexName = elasticSettings["SearchIndex"]?.GetValue<string>();
-        var defaultSearchFields = GetDefaultSearchFields(elasticSettings);
-
-        foreach (var indexObject in indexesObject)
-        {
-            var indexName = indexObject.Key;
-
-            var indexFullName = _indexNameProvider.GetFullIndexName(indexName);
-
-            var indexProfile = await _indexProfileManager.NewAsync(ElasticsearchConstants.ProviderName, IndexingConstants.ContentsIndexSource);
-            indexProfile.IndexName = indexName;
-            indexProfile.IndexFullName = indexFullName;
-            indexProfile.Name = indexName;
-
-            var counter = 1;
-
-            while (await _indexProfileManager.FindByNameAsync(indexProfile.Name) is not null)
+            if (string.IsNullOrEmpty(jsonContent))
             {
-                indexProfile.Name = $"{indexName}{counter++}";
+                return;
+            }
 
-                if (counter > 50)
+            var jsonObject = JsonNode.Parse(jsonContent);
+
+            if (jsonObject["ElasticIndexSettings"] is not JsonObject indexesObject)
+            {
+                return;
+            }
+
+            var siteService = scope.ServiceProvider.GetRequiredService<ISiteService>();
+            var site = await siteService.LoadSiteSettingsAsync();
+
+            var defaultSearchProvider = site.Properties["SearchSettings"]?["ProviderName"]?.GetValue<string>();
+            var elasticSettings = site.Properties["ElasticSettings"] ?? new JsonObject();
+
+            var defaultSearchIndexName = elasticSettings["SearchIndex"]?.GetValue<string>();
+            var defaultSearchFields = GetDefaultSearchFields(elasticSettings);
+
+            var indexProfileManager = scope.ServiceProvider.GetRequiredService<IIndexProfileManager>();
+            var indexNameProvider = scope.ServiceProvider.GetRequiredKeyedService<IIndexNameProvider>(ElasticsearchConstants.ProviderName);
+            var indexDocumentManager = scope.ServiceProvider.GetRequiredService<ElasticsearchDocumentIndexManager>();
+
+            foreach (var indexObject in indexesObject)
+            {
+                var indexName = indexObject.Key;
+
+                var indexFullName = indexNameProvider.GetFullIndexName(indexName);
+
+                var indexProfile = await indexProfileManager.NewAsync(ElasticsearchConstants.ProviderName, IndexingConstants.ContentsIndexSource);
+                indexProfile.IndexName = indexName;
+                indexProfile.IndexFullName = indexFullName;
+                indexProfile.Name = indexName;
+
+                var counter = 1;
+
+                while (await indexProfileManager.FindByNameAsync(indexProfile.Name) is not null)
                 {
-                    throw new InvalidOperationException($"Unable to create a unique index name for '{indexName}' after 50 attempts.");
-                }
-            }
+                    indexProfile.Name = $"{indexName}{counter++}";
 
-            var metadata = indexProfile.As<ContentIndexMetadata>();
-
-            if (string.IsNullOrEmpty(metadata.Culture))
-            {
-                metadata.Culture = indexObject.Value[nameof(metadata.Culture)]?.GetValue<string>();
-            }
-
-            var indexLatest = indexObject.Value[nameof(metadata.IndexLatest)]?.GetValue<bool>();
-
-            if (indexLatest.HasValue)
-            {
-                metadata.IndexLatest = indexLatest.Value;
-            }
-
-            var indexContentTypes = indexObject.Value[nameof(metadata.IndexedContentTypes)]?.AsArray();
-
-            if (indexContentTypes is not null)
-            {
-                var items = new HashSet<string>();
-
-                foreach (var indexContentType in indexContentTypes)
-                {
-                    var value = indexContentType.GetValue<string>();
-
-                    if (!string.IsNullOrEmpty(value))
+                    if (counter > 50)
                     {
-                        items.Add(value);
+                        throw new InvalidOperationException($"Unable to create a unique index name for '{indexName}' after 50 attempts.");
                     }
                 }
 
-                metadata.IndexedContentTypes = items.ToArray();
-            }
+                var metadata = indexProfile.As<ContentIndexMetadata>();
 
-            indexProfile.Put(metadata);
-
-            var elasticsearchMetadata = indexProfile.As<ElasticsearchIndexMetadata>();
-
-            var storeSourceData = indexObject.Value[nameof(elasticsearchMetadata.StoreSourceData)]?.GetValue<bool>();
-
-            if (storeSourceData.HasValue)
-            {
-                elasticsearchMetadata.StoreSourceData = storeSourceData.Value;
-            }
-
-            if (string.IsNullOrEmpty(elasticsearchMetadata.AnalyzerName))
-            {
-                elasticsearchMetadata.AnalyzerName = indexObject.Value[nameof(elasticsearchMetadata.AnalyzerName)]?.GetValue<string>();
-            }
-
-            var mapping = await _indexDocumentManager.GetIndexMappingsAsync(indexFullName);
-
-            elasticsearchMetadata.IndexMappings = new ElasticsearchIndexMap
-            {
-                KeyFieldName = ContentIndexingConstants.ContentItemIdKey,
-                Mapping = mapping,
-            };
-
-            indexProfile.Put(elasticsearchMetadata);
-
-            var queryMetadata = indexProfile.As<ElasticsearchDefaultQueryMetadata>();
-            if (string.IsNullOrEmpty(queryMetadata.QueryAnalyzerName))
-            {
-                queryMetadata.QueryAnalyzerName = indexObject.Value[nameof(queryMetadata.QueryAnalyzerName)]?.GetValue<string>();
-            }
-
-            if (string.IsNullOrEmpty(queryMetadata.QueryAnalyzerName))
-            {
-                queryMetadata.QueryAnalyzerName = elasticsearchMetadata.AnalyzerName;
-            }
-
-            queryMetadata.DefaultQuery = indexObject.Value[nameof(queryMetadata.DefaultQuery)]?.GetValue<string>();
-
-            if (string.IsNullOrEmpty(queryMetadata.DefaultQuery))
-            {
-                queryMetadata.DefaultQuery = elasticSettings["DefaultQuery"]?.GetValue<string>();
-            }
-
-            if (queryMetadata.DefaultSearchFields is null || queryMetadata.DefaultSearchFields.Length == 0)
-            {
-                queryMetadata.DefaultSearchFields = defaultSearchFields;
-            }
-
-            if (string.IsNullOrEmpty(queryMetadata.SearchType))
-            {
-                queryMetadata.SearchType = elasticSettings["SearchType"]?.GetValue<string>();
-            }
-
-            indexProfile.Put(queryMetadata);
-
-            await _indexProfileManager.CreateAsync(indexProfile);
-
-            if (indexName == defaultSearchIndexName && defaultSearchProvider == "Elasticsearch")
-            {
-                ShellScope.AddDeferredTask(async scope =>
+                if (string.IsNullOrEmpty(metadata.Culture))
                 {
-                    var siteService = scope.ServiceProvider.GetRequiredService<ISiteService>();
-                    var site = await siteService.LoadSiteSettingsAsync();
+                    metadata.Culture = indexObject.Value[nameof(metadata.Culture)]?.GetValue<string>();
+                }
 
+                var indexLatest = indexObject.Value[nameof(metadata.IndexLatest)]?.GetValue<bool>();
+
+                if (indexLatest.HasValue)
+                {
+                    metadata.IndexLatest = indexLatest.Value;
+                }
+
+                var indexContentTypes = indexObject.Value[nameof(metadata.IndexedContentTypes)]?.AsArray();
+
+                if (indexContentTypes is not null)
+                {
+                    var items = new HashSet<string>();
+
+                    foreach (var indexContentType in indexContentTypes)
+                    {
+                        var value = indexContentType.GetValue<string>();
+
+                        if (!string.IsNullOrEmpty(value))
+                        {
+                            items.Add(value);
+                        }
+                    }
+
+                    metadata.IndexedContentTypes = items.ToArray();
+                }
+
+                indexProfile.Put(metadata);
+
+                var elasticsearchMetadata = indexProfile.As<ElasticsearchIndexMetadata>();
+
+                var storeSourceData = indexObject.Value[nameof(elasticsearchMetadata.StoreSourceData)]?.GetValue<bool>();
+
+                if (storeSourceData.HasValue)
+                {
+                    elasticsearchMetadata.StoreSourceData = storeSourceData.Value;
+                }
+
+                if (string.IsNullOrEmpty(elasticsearchMetadata.AnalyzerName))
+                {
+                    elasticsearchMetadata.AnalyzerName = indexObject.Value[nameof(elasticsearchMetadata.AnalyzerName)]?.GetValue<string>();
+                }
+
+                var mapping = await indexDocumentManager.GetIndexMappingsAsync(indexFullName);
+
+                elasticsearchMetadata.IndexMappings = new ElasticsearchIndexMap
+                {
+                    KeyFieldName = ContentIndexingConstants.ContentItemIdKey,
+                    Mapping = mapping,
+                };
+
+                indexProfile.Put(elasticsearchMetadata);
+
+                var queryMetadata = indexProfile.As<ElasticsearchDefaultQueryMetadata>();
+                if (string.IsNullOrEmpty(queryMetadata.QueryAnalyzerName))
+                {
+                    queryMetadata.QueryAnalyzerName = indexObject.Value[nameof(queryMetadata.QueryAnalyzerName)]?.GetValue<string>();
+                }
+
+                if (string.IsNullOrEmpty(queryMetadata.QueryAnalyzerName))
+                {
+                    queryMetadata.QueryAnalyzerName = elasticsearchMetadata.AnalyzerName;
+                }
+
+                queryMetadata.DefaultQuery = indexObject.Value[nameof(queryMetadata.DefaultQuery)]?.GetValue<string>();
+
+                if (string.IsNullOrEmpty(queryMetadata.DefaultQuery))
+                {
+                    queryMetadata.DefaultQuery = elasticSettings["DefaultQuery"]?.GetValue<string>();
+                }
+
+                if (queryMetadata.DefaultSearchFields is null || queryMetadata.DefaultSearchFields.Length == 0)
+                {
+                    queryMetadata.DefaultSearchFields = defaultSearchFields;
+                }
+
+                if (string.IsNullOrEmpty(queryMetadata.SearchType))
+                {
+                    queryMetadata.SearchType = elasticSettings["SearchType"]?.GetValue<string>();
+                }
+
+                indexProfile.Put(queryMetadata);
+
+                await indexProfileManager.CreateAsync(indexProfile);
+
+                if (indexName == defaultSearchIndexName && defaultSearchProvider == "Elasticsearch")
+                {
                     site.Properties["SearchSettings"]["DefaultIndexProfileName"] = indexProfile.Name;
 
-                    await siteService.UpdateSiteSettingsAsync(site);
-                });
+                    try
+                    {
+                        await siteService.UpdateSiteSettingsAsync(site);
+                    }
+                    catch (Exception ex)
+                    {
+                        // Log the error but do not throw, as this is not critical to the migration.
+                        var logger = scope.ServiceProvider.GetRequiredService<ILogger<IndexingMigrations>>();
+
+                        logger.LogError(ex, "An error occurred while updating the default search index profile name in site settings.");
+                    }
+                }
             }
-        }
+        });
 
         return stepNumber;
     }

--- a/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Shell/Builders/Extensions/ServiceCollectionExtensions.cs
@@ -47,11 +47,12 @@ public static class ServiceCollectionExtensions
         if (!services.Any(d => d.ServiceType == typeof(TConfigure)))
         {
             services.AddTransient(typeof(TConfigure));
-            services.Initialize(async sp =>
+            services.Initialize(sp =>
             {
                 var options = sp.GetRequiredService<TOptions>();
                 var setup = sp.GetRequiredService<TConfigure>();
-                await setup.ConfigureAsync(options);
+
+                return setup.ConfigureAsync(options);
             });
         }
 

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/IIndexingTaskManager.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/IIndexingTaskManager.cs
@@ -3,18 +3,18 @@ using OrchardCore.Indexing.Models;
 namespace OrchardCore.Indexing;
 
 /// <summary>
-/// Provides services to create and retrieve <see cref="IndexingTask"/> instances.
+/// Provides services to create and retrieve <see cref="RecordIndexingTask"/> instances.
 /// It is used by indexers to track all content items that have to be indexed or re-indexed.
 /// </summary>
 public interface IIndexingTaskManager
 {
     /// <summary>
-    /// Returns a page of <see cref="IndexingTask"/>.
+    /// Returns a page of <see cref="RecordIndexingTask"/>.
     /// </summary>
-    Task<IEnumerable<IndexingTask>> GetIndexingTasksAsync(long afterTaskId, int count, string category);
+    Task<IEnumerable<RecordIndexingTask>> GetIndexingTasksAsync(long afterTaskId, int count, string category);
 
     /// <summary>
-    /// Creates a new <see cref="IndexingTask"/>.
+    /// Creates a new <see cref="RecordIndexingTask"/>.
     /// </summary>
     Task CreateTaskAsync(CreateIndexingTaskContext task);
 }

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/Models/CreateIndexingTaskContext.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/Models/CreateIndexingTaskContext.cs
@@ -3,7 +3,7 @@ namespace OrchardCore.Indexing.Models;
 public sealed class CreateIndexingTaskContext
 {
     /// <summary>
-    /// The id of the record that is represented by the <see cref="IndexingTask"/> instance.
+    /// The id of the record that is represented by the <see cref="RecordIndexingTask"/> instance.
     /// </summary>
     public string RecordId { get; set; }
 
@@ -15,9 +15,9 @@ public sealed class CreateIndexingTaskContext
     /// <summary>
     /// The type of task.
     /// </summary>
-    public IndexingTaskTypes Type { get; set; }
+    public RecordIndexingTaskTypes Type { get; set; }
 
-    public CreateIndexingTaskContext(string recordId, string category, IndexingTaskTypes type)
+    public CreateIndexingTaskContext(string recordId, string category, RecordIndexingTaskTypes type)
     {
         ArgumentException.ThrowIfNullOrEmpty(recordId);
         ArgumentException.ThrowIfNullOrEmpty(category);

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/RecordIndexingTask.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/RecordIndexingTask.cs
@@ -1,20 +1,20 @@
 namespace OrchardCore.Indexing;
 
-public enum IndexingTaskTypes
+public enum RecordIndexingTaskTypes
 {
     Update = 0,
     Delete = 1,
 }
 
-public sealed class IndexingTask
+public sealed class RecordIndexingTask
 {
     /// <summary>
-    /// The unique identifier of the <see cref="IndexingTask"/>.
+    /// The unique identifier of the <see cref="RecordIndexingTask"/>.
     /// </summary>
     public long Id { get; set; }
 
     /// <summary>
-    /// The id of the record that is represented by the <see cref="IndexingTask"/> instance.
+    /// The id of the record that is represented by the <see cref="RecordIndexingTask"/> instance.
     /// </summary>
     public string RecordId { get; set; }
 
@@ -31,5 +31,5 @@ public sealed class IndexingTask
     /// <summary>
     /// The type of task.
     /// </summary>
-    public IndexingTaskTypes Type { get; set; }
+    public RecordIndexingTaskTypes Type { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.Indexing.Core/ContentIndexingService.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Core/ContentIndexingService.cs
@@ -44,7 +44,7 @@ public sealed class ContentIndexingService : NamedIndexingService
         _contentItemIndexHandlers = contentItemIndexHandlers;
     }
 
-    protected override async Task BeforeProcessingTasksAsync(IEnumerable<IndexingTask> tasks, IEnumerable<IndexProfileEntryContext> contexts)
+    protected override async Task BeforeProcessingTasksAsync(IEnumerable<RecordIndexingTask> tasks, IEnumerable<IndexProfileEntryContext> contexts)
     {
         _readonlySession ??= _store.CreateSession(withTracking: false);
         _cultureAspects = new Dictionary<string, CultureAspect>();
@@ -78,7 +78,7 @@ public sealed class ContentIndexingService : NamedIndexingService
         }
 
         var updatedContentItemIds = tasks
-            .Where(x => x.Type == IndexingTaskTypes.Update)
+            .Where(x => x.Type == RecordIndexingTaskTypes.Update)
             .Select(x => x.RecordId)
             .ToArray();
 
@@ -102,9 +102,9 @@ public sealed class ContentIndexingService : NamedIndexingService
         }
     }
 
-    protected override async Task<BuildDocumentIndexContext> GetBuildDocumentIndexAsync(IndexProfileEntryContext entry, IndexingTask task)
+    protected override async Task<BuildDocumentIndexContext> GetBuildDocumentIndexAsync(IndexProfileEntryContext entry, RecordIndexingTask task)
     {
-        if (task.Type != IndexingTaskTypes.Update)
+        if (task.Type != RecordIndexingTaskTypes.Update)
         {
             return null;
         }

--- a/src/OrchardCore/OrchardCore.Indexing.Core/IndexingTaskManager.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Core/IndexingTaskManager.cs
@@ -24,7 +24,7 @@ public sealed class IndexingTaskManager : IIndexingTaskManager
     private readonly IDbConnectionAccessor _dbConnectionAccessor;
     private readonly ILogger _logger;
 
-    private readonly List<IndexingTask> _tasksQueue = [];
+    private readonly List<RecordIndexingTask> _tasksQueue = [];
 
     public IndexingTaskManager(
         IClock clock,
@@ -42,7 +42,7 @@ public sealed class IndexingTaskManager : IIndexingTaskManager
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        var indexingTask = new IndexingTask
+        var indexingTask = new RecordIndexingTask
         {
             CreatedUtc = _clock.UtcNow,
             RecordId = context.RecordId,
@@ -63,7 +63,7 @@ public sealed class IndexingTaskManager : IIndexingTaskManager
         return Task.CompletedTask;
     }
 
-    public async Task<IEnumerable<IndexingTask>> GetIndexingTasksAsync(long afterTaskId, int count, string category)
+    public async Task<IEnumerable<RecordIndexingTask>> GetIndexingTasksAsync(long afterTaskId, int count, string category)
     {
         await using var connection = _dbConnectionAccessor.CreateConnection();
         await connection.OpenAsync();
@@ -74,7 +74,7 @@ public sealed class IndexingTaskManager : IIndexingTaskManager
             var sqlBuilder = dialect.CreateBuilder(_store.Configuration.TablePrefix);
 
             sqlBuilder.Select();
-            sqlBuilder.Table(nameof(IndexingTask), alias: null, _store.Configuration.Schema);
+            sqlBuilder.Table(nameof(RecordIndexingTask), alias: null, _store.Configuration.Schema);
             sqlBuilder.Selector("*");
 
             if (count > 0)
@@ -89,7 +89,7 @@ public sealed class IndexingTaskManager : IIndexingTaskManager
             // they are created as the sql server does not guarantee ordering.
             sqlBuilder.OrderBy($"{dialect.QuoteForColumnName("Id")}");
 
-            return await connection.QueryAsync<IndexingTask>(sqlBuilder.ToSqlString(),
+            return await connection.QueryAsync<RecordIndexingTask>(sqlBuilder.ToSqlString(),
                 new
                 {
                     Id = afterTaskId,
@@ -103,9 +103,9 @@ public sealed class IndexingTaskManager : IIndexingTaskManager
         }
     }
 
-    private async Task FlushAsync(ShellScope scope, List<IndexingTask> tasks)
+    private async Task FlushAsync(ShellScope scope, List<RecordIndexingTask> tasks)
     {
-        var localQueue = new List<IndexingTask>(tasks);
+        var localQueue = new List<RecordIndexingTask>(tasks);
 
         var serviceProvider = scope.ServiceProvider;
 
@@ -137,7 +137,7 @@ public sealed class IndexingTaskManager : IIndexingTaskManager
             }
         }
 
-        var table = $"{store.Configuration.TablePrefix}{nameof(IndexingTask)}";
+        var table = $"{store.Configuration.TablePrefix}{nameof(RecordIndexingTask)}";
 
         await using var connection = dbConnectionAccessor.CreateConnection();
         await connection.OpenAsync();

--- a/src/OrchardCore/OrchardCore.Indexing.Core/IndexingTaskManager.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Core/IndexingTaskManager.cs
@@ -87,7 +87,7 @@ public sealed class IndexingTaskManager : IIndexingTaskManager
 
             // It is important to sort the tasks by Id to ensure that the tasks are processed in the order
             // they are created as the sql server does not guarantee ordering.
-            sqlBuilder.OrderBy($"{dialect.QuoteForColumnName("Id")}");
+            sqlBuilder.OrderBy(dialect.QuoteForColumnName("Id"));
 
             return await connection.QueryAsync<RecordIndexingTask>(sqlBuilder.ToSqlString(),
                 new

--- a/src/OrchardCore/OrchardCore.Indexing.Core/NamedIndexingService.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Core/NamedIndexingService.cs
@@ -116,7 +116,7 @@ public abstract class NamedIndexingService
             return;
         }
 
-        var tasks = new List<IndexingTask>();
+        var tasks = new List<RecordIndexingTask>();
 
         while (tasks.Count <= _batchSize)
         {
@@ -177,9 +177,9 @@ public abstract class NamedIndexingService
         }
     }
 
-    protected abstract Task<BuildDocumentIndexContext> GetBuildDocumentIndexAsync(IndexProfileEntryContext entry, IndexingTask task);
+    protected abstract Task<BuildDocumentIndexContext> GetBuildDocumentIndexAsync(IndexProfileEntryContext entry, RecordIndexingTask task);
 
-    protected virtual Task BeforeProcessingTasksAsync(IEnumerable<IndexingTask> tasks, IEnumerable<IndexProfileEntryContext> contexts)
+    protected virtual Task BeforeProcessingTasksAsync(IEnumerable<RecordIndexingTask> tasks, IEnumerable<IndexProfileEntryContext> contexts)
         => Task.CompletedTask;
 
     public sealed class IndexProfileEntryContext

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -59,6 +59,8 @@ if(context.Record is ContentItem contentItem) {
 
 - The `IIndexingTaskManager` interface was changed to be use as a universal task manager not only for content items. If you want to queue the content items in the index manager, you'll need to pass `Content` in the category argument. You may also store non-content-items in the index manager by passing a different category name.
 
+The `IndexingTask` table in the database has been renamed to `RecordIndexingTask` to better reflect its purpose as a universal task manager.
+
 ### Elasticsearch Module
 
 #### Deprecation of the NEST Library


### PR DESCRIPTION
In the preview version, we attempted to rename the 'ContentItemId' column to 'RecordId' and add a 'Category' column to the 'IndexingTask' table.
However, for large tables, this could lead to timeouts. To avoid this, we opted to create a new table called 'RecordIndexingTask' and migrate the data.
If the previous SQL statement (in the try block) throws an exception, it's likely the renaming already succeeded for this tenant.
In that case, we assume the new column names exist and use them when populating the new table.