### PR TITLE
Normalize input paths in cloud file stores to match IFileStore semantics

### DIFF
--- a/src/OrchardCore/OrchardCore.FileStorage.AmazonS3/AwsFileStorage.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AmazonS3/AwsFileStorage.cs
@@ -67,6 +67,8 @@ public class AwsFileStore : IFileStore
     public async IAsyncEnumerable<IFileStoreEntry> GetDirectoryContentAsync(string path = null,
         bool includeSubDirectories = false)
     {
+        path = this.NormalizePath(path);
+        
         var listObjectsResponse = await _amazonS3Client.ListObjectsV2Async(new ListObjectsV2Request
         {
             BucketName = _options.BucketName,

--- a/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
+++ b/src/OrchardCore/OrchardCore.FileStorage.AzureBlob/BlobFileStore.cs
@@ -124,6 +124,8 @@ public class BlobFileStore : IFileStore
 
     private async IAsyncEnumerable<IFileStoreEntry> GetDirectoryContentByHierarchyAsync(string path = null)
     {
+        path = this.NormalizePath(path);
+        
         var prefix = this.Combine(_basePrefix, path);
         prefix = NormalizePrefix(prefix);
 
@@ -158,6 +160,8 @@ public class BlobFileStore : IFileStore
 
     private async IAsyncEnumerable<IFileStoreEntry> GetDirectoryContentFlatAsync(string path = null)
     {
+        path = this.NormalizePath(path);
+        
         // Folders are considered case sensitive in blob storage.
         var directories = new HashSet<string>();
 


### PR DESCRIPTION
This PR fixes inconsistent path handling in cloud-based `IFileStore` implementations by normalizing input paths before they are used in comparisons and directory operations.

### Problem

`IFileStore` defines forward slash (`/`) as the path delimiter. However, some cloud file store implementations (Azure Blob and AWS S3) were using the raw `path` parameter in string comparisons (e.g. `EndsWith(path)`), which could lead to incorrect behavior when callers passed Windows-style paths using backslashes (`\`).

For example:

```
"folder/subfolder".EndsWith("folder\\subfolder")==false

```

This could result in incorrect directory listings or filtering behavior. The issue is less visible when using `FileSystemStore`, as it already normalizes paths internally.

### Changes

- Normalize the input `path` at the beginning of directory content methods to ensure consistent behavior with the `IFileStore` contract.
- Applied the same fix to both cloud providers to keep behavior aligned.

Specifically:

- **Azure Blob**
    - Normalize `path` in directory listing methods before performing comparisons.
- **AWS S3**
    - Normalize `path` in directory content retrieval before filtering.

### Why this change is correct

- `IFileStore` explicitly defines `/` as the canonical path separator.
- Other code paths (such as `Combine(...)`) already normalize paths, but direct string comparisons were still using unnormalized input.
- Normalizing at the provider boundary ensures consistent, predictable behavior without affecting callers that already pass normalized paths.

### Testing

- This change was not covered by automated tests because the affected providers require external cloud dependencies.
- The modification is limited to pure path normalization logic and does not alter cloud I/O behavior.
- Behavior is consistent with existing normalization patterns used elsewhere in the codebase.

If maintainers prefer extracting this logic for unit testing or adding provider-specific tests, I’m happy to update the PR accordingly.

Fixes #14328