### PR TITLE
Specifiation changes:

### DIFF
--- a/src/OrchardCore.Cms.Web/Program.cs
+++ b/src/OrchardCore.Cms.Web/Program.cs
@@ -6,6 +6,7 @@ builder.Host.UseNLogHost();
 
 builder.Services
     .AddOrchardCms()
+    .ConfigureReCaptchaSettings()
     .AddSetupFeatures("OrchardCore.AutoSetup");
 
 var app = builder.Build();

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaForgotPasswordFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaForgotPasswordFormDisplayDriver.cs
@@ -1,9 +1,9 @@
 using System.Globalization;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.Settings;
 using OrchardCore.Users.Models;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Drivers;
 

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaLoginFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaLoginFormDisplayDriver.cs
@@ -1,9 +1,9 @@
 using System.Globalization;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.Settings;
 using OrchardCore.Users.Models;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Drivers;
 
@@ -19,11 +19,6 @@ public sealed class ReCaptchaLoginFormDisplayDriver : DisplayDriver<LoginForm>
     public override async Task<IDisplayResult> EditAsync(LoginForm model, BuildEditorContext context)
     {
         var settings = await _siteService.GetSettingsAsync<ReCaptchaSettings>();
-
-        if (!settings.ConfigurationExists())
-        {
-            return null;
-        }
 
         return Dynamic("ReCaptcha", (m) =>
         {

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaResetPasswordFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaResetPasswordFormDisplayDriver.cs
@@ -1,9 +1,9 @@
 using System.Globalization;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.Settings;
 using OrchardCore.Users.Models;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Drivers;
 

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaSettingsDisplayDriver.cs
@@ -4,9 +4,9 @@ using OrchardCore.DisplayManagement.Entities;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.Environment.Shell;
-using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.ReCaptcha.ViewModels;
 using OrchardCore.Settings;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Drivers;
 

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/RegisterUserFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/RegisterUserFormDisplayDriver.cs
@@ -1,9 +1,9 @@
 using System.Globalization;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.Settings;
 using OrchardCore.Users.Models;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Drivers;
 

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Forms/ReCaptchaPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Forms/ReCaptchaPartDisplayDriver.cs
@@ -1,8 +1,8 @@
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.DisplayManagement.Views;
-using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.Settings;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Forms;
 

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Startup.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Modules;
 using OrchardCore.Navigation;
-using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.ReCaptcha.Core;
 using OrchardCore.ReCaptcha.Drivers;
 using OrchardCore.ReCaptcha.Users.Handlers;
@@ -11,6 +10,7 @@ using OrchardCore.Settings.Deployment;
 using OrchardCore.Users;
 using OrchardCore.Users.Events;
 using OrchardCore.Users.Models;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha;
 

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Configuration/ReCaptchaSettingsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Configuration/ReCaptchaSettingsConfiguration.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using OrchardCore.Settings;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Configuration;
 

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Extensions/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Extensions/OrchardCoreBuilderExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Configuration;
+using OrchardCore.Environment.Shell.Configuration;
+
+// MEIJIRO_TODO: Added this
+using OrchardCore.ReCaptcha.Settings;
+
+namespace Microsoft.Extensions.DependencyInjection;
+public static class OrchardCoreBuilderExtensions
+{
+    public static OrchardCoreBuilder ConfigureReCaptchaSettings(this OrchardCoreBuilder builder)
+    {
+        builder.ConfigureServices((tenantServices, serviceProvider) =>
+        {
+            var shellConfiguration = serviceProvider.GetRequiredService<IShellConfiguration>().GetSection("OrchardCore.ReCaptcha");
+
+            tenantServices.PostConfigure<ReCaptchaSettings>(settings => shellConfiguration.Bind(settings));
+        });
+
+        return builder;
+    }
+}

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using OrchardCore.ReCaptcha.Configuration;
 using OrchardCore.ReCaptcha.Services;
 using OrchardCore.ReCaptcha.TagHelpers;
 using Polly;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Core;
 

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaService.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaService.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using OrchardCore.ReCaptcha.Configuration;
+using OrchardCore.ReCaptcha.Settings;
 
 namespace OrchardCore.ReCaptcha.Services;
 

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Settings/ReCaptchaSettings.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Settings/ReCaptchaSettings.cs
@@ -1,4 +1,4 @@
-namespace OrchardCore.ReCaptcha.Configuration;
+namespace OrchardCore.ReCaptcha.Settings;
 
 public class ReCaptchaSettings
 {

--- a/src/docs/reference/modules/ReCaptcha/README.md
+++ b/src/docs/reference/modules/ReCaptcha/README.md
@@ -9,6 +9,21 @@ There are four features in the module:
 In order to activate the ReCaptcha feature, you have to create an account with Google and enter the secret and site key in the Admin section.
 You can sign up here: <https://developers.google.com/recaptcha/>
 
+The OrchardCore.ReCaptcha module can use configuration values to override the settings configured from the admin menu by calling `ConfigureReCaptchaSettings`
+extension methods from `OrchardCoreBuilder` when initializing the app.
+
+The following configuration can be applied to ReCaptchaSettings:
+
+``` json
+{
+    "OrchardCore.ReCaptcha": {
+        "SiteKey": "YOUR_SITE_KEY",
+        "SecretKey": "YOUR_SECRET_KEY"
+    }
+}
+```
+
+
 ### Users protection
 
 You can enable this feature in the admin section and your login pages will be protected against robots.


### PR DESCRIPTION
RecaptchaSettings.cs have been moved to it's own settings folder to better organize the application flow. RecaptchaShape now uses IOptions<Recaptcha> to allow post configuration of Recaptcha's builder extension method to allow envrionment variables use case. OrchardCoreBuilderExtensions.cs has been added as part of the extension method for RecaptchaSettings.

In  the orchardcore drivers, the adjusted namespace to account for RecaptchaSettings.cs new position have been set for the drivers, forms, and the startup.cs file itself.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

If there are any further questions, feel free to reach out to me, there may be some other files that need to account for the new specification of RecaptchaSettings.
