### PR TITLE
Ensure wwwroot is published by adding .placeholder file

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/OrchardCore.Templates.Cms.Web.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Web/OrchardCore.Templates.Cms.Web.csproj
@@ -12,6 +12,12 @@
     <Folder Include="Localization\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="wwwroot\.placeholder">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
   <!-- Watcher include and excludes -->
   <ItemGroup>
       <Watch Include="**\*.cs" Exclude="Recipes\**;Assets\**;node_modules\**\*;**\*.js.map;obj\**\*;bin\**\*" />

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/OrchardCore.Templates.Mvc.Web.csproj
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Mvc.Web/OrchardCore.Templates.Mvc.Web.csproj
@@ -12,6 +12,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Update="wwwroot\.placeholder">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="OrchardCore.Application.Mvc.Targets" Version="$(TemplateOrchardPackageVersion)" />
   </ItemGroup>
 

--- a/src/docs/getting-started/README.md
+++ b/src/docs/getting-started/README.md
@@ -13,6 +13,9 @@ In this article, we are going to see how easy it is to create a CMS Web applicat
 In Visual Studio (or [any other .NET IDE](../getting-started/development-tools.md)), create a new empty .NET web application, e.g. `Cms.Web`. Do not check "Place solution and project in the same directory", because later when you create modules and themes you will want them to live alongside the web application within the solution.
 
 !!! note
+    Ensure the web application contains a `wwwroot` folder when publishing. If needed, keep a placeholder file (for example `wwwroot/.placeholder`) so the folder is included in publish output.
+
+!!! note
     If you want to use the `preview` packages, [configure the OrchardCore Preview url in your Package sources](preview-package-source.md).
 
 To add a reference to the package, right-click on the project and click on `Manage NuGet packages...`, check `Include prerelease` if required. If you added the preview source above, select this from the `Package Source` selection in the top right.  In the `Browse` tab, search for `OrchardCore.Application.Cms.Targets` and `Install` the package.


### PR DESCRIPTION
Add a .placeholder file to wwwroot and update project files to always include it in publish output, ensuring the wwwroot folder is present even if empty. Update README.md to document this requirement for new web applications.

Fixes #17342

/cc @Piedone 