### PR TITLE
Make the TitlePart based on its actual value 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Drivers/TitlePartDisplayDriver.cs
@@ -28,7 +28,7 @@ public sealed class TitlePartDisplayDriver : ContentPartDisplayDriver<TitlePart>
 
         return Initialize<TitlePartViewModel>(GetDisplayShapeType(context), model =>
         {
-            model.Title = titlePart.ContentItem.DisplayText;
+            model.Title = titlePart.Title;
             model.TitlePart = titlePart;
             model.ContentItem = titlePart.ContentItem;
         }).Location(OrchardCoreConstants.DisplayType.Detail, "Header")
@@ -39,7 +39,7 @@ public sealed class TitlePartDisplayDriver : ContentPartDisplayDriver<TitlePart>
     {
         return Initialize<TitlePartViewModel>(GetEditorShapeType(context), model =>
         {
-            model.Title = titlePart.ContentItem.DisplayText;
+            model.Title = titlePart.Title;
             model.TitlePart = titlePart;
             model.ContentItem = titlePart.ContentItem;
             model.Settings = context.TypePartDefinition.GetSettings<TitlePartSettings>();


### PR DESCRIPTION
Make the Title rely on the actual `TitlePart.Title` value instead of `ContentItem.DisplayText`, since the `DisplayText` can be altered by handlers or other code. Depending on it may cause inconsistencies between the stored value and what gets displayed.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
