### PR TITLE
Escape curly braces in media format localization string

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Views/MediaField-Attached.Edit.cshtml
@@ -62,8 +62,7 @@
         <input type="hidden" id="t-uploads" value="@T["Uploads"]" />
         <input type="hidden" id="t-errors" value="@T["Errors"]" />
         <input type="hidden" id="t-clear-errors" value="@T["Clear Errors"]" />
-
-        <input type="hidden" id="t-selected-media-format" value="@T["{0}{1} ({2} KB)"]" />
+        <input type="hidden" id="t-selected-media-format" value="@T["{{0}}{{1}} ({{2}} KB)"]" />
     </div>
 
     <partial name="Shared/MediaFieldEditLocalization.cshtml" />


### PR DESCRIPTION
Changed single curly braces to double in the t-selected-media-format hidden input to prevent templating engines from misinterpreting placeholders. This ensures correct rendering in environments that use curly braces for variable interpolation.

Fixes an issue introduced by PR #19121