### PR TITLE
Fix Monaco Editor Script Loading Issues

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Liquid/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Liquid/ResourceManagementOptionsConfiguration.cs
@@ -22,7 +22,6 @@ public sealed class ResourceManagementOptionsConfiguration : IConfigureOptions<R
                 "~/OrchardCore.Liquid/monaco/liquid-intellisense.min.js",
                 "~/OrchardCore.Liquid/monaco/liquid-intellisense.js"
             )
-            .SetDependencies("monaco")
             .SetVersion("1.0.0");
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Create.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Create.cshtml
@@ -58,7 +58,7 @@
     </div>
 </form>
 
-<script asp-name="create-template" at="Foot" depends-on="liquid-intellisense">
+<script asp-name="create-template" at="Foot" depends-on="liquid-intellisense monaco">
     $(document).ready(function () {
         require(['vs/editor/editor.main'], function () {
             var settings = {

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Edit.cshtml
@@ -67,8 +67,8 @@ else
 </form>
 
 
-<script asp-name="edit-template" at="Foot" depends-on="liquid-intellisense">
-    $(document).ready(function () {
+<script asp-name="edit-template" at="Foot" depends-on="liquid-intellisense monaco">
+    document.addEventListener('DOMContentLoaded', function () {
         require(['vs/editor/editor.main'], function () {
             var settings = {
                 automaticLayout: true,

--- a/src/OrchardCore.Modules/OrchardCore.Themes/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/ResourceManagementOptionsConfiguration.cs
@@ -27,7 +27,6 @@ public sealed class ResourceManagementOptionsConfiguration
                 "~/OrchardCore.Themes/Scripts/theme-manager/theme-manager.js"
             )
             .SetDependencies("theme-head")
-            .SetAttribute("type", "module")
             .SetVersion("1.0.0");
     }
 

--- a/src/OrchardCore.Themes/TheAdmin/ResourceManagementOptionsConfiguration.cs
+++ b/src/OrchardCore.Themes/TheAdmin/ResourceManagementOptionsConfiguration.cs
@@ -14,7 +14,6 @@ public sealed class ResourceManagementOptionsConfiguration
 
         _manifest
             .DefineScript("the-admin")
-            .SetAttribute("type", "module")
             .SetDependencies("bootstrap", "admin-main", "theme-manager", "jQuery", "Sortable")
             .SetUrl("~/TheAdmin/js/theadmin/TheAdmin.min.js", "~/TheAdmin/js/theadmin/TheAdmin.js")
             .SetVersion("1.0.0");


### PR DESCRIPTION
Fixes two issues related to the Monaco editor integration in OrchardCore:

1. **Error:**
***"Can only have one anonymous define call per script file"***
This occurred due to scripts being loaded with `type="module"`. The fix removes the `type="module"` attribute from the affected scripts.

2. **JavaScript Warning:**
***"Duplicate definition of module 'vs/editor/editor.main'"***
This happened when using Liquid IntelliSense with Monaco. The solution is to load Liquid scripts **before** the Monaco editor. To achieve this, the dependency was removed from the resource definition and added explicitly at the usage site.

@Skrypt Could you please review this? You have the most expertise in this area.

Fixes #18142