### PR TITLE
Add logging to HttpBackgroundJob for better observability

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/BackgroundJobs/HttpBackgroundJob.cs
@@ -25,6 +25,12 @@ public static class HttpBackgroundJob
         // Allow a job to be triggered e.g. during a tenant setup, but later on only check if the tenant is running.
         if (!scope.ShellContext.Settings.IsRunning() && !scope.ShellContext.Settings.IsInitializing())
         {
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<ShellScope>>();
+            logger.LogWarning(
+                "Background job '{JobName}' was not executed because tenant '{TenantName}' is not running or initializing. Current state: {TenantState}.",
+                jobName,
+                scope.ShellContext.Settings.Name,
+                scope.ShellContext.Settings.State);
             return Task.CompletedTask;
         }
 
@@ -33,6 +39,11 @@ public static class HttpBackgroundJob
 
         if (httpContextAccessor.HttpContext == null)
         {
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<ShellScope>>();
+            logger.LogWarning(
+                "Background job '{JobName}' was not executed because it requires an HTTP context. Tenant: '{TenantName}'",
+                jobName,
+                scope.ShellContext.Settings.Name);
             return Task.CompletedTask;
         }
 
@@ -56,10 +67,15 @@ public static class HttpBackgroundJob
             // Wait for the current 'HttpContext' to be released with a timeout of 60s.
             while (httpContextAccessor.HttpContext != null)
             {
-                await Task.Delay(1_000);
+                await Task.Delay(100);
 
                 if (timeoutTask.IsCompleted)
                 {
+                    var logger = scope.ServiceProvider.GetRequiredService<ILogger<ShellScope>>();
+                    logger.LogWarning(
+                        "Background job '{JobName}' timed out waiting for HTTP context to be released after 60 seconds on tenant '{TenantName}'. Job will be skipped.",
+                        jobName,
+                        scope.ShellContext.Settings.Name);
                     return;
                 }
             }
@@ -71,6 +87,12 @@ public static class HttpBackgroundJob
             // Can't be executed e.g. if a tenant setup failed.
             if (!shellContext.Settings.IsRunning())
             {
+                var logger = scope.ServiceProvider.GetRequiredService<ILogger<ShellScope>>();
+                logger.LogWarning(
+                    "Background job '{JobName}' was not executed because tenant '{TenantName}' is no longer running after context reload. Current state: {TenantState}.",
+                    jobName,
+                    shellContext.Settings.Name,
+                    shellContext.Settings.State);
                 return;
             }
 


### PR DESCRIPTION
This pull request improves the reliability and observability of background job execution in the `HttpBackgroundJob` class by adding detailed logging for scenarios where jobs are skipped or not executed. The changes ensure that administrators and developers are informed about why a background job did not run, making troubleshooting easier. Additionally, the polling interval for waiting on HTTP context release has been reduced to make the process more responsive.

**Logging enhancements for skipped background jobs:**

* Added warnings when a background job is not executed because the tenant is not running or initializing, including the job name, tenant name, and tenant state.
* Added warnings when a background job requires an HTTP context but none is available, including the job name and tenant name.
* Added warnings when a background job times out waiting for the HTTP context to be released, including the job name and tenant name.
* Added warnings when a background job is not executed because the tenant is no longer running after context reload, including the job name, tenant name, and tenant state.

**Performance improvement:**

* Reduced the polling delay when waiting for the HTTP context to be released from 1,000ms to 100ms for increased responsiveness.
