### PR TITLE
Fix Redis data protection

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Redis/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Redis/Startup.cs
@@ -127,9 +127,6 @@ public sealed class RedisDataProtectionStartup : StartupBase
     {
         if (services.Any(d => d.ServiceType == typeof(IRedisService)))
         {
-            // Remove any previously registered options setups.
-            services.RemoveAll<IConfigureOptions<KeyManagementOptions>>();
-
             services.AddTransient<IConfigureOptions<KeyManagementOptions>, RedisKeyManagementOptionsSetup>();
         }
     }


### PR DESCRIPTION
Fixes a regression introduced by PR #18508. For Redis, the existing `IConfigureOptions<KeyManagementOptions>` must not be removed, because it is being altered by the `RedisKeyManagementOptionsSetup`. 

Fixes #18727