### PR TITLE
Use params only for RequireFeaturesAttribute

### DIFF
--- a/src/OrchardCore/OrchardCore.Abstractions/Modules/RequireFeaturesAttribute.cs
+++ b/src/OrchardCore/OrchardCore.Abstractions/Modules/RequireFeaturesAttribute.cs
@@ -9,17 +9,9 @@ namespace OrchardCore.Modules;
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 public class RequireFeaturesAttribute : Attribute
 {
-    public RequireFeaturesAttribute(string featureName)
+    public RequireFeaturesAttribute(params string[] featureNames)
     {
-        RequiredFeatureNames = new string[] { featureName };
-    }
-
-    public RequireFeaturesAttribute(string featureName, params string[] otherFeatureNames)
-    {
-        RequiredFeatureNames = new List<string>(otherFeatureNames)
-        {
-            featureName,
-        };
+        RequiredFeatureNames = featureNames;
     }
 
     /// <summary>


### PR DESCRIPTION
No need to have `string` and `params string` in `RequireFeaturesAttribute`. No docs are needed because the previous code should work as expected.

All existing call sites remain fully backward compatible. As a side effect, the previous two-constructor approach had a subtle ordering issue where the first `featureName` argument was appended to the *end* of the feature list; the simplified single `params string[]` constructor preserves natural argument order.

<!-- START COPILOT CODING AGENT TIPS -->
---

💡 You can make Copilot smarter by setting up custom instructions, customizing its development environment and configuring Model Context Protocol (MCP) servers. Learn more [Copilot coding agent tips](https://gh.io/copilot-coding-agent-tips) in the docs.