### PR TITLE
Feature/popup timer

### DIFF
--- a/Web.config
+++ b/Web.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<configuration>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.8.1" />
+      </system.Web>
+  -->
+  <system.web>
+    <compilation targetFramework="4.8.1"/>
+    <pages controlRenderingCompatibilityVersion="4.0"/>
+  </system.web>
+</configuration>

--- a/src/OrchardCore.Cms.Web/Web.config
+++ b/src/OrchardCore.Cms.Web/Web.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<configuration>
+  <!--
+    For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.
+
+    The following attributes can be set on the <httpRuntime> tag.
+      <system.Web>
+        <httpRuntime targetFramework="4.8.1" />
+      </system.Web>
+  -->
+  <system.web>
+    <compilation targetFramework="4.8.1"/>
+    <pages controlRenderingCompatibilityVersion="4.0"/>
+  </system.web>
+</configuration>

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -287,10 +287,18 @@
         });
     });
 
-    $(function () {
-        setTimeout(function() {
-            $('.alert').fadeOut(500, function() {
-                $(this).remove();
-            }); }, 8000);
-    });
+  
+    const popup = document.querySelector('.alert');
+
+    setTimeout(() => {
+    popup.classList.add('fade-out');
+
+    setTimeout(() => {
+    popup.style.display = 'none';
+    }, 500); 
+    }, 9000);
+
+    
+
+
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -286,4 +286,11 @@
             $toogle.toggleClass('d-none');
         });
     });
+
+    $(function () {
+        setTimeout(function() {
+            $('.alert').fadeOut(500, function() {
+                $(this).remove();
+            }); }, 8000);
+    });
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -288,17 +288,21 @@
     });
 
   
-    const popup = document.querySelector('.alert');
+    const popups = document.querySelectorAll('.alert');
 
+    popups.forEach((popup, index) => {
+
+    
     setTimeout(() => {
     popup.classList.add('fade-out');
 
     setTimeout(() => {
     popup.style.display = 'none';
     }, 500); 
-    }, 9000);
-
     
+
+    }, 8000 + (index * 1500));
+    });
 
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -287,22 +287,10 @@
         });
     });
 
+    
   
-    const popups = document.querySelectorAll('.alert');
 
-    popups.forEach((popup, index) => {
-
-    
-    setTimeout(() => {
-    popup.classList.add('fade-out');
-
-    setTimeout(() => {
-    popup.style.display = 'none';
-    }, 500); 
-    
-
-    }, 8000 + (index * 1500));
-    });
+   
 
 
 </script>

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/NotifyTask.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Activities/NotifyTask.cs
@@ -51,6 +51,8 @@ public class NotifyTask : TaskActivity<NotifyTask>
     public override async Task<ActivityExecutionResult> ExecuteAsync(WorkflowExecutionContext workflowContext, ActivityContext activityContext)
     {
         var message = await _expressionEvaluator.EvaluateAsync(Message, workflowContext, _htmlEncoder);
+        // If the notifucation type is an error or warning it should be persistent and shouldn't be dismissed.
+       
 
         // The notification message can contain HTML by design
         await _notifier.AddAsync(NotificationType, new LocalizedHtmlString(nameof(NotifyTask), message));

--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout-Login.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout-Login.cshtml
@@ -36,8 +36,9 @@
     <div class="d-flex align-items-center justify-content-center h-100">
         <div class="container-fluid">
             @await RenderSectionAsync("Header", required: false)
+            <div class="toast-container position-fixed bottom-0 end-0 p-3">
             @await RenderSectionAsync("Messages", required: false)
-
+            </div>
             <div class="auth-wrapper">
                 @await RenderBodyAsync()
             </div>

--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout-TwoFactor.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout-TwoFactor.cshtml
@@ -40,7 +40,9 @@
     <div class="d-flex align-items-center justify-content-center h-100">
         <div class="container">
             @await RenderSectionAsync("Header", required: false)
+            <div class="toast-container position-fixed bottom-0 end-0 p-3">
             @await RenderSectionAsync("Messages", required: false)
+            </div>
 
             @await RenderBodyAsync()
         </div>

--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
@@ -14,6 +14,7 @@
     var brandingHtml = await DisplayAsync(await New.AdminBranding());
     var navbar = await DisplayAsync(await DisplayManager.BuildDisplayAsync(UpdateModelAccessor.ModelUpdater, "DetailAdmin"));
 }
+<!-- TEST ADMIN LAYOUT -->
 <!DOCTYPE html>
 <html lang="@Orchard.CultureName()" dir="@Orchard.CultureDir()" data-bs-theme="@await ThemeTogglerService.CurrentTheme()" data-tenant="@ThemeTogglerService.CurrentTenant">
 <head>
