### PR TITLE
Allow to enable Liquid tags

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -341,6 +341,9 @@
     //  "Trimming": {
     //    "BatchSize": 1000
     //  }
+    //},
+    //"OrchardCore_Liquid": {
+    //  "AllowLiquidTag": true // Whether the Liquid Tag is allowed in the Liquid templates, false by default.
     //}
   }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Extensions/LiquidCoreServices.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Extensions/LiquidCoreServices.cs
@@ -1,6 +1,7 @@
 using Fluid;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy;
 using OrchardCore.DisplayManagement.Liquid;
@@ -8,6 +9,8 @@ using OrchardCore.DisplayManagement.Liquid.Filters;
 using OrchardCore.DisplayManagement.Liquid.TagHelpers;
 using OrchardCore.DisplayManagement.Liquid.Tags;
 using OrchardCore.DisplayManagement.Razor;
+using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.Environment.Shell.Scope;
 using OrchardCore.Liquid;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -17,6 +20,15 @@ public static class LiquidCoreServices
     public static IServiceCollection AddLiquidCoreServices(this IServiceCollection services)
     {
         services.AddSingleton<LiquidViewParser>();
+        services.Configure<FluidParserOptions>(options =>
+        {
+            var configuration = ShellScope.Services.GetRequiredService<IShellConfiguration>();
+            configuration.GetSection("OrchardCore_Liquid").Bind(options);
+
+            // Always enable the use of functions, do not expose it as a configuration option.
+            options.AllowFunctions = true;
+        });
+
         services.AddSingleton<IAnchorTag, AnchorTag>();
 
         services.AddTransient<IConfigureOptions<TemplateOptions>, TemplateOptionsFileProviderSetup>();

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewParser.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewParser.cs
@@ -10,8 +10,8 @@ namespace OrchardCore.DisplayManagement.Liquid;
 
 public class LiquidViewParser : FluidParser
 {
-    public LiquidViewParser(IOptions<LiquidViewOptions> liquidViewOptions)
-        : base(new FluidParserOptions() { AllowFunctions = true })
+    public LiquidViewParser(IOptions<LiquidViewOptions> liquidViewOptions, IOptions<FluidParserOptions> fluidParserOptions)
+        : base(fluidParserOptions?.Value ?? throw new ArgumentNullException(nameof(fluidParserOptions)))
     {
         RegisterEmptyTag("render_body", RenderBodyTag.WriteToAsync);
         RegisterParserTag("render_section", ArgumentsList, RenderSectionTag.WriteToAsync);

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -12,6 +12,22 @@ In the previous versions you need to use `OrhardCore` namespace in Razor pages o
 
 The `ContentRazorHelperExtensions` has been replaced by `ContentOrchardHelperExtensions`.
 
+### Liquid Module
+
+#### Liquid Tag Disabled by Default
+
+For reliability and performance reasons, the `liquid` tag has been disabled by default in Liquid templates. 
+
+To re-enable the `liquid` tag, you can configure it in your `appsettings.json`:
+
+```json
+{
+  "OrchardCore_Liquid": {
+    "AllowLiquidTags": true
+  }
+}
+```
+
 ### YesSql Changes
 
 Previously, we configured YesSql with the `ReadUncommitted` isolation level. We have now set `ReadCommitted` as the default and made it configurable through settings.


### PR DESCRIPTION
- Modified `LiquidViewParser` to accept `FluidParserOptions`, improving configurability.
- Updated `LiquidCoreServices` to configure `FluidParserOptions`.
- Added `OrchardCore_Liquid` section in `appsettings.json` to allow Liquid tags in templates.
- Updated documentation.

Fixes #18343 