### PR TITLE
Fix Complex Parts Placement and Documentations

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-BagPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-BagPart.Edit.cshtml
@@ -1,22 +1,19 @@
+@using System.Collections
 @using System.Collections.Generic
+@using System.Linq
+@using OrchardCore
+@using OrchardCore.ContentManagement
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
-@using OrchardCore.ContentManagement
 @using OrchardCore.ContentTypes
-@using OrchardCore
 @using OrchardCore.Localization.Data
 
 @inject IDataLocalizer D
 
 @{
-    var shapes = new List<object>();
+    var shapes = Model as IEnumerable<dynamic>;
 
-    foreach (var shape in Model)
-    {
-        shapes.Add(shape);
-    }
-
-    if (shapes.Count == 0)
+    if (shapes is null || !shapes.Any())
     {
         return;
     }
@@ -36,7 +33,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in shapes)
+        @foreach (var shape in Model)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-BagPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-BagPart.Edit.cshtml
@@ -1,3 +1,4 @@
+@using System.Collections.Generic
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
 @using OrchardCore.ContentManagement
@@ -8,6 +9,18 @@
 @inject IDataLocalizer D
 
 @{
+    var shapes = new List<object>();
+
+    foreach (var shape in Model)
+    {
+        shapes.Add(shape);
+    }
+
+    if (shapes.Count == 0)
+    {
+        return;
+    }
+
     ContentTypePartDefinition typePartDefinition = Model.ContentTypePartDefinition;
     var description = typePartDefinition.Description();
 }
@@ -23,7 +36,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in Model)
+        @foreach (var shape in shapes)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-BagPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-BagPart.Edit.cshtml
@@ -1,4 +1,3 @@
-@using System.Collections
 @using System.Collections.Generic
 @using System.Linq
 @using OrchardCore
