### PR TITLE
Add Star History chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ Cloudsmith is the only fully hosted, cloud-native, universal package management 
 
 See [our Code of Conduct](https://docs.orchardcore.net/en/latest/contributing/#code-of-conduct).
 
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=OrchardCMS/OrchardCore&type=Date)](https://star-history.com/#OrchardCMS/OrchardCore&Date)
+
 ## .NET Foundation
 
 This project is supported by the [.NET Foundation](http://www.dotnetfoundation.org).


### PR DESCRIPTION
## Summary
- Adds a Star History chart section to the README
- Visualizes the project's growth in GitHub stars over time
- Uses the embed from star-history.com as suggested in the issue

## Changes Made
- Added new "Star History" section to README.md before the ".NET Foundation" section
- Embedded clickable SVG chart that links to the interactive star-history.com page

## Test Plan
- Verified the markdown renders correctly
- Chart is clickable and links to the full interactive view at star-history.com

Fixes #15342