### PR TITLE
Optimize Playwright functional tests with shared multi-tenant server

### DIFF
--- a/test/OrchardCore.Tests.Functional/Helpers/OrchardTestFixture.cs
+++ b/test/OrchardCore.Tests.Functional/Helpers/OrchardTestFixture.cs
@@ -14,6 +14,7 @@ public sealed class OrchardTestFixture : IAsyncDisposable
 
     private readonly bool _isMvc;
     private readonly string _instanceId;
+    private readonly string _autoSetupRecipe;
 
     private OrchardTestServer _server;
     private IPlaywright _playwright;
@@ -23,10 +24,11 @@ public sealed class OrchardTestFixture : IAsyncDisposable
     public string BaseUrl { get; private set; }
     public IBrowser Browser => _browser;
 
-    public OrchardTestFixture(bool isMvc = false, string instanceId = null)
+    public OrchardTestFixture(bool isMvc = false, string instanceId = null, string autoSetupRecipe = null)
     {
         _isMvc = isMvc;
         _instanceId = instanceId;
+        _autoSetupRecipe = autoSetupRecipe;
     }
 
     private static string ProjectRoot =>
@@ -54,7 +56,7 @@ public sealed class OrchardTestFixture : IAsyncDisposable
         {
             _server = _isMvc
                 ? await OrchardTestServer.StartMvcAsync(AppDir, AppDataPath)
-                : await OrchardTestServer.StartCmsAsync(AppDir, AppDataPath, _instanceId);
+                : await OrchardTestServer.StartCmsAsync(AppDir, AppDataPath, _instanceId, _autoSetupRecipe);
 
             BaseUrl = _server.ServerAddress;
         }

--- a/test/OrchardCore.Tests.Functional/Helpers/OrchardTestServer.cs
+++ b/test/OrchardCore.Tests.Functional/Helpers/OrchardTestServer.cs
@@ -52,9 +52,13 @@ public sealed class OrchardTestServer : IAsyncDisposable
         _logCollector = logCollector;
     }
 
