### PR TITLE
Fix off-by-one error in `DefaultScriptingManager`

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Scripting/DefaultScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Scripting/DefaultScriptingManager.cs
@@ -23,7 +23,7 @@ public class DefaultScriptingManager : IScriptingManager
         IEnumerable<IGlobalMethodProvider> scopedMethodProviders)
     {
         var directiveIndex = directive.IndexOf(':');
-        if (directiveIndex == -1 || directiveIndex >= directive.Length - 2)
+        if (directiveIndex == -1 || directiveIndex >= directive.Length - 1)
         {
             return directive;
         }


### PR DESCRIPTION
This pull request makes a small correction to the directive parsing logic in the `DefaultScriptingManager.cs` file. The change fixes an off-by-one error in the condition that checks the position of the colon in the directive string.

Fixes #1727