### PR TITLE
Revert "Update dependency JsonPath.Net to v3"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="GraphQL.MicrosoftDI" Version="8.8.3" />
     <PackageVersion Include="GraphQL.SystemTextJson" Version="8.8.3" />
     <PackageVersion Include="Jint" Version="4.5.0" />
-    <PackageVersion Include="JsonPath.Net" Version="3.0.0" />
+    <PackageVersion Include="JsonPath.Net" Version="2.2.0" />
     <PackageVersion Include="HtmlSanitizer" Version="9.1.878-beta" />
     <PackageVersion Include="Parlot" Version="1.5.7" />
     <PackageVersion Include="libphonenumber-csharp" Version="9.0.23" />


### PR DESCRIPTION
Reverts OrchardCMS/OrchardCore#18780

Following the discussion on today's meeting, reverting this until we have the licensing questions sorted out.