### PR TITLE
Add AdditionalProperties collection for BuildDocumentIndexContext

### DIFF
--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/BuildDocumentIndexContext.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/BuildDocumentIndexContext.cs
@@ -22,4 +22,9 @@ public class BuildDocumentIndexContext
     public DocumentIndex DocumentIndex { get; }
 
     public IContentIndexSettings Settings { get; }
+
+    /// <summary>
+    /// Provides a dictionary to store additional data that can be used by index providers.
+    /// </summary>
+    public IDictionary<string, object> AdditionalProperties { get; set; }
 }


### PR DESCRIPTION
When building a document index, sometimes the user need to send additional data with the context. Currently, the user will have to inherit from `BuildDocumentIndexContext`  and add properties. Having `AdditionalProperties` makes it easier to send object along with the context when needed.