### PR TITLE
Fix query string params after editing admin menu node

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Controllers/NodeController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Controllers/NodeController.cs
@@ -225,10 +225,14 @@ public sealed class NodeController : Controller
             await _adminMenuService.SaveAsync(adminMenu);
 
             await _notifier.SuccessAsync(H["Admin node updated successfully."]);
+
             if (submit == "SaveAndContinue")
             {
-                model.Editor = editor;
-                return View(model);
+                return RedirectToAction(nameof(Edit), new
+                {
+                    id = model.AdminMenuId,
+                    treeNodeId = model.AdminNodeId,
+                });
             }
             else
             {


### PR DESCRIPTION
The actual implementation shows the menu item editor, but it loses the current query string params, so once the user refreshes the page, it shows 404