### PR TITLE
Sort user roles alphabetically in admin UI

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AdminController.cs
@@ -169,7 +169,7 @@ public sealed class AdminController : Controller
             new SelectListItem() { Text = S["Any role"], Value = string.Empty, Selected = options.SelectedRole == string.Empty },
             new SelectListItem() { Text = S["Authenticated (no roles)"], Value = OrchardCoreConstants.Roles.Authenticated, Selected = string.Equals(options.SelectedRole, OrchardCoreConstants.Roles.Authenticated, StringComparison.OrdinalIgnoreCase) },
             // TODO Candidate for dynamic localization.
-            .. roleNames.Select(roleName =>
+            .. roleNames.OrderBy(roleName => roleName).Select(roleName =>
                 new SelectListItem
                 {
                     Text = roleName,

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserRoleDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/UserRoleDisplayDriver.cs
@@ -75,7 +75,7 @@ public sealed class UserRoleDisplayDriver : DisplayDriver<User>
                 roleEntries.Add(roleEntry);
             }
 
-            model.Roles = roleEntries.ToArray();
+            model.Roles = roleEntries.OrderBy(role => role.Role).ToArray();
         })
         .Location("Content:1.10")
         .RenderWhen(() => _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, UsersPermissions.EditUsers, user));

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserRoles.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserRoles.cshtml
@@ -9,7 +9,7 @@
 
 <h4>@T["Roles"]</h4>
 <ul class="list-unstyled">
-    @foreach (var roleName in Model.User.RoleNames)
+    @foreach (var roleName in Model.User.RoleNames.OrderBy(r => r))
     {
         if (!roles.TryGetValue(roleName, out var role))
         {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserRolesMeta.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserRolesMeta.cshtml
@@ -8,7 +8,7 @@
 }
 
 <div data-bs-toggle="tooltip" title="@T["The roles this user has"]">
-    @foreach (var roleName in Model.User.RoleNames)
+    @foreach (var roleName in Model.User.RoleNames.OrderBy(r => r))
     {
         if (!roles.TryGetValue(roleName, out var role))
         {


### PR DESCRIPTION
Ensures that user roles are consistently displayed in alphabetical order across the admin interface. This affects role filters, user edit forms, and user role displays, improving usability and readability.

