### PR TITLE
Use Jint async scripting APIs

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/ContentMethodsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Scripting/ContentMethodsProvider.cs
@@ -20,69 +20,88 @@ public sealed class ContentMethodsProvider : IGlobalMethodProvider
         {
             Name = "newContentItem",
             Method = serviceProvider => (Func<string, IContent>)((contentType) =>
-            {
-                var contentManager = serviceProvider.GetRequiredService<IContentManager>();
-                var contentItem = contentManager.NewAsync(contentType).GetAwaiter().GetResult();
-
-                return contentItem;
-            }),
+                NewContentItemAsync(serviceProvider, contentType).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<string, Task<IContent>>)(contentType =>
+                NewContentItemAsync(serviceProvider, contentType)),
         };
 
         _createContentItemMethod = new GlobalMethod
         {
             Name = "createContentItem",
             Method = serviceProvider => (Func<string, bool?, object, IContent>)((contentType, publish, properties) =>
-            {
-                var contentManager = serviceProvider.GetRequiredService<IContentManager>();
-                var contentItem = contentManager.NewAsync(contentType).GetAwaiter().GetResult();
-                contentItem.Merge(properties);
-
-                var result = contentManager.ValidateAsync(contentItem).GetAwaiter().GetResult();
-
-                if (result.Succeeded)
-                {
-                    contentManager.CreateAsync(contentItem, publish == true ? VersionOptions.Published : VersionOptions.Draft).GetAwaiter().GetResult();
-
-                    return contentItem;
-                }
-
-                var session = serviceProvider.GetRequiredService<YesSql.ISession>();
-                session.CancelAsync().GetAwaiter().GetResult();
-                throw new ValidationException(string.Join(", ", result.Errors));
-            }),
+                CreateContentItemAsync(serviceProvider, contentType, publish, properties).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<string, bool?, object, Task<IContent>>)((contentType, publish, properties) =>
+                CreateContentItemAsync(serviceProvider, contentType, publish, properties)),
         };
 
         _updateContentItemMethod = new GlobalMethod
         {
             Name = "updateContentItem",
             Method = serviceProvider => (Action<ContentItem, object>)((contentItem, properties) =>
-            {
-                var contentManager = serviceProvider.GetRequiredService<IContentManager>();
-                contentItem.Merge(properties, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
-                contentManager.UpdateAsync(contentItem).GetAwaiter().GetResult();
-                var result = contentManager.ValidateAsync(contentItem).GetAwaiter().GetResult();
-                if (!result.Succeeded)
-                {
-                    var session = serviceProvider.GetRequiredService<YesSql.ISession>();
-                    session.CancelAsync().GetAwaiter().GetResult();
-                    throw new ValidationException(string.Join(", ", result.Errors));
-                }
-            }),
+                UpdateContentItemAsync(serviceProvider, contentItem, properties).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<ContentItem, object, Task>)((contentItem, properties) =>
+                UpdateContentItemAsync(serviceProvider, contentItem, properties)),
         };
 
         _deleteContentItemMethod = new GlobalMethod
         {
             Name = "deleteContentItem",
             Method = serviceProvider => (Action<ContentItem, object>)((contentItem, properties) =>
-            {
-                var contentManager = serviceProvider.GetRequiredService<IContentManager>();
-                contentManager.RemoveAsync(contentItem).GetAwaiter().GetResult();
-            }),
+                DeleteContentItemAsync(serviceProvider, contentItem).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<ContentItem, object, Task>)((contentItem, properties) =>
+                DeleteContentItemAsync(serviceProvider, contentItem)),
         };
     }
 
     public IEnumerable<GlobalMethod> GetMethods()
     {
         return new[] { _newContentItemMethod, _createContentItemMethod, _updateContentItemMethod, _deleteContentItemMethod };
+    }
+
+    private static async Task<IContent> NewContentItemAsync(IServiceProvider serviceProvider, string contentType)
+    {
+        var contentManager = serviceProvider.GetRequiredService<IContentManager>();
+
+        return await contentManager.NewAsync(contentType);
+    }
+
+    private static async Task<IContent> CreateContentItemAsync(IServiceProvider serviceProvider, string contentType, bool? publish, object properties)
+    {
+        var contentManager = serviceProvider.GetRequiredService<IContentManager>();
+        var contentItem = await contentManager.NewAsync(contentType);
+        contentItem.Merge(properties);
+
+        var result = await contentManager.ValidateAsync(contentItem);
+
+        if (result.Succeeded)
+        {
+            await contentManager.CreateAsync(contentItem, publish == true ? VersionOptions.Published : VersionOptions.Draft);
+
+            return contentItem;
+        }
+
+        var session = serviceProvider.GetRequiredService<YesSql.ISession>();
+        await session.CancelAsync();
+        throw new ValidationException(string.Join(", ", result.Errors));
+    }
+
+    private static async Task UpdateContentItemAsync(IServiceProvider serviceProvider, ContentItem contentItem, object properties)
+    {
+        var contentManager = serviceProvider.GetRequiredService<IContentManager>();
+        contentItem.Merge(properties, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
+        await contentManager.UpdateAsync(contentItem);
+        var result = await contentManager.ValidateAsync(contentItem);
+        if (!result.Succeeded)
+        {
+            var session = serviceProvider.GetRequiredService<YesSql.ISession>();
+            await session.CancelAsync();
+            throw new ValidationException(string.Join(", ", result.Errors));
+        }
+    }
+
+    private static async Task DeleteContentItemAsync(IServiceProvider serviceProvider, ContentItem contentItem)
+    {
+        var contentManager = serviceProvider.GetRequiredService<IContentManager>();
+        await contentManager.RemoveAsync(contentItem);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Queries/QueryGlobalMethodProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Queries/QueryGlobalMethodProvider.cs
@@ -17,24 +17,29 @@ public sealed class QueryGlobalMethodProvider : IGlobalMethodProvider
         {
             Name = "executeQuery",
             Method = serviceProvider => (Func<string, object, object>)((name, parameters) =>
-            {
-                var queryManager = serviceProvider.GetRequiredService<IQueryManager>();
-                var query = queryManager.GetQueryAsync(name).GetAwaiter().GetResult();
-
-                if (query == null)
-                {
-                    return null;
-                }
-
-                var result = queryManager.ExecuteQueryAsync(query, (IDictionary<string, object>)parameters).GetAwaiter().GetResult();
-
-                return result.Items;
-            }),
+                ExecuteQueryAsync(serviceProvider, name, parameters).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<string, object, Task<object>>)((name, parameters) =>
+                ExecuteQueryAsync(serviceProvider, name, parameters)),
         };
     }
 
     public IEnumerable<GlobalMethod> GetMethods()
     {
         return [_executeQuery];
+    }
+
+    private static async Task<object> ExecuteQueryAsync(IServiceProvider serviceProvider, string name, object parameters)
+    {
+        var queryManager = serviceProvider.GetRequiredService<IQueryManager>();
+        var query = await queryManager.GetQueryAsync(name);
+
+        if (query == null)
+        {
+            return null;
+        }
+
+        var result = await queryManager.ExecuteQueryAsync(query, (IDictionary<string, object>)parameters);
+
+        return result.Items;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Rules/Services/JavascriptConditionEvaluator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Rules/Services/JavascriptConditionEvaluator.cs
@@ -19,11 +19,11 @@ public class JavascriptConditionEvaluator : ConditionEvaluator<JavascriptConditi
         _serviceProvider = serviceProvider;
     }
 
