### PR TITLE
Trigger content items events when adding or editing items in BagPart and FlowPart

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
@@ -96,7 +96,7 @@ public sealed class BagPartDisplayDriver : ContentPartDisplayDriver<BagPart>
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        var contentItems = new Dictionary<string, ContentItem>(StringComparer.OrdinalIgnoreCase);
+        var contentItems = new Dictionary<string, ContentItem>();
         var existsingContentItems = part.ContentItems.ToDictionary(x => x.ContentItemId, StringComparer.OrdinalIgnoreCase);
 
         // Handle the content found in the request

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
@@ -30,9 +30,10 @@ public sealed class BagPartDisplayDriver : ContentPartDisplayDriver<BagPart>
     private readonly ILogger _logger;
     private readonly INotifier _notifier;
     private readonly IAuthorizationService _authorizationService;
+    private readonly IEnumerable<IContentHandler> _contentHandlers;
+    private readonly IEnumerable<IContentHandler> _reversedContentHandlers;
 
     internal readonly IHtmlLocalizer H;
-    private readonly IEnumerable<IContentHandler> _contentHandlers;
 
     public BagPartDisplayDriver(
         IContentManager contentManager,
@@ -54,6 +55,7 @@ public sealed class BagPartDisplayDriver : ContentPartDisplayDriver<BagPart>
         _notifier = notifier;
         H = htmlLocalizer;
         _contentHandlers = contentHandlers;
+        _reversedContentHandlers = contentHandlers.Reverse();
         _authorizationService = authorizationService;
     }
 
@@ -138,7 +140,7 @@ public sealed class BagPartDisplayDriver : ContentPartDisplayDriver<BagPart>
                 contentItem.Merge(existingContentItem);
 
                 await contentItemDisplayManager.UpdateEditorAsync(contentItem, context.Updater, context.IsNew, htmlFieldPrefix: model.Prefixes[i]);
-                await _contentHandlers.Reverse().InvokeAsync((handler, context) => handler.UpdatedAsync(context), updateContentContext, _logger);
+                await _reversedContentHandlers.InvokeAsync((handler, context) => handler.UpdatedAsync(context), updateContentContext, _logger);
             }
             else
             {
@@ -146,7 +148,7 @@ public sealed class BagPartDisplayDriver : ContentPartDisplayDriver<BagPart>
 
                 await _contentHandlers.InvokeAsync((handler, context) => handler.CreatingAsync(context), createContentContext, _logger);
                 await contentItemDisplayManager.UpdateEditorAsync(contentItem, context.Updater, context.IsNew, htmlFieldPrefix: model.Prefixes[i]);
-                await _contentHandlers.Reverse().InvokeAsync((handler, context) => handler.CreatedAsync(context), createContentContext, _logger);
+                await _reversedContentHandlers.InvokeAsync((handler, context) => handler.CreatedAsync(context), createContentContext, _logger);
             }
 
             contentItems.Add(contentItem);

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -120,7 +120,7 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
 
-        var contentItems = new Dictionary<string, ContentItem>(StringComparer.OrdinalIgnoreCase);
+        var contentItems = new Dictionary<string, ContentItem>();
         var existsingContentItems = part.Widgets.ToDictionary(x => x.ContentItemId, StringComparer.OrdinalIgnoreCase);
 
         // Handle the content found in the request

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -1,3 +1,6 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Localization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -5,13 +8,16 @@ using OrchardCore.ContentManagement;
 using OrchardCore.ContentManagement.Display;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
+using OrchardCore.ContentManagement.Handlers;
 using OrchardCore.ContentManagement.Metadata;
 using OrchardCore.ContentManagement.Metadata.Models;
-using OrchardCore.DisplayManagement;
+using OrchardCore.Contents;
 using OrchardCore.DisplayManagement.Notify;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Flows.Models;
 using OrchardCore.Flows.ViewModels;
+using OrchardCore.Modules;
+using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Flows.Drivers;
 
@@ -20,6 +26,10 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
     private readonly IContentDefinitionManager _contentDefinitionManager;
     private readonly IContentManager _contentManager;
     private readonly IServiceProvider _serviceProvider;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IEnumerable<IContentHandler> _contentHandlers;
+    private readonly IAuthorizationService _authorizationService;
+    private readonly IEnumerable<IContentHandler> _reversedContentHandlers;
     private readonly INotifier _notifier;
     private readonly ILogger _logger;
 
@@ -29,6 +39,9 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
         IContentDefinitionManager contentDefinitionManager,
         IContentManager contentManager,
         IServiceProvider serviceProvider,
+        IHttpContextAccessor httpContextAccessor,
+        IEnumerable<IContentHandler> contentHandlers,
+        IAuthorizationService authorizationService,
         IHtmlLocalizer<FlowPartDisplayDriver> htmlLocalizer,
         INotifier notifier,
         ILogger<FlowPartDisplayDriver> logger
@@ -37,6 +50,10 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
         _contentDefinitionManager = contentDefinitionManager;
         _contentManager = contentManager;
         _serviceProvider = serviceProvider;
+        _httpContextAccessor = httpContextAccessor;
+        _contentHandlers = contentHandlers;
+        _authorizationService = authorizationService;
+        _reversedContentHandlers = contentHandlers.Reverse();
         H = htmlLocalizer;
         _notifier = notifier;
         _logger = logger;
@@ -102,30 +119,99 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
 
         await context.Updater.TryUpdateModelAsync(model, Prefix);
 
-        var contentItems = new List<ContentItem>();
 
