### PR TITLE
Save changes to the database before returning from OpenId stores.

### DIFF
--- a/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
+++ b/src/OrchardCore/OrchardCore.OpenId.Core/YesSql/Stores/OpenIdTokenStore.cs
@@ -45,6 +45,8 @@ public class OpenIdTokenStore<TToken> : IOpenIdTokenStore<TToken>
         cancellationToken.ThrowIfCancellationRequested();
 
         await _session.SaveAsync(token, collection: OpenIdCollection, cancellationToken: cancellationToken);
+        // Commit the transaction immediately to avoid a race condition if the token is used before this ASP.NET request scope is disposed.
+        // This can happen when the response header includes the token since the response starts streaming before the request is fully processed.
         await _session.SaveChangesAsync(cancellationToken);
     }
 
@@ -435,6 +437,7 @@ public class OpenIdTokenStore<TToken> : IOpenIdTokenStore<TToken>
             await _session.SaveAsync(token, checkConcurrency: false, collection: OpenIdCollection, cancellationToken: cancellationToken);
         }
 
+        // Commit the transaction immediately to prevent the revoked token from being used.
         await _session.SaveChangesAsync(cancellationToken);
 
         return tokens.Count;
@@ -468,6 +471,7 @@ public class OpenIdTokenStore<TToken> : IOpenIdTokenStore<TToken>
             await _session.SaveAsync(token, checkConcurrency: false, collection: OpenIdCollection, cancellationToken: cancellationToken);
         }
 
+        // Commit the transaction immediately to prevent the revoked token from being used.
         await _session.SaveChangesAsync(cancellationToken);
 
         return tokens.Count;
@@ -501,6 +505,7 @@ public class OpenIdTokenStore<TToken> : IOpenIdTokenStore<TToken>
             await _session.SaveAsync(token, checkConcurrency: false, collection: OpenIdCollection, cancellationToken: cancellationToken);
         }
 
+        // Commit the transaction immediately to prevent the revoked token from being used.
         await _session.SaveChangesAsync(cancellationToken);
 
         return tokens.Count;
@@ -533,6 +538,7 @@ public class OpenIdTokenStore<TToken> : IOpenIdTokenStore<TToken>
             await _session.SaveAsync(token, checkConcurrency: false, collection: OpenIdCollection, cancellationToken: cancellationToken);
         }
 
+        // Commit the transaction immediately to prevent the revoked token from being used.
         await _session.SaveChangesAsync(cancellationToken);
 
         return tokens.Count;
@@ -680,6 +686,8 @@ public class OpenIdTokenStore<TToken> : IOpenIdTokenStore<TToken>
 
         try
         {
+            // Commit the transaction immediately to avoid a race condition if the token is used before this ASP.NET request scope is disposed.
+            // This can happen when the response header includes the token since the response starts streaming before the request is fully processed.
             await _session.SaveChangesAsync(cancellationToken);
         }
         catch (ConcurrencyException exception)


### PR DESCRIPTION
Fixes #18520.

This reverts some of the changes introduced in [#18039](https://github.com/OrchardCMS/OrchardCore/pull/18039).

With this change, database updates made by the OpenId stores are immediately committed to the database as they were before 2.1.7. This makes them immediately visible to other sessions and fixes the issue referenced above. 

This change also addresses caching problems that could have resulted from holding the changes until the session was disposed. The OpenIddict library uses these stores (e.g. OpenIdTokenStore) from the corresponding Manager class (e.g. OpenIddictTokenManager) which also maintains a cache (OpenIddictTokenCache). After the manager pushes the update through the Store it also notifies the Cache. The cache invalidates the created/updated/deleted entry. It assumes that the store has durably written the update before invalidating the cache. If that update was not actually committed, then the cache can get out of sync as another session could use the manager to read from the cache. Since the cache entry was just invalidated, it will result in a cache miss that goes to the database. That database read will not see the uncommitted transaction and will reload the stale data into the cache.

CC @sebastienros @kevinchalet 
