### PR TITLE
Fix Content Picker input width to match standard form inputs

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/ContentPickerField.Edit.cshtml
@@ -25,7 +25,7 @@
     <div class="@Orchard.GetEndClasses()">
         <div id="@vueElementId" class="vue-multiselect" data-part="@partName" data-field="@fieldName" data-editor-type="ContentPicker" data-selected-items="@selectedItems" data-edit-url="@editUrl" data-view-url="@viewUrl" data-search-url="@searchUrl" data-multiple="@multiple">
 
-            <ul class="mb-1 list-group w-lg-75 w-xxl-50 content-picker-default__list" v-show="arrayOfItems.length" v-cloak>
+            <ul class="mb-1 list-group w-100 content-picker-default__list" v-show="arrayOfItems.length" v-cloak>
                 <draggable v-model="arrayOfItems">
                     <li v-for="(item, i) in arrayOfItems"
                         class="cursor-move list-group-item content-picker-default__list-item d-flex align-items-start justify-content-between"
@@ -45,7 +45,7 @@
                 </draggable>
             </ul>
 
-            <div class="w-lg-75 w-xxl-50">
+            <div class="w-100">
                 <input asp-for="ContentItemIds" type="hidden" v-model="selectedIds" />
                 <vue-multiselect v-model="value" :options="options" track-by="id"
                                  label="displayText" placeholder="@(string.IsNullOrEmpty(settings.Placeholder) ? T["Type to search"] : settings.Placeholder)"

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Views/LocalizationSetContentPickerField.Edit.cshtml
@@ -27,7 +27,7 @@
     <div class="@Orchard.GetEndClasses()">
         <div id="@vueElementId" class="vue-multiselect" data-part="@partName" data-field="@fieldName" data-editor-type="LocalizationSetContentPicker" data-selected-items="@selectedItems" data-search-url="@searchUrl" data-multiple="@multiple">
 
-            <ul class="mb-1 list-group w-xl-50 content-picker-default__list" v-show="arrayOfItems.length" v-cloak>
+            <ul class="mb-1 list-group w-100 content-picker-default__list" v-show="arrayOfItems.length" v-cloak>
                 <draggable v-model="arrayOfItems">
                     <li v-for="(item, i) in arrayOfItems"
                         class="cursor-move list-group-item content-picker-default__list-item d-flex align-items-start justify-content-between"
@@ -41,7 +41,7 @@
                 </draggable>
             </ul>
 
-            <div class="w-xl-50">
+            <div class="w-100">
                 <input asp-for="LocalizationSets" type="hidden" v-model="selectedIds" />
                 <vue-multiselect v-model="value" :options="options" track-by="id"
                                  label="displayText" placeholder="@T["Type to search"]"


### PR DESCRIPTION
The Content Picker editor was using fixed width utility classes
(`w-lg-75`, `w-xxl-50`, and `w-xl-50`), causing it to appear narrower
than other inputs in the admin UI.

This change replaces those classes with `w-100` in both:

- ContentPickerField.Edit.cshtml
- LocalizationSetContentPickerField.Edit.cshtml

so the Content Picker spans the full available width, matching the
layout of other Orchard admin form inputs and improving visual
consistency.

Fixes #13867 