-    public override ValueTask<bool> EvaluateAsync(JavascriptCondition condition)
+    public override async ValueTask<bool> EvaluateAsync(JavascriptCondition condition)
     {
         _engine ??= _scriptingManager.GetScriptingEngine("js");
         _scope ??= _engine.CreateScope(_scriptingManager.GlobalMethodProviders.SelectMany(x => x.GetMethods()), _serviceProvider, null, null);
 
-        return Convert.ToBoolean(_engine.Evaluate(_scope, condition.Script)) ? True : False;
+        return Convert.ToBoolean(await _engine.EvaluateAsync(_scope, condition.Script));
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/ScriptExternalLoginEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/ScriptExternalLoginEventHandler.cs
@@ -63,7 +63,7 @@ public class ScriptExternalLoginEventHandler : IExternalLoginEventHandler
         await UpdateUserInternalAsync(context, loginSettings);
     }
 
-    private async Task UpdateUserInternalAsync(UpdateUserContext context, ExternalLoginSettings loginSettings)
+    public async Task UpdateUserInternalAsync(UpdateUserContext context, ExternalLoginSettings loginSettings)
     {
         if (!loginSettings.UseScriptToSyncProperties)
         {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/ScriptExternalLoginEventHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/ScriptExternalLoginEventHandler.cs
@@ -45,7 +45,7 @@ public class ScriptExternalLoginEventHandler : IExternalLoginEventHandler
 
             var script = $"js: function generateUsername(context) {{\n{registrationSettings.GenerateUsernameScript}\n}}\nvar context = {JConvert.SerializeObject(context, JOptions.CamelCase)};\ngenerateUsername(context);\nreturn context;";
 
-            dynamic evaluationResult = _scriptingManager.Evaluate(script, null, null, null);
+            dynamic evaluationResult = await _scriptingManager.EvaluateAsync(script, null, null, null);
 
             if (evaluationResult is IDictionary<string, object> data && data.TryGetValue("userName", out var userNameObj))
             {
@@ -60,10 +60,10 @@ public class ScriptExternalLoginEventHandler : IExternalLoginEventHandler
     {
         var loginSettings = await _siteService.GetSettingsAsync<ExternalLoginSettings>();
 
-        UpdateUserInternal(context, loginSettings);
+        await UpdateUserInternalAsync(context, loginSettings);
     }
 
-    public void UpdateUserInternal(UpdateUserContext context, ExternalLoginSettings loginSettings)
+    private async Task UpdateUserInternalAsync(UpdateUserContext context, ExternalLoginSettings loginSettings)
     {
         if (!loginSettings.UseScriptToSyncProperties)
         {
@@ -71,7 +71,7 @@ public class ScriptExternalLoginEventHandler : IExternalLoginEventHandler
         }
 
         var script = $"js: function syncRoles(context) {{\n{loginSettings.SyncPropertiesScript}\n}}\nvar context={JConvert.SerializeObject(context, JOptions.CamelCase)};\nsyncRoles(context);\nreturn context;";
-        dynamic evaluationResult = _scriptingManager.Evaluate(script, null, null, null);
+        dynamic evaluationResult = await _scriptingManager.EvaluateAsync(script, null, null, null);
         context.RolesToAdd.AddRange((evaluationResult.rolesToAdd as object[]).Select(i => i.ToString()));
         context.RolesToRemove.AddRange((evaluationResult.rolesToRemove as object[]).Select(i => i.ToString()));
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Scripting/HttpMethodsProvider.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Http/Scripting/HttpMethodsProvider.cs
@@ -68,11 +68,8 @@ public class HttpMethodsProvider : IGlobalMethodProvider
         _responseWriteMethod = new GlobalMethod
         {
             Name = "responseWrite",
-            Method = serviceProvider => (Action<string>)(text =>
-            {
-                httpContextAccessor.HttpContext.Items[WorkflowHttpResult.Instance] = WorkflowHttpResult.Instance;
-                httpContextAccessor.HttpContext.Response.WriteAsync(text).GetAwaiter().GetResult();
-            }),
+            Method = serviceProvider => (Action<string>)(text => ResponseWriteAsync(httpContextAccessor, text).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<string, Task>)(text => ResponseWriteAsync(httpContextAccessor, text)),
         };
 
         _absoluteUrlMethod = new GlobalMethod
@@ -89,13 +86,8 @@ public class HttpMethodsProvider : IGlobalMethodProvider
         _readBodyMethod = new GlobalMethod
         {
             Name = "readBody",
-            Method = serviceProvider => (Func<string>)(() =>
-            {
-                using var sr = new StreamReader(httpContextAccessor.HttpContext.Request.Body);
-
-                // Async read of the request body is mandatory.
-                return sr.ReadToEndAsync().GetAwaiter().GetResult();
-            }),
+            Method = serviceProvider => (Func<string>)(() => ReadBodyAsync(httpContextAccessor).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<Task<string>>)(() => ReadBodyAsync(httpContextAccessor)),
         };
 
         _requestFormMethod = new GlobalMethod
@@ -132,6 +124,7 @@ public class HttpMethodsProvider : IGlobalMethodProvider
         {
             Name = "queryStringAsJson",
             Method = serviceProvider => _deserializeRequestDataMethod.Method.Invoke(serviceProvider),
+            AsyncMethod = serviceProvider => _deserializeRequestDataMethod.AsyncMethod.Invoke(serviceProvider),
         };
 
         // This should be deprecated
@@ -139,83 +132,103 @@ public class HttpMethodsProvider : IGlobalMethodProvider
         {
             Name = "requestFormAsJson",
             Method = serviceProvider => _deserializeRequestDataMethod.Method.Invoke(serviceProvider),
+            AsyncMethod = serviceProvider => _deserializeRequestDataMethod.AsyncMethod.Invoke(serviceProvider),
         };
 
         _deserializeRequestDataMethod = new GlobalMethod
         {
             Name = "deserializeRequestData",
             Method = serviceProvider => (Func<Dictionary<string, object>>)(() =>
+                DeserializeRequestDataAsync(httpContextAccessor).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<Task<Dictionary<string, object>>>)(() =>
+                DeserializeRequestDataAsync(httpContextAccessor)),
+        };
+    }
+
+    private static async Task ResponseWriteAsync(IHttpContextAccessor httpContextAccessor, string text)
+    {
+        httpContextAccessor.HttpContext.Items[WorkflowHttpResult.Instance] = WorkflowHttpResult.Instance;
+        await httpContextAccessor.HttpContext.Response.WriteAsync(text);
+    }
+
+    private static async Task<string> ReadBodyAsync(IHttpContextAccessor httpContextAccessor)
+    {
+        using var sr = new StreamReader(httpContextAccessor.HttpContext.Request.Body);
+
+        // Async read of the request body is mandatory.
+        return await sr.ReadToEndAsync();
+    }
+
+    private static async Task<Dictionary<string, object>> DeserializeRequestDataAsync(IHttpContextAccessor httpContextAccessor)
+    {
+        Dictionary<string, object> result = null;
+
+        if (httpContextAccessor.HttpContext != null)
+        {
+            var method = httpContextAccessor.HttpContext.Request.Method;
+            if (method.Equals("POST", StringComparison.OrdinalIgnoreCase) || method.Equals("PUT", StringComparison.OrdinalIgnoreCase) || method.Equals("PATCH", StringComparison.OrdinalIgnoreCase))
             {
-                Dictionary<string, object> result = null;
-
-                if (httpContextAccessor.HttpContext != null)
+                if (httpContextAccessor.HttpContext.Request.HasFormContentType)
                 {
-                    var method = httpContextAccessor.HttpContext.Request.Method;
-                    if (method.Equals("POST", StringComparison.OrdinalIgnoreCase) || method.Equals("PUT", StringComparison.OrdinalIgnoreCase) || method.Equals("PATCH", StringComparison.OrdinalIgnoreCase))
+                    var formData = httpContextAccessor.HttpContext.Request.Form;
+
+                    // If we can parse first request form element key as JSON then we throw
+                    if (isValidJSON(formData.First().Key.ToString()))
                     {
-                        if (httpContextAccessor.HttpContext.Request.HasFormContentType)
-                        {
-                            var formData = httpContextAccessor.HttpContext.Request.Form;
-
-                            // If we can parse first request form element key as JSON then we throw
-                            if (isValidJSON(formData.First().Key.ToString()))
-                            {
-                                throw new Exception("Invalid form data passed in the request. The data passed was JSON while it should be form data.");
-                            }
-
-                            try
-                            {
-                                result = formData.ToDictionary(x => x.Key, x => (object)x.Value);
-                            }
-                            catch
-                            {
-                                throw new Exception("Invalid form data passed in the request.");
-                            }
-                        }
-                        else if (httpContextAccessor.HttpContext.Request.HasJsonContentType())
-                        {
-                            string json;
-                            using (var sr = new StreamReader(httpContextAccessor.HttpContext.Request.Body))
-                            {
-                                // Async read of the request body is mandatory.
-                                json = sr.ReadToEndAsync().GetAwaiter().GetResult();
-                            }
-
-                            try
-                            {
-                                result = JConvert.DeserializeObject<Dictionary<string, object>>(json);
-                            }
-                            catch
-                            {
-                                throw new Exception("Invalid JSON passed in the request.");
-                            }
-                        }
+                        throw new Exception("Invalid form data passed in the request. The data passed was JSON while it should be form data.");
                     }
-                    else if (httpContextAccessor.HttpContext.Request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase))
+
+                    try
                     {
-                        var queryData = httpContextAccessor.HttpContext.Request.Query;
-
-                        try
-                        {
-                            result = queryData.ToDictionary(x => x.Key, x => (object)x.Value);
-
-                            // We never need to keep the Workflow token
-                            result.Remove("token");
-                        }
-                        catch
-                        {
-                            throw new Exception("Invalid query string data passed in the request.");
-                        }
+                        result = formData.ToDictionary(x => x.Key, x => (object)x.Value);
                     }
-                    else
+                    catch
                     {
-                        throw new Exception("The request method is not supported");
+                        throw new Exception("Invalid form data passed in the request.");
                     }
                 }
+                else if (httpContextAccessor.HttpContext.Request.HasJsonContentType())
+                {
+                    string json;
+                    using (var sr = new StreamReader(httpContextAccessor.HttpContext.Request.Body))
+                    {
+                        // Async read of the request body is mandatory.
+                        json = await sr.ReadToEndAsync();
+                    }
 
-                return result;
-            }),
-        };
+                    try
+                    {
+                        result = JConvert.DeserializeObject<Dictionary<string, object>>(json);
+                    }
+                    catch
+                    {
+                        throw new Exception("Invalid JSON passed in the request.");
+                    }
+                }
+            }
+            else if (httpContextAccessor.HttpContext.Request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase))
+            {
+                var queryData = httpContextAccessor.HttpContext.Request.Query;
+
+                try
+                {
+                    result = queryData.ToDictionary(x => x.Key, x => (object)x.Value);
+
+                    // We never need to keep the Workflow token
+                    result.Remove("token");
+                }
+                catch
+                {
+                    throw new Exception("Invalid query string data passed in the request.");
+                }
+            }
+            else
+            {
+                throw new Exception("The request method is not supported");
+            }
+        }
+
+        return result;
     }
 
     private static bool isValidJSON(string json)

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Scripting/JavaScriptWorkflowScriptEvaluator.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Scripting/JavaScriptWorkflowScriptEvaluator.cs
@@ -41,7 +41,7 @@ public class JavaScriptWorkflowScriptEvaluator : IWorkflowScriptEvaluator
             var methodProviders = scopedMethodProviders.Concat(expressionContext.ScopedMethodProviders);
 
             // Some types cannot be cast (e.g., null to bool), so we need to catch the exception and return the default value.