-    public static async Task<OrchardTestServer> StartCmsAsync(string contentRoot, string appDataPath, string instanceId = null)
+    public static async Task<OrchardTestServer> StartCmsAsync(string contentRoot, string appDataPath, string instanceId = null, string autoSetupRecipe = null)
     {
         var loggerProvider = new FakeLoggerProvider();
+
+        // Ensure a clean database before building the host so the sync ConfigureServices
+        // doesn't need to block on DB operations.
+        var connectionString = await ResolveAndCleanDatabaseAsync(instanceId);
 
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -71,7 +75,7 @@ public sealed class OrchardTestServer : IAsyncDisposable
         // Serve test recipes from embedded resources instead of copying files.
         builder.Services.AddScoped<IRecipeHarvester, EmbeddedRecipeHarvester>();
 
-        ConfigureServices(builder, appDataPath, instanceId, loggerProvider);
+        ConfigureServices(builder, appDataPath, connectionString, loggerProvider, autoSetupRecipe);
 
         var app = builder.Build();
         app.UseStaticFiles();
@@ -96,7 +100,7 @@ public sealed class OrchardTestServer : IAsyncDisposable
             .AddOrchardCore()
             .AddMvc();
 
-        ConfigureServices(builder, appDataPath, instanceId: null, loggerProvider);
+        ConfigureServices(builder, appDataPath, connectionString: null, loggerProvider);
 
         var app = builder.Build();
         app.UseStaticFiles();
@@ -138,11 +142,41 @@ public sealed class OrchardTestServer : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Resolves the per-fixture connection string and drops/recreates the database asynchronously.
+    /// Returns the resolved connection string, or null when no external database is configured.
+    /// </summary>
+    private static async Task<string> ResolveAndCleanDatabaseAsync(string instanceId)
+    {
+        if (string.IsNullOrEmpty(_originalConnectionString) || string.IsNullOrEmpty(_originalDatabaseProvider))
+        {
+            return null;
+        }
+
+        var connectionString = _originalConnectionString;
+
+        if (!string.IsNullOrEmpty(instanceId))
+        {
+            var dbName = ExtractDatabaseName(_originalConnectionString);
+            if (dbName is not null)
+            {
+                connectionString = ReplaceDatabaseName(_originalConnectionString, $"{dbName}_{instanceId}");
+                await EnsureCleanDatabaseAsync(connectionString, _originalDatabaseProvider);
+            }
+        }
+
+        // Store for test helpers that need the fixture-specific connection string.
+        _currentConnectionString = connectionString;
+
+        return connectionString;
+    }
+
     private static void ConfigureServices(
         WebApplicationBuilder builder,
         string appDataPath,
-        string instanceId,
-        FakeLoggerProvider loggerProvider)
+        string connectionString,
+        FakeLoggerProvider loggerProvider,
+        string autoSetupRecipe = null)
     {
         builder.WebHost.UseUrls("http://127.0.0.1:0");
         builder.WebHost.UseSetting("suppressHostingStartup", "true");
@@ -159,23 +193,8 @@ public sealed class OrchardTestServer : IAsyncDisposable
 
         // Override database config via IConfiguration (higher priority than env vars)
         // so we never need to mutate global environment variables.
-        if (!string.IsNullOrEmpty(_originalConnectionString) && !string.IsNullOrEmpty(_originalDatabaseProvider))
+        if (!string.IsNullOrEmpty(connectionString) && !string.IsNullOrEmpty(_originalDatabaseProvider))
         {
-            var connectionString = _originalConnectionString;
-
-            if (!string.IsNullOrEmpty(instanceId))
-            {
-                var dbName = ExtractDatabaseName(_originalConnectionString);
-                if (dbName is not null)
-                {
-                    connectionString = ReplaceDatabaseName(_originalConnectionString, $"{dbName}_{instanceId}");
-                    EnsureCleanDatabase(connectionString, _originalDatabaseProvider);
-                }
-            }
-
-            // Store for test helpers that need the fixture-specific connection string.
-            _currentConnectionString = connectionString;
-
             // Write tenants.json so OrchardCore picks up the per-fixture database.
             Directory.CreateDirectory(resolvedAppDataPath);
             File.WriteAllText(
@@ -200,6 +219,27 @@ public sealed class OrchardTestServer : IAsyncDisposable
         // ConcurrencyException on SiteSettings with external databases.
         builder.Configuration["OrchardCore:OrchardCore_Documents:CheckConcurrency"] = "false";
 
+        // Configure AutoSetup so the tenant is provisioned on first request
+        // without browser-driven form submission.
+        if (!string.IsNullOrEmpty(autoSetupRecipe))
+        {
+            var config = TestUtils.DefaultConfig;
+            var dbProvider = _originalDatabaseProvider ?? "Sqlite";
+            var connString = connectionString ?? _originalConnectionString ?? string.Empty;
+
+            // Leave AutoSetupPath empty so the middleware is added inline (not branched
+            // via MapWhen), which preserves the full endpoint routing pipeline.
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:ShellName"] = "Default";
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:SiteName"] = $"Testing {autoSetupRecipe}";
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:SiteTimeZone"] = "America/New_York";
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:AdminUsername"] = config.Username;
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:AdminEmail"] = config.Email;
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:AdminPassword"] = config.Password;
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:DatabaseProvider"] = dbProvider;
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:DatabaseConnectionString"] = connString;
+            builder.Configuration["OrchardCore:OrchardCore_AutoSetup:Tenants:0:RecipeName"] = autoSetupRecipe;
+        }
+
         builder.Logging.AddFilter<FakeLoggerProvider>(level => level >= LogLevel.Warning);
         builder.Logging.AddProvider(loggerProvider);
     }
@@ -209,7 +249,7 @@ public sealed class OrchardTestServer : IAsyncDisposable
     /// Each test fixture uses its own database (e.g., "app_SaasFixture") to avoid
     /// cross-fixture interference. Dropping ensures no leftover tables from previous runs.
     /// </summary>
-    private static void EnsureCleanDatabase(string connectionString, string databaseProvider)
+    private static async Task EnsureCleanDatabaseAsync(string connectionString, string databaseProvider)
     {
         var dbName = ExtractDatabaseName(connectionString);
         if (dbName is null)
@@ -233,16 +273,16 @@ public sealed class OrchardTestServer : IAsyncDisposable
             return;
         }
 
-        using var connection = CreateConnection(serverConnectionString, databaseProvider);
+        await using var connection = CreateConnection(serverConnectionString, databaseProvider);
         if (connection is null)
         {
             return;
         }
 
-        connection.Open();
+        await connection.OpenAsync();
 
         // Check if the database exists.
-        using var checkCommand = connection.CreateCommand();
+        await using var checkCommand = connection.CreateCommand();
         var param = checkCommand.CreateParameter();
         param.ParameterName = "@dbName";
         param.Value = dbName;
@@ -262,21 +302,21 @@ public sealed class OrchardTestServer : IAsyncDisposable
         }
 
         // Drop if it already exists so we start clean (no leftover tables from previous runs).
-        if (checkCommand.ExecuteScalar() is not null)
+        if (await checkCommand.ExecuteScalarAsync() is not null)
         {
             // Terminate active connections before dropping (required by Postgres < 13 which lacks DROP ... WITH (FORCE)).
             if (databaseProvider == "Postgres")
             {
-                using var terminateCommand = connection.CreateCommand();
+                await using var terminateCommand = connection.CreateCommand();
                 var terminateParam = terminateCommand.CreateParameter();
                 terminateParam.ParameterName = "@dbName";
                 terminateParam.Value = dbName;
                 terminateCommand.Parameters.Add(terminateParam);
                 terminateCommand.CommandText = "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = @dbName AND pid <> pg_backend_pid()";
-                terminateCommand.ExecuteNonQuery();
+                await terminateCommand.ExecuteNonQueryAsync();
             }
 
-            using var dropCommand = connection.CreateCommand();
+            await using var dropCommand = connection.CreateCommand();
             dropCommand.CommandText = databaseProvider switch
             {
                 "Postgres" => $"DROP DATABASE \"{dbName.Replace("\"", "\"\"")}\"",
@@ -285,11 +325,11 @@ public sealed class OrchardTestServer : IAsyncDisposable
                 _ => null,
             };
 
