### PR TITLE
Preserve fields when welding parts in ContentElement

### DIFF
--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/ContentExtensions.cs
@@ -138,7 +138,13 @@ public static class ContentExtensions
     {
         if (!contentElement.Data.ContainsKey(name))
         {
-            element.Data = JObject.FromObject(element);
+            // If the element already has Data (e.g., it has been populated with fields),
+            // use it directly instead of creating a new JsonObject from the element object
+            if (element.Data is null || element.Data.Count == 0)
+            {
+                element.Data = JObject.FromObject(element);
+            }
+            
             element.ContentItem = contentElement.ContentItem;
 
             contentElement.Data[name] = element.Data;

--- a/test/OrchardCore.Tests/Data/ContentItemExtensions.cs
+++ b/test/OrchardCore.Tests/Data/ContentItemExtensions.cs
@@ -43,6 +43,65 @@ public class ContentItemExtensions
     }
 
     [Fact]
+    public void WeldPreservesFieldsWhenPartWeldedAfterFields()
+    {
+        // arrange
+        var firstValue = "Hello";
+        var secondValue = "World";
+        var contentItem = new ContentItem { ContentType = "Product" };
+        var productPart = new ContentPart();
+        
+        // Weld fields to the part first
+        productPart.Weld("First", new TextField { Text = firstValue });
+        productPart.Weld("Second", new TextField { Text = secondValue });
+        
+        // act - weld the part to the content item
+        contentItem.Weld("ProductPart", productPart);
+        
+        // assert - fields should be preserved
+        var retrievedPart = contentItem.Get<ContentPart>("ProductPart");
+        Assert.NotNull(retrievedPart);
+        
+        var firstField = retrievedPart.Get<TextField>("First");
+        Assert.NotNull(firstField);
+        Assert.Equal(firstValue, firstField.Text);
+        
+        var secondField = retrievedPart.Get<TextField>("Second");
+        Assert.NotNull(secondField);
+        Assert.Equal(secondValue, secondField.Text);
+    }
+
+    [Fact]
+    public void WeldPreservesFieldsWhenPartWeldedBeforeFields()
+    {
+        // arrange
+        var firstValue = "Hello";
+        var secondValue = "World";
+        var contentItem = new ContentItem { ContentType = "Product" };
+        var productPart = new ContentPart();
+        
+        // Weld the part to the content item first
+        contentItem.Weld("ProductPart", productPart);
+        
+        // act - weld fields to the part after
+        var retrievedPart = contentItem.Get<ContentPart>("ProductPart");
+        retrievedPart.Weld("First", new TextField { Text = firstValue });
+        retrievedPart.Weld("Second", new TextField { Text = secondValue });
+        
+        // assert - fields should be preserved
+        var finalPart = contentItem.Get<ContentPart>("ProductPart");
+        Assert.NotNull(finalPart);
+        
+        var firstField = finalPart.Get<TextField>("First");
+        Assert.NotNull(firstField);
+        Assert.Equal(firstValue, firstField.Text);
+        
+        var secondField = finalPart.Get<TextField>("Second");
+        Assert.NotNull(secondField);
+        Assert.Equal(secondValue, secondField.Text);
+    }
+
+    [Fact]
     public void MergeReflectsChangesToWellKnownProperties()
     {
         // Setup


### PR DESCRIPTION
Updated Weld to only set Data if null or empty, preserving existing fields when welding elements. Added tests to verify fields are retained regardless of weld order. Improves reliability of part and field composition.

Fixes #18757