### PR TITLE
Fix pager HTML validation error: remove invalid <a> when disabled

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapesTableProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Navigation/PagerShapesTableProvider.cs
@@ -508,31 +508,29 @@ public class PagerShapes : IShapeAttributeProvider
     }
 
     [Shape]
+    
     public IHtmlContent ActionLink(Shape shape, IUrlHelper Url, object Value, bool Disabled = false)
     {
         if (Disabled)
         {
+            // keep the parent <li> styled as disabled
             if (shape.TryGetProperty("Tag", out TagBuilder tagBuilder))
             {
                 tagBuilder.AddCssClass("disabled");
             }
+
+            
+            return HtmlString.Empty;
         }
 
         var routeValues = shape.GetProperty<RouteValueDictionary>("RouteValues") ?? [];
-        if (!Disabled)
-        {
-            shape.Attributes["href"] = Url.Action((string)routeValues["action"], (string)routeValues["controller"], routeValues);
-        }
-        else
-        {
-            shape.Attributes.Remove("href");
-        }
+        shape.Attributes["href"] = Url.Action((string)routeValues["action"], (string)routeValues["controller"], routeValues);
 
         var tag = shape.GetTagBuilder("a");
-
         tag.InnerHtml.AppendHtml(CoerceHtmlString(Value));
         return tag;
     }
+
 
     [Shape]
     public Task<IHtmlContent> Pager_Gap(IShape shape, DisplayContext displayContext)


### PR DESCRIPTION
When rendering the Pager shape, the “Previous” link is shown as disabled on the first page.  
However, it was still outputting an <a> element with a `rel` attribute but no `href`, which causes an HTML validation error.

Example before fix:
<li class="pager__item page-item disabled">
  <a rel="prev"><</a>
</li>

This PR updates the ActionLink shape to remove the <a> entirely when disabled, while keeping the <li class="disabled"> placeholder for consistent layout.

Example after fix:
<li class="pager__item page-item disabled"></li>

Fixes #17907
