### PR TITLE
Add Vite minify plugin for Orchard Core asset conventions

### DIFF
--- a/.scripts/assets-manager/plugins/vite-plugin-minify.mjs
+++ b/.scripts/assets-manager/plugins/vite-plugin-minify.mjs
@@ -1,0 +1,76 @@
+import { transform as esbuildTransform } from "esbuild";
+import { transform as lightningTransform } from "lightningcss";
+import { Buffer } from "buffer";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Vite plugin that minifies output and generates files following the
+ * Orchard Core asset-manager convention:
+ *
+ *   file.js      — minified WITH sourceMappingURL reference
+ *   file.min.js  — minified WITHOUT sourceMappingURL reference
+ *   file.map     — source map
+ *
+ *   file.css     — minified WITH sourceMappingURL reference
+ *   file.min.css — minified WITHOUT sourceMappingURL reference
+ *   file.css.map — source map
+ */
+export function minifyPlugin() {
+    let outDir = "";
+
+    return {
+        name: "orchard-minify",
+        apply: "build",
+        configResolved(config) {
+            outDir = config.build.outDir;
+        },
+        async writeBundle(_options, bundle) {
+            for (const [fileName, chunk] of Object.entries(bundle)) {
+                const filePath = path.resolve(outDir, fileName);
+
+                if (fileName.endsWith(".js") && chunk.type === "chunk") {
+                    const parsed = path.parse(filePath);
+
+                    const result = await esbuildTransform(chunk.code, {
+                        minify: true,
+                        sourcemap: true,
+                        sourcefile: path.basename(filePath),
+                    });
+
+                    const mapFileName = `${parsed.name}.map`;
+                    const minPath = path.join(parsed.dir, `${parsed.name}.min.js`);
+
+                    // .js — minified with sourcemap reference
+                    fs.writeFileSync(filePath, `${result.code}//# sourceMappingURL=${mapFileName}\n`);
+                    // .min.js — minified without sourcemap reference
+                    fs.writeFileSync(minPath, result.code);
+                    // .map — source map
+                    fs.writeFileSync(path.join(parsed.dir, mapFileName), result.map);
+                }
+
+                if (fileName.endsWith(".css") && chunk.type === "asset" && typeof chunk.source === "string") {
+                    const parsed = path.parse(filePath);
+
+                    const { code, map } = lightningTransform({
+                        code: Buffer.from(chunk.source, "utf-8"),
+                        minify: true,
+                        sourceMap: true,
+                        filename: path.basename(filePath),
+                    });
+
+                    const mapFileName = `${parsed.name}.css.map`;
+                    const minPath = path.join(parsed.dir, `${parsed.name}.min.css`);
+                    const minified = code.toString();
+
+                    // .css — minified with sourcemap reference
+                    fs.writeFileSync(filePath, `${minified}\n/*# sourceMappingURL=${mapFileName} */\n`);
+                    // .min.css — minified without sourcemap reference
+                    fs.writeFileSync(minPath, minified);
+                    // .css.map — source map
+                    fs.writeFileSync(path.join(parsed.dir, mapFileName), JSON.stringify(map));
+                }
+            }
+        },
+    };
+}

--- a/.scripts/assets-manager/vite.mjs
+++ b/.scripts/assets-manager/vite.mjs
@@ -2,15 +2,18 @@ import { build, createServer } from "vite";
 import JSON5 from "json5";
 import { Buffer } from "buffer";
 import process from "node:process";
+import { minifyPlugin } from "./plugins/vite-plugin-minify.mjs";
 
 async function runVite(command, assetConfig) {
     if (command === "build") {
         await build({
             root: assetConfig.source,
+            plugins: [minifyPlugin()],
         });
     } else if (command === "watch") {
         await build({
             root: assetConfig.source,
+            plugins: [minifyPlugin()],
             build: { watch: {} },
         });
     } else if (command === "host") {

--- a/src/docs/guides/assets-manager/README.md
+++ b/src/docs/guides/assets-manager/README.md
@@ -240,6 +240,45 @@ Or simply build that Vite app:
 yarn build -n my-vue-app
 ```
 
+#### Minification and Source Maps
+
+The asset manager automatically applies the `orchard-minify` Vite plugin during `build` and `watch` commands. This plugin runs after Vite writes the bundle and produces output files that follow the Orchard Core asset convention:
+
+**JavaScript:**
+
+| File | Description |
+|------|-------------|
+| `file.js` | Minified with `sourceMappingURL` reference |
+| `file.min.js` | Minified without `sourceMappingURL` reference |
+| `file.map` | Source map |
+
+**CSS:**
+
+| File | Description |
+|------|-------------|
+| `file.css` | Minified with `sourceMappingURL` reference |
+| `file.min.css` | Minified without `sourceMappingURL` reference |
+| `file.css.map` | Source map |
+
+The `.min.*` files are intended for production use (via `SetUrl()` in `ResourceManifestOptionsConfiguration`) since they do not reference a source map. The non-min files include the source map reference, making them suitable for development and debugging.
+
+**How it works:**
+
+- JavaScript is minified using [esbuild](https://esbuild.github.io/).
+- CSS is minified using [Lightning CSS](https://lightningcss.dev/).
+- The plugin is injected automatically by the asset manager — no configuration is needed in your `vite.config.ts`.
+
+**Important:** Because the plugin disables Vite's built-in minification and handles it in a post-build step, you should **not** set `build.minify` in your `vite.config.ts` when using the asset manager. The plugin will take care of it.
+
+**Resource manifest example:**
+
+```csharp
+_manifest
+    .DefineScript("my-app")
+    .SetUrl("~/MyModule/Scripts/my-app.min.js", "~/MyModule/Scripts/my-app.js")
+    .SetVersion("1.0.0");
+```
+
 ### Webpack
 
 Webpack bundler action will support any configuration. From bundling a vue app to compiling a simple library. It is working by configuration file. The asset management tool simply loads a given webpack.config.js file that we instruct to use from the Assets.json file.


### PR DESCRIPTION
Adds an orchard-minify Vite plugin that produces .js/.min.js/.map and .css/.min.css/.css.map output files matching the Orchard Core asset convention. The plugin uses esbuild for JS and Lightning CSS for CSS minification. It is automatically injected by the asset manager during build and watch commands. Documentation updated accordingly.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