-            return (T)_scriptingManager.Evaluate(directive, null, null, methodProviders);
+            return (T)await _scriptingManager.EvaluateAsync(directive, null, null, methodProviders);
         }
         catch (Exception ex)
         {

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/GlobalMethod.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/GlobalMethod.cs
@@ -4,4 +4,5 @@ public class GlobalMethod
 {
     public string Name { get; set; }
     public Func<IServiceProvider, Delegate> Method { get; set; }
+    public Func<IServiceProvider, Delegate> AsyncMethod { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IScriptingEngine.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IScriptingEngine.cs
@@ -6,5 +6,8 @@ public interface IScriptingEngine
 {
     string Prefix { get; }
     object Evaluate(IScriptingScope scope, string script);
+    Task<object> EvaluateAsync(IScriptingScope scope, string script, CancellationToken cancellationToken = default)
+        => Task.FromResult(Evaluate(scope, script));
+
     IScriptingScope CreateScope(IEnumerable<GlobalMethod> methods, IServiceProvider serviceProvider, IFileProvider fileProvider, string basePath);
 }

--- a/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure.Abstractions/Scripting/IScriptingManager.cs
@@ -26,6 +26,18 @@ public interface IScriptingManager
     object Evaluate(string directive, IFileProvider fileProvider, string basePath, IEnumerable<IGlobalMethodProvider> scopedMethodProviders);
 
     /// <summary>
+    /// Executes some prefixed script by looking for a matching scripting engine asynchronously.
+    /// </summary>
+    /// <param name="directive">The directive to execute. A directive is made of a. </param>
+    /// <param name="fileProvider">An optional <see cref="IFileProvider"/> instance.</param>
+    /// <param name="basePath">The base path.</param>
+    /// <param name="scopedMethodProviders">A list of method providers scoped to the script evaluation.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The result of the script if any.</returns>
+    Task<object> EvaluateAsync(string directive, IFileProvider fileProvider, string basePath, IEnumerable<IGlobalMethodProvider> scopedMethodProviders, CancellationToken cancellationToken = default)
+        => Task.FromResult(Evaluate(directive, fileProvider, basePath, scopedMethodProviders));
+
+    /// <summary>
     /// The list of available method providers for this <see cref="IScriptingManager"/>
     /// instance.
     /// </summary>

--- a/src/OrchardCore/OrchardCore.Infrastructure/Scripting/DefaultScriptingManager.cs
+++ b/src/OrchardCore/OrchardCore.Infrastructure/Scripting/DefaultScriptingManager.cs
@@ -22,14 +22,10 @@ public class DefaultScriptingManager : IScriptingManager
         string basePath,
         IEnumerable<IGlobalMethodProvider> scopedMethodProviders)
     {
-        var directiveIndex = directive.IndexOf(':');
-        if (directiveIndex == -1 || directiveIndex >= directive.Length - 1)
+        if (!TryParseDirective(directive, out var prefix, out var script))
         {
             return directive;
         }
-
-        var prefix = directive[..directiveIndex];
-        var script = directive[(directiveIndex + 1)..];
 
         var engine = GetScriptingEngine(prefix);
         if (engine == null)
@@ -42,8 +38,46 @@ public class DefaultScriptingManager : IScriptingManager
         return engine.Evaluate(scope, script);
     }
 
+    public async Task<object> EvaluateAsync(string directive,
+        IFileProvider fileProvider,
+        string basePath,
+        IEnumerable<IGlobalMethodProvider> scopedMethodProviders,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryParseDirective(directive, out var prefix, out var script))
+        {
+            return directive;
+        }
+
+        var engine = GetScriptingEngine(prefix);
+        if (engine == null)
+        {
+            return directive;
+        }
+
+        var methodProviders = scopedMethodProviders != null ? GlobalMethodProviders.Concat(scopedMethodProviders) : GlobalMethodProviders;
+        var scope = engine.CreateScope(methodProviders.SelectMany(x => x.GetMethods()), ShellScope.Services, fileProvider, basePath);
+        return await engine.EvaluateAsync(scope, script, cancellationToken);
+    }
+
     public IScriptingEngine GetScriptingEngine(string prefix)
     {
         return _engines.FirstOrDefault(x => x.Prefix == prefix);
+    }
+
+    private static bool TryParseDirective(string directive, out string prefix, out string script)
+    {
+        var directiveIndex = directive.IndexOf(':');
+        if (directiveIndex == -1 || directiveIndex >= directive.Length - 1)
+        {
+            prefix = null;
+            script = null;
+            return false;
+        }
+
+        prefix = directive[..directiveIndex];
+        script = directive[(directiveIndex + 1)..];
+
+        return true;
     }
 }

