### PR TITLE
Moveout UI layer methods to new interface.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -21,6 +21,7 @@ namespace OrchardCore.ContentTypes.Controllers;
 public sealed class AdminController : Controller
 {
     private readonly IContentDefinitionService _contentDefinitionService;
+    private readonly IContentDefinitionViewModelService _contentDefinitionAppService;
     private readonly IContentDefinitionManager _contentDefinitionManager;
     private readonly IAuthorizationService _authorizationService;
     private readonly IDocumentStore _documentStore;
@@ -34,6 +35,7 @@ public sealed class AdminController : Controller
     public AdminController(
         IContentDefinitionDisplayManager contentDefinitionDisplayManager,
         IContentDefinitionService contentDefinitionService,
+        IContentDefinitionViewModelService contentDefinitionAppService,
         IContentDefinitionManager contentDefinitionManager,
         IAuthorizationService authorizationService,
         IDocumentStore documentStore,
@@ -52,6 +54,7 @@ public sealed class AdminController : Controller
 
         H = htmlLocalizer;
         S = stringLocalizer;
+        _contentDefinitionAppService = contentDefinitionAppService;
     }
 
     public Task<ActionResult> Index()
@@ -71,7 +74,7 @@ public sealed class AdminController : Controller
 
         return View("List", new ListContentTypesViewModel
         {
-            Types = await _contentDefinitionService.GetTypesAsync(),
+            Types = await _contentDefinitionAppService.GetTypesAsync(),
         });
     }
 
@@ -101,7 +104,7 @@ public sealed class AdminController : Controller
         {
             ModelState.AddModelError("DisplayName", S["The Display Name can't be empty."]);
         }
