### PR TITLE
Fix pluralization for pagers with 0 or 1 item

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Menu/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Menu/List.cshtml
@@ -39,7 +39,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.AdminMenu.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.AdminMenu.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted form-label" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailAdminListSummary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailAdminListSummary.cshtml
@@ -2,7 +2,7 @@
 
 <div class="text-nowrap">
     <label class="my-1" id="items" for="select-all">
-        @T.Plural(Model.EventsCount, "1 item", "{0} items")
-        <span class="text-muted" title="@T["Items {0} to {1}", Model.StartIndex, Model.EndIndex]">@T.Plural(Model.TotalItemCount, " / 1 item in total", " / {0} items in total")</span>
+        @T.Plural(Model.EventsCount, "{0} item", "{0} items")
+		<span class="text-muted" title="@T["Items {0} to {1}", Model.StartIndex, Model.EndIndex]">@T.Plural(Model.TotalItemCount, " / {0} item in total", " / {0} items in total")</span>
     </label>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListSummary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListSummary.cshtml
@@ -4,7 +4,7 @@
     <div class="form-check my-1">
         <input type="checkbox" class="form-check-input" id="select-all">
         <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-        <label id="items" for="select-all">@T.Plural((int)Model.ContentItemsCount, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", (int)Model.StartIndex, (int)Model.EndIndex]">@T.Plural((int)Model.TotalItemCount, " / 1 item in total", " / {0} items in total")</span></label>
+		<label id="items" for="select-all">@T.Plural((int)Model.ContentItemsCount, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", (int)Model.StartIndex, (int)Model.EndIndex]">@T.Plural((int)Model.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
         <label id="selected-items" class="text-muted" for="select-all"></label>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteClient/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteClient/Index.cshtml
@@ -41,7 +41,7 @@
                             <div class="form-check my-1">
                                 <input type="checkbox" class="form-check-input" id="select-all">
                                 <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                                <label id="items" for="select-all">@T.Plural(Model.RemoteClients.Count(), "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                                <label id="items" for="select-all">@T.Plural(Model.RemoteClients.Count(), "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                                 <label id="selected-items" class="text-muted" for="select-all"></label>
                             </div>
                         </div>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteInstance/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteInstance/Index.cshtml
@@ -36,7 +36,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.RemoteInstances.Count(), "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.RemoteInstances.Count(), "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
@@ -36,7 +36,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.DeploymentPlans.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.DeploymentPlans.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/Views/Admin/Index.cshtml
@@ -44,7 +44,7 @@
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
                             <label id="items" for="select-all">
-                                @T.Plural(Model.Models.Count, "1 item", "{0} items")
+                                @T.Plural(Model.Models.Count, "{0} item", "{0} items")
                                 <span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">
                                     @T.Plural(Model.Models.Count, " / {0} item in total", " / {0} items in total")
                                 </span>

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Index.cshtml
@@ -37,7 +37,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.MediaProfiles.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.MediaProfiles.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsAdminListSummary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsAdminListSummary.cshtml
@@ -6,7 +6,7 @@
     <div class="form-check my-1">
         <input type="checkbox" class="form-check-input" id="select-all">
         <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-        <label id="items" for="select-all">@T.Plural((int)Model.NotificationsCount, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", (int)Model.StartIndex, (int)Model.EndIndex]">@T.Plural((int)Model.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+        <label id="items" for="select-all">@T.Plural((int)Model.NotificationsCount, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", (int)Model.StartIndex, (int)Model.EndIndex]">@T.Plural((int)Model.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
         <label id="selected-items" class="text-muted" for="select-all"></label>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Index.cshtml
@@ -37,7 +37,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.ShapePlacements.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.ShapePlacements.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
@@ -36,7 +36,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.Queries.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.Queries.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Index.cshtml
@@ -37,7 +37,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.ShortcodeTemplates.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.ShortcodeTemplates.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
@@ -41,7 +41,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.Sitemaps.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.Sitemaps.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
@@ -41,7 +41,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.SitemapIndexes.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.SitemapIndexes.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
@@ -45,7 +45,7 @@ else
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.Templates.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.Templates.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
@@ -40,7 +40,7 @@
                     <div class="form-check my-1">
                         <input type="checkbox" class="form-check-input" id="select-all">
                         <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                        <label id="items" for="select-all">@T.Plural(Model.ShellSettingsEntries.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                        <label id="items" for="select-all">@T.Plural(Model.ShellSettingsEntries.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                         <label id="selected-items" class="text-muted" for="select-all"></label>
                     </div>
                 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
@@ -37,7 +37,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.FeatureProfiles.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.FeatureProfiles.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/Admin/Index.cshtml
@@ -39,7 +39,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.Rules.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural(Model.Rules.Count, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.Rules.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural(Model.Rules.Count, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminListSummary.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminListSummary.cshtml
@@ -4,7 +4,7 @@
     <div class="form-check mt-2 me-n2">
         <input type="checkbox" class="form-check-input" id="select-all">
         <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-        <label id="items" for="select-all">@T.Plural((int)Model.UsersCount, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", (int)Model.StartIndex, (int)Model.EndIndex]">@T.Plural((int)Model.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+        <label id="items" for="select-all">@T.Plural((int)Model.UsersCount, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", (int)Model.StartIndex, (int)Model.EndIndex]">@T.Plural((int)Model.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
         <label id="selected-items" class="text-muted" for="select-all"></label>
     </div>
 </div>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
@@ -35,7 +35,7 @@
                             <div class="form-check mt-2 me-n2">
                                 <input type="checkbox" class="form-check-input" id="select-all">
                                 <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                                <label id="items" for="select-all">@T.Plural(Model.Workflows.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                                <label id="items" for="select-all">@T.Plural(Model.Workflows.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                                 <label id="selected-items" class="text-muted" for="select-all"></label>
                             </div>
                         </div>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
@@ -38,7 +38,7 @@
                         <div class="form-check my-1">
                             <input type="checkbox" class="form-check-input" id="select-all">
                             <label class="form-check-label" for="select-all" id="select-all-label" title="@T["Select All"]"></label>
-                            <label id="items" for="select-all">@T.Plural(Model.WorkflowTypes.Count, "1 item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
+                            <label id="items" for="select-all">@T.Plural(Model.WorkflowTypes.Count, "{0} item", "{0} items")<span class="text-muted" title="@T["Items {0} to {1}", startIndex, endIndex]">@T.Plural((int)Model.Pager.TotalItemCount, " / {0} item in total", " / {0} items in total")</span></label>
                             <label id="selected-items" class="text-muted" for="select-all"></label>
                         </div>
                     </div>


### PR DESCRIPTION
Change the first parameter of many @T.Plural() methods.
Ex: `1 item` has to be changed to `{0} item` because for languages like French whose `PluralRuleDelegate` is `n => (n > 1 ? 1 : 0)`, if there are 0 items, it will display the localization of "1 item" instead of replacing the count by 0 or 1.

https://github.com/OrchardCMS/OrchardCore/blob/6bb7c24a829c6976380f2fd319fe9397dd00455f/src/OrchardCore/OrchardCore.Localization.Core/DefaultPluralRuleProvider.cs#L19

Some of these are inside an if condition like this:
`@if (Model.Models.Count > 0)` 
so the 0 case won't occur, but some others like Menus, Content items, AuditTrails are not inside this kind of `.Count > 0` condition.

An annoying impact will be that the correct translations will be only effective when the strings are updated and translated on Crowdin, and then published in OrchardCore.Translations.

Before change, when there are 0 items and current culture is French:
<img width="550" height="311" alt="image" src="https://github.com/user-attachments/assets/a2c7c9ac-b4a4-4fa8-bd9e-edd59b90d06d" />

After change (current PR): 
<img width="433" height="307" alt="image" src="https://github.com/user-attachments/assets/076dac45-66a7-43cb-a541-d89f1a6671c3" />
 
Expected result when merged and fully translated:
<img width="550" height="311" alt="image" src="https://github.com/user-attachments/assets/1adc77a5-9516-46ca-8fb7-a0a9741e4f27" />
