### PR TITLE
Yarn - Warn Windows users to restart terminal

### DIFF
--- a/.scripts/assets-manager/build.mjs
+++ b/.scripts/assets-manager/build.mjs
@@ -52,7 +52,21 @@ const versionManagers = {
         },
         useNode(version) {
             execSync(`fnm install ${version}`, { stdio: "inherit" });
-            execSync(`fnm exec --using ${version} -- corepack enable`, { stdio: "inherit" });
+            try {
+                execSync(`fnm exec --using ${version} -- corepack enable`, { stdio: "inherit" });
+            } catch (err) {
+                if (process.platform === "win32") {
+                    console.log(
+                        chalk.yellow(
+                            `\nfnm was just installed but its shims are not yet on PATH in this terminal session.`
+                        )
+                    );
+                    console.log(chalk.yellow("Please restart your terminal (close and reopen it), then run:"));
+                    console.log(chalk.white("  yarn build"));
+                    process.exit(0);
+                }
+                throw err;
+            }
         },
         execCommand(version, args) {
             return `fnm exec --using ${version} -- corepack yarn ${args}`;
@@ -74,8 +88,22 @@ const versionManagers = {
             }
         },
         useNode(version) {
-            execSync(`volta install node@${version}`, { stdio: "inherit" });
-            execSync("corepack enable", { stdio: "inherit" });
+            try {
+                execSync(`volta install node@${version}`, { stdio: "inherit" });
+                execSync("corepack enable", { stdio: "inherit" });
+            } catch (err) {
+                if (process.platform === "win32") {
+                    console.log(
+                        chalk.yellow(
+                            `\nVolta was just installed but its shims are not yet on PATH in this terminal session.`
+                        )
+                    );
+                    console.log(chalk.yellow("Please restart your terminal (close and reopen it), then run:"));
+                    console.log(chalk.white("  yarn build"));
+                    process.exit(0);
+                }
+                throw err;
+            }
         },
         execCommand(version, args) {
             return `volta run --node ${version} -- corepack yarn ${args}`;

--- a/src/docs/guides/assets-manager/README.md
+++ b/src/docs/guides/assets-manager/README.md
@@ -25,8 +25,13 @@ Parcel is the easiest way to build assets so far as it doesn't require any confi
 
     Options 3-4 will automatically install the chosen version manager (if not already present), install the required Node.js version, enable corepack, and restart the build.
 
-    !!! note "Windows"
-        On Windows, if the version manager needs to be installed first, the process will exit after installation and ask you to restart your terminal before re-running the build.
+    !!! warning "Windows - Terminal Restart Required"
+        On Windows, when installing **fnm** or **Volta** for the first time, their executable shims may not be immediately available on the PATH in your current terminal session. If you encounter this issue, you will see one of these messages:
+        
+        - `fnm was just installed but its shims are not yet on PATH in this terminal session.`
+        - `Volta was just installed but its shims are not yet on PATH in this terminal session.`
+        
+        **If you see this message, please restart your terminal** (close and reopen it), then run your command again (e.g., `yarn build`). This is a Windows-specific limitation and necessary only when first installing a version manager.
 
 2. From the root of the repository, run the following commands. Be sure to indeed run **exactly** these, and verify that the Yarn version matches the `packageManager` value in the root `package.json` (currently v4.13.x).
     ```cmd


### PR DESCRIPTION
 when fnm/volta shims are not yet on PATH

When fnm or volta was just installed, their corepack shim may not be resolvable in the current terminal session. Instead of failing with a cryptic "program not found" error, prompt the user to restart the terminal and rerun yarn build.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
