### PR TITLE
Rename "Key" column to "Original" in translation tables

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.DataLocalization/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.DataLocalization/Views/Admin/Index.cshtml
@@ -89,7 +89,7 @@
             <table v-if="getFilteredStrings(provider.strings).length > 0" class="table">
                 <thead>
                     <tr>
-                        <th class="col-5">@T["Key"]</th>
+                        <th class="col-5">@T["Original"]</th>
                         <th class="col-7">@T["Translation"]</th>
                     </tr>
                 </thead>
@@ -118,7 +118,7 @@
                 <table class="table table-sm">
                     <thead>
                         <tr>
-                            <th class="col-5">@T["Key"]</th>
+                            <th class="col-5">@T["Original"]</th>
                             <th class="col-7">@T["Translation"]</th>
                         </tr>
                     </thead>


### PR DESCRIPTION
Updated the column header from "Key" to "Original" in two tables within Index.cshtml to better reflect that the column displays the original string, improving clarity in the user interface.

@hishamco We talked about this in the meeting, it makes more sense to keep "Original", "Key" is just an internal thing that has no meaning for the user.