### PR TITLE
Enable static graph restore by default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,7 @@
   <PropertyGroup>
     <!-- https://aka.ms/vs-build-acceleration -->
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
+    <RestoreUseStaticGraphEvaluation Condition="'$(RestoreUseStaticGraphEvaluation)' == ''">true</RestoreUseStaticGraphEvaluation>
   </PropertyGroup>
 
   <PropertyGroup Label="Analysis rules">


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

Default solution restores currently use the non-static graph path unless callers opt in manually. Enabling `RestoreUseStaticGraphEvaluation` by default lets MSBuild use static graph evaluation for restores while preserving an explicit override for callers that set the property themselves.

The measured impact in this workspace was positive: warm no-op `dotnet restore OrchardCore.slnx` improved from about 5.62s to 3.55s on average, and no-op `dotnet build OrchardCore.slnx` with restore included improved from 17.22s to 13.00s on average.

Validation:

- `dotnet restore OrchardCore.slnx`
- `dotnet build OrchardCore.slnx --no-restore -v:minimal`