### PR TITLE
Fix content item updating

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Controllers/AdminController.cs
@@ -456,7 +456,6 @@ public sealed class AdminController : Controller, IUpdateModel
         var stayOnSamePage = submitSave == "submit.SaveAndContinue";
         return EditInternalAsync(contentItemId, returnUrl, stayOnSamePage, async contentItem =>
         {
-            await _contentManager.UpdateAsync(contentItem);
             await _contentManager.SaveDraftAsync(contentItem);
 
             var typeDefinition = await _contentDefinitionManager.GetTypeDefinitionAsync(contentItem.ContentType);
@@ -743,6 +742,11 @@ public sealed class AdminController : Controller, IUpdateModel
 
         var model = await _contentItemDisplayManager.UpdateEditorAsync(contentItem, this, false);
 
+        if (ModelState.IsValid)
+        {
+            await _contentManager.UpdateAsync(contentItem);
+        }
+
         if (!ModelState.IsValid || !(await conditionallyPublish(contentItem)))
         {
             await _session.CancelAsync();
@@ -859,8 +863,6 @@ public sealed class AdminController : Controller, IUpdateModel
 
         return await EditInternalAsync(contentItemId, returnUrl, stayOnSamePage, async contentItem =>
         {
-            await _contentManager.UpdateAsync(contentItem);
-
             var hasBeenPublishedOrUnpublished = publish
                 ? await _contentManager.PublishAsync(contentItem)
                 : await _contentManager.UnpublishAsync(contentItem);


### PR DESCRIPTION
This pull request refactors the content update flow in `AdminController` so that `UpdateAsync` is only called when the model state is valid. This prevents invalid content items from being persisted and ensures that model errors added by content handlers during the update process correctly block the update.

Fixes #18749