### PR TITLE
Lucene BooleanQueryProvider throws NodeWrongType in case filter is an array (Lombiq Technologies: SANTA-90)

### DIFF
--- a/src/OrchardCore/OrchardCore.Search.Lucene.Core/QueryProviders/BooleanQueryProvider.cs
+++ b/src/OrchardCore/OrchardCore.Search.Lucene.Core/QueryProviders/BooleanQueryProvider.cs
@@ -81,12 +81,11 @@ public class BooleanQueryProvider : ILuceneQueryProvider
     private Query CreateFilteredQuery(ILuceneQueryService builder, LuceneQueryContext context, Query query, JsonNode filter)
     {
         Query filteredQuery = null;
-        var queryObj = filter.AsObject();
 
         switch (filter.GetValueKind())
         {
             case JsonValueKind.Object:
-                var first = queryObj.First();
+                var first = filter.AsObject().First();
 
                 foreach (var queryProvider in _filters)
                 {

--- a/src/OrchardCore/OrchardCore.Search.Lucene.Core/QueryProviders/BooleanQueryProvider.cs
+++ b/src/OrchardCore/OrchardCore.Search.Lucene.Core/QueryProviders/BooleanQueryProvider.cs
@@ -80,12 +80,16 @@ public class BooleanQueryProvider : ILuceneQueryProvider
 
     private Query CreateFilteredQuery(ILuceneQueryService builder, LuceneQueryContext context, Query query, JsonNode filter)
     {
-        Query filteredQuery = null;
+        Query filteredQuery;
 
         switch (filter.GetValueKind())
         {
             case JsonValueKind.Object:
-                var first = filter.AsObject().First();
+                var first = filter.AsObject().FirstOrDefault();
+                if (string.IsNullOrEmpty(first.Key))
+                {
+                    return null;
+                }
 
                 foreach (var queryProvider in _filters)
                 {
@@ -93,14 +97,18 @@ public class BooleanQueryProvider : ILuceneQueryProvider
 
                     if (filteredQuery != null)
                     {
-                        break;
+                        return filteredQuery;
                     }
                 }
                 break;
             case JsonValueKind.Array:
                 foreach (var item in filter.AsArray())
                 {
-                    var firstQuery = item.AsObject().First();
+                    var firstQuery = item.AsObject().FirstOrDefault();
+                    if (string.IsNullOrEmpty(firstQuery.Key))
+                    {
+                        return null;
+                    }
 
                     foreach (var queryProvider in _filters)
                     {
@@ -108,7 +116,7 @@ public class BooleanQueryProvider : ILuceneQueryProvider
 
                         if (filteredQuery != null)
                         {
-                            break;
+                            return filteredQuery;
                         }
                     }
                 }
@@ -116,6 +124,6 @@ public class BooleanQueryProvider : ILuceneQueryProvider
             default: throw new ArgumentException($"Invalid value in boolean query");
         }
 
-        return filteredQuery;
+        return null;
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Search.Lucene/BooleanQueryProviderTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Search.Lucene/BooleanQueryProviderTests.cs
@@ -1,0 +1,50 @@
+using System.Text.Json.Nodes;
+using Lucene.Net.Analysis;
+using Lucene.Net.Search;
+using OrchardCore.Search.Lucene;
+using OrchardCore.Search.Lucene.QueryProviders;
+
+namespace OrchardCore.Tests.Modules.OrchardCore.Search.Lucene;
+
+public partial class BooleanQueryProviderTests
+{
+    [Fact]
+    public void BoolQueryFilterAsArrayDoesNotThrow()
+    {
+        var arrayFilter = JsonNode.Parse("""
+        {
+            "filter": [
+              { "term": { "Content.ContentItem.ContentType": "BlogPost" } }
+            ]
+        }
+        """)!;
+        
+        RunBoolQueryFilterTest(arrayFilter.AsObject());
+    }
+    
+    [Fact]
+    public void BoolQueryFilterAsObjectDoesNotThrow()
+    {
+        var objectFilter = JsonNode.Parse("""
+        {
+            "filter": { "term": { "Content.ContentItem.ContentType": "BlogPost" } }
+        }
+        """)!;
+
+        RunBoolQueryFilterTest(objectFilter.AsObject());
+    }
+
+    private static void RunBoolQueryFilterTest(JsonObject filter)
+    {
+        // Arrange
+        var luceneQueryService = new Mock<ILuceneQueryService>();
+        var booleanQueryProvider = new BooleanQueryProvider([]);
+        var luceneQueryContext = new Mock<LuceneQueryContext>(It.IsAny<IndexSearcher>(), LuceneConstants.DefaultVersion, It.IsAny<Analyzer>());
+
+        // Act
+        var filterQuery = booleanQueryProvider.CreateQuery(luceneQueryService.Object, luceneQueryContext.Object, "bool", filter);
+
+        // Assert, null means there were no exceptions, we don't care about the actual result here.
+        Assert.Null(filterQuery);
+    }
+}


### PR DESCRIPTION
Fixes #18378 