+        var contentItems = new Dictionary<string, ContentItem>(StringComparer.OrdinalIgnoreCase);
+        var existsingContentItems = part.Widgets.ToDictionary(x => x.ContentItemId, StringComparer.OrdinalIgnoreCase);
+
+        // Handle the content found in the request
         for (var i = 0; i < model.Prefixes.Length; i++)
         {
             var contentItem = await _contentManager.NewAsync(model.ContentTypes[i]);
-            var existingContentItem = part.Widgets.FirstOrDefault(x => string.Equals(x.ContentItemId, model.ContentItems[i], StringComparison.OrdinalIgnoreCase));
 
-            // When the content item already exists merge its elements to reverse nested content item ids.
+            // Assign the owner of the item to ensure we can validate access to it later.
+            contentItem.Owner = GetCurrentOwner();
+
+            // Try to match the requested id with an existing id
+            ContentItem existingContentItem = null;
+
+            existsingContentItems.TryGetValue(model.ContentItems[i], out existingContentItem);
+
+            var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
+
+            if (existingContentItem == null && !await AuthorizeAsync(contentTypeDefinition, CommonPermissions.EditContent, contentItem))
+            {
+                // At this point the user is somehow trying to add content with no privileges. ignore the request
+                continue;
+            }
+
+            // When the content item already exists merge its elements to preserve nested content item ids.
             // All of the data for these merged items is then replaced by the model values on update, while a nested content item id is maintained.
             // This prevents nested items which rely on the content item id, i.e. the media attached field, losing their reference point.
             if (existingContentItem != null)
             {
+                if (!await AuthorizeAsync(contentTypeDefinition, CommonPermissions.EditContent, existingContentItem))
+                {
+                    // At this point, the user is somehow modifying existing content with no privileges.
+                    // honor the existing data and ignore the data in the request
+                    contentItems.Add(existingContentItem.ContentItemId, existingContentItem);
+
+                    continue;
+                }
+
+                contentItem.Weld(new FlowMetadata());
+
+                // At this point the user have privileges to edit, merge the data from the request
+                var updateContentContext = new UpdateContentContext(contentItem);
+
+                await _contentHandlers.InvokeAsync((handler, context) => handler.UpdatingAsync(context), updateContentContext, _logger);
+
                 contentItem.ContentItemId = model.ContentItems[i];
                 contentItem.Merge(existingContentItem);
+
+                await contentItemDisplayManager.UpdateEditorAsync(contentItem, context.Updater, context.IsNew, htmlFieldPrefix: model.Prefixes[i]);
+                await _reversedContentHandlers.InvokeAsync((handler, context) => handler.UpdatedAsync(context), updateContentContext, _logger);
+            }
+            else
+            {
+                contentItem.Weld(new FlowMetadata());
+
+                var createContentContext = new CreateContentContext(contentItem);
+
+                await _contentHandlers.InvokeAsync((handler, context) => handler.CreatingAsync(context), createContentContext, _logger);
+                await contentItemDisplayManager.UpdateEditorAsync(contentItem, context.Updater, context.IsNew, htmlFieldPrefix: model.Prefixes[i]);
+                await _reversedContentHandlers.InvokeAsync((handler, context) => handler.CreatedAsync(context), createContentContext, _logger);
             }
 
-            contentItem.Weld(new FlowMetadata());
-
-            var widgetModel = await contentItemDisplayManager.UpdateEditorAsync(contentItem, context.Updater, context.IsNew, htmlFieldPrefix: model.Prefixes[i]);
-
-            contentItems.Add(contentItem);
+            contentItems.Add(contentItem.ContentItemId, contentItem);
         }
 
-        part.Widgets = contentItems;
+        // At the end, lets add existing readonly contents.
+        foreach (var existingContentItem in part.Widgets)
+        {
+            if (contentItems.ContainsKey(existingContentItem.ContentItemId))
+            {
+                // Item was already added using the edit.
+
+                continue;
+            }
+
+            var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(existingContentItem.ContentType);
+
+            if (await AuthorizeAsync(contentTypeDefinition, CommonPermissions.DeleteContent, existingContentItem))
+            {
+                // At this point, the user has permission to delete a securable item or the type isn't securable
+                // if the existing content id isn't in the requested ids, don't add the content item... meaning the user deleted it.
+                if (!model.ContentItems.Contains(existingContentItem.ContentItemId))
+                {
+                    continue;
+                }
+            }
+
+            // Since the content item isn't editable, lets add it so it's not removed from the collection
+            contentItems.Add(existingContentItem.ContentItemId, existingContentItem);
+        }
+
+        part.Widgets = contentItems.Values.ToList();
 
         return EditInternal(part, context, model.Prefixes);
     }
@@ -141,5 +227,23 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
 
         return (await _contentDefinitionManager.ListWidgetTypeDefinitionsAsync())
             .Where(t => settings.ContainedContentTypes.Contains(t.Name));
+    }
+
+    private async Task<bool> AuthorizeAsync(ContentTypeDefinition contentTypeDefinition, Permission permission, ContentItem contentItem)
+    {
+        if (contentTypeDefinition is not null && contentTypeDefinition.IsSecurable())
+        {
+            return await AuthorizeAsync(permission, contentItem);
+        }
+
+        return true;
+    }
+
+    private Task<bool> AuthorizeAsync(Permission permission, ContentItem contentItem)
+        => _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, permission, contentItem);
+
+    private string GetCurrentOwner()
+    {
+        return _httpContextAccessor.HttpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
     }
 }


### PR DESCRIPTION
Fix #17645

This will properly trigger the events in the BagPart from the UI. I am wondering if this issue also impacting updating content items via API. I don't have time to look into the API at the moment. If someone else like to test it out, it would be great help. But at least this will fix the UI.