### PR TITLE
Adjusting Renovate config, removing unneeded package references (Lombiq Technologies: OCORE-236)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,7 +62,6 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.8.58" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
-    <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.23.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
@@ -114,6 +113,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
     <!-- Serilog.AspNetCore -->
     <PackageVersion Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageVersion Include="System.IO.Hashing" Version="9.0.8" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <!-- When removing this block, also remove the corresponding package rule in the root renovate.json5 config file. -->
@@ -133,5 +133,6 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
     <!-- Serilog.AspNetCore -->
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.3" />
+    <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/renovate.json5
+++ b/renovate.json5
@@ -45,6 +45,7 @@
                 'Microsoft.Extensions.Caching.StackExchangeRedis',
                 'Microsoft.Extensions.Http.Resilience',
                 'Serilog.AspNetCore',
+                'System.IO.Hashing',
                 'System.Text.Json',
             ],
             allowedVersions: '<9.0.0',


### PR DESCRIPTION
- Disables DB engine upgrades (e.g. https://github.com/OrchardCMS/OrchardCore/pull/18111, https://github.com/OrchardCMS/OrchardCore/pull/18113, https://github.com/OrchardCMS/OrchardCore/pull/18112).
- Disables Elasticsearch 9.x upgrades: https://github.com/OrchardCMS/OrchardCore/pull/18107.
- Fixes the config to disable .NET 8 dependencies being upgrades to .NET 9: https://github.com/OrchardCMS/OrchardCore/pull/18106, https://github.com/OrchardCMS/OrchardCore/pull/18110, https://github.com/OrchardCMS/OrchardCore/pull/18108