### PR TITLE
Add Category and UI filtering for Deployment Steps

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminMenu/Deployment/AdminMenuDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AdminMenu/Deployment/AdminMenuDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.AdminMenu.Deployment;
@@ -10,5 +11,11 @@ public class AdminMenuDeploymentStep : DeploymentStep
     public AdminMenuDeploymentStep()
     {
         Name = "AdminMenu";
+    }
+
+    public AdminMenuDeploymentStep(IStringLocalizer<AdminMenuDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Deployment/ContentDefinitionDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Deployment/ContentDefinitionDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.ContentTypes.Deployment;
@@ -10,6 +11,12 @@ public class ContentDefinitionDeploymentStep : DeploymentStep
     public ContentDefinitionDeploymentStep()
     {
         Name = "ContentDefinition";
+    }
+
+    public ContentDefinitionDeploymentStep(IStringLocalizer<ContentDefinitionDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 
     public bool IncludeAll { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Deployment/DeleteContentDefinitionDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Deployment/DeleteContentDefinitionDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.ContentTypes.Deployment;
@@ -10,6 +11,12 @@ public class DeleteContentDefinitionDeploymentStep : DeploymentStep
     public DeleteContentDefinitionDeploymentStep()
     {
         Name = "DeleteContentDefinition";
+    }
+
+    public DeleteContentDefinitionDeploymentStep(IStringLocalizer<DeleteContentDefinitionDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 
     public string[] ContentTypes { get; set; } = [];

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Deployment/ReplaceContentDefinitionDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Deployment/ReplaceContentDefinitionDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.ContentTypes.Deployment;
@@ -7,6 +8,12 @@ public class ReplaceContentDefinitionDeploymentStep : DeploymentStep
     public ReplaceContentDefinitionDeploymentStep()
     {
         Name = "ReplaceContentDefinition";
+    }
+
+    public ReplaceContentDefinitionDeploymentStep(IStringLocalizer<ReplaceContentDefinitionDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 
     public bool IncludeAll { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/AddToDeploymentPlan/ContentItemDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/AddToDeploymentPlan/ContentItemDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Contents.Deployment.AddToDeploymentPlan;
@@ -10,6 +11,12 @@ public class ContentItemDeploymentStep : DeploymentStep
     public ContentItemDeploymentStep()
     {
         Name = nameof(ContentItemDeploymentStep);
+    }
+
+    public ContentItemDeploymentStep(IStringLocalizer<ContentItemDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 
     public string ContentItemId { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/AllContentDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/AllContentDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Contents.Deployment;
@@ -10,6 +11,12 @@ public class AllContentDeploymentStep : DeploymentStep
     public AllContentDeploymentStep()
     {
         Name = "AllContent";
+    }
+
+    public AllContentDeploymentStep(IStringLocalizer<AllContentDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 
     public bool ExportAsSetupRecipe { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/ContentDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/ContentDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Contents.Deployment;
@@ -10,6 +11,12 @@ public class ContentDeploymentStep : DeploymentStep
     public ContentDeploymentStep()
     {
         Name = "ContentDeploymentStep";
+    }
+
+    public ContentDeploymentStep(IStringLocalizer<ContentDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 
     public string[] ContentTypes { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/ExportContentToDeploymentTarget/ExportContentToDeploymentTargetDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Deployment/ExportContentToDeploymentTarget/ExportContentToDeploymentTargetDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Contents.Deployment.ExportContentToDeploymentTarget;
@@ -10,5 +11,11 @@ public class ExportContentToDeploymentTargetDeploymentStep : DeploymentStep
     public ExportContentToDeploymentTargetDeploymentStep()
     {
         Name = nameof(ExportContentToDeploymentTargetDeploymentStep);
+    }
+
+    public ExportContentToDeploymentTargetDeploymentStep(IStringLocalizer<ExportContentToDeploymentTargetDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.CustomSettings/Deployment/CustomSettingsDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.CustomSettings/Deployment/CustomSettingsDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.CustomSettings.Deployment;
@@ -7,6 +8,12 @@ public class CustomSettingsDeploymentStep : DeploymentStep
     public CustomSettingsDeploymentStep()
     {
         Name = "CustomSettings";
+    }
+
+    public CustomSettingsDeploymentStep(IStringLocalizer<CustomSettingsDeploymentStep> S)
+        : this()
+    {
+        Category = S["Settings"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore.Modules/OrchardCore.DataLocalization/Deployment/AllDataTranslationsDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataLocalization/Deployment/AllDataTranslationsDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.DataLocalization.Deployment;
@@ -7,5 +8,11 @@ public class AllDataTranslationsDeploymentStep : DeploymentStep
     public AllDataTranslationsDeploymentStep()
     {
         Name = "AllDataTranslations";
+    }
+
+    public AllDataTranslationsDeploymentStep(IStringLocalizer<AllDataTranslationsDeploymentStep> S)
+        : this()
+    {
+        Category = S["Internationalization"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.DataLocalization/Deployment/TranslationsDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.DataLocalization/Deployment/TranslationsDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.DataLocalization.Deployment;
@@ -10,6 +11,12 @@ public class TranslationsDeploymentStep : DeploymentStep
     public TranslationsDeploymentStep()
     {
         Name = "Translations";
+    }
+
+    public TranslationsDeploymentStep(IStringLocalizer<TranslationsDeploymentStep> S)
+        : this()
+    {
+        Category = S["Internationalization"];
     }
 
     /// <summary>

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Controllers/DeploymentPlanController.cs
@@ -11,6 +11,7 @@ using OrchardCore.Deployment.ViewModels;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.ModelBinding;
 using OrchardCore.DisplayManagement.Notify;
+using OrchardCore.Mvc.Utilities;
 using OrchardCore.Navigation;
 using OrchardCore.Routing;
 using YesSql;
@@ -174,18 +175,36 @@ public sealed class DeploymentPlanController : Controller
             items.Add(item);
         }
 
-        var thumbnails = new Dictionary<string, dynamic>();
-        foreach (var factory in _factories)
+        var thumbnails = new List<DisplayDeploymentPlanThumbnailViewModel>();
+        foreach (var factory in _factories.OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase))
         {
             var step = factory.Create();
             var thumbnail = await _displayManager.BuildDisplayAsync(step, _updateModelAccessor.ModelUpdater, "Thumbnail");
             thumbnail.Properties["DeploymentStep"] = step;
-            thumbnails.Add(factory.Name, thumbnail);
+            var category = step.Category?.Value ?? string.Empty;
+
+            thumbnails.Add(new DisplayDeploymentPlanThumbnailViewModel
+            {
+                Category = category,
+                CategoryId = category.HtmlClassify(),
+                Thumbnail = thumbnail,
+                Type = factory.Name,
+            });
         }
 
         var model = new DisplayDeploymentPlanViewModel
         {
             DeploymentPlan = deploymentPlan,
+            Categories = thumbnails
+                .Where(x => !string.IsNullOrWhiteSpace(x.Category))
+                .Select(x => new DisplayDeploymentPlanCategoryViewModel
+                {
+                    Name = x.Category,
+                    Id = x.CategoryId,
+                })
+                .DistinctBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
             Items = items,
             Thumbnails = thumbnails,
         };

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Deployment/DeploymentPlanDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Deployment/DeploymentPlanDeploymentStep.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Localization;
+
 namespace OrchardCore.Deployment.Deployment;
 
 /// <summary>
@@ -8,6 +10,12 @@ public class DeploymentPlanDeploymentStep : DeploymentStep
     public DeploymentPlanDeploymentStep()
     {
         Name = "DeploymentPlan";
+    }
+
+    public DeploymentPlanDeploymentStep(IStringLocalizer<DeploymentPlanDeploymentStep> S)
+        : this()
+    {
+        Category = S["Deployment"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/CustomFileDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/CustomFileDeploymentStep.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Localization;
 
 namespace OrchardCore.Deployment.Steps;
 
@@ -10,6 +11,12 @@ public class CustomFileDeploymentStep : DeploymentStep
     public CustomFileDeploymentStep()
     {
         Name = nameof(CustomFileDeploymentStep);
+    }
+
+    public CustomFileDeploymentStep(IStringLocalizer<CustomFileDeploymentStep> S)
+        : this()
+    {
+        Category = S["Deployment"];
     }
 
     [Required]

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/JsonRecipeDeploymentStep.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Localization;
+
 namespace OrchardCore.Deployment.Steps;
 
 /// <summary>
@@ -8,6 +10,12 @@ public class JsonRecipeDeploymentStep : DeploymentStep
     public JsonRecipeDeploymentStep()
     {
         Name = "JsonRecipe";
+    }
+
+    public JsonRecipeDeploymentStep(IStringLocalizer<JsonRecipeDeploymentStep> S)
+        : this()
+    {
+        Category = S["Deployment"];
     }
 
     public string Json { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/RecipeFileDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Steps/RecipeFileDeploymentStep.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Localization;
+
 namespace OrchardCore.Deployment.Steps;
 
 /// <summary>
@@ -8,6 +10,12 @@ public class RecipeFileDeploymentStep : DeploymentStep
     public RecipeFileDeploymentStep()
     {
         Name = nameof(RecipeFileDeploymentStep);
+    }
+
+    public RecipeFileDeploymentStep(IStringLocalizer<RecipeFileDeploymentStep> S)
+        : this()
+    {
+        Category = S["Deployment"];
     }
 
     public string RecipeName { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/DisplayDeploymentPlanCategoryViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/DisplayDeploymentPlanCategoryViewModel.cs
@@ -1,0 +1,8 @@
+namespace OrchardCore.Deployment.ViewModels;
+
+public class DisplayDeploymentPlanCategoryViewModel
+{
+    public string Id { get; set; }
+
+    public string Name { get; set; }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/DisplayDeploymentPlanThumbnailViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/DisplayDeploymentPlanThumbnailViewModel.cs
@@ -1,0 +1,12 @@
+namespace OrchardCore.Deployment.ViewModels;
+
+public class DisplayDeploymentPlanThumbnailViewModel
+{
+    public string Category { get; set; }
+
+    public string CategoryId { get; set; }
+
+    public dynamic Thumbnail { get; set; }
+
+    public string Type { get; set; }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/DisplayDeploymentPlanThumbnailViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/DisplayDeploymentPlanThumbnailViewModel.cs
@@ -1,3 +1,5 @@
+using OrchardCore.DisplayManagement;
+
 namespace OrchardCore.Deployment.ViewModels;
 
 public class DisplayDeploymentPlanThumbnailViewModel
@@ -6,7 +8,7 @@ public class DisplayDeploymentPlanThumbnailViewModel
 
     public string CategoryId { get; set; }
 
-    public dynamic Thumbnail { get; set; }
+    public IShape Thumbnail { get; set; }
 
     public string Type { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/DisplayDeploymentPlanViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/ViewModels/DisplayDeploymentPlanViewModel.cs
@@ -3,6 +3,10 @@ namespace OrchardCore.Deployment.ViewModels;
 public class DisplayDeploymentPlanViewModel
 {
     public DeploymentPlan DeploymentPlan { get; set; }
+
+    public IEnumerable<DisplayDeploymentPlanCategoryViewModel> Categories { get; set; }
+
     public IEnumerable<dynamic> Items { get; set; }
-    public IDictionary<string, dynamic> Thumbnails { get; set; }
+
+    public IEnumerable<DisplayDeploymentPlanThumbnailViewModel> Thumbnails { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Display.cshtml
@@ -84,8 +84,8 @@
                         <div id="cards" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
                             @foreach (var thumbnail in Model.Thumbnails)
                             {
-                                thumbnail.Thumbnail.DeploymentPlan = Model.DeploymentPlan;
-                                thumbnail.Thumbnail.Type = thumbnail.Type;
+                                thumbnail.Thumbnail.Properties["DeploymentPlan"] = Model.DeploymentPlan;
+                                thumbnail.Thumbnail.Properties["Type"] = thumbnail.Type;
 
                                 <div class="col item deployment-step-item" data-category="@thumbnail.CategoryId">
                                     @await DisplayAsync(thumbnail.Thumbnail)

--- a/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Display.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Deployment/Views/DeploymentPlan/Display.cshtml
@@ -56,26 +56,43 @@
 
 <!-- Modal -->
 <div class="modal fade" id="modalSteps" tabindex="-1" role="dialog" aria-labelledby="available-steps-title" aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-dialog modal-xl" role="document">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="available-steps-title">@T["Available Steps"]</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <div class="mb-3">
-                    <input class="form-control" id="search-box" type="search" placeholder="@T["Filter"]" aria-label="@T["Filter"]" autofocus />
-                </div>
-                <div id="cards" class="row row-cols-1 row-cols-md-2 g-2">
-                    @foreach (var thumbnail in Model.Thumbnails.OrderBy(t => t.Key))
-                    {
-                        thumbnail.Value.DeploymentPlan = Model.DeploymentPlan;
-                        thumbnail.Value.Type = thumbnail.Key;
-
-                        <div class="col item">
-                            @await DisplayAsync(thumbnail.Value)
+                <div class="row">
+                    <div class="col-sm-3 col-md-3 col-lg-2">
+                        <div class="mb-3">
+                            <input class="form-control" id="search-box" type="search" placeholder="@T["Filter"]" aria-label="@T["Filter"]" autofocus />
                         </div>
-                    }
+                        <ul class="nav nav-pills flex-column" id="deployment-step-categories">
+                            <li class="nav-item">
+                                <a class="nav-link active" href="#all" data-category="all">@T["All"]</a>
+                            </li>
+                            @foreach (var category in Model.Categories)
+                            {
+                                <li class="nav-item">
+                                    <a class="nav-link" href="#@category.Id" data-category="@category.Id">@category.Name</a>
+                                </li>
+                            }
+                        </ul>
+                    </div>
+                    <div class="col-sm-9 col-md-9 col-lg-10">
+                        <div id="cards" class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-2">
+                            @foreach (var thumbnail in Model.Thumbnails)
+                            {
+                                thumbnail.Thumbnail.DeploymentPlan = Model.DeploymentPlan;
+                                thumbnail.Thumbnail.Type = thumbnail.Type;
+
+                                <div class="col item deployment-step-item" data-category="@thumbnail.CategoryId">
+                                    @await DisplayAsync(thumbnail.Thumbnail)
+                                </div>
+                            }
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="modal-footer">
@@ -120,9 +137,35 @@
     </div>
 </div>
 <script at="Foot">
+    function getDeploymentStepCategory() {
+        return $('#deployment-step-categories .nav-link.active').data('category') || 'all';
+    }
+
+    function filterDeploymentSteps() {
+        var search = replaceDiacritics(String($('#search-box').val() || '').toLowerCase());
+        var selectedCategory = getDeploymentStepCategory();
+
+        $('.deployment-step-item').each(function () {
+            var card = $(this);
+            var cardText = replaceDiacritics(card.text().toLowerCase());
+            var matchesSearch = search === '' || cardText.indexOf(search) > -1;
+            var matchesCategory = selectedCategory === 'all' || card.data('category') === selectedCategory;
+
+            card.toggle(matchesSearch && matchesCategory);
+        });
+    }
+
     $(document).ready(function () {
         $('#modalSteps').on('shown.bs.modal', function () {
             $('#search-box').trigger('focus');
+            filterDeploymentSteps();
+        });
+
+        $('#modalSteps').on('hidden.bs.modal', function () {
+            $('#search-box').val('');
+            $('#deployment-step-categories .nav-link').removeClass('active');
+            $('#deployment-step-categories .nav-link[data-category="all"]').addClass('active');
+            filterDeploymentSteps();
         });
     });
 
@@ -133,25 +176,15 @@
     $(function () {
         var searchBox = $('#search-box');
 
-        // On each keypress filter the list of cards
-        searchBox.keyup(function (e) {
-            var search = replaceDiacritics($(this).val().toLowerCase());
-            if (search == '') {
-                searchBox.val('');
-                $('.item').show();
-            }
-            else {
-                $('.item').each(function () {
-                    var filter = replaceDiacritics($(this).children().children().first().html().toLowerCase());
-                    var found = filter.indexOf(search) > -1;
-                    if (found) {
-                        $(this).show();
-                    }
-                    else {
-                        $(this).hide();
-                    }
-                });
-            }
+        searchBox.on('input', function () {
+            filterDeploymentSteps();
         });
-    })
+
+        $('#deployment-step-categories').on('click', '.nav-link', function (e) {
+            e.preventDefault();
+            $('#deployment-step-categories .nav-link').removeClass('active');
+            $(this).addClass('active');
+            filterDeploymentSteps();
+        });
+    });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Facebook/Deployment/FacebookLoginDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Facebook/Deployment/FacebookLoginDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Facebook.Deployment;
@@ -10,5 +11,11 @@ public class FacebookLoginDeploymentStep : DeploymentStep
     public FacebookLoginDeploymentStep()
     {
         Name = "Facebook Login";
+    }
+
+    public FacebookLoginDeploymentStep(IStringLocalizer<FacebookLoginDeploymentStep> S)
+        : this()
+    {
+        Category = S["Meta"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Features/Deployment/AllFeaturesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Deployment/AllFeaturesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Features.Deployment;
@@ -10,6 +11,12 @@ public class AllFeaturesDeploymentStep : DeploymentStep
     public AllFeaturesDeploymentStep()
     {
         Name = "AllFeatures";
+    }
+
+    public AllFeaturesDeploymentStep(IStringLocalizer<AllFeaturesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Infrastructure"];
     }
 
     public bool IgnoreDisabledFeatures { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Layers/Deployment/AllLayersDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Layers/Deployment/AllLayersDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Layers.Deployment;
@@ -10,5 +11,11 @@ public class AllLayersDeploymentStep : DeploymentStep
     public AllLayersDeploymentStep()
     {
         Name = "AllLayers";
+    }
+
+    public AllLayersDeploymentStep(IStringLocalizer<AllLayersDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Deployment/LuceneIndexDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Deployment/LuceneIndexDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Lucene.Deployment;
@@ -10,6 +11,12 @@ public class LuceneIndexDeploymentStep : DeploymentStep
     public LuceneIndexDeploymentStep()
     {
         Name = "LuceneIndex";
+    }
+
+    public LuceneIndexDeploymentStep(IStringLocalizer<LuceneIndexDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Deployment/LuceneIndexRebuildDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Deployment/LuceneIndexRebuildDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Lucene.Deployment;
@@ -10,6 +11,12 @@ public class LuceneIndexRebuildDeploymentStep : DeploymentStep
     public LuceneIndexRebuildDeploymentStep()
     {
         Name = "LuceneIndexRebuild";
+    }
+
+    public LuceneIndexRebuildDeploymentStep(IStringLocalizer<LuceneIndexRebuildDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Deployment/LuceneIndexResetDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Deployment/LuceneIndexResetDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Lucene.Deployment;
@@ -10,6 +11,12 @@ public class LuceneIndexResetDeploymentStep : DeploymentStep
     public LuceneIndexResetDeploymentStep()
     {
         Name = "LuceneIndexReset";
+    }
+
+    public LuceneIndexResetDeploymentStep(IStringLocalizer<LuceneIndexResetDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore.Modules/OrchardCore.Media/Deployment/AllMediaProfilesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Deployment/AllMediaProfilesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Media.Deployment;
@@ -10,5 +11,11 @@ public class AllMediaProfilesDeploymentStep : DeploymentStep
     public AllMediaProfilesDeploymentStep()
     {
         Name = "AllMediaProfiles";
+    }
+
+    public AllMediaProfilesDeploymentStep(IStringLocalizer<AllMediaProfilesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Media/Deployment/MediaDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Deployment/MediaDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Media.Deployment;
@@ -10,6 +11,12 @@ public class MediaDeploymentStep : DeploymentStep
     public MediaDeploymentStep()
     {
         Name = "Media";
+    }
+
+    public MediaDeploymentStep(IStringLocalizer<MediaDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Deployment/AzureADDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Deployment/AzureADDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Microsoft.Authentication.Deployment;
@@ -10,5 +11,11 @@ public class AzureADDeploymentStep : DeploymentStep
     public AzureADDeploymentStep()
     {
         Name = "Microsoft Entra ID";
+    }
+
+    public AzureADDeploymentStep(IStringLocalizer<AzureADDeploymentStep> S)
+        : this()
+    {
+        Category = S["Microsoft Authentication"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Deployment/MicrosoftAccountDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Microsoft.Authentication/Deployment/MicrosoftAccountDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Microsoft.Authentication.Deployment;
@@ -7,5 +8,11 @@ public sealed class MicrosoftAccountDeploymentStep : DeploymentStep
     public MicrosoftAccountDeploymentStep()
     {
         Name = "MicrosoftAccount";
+    }
+
+    public MicrosoftAccountDeploymentStep(IStringLocalizer<MicrosoftAccountDeploymentStep> S)
+        : this()
+    {
+        Category = S["Microsoft Authentication"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdServerDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.OpenId.Deployment;
@@ -10,5 +11,11 @@ public class OpenIdServerDeploymentStep : DeploymentStep
     public OpenIdServerDeploymentStep()
     {
         Name = "OpenID Server";
+    }
+
+    public OpenIdServerDeploymentStep(IStringLocalizer<OpenIdServerDeploymentStep> S)
+        : this()
+    {
+        Category = S["OpenID Connect"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdValidationDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.OpenId/Deployment/OpenIdValidationDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.OpenId.Deployment;
@@ -10,5 +11,11 @@ public class OpenIdValidationDeploymentStep : DeploymentStep
     public OpenIdValidationDeploymentStep()
     {
         Name = "OpenID Validation";
+    }
+
+    public OpenIdValidationDeploymentStep(IStringLocalizer<OpenIdValidationDeploymentStep> S)
+        : this()
+    {
+        Category = S["OpenID Connect"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Placements/Deployment/PlacementsDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Placements/Deployment/PlacementsDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Placements.Deployment;
@@ -10,5 +11,11 @@ public class PlacementsDeploymentStep : DeploymentStep
     public PlacementsDeploymentStep()
     {
         Name = "Placements";
+    }
+
+    public PlacementsDeploymentStep(IStringLocalizer<PlacementsDeploymentStep> S)
+        : this()
+    {
+        Category = S["Development"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Deployment/AllQueriesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Deployment/AllQueriesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Queries.Deployment;
@@ -10,5 +11,11 @@ public class AllQueriesDeploymentStep : DeploymentStep
     public AllQueriesDeploymentStep()
     {
         Name = "AllQueries";
+    }
+
+    public AllQueriesDeploymentStep(IStringLocalizer<AllQueriesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/Deployment/QueryBasedContentDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/Deployment/QueryBasedContentDeploymentStep.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Queries.Deployment;
@@ -11,6 +12,12 @@ public class QueryBasedContentDeploymentStep : DeploymentStep
     public QueryBasedContentDeploymentStep()
     {
         Name = "QueryBasedContentDeploymentStep";
+    }
+
+    public QueryBasedContentDeploymentStep(IStringLocalizer<QueryBasedContentDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 
     [Required]

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Deployment/AllRolesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Deployment/AllRolesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Roles.Deployment;
@@ -10,5 +11,11 @@ public class AllRolesDeploymentStep : DeploymentStep
     public AllRolesDeploymentStep()
     {
         Name = "AllRoles";
+    }
+
+    public AllRolesDeploymentStep(IStringLocalizer<AllRolesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Security"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Search/Deployment/SearchSettingsDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Search/Deployment/SearchSettingsDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Search.Deployment;
@@ -10,5 +11,11 @@ public class SearchSettingsDeploymentStep : DeploymentStep
     public SearchSettingsDeploymentStep()
     {
         Name = "SearchSettings";
+    }
+
+    public SearchSettingsDeploymentStep(IStringLocalizer<SearchSettingsDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Deployment/SiteSettingsDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Deployment/SiteSettingsDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Settings.Deployment;
@@ -10,6 +11,12 @@ public class SiteSettingsDeploymentStep : DeploymentStep
     public SiteSettingsDeploymentStep()
     {
         Name = nameof(SiteSettings);
+    }
+
+    public SiteSettingsDeploymentStep(IStringLocalizer<SiteSettingsDeploymentStep> S)
+        : this()
+    {
+        Category = S["Configuration"];
     }
 
     public string[] Settings { get; set; }

--- a/src/OrchardCore.Modules/OrchardCore.Shortcodes/Deployment/AllShortcodeTemplatesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Shortcodes/Deployment/AllShortcodeTemplatesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Shortcodes.Deployment;
@@ -7,5 +8,11 @@ public class AllShortcodeTemplatesDeploymentStep : DeploymentStep
     public AllShortcodeTemplatesDeploymentStep()
     {
         Name = "AllShortcodeTemplates";
+    }
+
+    public AllShortcodeTemplatesDeploymentStep(IStringLocalizer<AllShortcodeTemplatesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Sitemaps/Deployment/AllSitemapsDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Sitemaps/Deployment/AllSitemapsDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Sitemaps.Deployment;
@@ -7,5 +8,11 @@ public sealed class AllSitemapsDeploymentStep : DeploymentStep
     public AllSitemapsDeploymentStep()
     {
         Name = "AllSitemaps";
+    }
+
+    public AllSitemapsDeploymentStep(IStringLocalizer<AllSitemapsDeploymentStep> S)
+        : this()
+    {
+        Category = S["Content Management"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllAdminTemplatesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Templates.Deployment;
@@ -10,6 +11,12 @@ public class AllAdminTemplatesDeploymentStep : DeploymentStep
     public AllAdminTemplatesDeploymentStep()
     {
         Name = "AllAdminTemplates";
+    }
+
+    public AllAdminTemplatesDeploymentStep(IStringLocalizer<AllAdminTemplatesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Development"];
     }
     public bool ExportAsFiles { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Deployment/AllTemplatesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Templates.Deployment;
@@ -10,6 +11,12 @@ public class AllTemplatesDeploymentStep : DeploymentStep
     public AllTemplatesDeploymentStep()
     {
         Name = "AllTemplates";
+    }
+
+    public AllTemplatesDeploymentStep(IStringLocalizer<AllTemplatesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Development"];
     }
     public bool ExportAsFiles { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Deployment/AllFeatureProfilesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Deployment/AllFeatureProfilesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Tenants.Deployment;
@@ -7,5 +8,11 @@ public class AllFeatureProfilesDeploymentStep : DeploymentStep
     public AllFeatureProfilesDeploymentStep()
     {
         Name = "AllFeatureProfiles";
+    }
+
+    public AllFeatureProfilesDeploymentStep(IStringLocalizer<AllFeatureProfilesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Infrastructure"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Themes/Deployment/ThemesDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Themes/Deployment/ThemesDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Themes.Deployment;
@@ -10,5 +11,11 @@ public class ThemesDeploymentStep : DeploymentStep
     public ThemesDeploymentStep()
     {
         Name = "Themes";
+    }
+
+    public ThemesDeploymentStep(IStringLocalizer<ThemesDeploymentStep> S)
+        : this()
+    {
+        Category = S["Theming"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Deployment/AllUsersDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Deployment/AllUsersDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Users.Deployment;
@@ -10,5 +11,11 @@ public class AllUsersDeploymentStep : DeploymentStep
     public AllUsersDeploymentStep()
     {
         Name = "AllUsers";
+    }
+
+    public AllUsersDeploymentStep(IStringLocalizer<AllUsersDeploymentStep> S)
+        : this()
+    {
+        Category = S["Security"];
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Deployment/CustomUserSettingsDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Deployment/CustomUserSettingsDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Users.Deployment;
@@ -7,6 +8,12 @@ public class CustomUserSettingsDeploymentStep : DeploymentStep
     public CustomUserSettingsDeploymentStep()
     {
         Name = "CustomUserSettings";
+    }
+
+    public CustomUserSettingsDeploymentStep(IStringLocalizer<CustomUserSettingsDeploymentStep> S)
+        : this()
+    {
+        Category = S["Security"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Deployment/AllWorkflowTypeDeploymentStep.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Deployment/AllWorkflowTypeDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Workflows.Deployment;
@@ -7,5 +8,11 @@ public class AllWorkflowTypeDeploymentStep : DeploymentStep
     public AllWorkflowTypeDeploymentStep()
     {
         Name = "AllWorkflowType";
+    }
+
+    public AllWorkflowTypeDeploymentStep(IStringLocalizer<AllWorkflowTypeDeploymentStep> S)
+        : this()
+    {
+        Category = S["Workflows"];
     }
 }

--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Deployment/AzureAISearchIndexDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Deployment/AzureAISearchIndexDeploymentStep.cs
@@ -1,5 +1,6 @@
-using OrchardCore.Deployment;
+using Microsoft.Extensions.Localization;
 using OrchardCore.AzureAI.Recipes;
+using OrchardCore.Deployment;
 
 namespace OrchardCore.AzureAI.Deployment;
 
@@ -8,6 +9,12 @@ public class AzureAISearchIndexDeploymentStep : DeploymentStep
     public AzureAISearchIndexDeploymentStep()
     {
         Name = AzureAISearchIndexSettingsStep.Name;
+    }
+
+    public AzureAISearchIndexDeploymentStep(IStringLocalizer<AzureAISearchIndexDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Deployment/AzureAISearchIndexRebuildDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Deployment/AzureAISearchIndexRebuildDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.AzureAI.Deployment;
@@ -7,6 +8,12 @@ public class AzureAISearchIndexRebuildDeploymentStep : DeploymentStep
     public AzureAISearchIndexRebuildDeploymentStep()
     {
         Name = "AzureAISearchIndexRebuild";
+    }
+
+    public AzureAISearchIndexRebuildDeploymentStep(IStringLocalizer<AzureAISearchIndexRebuildDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; }

--- a/src/OrchardCore/OrchardCore.AzureAI.Core/Deployment/AzureAISearchIndexResetDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.AzureAI.Core/Deployment/AzureAISearchIndexResetDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.AzureAI.Deployment;
@@ -7,6 +8,12 @@ public class AzureAISearchIndexResetDeploymentStep : DeploymentStep
     public AzureAISearchIndexResetDeploymentStep()
     {
         Name = "AzureAISearchIndexReset";
+    }
+
+    public AzureAISearchIndexResetDeploymentStep(IStringLocalizer<AzureAISearchIndexResetDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; }

--- a/src/OrchardCore/OrchardCore.Deployment.Abstractions/DeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.Deployment.Abstractions/DeploymentStep.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Localization;
+
 namespace OrchardCore.Deployment;
 
 public abstract class DeploymentStep
@@ -5,4 +7,6 @@ public abstract class DeploymentStep
     public string Id { get; set; }
 
     public string Name { get; set; }
+
+    public LocalizedString Category { get; set; } = new(string.Empty, string.Empty);
 }

--- a/src/OrchardCore/OrchardCore.Deployment.Abstractions/IDeploymentStepFactory.cs
+++ b/src/OrchardCore/OrchardCore.Deployment.Abstractions/IDeploymentStepFactory.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.DependencyInjection;
+
 namespace OrchardCore.Deployment;
 
 public interface IDeploymentStepFactory
@@ -6,14 +8,20 @@ public interface IDeploymentStepFactory
     DeploymentStep Create();
 }
 
-public class DeploymentStepFactory<TStep> : IDeploymentStepFactory where TStep : DeploymentStep, new()
+public class DeploymentStepFactory<TStep> : IDeploymentStepFactory where TStep : DeploymentStep
 {
+    private readonly IServiceProvider _serviceProvider;
     private static readonly string _typeName = typeof(TStep).Name;
+
+    public DeploymentStepFactory(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
 
     public string Name => _typeName;
 
     public DeploymentStep Create()
     {
-        return new TStep();
+        return ActivatorUtilities.CreateInstance<TStep>(_serviceProvider);
     }
 }

--- a/src/OrchardCore/OrchardCore.Deployment.Abstractions/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Deployment.Abstractions/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddDeployment<TSource, TStep>(this IServiceCollection services)
         where TSource : IDeploymentSource
-        where TStep : DeploymentStep, new()
+        where TStep : DeploymentStep
     {
         services.AddDeploymentSource<TSource>()
             .AddDeploymentStep<TStep>();
@@ -27,7 +27,7 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddDeployment<TSource, TStep, TDisplayDriver>(this IServiceCollection services)
         where TSource : IDeploymentSource
-        where TStep : DeploymentStep, new()
+        where TStep : DeploymentStep
         where TDisplayDriver : DisplayDriver<DeploymentStep, TStep>
     {
         services.AddDeployment<TSource, TStep>()
@@ -37,7 +37,7 @@ public static class ServiceCollectionExtensions
     }
 
     public static IServiceCollection AddDeploymentWithoutSource<TStep, TDisplayDriver>(this IServiceCollection services)
-        where TStep : DeploymentStep, new()
+        where TStep : DeploymentStep
         where TDisplayDriver : DisplayDriver<DeploymentStep, TStep>
     {
         services.AddDeploymentStep<TStep>()
@@ -55,9 +55,9 @@ public static class ServiceCollectionExtensions
     }
 
     private static IServiceCollection AddDeploymentStep<TStep>(this IServiceCollection services)
-        where TStep : DeploymentStep, new()
+        where TStep : DeploymentStep
     {
-        services.TryAddEnumerable(ServiceDescriptor.Singleton<IDeploymentStepFactory>(new DeploymentStepFactory<TStep>()));
+        services.TryAddEnumerable(ServiceDescriptor.Transient<IDeploymentStepFactory, DeploymentStepFactory<TStep>>());
 
         // TStep instances are part for DeploymentPlan objects that are serialized to JSON
         services.AddJsonDerivedTypeInfo<TStep, DeploymentStep>();
@@ -67,7 +67,7 @@ public static class ServiceCollectionExtensions
 
     private static IServiceCollection AddDeploymentStepDisplayDriver<TDisplayDriver, TStep>(this IServiceCollection services)
         where TDisplayDriver : DisplayDriver<DeploymentStep, TStep>
-        where TStep : DeploymentStep, new()
+        where TStep : DeploymentStep
     {
         services.AddDisplayDriver<DeploymentStep, TDisplayDriver>();
 

--- a/src/OrchardCore/OrchardCore.Elasticsearch.Core/Deployment/ElasticsearchIndexDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.Elasticsearch.Core/Deployment/ElasticsearchIndexDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Elasticsearch.Core.Deployment;
@@ -10,6 +11,12 @@ public sealed class ElasticsearchIndexDeploymentStep : DeploymentStep
     public ElasticsearchIndexDeploymentStep()
     {
         Name = "ElasticIndexSettings";
+    }
+
+    public ElasticsearchIndexDeploymentStep(IStringLocalizer<ElasticsearchIndexDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore/OrchardCore.Elasticsearch.Core/Deployment/ElasticsearchIndexRebuildDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.Elasticsearch.Core/Deployment/ElasticsearchIndexRebuildDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Elasticsearch.Core.Deployment;
@@ -10,6 +11,12 @@ public sealed class ElasticsearchIndexRebuildDeploymentStep : DeploymentStep
     public ElasticsearchIndexRebuildDeploymentStep()
     {
         Name = "ElasticIndexRebuild";
+    }
+
+    public ElasticsearchIndexRebuildDeploymentStep(IStringLocalizer<ElasticsearchIndexRebuildDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore/OrchardCore.Elasticsearch.Core/Deployment/ElasticsearchIndexResetDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.Elasticsearch.Core/Deployment/ElasticsearchIndexResetDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Elasticsearch.Core.Deployment;
@@ -10,6 +11,12 @@ public sealed class ElasticsearchIndexResetDeploymentStep : DeploymentStep
     public ElasticsearchIndexResetDeploymentStep()
     {
         Name = "ElasticIndexReset";
+    }
+
+    public ElasticsearchIndexResetDeploymentStep(IStringLocalizer<ElasticsearchIndexResetDeploymentStep> S)
+        : this()
+    {
+        Category = S["Search"];
     }
 
     public bool IncludeAll { get; set; } = true;

--- a/src/OrchardCore/OrchardCore.Indexing.Core/Deployments/IndexProfileDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Core/Deployments/IndexProfileDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 using OrchardCore.Indexing.Core.Recipes;
 
@@ -8,6 +9,12 @@ public sealed class IndexProfileDeploymentStep : DeploymentStep
     public IndexProfileDeploymentStep()
     {
         Name = CreateOrUpdateIndexProfileStep.StepKey;
+    }
+
+    public IndexProfileDeploymentStep(IStringLocalizer<IndexProfileDeploymentStep> S)
+        : this()
+    {
+        Category = S["Indexing"];
     }
 
     public bool IncludeAll { get; set; }

--- a/src/OrchardCore/OrchardCore.Indexing.Core/Deployments/RebuildIndexDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Core/Deployments/RebuildIndexDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 using OrchardCore.Indexing.Core.Recipes;
 
@@ -8,6 +9,12 @@ public sealed class RebuildIndexDeploymentStep : DeploymentStep
     public RebuildIndexDeploymentStep()
     {
         Name = RebuildIndexStep.Key;
+    }
+
+    public RebuildIndexDeploymentStep(IStringLocalizer<RebuildIndexDeploymentStep> S)
+        : this()
+    {
+        Category = S["Indexing"];
     }
 
     public bool IncludeAll { get; set; }

--- a/src/OrchardCore/OrchardCore.Indexing.Core/Deployments/ResetIndexDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.Indexing.Core/Deployments/ResetIndexDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 using OrchardCore.Indexing.Core.Recipes;
 
@@ -8,6 +9,12 @@ public sealed class ResetIndexDeploymentStep : DeploymentStep
     public ResetIndexDeploymentStep()
     {
         Name = ResetIndexStep.Key;
+    }
+
+    public ResetIndexDeploymentStep(IStringLocalizer<ResetIndexDeploymentStep> S)
+        : this()
+    {
+        Category = S["Indexing"];
     }
 
     public bool IncludeAll { get; set; }

--- a/src/OrchardCore/OrchardCore.Settings.Core/Deployment/SiteSettingsPropertyDeploymentStep.cs
+++ b/src/OrchardCore/OrchardCore.Settings.Core/Deployment/SiteSettingsPropertyDeploymentStep.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Localization;
 using OrchardCore.Deployment;
 
 namespace OrchardCore.Settings.Deployment;
@@ -10,5 +11,11 @@ public class SiteSettingsPropertyDeploymentStep<TModel> : DeploymentStep where T
     public SiteSettingsPropertyDeploymentStep()
     {
         Name = typeof(TModel).Name + "_SiteSettingsPropertyDeploymentStep";
+    }
+
+    public SiteSettingsPropertyDeploymentStep(IStringLocalizer<SiteSettingsPropertyDeploymentStep<TModel>> S)
+        : this()
+    {
+        Category = S["Configuration"];
     }
 }


### PR DESCRIPTION
Here is how the UI looks now (same as Workflow Event selector)

- The reason I added the 2 constructors in the DeploymentStep implementation is because Because the steps are created in two different ways, and only one of them uses DI.

 1. UI/factory path
ActivatorUtilities.CreateInstance<TStep>(_serviceProvider) uses DI, so it can call: 

```
public MyStep(IStringLocalizer<MyStep> S)
```
 2. JSON deserialization path
Deployment steps are also materialized from stored JSON / recipe JSON. That path uses System.Text.Json, not DI. It
cannot supply IStringLocalizer<MyStep>.

So if a step only has the DI constructor, deserialization can’t create it.

The second constructor is not for ActivatorUtilities; it is there because the serializer needs a non-DI way to
construct the step.

<img width="1176" height="934" alt="image" src="https://github.com/user-attachments/assets/7c7e78e7-3224-4a64-a030-06b798eed7f9" />
