### PR TITLE
Convert Alerts to Dismissible Toasts

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -96,7 +96,7 @@ public sealed class AdminController : Controller
             {
                 var availableFeatures = await featureService.GetAvailableFeatures(model.FeatureIds);
 
-                await featureService.EnableOrDisableFeaturesAsync(availableFeatures, model.BulkAction, force, async (features, isEnabled) => await NotifyAsync(features, isEnabled));
+                await featureService.EnableOrDisableFeaturesAsync(availableFeatures, model.BulkAction, force, async (features, isEnabled) => await NotifyAsync(features.ToArray(), isEnabled));
             });
         }
 
@@ -132,7 +132,7 @@ public sealed class AdminController : Controller
                 return;
             }
 
-            await featureService.EnableOrDisableFeaturesAsync(new[] { feature }, FeaturesBulkAction.Disable, true, async (features, isEnabled) => await NotifyAsync(features, isEnabled));
+            await featureService.EnableOrDisableFeaturesAsync(new[] { feature }, FeaturesBulkAction.Disable, true, async (features, isEnabled) => await NotifyAsync(features.ToArray(), isEnabled));
         });
 
         if (!found)
@@ -165,7 +165,7 @@ public sealed class AdminController : Controller
 
             found = true;
 
-            await featureService.EnableOrDisableFeaturesAsync(new[] { feature }, FeaturesBulkAction.Enable, true, async (features, isEnabled) => await NotifyAsync(features, isEnabled));
+            await featureService.EnableOrDisableFeaturesAsync(new[] { feature }, FeaturesBulkAction.Enable, true, async (features, isEnabled) => await NotifyAsync(features.ToArray(), isEnabled));
         });
 
         if (!found)
@@ -231,11 +231,15 @@ public sealed class AdminController : Controller
         return Url.Action(nameof(Features));
     }
 
-    private async ValueTask NotifyAsync(IEnumerable<IFeatureInfo> features, bool enabled = true)
+    private async ValueTask NotifyAsync(IFeatureInfo[] features, bool enabled = true)
     {
-        foreach (var feature in features)
+        if (enabled)
         {
-            await _notifier.SuccessAsync(H["{0} was {1}.", feature.Name ?? feature.Id, enabled ? "enabled" : "disabled"]);
+            await _notifier.SuccessAsync(H.Plural(features.Length, "The feature {1} was enabled.", "The following features were enabled {1}: ", string.Join(", ", features.Select(f => f.Name ?? f.Id))));
+        }
+        else
+        {
+            await _notifier.SuccessAsync(H.Plural(features.Length, "The feature {1} was disabled.", "The following features were disabled {1}: ", string.Join(", ", features.Select(f => f.Name ?? f.Id))));
         }
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Controllers/AdminController.cs
@@ -235,11 +235,11 @@ public sealed class AdminController : Controller
     {
         if (enabled)
         {
-            await _notifier.SuccessAsync(H.Plural(features.Length, "The feature {1} was enabled.", "The following features were enabled {1}: ", string.Join(", ", features.Select(f => f.Name ?? f.Id))));
+            await _notifier.SuccessAsync(H.Plural(features.Length, "The feature {1} was enabled.", "The following features were enabled: {1}.", string.Join(", ", features.Select(f => f.Name ?? f.Id))));
         }
         else
         {
-            await _notifier.SuccessAsync(H.Plural(features.Length, "The feature {1} was disabled.", "The following features were disabled {1}: ", string.Join(", ", features.Select(f => f.Name ?? f.Id))));
+            await _notifier.SuccessAsync(H.Plural(features.Length, "The feature {1} was disabled.", "The following features were disabled: {1}.", string.Join(", ", features.Select(f => f.Name ?? f.Id))));
         }
     }
 }

--- a/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Layout.cshtml
@@ -75,7 +75,7 @@
             </div>
         </div>
 
