### PR TITLE
fix: Disabled anchor button in MediaField for non image media items

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
@@ -36,7 +36,7 @@
                     <i class="fa-solid fa-upload"></i>
                 </label>
                 <a href="javascript:;" v-show="allowMediaText" v-on:click="showMediaTextModal" class="btn btn-secondary btn-sm" v-bind:class="{ disabled : !selectedMedia }"><i class="far fa-comment" aria-hidden="true"></i></a>
-                <a href="javascript:;" v-show="allowAnchors" v-on:click="showAnchorModal" class="btn btn-secondary btn-sm" v-bind:class="{ disabled : !selectedMedia }"><i class="fa-solid fa-crosshairs" aria-hidden="true"></i></a>
+                <a href="javascript:;" v-show="allowAnchors" v-on:click="showAnchorModal" class="btn btn-secondary btn-sm" v-bind:class="{ disabled : !selectedMedia || !selectedMedia.mime.startsWith('image') }"><i class="fa-solid fa-crosshairs" aria-hidden="true"></i></a>
                 <a href="javascript:;" v-on:click="removeSelected" class="btn btn-secondary btn-sm" v-bind:class="{ disabled : !selectedMedia }"><i class="fa-solid fa-trash-alt" aria-hidden="true"></i></a>
             </div>
             <label class="selected-media-name form-label">

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField.Edit.cshtml
@@ -28,7 +28,7 @@
                 </button>
                 <a href="javascript:;" v-show="canAddMedia" v-on:click="showModal" class="btn btn-secondary btn-sm"><i class="fa-solid fa-plus" aria-hidden="true"></i></a>
                 <a href="javascript:;" v-show="allowMediaText" v-on:click="showMediaTextModal" class="btn btn-secondary btn-sm" v-bind:class="{ disabled : !selectedMedia }"><i class="far fa-comment" aria-hidden="true"></i></a>
-                <a href="javascript:;" v-show="allowAnchors" v-on:click="showAnchorModal" class="btn btn-secondary btn-sm" v-bind:class="{ disabled : !selectedMedia }"><i class="fa-solid fa-crosshairs" aria-hidden="true"></i></a>
+                <a href="javascript:;" v-show="allowAnchors" v-on:click="showAnchorModal" class="btn btn-secondary btn-sm" v-bind:class="{ disabled : !selectedMedia || !selectedMedia.mime.startsWith('image') }"><i class="fa-solid fa-crosshairs" aria-hidden="true"></i></a>
                 <a href="javascript:;" v-on:click="removeSelected" class="btn btn-secondary btn-sm" v-bind:class="{ disabled : !selectedMedia }"><i class="fa-solid fa-trash-alt" aria-hidden="true"></i></a>
             </div>
             <label class="selected-media-name form-label">


### PR DESCRIPTION
If a MediaField allowed users to set an anchor point and a non-image item (e.g., a PDF) is selected, the anchor button remained active. Clicking it opens the modal, but no image would be displayed.

This is a minor edge case—typically, if you're expecting documents, you wouldn’t enable anchor points in the settings. However, there are situations where you may want to support a mix of media types.

<img width="437" alt="mediafield-nonimage-selected" src="https://github.com/user-attachments/assets/9b798fb8-948f-40be-b479-6c645b7ed9d4" />
<img width="1074" alt="mediafield-nonimage-anchor" src="https://github.com/user-attachments/assets/40e3c5e6-fe72-4d7d-bf62-e2f474a50b39" />

Fix:

To handle this more gracefully, I’ve applied the same MIME type check used in the MediaFieldThumbsContainer component. I added a simple condition to the anchor buttons in the MediaField edit views to disable them when the selected media item is not an image.

<img width="438" alt="mediafield-nonimage-selected-fix" src="https://github.com/user-attachments/assets/2403a996-5182-406b-aa66-bcddaa8a2074" />

