### PR TITLE
Fix: OpenIdClientSettingsStep does not protect the client secret and throws null reference exceptions #18313

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdClientSettingsStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Recipes/OpenIdClientSettingsStep.cs
@@ -34,11 +34,7 @@ public sealed class OpenIdClientSettingsStep : NamedRecipeStepHandler
         settings.Authority = !string.IsNullOrEmpty(model.Authority) ? new Uri(model.Authority, UriKind.Absolute) : null;
         settings.CallbackPath = model.CallbackPath;
         settings.ClientId = model.ClientId;
-        if (string.IsNullOrEmpty(model.ClientSecret))
-        {
-            settings.ClientSecret = null;
-        }
-        else
+        if (!string.IsNullOrEmpty(model.ClientSecret))
         {
             var protector = _dataProtectionProvider.CreateProtector(nameof(OpenIdClientConfiguration));
             settings.ClientSecret = protector.Protect(model.ClientSecret);


### PR DESCRIPTION
Fix issue where client secret was not being protected when set from OpenIdClientSettings recipe step. Fix null reference exception when Scope isn't specified in the recipe step. Fixes #18313 