### PR TITLE
Enforce IsEnabled check on all login paths (#19218)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountBaseController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountBaseController.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Localization;
 using OrchardCore.Users.Models;
 using OrchardCore.Workflows.Services;
 
@@ -48,17 +47,5 @@ public abstract class AccountBaseController : Controller
         {
             ModelState.AddModelError(string.Empty, errorMessage);
         }
-    }
-
-    protected bool AddUserEnabledError(IUser user, IStringLocalizer S)
-    {
-        if (user is not User localUser || !localUser.IsEnabled)
-        {
-            ModelState.AddModelError(string.Empty, S["The specified user is not allowed to sign in."]);
-
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Handlers/DisabledUserLoginFormEvent.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Handlers/DisabledUserLoginFormEvent.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Localization;
+using OrchardCore.Mvc.Core.Utilities;
+using OrchardCore.Users.Controllers;
+using OrchardCore.Users.Events;
+using OrchardCore.Users.Models;
+
+namespace OrchardCore.Users.Handlers;
+
+internal sealed class DisabledUserLoginFormEvent : LoginFormEventBase
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly ITempDataDictionaryFactory _tempDataDictionaryFactory;
+
+    protected readonly IStringLocalizer S;
+
+    public DisabledUserLoginFormEvent(
+        IHttpContextAccessor httpContextAccessor,
+        ITempDataDictionaryFactory tempDataDictionaryFactory,
+        IStringLocalizer<DisabledUserLoginFormEvent> stringLocalizer)
+    {
+        _httpContextAccessor = httpContextAccessor;
+        _tempDataDictionaryFactory = tempDataDictionaryFactory;
+        S = stringLocalizer;
+    }
+
+    public override async Task<IActionResult> ValidatingLoginAsync(IUser user)
+    {
+        // Allow the login when the user account is enabled. The default User implementation
+        // exposes IsEnabled; non-User implementations are not subject to this check.
+        if (user is not User localUser || localUser.IsEnabled)
+        {
+            return null;
+        }
+
+        var httpContext = _httpContextAccessor.HttpContext;
+
+        // If the user reached this point through an external provider, the external authentication
+        // cookie has already been set. Sign it out so the disabled user is not left with a partial
+        // authentication state that other handlers could pick up.
+        await httpContext.SignOutAsync(IdentityConstants.ExternalScheme);
+
+        // Surface the error on the next request through the same TempData "error_*" channel that
+        // AccountBaseController.CopyTempDataErrorsToModelState reads on the login GET.
+        var tempData = _tempDataDictionaryFactory.GetTempData(httpContext);
+        tempData["error_disabled_user"] = S["The specified user is not allowed to sign in."].Value;
+
+        var routeValues = new RouteValueDictionary();
+
+        if (httpContext.Request.Query.TryGetValue("returnUrl", out var returnUrlValue))
+        {
+            routeValues.Add("returnUrl", returnUrlValue);
+        }
+
+        return new RedirectToActionResult(
+            actionName: nameof(AccountController.Login),
+            controllerName: typeof(AccountController).ControllerName(),
+            routeValues: routeValues);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Startup.cs
@@ -164,6 +164,7 @@ public sealed class Startup : StartupBase
         services.AddRecipeExecutionStep<CustomUserSettingsStep>();
         services.AddDisplayDriver<LoginForm, LoginFormDisplayDriver>();
         services.AddScoped<ILoginFormEvent, EmailConfirmationLoginFormEvent>();
+        services.AddScoped<ILoginFormEvent, DisabledUserLoginFormEvent>();
     }
 
     public override void Configure(IApplicationBuilder builder, IEndpointRouteBuilder routes, IServiceProvider serviceProvider)

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -496,6 +496,7 @@ This change streamlines the email confirmation process by moving it out of the u
     The **Confirm email** option will only be visible if the user has not yet been confirmed.
 
 - Fixed an intermittent redirect loop on the login page when "Use external provider for login" was enabled and only one external provider was configured. The login page now consistently redirects to the external provider, and displays an error message if the external provider returns a failure instead of looping. See [#17219](https://github.com/OrchardCMS/OrchardCore/issues/17219).
+- Fixed a security issue where disabled users could authenticate via external login providers or local credentials. A new `DisabledUserLoginFormEvent` enforces the `IsEnabled` flag on all login paths. See [#19218](https://github.com/OrchardCMS/OrchardCore/issues/19218).
 
 ### Search Module
 


### PR DESCRIPTION
## Summary

- Disabled users could authenticate via external providers and local credentials because `AddUserEnabledError` was no longer called after the external auth refactoring in #17050.
- Adds `DisabledUserLoginFormEvent : LoginFormEventBase`, which overrides `ValidatingLoginAsync` and blocks disabled users on **both** the local and external login paths via the existing `ILoginFormEvent` extension point.
- On rejection, signs out the `IdentityConstants.ExternalScheme` cookie (so a disabled user is not left with a partial external auth state) and redirects back to `/Login` with an error in TempData (read by `AccountBaseController.CopyTempDataErrorsToModelState`).
- Removes the now-dead `AddUserEnabledError` method from `AccountBaseController` (zero call sites).
- Adds a changelog entry under 3.0.0.

Closes #19218

## Test plan

- [ ] Create a user, set `IsEnabled = false`, attempt local login with valid password — should be rejected with "The specified user is not allowed to sign in." and stay on the login page.
- [ ] Same disabled user attempts external login through a configured provider — should be rejected with the same error, and the external scheme cookie should be cleared.
- [ ] Enabled user, local login — works as before.
- [ ] Enabled user, external login — works as before.
- [ ] `returnUrl` is preserved through t