### PR TITLE
Delay Renovate updates to avoid supply chain attacks (Lombiq Technologies: OCORE-257)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -171,6 +171,11 @@
             ],
         },
     ],
+    // Delay updates to try to avoid supply chain attacks by increasing the chance they're discovered.
+    minimumReleaseAge: '15 days',
+    // Without timestamp-optional, Renovate wouldn't update dependencies of package managers that don't provide
+    // timestamps, like GitHub Actions.
+    minimumReleaseAgeBehaviour: 'timestamp-optional',
     // With GitHub Actions, concurrency is not really an issue.
     prHourlyLimit: 0,
     // Between 0:00 and 6:00 UTC on Sundays. Large time window to ensure that Renovate runs at least once then:


### PR DESCRIPTION
While the recent axios fun doesn't affect us (also because we don't have automatic updates for NPM packages) but still, it's good practice to delay updates a bit.