### PR TITLE
Specify 'area' when using LinkGenerator in WorkflowTypeStep

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Recipes/WorkflowTypeStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Recipes/WorkflowTypeStep.cs
@@ -75,7 +75,7 @@ public sealed class WorkflowTypeStep : NamedRecipeStepHandler
 
         var token = _securityTokenService.CreateToken(new WorkflowPayload(workflow.WorkflowTypeId, activity.ActivityId), lifespan);
 
-        return _linkGenerator.GetPathByAction(_httpContextAccessor.HttpContext, "Invoke", "HttpWorkflow", new { token });
+        return _linkGenerator.GetPathByAction(_httpContextAccessor.HttpContext, "Invoke", "HttpWorkflow", new { area = "OrchardCore.Workflows", token });
     }
 }
 


### PR DESCRIPTION
This pull request introduces a small but important fix to the URL generation logic for HTTP workflow invocation. The change ensures that the correct route area is specified when generating the URL, which helps avoid routing issues in multi-area setups.

* Added the `area = "OrchardCore.Workflows"` parameter to the route values in the `GetRegenerateHttpRequestEventUrl` method in `WorkflowTypeStep.cs`, ensuring the generated URL correctly targets the workflows area.