### PR TITLE
Improve exception handling in InvokeExtensions

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Exceptions/ExceptionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Exceptions/ExceptionExtensions.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using System.Security;
+using Microsoft.Extensions.Logging;
 
 namespace OrchardCore.Modules;
 
@@ -22,4 +23,9 @@ public static class ExceptionExtensions
         ex is IOException &&
         (ex.HResult == ERROR_SHARING_VIOLATION ||
         ex.HResult == ERROR_LOCK_VIOLATION);
+
+    public static void LogException(this Exception ex, ILogger logger, Type sourceType, string method)
+    {
+        logger.LogError(ex, "{Exception} thrown from {Type} by {Method}", ex.GetType().Name, sourceType.Name, method);
+    }
 }

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Extensions/InvokeExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Extensions/InvokeExtensions.cs
@@ -15,9 +15,9 @@ public static class InvokeExtensions
             {
                 dispatch(sink);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
     }
@@ -33,9 +33,9 @@ public static class InvokeExtensions
             {
                 dispatch(sink, arg1);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
     }
@@ -51,9 +51,9 @@ public static class InvokeExtensions
                 var result = dispatch(sink);
                 results.Add(result);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
 
@@ -71,9 +71,9 @@ public static class InvokeExtensions
                 var result = dispatch(sink, arg1);
                 results.Add(result);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
 
@@ -91,9 +91,9 @@ public static class InvokeExtensions
                 var result = dispatch(sink);
                 results.AddRange(result);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
 
@@ -111,9 +111,9 @@ public static class InvokeExtensions
             {
                 await dispatch(sink);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
     }
@@ -129,9 +129,9 @@ public static class InvokeExtensions
             {
                 await dispatch(sink, arg1);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
     }
@@ -147,9 +147,9 @@ public static class InvokeExtensions
             {
                 await dispatch(sink, arg1, arg2);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
     }
@@ -165,9 +165,9 @@ public static class InvokeExtensions
             {
                 await dispatch(sink, arg1, arg2, arg3);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
     }
@@ -183,9 +183,9 @@ public static class InvokeExtensions
             {
                 await dispatch(sink, arg1, arg2, arg3, arg4);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
     }
@@ -201,9 +201,9 @@ public static class InvokeExtensions
             {
                 await dispatch(sink, arg1, arg2, arg3, arg4, arg5);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
     }
@@ -219,9 +219,9 @@ public static class InvokeExtensions
                 var result = await dispatch(sink);
                 results.Add(result);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
 
@@ -239,9 +239,9 @@ public static class InvokeExtensions
                 var result = await dispatch(sink, arg1);
                 results.Add(result);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
 
@@ -259,15 +259,16 @@ public static class InvokeExtensions
                 var result = await dispatch(sink);
                 results.AddRange(result);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                HandleException(ex, logger, typeof(TEvents).Name, sink.GetType().FullName);
+                ex.LogException(logger, typeof(TEvents), sink.GetType().FullName);
             }
         }
 
         return results;
     }
 
+    [Obsolete("This method throws a new exception instead of rethrowing, which loses the original call stack. It is not recommended for new code. Use ExceptionExtensions.LogException instead, which only logs exceptions without rethrowing.")]
     public static void HandleException(Exception ex, ILogger logger, string sourceType, string method)
     {
         if (IsLogged(ex))
@@ -283,6 +284,7 @@ public static class InvokeExtensions
             throw ex;
         }
     }
+
     private static bool IsLogged(Exception ex)
     {
         return !ex.IsFatal();

--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/Extensions/InvokeExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/Extensions/InvokeExtensions.cs
@@ -268,7 +268,8 @@ public static class InvokeExtensions
         return results;
     }
 
-    [Obsolete("This method throws a new exception instead of rethrowing, which loses the original call stack. It is not recommended for new code. Use ExceptionExtensions.LogException instead, which only logs exceptions without rethrowing.")]
+    [Obsolete("This method rethrows the given exception, which loses the original call stack. It is not recommended for new code. " +
+        "Use ExceptionExtensions.LogException instead, which only logs exceptions without rethrowing.")]
     public static void HandleException(Exception ex, ILogger logger, string sourceType, string method)
     {
         if (IsLogged(ex))

--- a/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Display/ContentDisplay/ContentItemDisplayCoordinator.cs
@@ -58,9 +58,9 @@ public class ContentItemDisplayCoordinator : IContentDisplayHandler
                     await result.ApplyAsync(context);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                InvokeExtensions.HandleException(ex, _logger, displayDriver.GetType().Name, nameof(BuildDisplayAsync));
+                ex.LogException(_logger, displayDriver.GetType(), nameof(BuildDisplayAsync));
             }
         }
 
@@ -90,9 +90,9 @@ public class ContentItemDisplayCoordinator : IContentDisplayHandler
                         await result.ApplyAsync(context);
                     }
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (!ex.IsFatal())
                 {
-                    InvokeExtensions.HandleException(ex, _logger, partDisplayDrivers.GetType().Name, nameof(BuildDisplayAsync));
+                    ex.LogException(_logger, partDisplayDrivers.GetType(), nameof(BuildDisplayAsync));
                 }
             }
             var tempContext = context;
@@ -184,9 +184,9 @@ public class ContentItemDisplayCoordinator : IContentDisplayHandler
                             await result.ApplyAsync(context);
                         }
                     }
-                    catch (Exception ex)
+                    catch (Exception ex) when (!ex.IsFatal())
                     {
-                        InvokeExtensions.HandleException(ex, _logger, fieldDisplayDriver.GetType().Name, nameof(BuildDisplayAsync));
+                        ex.LogException(_logger, fieldDisplayDriver.GetType(), nameof(BuildDisplayAsync));
                     }
                 }
             }
@@ -222,9 +222,9 @@ public class ContentItemDisplayCoordinator : IContentDisplayHandler
                     await result.ApplyAsync(context);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                InvokeExtensions.HandleException(ex, _logger, displayDriver.GetType().Name, nameof(BuildEditorAsync));
+                ex.LogException(_logger, displayDriver.GetType(), nameof(BuildEditorAsync));
             }
         }
 
@@ -313,9 +313,9 @@ public class ContentItemDisplayCoordinator : IContentDisplayHandler
                     await result.ApplyAsync(context);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!ex.IsFatal())
             {
-                InvokeExtensions.HandleException(ex, _logger, displayDriver.GetType().Name, nameof(UpdateEditorAsync));
+                ex.LogException(_logger, displayDriver.GetType(), nameof(UpdateEditorAsync));
             }
         }
 


### PR DESCRIPTION
This pull request improves exception handling in the `InvokeExtensions` class. Previously, the `HandleException` method rethrew exceptions using `throw ex;`, which caused the original stack trace to be lost and made debugging more difficult.

This update addresses the issue by proactively checking which exceptions to catch and avoiding unnecessary rethrows. This preserves the original stack trace and improves traceability and debugging clarity.