### PR TITLE
Fix placement of disabled button tooltips on features

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -155,22 +155,22 @@
                                         {
                                             @if (feature.IsEnabled)
                                             {
-                                                <div data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is automatically enabled based on dependency and cannot be manually disabled."]">
+                                                <span class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is automatically enabled based on dependency and cannot be manually disabled."]">
                                                     <button class="btn btn-danger btn-sm" disabled>@T["Disable"]</button>
-                                                </div>
+                                                </span>
                                             }
                                             else
                                             {
-                                                <div data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is automatically disabled based on dependency and cannot be manually enabled."]">
+                                                <span class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is automatically disabled based on dependency and cannot be manually enabled."]">
                                                     <button class="btn btn-primary btn-sm" disabled>@T["Enable"]</button>
-                                                </div>
+                                                </span>
                                             }
                                         }
                                         else if (feature.IsEnabled && isAlwaysEnabled)
                                         {
-                                            <div data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is always enabled and cannot be manually disabled."]">
+                                            <span class="d-inline-block" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="@T["This feature is always enabled and cannot be manually disabled."]">
                                                 <button class="btn btn-danger btn-sm" disabled>@T["Disable"]</button>
-                                            </div>
+                                            </span>
                                         }
                                         else
                                         {


### PR DESCRIPTION
Updated the HTML structure in Features.cshtml to wrap disabled Enable/Disable buttons with `<span class="d-inline-block">` instead of `<div>`. This ensures Bootstrap tooltips display correctly on disabled buttons, improving accessibility and UI consistency for features that are dependency-locked or always enabled.

Before:
<img width="419" height="187" alt="image" src="https://github.com/user-attachments/assets/7c49100b-15fe-4b95-b16d-2f938fbea749" />

After: 
<img width="388" height="205" alt="image" src="https://github.com/user-attachments/assets/92f5c4b4-b808-49fb-835c-6cd4e2d7ae75" />
