### PR TITLE
Increase WarmUpAsync timeout to 90 seconds in tests

### DIFF
--- a/test/OrchardCore.Tests.Functional/Helpers/OrchardTestServer.cs
+++ b/test/OrchardCore.Tests.Functional/Helpers/OrchardTestServer.cs
@@ -109,7 +109,7 @@ public sealed class OrchardTestServer : IAsyncDisposable
 
         // The OrchardCore tenant pipeline initializes lazily on the first request.
         // Warm up the app now so tests don't race against pipeline initialization.
-        await WarmUpAsync(address);
+        await WarmUpAsync(address, timeoutSeconds: 90);
 
         return new OrchardTestServer(app, address, loggerProvider.Collector);
     }


### PR DESCRIPTION
Set the timeoutSeconds parameter to 90 when calling WarmUpAsync during OrchardCore tenant pipeline initialization. This change aims to reduce test flakiness caused by slow application startup.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
