### PR TITLE
Fix default search index selection using index name

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Search/Drivers/SearchSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Drivers/SearchSettingsDisplayDriver.cs
@@ -49,7 +49,7 @@ public sealed class SearchSettingsDisplayDriver : SiteDisplayDriver<SearchSettin
             model.Placeholder = settings.Placeholder;
             model.PageTitle = settings.PageTitle;
             model.Indexes = (await _indexProfileStore.GetAllAsync())
-                .Select(index => new SelectListItem(index.Name, index.Id))
+                .Select(index => new SelectListItem(index.Name, index.Name))
                 .ToArray();
         }).Location("Content:2")
         .OnGroup(SettingsGroupId);


### PR DESCRIPTION
This PR fixes an issue where the configured default search index (in Elasticsearch) was not being applied when navigating to `/search/`, even though it was correctly saved in admin settings.

### **Problem**

The “Default search index” setting was populated and stored using `index.Id`, but `SearchController` resolves the default index using `FindByNameAsync(searchSettings.DefaultIndexProfileName)`. Since `searchSettings.DefaultIndexProfileName` contained an ID rather than a name, the lookup failed and the default index appeared to be unset.

### **Changes**

- Updated the search settings dropdown to use the **index name** as the stored value instead of the ID:
    
    ```csharp
    model.Indexes = (await _indexProfileStore.GetAllAsync())
        .Select(index =>new SelectListItem(index.Name, index.Name))
        .ToArray();
    ```
    
    This ensures that the value saved in `DefaultIndexProfileName` matches what `FindByNameAsync()` expects.
    

### **Why this change is correct**

- `DefaultIndexProfileName` semantically stores a **profile name**, not an ID.
- The controller lookup (`FindByNameAsync`) operates on the name.
- This change restores consistency between what is saved in settings and how it is resolved at runtime.

### **Manual verification steps**

Due to external dependencies (Elasticsearch), this fix has not been verified with a live search provider. However, the logic has been verified by inspection and by reproducing the mismatch in the referenced issue.

To manually verify:

1. Start OrchardCore with an Elasticsearch provider configured.
2. Create an index via Admin → Search → Indexes.
3. Set it as the default search index via Admin → Settings → Search → Site Search.
4. Navigate to `/search/` and confirm that the default index is respected.

### **References**

Fixes #18707