### PR TITLE
Support ReCaptcha config via appsettings and env vars

### DIFF
--- a/src/OrchardCore.Cms.Web/appsettings.json
+++ b/src/OrchardCore.Cms.Web/appsettings.json
@@ -352,6 +352,12 @@
     //},
     //"OrchardCore_Liquid": {
     //  "AllowLiquidTag": true // Whether the Liquid Tag is allowed in the Liquid templates, false by default.
+    //},
+    //"OrchardCore_ReCaptcha": {
+    //  "SiteKey": "",
+    //  "SecretKey": "",
+    //  "ReCaptchaScriptUri": "",
+    //  "ReCaptchaApiUri": ""
     //}
   }
 }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaForgotPasswordFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaForgotPasswordFormDisplayDriver.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.ReCaptcha.Configuration;
@@ -9,18 +10,15 @@ namespace OrchardCore.ReCaptcha.Drivers;
 
 public sealed class ReCaptchaForgotPasswordFormDisplayDriver : DisplayDriver<ForgotPasswordForm>
 {
-    private readonly ISiteService _siteService;
-
-    public ReCaptchaForgotPasswordFormDisplayDriver(ISiteService siteService)
+    private readonly ReCaptchaSettings _settings;
+    public ReCaptchaForgotPasswordFormDisplayDriver(IOptions<ReCaptchaSettings> options)
     {
-        _siteService = siteService;
+        _settings = options.Value;
     }
 
     public override async Task<IDisplayResult> EditAsync(ForgotPasswordForm model, BuildEditorContext context)
     {
-        var settings = await _siteService.GetSettingsAsync<ReCaptchaSettings>();
-
-        if (!settings.ConfigurationExists())
+        if (!_settings.ConfigurationExists())
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaForgotPasswordFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaForgotPasswordFormDisplayDriver.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.ReCaptcha.Drivers;
 public sealed class ReCaptchaForgotPasswordFormDisplayDriver : DisplayDriver<ForgotPasswordForm>
 {
     private readonly ReCaptchaSettings _settings;
+
     public ReCaptchaForgotPasswordFormDisplayDriver(IOptions<ReCaptchaSettings> options)
     {
         _settings = options.Value;

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaLoginFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaLoginFormDisplayDriver.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.ReCaptcha.Configuration;
@@ -9,18 +10,15 @@ namespace OrchardCore.ReCaptcha.Drivers;
 
 public sealed class ReCaptchaLoginFormDisplayDriver : DisplayDriver<LoginForm>
 {
-    private readonly ISiteService _siteService;
-
-    public ReCaptchaLoginFormDisplayDriver(ISiteService siteService)
+    private readonly ReCaptchaSettings _settings;
+    public ReCaptchaLoginFormDisplayDriver(IOptions<ReCaptchaSettings> options)
     {
-        _siteService = siteService;
+        _settings = options.Value;
     }
 
     public override async Task<IDisplayResult> EditAsync(LoginForm model, BuildEditorContext context)
     {
-        var settings = await _siteService.GetSettingsAsync<ReCaptchaSettings>();
-
-        if (!settings.ConfigurationExists())
+        if (!_settings.ConfigurationExists())
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaLoginFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaLoginFormDisplayDriver.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.ReCaptcha.Drivers;
 public sealed class ReCaptchaLoginFormDisplayDriver : DisplayDriver<LoginForm>
 {
     private readonly ReCaptchaSettings _settings;
+
     public ReCaptchaLoginFormDisplayDriver(IOptions<ReCaptchaSettings> options)
     {
         _settings = options.Value;

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaResetPasswordFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaResetPasswordFormDisplayDriver.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.ReCaptcha.Configuration;
@@ -9,18 +10,15 @@ namespace OrchardCore.ReCaptcha.Drivers;
 
 public sealed class ReCaptchaResetPasswordFormDisplayDriver : DisplayDriver<ResetPasswordForm>
 {
-    private readonly ISiteService _siteService;
-
-    public ReCaptchaResetPasswordFormDisplayDriver(ISiteService siteService)
+    private readonly ReCaptchaSettings _settings;
+    public ReCaptchaResetPasswordFormDisplayDriver(IOptions<ReCaptchaSettings> options)
     {
-        _siteService = siteService;
+        _settings = options.Value;
     }
 
     public override async Task<IDisplayResult> EditAsync(ResetPasswordForm model, BuildEditorContext context)
     {
-        var settings = await _siteService.GetSettingsAsync<ReCaptchaSettings>();
-
-        if (!settings.ConfigurationExists())
+        if (!_settings.ConfigurationExists())
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaResetPasswordFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/ReCaptchaResetPasswordFormDisplayDriver.cs
@@ -11,6 +11,7 @@ namespace OrchardCore.ReCaptcha.Drivers;
 public sealed class ReCaptchaResetPasswordFormDisplayDriver : DisplayDriver<ResetPasswordForm>
 {
     private readonly ReCaptchaSettings _settings;
+
     public ReCaptchaResetPasswordFormDisplayDriver(IOptions<ReCaptchaSettings> options)
     {
         _settings = options.Value;

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/RegisterUserFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Drivers/RegisterUserFormDisplayDriver.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
 using OrchardCore.ReCaptcha.Configuration;
@@ -9,18 +10,16 @@ namespace OrchardCore.ReCaptcha.Drivers;
 
 public sealed class RegisterUserFormDisplayDriver : DisplayDriver<RegisterUserForm>
 {
-    private readonly ISiteService _siteService;
+    private readonly ReCaptchaSettings _settings;
 
-    public RegisterUserFormDisplayDriver(ISiteService siteService)
+    public RegisterUserFormDisplayDriver(IOptions<ReCaptchaSettings> options)
     {
-        _siteService = siteService;
+        _settings = options.Value;
     }
 
     public override async Task<IDisplayResult> EditAsync(RegisterUserForm model, BuildEditorContext context)
     {
-        var settings = await _siteService.GetSettingsAsync<ReCaptchaSettings>();
-
-        if (!settings.ConfigurationExists())
+        if (!_settings.ConfigurationExists())
         {
             return null;
         }

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Extensions/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Extensions/OrchardCoreBuilderExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Environment.Shell.Configuration;
+using OrchardCore.ReCaptcha.Configuration;
+
+namespace OrchardCore.ReCaptcha.Extensions;
+
+public static class OrchardCoreBuilderExtensions
+{
+    public static OrchardCoreBuilder ConfigureReCaptchaSettings(this OrchardCoreBuilder builder)
+    {
+        builder.ConfigureServices((tenantServices, serviceProvider) =>
+        {
+            var configurationSection = serviceProvider.GetRequiredService<IShellConfiguration>().GetSection("OrchardCore_ReCaptcha");
+
+            tenantServices.PostConfigure<ReCaptchaSettings>(settings => configurationSection.Bind(settings));
+        });
+
+        return builder;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Forms/ReCaptchaPartDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ReCaptcha/Forms/ReCaptchaPartDisplayDriver.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using OrchardCore.ContentManagement.Display.ContentDisplay;
 using OrchardCore.ContentManagement.Display.Models;
 using OrchardCore.DisplayManagement.Views;
@@ -8,19 +9,18 @@ namespace OrchardCore.ReCaptcha.Forms;
 
 public sealed class ReCaptchaPartDisplayDriver : ContentPartDisplayDriver<ReCaptchaPart>
 {
-    private readonly ISiteService _siteService;
+    private readonly ReCaptchaSettings _settings;
 
-    public ReCaptchaPartDisplayDriver(ISiteService siteService)
+    public ReCaptchaPartDisplayDriver(IOptions<ReCaptchaSettings> options)
     {
-        _siteService = siteService;
+        _settings = options.Value;
     }
 
     public override IDisplayResult Display(ReCaptchaPart part, BuildPartDisplayContext context)
     {
         return Initialize<ReCaptchaPartViewModel>("ReCaptchaPart", async model =>
         {
-            var settings = await _siteService.GetSettingsAsync<ReCaptchaSettings>();
-            model.SettingsAreConfigured = settings.ConfigurationExists();
+            model.SettingsAreConfigured = _settings.ConfigurationExists();
         }).Location(OrchardCoreConstants.DisplayType.Detail, "Content");
     }
 
@@ -28,8 +28,7 @@ public sealed class ReCaptchaPartDisplayDriver : ContentPartDisplayDriver<ReCapt
     {
         return Initialize<ReCaptchaPartViewModel>("ReCaptchaPart_Fields_Edit", async model =>
         {
-            var settings = await _siteService.GetSettingsAsync<ReCaptchaSettings>();
-            model.SettingsAreConfigured = settings.ConfigurationExists();
+            model.SettingsAreConfigured = _settings.ConfigurationExists();
         });
     }
 }

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Configuration/ReCaptchaSettingsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Configuration/ReCaptchaSettingsConfiguration.cs
@@ -16,7 +16,11 @@ public sealed class ReCaptchaSettingsConfiguration : IConfigureOptions<ReCaptcha
     {
         var settings = _site.GetSettings<ReCaptchaSettings>();
 
-        options.SiteKey = settings.SiteKey;
-        options.SecretKey = settings.SecretKey;
+        if (settings != null)
+        {
+            // Only apply if NOT already set by appsettings.json via PostConfigure
+            options.SiteKey ??= settings.SiteKey;
+            options.SecretKey ??= settings.SecretKey;
+        }
     }
 }

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Configuration/ReCaptchaSettingsConfiguration.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Configuration/ReCaptchaSettingsConfiguration.cs
@@ -21,6 +21,8 @@ public sealed class ReCaptchaSettingsConfiguration : IConfigureOptions<ReCaptcha
             // Only apply if NOT already set by appsettings.json via PostConfigure
             options.SiteKey ??= settings.SiteKey;
             options.SecretKey ??= settings.SecretKey;
+            options.ReCaptchaScriptUri ??= settings.ReCaptchaScriptUri;
+            options.ReCaptchaApiUri ??= settings.ReCaptchaApiUri;
         }
     }
 }

--- a/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaShape.cs
+++ b/src/OrchardCore/OrchardCore.ReCaptcha.Core/Services/ReCaptchaShape.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.Localization;
@@ -16,18 +17,18 @@ namespace OrchardCore.ReCaptcha.Services;
 [Feature("OrchardCore.ReCaptcha")]
 public sealed class ReCaptchaShape : IShapeAttributeProvider
 {
-    private readonly ISiteService _siteService;
+    private readonly ReCaptchaSettings _settings;
     private readonly ILocalizationService _localizationService;
     private readonly IResourceManager _resourceManager;
     private readonly ILogger _logger;
 
     public ReCaptchaShape(
-        ISiteService siteService,
+        IOptions<ReCaptchaSettings> options,
         ILocalizationService localizationService,
         IResourceManager resourceManager,
         ILogger<ReCaptchaShape> logger)
     {
-        _siteService = siteService;
+        _settings = options.Value;
         _localizationService = localizationService;
         _resourceManager = resourceManager;
         _logger = logger;
@@ -36,21 +37,19 @@ public sealed class ReCaptchaShape : IShapeAttributeProvider
     [Shape]
     public async Task<IHtmlContent> ReCaptcha(string language, string onload)
     {
-        var settings = await _siteService.GetSettingsAsync<ReCaptchaSettings>();
-
-        if (!settings.ConfigurationExists())
+        if (!_settings.ConfigurationExists())
         {
             return HtmlString.Empty;
         }
 
         var script = new TagBuilder("script");
-        script.MergeAttribute("src", await GetReCaptchaScriptUrlAsync(settings.ReCaptchaScriptUri, language, onload));
+        script.MergeAttribute("src", await GetReCaptchaScriptUrlAsync(_settings.ReCaptchaScriptUri, language, onload));
 
         _resourceManager.RegisterFootScript(script);
 
         var div = new TagBuilder("div");
         div.AddCssClass("g-recaptcha");
-        div.MergeAttribute("data-sitekey", settings.SiteKey);
+        div.MergeAttribute("data-sitekey", _settings.SiteKey);
 
         return div;
     }

--- a/src/docs/reference/modules/ReCaptcha/README.md
+++ b/src/docs/reference/modules/ReCaptcha/README.md
@@ -58,3 +58,18 @@ Display for a reCaptcha challenge if the service is configured.
     ``` html
     <shape type="ReCaptcha" language="en-US" />
     ```
+
+## ReCaptcha Settings Configuration
+
+The `OrchardCore.ReCaptcha` module allows the user to use configuration values to override the settings configured from the admin area by calling the `ConfigureReCaptchaSettings()` extension method on `OrchardCoreBuilder` when initializing the app.
+
+The following configuration values can be customized:
+
+```json
+{
+  "OrchardCore_ReCaptcha": {
+    "SiteKey": "",
+    "SecretKey": ""
+  }
+}
+```

--- a/src/docs/reference/modules/ReCaptcha/README.md
+++ b/src/docs/reference/modules/ReCaptcha/README.md
@@ -69,7 +69,9 @@ The following configuration values can be customized:
 {
   "OrchardCore_ReCaptcha": {
     "SiteKey": "",
-    "SecretKey": ""
+    "SecretKey": "",
+    "ReCaptchaScriptUri": "",
+    "ReCaptchaApiUri": ""
   }
 }
 ```

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -720,3 +720,21 @@ The `IContentManager.RemoveAsync()` method now supports cancelable deletes and r
 ### Result Pattern
 
 Introduces a lightweight Result pattern to represent operation outcomes without throwing exceptions for control flow. The new `Result` and `Result<T>` types surface success/failure and carry zero or more `ResultError` entries (supports `LocalizedString` for localized messages).
+
+
+### Recaptcha Module
+
+In previous versions of `OrchardCore`, configuring `ReCaptchaSettings` required a manual trip to the admin dashboard to enter the SiteKey and SecretKey.
+
+With the latest updates, you can now streamline this process using the `ConfigureReCaptchaSettings()` extension method. This allows you to map your settings directly from environment variables or `appsettings.json`, ensuring the SiteKey and SecretKey are applied automatically during application initialization.
+
+```json
+{
+    "OrchardCore": {
+            "OrchardCore_ReCaptcha": {
+                "SiteKey": "",
+                "SecretKey": ""
+        }
+    } 
+}
+```

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -733,7 +733,9 @@ With the latest updates, you can now streamline this process using the `Configur
     "OrchardCore": {
             "OrchardCore_ReCaptcha": {
                 "SiteKey": "",
-                "SecretKey": ""
+                "SecretKey": "",
+                "ReCaptchaScriptUri": "",
+                "ReCaptchaApiUri": ""
         }
     } 
 }


### PR DESCRIPTION
- Refactored ReCaptcha module to allow SiteKey, SecretKey, and related settings to be configured from appsettings.json or environment variables, in addition to the admin UI.
- Replaced ISiteService dependencies with IOptions<ReCaptchaSettings> in display drivers and services.
- Added ConfigureReCaptchaSettings extension for easy configuration binding.
- Updated documentation and examples to reflect new configuration options. Site settings now only override values not set by configuration.

Fixes: #13909

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