-            dropCommand.ExecuteNonQuery();
+            await dropCommand.ExecuteNonQueryAsync();
         }
 
         // CREATE DATABASE is DDL and cannot be parameterized; quote per provider.
-        using var createCommand = connection.CreateCommand();
+        await using var createCommand = connection.CreateCommand();
         createCommand.CommandText = databaseProvider switch
         {
             "Postgres" => $"CREATE DATABASE \"{dbName.Replace("\"", "\"\"")}\"",
@@ -298,7 +338,7 @@ public sealed class OrchardTestServer : IAsyncDisposable
             _ => null,
         };
 
-        createCommand.ExecuteNonQuery();
+        await createCommand.ExecuteNonQueryAsync();
     }
 
     private static void ValidateDatabaseName(string dbName)

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/AgencyTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/AgencyTests.cs
@@ -11,7 +11,7 @@ public sealed class AgencyTests : CmsTestBase<AgencyFixture>, IClassFixture<Agen
     public async Task DisplaysTheHomePageOfTheAgencyTheme()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.GotoAsync("/");
+        await page.GotoAsync($"/{Fixture.Prefix}");
         await Assertions.Expect(page.Locator("#services")).ToContainTextAsync("Lorem ipsum dolor sit amet consectetur");
         await page.CloseAsync();
     }
@@ -20,8 +20,8 @@ public sealed class AgencyTests : CmsTestBase<AgencyFixture>, IClassFixture<Agen
     public async Task AgencyAdminLoginShouldWork()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.LoginAsync();
-        await page.GotoAsync("/Admin");
+        await page.LoginAsync($"/{Fixture.Prefix}");
+        await page.GotoAsync($"/{Fixture.Prefix}/Admin");
         await Assertions.Expect(page.Locator(".menu-admin")).ToHaveAttributeAsync("id", "adminMenu");
         await page.CloseAsync();
     }

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/BlogTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/BlogTests.cs
@@ -11,7 +11,7 @@ public sealed class BlogTests : CmsTestBase<BlogFixture>, IClassFixture<BlogFixt
     public async Task DisplaysTheHomePageOfTheBlogRecipe()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.GotoAsync("/");
+        await page.GotoAsync($"/{Fixture.Prefix}");
         await Assertions.Expect(page.Locator(".subheading")).ToContainTextAsync("This is the description of your blog");
         await page.CloseAsync();
     }
@@ -20,8 +20,8 @@ public sealed class BlogTests : CmsTestBase<BlogFixture>, IClassFixture<BlogFixt
     public async Task BlogAdminLoginShouldWork()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.LoginAsync();
