### PR TITLE
Add cleanup scripts to clean bin and obj folder

### DIFF
--- a/cleanup.bat
+++ b/cleanup.bat
@@ -1,0 +1,9 @@
+@echo off
+echo Deleting all bin and obj folders...
+for /d /r %%d in (bin,obj) do (
+    if exist "%%d" (
+        echo Deleting: %%d
+        rmdir /s /q "%%d"
+    )
+)
+echo Done.

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "Deleting all bin and obj folders..."
+
+find . -type d \( -name bin -o -name obj \) | while read -r dir; do
+    echo "Deleting: $dir"
+    rm -rf "$dir"
+done
+
+echo "Done."


### PR DESCRIPTION
When doing branch switching between older branches, sometimes we need to delete the `bin` and `obj` folders without changing the `App_Data` folders. These scripts will delete all the `bin` and `obj` folders.