-        var types = await _contentDefinitionService.LoadTypesAsync();
+        var types = await _contentDefinitionAppService.LoadTypesAsync();
 
         if (types.Any(t => string.Equals(t.DisplayName.Trim(), viewModel.DisplayName.Trim(), StringComparison.OrdinalIgnoreCase)))
         {
@@ -156,7 +159,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var typeViewModel = await _contentDefinitionService.GetTypeAsync(id);
+        var typeViewModel = await _contentDefinitionAppService.GetTypeAsync(id);
 
         if (typeViewModel == null)
         {
@@ -222,7 +225,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var typeViewModel = await _contentDefinitionService.LoadTypeAsync(id);
+        var typeViewModel = await _contentDefinitionAppService.LoadTypeAsync(id);
 
         if (typeViewModel == null)
         {
@@ -244,7 +247,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var typeViewModel = await _contentDefinitionService.GetTypeAsync(id);
+        var typeViewModel = await _contentDefinitionAppService.GetTypeAsync(id);
 
         if (typeViewModel == null)
         {
@@ -256,7 +259,7 @@ public sealed class AdminController : Controller
         var viewModel = new AddPartsViewModel
         {
             Type = typeViewModel,
-            PartSelections = (await _contentDefinitionService.GetPartsAsync(metadataPartsOnly: false))
+            PartSelections = (await _contentDefinitionAppService.GetPartsAsync(metadataPartsOnly: false))
                 .Where(cpd => !typePartNames.Contains(cpd.Name, StringComparer.OrdinalIgnoreCase) && cpd.PartDefinition != null && cpd.PartDefinition.GetSettings<ContentPartSettings>().Attachable)
                 .Select(cpd => new PartSelectionViewModel { PartName = cpd.Name, PartDisplayName = cpd.DisplayName, PartDescription = cpd.Description })
                 .ToList(),
@@ -273,14 +276,14 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var typeViewModel = await _contentDefinitionService.GetTypeAsync(id);
+        var typeViewModel = await _contentDefinitionAppService.GetTypeAsync(id);
 
         if (typeViewModel == null)
         {
             return NotFound();
         }
 
-        var reusableParts = (await _contentDefinitionService.GetPartsAsync(metadataPartsOnly: false))
+        var reusableParts = (await _contentDefinitionAppService.GetPartsAsync(metadataPartsOnly: false))
                 .Where(cpd => cpd.PartDefinition != null &&
                     cpd.PartDefinition.GetSettings<ContentPartSettings>().Attachable &&
                     cpd.PartDefinition.GetSettings<ContentPartSettings>().Reusable);
@@ -305,7 +308,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var typeViewModel = await _contentDefinitionService.LoadTypeAsync(id);
+        var typeViewModel = await _contentDefinitionAppService.LoadTypeAsync(id);
 
         if (typeViewModel == null)
         {
@@ -342,7 +345,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var typeViewModel = await _contentDefinitionService.LoadTypeAsync(id);
+        var typeViewModel = await _contentDefinitionAppService.LoadTypeAsync(id);
 
         if (typeViewModel == null)
         {
@@ -417,7 +420,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var typeViewModel = await _contentDefinitionService.LoadTypeAsync(id);
+        var typeViewModel = await _contentDefinitionAppService.LoadTypeAsync(id);
 
         if (typeViewModel == null)
         {
@@ -453,7 +456,7 @@ public sealed class AdminController : Controller
         return View(new ListContentPartsViewModel
         {
             // Only user-defined parts (not code as they are not configurable).
-            Parts = await _contentDefinitionService.GetPartsAsync(metadataPartsOnly: true),
+            Parts = await _contentDefinitionAppService.GetPartsAsync(metadataPartsOnly: true),
         });
     }
 
@@ -483,7 +486,7 @@ public sealed class AdminController : Controller
             ModelState.AddModelError("Name", S["The Technical Name can't be empty."]);
         }
 
-        if ((await _contentDefinitionService.LoadPartsAsync(false)).Any(p => string.Equals(p.Name.Trim(), viewModel.Name.Trim(), StringComparison.OrdinalIgnoreCase)))
+        if ((await _contentDefinitionAppService.LoadPartsAsync(false)).Any(p => string.Equals(p.Name.Trim(), viewModel.Name.Trim(), StringComparison.OrdinalIgnoreCase)))
         {
             ModelState.AddModelError("Name", S["A part with the same Technical Name already exists."]);
         }
@@ -508,7 +511,7 @@ public sealed class AdminController : Controller
             return View(viewModel);
         }
 
-        var partViewModel = await _contentDefinitionService.AddPartAsync(viewModel);
+        var partViewModel = await _contentDefinitionAppService.AddPartAsync(viewModel);
 
         if (partViewModel == null)
         {
@@ -586,7 +589,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var partViewModel = await _contentDefinitionService.LoadPartAsync(id);
+        var partViewModel = await _contentDefinitionAppService.LoadPartAsync(id);
 
         if (partViewModel == null)
         {
@@ -617,7 +620,7 @@ public sealed class AdminController : Controller
             return RedirectToAction(nameof(List));
         }
 
-        var partViewModel = await _contentDefinitionService.LoadPartAsync(id);
+        var partViewModel = await _contentDefinitionAppService.LoadPartAsync(id);
 
         if (partViewModel == null)
         {
@@ -642,7 +645,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var partViewModel = await _contentDefinitionService.LoadPartAsync(id);
+        var partViewModel = await _contentDefinitionAppService.LoadPartAsync(id);
 
         if (partViewModel == null)
         {
@@ -724,7 +727,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var partViewModel = await _contentDefinitionService.GetPartAsync(id);
+        var partViewModel = await _contentDefinitionAppService.GetPartAsync(id);
 
         if (partViewModel == null)
         {
@@ -767,7 +770,7 @@ public sealed class AdminController : Controller
             return NotFound();
         }
 
-        var partViewModel = await _contentDefinitionService.LoadPartAsync(id);
+        var partViewModel = await _contentDefinitionAppService.LoadPartAsync(id);
 
         if (partViewModel == null)
         {
@@ -793,7 +796,7 @@ public sealed class AdminController : Controller
                 ModelState.AddModelError("DisplayName", S["The Display Name can't be empty."]);
             }
 
-            if ((await _contentDefinitionService.LoadPartAsync(partViewModel.Name)).PartDefinition.Fields.Any(t => t.Name != viewModel.Name && string.Equals(t.DisplayName().Trim(), viewModel.DisplayName.Trim(), StringComparison.OrdinalIgnoreCase)))
+            if ((await _contentDefinitionAppService.LoadPartAsync(partViewModel.Name)).PartDefinition.Fields.Any(t => t.Name != viewModel.Name && string.Equals(t.DisplayName().Trim(), viewModel.DisplayName.Trim(), StringComparison.OrdinalIgnoreCase)))
             {
                 ModelState.AddModelError("DisplayName", S["A field with the same Display Name already exists."]);
             }
@@ -811,7 +814,7 @@ public sealed class AdminController : Controller
             await _notifier.InformationAsync(H["Display name changed to {0}.", viewModel.DisplayName]);
         }
 
-        await _contentDefinitionService.AlterFieldAsync(partViewModel, viewModel);
+        await _contentDefinitionAppService.AlterFieldAsync(partViewModel, viewModel);
 
         // Refresh the local field variable in case it has been altered
         field = (await _contentDefinitionManager.LoadPartDefinitionAsync(id)).Fields.FirstOrDefault(x => string.Equals(x.Name, viewModel.Name, StringComparison.OrdinalIgnoreCase));
@@ -837,7 +840,7 @@ public sealed class AdminController : Controller
         else
         {
             // Redirect to the type editor if a type exists with this name
-            var typeViewModel = await _contentDefinitionService.LoadTypeAsync(id);
+            var typeViewModel = await _contentDefinitionAppService.LoadTypeAsync(id);
             if (typeViewModel != null)
             {
                 return RedirectToAction(nameof(Edit), new { id });
@@ -855,7 +858,7 @@ public sealed class AdminController : Controller
             return Forbid();
         }
 
-        var partViewModel = await _contentDefinitionService.LoadPartAsync(id);
+        var partViewModel = await _contentDefinitionAppService.LoadPartAsync(id);
 
         if (partViewModel == null)
         {
@@ -873,7 +876,7 @@ public sealed class AdminController : Controller
 
         await _notifier.SuccessAsync(H["The \"{0}\" field has been removed.", field.DisplayName()]);
 
-        if (await _contentDefinitionService.LoadTypeAsync(id) != null)
+        if (await _contentDefinitionAppService.LoadTypeAsync(id) != null)
         {
             return RedirectToAction(nameof(Edit), new { id });
         }
@@ -977,7 +980,7 @@ public sealed class AdminController : Controller
             }
         }
 
-        await _contentDefinitionService.AlterTypePartAsync(viewModel);
+        await _contentDefinitionAppService.AlterTypePartAsync(viewModel);
 
         // Refresh the local part variable in case it has been altered
         part = (await _contentDefinitionManager.LoadTypeDefinitionAsync(id)).Parts.FirstOrDefault(x => string.Equals(x.Name, viewModel.Name, StringComparison.OrdinalIgnoreCase));

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/ContentDefinitionAppService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/ContentDefinitionAppService.cs
@@ -1,0 +1,234 @@
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using OrchardCore.ContentManagement.Metadata;
+using OrchardCore.ContentManagement.Metadata.Models;
+using OrchardCore.ContentManagement.Metadata.Settings;
+using OrchardCore.ContentTypes.Events;
+using OrchardCore.ContentTypes.ViewModels;
+using OrchardCore.Modules;
+
+namespace OrchardCore.ContentTypes.Services;
+
+public class ContentDefinitionViewModelService : IContentDefinitionViewModelService
+{
+    private readonly IEnumerable<Type> _contentPartTypes;
+    private readonly IContentDefinitionManager _contentDefinitionManager;
+    private readonly IEnumerable<IContentDefinitionEventHandler> _contentDefinitionEventHandlers;
+    protected readonly IStringLocalizer S;
+    private readonly ILogger _logger;
+
+    public ContentDefinitionViewModelService(IContentDefinitionManager contentDefinitionManager
+        , IEnumerable<Type> contentPartTypes
+        , IEnumerable<IContentDefinitionEventHandler> contentDefinitionEventHandlers
+        , IStringLocalizer s)
+    {
+        _contentDefinitionManager = contentDefinitionManager;
+        _contentPartTypes = contentPartTypes;
+        _contentDefinitionEventHandlers = contentDefinitionEventHandlers;
+        S = s;
+    }
+
+    public async Task<EditPartViewModel> AddPartAsync(CreatePartViewModel partViewModel)
+    {
+        var name = partViewModel.Name;
+
+        if (await _contentDefinitionManager.LoadPartDefinitionAsync(name) is not null)
+        {
+            throw new Exception(S["Cannot add part named '{0}'. It already exists.", name]);
+        }
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            await _contentDefinitionManager.AlterPartDefinitionAsync(name, builder => builder.Attachable());
+            var partDefinition = await _contentDefinitionManager.LoadPartDefinitionAsync(name);
+
+            var context = new ContentPartCreatedContext
+            {
+                ContentPartDefinition = partDefinition,
+            };
+
+            _contentDefinitionEventHandlers.Invoke((handler, ctx) => handler.ContentPartCreated(ctx), context, _logger);
+
+            return new EditPartViewModel(partDefinition);
+        }
+
+        return null;
+    }
+
+    public async Task AlterFieldAsync(EditPartViewModel partViewModel, EditFieldViewModel fieldViewModel)
+    {
+        await _contentDefinitionManager.AlterPartDefinitionAsync(partViewModel.Name, partBuilder =>
+        {
+            partBuilder.WithField(fieldViewModel.Name, fieldBuilder =>
+            {
+                fieldBuilder.WithDisplayName(fieldViewModel.DisplayName);
+                fieldBuilder.WithEditor(fieldViewModel.Editor);
+                fieldBuilder.WithDisplayMode(fieldViewModel.DisplayMode);
+            });
+        });
+
+        var context = new ContentPartFieldUpdatedContext
+        {
+            ContentPartName = partViewModel.Name,
+            ContentFieldName = fieldViewModel.Name,
+        };
+
+        _contentDefinitionEventHandlers.Invoke((handler, ctx) => handler.ContentPartFieldUpdated(ctx), context, _logger);
+    }
+
+    public async Task AlterTypePartAsync(EditTypePartViewModel typePartViewModel)
+    {
+        var typeDefinition = typePartViewModel.TypePartDefinition.ContentTypeDefinition;
+
+        await _contentDefinitionManager.AlterTypeDefinitionAsync(typeDefinition.Name, type =>
+        {
+            type.WithPart(typePartViewModel.Name, typePartViewModel.TypePartDefinition.PartDefinition, part =>
+            {
+                part.WithDisplayName(typePartViewModel.DisplayName);
+                part.WithDescription(typePartViewModel.Description);
+                part.WithEditor(typePartViewModel.Editor);
+                part.WithDisplayMode(typePartViewModel.DisplayMode);
+            });
+        });
+
+        var context = new ContentTypePartUpdatedContext
+        {
+            ContentTypeName = typeDefinition.Name,
+            ContentPartName = typePartViewModel.Name,
+        };
+
+        _contentDefinitionEventHandlers.Invoke((handler, ctx) => handler.ContentTypePartUpdated(ctx), context, _logger);
+    }
+
+    public async Task<EditPartViewModel> GetPartAsync(string name)
+    {
+        var contentPartDefinition = await _contentDefinitionManager.GetPartDefinitionAsync(name);
+
+        if (contentPartDefinition == null)
+        {
+            var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(name);
+
+            if (contentTypeDefinition == null)
+            {
+                return null;
+            }
+
+            contentPartDefinition = new ContentPartDefinition(name);
+        }
+
+        var viewModel = new EditPartViewModel(contentPartDefinition);
+
+        return viewModel;
+    }
+
+    public async Task<IEnumerable<EditPartViewModel>> GetPartsAsync(bool metadataPartsOnly)
+    {
+        var typeNames = new HashSet<string>((await GetTypesAsync()).Select(ctd => ctd.Name));
+
+        // User-defined parts.
+        // Except for those parts with the same name as a type (implicit type's part or a mistake).
+        var userContentParts = (await _contentDefinitionManager.ListPartDefinitionsAsync())
+            .Where(cpd => !typeNames.Contains(cpd.Name))
+            .Select(cpd => new EditPartViewModel(cpd))
+            .ToDictionary(k => k.Name);
+
+        // Code-defined parts.
+        var codeDefinedParts = metadataPartsOnly
+            ? []
+            : _contentPartTypes
+                .Where(cpd => !userContentParts.ContainsKey(cpd.Name))
+                .Select(cpi => new EditPartViewModel
+                {
+                    Name = cpi.Name,
+                    DisplayName = cpi.Name,
+                }).ToList();
+
+        // Order by display name.
+        return codeDefinedParts
+            .Union(userContentParts.Values)
+            .OrderBy(m => m.DisplayName);
+    }
+
+    public async Task<EditTypeViewModel> GetTypeAsync(string name)
+    {
+        var contentTypeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(name);
+
+        if (contentTypeDefinition == null)
+        {
+            return null;
+        }
+
+        return new EditTypeViewModel(contentTypeDefinition);
+    }
+
+    public async Task<IEnumerable<EditTypeViewModel>> GetTypesAsync()
+        => (await _contentDefinitionManager.ListTypeDefinitionsAsync())
+            .Select(ctd => new EditTypeViewModel(ctd))
+            .OrderBy(m => m.DisplayName);
+
+    public async Task<EditPartViewModel> LoadPartAsync(string name)
+    {
+        var contentPartDefinition = await _contentDefinitionManager.LoadPartDefinitionAsync(name);
+
+        if (contentPartDefinition == null)
+        {
+            var contentTypeDefinition = await _contentDefinitionManager.LoadTypeDefinitionAsync(name);
+
+            if (contentTypeDefinition == null)
+            {
+                return null;
+            }
+
+            contentPartDefinition = new ContentPartDefinition(name);
+        }
+
+        var viewModel = new EditPartViewModel(contentPartDefinition);
+
+        return viewModel;
+    }
+
+    public async Task<IEnumerable<EditPartViewModel>> LoadPartsAsync(bool metadataPartsOnly)
+    {
+        var typeNames = new HashSet<string>((await LoadTypesAsync()).Select(ctd => ctd.Name));
+
+        // User-defined parts.
+        // Except for those parts with the same name as a type (implicit type's part or a mistake).
+        var userContentParts = (await _contentDefinitionManager.LoadPartDefinitionsAsync())
+            .Where(cpd => !typeNames.Contains(cpd.Name))
+            .Select(cpd => new EditPartViewModel(cpd))
+            .ToDictionary(k => k.Name);
+
+        // Code-defined parts.
+        var codeDefinedParts = metadataPartsOnly
+            ? []
+            : _contentPartTypes
+                .Where(cpd => !userContentParts.ContainsKey(cpd.Name))
+                .Select(cpi => new EditPartViewModel
+                {
+                    Name = cpi.Name,
+                    DisplayName = cpi.Name,
+                }).ToList();
+
+        // Order by display name.
+        return codeDefinedParts
+            .Union(userContentParts.Values)
+            .OrderBy(m => m.DisplayName);
+    }
+
+    public async Task<EditTypeViewModel> LoadTypeAsync(string name)
+    {
+        var contentTypeDefinition = await _contentDefinitionManager.LoadTypeDefinitionAsync(name);
+
+        if (contentTypeDefinition == null)
+        {
+            return null;
+        }
+
+        return new EditTypeViewModel(contentTypeDefinition);
+    }
+
+    public async Task<IEnumerable<EditTypeViewModel>> LoadTypesAsync()
+        => (await _contentDefinitionManager.LoadTypeDefinitionsAsync())
+            .Select(ctd => new EditTypeViewModel(ctd))
+            .OrderBy(m => m.DisplayName);
+}

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/IContentDefinitionAppService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/IContentDefinitionAppService.cs
@@ -1,0 +1,29 @@
+using OrchardCore.ContentTypes.ViewModels;
+
+namespace OrchardCore.ContentTypes.Services;
+
+// This service for UI layering, not for core content definition management.
+public interface IContentDefinitionViewModelService
+{
+    Task<IEnumerable<EditTypeViewModel>> LoadTypesAsync();
+
+    Task<IEnumerable<EditTypeViewModel>> GetTypesAsync();
+
+    Task<EditTypeViewModel> LoadTypeAsync(string name);
+
+    Task<EditTypeViewModel> GetTypeAsync(string name);
+
+    Task<IEnumerable<EditPartViewModel>> LoadPartsAsync(bool metadataPartsOnly);
+
+    Task<IEnumerable<EditPartViewModel>> GetPartsAsync(bool metadataPartsOnly);
+
+    Task<EditPartViewModel> LoadPartAsync(string name);
+
+    Task<EditPartViewModel> GetPartAsync(string name);
+
+    Task<EditPartViewModel> AddPartAsync(CreatePartViewModel partViewModel);
+
+    Task AlterFieldAsync(EditPartViewModel partViewModel, EditFieldViewModel fieldViewModel);
+
+    Task AlterTypePartAsync(EditTypePartViewModel partViewModel);
+}

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/IContentDefinitionService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/IContentDefinitionService.cs
@@ -1,18 +1,9 @@
 using OrchardCore.ContentManagement.Metadata.Models;
-using OrchardCore.ContentTypes.ViewModels;
 
 namespace OrchardCore.ContentTypes.Services;
 
 public interface IContentDefinitionService
 {
-    Task<IEnumerable<EditTypeViewModel>> LoadTypesAsync();
-
-    Task<IEnumerable<EditTypeViewModel>> GetTypesAsync();
-
-    Task<EditTypeViewModel> LoadTypeAsync(string name);
-
-    Task<EditTypeViewModel> GetTypeAsync(string name);
-
     Task<ContentTypeDefinition> AddTypeAsync(string name, string displayName);
 
     Task RemoveTypeAsync(string name, bool deleteContent);
@@ -27,16 +18,6 @@ public interface IContentDefinitionService
 
     Task<string> GenerateFieldNameFromDisplayNameAsync(string partName, string displayName);
 
-    Task<IEnumerable<EditPartViewModel>> LoadPartsAsync(bool metadataPartsOnly);
-
-    Task<IEnumerable<EditPartViewModel>> GetPartsAsync(bool metadataPartsOnly);
-
-    Task<EditPartViewModel> LoadPartAsync(string name);
-
-    Task<EditPartViewModel> GetPartAsync(string name);
-
-    Task<EditPartViewModel> AddPartAsync(CreatePartViewModel partViewModel);
-
     Task RemovePartAsync(string name);
 
     Task<IEnumerable<Type>> GetFieldsAsync();
@@ -46,10 +27,6 @@ public interface IContentDefinitionService
     Task AddFieldToPartAsync(string fieldName, string displayName, string fieldTypeName, string partName);
 
     Task RemoveFieldFromPartAsync(string fieldName, string partName);
-
-    Task AlterFieldAsync(EditPartViewModel partViewModel, EditFieldViewModel fieldViewModel);
-
-    Task AlterTypePartAsync(EditTypePartViewModel partViewModel);
 
     Task AlterTypePartsOrderAsync(ContentTypeDefinition typeDefinition, string[] partNames);
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/StereotypeService.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Services/StereotypeService.cs
@@ -8,17 +8,17 @@ namespace OrchardCore.ContentTypes.Services;
 public class StereotypeService : IStereotypeService
 {
     private readonly IEnumerable<IStereotypesProvider> _providers;
-    private readonly IContentDefinitionService _contentDefinitionService;
+    private readonly IContentDefinitionViewModelService _contentDefinitionAppService;
     private readonly ILogger<StereotypeService> _logger;
 
     public StereotypeService(
         IEnumerable<IStereotypesProvider> providers,
-        IContentDefinitionService contentDefinitionService,
-        ILogger<StereotypeService> logger)
+        ILogger<StereotypeService> logger,
+        IContentDefinitionViewModelService contentDefinitionAppService)
     {
         _providers = providers;
-        _contentDefinitionService = contentDefinitionService;
         _logger = logger;
+        _contentDefinitionAppService = contentDefinitionAppService;
     }
 
     public async Task<IEnumerable<StereotypeDescription>> GetStereotypesAsync()
@@ -28,7 +28,7 @@ public class StereotypeService : IStereotypeService
         var stereotypes = providerStereotypes.Select(providerStereotype => providerStereotype.Stereotype)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
-        foreach (var contentType in await _contentDefinitionService.GetTypesAsync())
+        foreach (var contentType in await _contentDefinitionAppService.GetTypesAsync())
         {
             if (!contentType.TypeDefinition.TryGetStereotype(out var stereotype) ||
                 stereotypes.Contains(stereotype))

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Startup.cs
@@ -20,6 +20,7 @@ public sealed class Startup : StartupBase
         services.AddPermissionProvider<Permissions>();
         services.AddNavigationProvider<AdminMenu>();
         services.AddScoped<IContentDefinitionService, ContentDefinitionService>();
+        services.AddScoped<IContentDefinitionViewModelService, ContentDefinitionViewModelService>();
         services.AddScoped<IStereotypeService, StereotypeService>();
         services.AddScoped<IContentDefinitionDisplayHandler, ContentDefinitionDisplayCoordinator>();
         services.AddScoped<IContentDefinitionDisplayManager, DefaultContentDefinitionDisplayManager>();

--- a/src/OrchardCore.Modules/OrchardCore.DataLocalization/Services/ContentFieldLocalizationDataProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataLocalization/Services/ContentFieldLocalizationDataProvider.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using OrchardCore.ContentTypes.Services;
 using OrchardCore.Localization.Data;
 
@@ -8,18 +5,18 @@ namespace OrchardCore.DataLocalization.Services;
 
 public class ContentFieldDataLocalizationProvider : ILocalizationDataProvider
 {
-    private readonly IContentDefinitionService _contentDefinitionService;
+    private readonly IContentDefinitionViewModelService _contentDefinitionAppService;
 
     private static readonly string _contentFieldsContext = "Content Fields";
 
-    public ContentFieldDataLocalizationProvider(IContentDefinitionService contentDefinitionService)
+    public ContentFieldDataLocalizationProvider(IContentDefinitionViewModelService contentDefinitionAppService)
     {
-        _contentDefinitionService = contentDefinitionService;
+        _contentDefinitionAppService = contentDefinitionAppService;
     }
 
     // TODO: Check if there's a better way to get the fields
     public async Task<IEnumerable<DataLocalizedString>> GetDescriptorsAsync()
-        => (await _contentDefinitionService.GetTypesAsync())
+        => (await _contentDefinitionAppService.GetTypesAsync())
             .SelectMany(t => t.TypeDefinition.Parts)
             .SelectMany(p => p.PartDefinition.Fields.Select(f => new DataLocalizedString(_contentFieldsContext, f.Name, string.Empty)));
 }

--- a/src/OrchardCore.Modules/OrchardCore.DataLocalization/Services/ContentTypeLocalizationDataProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataLocalization/Services/ContentTypeLocalizationDataProvider.cs
@@ -1,6 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using OrchardCore.ContentTypes.Services;
 using OrchardCore.Localization.Data;
 
@@ -8,16 +5,16 @@ namespace OrchardCore.DataLocalization.Services;
 
 public class ContentTypeDataLocalizationProvider : ILocalizationDataProvider
 {
-    private readonly IContentDefinitionService _contentDefinitionService;
+    private readonly IContentDefinitionViewModelService _contentDefinitionAppService;
 
     private static readonly string _contentTypesContext = "Content Types";
 
-    public ContentTypeDataLocalizationProvider(IContentDefinitionService contentDefinitionService)
+    public ContentTypeDataLocalizationProvider(IContentDefinitionViewModelService contentDefinitionAppService)
     {
-        _contentDefinitionService = contentDefinitionService;
+        _contentDefinitionAppService = contentDefinitionAppService;
     }
 
     public async Task<IEnumerable<DataLocalizedString>> GetDescriptorsAsync()
-        => (await _contentDefinitionService.GetTypesAsync())
+        => (await _contentDefinitionAppService.GetTypesAsync())
             .Select(t => new DataLocalizedString(_contentTypesContext, t.DisplayName, string.Empty));
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/ContentTypeDataLocalizationProviderTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/ContentTypeDataLocalizationProviderTests.cs
@@ -9,7 +9,7 @@ public class ContentTypeDataLocalizationProviderTests
 
     public ContentTypeDataLocalizationProviderTests()
     {
-        var contentDefinitionService = new Mock<IContentDefinitionService>();
+        var contentDefinitionService = new Mock<IContentDefinitionViewModelService>();
         contentDefinitionService.Setup(service => service.GetTypesAsync())
             .ReturnsAsync(() => new List<EditTypeViewModel> {
                 new() { DisplayName = "Article" },

--- a/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/DataLocalizationProviderTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.DataLocalization/Services/DataLocalizationProviderTests.cs
@@ -10,7 +10,7 @@ public class DataLocalizationProviderTests
     [Fact]
     public async Task ContentTypeDataLocalizationProvider_GetLocalizedStrings()
     {
-        var contentDefinitionService = new Mock<IContentDefinitionService>();
+        var contentDefinitionService = new Mock<IContentDefinitionViewModelService>();
         contentDefinitionService.Setup(cds => cds.GetTypesAsync())
             .ReturnsAsync(() => new List<EditTypeViewModel> {
                 new() { DisplayName = "Article" },
@@ -27,7 +27,7 @@ public class DataLocalizationProviderTests
     [Fact]
     public async Task ContentFieldDataLocalizationProvider_GetLocalizedStrings()
     {
-        var contentDefinitionService = new Mock<IContentDefinitionService>();
+        var contentDefinitionService = new Mock<IContentDefinitionViewModelService>();
         contentDefinitionService.Setup(cds => cds.GetTypesAsync())
             .ReturnsAsync(() => new List<EditTypeViewModel>
             {


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

As i seen from comment and code , that IContentDefinitionService contains methods related to UI + Non UI functionality. So i created new abstraction IContentDefinitionViewModelService which will handle only UI layer view models.

May be new interface not placed at right location, please feel free to change. As still i am going through a code.

So,

IContentDefinitionManager  => handles caching, loading, storing, and building definitions.
IContentDefinitionViewModelService => handles UI layer view model
IContentDefinitionService => handles content management.

Please go through changes!

Regards.



