### PR TITLE
Fix ArgumentNullException in EditTypePart for non-reusable parts

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -963,8 +963,6 @@ public sealed class AdminController : Controller
         }
 
         viewModel.TypePartDefinition = part;
-        viewModel.DisplayName ??= part.DisplayName();
-
         if (part.PartDefinition.IsReusable())
         {
             if (part.DisplayName() != viewModel.DisplayName)
@@ -989,6 +987,10 @@ public sealed class AdminController : Controller
                     return View(viewModel);
                 }
             }
+        }
+        else
+        {
+            viewModel.DisplayName = part.DisplayName();
         }
 
         await _contentDefinitionService.AlterTypePartAsync(new AlterTypePartContext


### PR DESCRIPTION
Fix `ArgumentNullException` when validation fails in `EditTypePartPOST` for non-reusable parts

### Problem
PR #18761 introduced data localization to `EditTypePart.cshtml`, using `D[Model.DisplayName]` which throws `ArgumentNullException` when passed a null name. For non-reusable parts, `DisplayName` is not posted back from the form, so when validation fails and the view re-renders, `DisplayName` is null.

### Fix
Populate `viewModel.DisplayName` from the part definition before re-rendering, matching the behavior of the GET handler. Uses `??=` to preserve any user-submitted value for reusable parts.

Fixes #18907