### PR TITLE
Fix Obsolete warning when creating ManagedIdentityCredential object

### DIFF
--- a/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAIClientFactory.cs
+++ b/src/OrchardCore/OrchardCore.Search.AzureAI.Core/Services/AzureAIClientFactory.cs
@@ -89,5 +89,7 @@ public class AzureAIClientFactory
     }
 
     private ManagedIdentityCredential GetManagedIdentityCredential()
-        => new(_defaultOptions.IdentityClientId);
+        => !string.IsNullOrEmpty(_defaultOptions.IdentityClientId)
+        ? new(ManagedIdentityId.FromUserAssignedClientId(_defaultOptions.IdentityClientId))
+        : new(ManagedIdentityId.SystemAssigned);
 }


### PR DESCRIPTION
This pull request updates the logic for creating a `ManagedIdentityCredential` in the Azure AI client factory. The change ensures that when a user-assigned client ID is provided, it is used to create the credential; otherwise, a system-assigned identity is used.

Credential initialization improvements:

* Updated the `GetManagedIdentityCredential` method in `AzureAIClientFactory.cs` to use `ManagedIdentityId.FromUserAssignedClientId` when a user-assigned client ID is specified, and to fall back to `ManagedIdentityId.SystemAssigned` when it is not.