### PR TITLE
Fix Liquid StringValues HTML encoding

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Values/StringValuesValue.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/Values/StringValuesValue.cs
@@ -195,41 +195,31 @@ internal sealed class StringValuesValue : FluidValue
     public override void WriteTo(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
     {
         AssertWriteToParameters(writer, encoder, cultureInfo);
-
-        if (_stringValues.Count == 0)
-        {
-            return;
-        }
-        else if (_stringValues.Count == 1)
-        {
-            writer.Write(_stringValues[0]);
-        }
-        else
-        {
-            foreach (var v in _stringValues)
-            {
-                writer.Write(v);
-            }
-        }
+        WriteEncodedTo(writer, encoder);
     }
 
-    public override async ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
+    public override ValueTask WriteToAsync(TextWriter writer, TextEncoder encoder, CultureInfo cultureInfo)
     {
         AssertWriteToParameters(writer, encoder, cultureInfo);
+        WriteEncodedTo(writer, encoder);
+        return ValueTask.CompletedTask;
+    }
 
+    private void WriteEncodedTo(TextWriter writer, TextEncoder encoder)
+    {
         if (_stringValues.Count == 0)
         {
             return;
         }
         else if (_stringValues.Count == 1)
         {
-            await writer.WriteAsync(_stringValues[0]);
+            encoder.Encode(writer, _stringValues[0]);
         }
         else
         {
             foreach (var v in _stringValues)
             {
-                await writer.WriteAsync(v);
+                encoder.Encode(writer, v);
             }
         }
     }

--- a/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/LiquidTests.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Http;
 using Fluid;
 using OrchardCore.ContentFields.Fields;
 using OrchardCore.ContentManagement;
@@ -482,6 +484,58 @@ public class LiquidTests
         });
     }
 
+    [Fact]
+    public async Task StringValuesValue_ShouldHtmlEncodeOutput()
+    {
+        var context = new SiteContext();
+        await context.InitializeAsync();
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            const string template = "{{ Model }}";
+            var liquidTemplateManager = scope.ServiceProvider.GetRequiredService<ILiquidTemplateManager>();
+            var result = await liquidTemplateManager.RenderStringAsync(template, HtmlEncoder.Default, new StringValues("""<script>alert("xss")</script>"""));
+
+            Assert.Equal("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;", result);
+        });
+    }
+
+    [Fact]
+    public async Task RequestQueryStringValues_ShouldHtmlEncodeOutput()
+    {
+        var result = await RenderRequestValueAsync("{{ Request.Query.q }}", request =>
+        {
+            request.QueryString = new QueryString("""?q=<script>alert("xss")</script>""");
+        });
+
+        Assert.Equal("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;", result);
+    }
+
+    [Fact]
+    public async Task RequestHeaderStringValues_ShouldHtmlEncodeOutput()
+    {
+        var result = await RenderRequestValueAsync("{{ Request.Headers.test }}", request =>
+        {
+            request.Headers["test"] = """<script>alert("xss")</script>""";
+        });
+
+        Assert.Equal("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;", result);
+    }
+
+    [Fact]
+    public async Task RequestFormStringValues_ShouldHtmlEncodeOutput()
+    {
+        var result = await RenderRequestValueAsync("{{ Request.Form.q }}", request =>
+        {
+            request.ContentType = "application/x-www-form-urlencoded";
+            request.Form = new FormCollection(new Dictionary<string, StringValues>
+            {
+                ["q"] = """<script>alert("xss")</script>""",
+            });
+        });
+
+        Assert.Equal("&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;", result);
+    }
+
     public static ContentItem[] FakeContentItems => new[] { "30_true", "20_false", "40_true", "60_true", "50_true", "10_true" }.Select(x => CreateFakeContentItem(decimal.Parse(x.Split('_')[0]), x.Split('_')[1] == "true")).ToArray();
 
     public static ContentItem CreateFakeContentItem(decimal order, bool addtoHotActionsMenu)
@@ -507,5 +561,24 @@ public class LiquidTests
     public class MyField : ContentField
     {
         public int Value { get; set; }
+    }
+
+    private static async Task<string> RenderRequestValueAsync(string template, Action<HttpRequest> configureRequest)
+    {
+        var context = new SiteContext();
+        await context.InitializeAsync();
+
+        string result = null;
+
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var request = SiteContext.HttpContextAccessor.HttpContext.Request;
+            configureRequest(request);
+
+            var liquidTemplateManager = scope.ServiceProvider.GetRequiredService<ILiquidTemplateManager>();
+            result = await liquidTemplateManager.RenderStringAsync(template, HtmlEncoder.Default);
+        });
+
+        return result;
     }
 }


### PR DESCRIPTION
## Summary
GHSL-2026-072 reports that `StringValuesValue` bypasses Fluid's HTML output encoding when Liquid templates render request-backed `StringValues`, which can turn common patterns like `Request.Query`, `Request.Headers`, and `Request.Form` into XSS sinks.

This change restores Fluid's default encoding contract by routing `StringValuesValue` output through the provided `TextEncoder`.

## Changes
- encode `StringValuesValue` output in both `WriteTo()` and `WriteToAsync()`
- add regressions for direct `StringValues` rendering
- add regressions for `Request.Query`, `Request.Headers`, and `Request.Form` Liquid output

## Notes
- the vulnerable path was introduced on `main` by `6daaebce6` (`Simplify using StringValues in Liquid templates`)
- `release/2.2` and `v2.2.1` do not contain that commit and still expose these values through `ArrayValue`/`StringValue`, so this specific issue does not affect that older `2.x` line