### PR TITLE
Use permission name in case the description is missing

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Edit.cshtml
@@ -90,9 +90,12 @@
                         <tbody>
                             @foreach (var permission in group.Value.OrderBy(x => x.Description))
                             {
-                                <tr data-text="@permission.Description">
+                                var description = string.IsNullOrEmpty(permission.Description)
+                                    ? permission.Name
+                                    : permission.Description;
+                                <tr data-text="@description">
                                     <td class="col-10">
-                                        @permission.Description
+                                        @description
                                         @if (permission.IsSecurityCritical)
                                         {
                                             <div class="float-end">


### PR DESCRIPTION
This is how it looks when the permission description is missing

<img width="1555" height="201" alt="Screenshot 2025-09-11 073439" src="https://github.com/user-attachments/assets/2606279d-cfc1-4185-ba8d-55c2e2a07343" />

After the fix

<img width="1552" height="188" alt="image" src="https://github.com/user-attachments/assets/35ed8512-69f3-461f-beeb-6bf6e967478c" />