### PR TITLE
Add DocumentsAddedOrUpdated and DocumentsDeleted events to IDocumentIndexHandler

### DIFF
--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAISearchDocumentIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAISearchDocumentIndexManager.cs
@@ -3,6 +3,7 @@ using Azure.Search.Documents;
 using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Logging;
 using OrchardCore.AzureAI.Models;
+using OrchardCore.ContentManagement;
 using OrchardCore.Contents.Indexing;
 using OrchardCore.Entities;
 using OrchardCore.Indexing;
@@ -95,7 +96,8 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
             var keyName = GetKeyFieldNameOrThrow(index);
 
             await client.DeleteDocumentsAsync(keyName, documentIds);
-            await NotifyDocumentsDeletedAsync(index, documentIds);
+
+            await _documentIndexHandlers.InvokeAsync((handler, indexProfile, documentIds) => handler.DocumentsDeletedAsync(indexProfile, documentIds), index, documentIds, _logger);
 
             return true;
         }
@@ -170,7 +172,7 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
                 await client.MergeOrUploadDocumentsAsync(docs);
             }
 
-            await NotifyDocumentsAddedOrUpdatedAsync(index, indexDocuments);
+            await _documentIndexHandlers.InvokeAsync((handler, indexProfile, docs) => handler.DocumentsAddedOrUpdatedAsync(indexProfile, docs), index, indexDocuments, _logger);
 
             return true;
         }
@@ -231,42 +233,6 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
 
     public IContentIndexSettings GetContentIndexSettings()
         => new AzureAISearchContentIndexSettings();
-
-    private async Task NotifyDocumentsAddedOrUpdatedAsync(IndexProfile indexProfile, IEnumerable<DocumentIndex> documents)
-    {
-        if (!_documentIndexHandlers.Any())
-        {
-            return;
-        }
-
-        var documentIds = documents
-            .Select(document => document.Id)
-            .Where(id => !string.IsNullOrWhiteSpace(id))
-            .ToArray();
-
-        if (documentIds.Length == 0)
-        {
-            return;
-        }
-
-        await _documentIndexHandlers.InvokeAsync(
-            (handler, context) => handler.DocumentsAddedOrUpdatedAsync(context.IndexProfile, context.DocumentIds),
-            new DocumentIndexNotificationContext(indexProfile, documentIds),
-            _logger);
-    }
-
-    private async Task NotifyDocumentsDeletedAsync(IndexProfile indexProfile, IEnumerable<string> documentIds)
-    {
-        if (!_documentIndexHandlers.Any() || !documentIds.Any())
-        {
-            return;
-        }
-
-        await _documentIndexHandlers.InvokeAsync(
-            (handler, context) => handler.DocumentsDeletedAsync(context.IndexProfile, context.DocumentIds),
-            new DocumentIndexNotificationContext(indexProfile, documentIds),
-            _logger);
-    }
 
     private static string GetKeyFieldNameOrThrow(IndexProfile index)
     {
@@ -476,6 +442,4 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
             map.AzureFieldKey == AzureAISearchIndexManager.DisplayTextAnalyzedKey ||
             !map.IsCollection;
     }
-
-    private sealed record DocumentIndexNotificationContext(IndexProfile IndexProfile, IEnumerable<string> DocumentIds);
 }

--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAISearchDocumentIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Services/AzureAISearchDocumentIndexManager.cs
@@ -2,12 +2,12 @@ using System.Reflection;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Models;
 using Microsoft.Extensions.Logging;
+using OrchardCore.AzureAI.Models;
 using OrchardCore.Contents.Indexing;
 using OrchardCore.Entities;
 using OrchardCore.Indexing;
 using OrchardCore.Indexing.Models;
 using OrchardCore.Modules;
-using OrchardCore.AzureAI.Models;
 using static OrchardCore.Indexing.DocumentIndex;
 
 namespace OrchardCore.AzureAI.Services;
