### PR TITLE
Upgrade xunit.v3 to v3 and migrating all subresource integrity hashes to SHA384 (Lombiq Technologies: OCORE-238)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -63,7 +63,7 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
     <PackageVersion Include="System.IO.Hashing" Version="8.0.0" />
-    <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.23.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="YesSql" Version="5.4.2" />

--- a/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Resources/ResourceManagementOptionsConfiguration.cs
@@ -1007,8 +1007,8 @@ public sealed class ResourceManagementOptionsConfiguration
                 "https://cdn.jsdelivr.net/npm/vue@3.5.13/dist/vue.global.js"
             )
             .SetCdnIntegrity(
-                "sha256-xFm6fMjbZcmCWJ+l1kx/9HiHfo5bD9dWgyB87GpOieg=",
-                "sha256-Nw0E5oMsQLilVXzUCx00vxQTGV+x1C83EG8rUPawe8A="
+                "sha384-W/1Fp/LgAYO/oTn9Gs+PbeWuMuq1eQCnUMPCeg8POmMYchhzxctjEqtbiCIxDOON",
+                "sha384-G++pO/TtP6SeNEBuO/CYuppmlcEhA0Rj9IcY5feVJXhyYraEA8CKVZV38iDXLTyJ"
             )
             .SetVersion("3.5.13");
 
@@ -1042,8 +1042,8 @@ public sealed class ResourceManagementOptionsConfiguration
                 "https://cdn.jsdelivr.net/npm/vue-multiselect@3.2.0/dist/vue-multiselect.umd.js"
             )
             .SetCdnIntegrity(
-                "sha256-WPNu0JAREY1Irusgtihcuzati2fLtA70vyK1TDs55PY=",
-                "sha256-bgP1jhSlmX0vEY01VGFi6FMuUzU5Vbd1AdXKm9o0i4Q="
+                "sha384-7HofOP/3o+/jDuC4RmU64mOramSz9btGjs7S9tsRd4U6lerpHI0P1jEFjjvxIBi6",
+                "sha384-7EnWodE8EplOPsNbw/n7oUIXVb0xsbUhgfxnzJc+MGgbzzLpJwlA0OccVdY0EU/w"
             )
             .SetVersion("3.2.0");
 
@@ -1165,8 +1165,8 @@ public sealed class ResourceManagementOptionsConfiguration
                 "https://cdnjs.cloudflare.com/ajax/libs/fontawesome-iconpicker/3.2.0/js/fontawesome-iconpicker.js"
             )
             .SetCdnIntegrity(
-                "sha512-7dlzSK4Ulfm85ypS8/ya0xLf3NpXiML3s6HTLu4qDq7WiJWtLLyrXb9putdP3/1umwTmzIvhuu9EW7gHYSVtCQ==",
-                "sha512-ARPApqjym7fPaYMaezrx4XTD8mGd0JAvugmK2JDkjb/WTog2b33SwzcSlAnnwFTq9PiTas0U2VqCMzuhpzKREA=="
+                "sha384-f79rMAyeEq3Bvj5Pjl48cYqpDhVyoQAJ+vrYoD0MMgTrv25Dy0RS1KDiRPeq8zkF",
+                "sha384-2EkuuraR//RiFSIZRE4gIPPt14JYXgrb4+TzsdwTdZZp5IC5vrZyL3yFLEF3aEp2"
             )
             .SetVersion("3.2.0");
 

--- a/test/OrchardCore.Tests/CIFact.cs
+++ b/test/OrchardCore.Tests/CIFact.cs
@@ -1,47 +1,26 @@
-using Xunit.v3;
+using System.Runtime.CompilerServices;
 using SystemEnvironment = System.Environment;
 
 #nullable enable
 
 namespace OrchardCore.Tests;
 
+/// <summary>
+/// A test attribute for tests that are only run in Continuous Integration (CI) environments, like GitHub Actions or
+/// Azure DevOps.
+/// </summary>
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-public class CIFactAttribute : Attribute, IFactAttribute
+public class CIFactAttribute : FactAttribute
 {
-    /// <inheritdoc/>
-    public string? DisplayName { get; set; }
-
-    /// <inheritdoc/>
-    public bool Explicit { get; set; }
-
-    /// <inheritdoc/>
-    public string? Skip
+    public CIFactAttribute([CallerFilePath] string? sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = -1)
+        : base(sourceFilePath, sourceLineNumber)
     {
-        get
+        // "CI" is defined by GitHub Actions.
+        // "BUILD_BUILDID" is defined by Azure DevOps.
+        if (SystemEnvironment.GetEnvironmentVariable("BUILD_BUILDID") == null &&
+            SystemEnvironment.GetEnvironmentVariable("CI") == null)
         {
-            // "CI" is defined by GitHub actions
-            // "BUILD_BUILDID" is defined by Azure DevOps
-            if (SystemEnvironment.GetEnvironmentVariable("BUILD_BUILDID") == null &&
-                SystemEnvironment.GetEnvironmentVariable("CI") == null)
-            {
-                return $"{nameof(CIFactAttribute)} tests are not run locally. To run them locally create a \"CI\" environment variable.";
-            }
-
-            return null!;
+            Skip = $"{nameof(CIFactAttribute)} tests are not run locally. To run them locally create a \"CI\" environment variable.";
         }
     }
-
-    /// <inheritdoc/>
-    public Type? SkipType { get; set; }
-
-    /// <inheritdoc/>
-    public string? SkipUnless { get; set; }
-
-    /// <inheritdoc/>
-    public string? SkipWhen { get; set; }
-
-    /// <inheritdoc/>
-    public int Timeout { get; set; }
-
-    public Type[]? SkipExceptions => Array.Empty<Type>();
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Resources/SubResourceIntegrityTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Resources/SubResourceIntegrityTests.cs
@@ -42,7 +42,7 @@ public class SubResourceIntegrityTests
                         var resourceIntegrity = await GetSubResourceIntegrityAsync(httpClient, resourceDefinition.UrlCdnDebug);
 
                         Assert.True(resourceIntegrity.Equals(resourceDefinition.CdnDebugIntegrity, StringComparison.Ordinal),
-                            $"The {resourceType} {resourceDefinition.UrlCdnDebug} has invalid SRI hash, please use '{resourceIntegrity}' instead.");
+                            $"The debug {resourceType} {resourceDefinition.UrlCdnDebug} has invalid SRI hash, please use '{resourceIntegrity}' instead.");
                     }
 
                     if (!string.IsNullOrEmpty(resourceDefinition.CdnIntegrity) && !string.IsNullOrEmpty(resourceDefinition.UrlCdn))
@@ -50,7 +50,7 @@ public class SubResourceIntegrityTests
                         var resourceIntegrity = await GetSubResourceIntegrityAsync(httpClient, resourceDefinition.UrlCdn);
 
                         Assert.True(resourceIntegrity.Equals(resourceDefinition.CdnIntegrity, StringComparison.Ordinal),
-                            $"The {resourceType} {resourceDefinition.UrlCdn} has invalid SRI hash, please use '{resourceIntegrity}' instead.");
+                            $"The production {resourceType} {resourceDefinition.UrlCdn} has invalid SRI hash, please use '{resourceIntegrity}' instead.");
                     }
                 }
             }


### PR DESCRIPTION
`SavedSubResourceIntegritiesShouldMatchCurrentResources` wasn't actually run in CI, I suppose since the `xunit.v3` upgrade. Fixing that too, in addition to upgrading `xunit.v3` to v3.

Branched off from https://github.com/OrchardCMS/OrchardCore/pull/18183.