-        await page.GotoAsync("/Admin");
+        await page.LoginAsync($"/{Fixture.Prefix}");
+        await page.GotoAsync($"/{Fixture.Prefix}/Admin");
         await Assertions.Expect(page.Locator(".menu-admin")).ToHaveAttributeAsync("id", "adminMenu");
         await page.CloseAsync();
     }

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/CmsRecipeFixture.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/CmsRecipeFixture.cs
@@ -5,53 +5,32 @@ namespace OrchardCore.Tests.Functional.Tests.Cms;
 
 public abstract class CmsRecipeFixture : IAsyncLifetime
 {
-    private readonly OrchardTestFixture _testFixture;
-
     protected abstract string RecipeName { get; }
 
-    public IBrowser Browser => _testFixture.Browser;
-    public string BaseUrl => _testFixture.BaseUrl;
+    /// <summary>
+    /// The URL prefix for this recipe's tenant (e.g., "blog", "agency").
+    /// </summary>
+    public string Prefix { get; private set; }
 
-    protected CmsRecipeFixture()
-    {
-        _testFixture = new OrchardTestFixture(instanceId: GetType().Name);
-    }
+    public IBrowser Browser => CmsServer.Browser;
+    public string BaseUrl => CmsServer.BaseUrl;
 
     public async ValueTask InitializeAsync()
     {
-        await _testFixture.InitializeAsync();
-
-        var page = await CreatePageAsync();
-        try
-        {
-            await page.GotoAsync("/");
-
-            if (await page.Locator("#SiteName").CountAsync() > 0)
-            {
-                await page.SiteSetupAsync(new TenantInfo
-                {
-                    Name = $"Testing {RecipeName}",
-                    Prefix = string.Empty,
-                    SetupRecipe = RecipeName,
-                });
-            }
-        }
-        finally
-        {
-            await page.CloseAsync();
-        }
+        await CmsServer.AcquireAsync();
+        Prefix = CmsServer.GetPrefix(RecipeName);
     }
 
-    public void AssertNoLoggedIssues() => _testFixture.AssertNoLoggedIssues();
+    public void AssertNoLoggedIssues() => CmsServer.AssertNoLoggedIssues();
 
     public async Task<IPage> CreatePageAsync()
     {
-        return await _testFixture.CreatePageAsync();
+        return await CmsServer.CreatePageAsync();
     }
 
     public async ValueTask DisposeAsync()
     {
-        await _testFixture.DisposeAsync();
+        await CmsServer.ReleaseAsync();
     }
 }
 

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/CmsServerFixture.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/CmsServerFixture.cs
@@ -1,0 +1,134 @@
+using Microsoft.Playwright;
+using OrchardCore.Tests.Functional.Helpers;
+
+namespace OrchardCore.Tests.Functional.Tests.Cms;
+
+/// <summary>
+/// Shared CMS server used by all recipe-based test classes.
+/// Starts ONE CMS server with the SaaS recipe (enabling multi-tenancy),
+/// then creates all child tenants upfront during initialization.
+/// Uses lazy async initialization so the first fixture to access it triggers setup.
+/// </summary>
+public static class CmsServer
+{
+    /// <summary>
+    /// All recipe tenants to create during initialization.
+    /// </summary>
+    private static readonly string[] _recipes = ["Agency", "Blog", "ComingSoon", "Headless", "Migrations"];
+
+    private static readonly SemaphoreSlim _initLock = new(1, 1);
+    private static OrchardTestFixture _testFixture;
+    private static Dictionary<string, string> _tenantPrefixes;
+    private static Exception _initError;
+    private static int _refCount;
+
+    public static IBrowser Browser => _testFixture?.Browser;
+    public static string BaseUrl => _testFixture?.BaseUrl;
+
+    /// <summary>
+    /// Gets the URL prefix for a recipe tenant (e.g., "blog" for the Blog recipe).
+    /// </summary>
+    public static string GetPrefix(string recipeName) => _tenantPrefixes[recipeName];
+
+    /// <summary>
+    /// Ensures the shared server is initialized. Safe to call from multiple fixtures concurrently.
+    /// </summary>
+    public static async Task AcquireAsync()
+    {
+        await _initLock.WaitAsync();
+        try
+        {
+            _refCount++;
+            if (_testFixture is not null)
+            {
+                if (_initError is not null)
+                {
+                    throw new InvalidOperationException("CmsServer initialization failed previously.", _initError);
+                }
+
+                return;
+            }
+
+            var fixture = new OrchardTestFixture(instanceId: nameof(CmsServer), autoSetupRecipe: "SaaS");
+            _tenantPrefixes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            try
+            {
+                await fixture.InitializeAsync();
+            }
+            catch (Exception ex)
+            {
+                _testFixture = fixture; // Mark as attempted so we don't retry.
+                _initError = ex;
+                throw;
+            }
+
+            _testFixture = fixture;
+
+            // Trigger AutoSetup for the Default/SaaS tenant and create all recipe tenants.
+            // Use a longer timeout for initialization since concurrent server startups
+            // (e.g., MVC) can cause resource contention.
+            var page = await _testFixture.CreatePageAsync();
+            page.SetDefaultTimeout(60_000);
+            try
+            {
+                await page.GotoAsync("/");
+                await page.WaitForLoadStateAsync(LoadState.NetworkIdle);
+
+                await page.LoginAsync();
+                await page.SetPageSizeAsync(string.Empty, "100");
+
+                foreach (var recipe in _recipes)
+                {
+                    var prefix = recipe.ToLowerInvariant();
+                    var tenant = new TenantInfo
+                    {
+                        Name = prefix,
+                        Prefix = prefix,
+                        SetupRecipe = recipe,
+                        TablePrefix = prefix,
+                    };
+
+                    await page.CreateTenantAsync(tenant);
+                    await page.VisitTenantSetupPageAsync(tenant);
+                    await page.SiteSetupAsync(tenant);
+                    _tenantPrefixes[recipe] = prefix;
+                }
+            }
+            finally
+            {
+                await page.CloseAsync();
+            }
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+
+    public static async Task<IPage> CreatePageAsync()
+    {
+        return await _testFixture.CreatePageAsync();
+    }
+
+    public static void AssertNoLoggedIssues() => _testFixture?.AssertNoLoggedIssues();
+
+    public static async Task ReleaseAsync()
+    {
+        await _initLock.WaitAsync();
+        try
+        {
+            _refCount--;
+            if (_refCount <= 0 && _testFixture is not null)
+            {
+                await _testFixture.DisposeAsync();
+                _testFixture = null;
+                _tenantPrefixes = null;
+            }
+        }
+        finally
+        {
+            _initLock.Release();
+        }
+    }
+}

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/ComingSoonTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/ComingSoonTests.cs
@@ -11,7 +11,7 @@ public sealed class ComingSoonTests : CmsTestBase<ComingSoonFixture>, IClassFixt
     public async Task DisplaysTheHomePageOfTheComingSoonTheme()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.GotoAsync("/");
+        await page.GotoAsync($"/{Fixture.Prefix}");
         await Assertions.Expect(page.Locator("h1")).ToContainTextAsync("Coming Soon");
         await Assertions.Expect(page.Locator("p")).ToContainTextAsync("We're working hard to finish the development of this site.");
         await page.CloseAsync();
@@ -21,8 +21,8 @@ public sealed class ComingSoonTests : CmsTestBase<ComingSoonFixture>, IClassFixt
     public async Task ComingSoonAdminLoginShouldWork()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.LoginAsync();
-        await page.GotoAsync("/Admin");
+        await page.LoginAsync($"/{Fixture.Prefix}");
+        await page.GotoAsync($"/{Fixture.Prefix}/Admin");
         await Assertions.Expect(page.Locator(".menu-admin")).ToHaveAttributeAsync("id", "adminMenu");
         await page.CloseAsync();
     }

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/HeadlessTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/HeadlessTests.cs
@@ -11,7 +11,7 @@ public sealed class HeadlessTests : CmsTestBase<HeadlessFixture>, IClassFixture<
     public async Task DisplaysTheLoginScreenForTheHeadlessTheme()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.GotoAsync("/");
+        await page.GotoAsync($"/{Fixture.Prefix}");
         await Assertions.Expect(page.Locator("h1")).ToContainTextAsync("Log in");
         await page.CloseAsync();
     }
