### PR TITLE
Fix invalid aria-labelledby attribute on ul elements

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Themes/Views/ToggleTheme.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Views/ToggleTheme.cshtml
@@ -4,7 +4,7 @@
             <span class="theme-icon-active"><i class="fa-solid fa-circle-half-stroke"></i></span>
             <span class="d-none" id="bd-theme-text">@T["Toggle theme"]</span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-end position-absolute" aria-labelledby="bd-theme-text">
+        <ul class="dropdown-menu dropdown-menu-end position-absolute">
             <li>
                 <button type="button" class="dropdown-item" data-bs-theme-value="auto" aria-pressed="false">
                     <span class="theme-icon">

--- a/src/OrchardCore.Themes/TheAdmin/Views/ToggleTheme.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/ToggleTheme.cshtml
@@ -4,7 +4,7 @@
             <span class="theme-icon-active"><i class="fa-solid fa-circle-half-stroke"></i></span>
             <span class="d-none" id="bd-theme-text">@T["Toggle theme"]</span>
         </button>
-        <ul class="dropdown-menu dropdown-menu-end position-absolute" aria-labelledby="bd-theme-text">
+        <ul class="dropdown-menu dropdown-menu-end position-absolute">
             <li>
                 <button type="button" class="dropdown-item" data-bs-theme-value="auto" aria-pressed="false">
                     <span class="theme-icon">

--- a/src/OrchardCore.Themes/TheTheme/Views/ToggleTheme.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/ToggleTheme.cshtml
@@ -3,7 +3,7 @@
         <span class="theme-icon-active"><i class="fa-solid fa-circle-half-stroke"></i></span>
         <span class="d-none" id="bd-theme-text">@T["Toggle theme"]</span>
     </a>
-    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bd-theme-text">
+    <ul class="dropdown-menu dropdown-menu-end">
         <li>
             <button type="button" class="dropdown-item" data-bs-theme-value="auto" aria-pressed="false">
                 <span class="theme-icon">


### PR DESCRIPTION
## Description

This PR removes invalid `aria-labelledby="bd-theme-text"` attributes from `<ul>` elements in ToggleTheme views across themes. According to HTML validation rules (https://html-validate.org/rules/aria-label-misuse.html), `aria-labelledby` should not be used on `<ul>` elements.

## Changes Made

- Removed `aria-labelledby="bd-theme-text"` from `<ul>` elements in:
  - `src/OrchardCore.Themes/TheTheme/Views/ToggleTheme.cshtml`
  - `src/OrchardCore.Themes/TheAdmin/Views/ToggleTheme.cshtml`
  - `src/OrchardCore.Modules/OrchardCore.Themes/Views/ToggleTheme.cshtml`

## Verification

- ✅ Build succeeds with 0 warnings and 0 errors
- ✅ All occurrences of the invalid attribute have been removed
- ✅ No linting errors introduced

Fixes #18510