### PR TITLE
Add instance counter to CmsRecipeFixture for unique App_Data paths

### DIFF
--- a/test/OrchardCore.Tests.Functional/Tests/Cms/CmsRecipeFixture.cs
+++ b/test/OrchardCore.Tests.Functional/Tests/Cms/CmsRecipeFixture.cs
@@ -5,6 +5,7 @@ namespace OrchardCore.Tests.Functional.Tests.Cms;
 
 public abstract class CmsRecipeFixture : IAsyncLifetime
 {
+    private static int _instanceCounter;
     private readonly OrchardTestFixture _testFixture;
 
     protected abstract string RecipeName { get; }
@@ -14,7 +15,7 @@ public abstract class CmsRecipeFixture : IAsyncLifetime
 
     protected CmsRecipeFixture()
     {
-        _testFixture = new OrchardTestFixture(instanceId: GetType().Name);
+        _testFixture = new OrchardTestFixture(instanceId: $"{GetType().Name}_{_instanceCounter++}");
     }
 
     public async ValueTask InitializeAsync()


### PR DESCRIPTION
Guards against App_Data path collisions if the same fixture subclass is ever instantiated more than once within a test run.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
