### PR TITLE
Update README to use full_text Liquid filter

### DIFF
--- a/src/docs/guides/implement-fulltext-search/README.md
+++ b/src/docs/guides/implement-fulltext-search/README.md
@@ -99,14 +99,14 @@ We can use the "Use custom full-text" to include the content of widgets or bags 
 
 ```html
 {% for contentItem in Model.Content.FlowPart.Widgets %}
-  {{ contentItem | full_text_aspect }}
+  {{ contentItem | full_text }}
 {% endfor %}
 ```
 
 Or simply use:
 
 ```html
-{{ Model.Content.FlowPart.Widgets | full_text_aspect }}
+{{ Model.Content.FlowPart.Widgets | full_text }}
 ```
 
 ## Optional : Search templates customization


### PR DESCRIPTION
Updated code examples in README.md to use the full_text Liquid filter instead of full_text_aspect for including widget or bag content in the full-text search index. This applies to both looped and direct usage with FlowPart widgets.

closes #19226

