### PR TITLE
Fix that the Email Test Sender doesn't take effect (Lombiq Technologies: OCORE-237)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email/Controllers/AdminController.cs
@@ -119,7 +119,7 @@ public sealed class AdminController : Controller
 
         if (!string.IsNullOrWhiteSpace(testSettings.From))
         {
-            message.Sender = testSettings.From;
+            message.From = testSettings.From;
         }
 
         if (!string.IsNullOrWhiteSpace(testSettings.Subject))


### PR DESCRIPTION
Fixes #18168.

While the fix itself is trivial, I'm not too happy about mixing up "From" and "Sender", which are different things. However, the controller already used `From` (unlike the admin UI saying "sender"), and `SmtpEmailProviderBase` mixes the two too: https://github.com/OrchardCMS/OrchardCore/blob/b129dfe78a093a486682723f5e1891bb0cf2280d/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/SmtpEmailProviderBase.cs#L45