### PR TITLE
Remove Role prefix from both RoleName and RoleDescription

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/UserPickerFieldSettingsDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/Settings/UserPickerFieldSettingsDriver.cs
@@ -27,8 +27,8 @@ public sealed class UserPickerFieldSettingsDriver : ContentPartFieldDefinitionDi
             var roles = await _roleService.GetAssignableRolesAsync();
             var roleEntries = roles.Select(role => new RoleEntry
             {
-                Role = role.RoleName,
-                IsSelected = settings.DisplayedRoles.Contains(role.RoleName, StringComparer.OrdinalIgnoreCase),
+                Role = role.Name,
+                IsSelected = settings.DisplayedRoles.Contains(role.Name, StringComparer.OrdinalIgnoreCase),
             }).ToArray();
 
             model.Roles = roleEntries;
@@ -54,7 +54,7 @@ public sealed class UserPickerFieldSettingsDriver : ContentPartFieldDefinitionDi
         var roles = await _roleService.GetAssignableRolesAsync();
 
         var selectedRoles = model.Roles
-            .Where(x => x.IsSelected && roles.Any(y => y.RoleName == x.Role))
+            .Where(x => x.IsSelected && roles.Any(y => y.Name == x.Role))
             .Select(x => x.Role)
             .ToArray();
 

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Controllers/AdminController.cs
@@ -70,18 +70,18 @@ public sealed class AdminController : Controller
             RoleEntries = [],
         };
 
