### PR TITLE
Fix own permission check in ListPart

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/UserPickerAdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Controllers/UserPickerAdminController.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Admin;
@@ -43,7 +42,6 @@ public sealed class UserPickerAdminController : Controller
         }
 
         var contentItem = await _contentManager.NewAsync(contentType);
-        contentItem.Owner = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
         if (!await _authorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, contentItem))
         {

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Controllers/AdminController.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Localization;
@@ -53,9 +52,6 @@ public sealed class AdminController : Controller
         }
 
         var checkContentItem = await _contentManager.NewAsync(contentItem.ContentType);
-
-        // Set the current user as the owner to check for ownership permissions on creation
-        checkContentItem.Owner = User.FindFirstValue(ClaimTypes.NameIdentifier);
 
         if (!await _authorizationService.AuthorizeAsync(User, CommonPermissions.EditContent, checkContentItem))
         {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -3,10 +3,8 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Localization;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Routing;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
 using OrchardCore.Admin;
@@ -335,12 +333,7 @@ public sealed class AdminController : Controller, IUpdateModel
     [Admin("Contents/ContentTypes/{id}/Create", "CreateContentItem")]
     public async Task<IActionResult> Create(string id)
     {
-        if (string.IsNullOrWhiteSpace(id))
-        {
-            return NotFound();
-        }
-
-        var contentItem = await CreateContentItemOwnedByCurrentUserAsync(id);
+        var contentItem = await _contentManager.NewAsync(id);
 
         if (!await IsAuthorizedAsync(CommonPermissions.EditContent, contentItem))
         {
@@ -695,7 +688,7 @@ public sealed class AdminController : Controller, IUpdateModel
         bool stayOnSamePage,
         Func<ContentItem, Task<bool>> conditionallyPublish)
     {
-        var contentItem = await CreateContentItemOwnedByCurrentUserAsync(id);
+        var contentItem = await _contentManager.NewAsync(id);
 
         if (!await IsAuthorizedAsync(CommonPermissions.EditContent, contentItem))
         {
@@ -823,14 +816,6 @@ public sealed class AdminController : Controller, IUpdateModel
         }
 
         return items;
-    }
-
-    private async Task<ContentItem> CreateContentItemOwnedByCurrentUserAsync(string contentType)
-    {
-        var contentItem = await _contentManager.NewAsync(contentType);
-        contentItem.Owner = CurrentUserId();
-
-        return contentItem;
     }
 
     private string _currentUserId;

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Endpoints/Api/CreateEndpoint.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Endpoints/Api/CreateEndpoint.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using System.Text.Json.Settings;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
@@ -63,7 +62,6 @@ public static class CreateEndpoint
             }
 
             contentItem = await contentManager.NewAsync(model.ContentType);
-            contentItem.Owner = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
 
             if (!await authorizationService.AuthorizeAsync(httpContext.User, CommonPermissions.PublishContent, contentItem))
             {

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/BagPartDisplayDriver.cs
@@ -104,9 +104,6 @@ public sealed class BagPartDisplayDriver : ContentPartDisplayDriver<BagPart>
         {
             var contentItem = await _contentManager.NewAsync(model.ContentTypes[i]);
 
-            // Assign the owner of the item to ensure we can validate access to it later.
-            contentItem.Owner = GetCurrentOwner();
-
             // Try to match the requested id with an existing id
             ContentItem existingContentItem = null;
 

--- a/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Flows/Drivers/FlowPartDisplayDriver.cs
@@ -128,9 +128,6 @@ public sealed class FlowPartDisplayDriver : ContentPartDisplayDriver<FlowPart>
         {
             var contentItem = await _contentManager.NewAsync(model.ContentTypes[i]);
 
-            // Assign the owner of the item to ensure we can validate access to it later.
-            contentItem.Owner = GetCurrentOwner();
-
             // Try to match the requested id with an existing id
             ContentItem existingContentItem = null;
 

--- a/src/OrchardCore.Modules/OrchardCore.Lists/RemotePublishing/MetaWeblogHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/RemotePublishing/MetaWeblogHandler.cs
@@ -265,7 +265,6 @@ public class MetaWeblogHandler : IXmlRpcHandler
         var postType = (await GetContainedContentTypesAsync(list)).FirstOrDefault();
         var contentItem = await _contentManager.NewAsync(postType.Name);
 
-        contentItem.Owner = user.FindFirstValue(ClaimTypes.NameIdentifier);
         contentItem.Alter<ContainedPart>(x => x.ListContentItemId = list.ContentItemId);
 
         foreach (var driver in _metaWeblogDrivers)

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
@@ -12,7 +12,7 @@
         {
             continue;
         }
-        
+
         authorizedContentTypeDefinitions.Add(contentTypeDefinition);
     }
 }
@@ -36,12 +36,9 @@
             {
                 var contentTypeDefinition = authorizedContentTypeDefinitions.FirstOrDefault();
 
-                if (await AuthorizationService.AuthorizeContentTypeAsync(User, CommonPermissions.EditContent, contentTypeDefinition, User.Identity.Name))
-                {
-                    <a class="btn btn-secondary" asp-action="Create" asp-controller="Admin" asp-route-id="@contentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.Container.ContentItemId" asp-route-ListPart.ContainerContentType="@Model.ContainerContentTypeDefinition?.Name" asp-route-ListPart.ContentType="@contentTypeDefinition.Name" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
-                        @T["Create {0}", contentTypeDefinition.DisplayName]
-                    </a>
-                }
+                <a class="btn btn-secondary" asp-action="Create" asp-controller="Admin" asp-route-id="@contentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.Container.ContentItemId" asp-route-ListPart.ContainerContentType="@Model.ContainerContentTypeDefinition?.Name" asp-route-ListPart.ContentType="@contentTypeDefinition.Name" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
+                    @T["Create {0}", contentTypeDefinition.DisplayName]
+                </a>
             }
             else if (authorizedContentTypeDefinitions.Count > 1)
             {
@@ -51,10 +48,6 @@
                 <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
                     @foreach (var containedContentTypeDefinition in authorizedContentTypeDefinitions)
                     {
-                        if (!await AuthorizationService.AuthorizeContentTypeAsync(User, CommonPermissions.EditContent, containedContentTypeDefinition, User.Identity.Name))
-                        {
-                            continue;
-                        }
                         <li>
                             <a class="dropdown-item" asp-action="Create" asp-controller="Admin" asp-route-id="@containedContentTypeDefinition.Name" asp-route-area="OrchardCore.Contents" asp-route-ListPart.ContainerId="@Model.Container.ContentItemId" asp-route-ListPart.ContainerContentType="@Model.ContainerContentTypeDefinition?.Name" asp-route-ListPart.ContentType="@containedContentTypeDefinition.Name" asp-route-ListPart.EnableOrdering="@Model.EnableOrdering" asp-route-returnUrl="@FullRequestPath">
                                 @containedContentTypeDefinition.DisplayName

--- a/src/OrchardCore/OrchardCore.ContentManagement/Handlers/UpdateContentsHandler.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/Handlers/UpdateContentsHandler.cs
@@ -9,10 +9,26 @@ public class UpdateContentsHandler : ContentHandlerBase
     private readonly IClock _clock;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public UpdateContentsHandler(IClock clock, IHttpContextAccessor httpContextAccessor)
+    public UpdateContentsHandler(
+        IClock clock,
+        IHttpContextAccessor httpContextAccessor)
     {
         _clock = clock;
         _httpContextAccessor = httpContextAccessor;
+    }
+
+    public override Task InitializingAsync(InitializingContentContext context)
+    {
+        var httpContext = _httpContextAccessor.HttpContext;
+
+        // It is imortant to set the owner during initialization own permission are validated correctly everywhere.
+        if (httpContext?.User.Identity?.IsAuthenticated == true)
+        {
+            context.ContentItem.Owner = httpContext.User.FindFirstValue(ClaimTypes.NameIdentifier);
+            context.ContentItem.Author = httpContext.User.Identity.Name;
+        }
+
+        return Task.CompletedTask;
     }
 
     public override Task CreatingAsync(CreateContentContext context)

--- a/src/OrchardCore/OrchardCore.Contents.Core/AuthorizationServiceExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Contents.Core/AuthorizationServiceExtensions.cs
@@ -54,7 +54,6 @@ public static class AuthorizationServiceExtensions
             var dynamicPermission = ContentTypePermissionsHelper.CreateDynamicPermission(contentTypePermission, contentTypeDefinition);
 
             var contentItem = await contentManager.NewAsync(contentTypeDefinition.Name);
-            contentItem.Owner = user.FindFirstValue(ClaimTypes.NameIdentifier);
 
             if (await service.AuthorizeAsync(user, dynamicPermission, contentItem))
             {


### PR DESCRIPTION
Fixes #18412

This change ensures that the **owner** is correctly set during the initialization of a content item.

* This guarantees that permission checks (e.g., "Edit own …") are evaluated properly.
* It also cleans up multiple areas of the code where the owner was being set manually.
* Finally, it resolves the referenced issue where a user with the **"Edit own blog post"** permission was unable to create a new blog post.