--- a/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/Services/RecipeExecutor.cs
@@ -169,7 +169,7 @@ public class RecipeExecutor : IRecipeExecutor
             var scriptingManager = scope.ServiceProvider.GetRequiredService<IScriptingManager>();
 
             // Substitutes the script elements by their actual values.
-            EvaluateJsonTree(scriptingManager, recipeStep, recipeStep.Step);
+            await EvaluateJsonTreeAsync(scriptingManager, recipeStep, recipeStep.Step);
 
             if (_logger.IsEnabled(LogLevel.Information))
             {
@@ -195,7 +195,7 @@ public class RecipeExecutor : IRecipeExecutor
     /// <summary>
     /// Traverse all the nodes of the json document and replaces their value if they are scripted.
     /// </summary>
-    private JsonNode EvaluateJsonTree(IScriptingManager scriptingManager, RecipeExecutionContext context, JsonNode node)
+    private async Task<JsonNode> EvaluateJsonTreeAsync(IScriptingManager scriptingManager, RecipeExecutionContext context, JsonNode node)
     {
         if (node is null)
         {
@@ -208,7 +208,7 @@ public class RecipeExecutor : IRecipeExecutor
                 var array = node.AsArray();
                 for (var i = 0; i < array.Count; i++)
                 {
-                    var item = EvaluateJsonTree(scriptingManager, context, array[i]);
+                    var item = await EvaluateJsonTreeAsync(scriptingManager, context, array[i]);
                     if (item is JsonValue && item != array[i])
                     {
                         array[i] = item;
@@ -221,7 +221,7 @@ public class RecipeExecutor : IRecipeExecutor
                 var properties = node.AsObject();
                 foreach (var property in properties.ToArray())
                 {
-                    var newProperty = EvaluateJsonTree(scriptingManager, context, property.Value);
+                    var newProperty = await EvaluateJsonTreeAsync(scriptingManager, context, property.Value);
                     if (newProperty is JsonValue && newProperty != property.Value)
                     {
                         properties[property.Key] = newProperty;
@@ -247,7 +247,7 @@ public class RecipeExecutor : IRecipeExecutor
 
                     value = value.Trim('[', ']');
 
-                    value = (scriptingManager.Evaluate(
+                    value = (await scriptingManager.EvaluateAsync(
                         value,
                         context.RecipeDescriptor.FileProvider,
                         context.RecipeDescriptor.BasePath,

--- a/src/OrchardCore/OrchardCore.Recipes.Core/VariablesMethodProvider.cs
+++ b/src/OrchardCore/OrchardCore.Recipes.Core/VariablesMethodProvider.cs
@@ -18,28 +18,9 @@ public sealed class VariablesMethodProvider : IGlobalMethodProvider
         {
             Name = GlobalMethodName,
             Method = serviceProvider => (Func<string, object>)(name =>
-            {
-                var variable = variables[name];
-
-                if (variable == null)
-                {
-                    var S = serviceProvider.GetService<IStringLocalizer<VariablesMethodProvider>>();
-
-                    throw new ValidationException(S["The variable '{0}' was used in the recipe but not defined. Make sure you add the '{0}' variable in the '{1}' section of the recipe.", name, GlobalMethodName]);
-                }
-
-                var value = variable.Value<string>();
-
-                // Replace variable value while the result returns another script.
-                while (value.StartsWith('[') && value.EndsWith(']'))
-                {
-                    value = value.Trim('[', ']');
-                    value = (ScriptingManager.Evaluate(value, null, null, scopedMethodProviders) ?? "").ToString();
-                    variables[name] = value;
-                }
-
-                return value;
-            }),
+                GetVariableValueAsync(serviceProvider, variables, scopedMethodProviders, name).GetAwaiter().GetResult()),
+            AsyncMethod = serviceProvider => (Func<string, Task<object>>)(name =>
+                GetVariableValueAsync(serviceProvider, variables, scopedMethodProviders, name)),
         };
     }
 
@@ -48,5 +29,33 @@ public sealed class VariablesMethodProvider : IGlobalMethodProvider
     public IEnumerable<GlobalMethod> GetMethods()
     {
         yield return _globalMethod;
+    }
+
+    private static async Task<object> GetVariableValueAsync(
+        IServiceProvider serviceProvider,
+        JsonObject variables,
+        List<IGlobalMethodProvider> scopedMethodProviders,
+        string name)
+    {
+        var variable = variables[name];
+
+        if (variable == null)
+        {
+            var S = serviceProvider.GetService<IStringLocalizer<VariablesMethodProvider>>();
+
+            throw new ValidationException(S["The variable '{0}' was used in the recipe but not defined. Make sure you add the '{0}' variable in the '{1}' section of the recipe.", name, GlobalMethodName]);
+        }
+
+        var value = variable.Value<string>();
+
+        // Replace variable value while the result returns another script.
+        while (value.StartsWith('[') && value.EndsWith(']'))
+        {
+            value = value.Trim('[', ']');
+            value = (await ScriptingManager.EvaluateAsync(value, null, null, scopedMethodProviders) ?? "").ToString();
+            variables[name] = value;
+        }
+
+        return value;
     }
 }

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptEngine.cs
@@ -15,6 +15,7 @@ public sealed class JavaScriptEngine : IScriptingEngine
     {
         _memoryCache = memoryCache;
         _jintOptions = jintOptions.Value;
+        _jintOptions.ExperimentalFeatures |= ExperimentalFeature.TaskInterop;
     }
 
     public string Prefix => "js";
@@ -23,30 +24,40 @@ public sealed class JavaScriptEngine : IScriptingEngine
     {
         var engine = new Engine(_jintOptions);
 
-        foreach (var method in methods)
-        {
-            engine.SetValue(method.Name, method.Method(serviceProvider));
-        }
-
-        return new JavaScriptScope(engine, serviceProvider);
+        return new JavaScriptScope(engine, serviceProvider, methods);
     }
 
     public object Evaluate(IScriptingScope scope, string script)
     {
-        static void ThrowInvalidScopeTypeException()
-        {
-            throw new ArgumentException($"Expected a scope of type {nameof(JavaScriptScope)}", nameof(scope));
-        }
-
-        if (scope is not JavaScriptScope jsScope)
-        {
-            ThrowInvalidScopeTypeException();
-        }
+        var jsScope = GetJavaScriptScope(scope);
+        jsScope.UseSyncMethods();
 
         var parsedAst = _memoryCache.GetOrCreate(script, static entry => Engine.PrepareScript((string)entry.Key));
 
         var result = jsScope.Engine.Evaluate(parsedAst).ToObject();
 
         return result;
+    }
+
+    public async Task<object> EvaluateAsync(IScriptingScope scope, string script, CancellationToken cancellationToken = default)
+    {
+        var jsScope = GetJavaScriptScope(scope);
+        jsScope.UseAsyncMethods();
+
+        var parsedAst = _memoryCache.GetOrCreate(script, static entry => Engine.PrepareScript((string)entry.Key));
+
+        var result = await jsScope.Engine.EvaluateAsync(parsedAst, cancellationToken);
+
+        return result.ToObject();
+    }
+
+    private static JavaScriptScope GetJavaScriptScope(IScriptingScope scope)
+    {
+        if (scope is not JavaScriptScope jsScope)
+        {
+            throw new ArgumentException($"Expected a scope of type {nameof(JavaScriptScope)}", nameof(scope));
+        }
+
+        return jsScope;
     }
 }

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptScope.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/JavaScriptScope.cs
@@ -4,13 +4,34 @@ namespace OrchardCore.Scripting.JavaScript;
 
 public class JavaScriptScope : IScriptingScope
 {
-    public JavaScriptScope(Engine engine, IServiceProvider serviceProvider)
+    private readonly GlobalMethod[] _methods;
+
+    public JavaScriptScope(Engine engine, IServiceProvider serviceProvider, IEnumerable<GlobalMethod> methods)
     {
         Engine = engine;
         ServiceProvider = serviceProvider;
+        _methods = methods.ToArray();
+
+        SetGlobalMethods(useAsyncMethods: false);
     }
 
     public Engine Engine { get; }
 
     public IServiceProvider ServiceProvider { get; }
+
+    public void UseSyncMethods() => SetGlobalMethods(useAsyncMethods: false);
+
+    public void UseAsyncMethods() => SetGlobalMethods(useAsyncMethods: true);
+
+    private void SetGlobalMethods(bool useAsyncMethods)
+    {
+        foreach (var method in _methods)
+        {
+            var methodFactory = useAsyncMethods && method.AsyncMethod != null
+                ? method.AsyncMethod
+                : method.Method;
+
+            Engine.SetValue(method.Name, methodFactory(ServiceProvider));
+        }
+    }
 }

--- a/src/OrchardCore/OrchardCore.Scripting.JavaScript/ServiceCollectionExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Scripting.JavaScript/ServiceCollectionExtensions.cs
@@ -13,15 +13,18 @@ public static class ServiceCollectionExtensions
     {
         services.AddSingleton<IScriptingEngine, JavaScriptEngine>();
 
-        services.Configure<Options>(option => option.SetWrapObjectHandler(static (e, target, type) =>
-        target switch
+        services.Configure<Options>(option =>
+        {
+            option.ExperimentalFeatures |= ExperimentalFeature.TaskInterop;
+            option.SetWrapObjectHandler(static (e, target, type) => target switch
             {
                 JsonDynamicObject dynamicObject => ObjectWrapper.Create(e, (JsonObject)dynamicObject, type),
                 JsonDynamicArray dynamicArray => ObjectWrapper.Create(e, (JsonArray)dynamicArray, type),
                 JsonDynamicValue dynamicValue => ObjectWrapper.Create(e, (JsonValue)dynamicValue, type),
                 StringValues stringValues => ObjectWrapper.Create(e, stringValues.Count <= 1 ? stringValues.ToString() : stringValues.ToArray(), type),
                 _ => ObjectWrapper.Create(e, target, type)
-            }));
+            });
+        });
 
         return services;
     }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Rules/RuleTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Rules/RuleTests.cs
@@ -184,6 +184,34 @@ public class RuleTests
         Assert.Equal(expected, await ruleService.EvaluateAsync(rule));
     }
 
+    [Fact]
+    public async Task ShouldEvaluateJavascriptConditionWithAsyncGlobalMethod()
+    {
+        var rule = new Rule
+        {
+            Conditions =
+            [
+                new JavascriptCondition
+                {
+                    Script = "isAllowedAsync()",
+                }
+            ],
+        };
+
+        var services = CreateRuleServiceCollection()
+            .AddRuleCondition<JavascriptCondition, JavascriptConditionEvaluator>()
+            .AddSingleton<IGlobalMethodProvider, AsyncBooleanMethodProvider>()
+            .AddMemoryCache()
+            .AddScripting()
+            .AddJavaScriptEngine();
+
+        var serviceProvider = services.BuildServiceProvider();
+
+        var ruleService = serviceProvider.GetRequiredService<IRuleService>();
+
+        Assert.True(await ruleService.EvaluateAsync(rule));
+    }
+
     public static ServiceCollection CreateRuleServiceCollection()
     {
         var services = new ServiceCollection();
@@ -201,5 +229,22 @@ public class RuleTests
         services.AddTransient<IConfigureOptions<ConditionOperatorOptions>, ConditionOperatorConfigureOptions>();
 
         return services;
+    }
+
+    private sealed class AsyncBooleanMethodProvider : IGlobalMethodProvider
+    {
+        public IEnumerable<GlobalMethod> GetMethods()
+        {
+            yield return new GlobalMethod
+            {
+                Name = "isAllowedAsync",
+                Method = serviceProvider => (Func<bool>)(() => false),
+                AsyncMethod = serviceProvider => (Func<Task<bool>>)(async () =>
+                {
+                    await Task.Yield();
+                    return true;
+                }),
+            };
+        }
     }
 }

--- a/test/OrchardCore.Tests/Modules/OrchardCore.Users/AccountControllerTests.cs
+++ b/test/OrchardCore.Tests/Modules/OrchardCore.Users/AccountControllerTests.cs
@@ -85,7 +85,7 @@ public class AccountControllerTests
                     }
                     """,
             };
-            scriptExternalLoginEventHandler.UpdateUserInternal(context, loginSettings);
+            await scriptExternalLoginEventHandler.UpdateUserInternalAsync(context, loginSettings);
 
             if (await userManager.UpdateUserPropertiesAsync(user, context))
             {
@@ -143,7 +143,7 @@ public class AccountControllerTests
                     };
                     """,
             };
-            scriptExternalLoginEventHandler.UpdateUserInternal(updateContext, loginSettings);
+            await scriptExternalLoginEventHandler.UpdateUserInternalAsync(updateContext, loginSettings);
 
             if (await userManager.UpdateUserPropertiesAsync(user, updateContext))
             {

--- a/test/OrchardCore.Tests/Scripting/ScriptFunctionsTest.cs
+++ b/test/OrchardCore.Tests/Scripting/ScriptFunctionsTest.cs
@@ -7,6 +7,37 @@ namespace OrchardCore.Tests.Scripting;
 public class ScriptFunctionsTest
 {
     [Fact]
+    public async Task TheScriptingManagerShouldEvaluateAsyncGlobalMethods()
+    {
+        using var context = new SiteContext();
+        await context.InitializeAsync();
+        await context.UsingTenantScopeAsync(async scope =>
+        {
+            var syncMethodInvoked = false;
+            var asyncMethod = new GlobalMethod
+            {
+                Name = "getValueAsync",
+                Method = sp => (Func<string>)(() =>
+                {
+                    syncMethodInvoked = true;
+                    return "sync";
+                }),
+                AsyncMethod = sp => (Func<Task<string>>)(async () =>
+                {
+                    await Task.Yield();
+                    return "async";
+                }),
+            };
+
+            var scriptingManager = scope.ServiceProvider.GetRequiredService<IScriptingManager>();
+            var result = await scriptingManager.EvaluateAsync("js:getValueAsync()", null, null, [new TestGlobalMethodProvider(asyncMethod)]);
+
+            Assert.Equal("async", result);
+            Assert.False(syncMethodInvoked);
+        });
+    }
+
+    [Fact]
     public async Task TheScriptingEngineShouldBeAbleToHandleJsonObject()
     {
         using var context = new SiteContext();
@@ -85,5 +116,20 @@ public class ScriptFunctionsTest
 
             return Task.CompletedTask;
         });
+    }
+
+    private sealed class TestGlobalMethodProvider : IGlobalMethodProvider
+    {
+        private readonly GlobalMethod _method;
+
+        public TestGlobalMethodProvider(GlobalMethod method)
+        {
+            _method = method;
+        }
+
+        public IEnumerable<GlobalMethod> GetMethods()
+        {
+            yield return _method;
+        }
     }
 }

--- a/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
+++ b/test/OrchardCore.Tests/Workflows/WorkflowManagerTests.cs
@@ -71,6 +71,29 @@ public class WorkflowManagerTests
     }
 
     [Fact]
