### PR TITLE
Remove all `aria-labelledby` attribtes of `<ul>` elements (Lombiq Technologies: OSOE-925)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/Dashboard/Manage.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/Dashboard/Manage.cshtml
@@ -29,7 +29,7 @@
             <button class="btn btn-secondary btn-sm dropdown-toggle" type="button" id="new-dropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 @T["Add Widget"]
             </button>
-            <ul class="dropdown-menu dropdown-menu-end scrollable" aria-labelledby="bulk-action-menu-button">
+            <ul class="dropdown-menu dropdown-menu-end scrollable">
                 @foreach (var item in Model.Creatable)
                 {
                     <li><a class="dropdown-item add-list-widget btn-sm" href="@Url.RouteUrl(new { area = "OrchardCore.Contents", controller = "Admin", action = "Create", id = @item.Value, returnUrl = FullRequestPath })">@T[Html.Encode(item.Text)]</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Menu/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Views/Menu/List.cshtml
@@ -48,7 +48,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailAdminListSearch.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailAdminListSearch.cshtml
@@ -20,7 +20,7 @@
     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" id="filter-dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="fa-solid fa-filter" title="@T["Filters"]" aria-hidden="true"></i>
     </button>
-    <ul class="@string.Join(' ', dropdownClassList)" aria-labelledby="filter-dropdown">
+    <ul class="@string.Join(' ', dropdownClassList)">
         @foreach (var category in categories)
         {
             <li><a class="dropdown-item" href="?q=category:@category.Name">@category.LocalizedName(Context.RequestServices)</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList.Fields.BulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminList.Fields.BulkActions.cshtml
@@ -5,7 +5,7 @@
     <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         @T["Actions"]
     </button>
-    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+    <ul class="dropdown-menu dropdown-menu-end">
         @{
             var bulkActions = await ContentOptionsDisplayManager.BuildDisplayAsync(Model, null, "BulkActions");
             if (bulkActions.TryGetProperty<IShape>("Content", out var content))

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListCreate.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsAdminListCreate.cshtml
@@ -14,7 +14,7 @@ else
         <button class="btn btn-secondary dropdown-toggle" type="button" id="new-dropdown" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             @T["New"]
         </button>
-        <ul class="dropdown-menu dropdown-menu-end scrollable" aria-labelledby="bulk-action-menu-button">
+        <ul class="dropdown-menu dropdown-menu-end scrollable">
             @foreach (var item in Model.CreatableTypes)
             {
                 <li><a class="dropdown-item" href="@Url.RouteUrl(new { area = "OrchardCore.Contents", controller = "Admin", action = "Create", id = @item.Value, returnUrl = FullRequestPath })">@T[Html.Encode(item.Text)]</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteClient/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteClient/Index.cshtml
@@ -52,7 +52,7 @@
                                 <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     @T["Actions"]
                                 </button>
-                                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                                <ul class="dropdown-menu dropdown-menu-end">
                                     @foreach (var item in Model.Options.ContentsBulkAction)
                                     {
                                         <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteInstance/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment.Remote/Views/RemoteInstance/Index.cshtml
@@ -45,7 +45,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Index.cshtml
@@ -45,7 +45,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.DeploymentPlansBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -28,7 +28,7 @@
                         <button class="btn btn-secondary dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             @T["Bulk Actions"]
                         </button>
-                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                        <ul class="dropdown-menu dropdown-menu-end">
                             <li><a class="dropdown-item" href="#" data-action="@nameof(FeaturesBulkAction.Disable)">@T["Disable"]</a></li>
                             <li><a class="dropdown-item" href="#" data-action="@nameof(FeaturesBulkAction.Enable)">@T["Enable"]</a></li>
                             <li><a class="dropdown-item" href="#" data-action="@nameof(FeaturesBulkAction.Toggle)">@T["Toggle"]</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/Views/Admin/Index.cshtml
@@ -57,7 +57,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.BulkActions)
                                 {
                                     <li>

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Views/Admin/Index.cshtml
@@ -78,7 +78,7 @@
                                         <button type="button" class="btn btn-primary btn-sm dropdown-toggle" id="@htmlId" data-bs-toggle="dropdown" aria-expanded="false">
                                             @T["Add Widget"]
                                         </button>
-                                        <ul class="dropdown-menu px-2 overflow-auto" aria-labelledby="@htmlId" style="max-height: 15rem;">
+                                        <ul class="dropdown-menu px-2 overflow-auto" style="max-height: 15rem;">
                                             @foreach (var type in widgetContentTypes)
                                             {
                                                 var contentItem = await ContentManager.NewAsync(type.Name);

--- a/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Lists/Views/ListPartNavigationAdmin.cshtml
@@ -45,7 +45,7 @@
                 <a class="btn btn-secondary dropdown-toggle" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     @T["New"]
                 </a>
-                <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+                <ul class="dropdown-menu">
                     @foreach (var containedContentTypeDefinition in authorizedContentTypeDefinitions)
                     {
                         <li>

--- a/src/OrchardCore.Modules/OrchardCore.Localization/Views/AdminCulturePicker.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Views/AdminCulturePicker.cshtml
@@ -6,7 +6,7 @@
 <li class="nav-item">
     <div class="dropdown">
         <button type="button" class="nav-link dropdown-toggle" id="oc-culture-picker" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-language-current-value="@Model.CurrentCulture.Name" data-cookie-name="@AdminCookieCultureProvider.MakeCookieName(ShellSettings)" data-cookie-path="@AdminCookieCultureProvider.MakeCookiePath(Context)">@Model.CurrentCulture.NativeName</button>
-        <ul class="dropdown-menu dropdown-menu-end position-absolute" aria-labelledby="oc-culture-picker">
+        <ul class="dropdown-menu dropdown-menu-end position-absolute">
             @foreach (var culture in Model.SupportedCultures)
             {
                 if (culture.Name != Model.CurrentCulture.Name)

--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaProfiles/Index.cshtml
@@ -46,7 +46,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsAdminList.Fields.BulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsAdminList.Fields.BulkActions.cshtml
@@ -6,7 +6,7 @@
     <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         @T["Actions"]
     </button>
-    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+    <ul class="dropdown-menu dropdown-menu-end">
         @{
             var bulkActions = await OptionsDisplayManager.BuildDisplayAsync(Model, null, "BulkActions");
             if (bulkActions.TryGetProperty<IShape>("Content", out var content))

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Views/Admin/Index.cshtml
@@ -46,7 +46,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Views/Admin/Index.cshtml
@@ -45,7 +45,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Views/Admin/Index.cshtml
@@ -46,7 +46,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/Admin/List.cshtml
@@ -50,7 +50,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Views/SitemapIndex/List.cshtml
@@ -50,7 +50,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Views/Template/Index.cshtml
@@ -54,7 +54,7 @@ else
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/Admin/Index.cshtml
@@ -49,7 +49,7 @@
                         <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             @T["Actions"]
                         </button>
-                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                        <ul class="dropdown-menu dropdown-menu-end">
                             @foreach (var item in Model.Options.TenantsBulkAction)
                             {
                                 @if (item.Value == nameof(TenantsBulkAction.Remove) && !TenantsOptions.Value.TenantRemovalAllowed)

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/FeatureProfiles/Index.cshtml
@@ -46,7 +46,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.ContentsBulkAction)
                                 {
                                     <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/Admin/Index.cshtml
@@ -48,7 +48,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 @foreach (var item in Model.Options.BulkActions)
                                 {
                                     <li>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenu.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenu.DetailAdmin.cshtml
@@ -12,7 +12,7 @@
     </button>
     @if (Model.Content != null)
     {
-        <ul class="dropdown-menu dropdown-menu-end position-absolute" aria-labelledby="navbarDropdown">
+        <ul class="dropdown-menu dropdown-menu-end position-absolute">
             @await DisplayAsync(Model.Content)
         </ul>
     }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenu.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenu.cshtml
@@ -14,7 +14,7 @@
                 }
             </a>
 
-            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+            <ul class="dropdown-menu dropdown-menu-end">
                 @await DisplayAsync(Model.AnonymousContent)
             </ul>
         </li>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminList.Fields.BulkActions.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminList.Fields.BulkActions.cshtml
@@ -6,7 +6,7 @@
         <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             @T["Actions"]
         </button>
-        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+        <ul class="dropdown-menu dropdown-menu-end">
             @{
                 var bulkActions = await UserOptionsDisplayManager.BuildDisplayAsync(Model, null, "BulkActions");
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminListSearch.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UsersAdminListSearch.cshtml
@@ -18,7 +18,7 @@
     <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" id="filter-dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="fa-solid fa-filter" title="@T["Filters"]" aria-hidden="true"></i>
     </button>
-    <ul class="@string.Join(' ', dropdownClassList)" aria-labelledby="filter-dropdown">
+    <ul class="@string.Join(' ', dropdownClassList)">
         <li><a class="dropdown-item" href="?q=status:Enabled">@T["Only enabled users"]</a></li>
         <li><a class="dropdown-item" href="?q=status:Disabled">@T["Only disabled users"]</a></li>
         <li><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#modalUserIndexOptionsFilterSyntax">@T["Filter syntax"]</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/Workflow/Index.cshtml
@@ -44,7 +44,7 @@
                                 <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                     @T["Actions"]
                                 </button>
-                                <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                                <ul class="dropdown-menu dropdown-menu-end">
                                     @foreach (var item in Model.Options.WorkflowsBulkAction)
                                     {
                                         <li><a class="dropdown-item" href="javascript:void(0)" data-action="@item.Value" data-title="@T["Bulk Action"]" data-message="@T["Are you sure you want to {0} these items?", @item.Text.ToLower()]">@item.Text</a></li>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Views/WorkflowType/Index.cshtml
@@ -47,7 +47,7 @@
                             <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="bulk-action-menu-button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                 @T["Actions"]
                             </button>
-                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="bulk-action-menu-button">
+                            <ul class="dropdown-menu dropdown-menu-end">
                                 <li><a class="dropdown-item" href="javascript:void(0)" data-action="Export" data-title="@T["Bulk Action"]">Export</a></li>
                                 @foreach (var item in Model.Options.WorkflowTypesBulkAction)
                                 {


### PR DESCRIPTION
It is not needed or recommended, see https://html-validate.org/rules/aria-label-misuse.html.
This is a follow-up for https://github.com/OrchardCMS/OrchardCore/issues/18510.