@@ -20,8 +20,8 @@ public sealed class HeadlessTests : CmsTestBase<HeadlessFixture>, IClassFixture<
     public async Task HeadlessAdminLoginShouldWork()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.LoginAsync();
-        await page.GotoAsync("/Admin");
+        await page.LoginAsync($"/{Fixture.Prefix}");
+        await page.GotoAsync($"/{Fixture.Prefix}/Admin");
         await Assertions.Expect(page.Locator(".menu-admin")).ToHaveAttributeAsync("id", "adminMenu");
         await page.CloseAsync();
     }

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/MigrationsTests.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/MigrationsTests.cs
@@ -11,7 +11,7 @@ public sealed class MigrationsTests : CmsTestBase<MigrationsFixture>, IClassFixt
     public async Task DisplaysTheHomePageOfTheMigrationsRecipe()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.GotoAsync("/");
+        await page.GotoAsync($"/{Fixture.Prefix}");
         await Assertions.Expect(page.GetByText("Testing features having database migrations")).ToBeVisibleAsync();
         await page.CloseAsync();
     }
@@ -20,8 +20,8 @@ public sealed class MigrationsTests : CmsTestBase<MigrationsFixture>, IClassFixt
     public async Task MigrationsAdminLoginShouldWork()
     {
         var page = await Fixture.CreatePageAsync();
-        await page.LoginAsync();
-        await page.GotoAsync("/Admin");
+        await page.LoginAsync($"/{Fixture.Prefix}");
+        await page.GotoAsync($"/{Fixture.Prefix}/Admin");
         await Assertions.Expect(page.Locator(".menu-admin")).ToHaveAttributeAsync("id", "adminMenu");
         await page.CloseAsync();
     }