+    public async Task WorkflowScriptEvaluatorShouldEvaluateAsyncScopedGlobalMethods()
+    {
+        var serviceProvider = CreateServiceProvider();
+        var scriptEvaluator = CreateWorkflowScriptEvaluator(serviceProvider);
+        using var workflowContext = new WorkflowExecutionContext(
+            new WorkflowType(),
+            new Workflow { WorkflowId = IdGenerator.GenerateId() },
+            null,
+            null,
+            null,
+            null,
+            null,
+            []);
+
+        var result = await scriptEvaluator.EvaluateAsync(
+            new WorkflowExpression<string>("getValueAsync()"),
+            workflowContext,
+            new AsyncStringMethodProvider());
+
+        Assert.Equal("async", result);
+    }
+
+    [Fact]
     public async Task TriggerEventAsync_ShouldAllowReexecutionAfterUnexpectedError()
     {
         const string nonExistentActivityId = "missing";
@@ -276,6 +299,23 @@ public class WorkflowManagerTests
             _onExecute();
 
             throw new InvalidOperationException("Simulated activity failure");
+        }
+    }
+
+    private sealed class AsyncStringMethodProvider : IGlobalMethodProvider
+    {
+        public IEnumerable<GlobalMethod> GetMethods()
+        {
+            yield return new GlobalMethod
+            {
+                Name = "getValueAsync",
+                Method = serviceProvider => (Func<string>)(() => "sync"),
+                AsyncMethod = serviceProvider => (Func<Task<string>>)(async () =>
+                {
+                    await Task.Yield();
+                    return "async";
+                }),
+            };
         }
     }
 }


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

Jint 4.8 can now await promises and .NET task interop asynchronously. Orchard's JavaScript scripting paths were still executing through synchronous evaluation, which meant script-exposed async services had to block with `GetAwaiter().GetResult()`.

## Summary

- Adds async scripting evaluation APIs on `IScriptingEngine` and `IScriptingManager`, with sync-compatible defaults.
- Updates the JavaScript engine to use Jint's `EvaluateAsync` path and enable task interop.
- Adds `GlobalMethod.AsyncMethod` so async evaluation can install task-returning delegates while sync evaluation keeps the existing delegates.
- Moves workflow, rules, recipes, and external-login script evaluation to the async scripting path.
- Adds async delegates for content, query, HTTP workflow, and recipe variable script methods.
- Adds tests that verify async global methods are selected and awaited through scripting manager, JavaScript rules, and workflow script evaluation.

