### PR TITLE
Normalize line endings in Vite minify plugin for cross-platform consi…

### DIFF
--- a/.scripts/assets-manager/plugins/vite-plugin-minify.mjs
+++ b/.scripts/assets-manager/plugins/vite-plugin-minify.mjs
@@ -40,13 +40,15 @@ export function minifyPlugin() {
 
                     const mapFileName = `${parsed.name}.map`;
                     const minPath = path.join(parsed.dir, `${parsed.name}.min.js`);
+                    const normalizedCode = result.code.replace(/\r\n/g, "\n");
+                    const normalizedMap = result.map.replace(/\r\n/g, "\n");
 
                     // .js — minified with sourcemap reference
-                    fs.writeFileSync(filePath, `${result.code}//# sourceMappingURL=${mapFileName}\n`);
+                    fs.writeFileSync(filePath, `${normalizedCode}//# sourceMappingURL=${mapFileName}\n`);
                     // .min.js — minified without sourcemap reference
-                    fs.writeFileSync(minPath, result.code);
+                    fs.writeFileSync(minPath, normalizedCode);
                     // .map — source map
-                    fs.writeFileSync(path.join(parsed.dir, mapFileName), result.map);
+                    fs.writeFileSync(path.join(parsed.dir, mapFileName), normalizedMap);
                 }
 
                 if (fileName.endsWith(".css") && chunk.type === "asset" && typeof chunk.source === "string") {
@@ -61,7 +63,7 @@ export function minifyPlugin() {
 
                     const mapFileName = `${parsed.name}.css.map`;
                     const minPath = path.join(parsed.dir, `${parsed.name}.min.css`);
-                    const minified = code.toString();
+                    const minified = code.toString().replace(/\r\n/g, "\n");
 
                     // .css — minified with sourcemap reference
                     fs.writeFileSync(filePath, `${minified}\n/*# sourceMappingURL=${mapFileName} */\n`);


### PR DESCRIPTION
…stency

The `esbuild` and `lightningcss` native binaries can produce `\r\n` line endings on Windows, causing the assets validation CI (running on Linux) to detect differences in the rebuilt output files. This adds `.replace(/\r\n/g, "\n")` to all JS code, JS source maps, and CSS output in the Vite minify plugin, matching the normalization already done in `min.mjs`, `concat.mjs`, and `parcel.mjs`.

(cherry picked from commit ba1205bdbc43190b2a14f9b29d58236cb2ae68ec)

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
