### PR TITLE
Allow "mailto" and "tel" links in HTML sanitizer configuration

### DIFF
--- a/src/OrchardCore/OrchardCore.Infrastructure/Html/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Html/OrchardCoreBuilderExtensions.cs
@@ -20,6 +20,7 @@ public static partial class OrchardCoreBuilderExtensions
                 sanitizer.AllowedTags.Remove("form");
 
                 sanitizer.AllowedSchemes.Add("mailto");
+                sanitizer.AllowedSchemes.Add("tel");
             });
 
             services.AddSingleton<IHtmlSanitizerService, HtmlSanitizerService>();

--- a/src/docs/reference/modules/Sanitizer/README.md
+++ b/src/docs/reference/modules/Sanitizer/README.md
@@ -25,7 +25,7 @@ The elements sanitized by default are listed on this page: <https://github.com/m
 Orchard Core changes these defaults by:
 
 - allowing the attribute `class`
-- allowing the `mailto` scheme
+- allowing the `mailto` and `tel` schemes
 - removing the tag `form`
 
 ## Configuring the Sanitizer


### PR DESCRIPTION
Added "mailto" and "tel" to the list of allowed URL schemes in the HTML sanitizer, enabling support for email links and phone numbers in sanitized HTML content.

Fixes #18782