### PR TITLE
Fix the warning NU1902

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="GraphQL.SystemTextJson" Version="8.8.3" />
     <PackageVersion Include="Jint" Version="4.5.0" />
     <PackageVersion Include="JsonPath.Net" Version="2.2.0" />
-    <PackageVersion Include="HtmlSanitizer" Version="9.1.878-beta" />
+    <PackageVersion Include="HtmlSanitizer" Version="9.1.893-beta" />
     <PackageVersion Include="Parlot" Version="1.5.7" />
     <PackageVersion Include="libphonenumber-csharp" Version="9.0.23" />
     <PackageVersion Include="Lorem.Universal.NET" Version="5.0.0" />


### PR DESCRIPTION
Package 'HtmlSanitizer' 9.1.878-beta has a known moderate severity vulnerability, https://github.com/advisories/GHSA-j92c-7v7g-gj3f
