### PR TITLE
Fix Column Placements Grouping

### DIFF
--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneShapes.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneShapes.cs
@@ -35,7 +35,7 @@ public class ZoneShapes : IShapeAttributeProvider
         var htmlContentBuilder = new HtmlContentBuilder();
 
         // This maybe a collection of IShape, IHtmlContent, or plain object.
-        var shapes = ((IEnumerable<object>)Shape);
+        var shapes = (IEnumerable<object>)Shape;
 
         // Evaluate shapes for grouping metadata, when it is not an IShape it cannot be grouped.
         var isGrouped = shapes.Any(x => x is IShape s &&
@@ -54,11 +54,11 @@ public class ZoneShapes : IShapeAttributeProvider
             return htmlContentBuilder;
         }
 
-        string identifier = Shape.Identifier ?? string.Empty;
+        var identifier = Shape.Identifier ?? string.Empty;
 
-        var groupings = shapes.ToLookup(x =>
+        var groupings = shapes.ToLookup(shape =>
         {
-            if (x is IShape s)
+            if (shape is IShape s)
             {
                 var tabGrouping = s.Metadata.TabGrouping;
                 if (!tabGrouping.HasValue)
@@ -77,8 +77,8 @@ public class ZoneShapes : IShapeAttributeProvider
         {
             var orderedGroupings = groupings.OrderBy(grouping =>
             {
-                var firstGroupWithModifier = grouping.FirstOrDefault(group =>
-                    group is IShape s && !string.IsNullOrEmpty(s.Metadata.TabGrouping.Position));
+                var firstGroupWithModifier = grouping.FirstOrDefault(group => group is IShape shape &&
+                    !string.IsNullOrEmpty(shape.Metadata.TabGrouping.Position));
 
                 if (firstGroupWithModifier is IShape shape)
                 {
@@ -88,7 +88,7 @@ public class ZoneShapes : IShapeAttributeProvider
                 return null;
             }, FlatPositionComparer.Instance).ToArray();
 
-            var container = (GroupingsViewModel)await ShapeFactory.CreateAsync<GroupingsViewModel>("TabContainer", m =>
+            var container = await ShapeFactory.CreateAsync<GroupingsViewModel>("TabContainer", m =>
             {
                 m.Identifier = identifier;
                 m.Groupings = orderedGroupings;
@@ -98,7 +98,7 @@ public class ZoneShapes : IShapeAttributeProvider
 
             foreach (var orderedGrouping in orderedGroupings)
             {
-                var groupingShape = (GroupingViewModel)await ShapeFactory.CreateAsync<GroupingViewModel>("Tab", m =>
+                var groupingShape = await ShapeFactory.CreateAsync<GroupingViewModel>("Tab", m =>
                 {
                     m.Identifier = identifier;
                     m.Grouping = orderedGrouping;
@@ -117,7 +117,7 @@ public class ZoneShapes : IShapeAttributeProvider
         else if (groupings.Count == 1)
         {
             // Evaluate for cards.
-            var cardGrouping = (GroupingViewModel)await ShapeFactory.CreateAsync<GroupingViewModel>("CardGrouping", m =>
+            var cardGrouping = await ShapeFactory.CreateAsync<GroupingViewModel>("CardGrouping", m =>
             {
                 m.Identifier = identifier;
                 m.Grouping = groupings.ElementAt(0);
@@ -154,6 +154,13 @@ public class ZoneShapes : IShapeAttributeProvider
 
         if (groupings.Count > 1)
         {
+            var container = await ShapeFactory.CreateAsync<GroupViewModel>("CardContainer", m =>
+            {
+                m.Identifier = Shape.Identifier;
+            });
+
+            container.Classes.Add("accordion");
+
             var orderedGroupings = groupings.OrderBy(grouping =>
             {
                 var firstGroupWithModifier = grouping.FirstOrDefault(group =>
@@ -167,16 +174,9 @@ public class ZoneShapes : IShapeAttributeProvider
                 return null;
             }, FlatPositionComparer.Instance);
 
-            var container = (GroupViewModel)await ShapeFactory.CreateAsync<GroupViewModel>("CardContainer", m =>
-            {
-                m.Identifier = Shape.Identifier;
-            });
-
-            container.Classes.Add("accordion");
-
             foreach (var orderedGrouping in orderedGroupings)
             {
-                var groupingShape = (GroupingViewModel)await ShapeFactory.CreateAsync<GroupingViewModel>("Card", m =>
+                var groupingShape = await ShapeFactory.CreateAsync<GroupingViewModel>("Card", m =>
                 {
                     m.Identifier = Shape.Identifier;
                     m.Grouping = orderedGrouping;
@@ -195,7 +195,7 @@ public class ZoneShapes : IShapeAttributeProvider
         else
         {
             // Evaluate for columns.
-            var groupingShape = (GroupingViewModel)await ShapeFactory.CreateAsync<GroupingViewModel>("ColumnGrouping", m =>
+            var groupingShape = await ShapeFactory.CreateAsync<GroupingViewModel>("ColumnGrouping", m =>
             {
                 m.Identifier = Shape.Identifier;
                 m.Grouping = Shape.Grouping;
@@ -214,80 +214,98 @@ public class ZoneShapes : IShapeAttributeProvider
     {
         var htmlContentBuilder = new HtmlContentBuilder();
 
-        var groupings = Shape.Grouping.ToLookup(x =>
-        {
-            if (x is IShape s)
-            {
-                var columnGrouping = s.Metadata.ColumnGrouping;
-                if (!columnGrouping.HasValue)
-                {
-                    return ContentKey;
-                }
+        var allItems = Shape.Grouping.ToList();
+        var hasColumnItems = allItems.Any(x => x is IShape s && s.Metadata.ColumnGrouping.HasValue);
 
-                return columnGrouping.Name;
+        if (hasColumnItems)
+        {
+            // Each column-specified item gets its own column wrapper within a row.
+            // Non-column items render outside the row at their natural position.
+            var beforeRow = new List<object>();
+            var afterRow = new List<object>();
+            var columnItems = new List<IShape>();
+            var foundFirstColumnItem = false;
+
+            foreach (var item in allItems)
+            {
+                if (item is IShape s && s.Metadata.ColumnGrouping.HasValue)
+                {
+                    foundFirstColumnItem = true;
+                    columnItems.Add(s);
+                }
+                else
+                {
+                    if (!foundFirstColumnItem)
+                    {
+                        beforeRow.Add(item);
+                    }
+                    else
+                    {
+                        afterRow.Add(item);
+                    }
+                }
             }
 
-            return ContentKey;
-        });
-
-        if (groupings.Count > 1)
-        {
-            var positionModifiers = GetColumnPositions(groupings);
-
-            var orderedGroupings = groupings.OrderBy(grouping =>
+            // Render non-column items that appear before the first column item.
+            foreach (var item in beforeRow)
             {
-                positionModifiers.TryGetValue(grouping.Key, out var position);
-                return position;
-            }, FlatPositionComparer.Instance);
+                htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync((IShape)item));
+            }
 
-            var columnModifiers = GetColumnModifiers(orderedGroupings);
+            // Sort column items by their column position.
+            var sortedColumnItems = columnItems
+                .OrderBy(s => s.Metadata.ColumnGrouping.Position, FlatPositionComparer.Instance);
 
             var container = (GroupViewModel)await ShapeFactory.CreateAsync<GroupViewModel>("ColumnContainer", m =>
             {
                 m.Identifier = Shape.Identifier;
             });
 
-            foreach (var orderedGrouping in orderedGroupings)
+            foreach (var columnItem in sortedColumnItems)
             {
-                var groupingShape = (GroupingViewModel)await ShapeFactory.CreateAsync<GroupingViewModel>("Column", m =>
+                var columnGrouping = columnItem.Metadata.ColumnGrouping;
+
+                var columnShape = (GroupViewModel)await ShapeFactory.CreateAsync<GroupViewModel>("Column", m =>
                 {
                     m.Identifier = Shape.Identifier;
-                    m.Grouping = orderedGrouping;
                 });
 
-                groupingShape.Classes.Add("ta-col-grouping");
-                groupingShape.Classes.Add("column-" + orderedGrouping.Key.HtmlClassify());
+                columnShape.Classes.Add("ta-col-grouping");
+                columnShape.Classes.Add("column-" + columnGrouping.Name.HtmlClassify());
 
                 // To adjust this breakpoint apply a modifier of lg-3 to every column.
                 var columnClasses = "col-12 col-md";
-                if (columnModifiers.TryGetValue(orderedGrouping.Key, out var columnModifier))
+                if (!string.IsNullOrEmpty(columnGrouping.Width))
                 {
                     // When the modifier also has a - assume it is providing a breakpointed class.
-                    if (columnModifier.Contains('-'))
+                    if (columnGrouping.Width.Contains('-'))
                     {
-                        columnClasses = "col-12 col-" + columnModifier;
+                        columnClasses = "col-12 col-" + columnGrouping.Width;
                     }
                     else // Otherwise assume a default md breakpoint.
                     {
-                        columnClasses = "col-12 col-md-" + columnModifier;
+                        columnClasses = "col-12 col-md-" + columnGrouping.Width;
                     }
                 }
 
-                groupingShape.Classes.Add(columnClasses);
+                columnShape.Classes.Add(columnClasses);
 
-                foreach (var item in orderedGrouping)
-                {
-                    await groupingShape.AddAsync(item);
-                }
-                await container.AddAsync(groupingShape);
+                await columnShape.AddAsync(columnItem);
+                await container.AddAsync(columnShape);
             }
 
             htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync(container));
+
+            // Render non-column items that appear after the column row.
+            foreach (var item in afterRow)
+            {
+                htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync((IShape)item));
+            }
         }
         else
         {
             // When nothing is grouped in a column, the grouping is rendered directly.
-            foreach (var item in Shape.Grouping)
+            foreach (var item in allItems)
             {
                 htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync((IShape)item));
             }
@@ -296,39 +314,4 @@ public class ZoneShapes : IShapeAttributeProvider
         return htmlContentBuilder;
     }
 
-    private static Dictionary<string, string> GetColumnPositions(ILookup<string, object> groupings)
-    {
-        var positionModifiers = new Dictionary<string, string>();
-        foreach (var grouping in groupings)
-        {
-            var firstGroupWithModifier = grouping.FirstOrDefault(group =>
-                group is IShape s && !string.IsNullOrEmpty(s.Metadata.ColumnGrouping.Position));
-
-            if (firstGroupWithModifier is IShape shape)
-            {
-                var columnGrouping = shape.Metadata.ColumnGrouping;
-                positionModifiers.Add(columnGrouping.Name, columnGrouping.Position);
-            }
-        }
-
-        return positionModifiers;
-    }
-
-    private static Dictionary<string, string> GetColumnModifiers(IEnumerable<IGrouping<string, object>> groupings)
-    {
-        var columnModifiers = new Dictionary<string, string>();
-        foreach (var grouping in groupings)
-        {
-            var firstGroupWithModifier = grouping.FirstOrDefault(group =>
-                group is IShape s && !string.IsNullOrEmpty(s.Metadata.ColumnGrouping.Width));
-
-            if (firstGroupWithModifier is IShape shape)
-            {
-                var columnGrouping = shape.Metadata.ColumnGrouping;
-                columnModifiers.Add(columnGrouping.Name, columnGrouping.Width);
-            }
-        }
-
-        return columnModifiers;
-    }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneShapes.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Zones/ZoneShapes.cs
@@ -214,6 +214,7 @@ public class ZoneShapes : IShapeAttributeProvider
     {
         var htmlContentBuilder = new HtmlContentBuilder();
 
+        // Shape.Grouping enumeration already preserves the existing item position ordering.
         var allItems = Shape.Grouping.ToList();
         var hasColumnItems = allItems.Any(x => x is IShape s && s.Metadata.ColumnGrouping.HasValue);
 
@@ -221,8 +222,8 @@ public class ZoneShapes : IShapeAttributeProvider
         {
             // Each column-specified item gets its own column wrapper within a row.
             // Non-column items render outside the row at their natural position.
-            var beforeRow = new List<object>();
-            var afterRow = new List<object>();
+            List<object> beforeRow = null;
+            List<object> afterRow = null;
             var columnItems = new List<IShape>();
             var foundFirstColumnItem = false;
 
@@ -237,19 +238,22 @@ public class ZoneShapes : IShapeAttributeProvider
                 {
                     if (!foundFirstColumnItem)
                     {
-                        beforeRow.Add(item);
+                        (beforeRow ??= []).Add(item);
                     }
                     else
                     {
-                        afterRow.Add(item);
+                        (afterRow ??= []).Add(item);
                     }
                 }
             }
 
             // Render non-column items that appear before the first column item.
-            foreach (var item in beforeRow)
+            if (beforeRow is not null)
             {
-                htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync((IShape)item));
+                foreach (var item in beforeRow)
+                {
+                    htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync((IShape)item));
+                }
             }
 
             // Sort column items by their column position.
@@ -297,9 +301,12 @@ public class ZoneShapes : IShapeAttributeProvider
             htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync(container));
 
             // Render non-column items that appear after the column row.
-            foreach (var item in afterRow)
+            if (afterRow is not null)
             {
-                htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync((IShape)item));
+                foreach (var item in afterRow)
+                {
+                    htmlContentBuilder.AppendHtml(await DisplayAsync.ShapeExecuteAsync((IShape)item));
+                }
             }
         }
         else

--- a/src/docs/reference/modules/Placement/README.md
+++ b/src/docs/reference/modules/Placement/README.md
@@ -270,6 +270,74 @@ We also specify that the `Content` column will take 9 columns, of the default 12
     By default the columns will break responsively at the `md` breakpoint, and a modifier will be parsed to `col-md-9`.
     If you want to change the breakpoint, you could also specify `Content_lg-9`, which is parsed to `col-lg-9`.
 
+#### Column layout behavior
+
+Each shape with a column modifier (`|ColumnName`) gets its own **column wrapper** inside a Bootstrap **row** (`<div class="row">`). The column name is an arbitrary label used for the CSS class — it has no special meaning (e.g., `|MyCol_4` is the same as `|Sidebar_4` — neither implies left or right positioning).
+
+The column **width** (the number after `_`) maps to Bootstrap's 12-column grid. For example, `_4` means `col-md-4` (4/12 = 1/3 width). If the total widths exceed 12, columns wrap to the next line automatically (standard Bootstrap behavior).
+
+The column **position** (the number after `;`) determines the order of columns within the row.
+
+Shapes **without** a column modifier are rendered as **full-width content outside the row**. Their vertical position relative to the column row is determined by their order in the placement sequence:
+
+- Shapes positioned **before** the first column-specified shape render above the row.
+- Shapes positioned **after** the first column-specified shape render below the row.
+
+**Example: Three equal-width columns with a full-width field below**
+
+``` json
+{
+    "TextField_Edit" : [
+        {
+            "place" : "Parts:1%Details;1|Col_4;1",
+            "differentiator": "MyPart-FieldA"
+        },
+        {
+            "place" : "Parts:1%Details;1|Col_4;2",
+            "differentiator": "MyPart-FieldB"
+        },
+        {
+            "place" : "Parts:1%Details;1|Col_4;3",
+            "differentiator": "MyPart-FieldC"
+        },
+        {
+            "place": "Parts:2%Details;1",
+            "differentiator": "MyPart-FieldD"
+        }
+    ]
+}
+```
+
+This produces:
+
+- A row with three columns, each 4/12 width (1/3): FieldA, FieldB, FieldC side by side.
+- Below the row: FieldD rendered at full width (no column wrapper).
+
+**Example: Two columns with different widths**
+
+``` json
+{
+    "TextField_Edit" : [
+        {
+            "place" : "Parts:1|Sidebar_3;1",
+            "differentiator": "MyPart-FieldA"
+        },
+        {
+            "place" : "Parts:1|Main_9;2",
+            "differentiator": "MyPart-FieldB"
+        }
+    ]
+}
+```
+
+This produces a row with a 3/12 width column (FieldA) and a 9/12 width column (FieldB).
+
+!!! note
+    The column name (e.g., `Col`, `Sidebar`, `Main`) is just an identifier used for CSS targeting via the generated class `column-{name}`. You can use any name — it does not affect positioning. To put multiple fields in separate columns, give each field a column modifier; the position (`;N`) controls their order in the row.
+
+!!! warning
+    All column-specified shapes within the same grouping level (same tab/card) share a single row. If you need multiple separate column rows, place them in different cards.
+
 ### Dynamic part placement
 
 In the following example we place a dynamic part (part without driver, i.e. created in json) `GalleryPart` in a zone called `MyGalleryZone`. When displaying that part inside Content template we would execute:

--- a/test/OrchardCore.Tests/DisplayManagement/Zones/ZoneShapesTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Zones/ZoneShapesTests.cs
@@ -287,6 +287,29 @@ public class ZoneShapesTests
         Assert.Equal(string.Empty, html);
     }
 
+    [Fact]
+    public async Task ContentZone_WithoutGrouping_ShouldPreserveExistingPositionOrder()
+    {
+        // Arrange
+        var first = CreateTestShape("First");
+        var second = CreateTestShape("Second");
+        var third = CreateTestShape("Third");
+
+        var zone = new Shape();
+        await zone.AddAsync(third, "3");
+        await zone.AddAsync(first, "1");
+        await zone.AddAsync(second, "2");
+
+        // Act
+        dynamic dynamicZone = zone;
+        var result = await _zoneShapes.ContentZone(_displayHelper, dynamicZone, _shapeFactory);
+
+        // Assert
+        var html = GetHtmlString(result);
+        Assert.True(html.IndexOf("First", StringComparison.Ordinal) < html.IndexOf("Second", StringComparison.Ordinal));
+        Assert.True(html.IndexOf("Second", StringComparison.Ordinal) < html.IndexOf("Third", StringComparison.Ordinal));
+    }
+
     #endregion
 
     #region ContentZone Tests - Tab Grouping
@@ -807,6 +830,40 @@ public class ZoneShapesTests
         var firstShapeIndex = html.IndexOf("<div>TestShape</div>", StringComparison.Ordinal);
         var rowIndex = html.IndexOf("row", StringComparison.Ordinal);
         Assert.True(firstShapeIndex < rowIndex, "Non-column shape should appear before the row");
+    }
+
+    [Fact]
+    public async Task ColumnGrouping_ShouldPreserveExistingPositionOrderForNonColumnItems()
+    {
+        // Arrange
+        var beforeSecond = CreateTestShape("BeforeSecond");
+        var beforeFirst = CreateTestShape("BeforeFirst");
+        var column = CreateShapeWithColumnGrouping("Center", "1", null);
+        var afterSecond = CreateTestShape("AfterSecond");
+        var afterFirst = CreateTestShape("AfterFirst");
+
+        var zone = new Shape();
+        await zone.AddAsync(afterSecond, "5");
+        await zone.AddAsync(column, "3");
+        await zone.AddAsync(beforeSecond, "2");
+        await zone.AddAsync(afterFirst, "4");
+        await zone.AddAsync(beforeFirst, "1");
+
+        var grouping = zone.Cast<object>().ToLookup(_ => "TestGroup").First();
+        var viewModel = new GroupingViewModel
+        {
+            Identifier = "test-id",
+            Grouping = grouping,
+        };
+
+        // Act
+        var result = await _zoneShapes.ColumnGrouping(_displayHelper, viewModel, _shapeFactory);
+
+        // Assert
+        var html = GetHtmlString(result);
+        Assert.True(html.IndexOf("BeforeFirst", StringComparison.Ordinal) < html.IndexOf("BeforeSecond", StringComparison.Ordinal));
+        Assert.True(html.IndexOf("BeforeSecond", StringComparison.Ordinal) < html.IndexOf("row", StringComparison.Ordinal));
+        Assert.True(html.LastIndexOf("AfterFirst", StringComparison.Ordinal) < html.LastIndexOf("AfterSecond", StringComparison.Ordinal));
     }
 
     #endregion

--- a/test/OrchardCore.Tests/DisplayManagement/Zones/ZoneShapesTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Zones/ZoneShapesTests.cs
@@ -570,9 +570,9 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_WithSingleColumn_ShouldRenderDirectly()
+    public async Task ColumnGrouping_WithSameColumnName_ShouldCreateSeparateColumns()
     {
-        // Arrange
+        // Arrange - items with same column name each get their own column wrapper
         var shape1 = CreateShapeWithColumnGrouping("Col1", "1", null);
         var shape2 = CreateShapeWithColumnGrouping("Col1", "2", null);
 
@@ -589,12 +589,16 @@ public class ZoneShapesTests
         // Assert
         Assert.NotNull(result);
         var html = GetHtmlString(result);
-        // Should render shapes directly without container
-        Assert.DoesNotContain("row", html);
-        Assert.Contains("<div>TestShape</div>", html);
+        // Each item should get its own column wrapper in a row
+        Assert.Contains("row", html);
+        Assert.Contains("ta-col-grouping", html);
+        Assert.Contains("column-col1", html);
         // Verify there are 2 shapes rendered
         var shapeCount = System.Text.RegularExpressions.Regex.Count(html, "<div>TestShape</div>");
         Assert.Equal(2, shapeCount);
+        // Verify there are 2 separate column wrappers
+        var colGroupCount = System.Text.RegularExpressions.Regex.Count(html, "ta-col-grouping");
+        Assert.Equal(2, colGroupCount);
     }
 
     [Fact]
@@ -709,7 +713,7 @@ public class ZoneShapesTests
     }
 
     [Fact]
-    public async Task ColumnGrouping_WithContentKey_ShouldHandleDefault()
+    public async Task ColumnGrouping_WithContentKey_ShouldRenderNonColumnItemsOutsideRow()
     {
         // Arrange
         var shape1 = CreateShapeWithColumnGrouping("Col1", "1", null);
@@ -728,13 +732,81 @@ public class ZoneShapesTests
         // Assert
         Assert.NotNull(result);
         var html = GetHtmlString(result);
-        // Should handle both grouped and ungrouped shapes
+        // Should create a row for column items only
         Assert.Contains("row", html);
         Assert.Contains("ta-col-grouping", html);
-        Assert.Contains("column-content", html);
         Assert.Contains("column-col1", html);
-        Assert.Contains("col-12 col-md", html);
-        Assert.Contains("<div>TestShape</div>", html);
+        // Non-column items should NOT be inside the row as a "column-content" div
+        Assert.DoesNotContain("column-content", html);
+        // Both shapes should still be rendered
+        var shapeCount = System.Text.RegularExpressions.Regex.Count(html, "<div>TestShape</div>");
+        Assert.Equal(2, shapeCount);
+    }
+
+    [Fact]
+    public async Task ColumnGrouping_NonColumnItemsAfterColumns_ShouldRenderAfterRow()
+    {
+        // Arrange - column items first, then non-column item
+        var shape1 = CreateShapeWithColumnGrouping("Left", "1", "4");
+        var shape2 = CreateShapeWithColumnGrouping("Right", "2", "8");
+        var shape3 = CreateShapeWithoutGrouping(); // Goes to "Content" key, after columns
+
+        var grouping = CreateMockGrouping(shape1, shape2, shape3);
+        var viewModel = new GroupingViewModel
+        {
+            Identifier = "test-id",
+            Grouping = grouping,
+        };
+
+        // Act
+        var result = await _zoneShapes.ColumnGrouping(_displayHelper, viewModel, _shapeFactory);
+
+        // Assert
+        Assert.NotNull(result);
+        var html = GetHtmlString(result);
+        // Should have a row with column items
+        Assert.Contains("row", html);
+        Assert.Contains("column-left", html);
+        Assert.Contains("column-right", html);
+        Assert.Contains("col-12 col-md-4", html);
+        Assert.Contains("col-12 col-md-8", html);
+        // Non-column item should NOT be in a column wrapper
+        Assert.DoesNotContain("column-content", html);
+        // Non-column item should appear after the row
+        var rowEndIndex = html.LastIndexOf("</div></div>", StringComparison.Ordinal);
+        var lastShapeIndex = html.LastIndexOf("<div>TestShape</div>", StringComparison.Ordinal);
+        Assert.True(lastShapeIndex > html.IndexOf("row", StringComparison.Ordinal), "Non-column shape should appear after the row starts");
+    }
+
+    [Fact]
+    public async Task ColumnGrouping_NonColumnItemsBeforeColumns_ShouldRenderBeforeRow()
+    {
+        // Arrange - non-column item first, then column items
+        var shape1 = CreateShapeWithoutGrouping(); // Goes to "Content" key, before columns
+        var shape2 = CreateShapeWithColumnGrouping("Left", "1", "6");
+        var shape3 = CreateShapeWithColumnGrouping("Right", "2", "6");
+
+        var grouping = CreateMockGrouping(shape1, shape2, shape3);
+        var viewModel = new GroupingViewModel
+        {
+            Identifier = "test-id",
+            Grouping = grouping,
+        };
+
+        // Act
+        var result = await _zoneShapes.ColumnGrouping(_displayHelper, viewModel, _shapeFactory);
+
+        // Assert
+        Assert.NotNull(result);
+        var html = GetHtmlString(result);
+        // Should have a row with column items
+        Assert.Contains("row", html);
+        Assert.Contains("column-left", html);
+        Assert.Contains("column-right", html);
+        // Non-column item should appear before the row
+        var firstShapeIndex = html.IndexOf("<div>TestShape</div>", StringComparison.Ordinal);
+        var rowIndex = html.IndexOf("row", StringComparison.Ordinal);
+        Assert.True(firstShapeIndex < rowIndex, "Non-column shape should appear before the row");
     }
 
     #endregion


### PR DESCRIPTION
Currently there is a bug in the placement of the column when mixing fields with columns and fields without. 

Here is a recipe you can test with:
```json
{
  "steps": [
    {
      "name": "ContentDefinition",
      "ContentTypes": [
        {
          "Name": "PlacementTest",
          "DisplayName": "PlacementTest",
          "Settings": {
            "ContentTypeSettings": {
              "Creatable": true,
              "Listable": true,
              "Draftable": true,
              "Versionable": true,
              "Securable": true,
              "ThumbnailPath": "~/OrchardCore.ContentTypes/placeholder.png"
            }
          },
          "ContentTypePartDefinitionRecords": [
            {
              "PartName": "PlacementTest",
              "Name": "PlacementTest",
              "Settings": {}
            },
            {
              "PartName": "BagPart",
              "Name": "BagPart",
              "Settings": {
                "ContentTypePartSettings": {
                  "DisplayName": "Bag",
                  "Description": "Provides a collection behavior for your content item where you can place other content items."
                },
                "BagPartSettings": {
                  "ContainedContentTypes": [
                    "Article"
                  ],
                  "ContainedStereotypes": [],
                  "CollapseContainedItems": false
                }
              }
            },
            {
              "PartName": "TestOne",
              "Name": "TestOne",
              "Settings": {}
            },
            {
              "PartName": "TestTwo",
              "Name": "TestTwo",
              "Settings": {}
            }
          ]
        }
      ],
      "ContentParts": [
        {
          "Name": "BagPart",
          "Settings": {
            "ContentPartSettings": {
              "Attachable": true,
              "Reusable": true,
              "Description": "Provides a collection behavior for your content item where you can place other content items."
            }
          },
          "ContentPartFieldDefinitionRecords": []
        },
        {
          "Name": "TestOne",
          "Settings": {
            "ContentPartSettings": {
              "Attachable": true,
              "Reusable": false
            }
          },
          "ContentPartFieldDefinitionRecords": [
            {
              "FieldName": "TextField",
              "Name": "Third",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "Third",
                  "Position": "2"
                }
              }
            },
            {
              "FieldName": "TextField",
              "Name": "First",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "First",
                  "Position": "0"
                }
              }
            },
            {
              "FieldName": "TextField",
              "Name": "Second",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "Second",
                  "Position": "1"
                }
              }
            },
            {
              "FieldName": "TextField",
              "Name": "Fourth",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "Fourth",
                  "Editor": "TextArea",
                  "Position": "3"
                },
                "TextFieldSettings": {
                  "Type": 0,
                  "Required": false
                }
              }
            },
            {
              "FieldName": "TextField",
              "Name": "Fifth",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "Fifth",
                  "Position": "4"
                }
              }
            }
          ]
        },
        {
          "Name": "TestTwo",
          "Settings": {
            "ContentPartSettings": {
              "Attachable": true,
              "Reusable": false
            }
          },
          "ContentPartFieldDefinitionRecords": [
            {
              "FieldName": "TextField",
              "Name": "Large",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "Large",
                  "Editor": "TextArea"
                },
                "TextFieldSettings": {
                  "Type": 0,
                  "Required": false
                }
              }
            },
            {
              "FieldName": "TextField",
              "Name": "InitialOne",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "InitialOne"
                }
              }
            },
            {
              "FieldName": "TextField",
              "Name": "InitialTwo",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "InitialTwo"
                }
              }
            },
            {
              "FieldName": "TextField",
              "Name": "InitialThree",
              "Settings": {
                "ContentPartFieldSettings": {
                  "DisplayName": "InitialThree"
                }
              }
            }
          ]
        }
      ]
    },
    {
      "name": "Placements",
      "Placements": {
        "TextField_Edit": [
          {
            "place": "Parts:2%Card One;2|Col_6;1",
            "differentiator": "TestOne-First",
            "contentType": [
              "PlacementTest"
            ]
          },
          {
            "place": "Parts:2%Card One;2|Col_12;3",
            "differentiator": "TestOne-Third",
            "contentType": [
              "PlacementTest"
            ]
          },
          {
            "place": "Parts:2%Card One;2|Col_6;2",
            "differentiator": "TestOne-Second",
            "contentType": [
              "PlacementTest"
            ]
          },
          {
            "place": "Parts:1%Card One;2",
            "differentiator": "TestOne-Fourth",
            "contentType": [
              "PlacementTest"
            ]
          }
        ]
      }
    }
  ]
}
```

With the above recipe, create `PlacementTest` content item to see how the UI looks.


Now columns work as expected: here is a working example after this PR
<img width="1650" height="372" alt="image" src="https://github.com/user-attachments/assets/891e431f-7d90-495e-bc39-25dea4056262" />

### Before

Here how the same placement look before
<img width="1641" height="453" alt="image" src="https://github.com/user-attachments/assets/7b63321d-46ec-44ef-bb1e-e7f3678303b4" />


and if I change the placement to the following: "each column has different name"

```
[
  {
    "place": "Parts:2%Card One;2|Col1_6;1",
    "differentiator": "TestOne-First",
    "contentType": [
      "PlacementTest"
    ]
  },
  {
    "place": "Parts:2%Card One;2|Col2_12;3",
    "differentiator": "TestOne-Third",
    "contentType": [
      "PlacementTest"
    ]
  },
  {
    "place": "Parts:2%Card One;2|Col3_6;2",
    "differentiator": "TestOne-Second",
    "contentType": [
      "PlacementTest"
    ]
  },
  {
    "place": "Parts:1%Card One;2",
    "differentiator": "TestOne-Fourth",
    "contentType": [
      "PlacementTest"
    ]
  }
]
```


<img width="1641" height="376" alt="image" src="https://github.com/user-attachments/assets/9cebb522-4b44-401c-985f-1bc9b9a6d1f1" />



This pull request refactors and enhances the column grouping logic in Orchard Core's display management system, clarifying how shapes with and without column modifiers are rendered. The changes improve both the implementation in `ZoneShapes.cs` and the documentation and tests, ensuring that column-based layouts behave predictably and are easier to understand and verify.

**Column grouping logic improvements:**

* Refactored the `ColumnGrouping` method in `ZoneShapes.cs` to ensure that each shape with a column modifier gets its own column wrapper inside a single Bootstrap row, while shapes without column modifiers are rendered outside the row, either before or after the columns depending on their placement order. This replaces the previous grouping-based logic and removes the now-unnecessary `GetColumnPositions` and `GetColumnModifiers` helper methods. [[1]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L217-R308) [[2]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L299-L333)
* Updated variable naming and usage throughout `ZoneShapes.cs` for clarity and consistency, such as using `var` instead of explicit types and improving lambda parameter names. [[1]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L38-R38) [[2]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L57-R61) [[3]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L80-R81) [[4]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L91-R91) [[5]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L101-R101) [[6]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L120-R120) [[7]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59R157-R163) [[8]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L170-R179) [[9]](diffhunk://#diff-adcecf0d9efc9eef92f396ce2b00f48c858e4edb6cd677210540a1d3719e5f59L198-R198)

**Documentation updates:**

* Expanded the Placement module documentation to clearly describe the new column layout behavior, including how column names, widths, and positions work, and how non-column shapes are rendered relative to columns. Added detailed examples for common scenarios.

**Test enhancements:**

* Updated and added tests in `ZoneShapesTests.cs` to verify that shapes with the same column name each get their own column wrapper, and that non-column items are rendered outside the column row as expected. [[1]](diffhunk://#diff-df7b4e36afa47329f16ed0416e08457ef0442ee718dfb305b5b5d67e9afd0209L573-R575) [[2]](diffhunk://#diff-df7b4e36afa47329f16ed0416e08457ef0442ee718dfb305b5b5d67e9afd0209L592-R601) [[3]](diffhunk://#diff-df7b4e36afa47329f16ed0416e08457ef0442ee718dfb305b5b5d67e9afd0209L712-R716)