@@ -16,17 +16,20 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
 {
     private readonly AzureAIClientFactory _clientFactory;
     private readonly IEnumerable<IAzureAISearchDocumentEvents> _documentEvents;
+    private readonly IEnumerable<IDocumentIndexHandler> _documentIndexHandlers;
     private readonly IIndexProfileStore _indexStore;
     private readonly ILogger _logger;
 
     public AzureAISearchDocumentIndexManager(
         AzureAIClientFactory clientFactory,
         IEnumerable<IAzureAISearchDocumentEvents> documentEvents,
+        IEnumerable<IDocumentIndexHandler> documentIndexHandlers,
         IIndexProfileStore indexStore,
         ILogger<AzureAISearchDocumentIndexManager> logger)
     {
         _clientFactory = clientFactory;
         _documentEvents = documentEvents;
+        _documentIndexHandlers = documentIndexHandlers;
         _indexStore = indexStore;
         _logger = logger;
     }
@@ -92,6 +95,7 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
             var keyName = GetKeyFieldNameOrThrow(index);
 
             await client.DeleteDocumentsAsync(keyName, documentIds);
+            await NotifyDocumentsDeletedAsync(index, documentIds);
 
             return true;
         }
@@ -166,6 +170,8 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
                 await client.MergeOrUploadDocumentsAsync(docs);
             }
 
+            await NotifyDocumentsAddedOrUpdatedAsync(index, indexDocuments);
+
             return true;
         }
         catch (Exception ex)
@@ -225,6 +231,42 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
 
     public IContentIndexSettings GetContentIndexSettings()
         => new AzureAISearchContentIndexSettings();
+
+    private async Task NotifyDocumentsAddedOrUpdatedAsync(IndexProfile indexProfile, IEnumerable<DocumentIndex> documents)
+    {
+        if (!_documentIndexHandlers.Any())
+        {
+            return;
+        }
+
+        var documentIds = documents
+            .Select(document => document.Id)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToArray();
+
+        if (documentIds.Length == 0)
+        {
+            return;
+        }
+
+        await _documentIndexHandlers.InvokeAsync(
+            (handler, context) => handler.DocumentsAddedOrUpdatedAsync(context.IndexProfile, context.DocumentIds),
+            new DocumentIndexNotificationContext(indexProfile, documentIds),
+            _logger);
+    }
+
+    private async Task NotifyDocumentsDeletedAsync(IndexProfile indexProfile, IEnumerable<string> documentIds)
+    {
+        if (!_documentIndexHandlers.Any() || !documentIds.Any())
+        {
+            return;
+        }
+
+        await _documentIndexHandlers.InvokeAsync(
+            (handler, context) => handler.DocumentsDeletedAsync(context.IndexProfile, context.DocumentIds),
+            new DocumentIndexNotificationContext(indexProfile, documentIds),
+            _logger);
+    }
 
     private static string GetKeyFieldNameOrThrow(IndexProfile index)
     {
@@ -434,4 +476,6 @@ public sealed class AzureAISearchDocumentIndexManager : IDocumentIndexManager
             map.AzureFieldKey == AzureAISearchIndexManager.DisplayTextAnalyzedKey ||
             !map.IsCollection;
     }
+
+    private sealed record DocumentIndexNotificationContext(IndexProfile IndexProfile, IEnumerable<string> DocumentIds);
 }

--- a/src/OrchardCore/OrchardCore.Elasticsearch.Core/Services/ElasticsearchDocumentIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Elasticsearch.Core/Services/ElasticsearchDocumentIndexManager.cs
@@ -94,7 +94,7 @@ public sealed class ElasticsearchDocumentIndexManager : IDocumentIndexManager
 
         if (response.IsValidResponse)
         {
-            await NotifyDocumentsDeletedAsync(index, ids);
+            await _documentIndexHandlers.InvokeAsync((handler, indexProfile, documentIds) => handler.DocumentsDeletedAsync(indexProfile, documentIds), index, ids, _logger);
         }
 
         return response.IsValidResponse;