-        <div class="ta-content">
+        <div class="ta-content" style="--oc-notify-offset-top: var(--oc-top-nav-height);">
             @await RenderSectionAsync("Header", required: false)
             @await RenderSectionAsync("Messages", required: false)
             @await RenderSectionAsync("Breadcrumbs", required: false)

--- a/src/OrchardCore.Themes/TheAdmin/Views/Message.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/Message.cshtml
@@ -2,13 +2,26 @@
     string type = Model.Type.ToString().ToLowerInvariant();
     var bsClassName = type switch
     {
-        "information" => "alert-info",
-        "error" => "alert-danger",
-        _ => $"alert-{type}",
+        "information" => "info",
+        "error" => "danger",
+        _ => type,
     };
+
+    var closeButtonClass = bsClassName is "danger" or "success" ? "btn-close btn-close-white" : "btn-close";
+    int? milliseconds = Model.Milliseconds;
+    var autoHide = milliseconds is > 0;
 }
 
-<div class="alert alert-dismissible @bsClassName fade show message-@type" role="alert">
-    @Model.Message
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+<div class="toast border-0 shadow message-@type text-bg-@bsClassName"
+     role="alert"
+     aria-live="assertive"
+     aria-atomic="true"
+     data-bs-autohide="@autoHide.ToString().ToLowerInvariant()"
+     data-bs-delay="@(autoHide ? milliseconds : 5000)">
+    <div class="d-flex">
+        <div class="toast-body">
+            @Model.Message
+        </div>
+        <button type="button" class="@closeButtonClass me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
 </div>

--- a/src/OrchardCore.Themes/TheAdmin/Views/NotifyMessages.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/NotifyMessages.cshtml
@@ -1,0 +1,31 @@
+@using OrchardCore.DisplayManagement.Notify
+<style at="Head">
+    .oc-notify-toast-container {
+        inset-inline-start: auto;
+        inset-inline-end: 1rem;
+        /*top: calc(var(--oc-notify-offset-top, 0px) + .25rem);*/
+        z-index: 1080;
+    }
+
+</style>
+
+<div class="toast-container position-fixed p-3 oc-notify-toast-container">
+@foreach (var entry in (IEnumerable<NotifyEntry>)Model.Entries)
+{
+    @await DisplayAsync(await New.Message(Type: entry.Type, Message: entry.Message, Milliseconds: entry.Milliseconds))
+}
+</div>
+
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.bootstrap?.Toast) {
+            return;
+        }
+
+        for (const toastElement of document.querySelectorAll('.oc-notify-toast-container .toast')) {
+            const toast = bootstrap.Toast.getOrCreateInstance(toastElement);
+            toast.show();
+            toastElement.addEventListener('hidden.bs.toast', () => toastElement.remove(), { once: true });
+        }
+    });
+</script>

--- a/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Layout.cshtml
@@ -57,7 +57,7 @@
         </div>
     </nav>
     @await RenderSectionAsync("Header", required: false)
-    <main class="container">
+    <main class="container" style="--oc-notify-offset-top: 60px;">
         @await RenderSectionAsync("Messages", required: false)
         @await RenderBodyAsync()
     </main>

--- a/src/OrchardCore.Themes/TheTheme/Views/Message.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/Message.cshtml
@@ -2,13 +2,26 @@
     string type = Model.Type.ToString().ToLowerInvariant();
     var bsClassName = type switch
     {
-        "information" => "alert-info",
-        "error" => "alert-danger",
-        _ => $"alert-{type}",
+        "information" => "info",
+        "error" => "danger",
+        _ => type,
     };
+
+    var closeButtonClass = bsClassName is "danger" or "success" ? "btn-close btn-close-white" : "btn-close";
+    int? milliseconds = Model.Milliseconds;
+    var autoHide = milliseconds is > 0;
 }
 
-<div class="alert alert-dismissible @bsClassName fade show message-@type" role="alert">
-    @Model.Message
-    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+<div class="toast border-0 shadow message-@type text-bg-@bsClassName"
+     role="alert"
+     aria-live="assertive"
+     aria-atomic="true"
+     data-bs-autohide="@autoHide.ToString().ToLowerInvariant()"
+     data-bs-delay="@(autoHide ? milliseconds : 5000)">
+    <div class="d-flex">
+        <div class="toast-body">
+            @Model.Message
+        </div>
+        <button type="button" class="@closeButtonClass me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
 </div>

