### PR TITLE
[release/2.2] Allow Liquid tags

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -329,6 +329,9 @@
     //  "Trimming": {
     //    "BatchSize": 1000
     //  }
+    //},
+    //"OrchardCore_Liquid": {
+    //  "AllowLiquidTag": false // Whether the Liquid Tag is allowed in the Liquid templates, true by default.
     //}
   }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewParser.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewParser.cs
@@ -10,8 +10,8 @@ namespace OrchardCore.DisplayManagement.Liquid;
 
 public class LiquidViewParser : FluidParser
 {
-    public LiquidViewParser(IOptions<LiquidViewOptions> liquidViewOptions)
-        : base(new FluidParserOptions() { AllowFunctions = true })
+    public LiquidViewParser(IOptions<LiquidViewOptions> liquidViewOptions, IOptions<FluidParserOptions> fluidParserOptions)
+        : base(fluidParserOptions?.Value ?? throw new ArgumentNullException(nameof(fluidParserOptions)))
     {
         RegisterEmptyTag("render_body", RenderBodyTag.WriteToAsync);
         RegisterParserTag("render_section", ArgumentsList, RenderSectionTag.WriteToAsync);

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/OrchardCoreBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using Fluid;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Razor.Compilation;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Descriptors.ShapeTemplateStrategy;
 using OrchardCore.DisplayManagement.Liquid;
@@ -8,6 +9,8 @@ using OrchardCore.DisplayManagement.Liquid.Filters;
 using OrchardCore.DisplayManagement.Liquid.TagHelpers;
 using OrchardCore.DisplayManagement.Liquid.Tags;
 using OrchardCore.DisplayManagement.Razor;
+using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.Environment.Shell.Scope;
 using OrchardCore.Liquid;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -22,6 +25,17 @@ public static class OrchardCoreBuilderExtensions
         builder.ConfigureServices(services =>
         {
             services.AddSingleton<LiquidViewParser>();
+            services.Configure<FluidParserOptions>(options =>
+            {
+                options.AllowLiquidTag = true; // Enable Liquid tags by default.
+
+                var configuration = ShellScope.Services.GetRequiredService<IShellConfiguration>();
+                configuration.GetSection("OrchardCore_Liquid").Bind(options);
+
+                // Always enable the use of functions, do not expose it as a configuration option.
+                options.AllowFunctions = true;
+            });
+
             services.AddSingleton<IAnchorTag, AnchorTag>();
 
             services.AddTransient<IConfigureOptions<TemplateOptions>, TemplateOptionsFileProviderSetup>();


### PR DESCRIPTION
Backport of #18248 to release/2.2

This is **not** a direct 1:1 backport. In this version, I’ve **re-enabled Liquid tags by default**, as disabling them introduced a breaking change that should have been reserved for a major version (v3). The breaking behavior was unintentionally introduced in release/2.2 through an update to the YesSql package.

Restoring the previous default behavior ensures better backward compatibility for users upgrading to 2.2.

/cc @MikeAlhayek