@@ -194,46 +194,10 @@ public sealed class ElasticsearchDocumentIndexManager : IDocumentIndexManager
 
         if (succeeded)
         {
-            await NotifyDocumentsAddedOrUpdatedAsync(index, documents);
+            await _documentIndexHandlers.InvokeAsync((handler, indexProfile, docs) => handler.DocumentsAddedOrUpdatedAsync(indexProfile, docs), index, documents, _logger);
         }
 
         return succeeded;
-    }
-
-    private async Task NotifyDocumentsAddedOrUpdatedAsync(IndexProfile indexProfile, IEnumerable<DocumentIndex> documents)
-    {
-        if (!_documentIndexHandlers.Any())
-        {
-            return;
-        }
-
-        var documentIds = documents
-            .Select(document => document.Id)
-            .Where(id => !string.IsNullOrWhiteSpace(id))
-            .ToArray();
-
-        if (documentIds.Length == 0)
-        {
-            return;
-        }
-
-        await _documentIndexHandlers.InvokeAsync(
-            (handler, context) => handler.DocumentsAddedOrUpdatedAsync(context.IndexProfile, context.DocumentIds),
-            new DocumentIndexNotificationContext(indexProfile, documentIds),
-            _logger);
-    }
-
-    private async Task NotifyDocumentsDeletedAsync(IndexProfile indexProfile, IEnumerable<string> documentIds)
-    {
-        if (!_documentIndexHandlers.Any() || !documentIds.Any())
-        {
-            return;
-        }
-
-        await _documentIndexHandlers.InvokeAsync(
-            (handler, context) => handler.DocumentsDeletedAsync(context.IndexProfile, context.DocumentIds),
-            new DocumentIndexNotificationContext(indexProfile, documentIds),
-            _logger);
     }
 
     internal async Task<TypeMapping> GetIndexMappingsAsync(string indexFullName)
@@ -409,6 +373,4 @@ public sealed class ElasticsearchDocumentIndexManager : IDocumentIndexManager
             }
         }
     }
-
-    private sealed record DocumentIndexNotificationContext(IndexProfile IndexProfile, IEnumerable<string> DocumentIds);
 }

--- a/src/OrchardCore/OrchardCore.Elasticsearch.Core/Services/ElasticsearchDocumentIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Elasticsearch.Core/Services/ElasticsearchDocumentIndexManager.cs
@@ -6,23 +6,27 @@ using Elastic.Clients.Elasticsearch.QueryDsl;
 using Microsoft.Extensions.Logging;
 using OrchardCore.ContentManagement;
 using OrchardCore.Contents.Indexing;
+using OrchardCore.Elasticsearch.Core.Models;
 using OrchardCore.Entities;
 using OrchardCore.Indexing;
 using OrchardCore.Indexing.Models;
-using OrchardCore.Elasticsearch.Core.Models;
+using OrchardCore.Modules;
 
 namespace OrchardCore.Elasticsearch.Core.Services;
 
 public sealed class ElasticsearchDocumentIndexManager : IDocumentIndexManager
 {
     private readonly ElasticsearchClient _client;
+    private readonly IEnumerable<IDocumentIndexHandler> _documentIndexHandlers;
     private readonly ILogger _logger;
 
     public ElasticsearchDocumentIndexManager(
         ElasticsearchClient client,
+        IEnumerable<IDocumentIndexHandler> documentIndexHandlers,
         ILogger<ElasticsearchDocumentIndexManager> logger)
     {
         _client = client;
+        _documentIndexHandlers = documentIndexHandlers;
         _logger = logger;
     }
 
@@ -86,6 +90,11 @@ public sealed class ElasticsearchDocumentIndexManager : IDocumentIndexManager
             {
                 _logger.LogWarning("There were issues deleting documents in an Elasticsearch index");
             }
+        }
+
+        if (response.IsValidResponse)
+        {
+            await NotifyDocumentsDeletedAsync(index, ids);
         }
 
         return response.IsValidResponse;
