### PR TITLE
Prevent intermittent external login redirect loop

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
@@ -656,7 +656,7 @@ public sealed class ExternalAuthenticationsController : AccountBaseController
     {
         CopyModelStateErrorsToTempData();
 
-        return RedirectToAction(nameof(AccountController.Login), typeof(AccountController).ControllerName(), new { returnUrl });
+        return RedirectToAction(nameof(AccountController.Login), typeof(AccountController).ControllerName(), new { returnUrl, externalLoginError = true });
     }
 
     private RedirectToActionResult RedirectToLogin()

--- a/src/OrchardCore.Modules/OrchardCore.Users/Services/ExternalLoginFormEvents.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Services/ExternalLoginFormEvents.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Options;
 using OrchardCore.Mvc.Core.Utilities;
@@ -13,34 +12,21 @@ namespace OrchardCore.Users.Services;
 
 public sealed class ExternalLoginFormEvents : LoginFormEventBase
 {
-    private const string ExternalLoginAutoRedirectKeyName = "ELAR";
-
     private readonly ExternalLoginOptions _externalLoginOptions;
     private readonly SignInManager<IUser> _signInManager;
     private readonly LinkGenerator _linkGenerator;
-    private readonly ITempDataDictionaryFactory _tempDataDictionaryFactory;
     private readonly IHttpContextAccessor _httpContextAccessor;
 
     public ExternalLoginFormEvents(
         IOptions<ExternalLoginOptions> externalLoginOptions,
         SignInManager<IUser> signInManager,
         LinkGenerator linkGenerator,
-        ITempDataDictionaryFactory tempDataDictionaryFactory,
         IHttpContextAccessor httpContextAccessor)
     {
         _externalLoginOptions = externalLoginOptions.Value;
         _signInManager = signInManager;
         _linkGenerator = linkGenerator;
-        _tempDataDictionaryFactory = tempDataDictionaryFactory;
         _httpContextAccessor = httpContextAccessor;
-    }
-
-    public override Task LoggedInAsync(IUser user)
-    {
-        var tempData = _tempDataDictionaryFactory.GetTempData(_httpContextAccessor.HttpContext);
-        tempData.Remove(ExternalLoginAutoRedirectKeyName);
-
-        return Task.CompletedTask;
     }
 
     public override async Task<IActionResult> LoggingInAsync()
@@ -50,10 +36,9 @@ public sealed class ExternalLoginFormEvents : LoginFormEventBase
             return null;
         }
 
-        var tempData = _tempDataDictionaryFactory.GetTempData(_httpContextAccessor.HttpContext);
-
-        // To prevent infinite redirects, we add temp data.
-        if (tempData.ContainsKey(ExternalLoginAutoRedirectKeyName))
+        // When the external provider returned a failure, the callback redirects back to /Login
+        // with externalLoginError=true so the user can see the error instead of being challenged again.
+        if (_httpContextAccessor.HttpContext.Request.Query.ContainsKey("externalLoginError"))
         {
             return null;
         }
@@ -63,8 +48,6 @@ public sealed class ExternalLoginFormEvents : LoginFormEventBase
         if (schemes.Count() == 1)
         {
             var provider = schemes.First().Name;
-
-            tempData.Add(ExternalLoginAutoRedirectKeyName, true);
 
             var model = new RouteValueDictionary();
 

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -495,6 +495,8 @@ This change streamlines the email confirmation process by moving it out of the u
 !!! note
     The **Confirm email** option will only be visible if the user has not yet been confirmed.
 
+- Fixed an intermittent redirect loop on the login page when "Use external provider for login" was enabled and only one external provider was configured. The login page now consistently redirects to the external provider, and displays an error message if the external provider returns a failure instead of looping. See [#17219](https://github.com/OrchardCMS/OrchardCore/issues/17219).
+
 ### Search Module
 
 The Search Module now supports **Highlights**. If the search service provider supports Highlights, they will be rendered by default. If Highlights are unavailable, the module will fall back to displaying the `ContentItem` in a **Summary** display type.


### PR DESCRIPTION

Fixes #17219

Root cause: When `UseExternalProviderIfOnlyOneDefined` is enabled, `LoggingInAsync()` fires on every login page load, including when returning from a failed IdP attempt. This caused an infinite redirect loop, swallowing the error message stored in TempData.
Changes:

- `ExternalLoginFormEvents.cs` Added `externalLoginError` query parameter check before the auto-redirect, so the login form renders with the error message when returning from a failed IdP attempt
- `ExternalAuthenticationsController.cs` , `RedirectToLogin(string returnUrl)` now appends `externalLoginError=true` to all external login failure redirects

Result: Normal flow always redirects to the external provider. If the provider returns a failure, the user sees the login form with a descriptive error message instead of looping.