--- a/src/OrchardCore.Themes/TheTheme/Views/NotifyMessages.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/NotifyMessages.cshtml
@@ -1,0 +1,31 @@
+@using OrchardCore.DisplayManagement.Notify
+<style at="Head">
+    .oc-notify-toast-container {
+        inset-inline-start: auto;
+        inset-inline-end: 1rem;
+        top: calc(var(--oc-notify-offset-top, 0px) + 1rem);
+        z-index: 1080;
+    }
+
+</style>
+
+<div class="toast-container position-fixed p-3 oc-notify-toast-container">
+@foreach (var entry in (IEnumerable<NotifyEntry>)Model.Entries)
+{
+    @await DisplayAsync(await New.Message(Type: entry.Type, Message: entry.Message, Milliseconds: entry.Milliseconds))
+}
+</div>
+
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', () => {
+        if (!window.bootstrap?.Toast) {
+            return;
+        }
+
+        for (const toastElement of document.querySelectorAll('.oc-notify-toast-container .toast')) {
+            const toast = bootstrap.Toast.getOrCreateInstance(toastElement);
+            toast.show();
+            toastElement.addEventListener('hidden.bs.toast', () => toastElement.remove(), { once: true });
+        }
+    });
+</script>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/INotifier.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/INotifier.cs
@@ -23,6 +23,16 @@ public interface INotifier
     ValueTask AddAsync(NotifyType type, LocalizedHtmlString message);
 
     /// <summary>
+    /// Adds a new UI notification asynchronously with additional rendering context.
+    /// </summary>
+    /// <param name="type">
+    /// The type of the notification (notifications with different types can be displayed differently).</param>
+    /// <param name="message">A localized message to display.</param>
+    /// <param name="context">Additional context used when rendering the notification.</param>
+    ValueTask AddAsync(NotifyType type, LocalizedHtmlString message, NotifyContext context)
+        => AddAsync(type, message);
+
+    /// <summary>
     /// Get all notifications added.
     /// </summary>
     IList<NotifyEntry> List();

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/Notifier.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/Notifier.cs
@@ -14,13 +14,21 @@ public class Notifier : INotifier
     }
 
     public ValueTask AddAsync(NotifyType type, LocalizedHtmlString message)
