### PR TITLE
LocalLockTests intermittent CI failure

### DIFF
--- a/test/OrchardCore.Tests/Locking/LocalLockTests.cs
+++ b/test/OrchardCore.Tests/Locking/LocalLockTests.cs
@@ -58,10 +58,13 @@ public class LocalLockTests
         var locker = await localLock.AcquireLockAsync("EXP_KEY", TimeSpan.FromMilliseconds(100));
         Assert.True(await localLock.IsLockAcquiredAsync("EXP_KEY"));
 
-        // Wait long enough for expiration callback to fire and release the semaphore.
-        await Task.Delay(300, TestContext.Current.CancellationToken);
-
-        Assert.False(await localLock.IsLockAcquiredAsync("EXP_KEY"));
+        // Poll until the expiration callback fires, with a generous timeout for slow CI runners.
+        var sw = Stopwatch.StartNew();
+        while (await localLock.IsLockAcquiredAsync("EXP_KEY"))
+        {
+            Assert.True(sw.ElapsedMilliseconds < 5000, "Lock did not auto-release within 5 seconds.");
+            await Task.Delay(50, TestContext.Current.CancellationToken);
+        }
 
         var (locker2, locked2) = await localLock.TryAcquireLockAsync("EXP_KEY", TimeSpan.FromMilliseconds(50));
         Assert.True(locked2);


### PR DESCRIPTION
Fix flaky LocalLockTests on CI by replacing hard-coded delay with polling

The Acquire_With_Expiration_Auto_Releases test used a fixed 300ms Task.Delay to wait for a 100ms lock expiration, leaving only 200ms of buffer for the timer callback to fire. On slow CI runners this was insufficient, causing intermittent failures.

Replace with a polling loop (50ms intervals, 5s timeout) that adapts to the actual execution speed of the environment.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
