### PR TITLE
Reduce empty array allocations.

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Filters/LiquidViewFilters.cs
@@ -17,7 +17,7 @@ public static class LiquidViewFilters
             return ThrowArgumentException<ValueTask<FluidValue>>("ViewLocalizer missing while invoking 't'");
         }
 
-        var parameters = new object[arguments.Count];
+        var parameters = arguments.Count > 0 ? new object[arguments.Count] : [];
         for (var i = 0; i < arguments.Count; i++)
         {
             parameters[i] = arguments.At(i).ToStringValue();

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeAttributeStrategy/ShapeAttributeBindingStrategy.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Descriptors/ShapeAttributeStrategy/ShapeAttributeBindingStrategy.cs
@@ -75,7 +75,7 @@ public class ShapeAttributeBindingStrategy : ShapeTableProvider, IShapeTableHarv
         {
             action = (s, d) =>
             {
-                var arguments = new object[argumentBuilders.Length];
+                var arguments = argumentBuilders.Length > 0 ? new object[argumentBuilders.Length] : [];
                 for (var i = 0; i < arguments.Length; i++)
                 {
                     arguments[i] = argumentBuilders[i](d);
@@ -88,7 +88,7 @@ public class ShapeAttributeBindingStrategy : ShapeTableProvider, IShapeTableHarv
         {
             action = (s, d) =>
             {
-                var arguments = new object[argumentBuilders.Length];
+                var arguments = argumentBuilders.Length > 0 ? new object[argumentBuilders.Length] : [];
                 for (var i = 0; i < arguments.Length; i++)
                 {
                     arguments[i] = argumentBuilders[i](d);
@@ -101,7 +101,7 @@ public class ShapeAttributeBindingStrategy : ShapeTableProvider, IShapeTableHarv
         {
             action = (s, d) =>
             {
-                var arguments = new object[argumentBuilders.Length];
+                var arguments = argumentBuilders.Length > 0 ? new object[argumentBuilders.Length] : [];
                 for (var i = 0; i < arguments.Length; i++)
                 {
                     arguments[i] = argumentBuilders[i](d);


### PR DESCRIPTION
Profiling revealed a significant number of empty arrays being allocated by `LiquidViewFilters.Localize` and the `ShapeAttributeBindingStrategy`, so I added a quick special case to avoid those allocations.