### PR TITLE
Trigger workflows in a deferred task

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Handlers/ContentsHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Workflows/Handlers/ContentsHandler.cs
@@ -19,39 +19,25 @@ public class ContentsHandler : ContentHandlerBase
     }
 
     public override Task CreatedAsync(CreateContentContext context)
-    {
-        return AddEventAsync(nameof(ContentCreatedEvent), context.ContentItem);
-    }
+        => AddEventAsync(nameof(ContentCreatedEvent), context.ContentItem);
 
     public override Task UpdatedAsync(UpdateContentContext context)
-    {
-        return AddEventAsync(nameof(ContentUpdatedEvent), context.ContentItem);
-    }
+        => AddEventAsync(nameof(ContentUpdatedEvent), context.ContentItem);
 
     public override Task DraftSavedAsync(SaveDraftContentContext context)
-    {
-        return AddEventAsync(nameof(ContentDraftSavedEvent), context.ContentItem);
-    }
+        => AddEventAsync(nameof(ContentDraftSavedEvent), context.ContentItem);
 
     public override Task PublishedAsync(PublishContentContext context)
-    {
-        return AddEventAsync(nameof(ContentPublishedEvent), context.ContentItem);
-    }
+        => AddEventAsync(nameof(ContentPublishedEvent), context.ContentItem);
 
     public override Task UnpublishedAsync(PublishContentContext context)
-    {
-        return AddEventAsync(nameof(ContentUnpublishedEvent), context.ContentItem);
-    }
+        => AddEventAsync(nameof(ContentUnpublishedEvent), context.ContentItem);
 
     public override Task RemovedAsync(RemoveContentContext context)
-    {
-        return AddEventAsync(nameof(ContentDeletedEvent), context.ContentItem);
-    }
+        => AddEventAsync(nameof(ContentDeletedEvent), context.ContentItem);
 
     public override Task VersionedAsync(VersionContentContext context)
-    {
-        return AddEventAsync(nameof(ContentVersionedEvent), context.ContentItem);
-    }
+        => AddEventAsync(nameof(ContentVersionedEvent), context.ContentItem);
 
     private Task AddEventAsync(string name, ContentItem contentItem)
     {


### PR DESCRIPTION
This PR addresses an issue where workflows may be triggered before all content handlers (such as the one responsible for updating parts) have completed execution. This could result in incomplete data being available to the workflow.

To resolve this, workflows are now scheduled as deferred tasks. This ensures:

- All content handlers have finished processing before the workflow starts.
- The content item is fully committed to the database when the workflow is executed.

This change follows the same design pattern used by the `IndexingContentHandler`, which also defers its execution to ensure it runs after all other content handlers have completed. 

### Potential Considerations
With this change, workflows are now always executed **after the HTTP request completes** and after the content item has been committed to the database. As a result, any modifications made to the content item within the workflow will occur in a new database transaction. This may affect scenarios where workflows were previously expected to run within the same request or transaction context as the content creation.

Fixes #18119