### PR TITLE
Add distributed & memory cache for alias content handles

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Handlers/AliasPartHandler.cs
@@ -58,14 +58,14 @@ public class AliasPartHandler : ContentPartHandler<AliasPart>
 
     public override Task PublishedAsync(PublishContentContext context, AliasPart instance)
     {
-        return _tagCache.RemoveTagAsync(AliasConstants.AliasPrefix + instance.Alias);
+        return RemoveTagAsync(instance.Alias);
     }
 
     public override Task RemovedAsync(RemoveContentContext context, AliasPart instance)
     {
         if (context.NoActiveVersionLeft)
         {
-            return _tagCache.RemoveTagAsync(AliasConstants.AliasPrefix + instance.Alias);
+            return RemoveTagAsync(instance.Alias);
         }
 
         return Task.CompletedTask;
@@ -73,7 +73,7 @@ public class AliasPartHandler : ContentPartHandler<AliasPart>
 
     public override Task UnpublishedAsync(PublishContentContext context, AliasPart instance)
     {
-        return _tagCache.RemoveTagAsync(AliasConstants.AliasPrefix + instance.Alias);
+        return RemoveTagAsync(instance.Alias);
     }
 
     public override async Task CloningAsync(CloneContentContext context, AliasPart part)
@@ -82,6 +82,12 @@ public class AliasPartHandler : ContentPartHandler<AliasPart>
         clonedPart.Alias = await GenerateUniqueAliasAsync(part.Alias, clonedPart);
 
         clonedPart.Apply();
+    }
+
+    private Task RemoveTagAsync(string alias)
+    {
+        // Use lowercase alias for tag consistency with AliasPartContentHandleProvider caching.
+        return _tagCache.RemoveTagAsync(AliasConstants.AliasPrefix + alias?.ToLowerInvariant());
     }
 
     private async Task ComputeAliasAsync(AliasPart part)

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Services/AliasPartContentHandleProvider.cs
@@ -1,32 +1,151 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OrchardCore.Alias.Handlers;
 using OrchardCore.Alias.Indexes;
 using OrchardCore.ContentManagement;
+using OrchardCore.Environment.Cache;
 using YesSql;
 
 namespace OrchardCore.Alias.Services;
 