+        => AddAsync(type, message, context: null);
+
+    public ValueTask AddAsync(NotifyType type, LocalizedHtmlString message, NotifyContext context)
     {
         if (_logger.IsEnabled(LogLevel.Information))
         {
             _logger.LogInformation("Notification '{NotificationType}' with message '{NotificationMessage}'", type, message);
         }
 
-        _entries.Add(new NotifyEntry { Type = type, Message = message });
+        _entries.Add(new NotifyEntry
+        {
+            Type = type,
+            Message = message,
+            Milliseconds = context?.Milliseconds,
+        });
 
         return ValueTask.CompletedTask;
     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifierExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifierExtensions.cs
@@ -7,36 +7,76 @@ public static class NotifierExtensions
     /// <summary>
     /// Adds a new UI notification of type Information.
     /// </summary>
-    /// <seealso cref="INotifier.AddAsync"/>
+    /// <seealso cref="INotifier.AddAsync(NotifyType, LocalizedHtmlString, NotifyContext)"/>
     /// <param name="notifier">The <see cref="INotifier"/>.</param>
     /// <param name="message">A localized message to display.</param>
     public static ValueTask InformationAsync(this INotifier notifier, LocalizedHtmlString message)
         => notifier.AddAsync(NotifyType.Information, message);
 
     /// <summary>
+    /// Adds a new UI notification of type Information with an auto-dismiss delay.
+    /// </summary>
+    /// <seealso cref="INotifier.AddAsync(NotifyType, LocalizedHtmlString, NotifyContext)"/>
+    /// <param name="notifier">The <see cref="INotifier"/>.</param>
+    /// <param name="message">A localized message to display.</param>
+    /// <param name="milliseconds">The auto-dismiss delay in milliseconds.</param>
+    public static ValueTask InformationAsync(this INotifier notifier, LocalizedHtmlString message, int milliseconds)
+        => notifier.AddAsync(NotifyType.Information, message, new NotifyContext { Milliseconds = milliseconds });
+
+    /// <summary>
     /// Adds a new UI notification of type Warning.
     /// </summary>
-    /// <seealso cref="INotifier.AddAsync"/>
+    /// <seealso cref="INotifier.AddAsync(NotifyType, LocalizedHtmlString, NotifyContext)"/>
     /// <param name="notifier">The <see cref="INotifier"/>.</param>
     /// <param name="message">A localized message to display.</param>
     public static ValueTask WarningAsync(this INotifier notifier, LocalizedHtmlString message)
         => notifier.AddAsync(NotifyType.Warning, message);
 
     /// <summary>
+    /// Adds a new UI notification of type Warning with an auto-dismiss delay.
+    /// </summary>
+    /// <seealso cref="INotifier.AddAsync(NotifyType, LocalizedHtmlString, NotifyContext)"/>
+    /// <param name="notifier">The <see cref="INotifier"/>.</param>
+    /// <param name="message">A localized message to display.</param>
+    /// <param name="milliseconds">The auto-dismiss delay in milliseconds.</param>
+    public static ValueTask WarningAsync(this INotifier notifier, LocalizedHtmlString message, int milliseconds)
+        => notifier.AddAsync(NotifyType.Warning, message, new NotifyContext { Milliseconds = milliseconds });
+
+    /// <summary>
     /// Adds a new UI notification of type Error.
     /// </summary>
-    /// <seealso cref="INotifier.AddAsync"/>
+    /// <seealso cref="INotifier.AddAsync(NotifyType, LocalizedHtmlString, NotifyContext)"/>
     /// <param name="notifier">The <see cref="INotifier"/>.</param>
     /// <param name="message">A localized message to display.</param>
     public static ValueTask ErrorAsync(this INotifier notifier, LocalizedHtmlString message)
-        => notifier.AddAsync(NotifyType.Error, message);
+        => notifier.AddAsync(NotifyType.Error, message, new NotifyContext { Milliseconds = 3000 });
+
+    /// <summary>
+    /// Adds a new UI notification of type Error with an auto-dismiss delay.
+    /// </summary>
+    /// <seealso cref="INotifier.AddAsync(NotifyType, LocalizedHtmlString, NotifyContext)"/>
+    /// <param name="notifier">The <see cref="INotifier"/>.</param>
+    /// <param name="message">A localized message to display.</param>
+    /// <param name="milliseconds">The auto-dismiss delay in milliseconds.</param>
+    public static ValueTask ErrorAsync(this INotifier notifier, LocalizedHtmlString message, int milliseconds)
+        => notifier.AddAsync(NotifyType.Error, message, new NotifyContext { Milliseconds = milliseconds });
 
     /// <summary>
     /// Adds a new UI notification of type Success.
     /// </summary>
-    /// <seealso cref="INotifier.AddAsync"/>
+    /// <seealso cref="INotifier.AddAsync(NotifyType, LocalizedHtmlString, NotifyContext)"/>
     /// <param name="notifier">The <see cref="INotifier"/>.</param>
     /// <param name="message">A localized message to display.</param>
     public static ValueTask SuccessAsync(this INotifier notifier, LocalizedHtmlString message)
-        => notifier.AddAsync(NotifyType.Success, message);
+        => notifier.AddAsync(NotifyType.Success, message, new NotifyContext { Milliseconds = 3000 });
+
+    /// <summary>
+    /// Adds a new UI notification of type Success with an auto-dismiss delay.
+    /// </summary>
+    /// <seealso cref="INotifier.AddAsync(NotifyType, LocalizedHtmlString, NotifyContext)"/>
+    /// <param name="notifier">The <see cref="INotifier"/>.</param>
+    /// <param name="message">A localized message to display.</param>
+    /// <param name="milliseconds">The auto-dismiss delay in milliseconds.</param>
+    public static ValueTask SuccessAsync(this INotifier notifier, LocalizedHtmlString message, int milliseconds)
+        => notifier.AddAsync(NotifyType.Success, message, new NotifyContext { Milliseconds = milliseconds });
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifierExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifierExtensions.cs
@@ -49,7 +49,7 @@ public static class NotifierExtensions
     /// <param name="notifier">The <see cref="INotifier"/>.</param>
     /// <param name="message">A localized message to display.</param>
     public static ValueTask ErrorAsync(this INotifier notifier, LocalizedHtmlString message)
-        => notifier.AddAsync(NotifyType.Error, message, new NotifyContext { Milliseconds = 3000 });
+        => notifier.AddAsync(NotifyType.Error, message);
 
     /// <summary>
     /// Adds a new UI notification of type Error with an auto-dismiss delay.
@@ -68,7 +68,7 @@ public static class NotifierExtensions
     /// <param name="notifier">The <see cref="INotifier"/>.</param>
     /// <param name="message">A localized message to display.</param>
     public static ValueTask SuccessAsync(this INotifier notifier, LocalizedHtmlString message)
-        => notifier.AddAsync(NotifyType.Success, message, new NotifyContext { Milliseconds = 3000 });
+        => notifier.AddAsync(NotifyType.Success, message, new NotifyContext { Milliseconds = 5000 });
 
     /// <summary>
     /// Adds a new UI notification of type Success with an auto-dismiss delay.

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyContext.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyContext.cs
@@ -1,0 +1,9 @@
+namespace OrchardCore.DisplayManagement.Notify;
+
+public sealed class NotifyContext
+{
+    /// <summary>
+    /// Total Milliseconds to auto dismiss the alert.
+    /// </summary>
+    public int? Milliseconds { get; set; }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyEntry.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyEntry.cs
@@ -19,7 +19,10 @@ public partial class NotifyEntry
     private (HtmlEncoder HtmlEncoder, string Message) _cache;
 
     public NotifyType Type { get; set; }
+
     public IHtmlContent Message { get; set; }
+
+    public int? Milliseconds { get; set; }
 
     public string ToHtmlString(HtmlEncoder htmlEncoder)
     {

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyEntryConverter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyEntryConverter.cs
@@ -27,6 +27,7 @@ public class NotifyEntryConverter : JsonConverter<NotifyEntry>
         var notifyEntry = new NotifyEntry
         {
             Message = new HtmlString(jo.Value<string>("Message")),
+            Milliseconds = jo[nameof(NotifyEntry.Milliseconds)]?.GetValue<int?>(),
         };
 
         if (Enum.TryParse<NotifyType>(jo.Value<string>("Type"), out var type))
@@ -50,6 +51,11 @@ public class NotifyEntryConverter : JsonConverter<NotifyEntry>
             { nameof(NotifyEntry.Type), notifyEntry.Type.ToString() },
             { nameof(NotifyEntry.Message), notifyEntry.ToHtmlString(_htmlEncoder) },
         };
+
+        if (notifyEntry.Milliseconds.HasValue)
+        {
+            o[nameof(NotifyEntry.Milliseconds)] = notifyEntry.Milliseconds.Value;
+        }
 
         o.WriteTo(writer);
     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Notify/NotifyFilter.cs
@@ -156,11 +156,8 @@ public sealed class NotifyFilter : IActionFilter, IAsyncResultFilter, IPageFilte
 
         if (messagesZone is IShape zone)
         {
-            foreach (var messageEntry in _existingEntries)
-            {
-                // Also retrieve the actual zone in case it was only a temporary empty zone created on demand.
-                zone = await zone.AddAsync(await _shapeFactory.CreateAsync("Message", Arguments.From(messageEntry)));
-            }
+            // Also retrieve the actual zone in case it was only a temporary empty zone created on demand.
+            zone = await zone.AddAsync(await _shapeFactory.CreateAsync("NotifyMessages", new { Entries = _existingEntries }));
         }
 
         DeleteCookies(filterContext);

--- a/src/docs/reference/modules/Notifications/README.md
+++ b/src/docs/reference/modules/Notifications/README.md
@@ -1,7 +1,10 @@
 # Notifications (`OrchardCore.Notifications`)
 
-The `Notifications` module offers a comprehensive infrastructure for managing notifications effectively. It includes a centralized notification center and streamlined mechanisms for seamlessly dispatching notifications to users within the application.
-## Configurations 
+The `Notifications` module offers a comprehensive infrastructure for managing notifications effectively. It includes a centralized notification center and streamlined mechanisms for dispatching notifications to users within the application.
+
+Orchard Core also provides `INotifier` for transient UI notifications rendered by the active theme. Use `INotificationService` for persistent user notifications in the notification center, and use `INotifier` for per-request status messages such as success, warning, and error messages shown after an admin action.
+
+## Configurations
 
 You can customize the default notification options through the configuration provider using the following settings:
 
@@ -64,6 +67,192 @@ public class EmailNotificationsStartup : StartupBase
 ## How to send a notification
 
 You can send notification to a user via code by injecting `INotificationService` then calling the `SendAsync(...)` method. Alternatively, you can use workflows to notify a user about an event that took place.
+
+```csharp
+using OrchardCore.Notifications;
+
+public sealed class PublishNotificationService
+{
+    private readonly INotificationService _notificationService;
+
+    public PublishNotificationService(INotificationService notificationService)
+    {
+        _notificationService = notificationService;
+    }
+
+    public Task NotifyAsync(IUser user)
+    {
+        return _notificationService.SendAsync(user, new Notification
+        {
+            Summary = "Content published",
+            Body = "Your content item has been published successfully.",
+        });
+    }
+}
+```
+
+## UI notifications with `INotifier`
+
+`INotifier` is used for transient UI notifications that are rendered in the `Messages` zone of the current theme. These entries survive redirects for the next request and are intended for immediate feedback in the UI.
+
+The default `TheAdmin` and `TheTheme` themes currently render these entries as Bootstrap toasts through the `NotifyMessages` and `Message` shapes.
+
+```csharp
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Localization;
+using OrchardCore.DisplayManagement.Notify;
+
+public sealed class SampleController : Controller
+{
+    private readonly INotifier _notifier;
+    private readonly IHtmlLocalizer H;
+
+    public SampleController(
+        INotifier notifier,
+        IHtmlLocalizer<SampleController> htmlLocalizer)
+    {
+        _notifier = notifier;
+        H = htmlLocalizer;
+    }
+
+    public async Task<IActionResult> Publish()
+    {
+        await _notifier.SuccessAsync(H["The content item was published successfully."]);
+
+        await _notifier.AddAsync(
+            NotifyType.Warning,
+            H["Review the generated slug before sharing it."],
+            new NotifyContext { Milliseconds = 10000 });
+
+        return RedirectToAction(nameof(Index));
+    }
+}
+```
+
+Available helpers include:
+
+- `SuccessAsync(...)`
+- `InformationAsync(...)`
+- `WarningAsync(...)`
+- `ErrorAsync(...)`
+- `AddAsync(...)` when you need to set the `NotifyType` and optional `NotifyContext` explicitly.
+
+`NotifyContext.Milliseconds` controls the auto-dismiss delay. A `null` value keeps the message visible until it is dismissed manually.
+
+## Customizing the toast or restoring alert-style messages
+
+The toast UI is only the default rendering. You can replace it by overriding the `Message` shape, and if you want to change the container or placement you can also override `NotifyMessages`.
+
+To fully switch back to inline alert-style messages instead of toasts, override both shapes.
+
+### `Message` shape
+
+This shape renders a single notification entry.
+
+=== "Razor"
+
+    Create `Views/Message.cshtml` in your theme or admin theme:
+
+    ```cshtml
+    @{
+        string type = Model.Type.ToString().ToLowerInvariant();
+        var bsClassName = type switch
+        {
+            "information" => "info",
+            "error" => "danger",
+            _ => type,
+        };
+    }
+
+    <div class="alert alert-@bsClassName alert-dismissible fade show message-@type" role="alert">
+        @Model.Message
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    ```
+
+=== "Liquid"
+
+    Create `Views/Message.liquid` in your theme:
+
+    ```liquid
+    {% assign type = Model.Type | downcase %}
+    {% assign bs_class = type %}
+    {% if type == "information" %}
+      {% assign bs_class = "info" %}
+    {% elsif type == "error" %}
+      {% assign bs_class = "danger" %}
+    {% endif %}
+
+    <div class="alert alert-{{ bs_class }} alert-dismissible fade show message-{{ type }}" role="alert">
+        {{ Model.Message | raw }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    ```
+
+=== "Admin Templates UI"
+
+    To customize the admin toast item from the dashboard:
+
+    1. Enable the `OrchardCore.AdminTemplates` feature.
+    2. Go to **Design** -> **Admin Templates**.
+    3. Create or edit the `Message` template.
+    4. Paste the Liquid template shown above and save it.
+
+    This overrides the admin `Message` shape without changing your front-end theme.
+
+```liquid
+    {% assign type = Model.Type | downcase %}
+    {% assign bs_class = type %}
+    {% if type == "information" %}
+      {% assign bs_class = "info" %}
+    {% elsif type == "error" %}
+      {% assign bs_class = "danger" %}
+    {% endif %}
+
+    <div class="alert alert-{{ bs_class }} alert-dismissible fade show message-{{ type }}" role="alert">
+        {{ Model.Message | raw }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+```
+
+### `NotifyMessages` shape
+
+This shape renders the collection of notification entries. The default implementation adds the toast container and JavaScript that shows each Bootstrap toast. Replace it if you want inline messages in the normal `Messages` zone.
+
+=== "Razor"
+
+    Create `Views/NotifyMessages.cshtml` in your theme or admin theme:
+
+    ```cshtml
+    @using OrchardCore.DisplayManagement.Notify
+
+    @foreach (var entry in (IEnumerable<NotifyEntry>)Model.Entries)
+    {
+        @await DisplayAsync(await New.Message(Type: entry.Type, Message: entry.Message, Milliseconds: entry.Milliseconds))
+    }
+    ```
+
+=== "Liquid"
+
+    Create `Views/NotifyMessages.liquid` in your theme:
+
+    ```liquid
+    {% for entry in Model.Entries %}
+        {% shape "Message", type: entry.Type, message: entry.Message, milliseconds: entry.Milliseconds %}
+    {% endfor %}
+    ```
+
+### Admin Templates UI
+
+If you want to customize the full admin notification rendering from the dashboard instead of from a theme:
+
+1. Enable the `OrchardCore.AdminTemplates` feature.
+2. Go to **Design** -> **Admin Templates**.
+3. Create or edit the `Message` template to change each notification item.
+4. Create or edit the `NotifyMessages` template to change the container and placement.
+5. Paste the Liquid versions shown above and save them.
+
+Admin Templates affect only the admin UI. For the front-end, override the same shapes from your site theme.
 
 ## Workflow Activities
 

--- a/test/OrchardCore.Tests/DisplayManagement/Notify/NotifierTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Notify/NotifierTests.cs
@@ -10,7 +10,7 @@ namespace OrchardCore.Tests.DisplayManagement.Notify;
 public class NotifierTests
 {
     [Fact]
-    public async Task SuccessAsync_WithoutMilliseconds_DoesNotSetMilliseconds()
+    public async Task SuccessAsync_WithoutMilliseconds_SetsDefaultMilliseconds()
     {
         var notifier = new Notifier(NullLogger<Notifier>.Instance);
 
@@ -18,6 +18,18 @@ public class NotifierTests
 
         var entry = Assert.Single(notifier.List());
         Assert.Equal(NotifyType.Success, entry.Type);
+        Assert.Equal(5000, entry.Milliseconds);
+    }
+
+    [Fact]
+    public async Task ErrorAsync_WithoutMilliseconds_DoesNotSetMilliseconds()
+    {
+        var notifier = new Notifier(NullLogger<Notifier>.Instance);
+
+        await notifier.ErrorAsync(new LocalizedHtmlString("Problem", "Problem"));
+
+        var entry = Assert.Single(notifier.List());
+        Assert.Equal(NotifyType.Error, entry.Type);
         Assert.Null(entry.Milliseconds);
     }
 

--- a/test/OrchardCore.Tests/DisplayManagement/Notify/NotifierTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/Notify/NotifierTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Localization;
+using Microsoft.Extensions.Logging.Abstractions;
+using OrchardCore.DisplayManagement.Notify;
+
+namespace OrchardCore.Tests.DisplayManagement.Notify;
+
+public class NotifierTests
+{
+    [Fact]
+    public async Task SuccessAsync_WithoutMilliseconds_DoesNotSetMilliseconds()
+    {
+        var notifier = new Notifier(NullLogger<Notifier>.Instance);
+
+        await notifier.SuccessAsync(new LocalizedHtmlString("Saved", "Saved"));
+
+        var entry = Assert.Single(notifier.List());
+        Assert.Equal(NotifyType.Success, entry.Type);
+        Assert.Null(entry.Milliseconds);
+    }
+
+    [Fact]
+    public async Task SuccessAsync_WithMilliseconds_SetsMillisecondsOnNotifyEntry()
+    {
+        var notifier = new Notifier(NullLogger<Notifier>.Instance);
+
+        await notifier.SuccessAsync(new LocalizedHtmlString("Saved", "Saved"), 3000);
+
+        var entry = Assert.Single(notifier.List());
+        Assert.Equal(NotifyType.Success, entry.Type);
+        Assert.Equal(3000, entry.Milliseconds);
+    }
+
+    [Fact]
+    public void NotifyEntryConverter_RoundTripsMilliseconds()
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new NotifyEntryConverter(HtmlEncoder.Default));
+
+        var entry = new NotifyEntry
+        {
+            Type = NotifyType.Warning,
+            Message = new HtmlString("<strong>Heads up</strong>"),
+            Milliseconds = 3000,
+        };
+
+        var json = JsonSerializer.Serialize(entry, options);
+        var result = JsonSerializer.Deserialize<NotifyEntry>(json, options);
+
+        Assert.Contains(@"""Milliseconds"":3000", json);
+        Assert.NotNull(result);
+        Assert.Equal(NotifyType.Warning, result.Type);
+        Assert.Equal(3000, result.Milliseconds);
+        Assert.Equal("<strong>Heads up</strong>", result.ToHtmlString(HtmlEncoder.Default));
+    }
+}


### PR DESCRIPTION
Notification messages generated by `INotifier` will now display as toast alerts. By default, only Success notifications are automatically dismissed after 5 seconds, while Error, Warning, and Information notifications remain visible until manually dismissed.

Developers can customize the dismissal timeout or disable automatic dismissal entirely. All notification types can also be manually closed by users using the X button.

This improves the user experience by preventing transient success messages from permanently occupying screen space, while ensuring more important notifications remain visible without affecting the layout or positioning of HTML components such as buttons.

Fixes #19238

Here is a screenshot

<img width="1068" height="799" alt="image" src="https://github.com/user-attachments/assets/b979255a-cca5-4c7f-86c9-ac050fe9eb4c" />

I also fixed the features bulk action to show one message instead of multiple messages

<img width="1060" height="718" alt="image" src="https://github.com/user-attachments/assets/eafb174c-b1d4-47eb-8f22-1b6fd2ea9c46" />