@@ -11,7 +10,7 @@
 @inject IDataLocalizer D
 
 @{
-    var shapes = Model as IEnumerable<dynamic>;
+    var shapes = Model as IEnumerable<IShape>;
 
     if (shapes is null || !shapes.Any())
     {
@@ -33,7 +32,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in Model)
+        @foreach (var shape in shapes)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-FlowPart.Edit.cshtml
@@ -1,22 +1,18 @@
+@using System.Collections
 @using System.Collections.Generic
+@using OrchardCore
+@using OrchardCore.ContentManagement
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
-@using OrchardCore.ContentManagement
 @using OrchardCore.ContentTypes
-@using OrchardCore
 @using OrchardCore.Localization.Data
 
 @inject IDataLocalizer D
 
 @{
-    var shapes = new List<object>();
+    var shapes = Model as IEnumerable<dynamic>;
 
-    foreach (var shape in Model)
-    {
-        shapes.Add(shape);
-    }
-
-    if (shapes.Count == 0)
+    if (shapes is null || !shapes.Any())
     {
         return;
     }
@@ -35,7 +31,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in shapes)
+        @foreach (var shape in Model)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-FlowPart.Edit.cshtml
@@ -1,3 +1,4 @@
+@using System.Collections.Generic
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
 @using OrchardCore.ContentManagement
@@ -8,10 +9,21 @@
 @inject IDataLocalizer D
 
 @{
+    var shapes = new List<object>();
+
+    foreach (var shape in Model)
+    {
+        shapes.Add(shape);
+    }
+
+    if (shapes.Count == 0)
+    {
+        return;
+    }
+
     ContentTypePartDefinition typePartDefinition = Model.ContentTypePartDefinition;
     var description = typePartDefinition.Description();
 }
-
 <div class="@Orchard.GetPartWrapperClasses(typePartDefinition)">
     <div class="@Orchard.GetLabelClasses()">
         @D[typePartDefinition.DisplayName(), DataLocalizationContext.ContentType]
@@ -23,7 +35,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in Model)
+        @foreach (var shape in shapes)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-FlowPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-FlowPart.Edit.cshtml
@@ -10,7 +10,7 @@
 @inject IDataLocalizer D
 
 @{
-    var shapes = Model as IEnumerable<dynamic>;
+    var shapes = Model as IEnumerable<IShape>;
 
     if (shapes is null || !shapes.Any())
     {
@@ -31,7 +31,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in Model)
+        @foreach (var shape in shapes)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-WidgetsListPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-WidgetsListPart.Edit.cshtml
@@ -1,22 +1,18 @@
+@using System.Collections
 @using System.Collections.Generic
+@using OrchardCore
+@using OrchardCore.ContentManagement
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
-@using OrchardCore.ContentManagement
 @using OrchardCore.ContentTypes
-@using OrchardCore
 @using OrchardCore.Localization.Data
 
 @inject IDataLocalizer D
 
 @{
-    var shapes = new List<object>();
+    var shapes = Model as IEnumerable<dynamic>;
 
-    foreach (var shape in Model)
-    {
-        shapes.Add(shape);
-    }
-
-    if (shapes.Count == 0)
+    if (shapes is null || !shapes.Any())
     {
         return;
     }
@@ -36,7 +32,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in shapes)
+        @foreach (var shape in Model)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-WidgetsListPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-WidgetsListPart.Edit.cshtml
@@ -1,3 +1,4 @@
+@using System.Collections.Generic
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
 @using OrchardCore.ContentManagement
@@ -8,6 +9,18 @@
 @inject IDataLocalizer D
 
 @{
+    var shapes = new List<object>();
+
+    foreach (var shape in Model)
+    {
+        shapes.Add(shape);
+    }
+
+    if (shapes.Count == 0)
+    {
+        return;
+    }
+
     ContentTypePartDefinition typePartDefinition = Model.ContentTypePartDefinition;
     var description = typePartDefinition.Description();
 }
@@ -23,7 +36,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in Model)
+        @foreach (var shape in shapes)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-WidgetsListPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart-WidgetsListPart.Edit.cshtml
@@ -10,7 +10,7 @@
 @inject IDataLocalizer D
 
 @{
-    var shapes = Model as IEnumerable<dynamic>;
+    var shapes = Model as IEnumerable<IShape>;
 
     if (shapes is null || !shapes.Any())
     {
@@ -32,7 +32,7 @@
     </div>
 
     <div class="@Orchard.GetEndClasses()">
-        @foreach (var shape in Model)
+        @foreach (var shape in shapes)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart.Edit.cshtml
@@ -1,3 +1,4 @@
+@using System.Collections.Generic
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
 @using OrchardCore.ContentManagement
@@ -8,6 +9,18 @@
 @inject IDataLocalizer D
 
 @{
+    var shapes = new List<object>();
+
+    foreach (var shape in Model)
+    {
+        shapes.Add(shape);
+    }
+
+    if (shapes.Count == 0)
+    {
+        return;
+    }
+
     ContentPart contentPart = Model.ContentPart;
     ContentTypePartDefinition typePartDefinition = Model.ContentTypePartDefinition;
     var description = typePartDefinition.Description();
@@ -27,15 +40,15 @@
         </div>
 
         <div class="@Orchard.GetEndClasses()">
-            @foreach (var shape in Model)
+            @foreach (var shape in shapes)
             {
                 @await DisplayAsync(shape)
             }
         </div>
     }
     else
-    {   
-        foreach (var shape in Model)
+    {
+        foreach (var shape in shapes)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart.Edit.cshtml
@@ -1,22 +1,18 @@
+@using System.Collections
 @using System.Collections.Generic
+@using OrchardCore
+@using OrchardCore.ContentManagement
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
-@using OrchardCore.ContentManagement
 @using OrchardCore.ContentTypes
-@using OrchardCore
 @using OrchardCore.Localization.Data
 
 @inject IDataLocalizer D
 
 @{
-    var shapes = new List<object>();
+    var shapes = Model as IEnumerable<dynamic>;
 
-    foreach (var shape in Model)
-    {
-        shapes.Add(shape);
-    }
-
-    if (shapes.Count == 0)
+    if (shapes is null || !shapes.Any())
     {
         return;
     }
@@ -40,7 +36,7 @@
         </div>
 
         <div class="@Orchard.GetEndClasses()">
-            @foreach (var shape in shapes)
+            @foreach (var shape in Model)
             {
                 @await DisplayAsync(shape)
             }
@@ -48,7 +44,7 @@
     }
     else
     {
-        foreach (var shape in shapes)
+        foreach (var shape in Model)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentPart.Edit.cshtml
@@ -10,7 +10,7 @@
 @inject IDataLocalizer D
 
 @{
-    var shapes = Model as IEnumerable<dynamic>;
+    var shapes = Model as IEnumerable<IShape>;
 
     if (shapes is null || !shapes.Any())
     {
@@ -36,7 +36,7 @@
         </div>
 
         <div class="@Orchard.GetEndClasses()">
-            @foreach (var shape in Model)
+            @foreach (var shape in shapes)
             {
                 @await DisplayAsync(shape)
             }
@@ -44,7 +44,7 @@
     }
     else
     {
-        foreach (var shape in Model)
+        foreach (var shape in shapes)
         {
             @await DisplayAsync(shape)
         }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Views/ContentPart-TitlePart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Views/ContentPart-TitlePart.Edit.cshtml
@@ -1,21 +1,23 @@
 @using System.Collections.Generic
+@using OrchardCore
+@using OrchardCore.ContentManagement
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
-@using OrchardCore.ContentManagement
-@using OrchardCore
+@using OrchardCore.DisplayManagement
 @using OrchardCore.Title.Models
 
 @{
-    ContentTypePartDefinition typePartDefinition = Model.ContentTypePartDefinition;
-    var settings = typePartDefinition.GetSettings<TitlePartSettings>();
-    var shapes = new List<object>();
+    var shapes = Model as IEnumerable<IShape>;
 
-    foreach (var shape in Model)
+    if (shapes is null || !shapes.Any())
     {
-        shapes.Add(shape);
+        return;
     }
 
-    if (settings.Options == TitlePartOptions.GeneratedHidden || shapes.Count == 0)
+    ContentTypePartDefinition typePartDefinition = Model.ContentTypePartDefinition;
+    var settings = typePartDefinition.GetSettings<TitlePartSettings>();
+
+    if (settings.Options == TitlePartOptions.GeneratedHidden)
     {
         return;
     }

--- a/src/OrchardCore.Modules/OrchardCore.Title/Views/ContentPart-TitlePart.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Title/Views/ContentPart-TitlePart.Edit.cshtml
@@ -1,3 +1,4 @@
+@using System.Collections.Generic
 @using OrchardCore.ContentManagement.Metadata.Models
 @using OrchardCore.ContentManagement.Metadata.Settings
 @using OrchardCore.ContentManagement
@@ -7,15 +8,21 @@
 @{
     ContentTypePartDefinition typePartDefinition = Model.ContentTypePartDefinition;
     var settings = typePartDefinition.GetSettings<TitlePartSettings>();
-}
+    var shapes = new List<object>();
 
-@if (settings.Options == TitlePartOptions.GeneratedHidden)
-{
-    return;
+    foreach (var shape in Model)
+    {
+        shapes.Add(shape);
+    }
+
+    if (settings.Options == TitlePartOptions.GeneratedHidden || shapes.Count == 0)
+    {
+        return;
+    }
 }
 
 <div class="@Orchard.GetPartWrapperClasses(typePartDefinition)">
-    @foreach (var shape in Model)
+    @foreach (var shape in shapes)
     {
         @await DisplayAsync(shape)
     }

--- a/src/docs/reference/modules/Flow/BagPart.md
+++ b/src/docs/reference/modules/Flow/BagPart.md
@@ -143,6 +143,49 @@ The name of a BagPart is used as the differentiator in `placement.json`
 }
 ```
 
+This targets the BagPart display shape itself. For example, the following hides a named `Services` BagPart on the front end:
+
+```json
+{
+    "BagPart": [
+        {
+            "differentiator": "Services",
+            "place": "-"
+        }
+    ]
+}
+```
+
+To hide or move the **editor** in the admin UI, target the `ContentPart_Edit` wrapper shape instead of `BagPart_Edit`. The part editor is rendered inside this wrapper, whose differentiator is `{ContentType}-{PartName}`.
+
+For example, to hide a named `Services` BagPart on the `LandingPage` content type editor:
+
+```json
+{
+    "ContentPart_Edit": [
+        {
+            "differentiator": "LandingPage-Services",
+            "place": "-"
+        }
+    ]
+}
+```
+
+For a non-named BagPart, use the part type as the part name:
+
+```json
+{
+    "ContentPart_Edit": [
+        {
+            "differentiator": "LandingPage-BagPart",
+            "place": "-"
+        }
+    ]
+}
+```
+
+`BagPart_Edit` only targets the inner editor shape. If you want to hide or reposition the whole editor, including its label and description wrapper, use `ContentPart_Edit`.
+
 ## Video
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/JYES1i6BdWs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/src/docs/reference/modules/Flow/README.md
+++ b/src/docs/reference/modules/Flow/README.md
@@ -32,6 +32,40 @@ And if you'd like to use the same template for Flow parts that have items and Fl
 }
 ```
 
+## Placement
+
+For front-end placement, the `FlowPart` display shape uses the part name as its differentiator.
+
+For example, to hide a standard `FlowPart` on the front end:
+
+```json
+{
+    "FlowPart": [
+        {
+            "differentiator": "FlowPart",
+            "place": "-"
+        }
+    ]
+}
+```
+
+To hide or move the **editor** in the admin UI, target the `ContentPart_Edit` wrapper shape instead of `FlowPart_Edit`. The wrapper differentiator is `{ContentType}-{PartName}`.
+
+For example, to hide the `FlowPart` editor row on a `LandingPage` content type:
+
+```json
+{
+    "ContentPart_Edit": [
+        {
+            "differentiator": "LandingPage-FlowPart",
+            "place": "-"
+        }
+    ]
+}
+```
+
+`FlowPart_Edit` only targets the inner editor shape. Use `ContentPart_Edit` when you need to hide or move the whole editor row, including its wrapper, label, and description.
+
 ## Blocks Editor
 
 The blocks editor provides an alternative editor for FlowPart and BagPart that uses a modal-based content type picker instead of the standard dropdown menu. Content types displayed in the picker can be organised with categories and thumbnails. See [Content Type Settings for Block Pickers](../ContentTypes/README.md#content-type-settings-for-block-pickers) for configuration details.

--- a/src/docs/reference/modules/Placement/README.md
+++ b/src/docs/reference/modules/Placement/README.md
@@ -46,6 +46,109 @@ Currently you can filter shapes by:
 }
 ```
 
+The same distinction applies to editors. Content part editors are wrapped in a `ContentPart_Edit` shape, so hiding or moving the whole editor row in the admin UI should target `ContentPart_Edit`, not only the inner part editor shape.
+
+For example, to hide the `Services` named part on the `LandingPage` editor:
+
+```json
+{
+  "ContentPart_Edit": [{
+    "place":"-",
+    "differentiator":"LandingPage-Services"
+  }]
+}
+```
+
+If you target only an inner editor shape such as `BagPart_Edit`, the wrapper may still render unless its child shapes are also removed.
+
+## Differentiator patterns
+
+The differentiator to use depends on **which shape type you are targeting**, not just on the content part or field you are thinking about.
+
+| Shape type | Typical usage | Differentiator pattern | Example |
+|---|---|---|---|
+| `BagPart`, `FlowPart`, `TitlePart` | Part display shape, or inner `XxxPart_Edit` shape from a part driver | `{PartName}` | `Services`, `FlowPart`, `TitlePart` |
+| `ContentPart` | Display wrapper for parts without their own display driver | `{PartName}` | `GalleryPart` |
+| `ContentPart_Edit` | Admin editor wrapper for a content part | `{ContentType}-{PartName}` | `PlacementTest-BagPart`, `LandingPage-Services`, `Article-TitlePart` |
+| `TextField`, `HtmlField`, `ContentPickerField`, etc. | Standard field display/editor shapes | `{PartName}-{FieldName}` | `Article-Subtitle`, `Address-City` |
+| `TextField_Display`, `HtmlField_Display`, etc. | Field display-mode shapes | `{PartName}-{FieldName}-{FieldType}_Display__{DisplayMode}` | `Blog-Subtitle-TextField_Display__Header` |
+
+`PartName` is the name of the attached part. For non-named parts this is usually the part type, such as `BagPart`, `FlowPart`, `WidgetsListPart`, or `TitlePart`. For named parts, use the custom part name such as `Services`.
+
+### Examples by shape type
+
+#### Content part display shapes
+
+To hide a named `Services` BagPart on the front end:
+
+```json
+{
+  "BagPart": [{
+    "differentiator":"Services",
+    "place":"-"
+  }]
+}
+```
+
+To hide a `TitlePart` display shape on the front end:
+
+```json
+{
+  "TitlePart": [{
+    "differentiator":"TitlePart",
+    "place":"-"
+  }]
+}
+```
+
+#### Content part editor wrappers
+
+To hide the whole BagPart editor row on the `PlacementTest` editor:
+
+```json
+{
+  "ContentPart_Edit": [{
+    "differentiator":"PlacementTest-BagPart",
+    "place":"-"
+  }]
+}
+```
+
+To hide the whole FlowPart editor row:
+
+```json
+{
+  "ContentPart_Edit": [{
+    "differentiator":"PlacementTest-FlowPart",
+    "place":"-"
+  }]
+}
+```
+
+To hide the whole WidgetsListPart editor row:
+
+```json
+{
+  "ContentPart_Edit": [{
+    "differentiator":"PlacementTest-WidgetsListPart",
+    "place":"-"
+  }]
+}
+```
+
+To hide the whole TitlePart editor row:
+
+```json
+{
+  "ContentPart_Edit": [{
+    "differentiator":"PlacementTest-TitlePart",
+    "place":"-"
+  }]
+}
+```
+
+Use `ContentPart_Edit` when you want to move or hide the whole editor row, including its label, description, and wrapper. Shapes such as `BagPart_Edit`, `FlowPart_Edit`, or `TitlePart_Edit` only target the inner editor content.
+
 Additional custom filter providers can be added by implementing `IPlacementNodeFilterProvider`.
 
 For shapes that are built from a content item, you can filter by the following built in filter providers:
@@ -126,6 +229,28 @@ Fields have a custom differentiator as their shape is used in many places.
 It is built using the `Part` it's contained in, and the name of the `Field`.  
 For instance, if a field named `MyField` would be added to an `Article` content type, its differentiator would be `Article-MyField`.  
 If a field named `City` was added to an `Address` part then its differentiator would be `Address-City`.
+
+For example, to place a `TextField` named `Subtitle` attached directly to the `Article` content type:
+
+```json
+{
+  "TextField": [{
+    "differentiator":"Article-Subtitle",
+    "place":"Content:2"
+  }]
+}
+```
+
+For a field named `City` attached to an `Address` part:
+
+```json
+{
+  "TextField": [{
+    "differentiator":"Address-City",
+    "place":"Content:3"
+  }]
+}
+```
 
 ### Field Display Modes
 

--- a/src/docs/reference/modules/Title/README.md
+++ b/src/docs/reference/modules/Title/README.md
@@ -35,3 +35,37 @@ The following properties are available in the `TitlePartViewModel` class.
 |-------------|-------------|---------------------------------|
 | `Title`     | `string`    | The title property of the part. |
 | `TitlePart` | `TitlePart` | The `TitlePart` instance.       |
+
+## Placement
+
+For front-end placement, the `TitlePart` shape uses the part name as its differentiator.
+
+For example, to hide the title on the front end:
+
+```json
+{
+    "TitlePart": [
+        {
+            "differentiator": "TitlePart",
+            "place": "-"
+        }
+    ]
+}
+```
+
+To hide or move the **editor** in the admin UI, target the `ContentPart_Edit` wrapper shape instead of `TitlePart_Edit`. The wrapper differentiator is `{ContentType}-{PartName}`.
+
+For example, to hide the `TitlePart` editor row on the `Article` content type editor:
+
+```json
+{
+    "ContentPart_Edit": [
+        {
+            "differentiator": "Article-TitlePart",
+            "place": "-"
+        }
+    ]
+}
+```
+
+`TitlePart_Edit` only targets the inner editor shape. Use `ContentPart_Edit` when you want to hide or move the whole editor row, including its wrapper.

--- a/src/docs/reference/modules/Widgets/README.md
+++ b/src/docs/reference/modules/Widgets/README.md
@@ -111,6 +111,27 @@ Optionally, you can change these alternates:
 | `Widget_Wrapper__[ContentType]`       | `Widget_Wrapper__Paragraph`    | `Widget-Paragraph.Wrapper.cshtml`   |
 | `Widget_Wrapper__Zone__[ContentZone]` | `Widget_Wrapper__Zone__Footer` | `Widget-Zone-Footer.Wrapper.cshtml` |
 
+## WidgetsListPart editor placement
+
+`WidgetsListPart` does not render its own front-end part shape. Instead, it injects widgets directly into the target layout zones.
+
+To hide or move the **editor** in the admin UI, target the `ContentPart_Edit` wrapper shape. Its differentiator is `{ContentType}-{PartName}`.
+
+For example, to hide the `WidgetsListPart` editor row on the `PlacementTest` content type:
+
+```json
+{
+    "ContentPart_Edit": [
+        {
+            "differentiator": "PlacementTest-WidgetsListPart",
+            "place": "-"
+        }
+    ]
+}
+```
+
+If the part is attached as a named part, use that part name instead of `WidgetsListPart`.
+
 ## Videos
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/9gARrrvoAY4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
This pull request improves how content part editors are rendered and clarifies placement rules in the documentation for BagPart, FlowPart, TitlePart, and WidgetsListPart. The main code changes ensure that if there are no child shapes to display in a part editor, the editor markup is not rendered at all, preventing empty wrappers. The documentation is expanded with detailed guidance and examples on how to use placement rules for both front-end and admin UI, especially regarding differentiator patterns and targeting the correct shapes for hiding or moving content part editors.

**Rendering logic improvements:**

* All content part editor views (`ContentPart.Edit.cshtml`, `ContentPart-BagPart.Edit.cshtml`, `ContentPart-FlowPart.Edit.cshtml`, `ContentPart-WidgetsListPart.Edit.cshtml`, and `ContentPart-TitlePart.Edit.cshtml`) now collect child shapes into a list and early-return if the list is empty, avoiding rendering empty editor wrappers. All loops over `Model` are replaced with loops over the new `shapes` list. [[1]](diffhunk://#diff-1ec86ef6404dfbc148d10149a0b4b68c4d5e30a0a004640f46b349029e21d0bbR1) [[2]](diffhunk://#diff-1ec86ef6404dfbc148d10149a0b4b68c4d5e30a0a004640f46b349029e21d0bbR12-R23) [[3]](diffhunk://#diff-1ec86ef6404dfbc148d10149a0b4b68c4d5e30a0a004640f46b349029e21d0bbL30-R51) [[4]](diffhunk://#diff-d4bd3d405f8ff76c9da95a20dffd6e49986bef5efdcda9998f7900a40c3db397R1) [[5]](diffhunk://#diff-d4bd3d405f8ff76c9da95a20dffd6e49986bef5efdcda9998f7900a40c3db397R12-R23) [[6]](diffhunk://#diff-d4bd3d405f8ff76c9da95a20dffd6e49986bef5efdcda9998f7900a40c3db397L26-R39) [[7]](diffhunk://#diff-5e6d8dd3768f61551a1abadc439e0a449e01e2ab1ad4e8e15fdb33bcd19bd2cbR1) [[8]](diffhunk://#diff-5e6d8dd3768f61551a1abadc439e0a449e01e2ab1ad4e8e15fdb33bcd19bd2cbR12-L14) [[9]](diffhunk://#diff-5e6d8dd3768f61551a1abadc439e0a449e01e2ab1ad4e8e15fdb33bcd19bd2cbL26-R38) [[10]](diffhunk://#diff-b321b9a86dc34f58614cee30b3b818025cf9c5deb4d107d20df663fa7d06a74eR1) [[11]](diffhunk://#diff-b321b9a86dc34f58614cee30b3b818025cf9c5deb4d107d20df663fa7d06a74eR11-R25)

**Documentation updates—Placement rules and examples:**

* The BagPart, FlowPart, TitlePart, and WidgetsListPart documentation now clearly explains the difference between targeting the display shape (e.g., `BagPart`, `FlowPart`, `TitlePart`) and the editor wrapper (`ContentPart_Edit`) in placement rules. It provides concrete JSON examples for hiding or moving parts in both the front-end and admin UI, and explains differentiator patterns for both named and unnamed parts. [[1]](diffhunk://#diff-93fac9b351e7e2c3188ca954f8f907dedc1afda67202abfb48795e92e61c9325R146-R188) [[2]](diffhunk://#diff-08ed2d1a20e74f6318a79f7c617bd6190a2f918f42a094f26d46a6ff59350567R35-R68) [[3]](diffhunk://#diff-c5ba0e45f5bb4629304b14b692ba108e72cd0047af4139d7e75b1cf068e291daR38-R71) [[4]](diffhunk://#diff-89eceb83378a99e18acf2cd330312d216a2aff48b0bf5efbce7a12473b29d686R114-R134) [[5]](diffhunk://#diff-3c0c6e944072dccc939a33c0cf78ea51c0ba0911aa034879c7b3cae58abef381R49-R151) [[6]](diffhunk://#diff-3c0c6e944072dccc939a33c0cf78ea51c0ba0911aa034879c7b3cae58abef381R233-R254)

* The placement documentation (`Placement/README.md`) now includes a comprehensive table of differentiator patterns for all major shape types, including part editors, part displays, and field shapes, with examples for each.

These changes make part editor rendering more robust and provide much clearer guidance for developers and site builders on how to control placement of content parts and fields.