-        foreach (var role in roles.OrderBy(r => r.RoleName))
+        foreach (var role in roles.OrderBy(r => r.Name))
         {
             var entry = new RoleEntry
             {
-                Name = role.RoleName,
-                Description = role.RoleDescription,
-                IsSystemRole = await _roleService.IsSystemRoleAsync(role.RoleName),
+                Name = role.Name,
+                Description = role.Description,
+                IsSystemRole = await _roleService.IsSystemRoleAsync(role.Name),
             };
 
             if (entry.IsSystemRole)
             {
-                entry.IsAdminRole = await _roleService.IsAdminRoleAsync(role.RoleName);
+                entry.IsAdminRole = await _roleService.IsAdminRoleAsync(role.Name);
             }
 
             model.RoleEntries.Add(entry);
@@ -114,8 +114,8 @@ public sealed class AdminController : Controller
         {
             var role = new Role
             {
-                RoleName = model.RoleName,
-                RoleDescription = model.RoleDescription,
+                Name = model.RoleName,
+                Description = model.RoleDescription,
             };
 
             var result = await _roleManager.CreateAsync(role);
@@ -154,9 +154,9 @@ public sealed class AdminController : Controller
         var model = new EditRoleViewModel
         {
             Role = role,
-            Name = role.RoleName,
-            RoleDescription = role.RoleDescription,
-            IsAdminRole = await _roleService.IsAdminRoleAsync(role.RoleName),
+            Name = role.Name,
+            RoleDescription = role.Description,
+            IsAdminRole = await _roleService.IsAdminRoleAsync(role.Name),
         };
 
         var installedPermissions = await GetInstalledPermissionsAsync();
@@ -168,7 +168,7 @@ public sealed class AdminController : Controller
             .Select(g => g.First().Name)
             .ToArray();
 
-        if (!await _roleService.IsAdminRoleAsync(role.RoleName))
+        if (!await _roleService.IsAdminRoleAsync(role.Name))
         {
             model.EffectivePermissions = await GetEffectivePermissions(role, allPermissions);
             model.RoleCategoryPermissions = installedPermissions;
@@ -190,9 +190,9 @@ public sealed class AdminController : Controller
             return NotFound();
         }
 
-        role.RoleDescription = roleDescription;
+        role.Description = roleDescription;
 
-        if (!await _roleService.IsAdminRoleAsync(role.RoleName))
+        if (!await _roleService.IsAdminRoleAsync(role.Name))
         {
             role.RoleClaims.RemoveAll(c => c.ClaimType == Permission.ClaimType);
             role.RoleClaims.AddRange(ExtractSelectedPermissions());
@@ -220,7 +220,7 @@ public sealed class AdminController : Controller
             return NotFound();
         }
 
-        if (await _roleService.IsSystemRoleAsync(role.RoleName))
+        if (await _roleService.IsSystemRoleAsync(role.Name))
         {
             await _notifier.ErrorAsync(H["System roles cannot be deleted."]);
 
@@ -292,7 +292,7 @@ public sealed class AdminController : Controller
             return NotFound();
         }
 
-        var model = await GetEditRoleViewModelAsync(role, role.RoleName, role.RoleDescription);
+        var model = await GetEditRoleViewModelAsync(role, role.Name, role.Description);
 
         return View(nameof(Edit), model);
     }
@@ -322,8 +322,8 @@ public sealed class AdminController : Controller
         {
             var newRole = new Role
             {
-                RoleName = name,
-                RoleDescription = roleDescription,
+                Name = name,
+                Description = roleDescription,
                 RoleClaims = [.. ExtractSelectedPermissions()],
             };
 
@@ -391,11 +391,11 @@ public sealed class AdminController : Controller
     {
         // Create a fake user to check the actual permissions. If the role is anonymous
         // IsAuthenticated needs to be false.
-        var authenticationType = !string.Equals(role.RoleName, OrchardCoreConstants.Roles.Anonymous, StringComparison.OrdinalIgnoreCase)
+        var authenticationType = !string.Equals(role.Name, OrchardCoreConstants.Roles.Anonymous, StringComparison.OrdinalIgnoreCase)
             ? "FakeAuthenticationType"
             : null;
 
-        var fakeIdentity = new ClaimsIdentity([new Claim(ClaimTypes.Role, role.RoleName)], authenticationType);
+        var fakeIdentity = new ClaimsIdentity([new Claim(ClaimTypes.Role, role.Name)], authenticationType);
 
         // Add role claims.
         fakeIdentity.AddClaims(role.RoleClaims.Select(c => c.ToClaim()));

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Deployment/AllRolesDeploymentSource.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Deployment/AllRolesDeploymentSource.cs
@@ -31,15 +31,15 @@ public sealed class AllRolesDeploymentSource
 
         foreach (var role in allRoles)
         {
-            var currentRole = await _roleManager.FindByNameAsync(role.RoleName);
+            var currentRole = await _roleManager.FindByNameAsync(role.Name);
 
             if (currentRole is Role r)
             {
                 permissions.Add(JObject.FromObject(
                     new RolesStepRoleModel
                     {
-                        Name = r.RoleName,
-                        Description = r.RoleDescription,
+                        Name = r.Name,
+                        Description = r.Description,
                         Permissions = r.RoleClaims.Where(x => x.ClaimType == Permission.ClaimType).Select(x => x.ClaimValue).ToArray(),
                     }));
             }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Migrations/RolesMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Migrations/RolesMigrations.cs
@@ -86,7 +86,7 @@ public sealed class RolesMigrations : DataMigration
                 // Check to see if the role contains the obsolete 'SiteOwner' permission claim.
                 var hasSiteOwner = r.RoleClaims is not null && r.RoleClaims.Any(x => x.ClaimValue == "SiteOwner");
 
-                if (r.RoleName.Equals(OrchardCoreConstants.Roles.Administrator, StringComparison.OrdinalIgnoreCase))
+                if (r.Name.Equals(OrchardCoreConstants.Roles.Administrator, StringComparison.OrdinalIgnoreCase))
                 {
                     if (!hasSiteOwner)
                     {
@@ -101,7 +101,7 @@ public sealed class RolesMigrations : DataMigration
 
                         await roleManager.CreateAsync(new Role
                         {
-                            RoleName = adminSystemRoleName,
+                            Name = adminSystemRoleName,
                         });
                     }
                     else
@@ -135,7 +135,7 @@ public sealed class RolesMigrations : DataMigration
 
                     foreach (var adminRole in adminRoles)
                     {
-                        var users = await userManager.GetUsersInRoleAsync(adminRole.RoleName);
+                        var users = await userManager.GetUsersInRoleAsync(adminRole.Name);
 
                         if (users.Count > 0)
                         {
@@ -187,5 +187,5 @@ public sealed class RolesMigrations : DataMigration
     }
 
     private static bool RoleExists(List<IRole> roles, string roleName)
-        => roles.Any(role => role.RoleName.Equals(roleName, StringComparison.OrdinalIgnoreCase));
+        => roles.Any(role => role.Name.Equals(roleName, StringComparison.OrdinalIgnoreCase));
 }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Migrations/SystemRolesMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Migrations/SystemRolesMigrations.cs
@@ -27,7 +27,7 @@ public sealed class SystemRolesMigrations : DataMigration
 
         foreach (var systemRole in systemRoles)
         {
-            if (!await _roleManager.RoleExistsAsync(systemRole.RoleName))
+            if (!await _roleManager.RoleExistsAsync(systemRole.Name))
             {
                 await _roleManager.CreateAsync(systemRole);
             }

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Recipes/RolesStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Recipes/RolesStep.cs
@@ -44,13 +44,13 @@ public sealed class RolesStep : NamedRecipeStepHandler
             {
                 role = new Role
                 {
-                    RoleName = roleName,
+                    Name = roleName,
                 };
             }
 
             if (role is Role r)
             {
-                r.RoleDescription = roleEntry.Description;
+                r.Description = roleEntry.Description;
 
                 if (roleEntry.PermissionBehavior == PermissionBehavior.Replace)
                 {

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleStore.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleStore.cs
@@ -75,7 +75,7 @@ public class RoleStore : IRoleClaimStore<IRole>, IQueryableRoleStore<IRole>
         var roleCreatedEventHandlers = _serviceProvider.GetRequiredService<IEnumerable<IRoleCreatedEventHandler>>();
 
         await roleCreatedEventHandlers.InvokeAsync((handler, roleToCreate) =>
-            handler.RoleCreatedAsync(roleToCreate.RoleName), roleToCreate, _logger);
+            handler.RoleCreatedAsync(roleToCreate.Name), roleToCreate, _logger);
 
         return IdentityResult.Success;
     }
@@ -92,7 +92,7 @@ public class RoleStore : IRoleClaimStore<IRole>, IQueryableRoleStore<IRole>
             });
         }
 
-        if (_systemRoleProvider.IsSystemRole(roleToRemove.RoleName))
+        if (_systemRoleProvider.IsSystemRole(roleToRemove.Name))
         {
             return IdentityResult.Failed(new IdentityError
             {
@@ -103,10 +103,10 @@ public class RoleStore : IRoleClaimStore<IRole>, IQueryableRoleStore<IRole>
         var roleRemovedEventHandlers = _serviceProvider.GetRequiredService<IEnumerable<IRoleRemovedEventHandler>>();
 
         await roleRemovedEventHandlers.InvokeAsync((handler, roleToRemove) =>
-            handler.RoleRemovedAsync(roleToRemove.RoleName), roleToRemove, _logger);
+            handler.RoleRemovedAsync(roleToRemove.Name), roleToRemove, _logger);
 
         var roles = await LoadRolesAsync();
-        roleToRemove = roles.Roles.FirstOrDefault(r => string.Equals(r.RoleName, roleToRemove.RoleName, StringComparison.OrdinalIgnoreCase));
+        roleToRemove = roles.Roles.FirstOrDefault(r => string.Equals(r.Name, roleToRemove.Name, StringComparison.OrdinalIgnoreCase));
         roles.Roles.Remove(roleToRemove);
 
         await UpdateRolesAsync(roles);
@@ -119,7 +119,7 @@ public class RoleStore : IRoleClaimStore<IRole>, IQueryableRoleStore<IRole>
         // While updating find a role from the loaded document being mutated.
         var roles = _updating ? await LoadRolesAsync() : await GetRolesAsync();
 
-        var role = roles.Roles.FirstOrDefault(x => string.Equals(x.RoleName, roleId, StringComparison.OrdinalIgnoreCase));
+        var role = roles.Roles.FirstOrDefault(x => string.Equals(x.Name, roleId, StringComparison.OrdinalIgnoreCase));
 
         if (role == null)
         {
@@ -153,21 +153,21 @@ public class RoleStore : IRoleClaimStore<IRole>, IQueryableRoleStore<IRole>
             return Task.FromResult(r.NormalizedRoleName);
         }
 
-        return Task.FromResult(role.RoleName);
+        return Task.FromResult(role.Name);
     }
 
     public Task<string> GetRoleIdAsync(IRole role, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(role);
 
-        return Task.FromResult(role.RoleName.ToUpperInvariant());
+        return Task.FromResult(role.Name.ToUpperInvariant());
     }
 
     public Task<string> GetRoleNameAsync(IRole role, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(role);
 
-        return Task.FromResult(role.RoleName);
+        return Task.FromResult(role.Name);
     }
 
     public Task SetNormalizedRoleNameAsync(IRole role, string normalizedName, CancellationToken cancellationToken)
@@ -188,7 +188,7 @@ public class RoleStore : IRoleClaimStore<IRole>, IQueryableRoleStore<IRole>
 
         if (role is Role r)
         {
-            r.RoleName = roleName;
+            r.Name = roleName;
         }
 
         return Task.CompletedTask;
@@ -199,7 +199,7 @@ public class RoleStore : IRoleClaimStore<IRole>, IQueryableRoleStore<IRole>
         ArgumentNullException.ThrowIfNull(role);
 
         var roles = await LoadRolesAsync();
-        var existingRole = roles.Roles.FirstOrDefault(x => string.Equals(x.RoleName, role.RoleName, StringComparison.OrdinalIgnoreCase));
+        var existingRole = roles.Roles.FirstOrDefault(x => string.Equals(x.Name, role.Name, StringComparison.OrdinalIgnoreCase));
         roles.Roles.Remove(existingRole);
 
         if (role is Role r)

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Services/RoleUpdater.cs
@@ -71,7 +71,7 @@ public class RoleUpdater : FeatureEventHandler, IRoleCreatedEventHandler, IRoleR
             var stereotypes = provider.GetDefaultStereotypes();
             foreach (var stereotype in stereotypes)
             {
-                var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.RoleName, stereotype.Name, StringComparison.OrdinalIgnoreCase));
+                var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.Name, stereotype.Name, StringComparison.OrdinalIgnoreCase));
                 if (role == null)
                 {
                     continue;
@@ -112,7 +112,7 @@ public class RoleUpdater : FeatureEventHandler, IRoleCreatedEventHandler, IRoleR
         var rolesDocument = await _documentManager.GetOrCreateMutableAsync();
         foreach (var role in rolesDocument.Roles)
         {
-            if (!rolesDocument.MissingFeaturesByRole.TryGetValue(role.RoleName, out var missingFeatures) ||
+            if (!rolesDocument.MissingFeaturesByRole.TryGetValue(role.Name, out var missingFeatures) ||
                 !missingFeatures.Contains(feature.Id))
             {
                 continue;
@@ -133,7 +133,7 @@ public class RoleUpdater : FeatureEventHandler, IRoleCreatedEventHandler, IRoleR
     private async Task UpdateRoleForInstalledFeaturesAsync(string roleName)
     {
         var rolesDocument = await _documentManager.GetOrCreateMutableAsync();
-        var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.RoleName, roleName, StringComparison.OrdinalIgnoreCase));
+        var role = rolesDocument.Roles.FirstOrDefault(role => string.Equals(role.Name, roleName, StringComparison.OrdinalIgnoreCase));
         if (role == null)
         {
             return;
@@ -182,7 +182,7 @@ public class RoleUpdater : FeatureEventHandler, IRoleCreatedEventHandler, IRoleR
     {
         var stereotypes = providers
             .SelectMany(provider => provider.GetDefaultStereotypes())
-            .Where(stereotype => string.Equals(stereotype.Name, role.RoleName, StringComparison.OrdinalIgnoreCase));
+            .Where(stereotype => string.Equals(stereotype.Name, role.Name, StringComparison.OrdinalIgnoreCase));
 
         if (!stereotypes.Any())
         {
@@ -203,7 +203,7 @@ public class RoleUpdater : FeatureEventHandler, IRoleCreatedEventHandler, IRoleR
 
     private bool UpdatePermissions(Role role, IEnumerable<string> permissions)
     {
-        if (_systemRoleProvider.IsAdminRole(role.RoleName))
+        if (_systemRoleProvider.IsAdminRole(role.Name))
         {
             // Don't update claims for admin role.
             return true;
@@ -227,7 +227,7 @@ public class RoleUpdater : FeatureEventHandler, IRoleCreatedEventHandler, IRoleR
         {
             if (_logger.IsEnabled(LogLevel.Debug))
             {
-                _logger.LogDebug("Default role '{RoleName}' granted permission '{PermissionName}'.", role.RoleName, permission);
+                _logger.LogDebug("Default role '{RoleName}' granted permission '{PermissionName}'.", role.Name, permission);
             }
 
             role.RoleClaims.Add(RoleClaim.Create(permission));

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Edit.cshtml
@@ -7,7 +7,7 @@
     <h1>
         @if (Model.IsCloning)
         {
-            @RenderTitleSegments(T["Clone '{0}' Role", Model.Role.RoleName])
+            @RenderTitleSegments(T["Clone '{0}' Role", Model.Role.Name])
         }
         else
         {

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Services/SuperUserHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Services/SuperUserHandler.cs
@@ -32,7 +32,7 @@ public class SuperUserHandler : IAuthorizationHandler
 
         var adminRole = _systemRoleProvider.GetAdminRole();
 
-        if (user.IsInRole(adminRole.RoleName))
+        if (user.IsInRole(adminRole.Name))
         {
             SucceedAllRequirements(context);
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RoleLoginSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/RoleLoginSettingsDisplayDriver.cs
@@ -46,8 +46,8 @@ public sealed class RoleLoginSettingsDisplayDriver : SiteDisplayDriver<RoleLogin
             model.Roles = roles
                 .Select(role => new RoleEntry()
                 {
-                    Role = role.RoleName,
-                    IsSelected = settings.Roles != null && settings.Roles.Contains(role.RoleName, StringComparer.OrdinalIgnoreCase),
+                    Role = role.Name,
+                    IsSelected = settings.Roles != null && settings.Roles.Contains(role.Name, StringComparer.OrdinalIgnoreCase),
                 }).OrderBy(entry => entry.Role)
                 .ToArray();
         }).Location("Content:6#Two-Factor Authentication")
@@ -71,7 +71,7 @@ public sealed class RoleLoginSettingsDisplayDriver : SiteDisplayDriver<RoleLogin
             var roles = await _roleService.GetAssignableRolesAsync();
 
             var selectedRoles = model.Roles.Where(x => x.IsSelected)
-                .Join(roles, e => e.Role, r => r.RoleName, (e, r) => r.RoleName)
+                .Join(roles, e => e.Role, r => r.Name, (e, r) => r.Name)
                 .ToArray();
 
             if (selectedRoles.Length == 0)

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserRoleDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserRoleDisplayDriver.cs
@@ -94,7 +94,7 @@ public sealed class UserRoleDisplayDriver : DisplayDriver<User>
         var currentUserRoleNames = await _userRoleStore.GetRolesAsync(user, default);
 
         var selectedRoleNames = model.Roles.Where(x => x.IsSelected).Select(x => x.Role);
-        var selectedRoles = roles.Where(x => selectedRoleNames.Contains(x.RoleName, StringComparer.OrdinalIgnoreCase));
+        var selectedRoles = roles.Where(x => selectedRoleNames.Contains(x.Name, StringComparer.OrdinalIgnoreCase));
         var accessibleAndSelectedRoleNames = await GetAccessibleRoleNamesAsync(selectedRoles);
 
         if (context.IsNew)
@@ -162,7 +162,7 @@ public sealed class UserRoleDisplayDriver : DisplayDriver<User>
         {
             if (await _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, UsersPermissions.AssignRoleToUsers, role))
             {
-                authorizedRoleNames.Add(role.RoleName);
+                authorizedRoleNames.Add(role.Name);
             }
         }
 

--- a/src/OrchardCore.Modules/OrchardCore.Users/Roles/Handlers/RoleAuthorizationHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Roles/Handlers/RoleAuthorizationHandler.cs
@@ -39,7 +39,7 @@ public sealed class RoleAuthorizationHandler : AuthorizationHandler<PermissionRe
 
         if (context.Resource is IRole role)
         {
-            var variantPermission = GetPermissionVariation(requirement.Permission, role.RoleName);
+            var variantPermission = GetPermissionVariation(requirement.Permission, role.Name);
 
             if (variantPermission != null && await _authorizationService.AuthorizeAsync(context.User, variantPermission))
             {
@@ -75,7 +75,7 @@ public sealed class RoleAuthorizationHandler : AuthorizationHandler<PermissionRe
             {
                 // When the user is in no roles, we check to see if the current user can manage any roles.
                 roleNames = (await _roleService.GetAssignableRolesAsync())
-                    .Select(x => x.RoleName);
+                    .Select(x => x.Name);
             }
 
             // Check every role to see if the current user has permission to at least one role.

--- a/src/OrchardCore.Modules/OrchardCore.Users/Roles/Services/RolesAdminListFilterProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Roles/Services/RolesAdminListFilterProvider.cs
@@ -27,7 +27,7 @@ public sealed class RolesAdminListFilterProvider : IUsersAdminListFilterProvider
                 if (user != null && !await authorizationService.AuthorizeAsync(user, UsersPermissions.ListUsers))
                 {
                     // At this point the user cannot see all users, so lets see what role does he have access too and filter by them.
-                    var accessibleRoles = (await roleService.GetAssignableRolesAsync()).Select(x => x.RoleName);
+                    var accessibleRoles = (await roleService.GetAssignableRolesAsync()).Select(x => x.Name);
 
                     query.With<UserByRoleNameIndex>(index => index.RoleName.IsIn(accessibleRoles));
                 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Roles/Services/UserRolePermissions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Roles/Services/UserRolePermissions.cs
@@ -20,7 +20,7 @@ public sealed class UserRolePermissions : IPermissionProvider
         };
 
         var roleNames = (await _roleService.GetAssignableRolesAsync())
-            .Select(role => role.RoleName)
+            .Select(role => role.Name)
             .OrderBy(roleName => roleName);
 
         foreach (var roleName in roleNames)

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserRoles.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserRoles.cshtml
@@ -4,7 +4,7 @@
 
 @inject IRoleService RoleService
 @{
-    var roles = (await RoleService.GetRolesAsync()).ToDictionary(x => x.RoleName, x => x, StringComparer.OrdinalIgnoreCase);
+    var roles = (await RoleService.GetRolesAsync()).ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
 }
 
 <h4>@T["Roles"]</h4>
@@ -16,6 +16,6 @@
             continue;
         }
 
-        <li>@role.RoleName</li>
+        <li>@role.Name</li>
     }
 </ul>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserRolesMeta.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserRolesMeta.cshtml
@@ -4,7 +4,7 @@
 @inject IRoleService RoleService
 
 @{
-    var roles = (await RoleService.GetRolesAsync()).ToDictionary(x => x.RoleName, x => x, StringComparer.OrdinalIgnoreCase);
+    var roles = (await RoleService.GetRolesAsync()).ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
 }
 
 <div data-bs-toggle="tooltip" title="@T["The roles this user has"]">
@@ -15,6 +15,6 @@
             continue;
         }
 
-        <span class="badge ta-badge">@role.RoleName</span>
+        <span class="badge ta-badge">@role.Name</span>
     }
 </div>

--- a/src/OrchardCore/OrchardCore.Roles.Abstractions/Extensions/SystemRoleProviderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Abstractions/Extensions/SystemRoleProviderExtensions.cs
@@ -8,6 +8,6 @@ public static class SystemRoleProviderExtensions
 
         var adminRole = systemRoleNameProvider.GetAdminRole();
 
-        return adminRole.RoleName.Equals(name, StringComparison.OrdinalIgnoreCase);
+        return adminRole.Name.Equals(name, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/OrchardCore/OrchardCore.Roles.Abstractions/IRole.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Abstractions/IRole.cs
@@ -2,7 +2,7 @@ namespace OrchardCore.Security;
 
 public interface IRole
 {
-    string RoleName { get; }
+    string Name { get; }
 
-    string RoleDescription { get; }
+    string Description { get; }
 }

--- a/src/OrchardCore/OrchardCore.Roles.Abstractions/Role.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Abstractions/Role.cs
@@ -2,9 +2,9 @@ namespace OrchardCore.Security;
 
 public class Role : IRole
 {
-    public string RoleName { get; set; }
+    public string Name { get; set; }
 
-    public string RoleDescription { get; set; }
+    public string Description { get; set; }
 
     public string NormalizedRoleName { get; set; }
 
@@ -14,8 +14,8 @@ public class Role : IRole
     {
         var role = new Role
         {
-            RoleName = RoleName,
-            RoleDescription = RoleDescription,
+            Name = Name,
+            Description = Description,
             NormalizedRoleName = NormalizedRoleName,
         };
 

--- a/src/OrchardCore/OrchardCore.Roles.Abstractions/RoleServiceExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Abstractions/RoleServiceExtensions.cs
@@ -10,7 +10,7 @@ public static class RoleServiceExtensions
     {
         var roles = await roleService.GetRolesAsync();
 
-        return roles.Select(r => r.RoleName);
+        return roles.Select(r => r.Name);
     }
 
     public static async Task<IEnumerable<IRole>> GetAssignableRolesAsync(this IRoleService roleService)
@@ -20,7 +20,7 @@ public static class RoleServiceExtensions
         var assignableRoles = new List<IRole>();
         foreach (var role in roles)
         {
-            if (!await roleService.IsAdminRoleAsync(role.RoleName) && await roleService.IsSystemRoleAsync(role.RoleName))
+            if (!await roleService.IsAdminRoleAsync(role.Name) && await roleService.IsSystemRoleAsync(role.Name))
             {
                 continue;
             }

--- a/src/OrchardCore/OrchardCore.Roles.Core/DefaultSystemRoleProvider.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Core/DefaultSystemRoleProvider.cs
@@ -27,25 +27,25 @@ public sealed class DefaultSystemRoleProvider : ISystemRoleProvider
 
         _adminRole = new Role
         {
-            RoleName = adminRoleName,
-            RoleDescription = "A system role that grants all permissions to the assigned users.",
+            Name = adminRoleName,
+            Description = "A system role that grants all permissions to the assigned users.",
         };
 
         _systemRoles = new Dictionary<string, Role>()
         {
-            { _adminRole.RoleName, _adminRole },
+            { _adminRole.Name, _adminRole },
             {
                 OrchardCoreConstants.Roles.Authenticated, new Role
                 {
-                    RoleName = OrchardCoreConstants.Roles.Authenticated,
-                    RoleDescription = "A system role representing all authenticated users.",
+                    Name = OrchardCoreConstants.Roles.Authenticated,
+                    Description = "A system role representing all authenticated users.",
                 }
             },
             {
                 OrchardCoreConstants.Roles.Anonymous, new Role
                 {
-                    RoleName = OrchardCoreConstants.Roles.Anonymous,
-                    RoleDescription = "A system role representing all non-authenticated users.",
+                    Name = OrchardCoreConstants.Roles.Anonymous,
+                    Description = "A system role representing all non-authenticated users.",
                 }
             },
         }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);

--- a/src/OrchardCore/OrchardCore.Roles.Core/Extensions/RoleServiceExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Core/Extensions/RoleServiceExtensions.cs
@@ -10,6 +10,6 @@ public static class RoleServiceExtensions
 
         var roles = await roleService.GetRolesAsync();
 
-        return roles.Select(role => role.RoleName);
+        return roles.Select(role => role.Name);
     }
 }

--- a/src/OrchardCore/OrchardCore.Roles.Core/Services/DefaultSystemRoleNameProvider.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Core/Services/DefaultSystemRoleNameProvider.cs
@@ -15,11 +15,11 @@ internal sealed class DefaultSystemRoleNameProvider : ISystemRoleNameProvider
     public DefaultSystemRoleNameProvider(ISystemRoleProvider provider)
     {
         _provider = provider;
-        _systemRoleNames = provider.GetSystemRoles().Select(x => x.RoleName).ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        _systemRoleNames = provider.GetSystemRoles().Select(x => x.Name).ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
     public ValueTask<string> GetAdminRoleAsync()
-        => ValueTask.FromResult(_provider.GetAdminRole().RoleName);
+        => ValueTask.FromResult(_provider.GetAdminRole().Name);
 
     public ValueTask<FrozenSet<string>> GetSystemRolesAsync()
         => ValueTask.FromResult(_systemRoleNames);

--- a/src/OrchardCore/OrchardCore.Roles.Core/Services/RoleService.cs
+++ b/src/OrchardCore/OrchardCore.Roles.Core/Services/RoleService.cs
@@ -45,7 +45,7 @@ public class RoleService : IRoleService
 
     public Task<IEnumerable<string>> GetNormalizedRoleNamesAsync()
     {
-        return Task.FromResult<IEnumerable<string>>(_roleManager.Roles.Select(a => _roleManager.NormalizeKey(a.RoleName)));
+        return Task.FromResult<IEnumerable<string>>(_roleManager.Roles.Select(a => _roleManager.NormalizeKey(a.Name)));
     }
 
     public ValueTask<bool> IsAdminRoleAsync(string role)

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Roles/PermissionHandlerHelperTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Roles/PermissionHandlerHelperTests.cs
@@ -20,7 +20,7 @@ public class PermissionHandlerHelperTests
         var permissionHandler = CreatePermissionHandler(
             new Role
             {
-                RoleName = OrchardCoreConstants.Roles.Anonymous,
+                Name = OrchardCoreConstants.Roles.Anonymous,
                 RoleClaims =
                 [
                     RoleClaim.Create("AllowAnonymous"),
@@ -28,7 +28,7 @@ public class PermissionHandlerHelperTests
             },
             new Role
             {
-                RoleName = OrchardCoreConstants.Roles.Authenticated,
+                Name = OrchardCoreConstants.Roles.Authenticated,
                 RoleClaims =
                 [
                     RoleClaim.Create("AllowAuthenticated"),
@@ -73,7 +73,7 @@ public class PermissionHandlerHelperTests
         var permissionHandler = CreatePermissionHandler(
             new Role
             {
-                RoleName = OrchardCoreConstants.Roles.Anonymous,
+                Name = OrchardCoreConstants.Roles.Anonymous,
                 RoleClaims =
                 [
                     RoleClaim.Create("Implicit2"),
@@ -99,7 +99,7 @@ public class PermissionHandlerHelperTests
         var permissionHandler = CreatePermissionHandler(
             new Role
             {
-                RoleName = OrchardCoreConstants.Roles.Anonymous,
+                Name = OrchardCoreConstants.Roles.Anonymous,
                 RoleClaims =
                 [
                     RoleClaim.Create("aLlOwAnOnYmOuS"),
@@ -107,7 +107,7 @@ public class PermissionHandlerHelperTests
             },
             new Role
             {
-                RoleName = OrchardCoreConstants.Roles.Authenticated,
+                Name = OrchardCoreConstants.Roles.Authenticated,
                 RoleClaims =
                 [
                     RoleClaim.Create("aLlOwAuThEnTiCaTeD"),
@@ -128,7 +128,7 @@ public class PermissionHandlerHelperTests
 
         foreach (var role in roles)
         {
-            roleManager.Setup(m => m.FindByNameAsync(role.RoleName)).ReturnsAsync(role);
+            roleManager.Setup(m => m.FindByNameAsync(role.Name)).ReturnsAsync(role);
         }
 
         var permissionGrantingService = new DefaultPermissionGrantingService();

--- a/test/OrchardCore.Tests/Roles/DefaultSystemRoleProviderTests.cs
+++ b/test/OrchardCore.Tests/Roles/DefaultSystemRoleProviderTests.cs
@@ -19,7 +19,7 @@ public class DefaultSystemRoleProviderTests
         var roles = provider.GetSystemRoles();
 
         // Assert
-        var roleNames = roles.Select(r => r.RoleName);
+        var roleNames = roles.Select(r => r.Name);
         Assert.Contains(OrchardCoreConstants.Roles.Administrator, roleNames);
         Assert.Contains(OrchardCoreConstants.Roles.Authenticated, roleNames);
         Assert.Contains(OrchardCoreConstants.Roles.Anonymous, roleNames);
@@ -44,8 +44,8 @@ public class DefaultSystemRoleProviderTests
         var role = provider.GetAdminRole();
 
         // Assert
-        Assert.Equal(configureSystemAdminRoleName, role.RoleName);
-        Assert.NotEqual(OrchardCoreConstants.Roles.Administrator, role.RoleName);
+        Assert.Equal(configureSystemAdminRoleName, role.Name);
+        Assert.NotEqual(OrchardCoreConstants.Roles.Administrator, role.Name);
     }
 
     [Fact]
@@ -66,8 +66,8 @@ public class DefaultSystemRoleProviderTests
         var role = provider.GetAdminRole();
 
         // Assert
-        Assert.Equal(adminRoleName, role.RoleName);
-        Assert.NotEqual(OrchardCoreConstants.Roles.Administrator, role.RoleName);
+        Assert.Equal(adminRoleName, role.Name);
+        Assert.NotEqual(OrchardCoreConstants.Roles.Administrator, role.Name);
     }
 
     [Theory]


### PR DESCRIPTION
While we are in `IRole` or `Role` no need to prefix properties with the type name