@@ -181,7 +190,50 @@ public sealed class ElasticsearchDocumentIndexManager : IDocumentIndexManager
             }
         }
 
-        return totalBatchesProcessed == totalBatchesSucceeded;
+        var succeeded = totalBatchesProcessed == totalBatchesSucceeded;
+
+        if (succeeded)
+        {
+            await NotifyDocumentsAddedOrUpdatedAsync(index, documents);
+        }
+
+        return succeeded;
+    }
+
+    private async Task NotifyDocumentsAddedOrUpdatedAsync(IndexProfile indexProfile, IEnumerable<DocumentIndex> documents)
+    {
+        if (!_documentIndexHandlers.Any())
+        {
+            return;
+        }
+
+        var documentIds = documents
+            .Select(document => document.Id)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .ToArray();
+
+        if (documentIds.Length == 0)
+        {
+            return;
+        }
+
+        await _documentIndexHandlers.InvokeAsync(
+            (handler, context) => handler.DocumentsAddedOrUpdatedAsync(context.IndexProfile, context.DocumentIds),
+            new DocumentIndexNotificationContext(indexProfile, documentIds),
+            _logger);
+    }
+
+    private async Task NotifyDocumentsDeletedAsync(IndexProfile indexProfile, IEnumerable<string> documentIds)
+    {
+        if (!_documentIndexHandlers.Any() || !documentIds.Any())
+        {
+            return;
+        }
+
+        await _documentIndexHandlers.InvokeAsync(
+            (handler, context) => handler.DocumentsDeletedAsync(context.IndexProfile, context.DocumentIds),
+            new DocumentIndexNotificationContext(indexProfile, documentIds),
+            _logger);
     }
 
     internal async Task<TypeMapping> GetIndexMappingsAsync(string indexFullName)
@@ -357,4 +409,6 @@ public sealed class ElasticsearchDocumentIndexManager : IDocumentIndexManager
             }
         }
     }
+
+    private sealed record DocumentIndexNotificationContext(IndexProfile IndexProfile, IEnumerable<string> DocumentIds);
 }

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/IDocumentIndexHandler.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/IDocumentIndexHandler.cs
@@ -20,11 +20,11 @@ public interface IDocumentIndexHandler
     /// Notifies the handler after documents have been added to or updated in a provider-specific index.
     /// </summary>
     /// <param name="indexProfile">The index profile that was updated.</param>
-    /// <param name="documentIds">The distinct identifiers of the documents that were successfully added or updated.</param>
+    /// <param name="documents">The documents that were successfully added or updated.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the notification.</param>
     Task DocumentsAddedOrUpdatedAsync(
         IndexProfile indexProfile,
-        IEnumerable<string> documentIds,
+        IEnumerable<DocumentIndex> documents,
         CancellationToken cancellationToken = default)
         => Task.CompletedTask;
 

--- a/src/OrchardCore/OrchardCore.Indexing.Abstractions/IDocumentIndexHandler.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Abstractions/IDocumentIndexHandler.cs
@@ -1,3 +1,5 @@
+using OrchardCore.Indexing.Models;
+
 namespace OrchardCore.Indexing;
 
 /// <summary>
