### PR TITLE
Avoid sorting empty _items collections

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/Shape.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/Shape.cs
@@ -29,7 +29,7 @@ public class Shape : Composite, IShape, IPositioned, IEnumerable<object>
         {
             _items ??= [];
 
-            if (!_sorted)
+            if (!_sorted && _items.Count > 0)
             {
                 _items = _items.OrderBy(x => x, FlatPositionComparer.Instance).ToList();
                 _sorted = true;
@@ -129,7 +129,7 @@ public class Shape : Composite, IShape, IPositioned, IEnumerable<object>
             return Enumerable.Empty<object>().GetEnumerator();
         }
 
-        if (!_sorted)
+        if (!_sorted && _items.Count > 0)
         {
             _items = _items.OrderBy(x => x, FlatPositionComparer.Instance).ToList();
             _sorted = true;
@@ -145,7 +145,7 @@ public class Shape : Composite, IShape, IPositioned, IEnumerable<object>
             return Enumerable.Empty<object>().GetEnumerator();
         }
 
-        if (!_sorted)
+        if (!_sorted && _items.Count > 0)
         {
             _items = _items.OrderBy(x => x, FlatPositionComparer.Instance).ToList();
             _sorted = true;

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeViewModel.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Views/ShapeViewModel.cs
@@ -55,7 +55,7 @@ public class ShapeViewModel : IShape, IPositioned
         {
             _items ??= [];
 
-            if (!_sorted)
+            if (!_sorted && _items.Count > 0)
             {
                 _items = _items.OrderBy(x => x, FlatPositionComparer.Instance).ToList();
                 _sorted = true;


### PR DESCRIPTION
Updated Shape and ShapeViewModel to only sort the _items collection when it is not empty and not already sorted. This prevents unnecessary sorting operations on empty lists, improving efficiency.
