### PR TITLE
Fix Asset Manager warning

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Forms/Assets.json
+++ b/src/OrchardCore.Modules/OrchardCore.Forms/Assets.json
@@ -12,12 +12,6 @@
     "tags": [ "admin", "dashboard", "js" ]
   },
   {
-    "inputs": [
-      "Assets/js/formElementLabelManager.js"
-    ],
-    "output": "wwwroot/Scripts/formElementLabelManager.js"
-  },
-  {
     "action": "min",
     "name": "form-visibility",
     "source": "Assets/js/form-visibility.js",


### PR DESCRIPTION
When doing `yarn build` we always get this undefined group console log warning.
It's caused by an Asset action that is from the old configs which has been replaced already.
I simply forgot to remove the old config.

PS D:\Repositories\Orchard\OrchardCore> yarn build Loading build.config.mjs... file:///D:/Repositories/Orchard/OrchardCore/build.config.mjs Task:  build
The following group was not handled by our build process undefined

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