@@ -5,5 +7,36 @@ namespace OrchardCore.Indexing;
 /// </summary>
 public interface IDocumentIndexHandler
 {
+    /// <summary>
+    /// Builds index entries for the current record by adding values to <see cref="BuildDocumentIndexContext.DocumentIndex"/>.
+    /// </summary>
+    /// <param name="context">
+    /// The context for the current indexing operation, including the source record, target document,
+    /// generated field keys, and provider-specific index settings.
+    /// </param>
     Task BuildIndexAsync(BuildDocumentIndexContext context);
+
+    /// <summary>
+    /// Notifies the handler after documents have been added to or updated in a provider-specific index.
+    /// </summary>
+    /// <param name="indexProfile">The index profile that was updated.</param>
+    /// <param name="documentIds">The distinct identifiers of the documents that were successfully added or updated.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the notification.</param>
+    Task DocumentsAddedOrUpdatedAsync(
+        IndexProfile indexProfile,
+        IEnumerable<string> documentIds,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <summary>
+    /// Notifies the handler after documents have been removed from a provider-specific index.
+    /// </summary>
+    /// <param name="indexProfile">The index profile that was updated.</param>
+    /// <param name="documentIds">The distinct identifiers of the documents that were successfully deleted.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the notification.</param>
+    Task DocumentsDeletedAsync(
+        IndexProfile indexProfile,
+        IEnumerable<string> documentIds,
+        CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 }

--- a/src/OrchardCore/OrchardCore.Lucene.Core/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Lucene.Core/Services/LuceneIndexManager.cs
@@ -180,7 +180,7 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
             writer.DeleteDocuments(documentIds.Select(id => new Term(metadata.IndexMappings.KeyFieldName, id)).ToArray());
         });
 
-        await NotifyDocumentsDeletedAsync(index, documentIds);
+        await _documentIndexHandlers.InvokeAsync((handler, indexProfile, ids) => handler.DocumentsDeletedAsync(indexProfile, ids), index, documentIds, _logger);
 
         return true;
     }
@@ -214,7 +214,7 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
             return false;
         }
 
-        await NotifyDocumentsAddedOrUpdatedAsync(index, documents);
+        await _documentIndexHandlers.InvokeAsync((handler, indexProfile, docs) => handler.DocumentsAddedOrUpdatedAsync(indexProfile, docs), index, documents, _logger);
 
         return true;
     }
@@ -249,43 +249,6 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
 
     public IContentIndexSettings GetContentIndexSettings()
          => new LuceneContentIndexSettings();
-
-    private async Task NotifyDocumentsAddedOrUpdatedAsync(IndexProfile indexProfile, IEnumerable<DocumentIndex> documents)
-    {
-        if (!_documentIndexHandlers.Any())
-        {
-            return;
-        }
-
-        var documentIds = documents
-            .Select(document => document.Id)
-            .Where(id => !string.IsNullOrWhiteSpace(id))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
-
-        if (documentIds.Length == 0)
-        {
-            return;
-        }
-
-        await _documentIndexHandlers.InvokeAsync(
-            (handler, context) => handler.DocumentsAddedOrUpdatedAsync(context.IndexProfile, context.DocumentIds),
-            new DocumentIndexNotificationContext(indexProfile, documentIds),
-            _logger);
-    }
-
-    private async Task NotifyDocumentsDeletedAsync(IndexProfile indexProfile, IEnumerable<string> documentIds)
-    {
-        if (!_documentIndexHandlers.Any() || !documentIds.Any())
-        {
-            return;
-        }
-
-        await _documentIndexHandlers.InvokeAsync(
-            (handler, context) => handler.DocumentsDeletedAsync(context.IndexProfile, context.DocumentIds),
-            new DocumentIndexNotificationContext(indexProfile, documentIds),
-            _logger);
-    }
 
     private Document CreateLuceneDocument(DocumentIndex document, bool storeSourceData)
     {
@@ -464,6 +427,4 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
 
         return doc;
     }
-
-    private sealed record DocumentIndexNotificationContext(IndexProfile IndexProfile, IEnumerable<string> DocumentIds);
 }

--- a/src/OrchardCore/OrchardCore.Lucene.Core/Services/LuceneIndexManager.cs
+++ b/src/OrchardCore/OrchardCore.Lucene.Core/Services/LuceneIndexManager.cs
@@ -10,9 +10,9 @@ using OrchardCore.Indexing;
 using OrchardCore.Indexing.Models;
 using OrchardCore.Locking.Distributed;
 using OrchardCore.Lucene.Core;
-using OrchardCore.Modules;
 using OrchardCore.Lucene.Model;
 using OrchardCore.Lucene.Models;