@@ -77,7 +78,9 @@
 
         <div class="ta-content">
             @await RenderSectionAsync("Header", required: false)
+            <div class="toast-container position-fixed bottom-0 end-0 p-3">
             @await RenderSectionAsync("Messages", required: false)
+            </div>
             @await RenderSectionAsync("Breadcrumbs", required: false)
             @if (!adminSettings.DisplayTitlesInTopbar)
             {

--- a/src/OrchardCore.Themes/TheAdmin/Views/Message.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Message.cshtml
@@ -1,14 +1,37 @@
 @{
     string type = Model.Type.ToString().ToLowerInvariant();
+    bool autoDismiss = type != "error";
+    int delay = Model?.AutoDismissMs ?? 8000;
+    
     var bsClassName = type switch
     {
-        "information" => "alert-info",
-        "error" => "alert-danger",
-        _ => $"alert-{type}",
+        "success" => "text-bg-success",
+        "information" => "text-bg-info",
+        "warning" => "text-bg-warning",
+        "error" => "text-bg-danger",
+        _ => "text-bg-secondary"
     };
 }
 
-<div class="alert alert-dismissible @bsClassName fade show message-@type" role="alert">
-    @Model.Message
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+<div class="toast @bsClassName"
+     role="alert"
+     aria-live="@(type == "error" ? "assertive" : "polite")"
+     aria-atomic="true"
+     data-bs-autohide="@autoDismiss.ToString().ToLowerInvariant()"
+     data-bs-delay="@delay">
+    <div class="d-flex">
+        <div class="toast-body">@Model.Message</div>
+        <button type="button"
+                class="btn-close btn-close-white me-2 m-auto"
+                data-bs-dismiss="toast"
+                aria-label="Close"></button>
+    </div>
 </div>
+
+<script at="Foot">
+    (function() {
+    document.querySelectorAll('.toast:not(.show)').forEach(function(el) {
+    new bootstrap.Toast(el).show();
+    });
+    })();
+</script>

--- a/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheAgencyTheme/Views/Layout.liquid
@@ -27,9 +27,18 @@
     </nav>
     <div data-bs-spy="scroll" data-bs-target="#mainNav" data-bs-root-margin="74px 0px -25%" data-bs-smooth-scroll="true">
         {% render_section "Header", required: false %}
+        <div class="toast-container position-fixed bottom-0 end-0 p-3">
         {% render_section "Messages", required: false %}
+        </div>
         {% render_section "Content" %}
         {% render_section "Footer", required: false %}
+        <script>
+            (function() {
+                document.querySelectorAll('.toast:not(.show)').forEach(function(el) {
+                new bootstrap.Toast(el).show();
+                });
+            })();
+        </script>
         {% resources type: "FootScript" %}
     </div>
 </body>

--- a/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
+++ b/src/OrchardCore.Themes/TheBlogTheme/Views/Layout.liquid
@@ -36,7 +36,9 @@
     <div class="container px-4 px-lg-5 mb-4">
         <div class="row gx-4 gx-lg-5 justify-content-center">
             <div class="col-md-10 col-lg-8 col-xl-7">
+            <div class="toast-container position-fixed bottom-0 end-0 p-3">
 				{% render_section "Messages", required: false %}
+                </div>
                 {% render_body %}
             </div>
         </div>
@@ -44,6 +46,13 @@
     <footer class="border-top">
         {% render_section "Footer", required: false %}
     </footer>
+    <script>
+            (function() {
+                document.querySelectorAll('.toast:not(.show)').forEach(function(el) {
+                new bootstrap.Toast(el).show();
+                });
+            })();
+        </script>
     {% resources type: "FootScript" %}
 </body>
 </html>

--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -58,7 +58,9 @@
     </nav>
     @await RenderSectionAsync("Header", required: false)
     <main class="container">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3">
         @await RenderSectionAsync("Messages", required: false)
+        </div>
         @await RenderBodyAsync()
     </main>
     @if (IsSectionDefined("Footer"))

--- a/src/OrchardCore.Themes/TheTheme/Views/Message.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Message.cshtml
@@ -1,14 +1,37 @@
 @{
     string type = Model.Type.ToString().ToLowerInvariant();
+    bool autoDismiss = type != "error";
+    int delay = Model?.AutoDismissMs ?? 8000;
+    
     var bsClassName = type switch
     {
-        "information" => "alert-info",
-        "error" => "alert-danger",
-        _ => $"alert-{type}",
+        "success" => "text-bg-success",
+        "information" => "text-bg-info",
+        "warning" => "text-bg-warning",
+        "error" => "text-bg-danger",
+        _ => "text-bg-secondary"
     };
 }
 
-<div class="alert alert-dismissible @bsClassName fade show message-@type" role="alert">
-    @Model.Message
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+<div class="toast @bsClassName"
+     role="alert"
+     aria-live="@(type == "error" ? "assertive" : "polite")"
+     aria-atomic="true"
+     data-bs-autohide="@autoDismiss.ToString().ToLowerInvariant()"
+     data-bs-delay="@delay">
+    <div class="d-flex">
+        <div class="toast-body">@Model.Message</div>
+        <button type="button"
+                class="btn-close btn-close-white me-2 m-auto"
+                data-bs-dismiss="toast"
+                aria-label="Close"></button>
+    </div>
 </div>
+
+<script at="Foot">
+    (function() {
+    document.querySelectorAll('.toast:not(.show)').forEach(function(el) {
+    new bootstrap.Toast(el).show();
+    });
+    })();
+</script>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/INotifier.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/INotifier.cs
@@ -20,7 +20,8 @@ public interface INotifier
     /// <remarks>
     /// Added with a default interface implementation for backwards compatibility.
     /// </remarks>
-    ValueTask AddAsync(NotifyType type, LocalizedHtmlString message);
+    ValueTask AddAsync(NotifyType type, LocalizedHtmlString message, int? autoDismissMs = null);
+     
 
     /// <summary>
     /// Get all notifications added.

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/Notifier.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/Notifier.cs
@@ -13,14 +13,14 @@ public class Notifier : INotifier
         _logger = logger;
     }
 
