### PR TITLE
Fix static code analysis failure in CI

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/AlternatesCollection.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/AlternatesCollection.cs
@@ -7,7 +7,7 @@ namespace OrchardCore.DisplayManagement.Shapes;
 /// </summary>
 public sealed class AlternatesCollection : IEnumerable<string>
 {
-    public static readonly AlternatesCollection Empty = [];
+    public static readonly AlternatesCollection Empty = new();
 
     private readonly OrderedDictionary<string, string> _items = new(StringComparer.Ordinal);
 

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeMetadata.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeMetadata.cs
@@ -76,9 +76,9 @@ public class ShapeMetadata
 
     public string Differentiator { get; set; }
 
-    public AlternatesCollection Wrappers { get; set; } = [];
+    public AlternatesCollection Wrappers { get; set; } = new();
 
-    public AlternatesCollection Alternates { get; set; } = [];
+    public AlternatesCollection Alternates { get; set; } = new();
 
     public bool IsCached => UseMainCacheContext
         ? _mainCacheContext.Context is not null

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
@@ -528,7 +528,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
                         ResolvedType = where,
                     }
                 ],
-#pragma warning enable CA1825 // Avoid unnecessary zero-length array allocations, false positive. 
+#pragma warning restore CA1825 // Avoid unnecessary zero-length array allocations, false positive. 
             },
             RequestServices = services,
         };

--- a/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
+++ b/test/OrchardCore.Tests/Apis/GraphQL/ContentItemsFieldTypeTests.cs
@@ -518,6 +518,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
                 {
                     Name = "Animal",
                 }),
+#pragma warning disable CA1825 // Avoid unnecessary zero-length array allocations, false positive. 
                 Arguments =
                 [
                     new QueryArgument<WhereInputObjectGraphType>
@@ -527,6 +528,7 @@ public class ContentItemsFieldTypeTests : IAsyncLifetime
                         ResolvedType = where,
                     }
                 ],
+#pragma warning enable CA1825 // Avoid unnecessary zero-length array allocations, false positive. 
             },
             RequestServices = services,
         };


### PR DESCRIPTION
My checks in multiple PRs keep failing with the following errors:

```
Error: /home/runner/work/OrchardCore/OrchardCore/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/AlternatesCollection.cs(10,57): error CA1825: Avoid unnecessary zero-length array allocations.  Use Array.Empty<string>() instead. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825) [/home/runner/work/OrchardCore/OrchardCore/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj::TargetFramework=net10.0]
Error: /home/runner/work/OrchardCore/OrchardCore/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeMetadata.cs(79,58): error CA1825: Avoid unnecessary zero-length array allocations.  Use Array.Empty<string>() instead. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825) [/home/runner/work/OrchardCore/OrchardCore/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj::TargetFramework=net10.0]
Error: /home/runner/work/OrchardCore/OrchardCore/src/OrchardCore/OrchardCore.DisplayManagement/Shapes/ShapeMetadata.cs(81,60): error CA1825: Avoid unnecessary zero-length array allocations.  Use Array.Empty<string>() instead. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825) [/home/runner/work/OrchardCore/OrchardCore/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCore.DisplayManagement.csproj::TargetFramework=net10.0]
```

This should fix it.