### PR TITLE
Prevent unnecessary exception "Error deleting cache folder ..." when the folder doesn't exist

### DIFF
--- a/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/DefaultMediaFileStoreCacheFileProvider.cs
@@ -128,7 +128,10 @@ public class DefaultMediaFileStoreCacheFileProvider : PhysicalFileProvider, IMed
     {
         var directoryInfo = GetFileInfo(path);
         
-        if (!directoryInfo.Exists) return Task.FromResult(false);
+        if (!directoryInfo.Exists)
+        {
+            return Task.FromResult(false);
+        }
 
         try
         {


### PR DESCRIPTION
We keep getting a lot of this type of errors after deployment:

```
System.IO.DirectoryNotFoundException: Error deleting cache folder C:\home\site\wwwroot\[...]
   at System.IO.FileSystem.GetFindData (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.IO.FileSystem.RemoveDirectory (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at System.IO.Directory.Delete (System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e)
   at OrchardCore.Media.Core.DefaultMediaFileStoreCacheFileProvider.TryDeleteDirectoryAsync (OrchardCore.Media.Core, Version=2.1.9.0, Culture=neutral, PublicKeyToken=null)
```

It creates a lot of unnecessary logs, so it's worth to check and prevent the exception.