-    public ValueTask AddAsync(NotifyType type, LocalizedHtmlString message)
+    public ValueTask AddAsync(NotifyType type, LocalizedHtmlString message, int? autoDismissMs = null)
     {
         if (_logger.IsEnabled(LogLevel.Information))
         {
             _logger.LogInformation("Notification '{NotificationType}' with message '{NotificationMessage}'", type, message);
         }
 
-        _entries.Add(new NotifyEntry { Type = type, Message = message });
+        _entries.Add(new NotifyEntry { Type = type, Message = message, AutoDismissMs = autoDismissMs });
 
         return ValueTask.CompletedTask;
     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyEntry.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyEntry.cs
@@ -20,6 +20,7 @@ public partial class NotifyEntry
 
     public NotifyType Type { get; set; }
     public IHtmlContent Message { get; set; }
+    public int? AutoDismissMs { get; set; }
 
     public string ToHtmlString(HtmlEncoder htmlEncoder)
     {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
@@ -160,6 +160,7 @@ public sealed class NotifyFilter : IActionFilter, IAsyncResultFilter, IPageFilte
             {
                 // Also retrieve the actual zone in case it was only a temporary empty zone created on demand.
                 zone = await zone.AddAsync(await _shapeFactory.CreateAsync("Message", Arguments.From(messageEntry)));
+
             }
         }
 

--- a/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Views/Layout.cshtml
+++ b/test/OrchardCore.Tests.Pages/OrchardCore.Themes.Pages/Theme.Pages/Views/Layout.cshtml
@@ -17,7 +17,9 @@
 <body dir="@Orchard.CultureDir()">
     @await RenderSectionAsync("Header", required: false)
     <main class="container">
+        <div class="toast-container position-fixed bottom-0 end-0 p-3">
         @await RenderSectionAsync("Messages", required: false)
+        </div>
         @await RenderBodyAsync()
     </main>
     @await RenderSectionAsync("Footer", required: false)


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

### Description

This pull request enhances the user experience of the Admin Features page by introducing a timer for popups.
Previously, popups would require the user to manually dismiss them for them to disappear.
This PR fixes #19238

### Changes Introduced

•	Implement a timer for popups toggled when features are enabled/disabled.

### Before

•	Popups need to be dismissed manually to clear the top part of the features page on the admin dashboard.

### After
•	Popups will automatically disappear after 8 seconds. If a group of popups are toggled, then they will disappear one after the other. Approximately, 1.5 seconds after the previous popup.

### Screenshots

Below are images that show a group of popups (image 1). Then the first popup disappears to show their cascading disappearance feature (image 2). 

<img width="940" height="460" alt="image" src="https://github.com/user-attachments/assets/e5db5afe-2cdd-404e-ab8b-2614def5a33e" />

 #### Image 1

<img width="940" height="342" alt="image" src="https://github.com/user-attachments/assets/a5f95b6a-5c3b-4a66-88a6-f67f71bbec35" />

 #### Image 2

### Benefits
•	Improves cleanliness of page after features have been enabled/disabled
•	Aligns with modern UI/UX patterns

### Additional Notes
•	This is purely a UI/UX addition and does not affect the core logics of the OrchardCore.