--- a/test/OrchardCore.Tests.Functional/Tests/Cms/SaasFixture.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/SaasFixture.cs
@@ -5,32 +5,18 @@ namespace OrchardCore.Tests.Functional.Tests.Cms;
 
 public sealed class SaasFixture : IAsyncLifetime
 {
-    private readonly OrchardTestFixture _testFixture = new(instanceId: nameof(SaasFixture));
-
-    public IBrowser Browser => _testFixture.Browser;
-    public string BaseUrl => _testFixture.BaseUrl;
+    public IBrowser Browser => CmsServer.Browser;
+    public string BaseUrl => CmsServer.BaseUrl;
     public TenantInfo Tenant { get; private set; }
 
     public async ValueTask InitializeAsync()
     {
-        await _testFixture.InitializeAsync();
+        await CmsServer.AcquireAsync();
 
-        var page = await CreatePageAsync();
+        // Create an additional child tenant to verify multi-tenancy (beyond the recipe tenants).
+        var page = await CmsServer.CreatePageAsync();
         try
         {
-            await page.GotoAsync("/");
-
-            if (await page.Locator("#SiteName").CountAsync() > 0)
-            {
-                await page.SiteSetupAsync(new TenantInfo
-                {
-                    Name = "Testing SaaS",
-                    Prefix = string.Empty,
-                    SetupRecipe = "SaaS",
-                });
-            }
-
-            // Create a test tenant to verify multi-tenancy.
             Tenant = TestUtils.GenerateTenantInfo("SaaS");
             await page.LoginAsync();
             await page.SetPageSizeAsync(string.Empty, "100");
@@ -44,15 +30,15 @@ public sealed class SaasFixture : IAsyncLifetime
         }
     }
 
-    public void AssertNoLoggedIssues() => _testFixture.AssertNoLoggedIssues();
+    public void AssertNoLoggedIssues() => CmsServer.AssertNoLoggedIssues();
 
     public async Task<IPage> CreatePageAsync()
     {
-        return await _testFixture.CreatePageAsync();
+        return await CmsServer.CreatePageAsync();
     }
 
     public async ValueTask DisposeAsync()
     {
-        await _testFixture.DisposeAsync();
+        await CmsServer.ReleaseAsync();
     }
 }


### PR DESCRIPTION
Replace 6 separate CMS server instances (one per recipe fixture) with a single shared server using SaaS multi-tenancy. Each recipe (Blog, Agency, etc.) is now a child tenant with its own URL prefix, eliminating redundant server startups, database creations, and browser-based setup.

Key changes:
- Add static CmsServer that starts one CMS host with AutoSetup and creates all recipe tenants upfront during initialization
- Configure OrchardCore.AutoSetup via builder.Configuration so the Default tenant is provisioned on first request without browser form filling
- Convert EnsureCleanDatabase to async (EnsureCleanDatabaseAsync) and extract it from ConfigureServices into the async StartCmsAsync call path
- Update all CMS test classes to navigate via tenant prefix (/{prefix}/)
- Refactor SaasFixture to reuse the shared server for its parent tenant

Verified on all databases running locally:

| Database | Tests | Result | Duration |
|----------|-------|--------|----------|
| SQLite | 12/12 | **Passed** | 29s |
| PostgreSQL | 12/12 | **Passed** | 31s |
| MySQL | 12/12 | **Passed** | 42s |
| SQL Server | 12/12 | **Passed** | 31s |

PR execution time for all databases: [4m 26s](https://github.com/OrchardCMS/OrchardCore/actions/runs/23691727466/usage)

Main branch execution time for all databases: [4m 8s](https://github.com/OrchardCMS/OrchardCore/actions/runs/23691839945/usage)

# Comments

To be honest I'm pushing this as a draft because I want to see if we can optimize this to be faster but I don't think it will be making a huge difference. I need to compare with what I merged already.

So actually these changes were supposed to be an optimization for perf and they end up taking more time than what I originally did.