+using OrchardCore.Modules;
 using Spatial4n.Context;
 
 namespace OrchardCore.Lucene;
@@ -23,6 +23,7 @@ namespace OrchardCore.Lucene;
 /// </summary>
 public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
 {
+    private readonly IEnumerable<IDocumentIndexHandler> _documentIndexHandlers;
     private readonly ILuceneIndexStore _indexStore;
     private readonly ILuceneIndexingState _indexingState;
     private readonly ILogger _logger;
@@ -36,10 +37,12 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
         ILuceneIndexStore indexStore,
         ILuceneIndexingState indexingState,
         ILogger<LuceneIndexManager> logger,
+        IEnumerable<IDocumentIndexHandler> documentIndexHandlers,
         IEnumerable<IIndexEvents> indexEvents,
         IDistributedLock distributedLock
         )
     {
+        _documentIndexHandlers = documentIndexHandlers;
         _indexStore = indexStore;
         _indexingState = indexingState;
         _logger = logger;
@@ -177,6 +180,8 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
             writer.DeleteDocuments(documentIds.Select(id => new Term(metadata.IndexMappings.KeyFieldName, id)).ToArray());
         });
 
+        await NotifyDocumentsDeletedAsync(index, documentIds);
+
         return true;
     }
 
@@ -196,9 +201,9 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
             {
                 var metadata = index.GetOrCreate<LuceneIndexMetadata>();
 
-                foreach (var indexDocument in documents)
+                foreach (var document in documents)
                 {
-                    writer.UpdateDocument(new Term(metadata.IndexMappings.KeyFieldName, indexDocument.Id), CreateLuceneDocument(indexDocument, metadata.StoreSourceData));
+                    writer.UpdateDocument(new Term(metadata.IndexMappings.KeyFieldName, document.Id), CreateLuceneDocument(document, metadata.StoreSourceData));
                 }
             });
         }
@@ -208,6 +213,8 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
 
             return false;
         }
+
+        await NotifyDocumentsAddedOrUpdatedAsync(index, documents);
 
         return true;
     }
@@ -242,6 +249,43 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
 
     public IContentIndexSettings GetContentIndexSettings()
          => new LuceneContentIndexSettings();
+
+    private async Task NotifyDocumentsAddedOrUpdatedAsync(IndexProfile indexProfile, IEnumerable<DocumentIndex> documents)
+    {
+        if (!_documentIndexHandlers.Any())
+        {
+            return;
+        }
+
+        var documentIds = documents
+            .Select(document => document.Id)
+            .Where(id => !string.IsNullOrWhiteSpace(id))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (documentIds.Length == 0)
+        {
+            return;
+        }
+
+        await _documentIndexHandlers.InvokeAsync(
+            (handler, context) => handler.DocumentsAddedOrUpdatedAsync(context.IndexProfile, context.DocumentIds),
+            new DocumentIndexNotificationContext(indexProfile, documentIds),
+            _logger);
+    }
+
+    private async Task NotifyDocumentsDeletedAsync(IndexProfile indexProfile, IEnumerable<string> documentIds)
+    {
+        if (!_documentIndexHandlers.Any() || !documentIds.Any())
+        {
+            return;
+        }
+
+        await _documentIndexHandlers.InvokeAsync(
+            (handler, context) => handler.DocumentsDeletedAsync(context.IndexProfile, context.DocumentIds),
+            new DocumentIndexNotificationContext(indexProfile, documentIds),
+            _logger);
+    }
 
     private Document CreateLuceneDocument(DocumentIndex document, bool storeSourceData)
     {
@@ -420,4 +464,6 @@ public sealed class LuceneIndexManager : IIndexManager, IDocumentIndexManager
 
         return doc;
     }
+
+    private sealed record DocumentIndexNotificationContext(IndexProfile IndexProfile, IEnumerable<string> DocumentIds);
 }


### PR DESCRIPTION
These events are needed to allow other projects to be able to implement handler for synchronization purpose like when an index is updated, update another data source.