-public class AliasPartContentHandleProvider : IContentHandleProvider
+public class AliasPartContentHandleProvider : IContentHandleProvider, ITagRemovedEventHandler
 {
-    private readonly ISession _session;
+    private const string CacheKeyPrefix = "AliasPartContentHandleProvider_";
 
-    public AliasPartContentHandleProvider(ISession session)
+    private static readonly DistributedCacheEntryOptions _defaultCacheOptions = new()
+    {
+        SlidingExpiration = TimeSpan.FromHours(1),
+    };
+
+    private readonly ISession _session;
+    private readonly IDistributedCache _distributedCache;
+    private readonly IMemoryCache _memoryCache;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger _logger;
+
+    private ITagCache _tagCache;
+
+    public AliasPartContentHandleProvider(
+        ISession session,
+        IDistributedCache distributedCache,
+        IMemoryCache memoryCache,
+        IServiceProvider serviceProvider,
+        ILogger<AliasPartContentHandleProvider> logger)
     {
         _session = session;
+        _distributedCache = distributedCache;
+        _memoryCache = memoryCache;
+        _serviceProvider = serviceProvider;
+        _logger = logger;
     }
 
     public int Order => 100;
 
     public async Task<string> GetContentItemIdAsync(string handle)
     {
-        if (handle.StartsWith(AliasConstants.AliasPrefix, StringComparison.OrdinalIgnoreCase))
+        if (!handle.StartsWith(AliasConstants.AliasPrefix, StringComparison.OrdinalIgnoreCase))
         {
-            handle = handle[AliasConstants.AliasPrefix.Length..];
-
-            var aliasPartIndex = await AliasPartContentHandleHelper.QueryAliasIndex(_session, handle);
-            return aliasPartIndex?.ContentItemId;
+            return null;
         }
 
-        return null;
+        var alias = handle[AliasConstants.AliasPrefix.Length..];
+        var normalizedAlias = alias.ToLowerInvariant();
+        var cacheKey = GetCacheKey(normalizedAlias);
+
+        // Try to get from memory cache first.
+        if (_memoryCache.TryGetValue(cacheKey, out string contentItemId))
+        {
+            return NullIfEmpty(contentItemId);
+        }
+
+        // Try to get from distributed cache.
+        try
+        {
+            contentItemId = await _distributedCache.GetStringAsync(cacheKey);
+
+            if (contentItemId is not null)
+            {
+                // Cache in memory for faster subsequent lookups.
+                _memoryCache.Set(cacheKey, contentItemId, new MemoryCacheEntryOptions
+                {
+                    SlidingExpiration = TimeSpan.FromMinutes(5),
+                });
+
+                return NullIfEmpty(contentItemId);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read the alias '{Alias}' from the distributed cache.", alias);
+        }
+
+        // Query the database.
+        var aliasPartIndex = await AliasPartContentHandleHelper.QueryAliasIndex(_session, alias);
+        contentItemId = aliasPartIndex?.ContentItemId;
+
+        // Cache the result (including null/empty results to avoid repeated database queries).
+        var tag = GetTag(normalizedAlias);
+        await CacheResultAsync(cacheKey, tag, contentItemId);
+
+        return contentItemId;
     }
+
+    /// <summary>
+    /// Handles cache eviction when a tag is removed.
+    /// This is called by <see cref="ITagCache"/> when <see cref="AliasPartHandler"/> removes the alias tag.
+    /// </summary>
+    public Task TagRemovedAsync(string tag, IEnumerable<string> keys)
+    {
+        if (!tag.StartsWith(AliasConstants.AliasPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return Task.CompletedTask;
+        }
+
+        // Remove from memory cache for immediate eviction within this instance.
+        foreach (var key in keys)
+        {
+            _memoryCache.Remove(key);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private async Task CacheResultAsync(string cacheKey, string tag, string contentItemId)
+    {
+        // Use empty string as a placeholder for null to distinguish between "not cached" and "cached as null".
+        var cacheValue = contentItemId ?? string.Empty;
+
+        // Cache in memory.
+        _memoryCache.Set(cacheKey, cacheValue, new MemoryCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(5),
+        });
+
+        // Cache in distributed cache and tag for eviction.
+        try
+        {
+            await _distributedCache.SetStringAsync(cacheKey, cacheValue, _defaultCacheOptions);
+
+            // Lazy load ITagCache to prevent circular dependency.
+            _tagCache ??= _serviceProvider.GetRequiredService<ITagCache>();
+            await _tagCache.TagAsync(cacheKey, tag);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to write the alias cache key '{CacheKey}' to the distributed cache.", cacheKey);
+        }
+    }
+
+    private static string GetCacheKey(string normalizedAlias)
+        => CacheKeyPrefix + normalizedAlias;
+
+    private static string GetTag(string normalizedAlias)
+        => AliasConstants.AliasPrefix + normalizedAlias;
+
+    private static string NullIfEmpty(string value)
+        => string.IsNullOrEmpty(value) ? null : value;
 }
 
 internal sealed class AliasPartContentHandleHelper

--- a/src/OrchardCore.Modules/OrchardCore.Alias/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Alias/Startup.cs
@@ -16,6 +16,7 @@ using OrchardCore.ContentTypes.Editors;
 using OrchardCore.Data;
 using OrchardCore.Data.Migration;
 using OrchardCore.DisplayManagement;
+using OrchardCore.Environment.Cache;
 using OrchardCore.Indexing;
 using OrchardCore.Liquid;
 using OrchardCore.Modules;
@@ -62,7 +63,11 @@ public sealed class Startup : StartupBase
         services.AddScoped<IContentHandler>(sp => sp.GetRequiredService<AliasPartIndexProvider>());
 
         services.AddDataMigration<Migrations>();
-        services.AddScoped<IContentHandleProvider, AliasPartContentHandleProvider>();
+
+        // Register as both IContentHandleProvider and ITagRemovedEventHandler for cache eviction.
+        services.AddScoped<AliasPartContentHandleProvider>();
+        services.AddScoped<IContentHandleProvider>(sp => sp.GetRequiredService<AliasPartContentHandleProvider>());
+        services.AddScoped<ITagRemovedEventHandler>(sp => sp.GetRequiredService<AliasPartContentHandleProvider>());
 
         // Identity Part
         services.AddContentPart<AliasPart>()


### PR DESCRIPTION
Introduce distributed and in-memory caching for alias-to-content item ID lookups in AliasPartContentHandleProvider to improve performance and reduce database queries. Implement ITagRemovedEventHandler for cache eviction on alias changes, ensuring consistency across distributed environments. Normalize cache keys and tags to lowercase. Refactor AliasPartHandler to use a unified RemoveTagAsync method. Update Startup to register the provider for both handle resolution and cache eviction. Add error handling and logging for cache operations.

