### PR TITLE
Add optional debug output when rendering shapes.

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Templates/Services/AdminTemplatesShapeBindingResolver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Services/AdminTemplatesShapeBindingResolver.cs
@@ -70,7 +70,7 @@ public class AdminTemplatesShapeBindingResolver : IShapeBindingResolver
         return new ShapeBinding()
         {
             BindingName = shapeType,
-            BindingSource = shapeType,
+            BindingSource = $"AdminTemplates/{shapeType}.liquid",
             BindingAsync = displayContext => _liquidTemplateManager.RenderHtmlContentAsync(template.Content, _htmlEncoder, displayContext.Value),
         };
     }

--- a/src/OrchardCore.Modules/OrchardCore.Templates/Services/TemplatesShapeBindingResolver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Templates/Services/TemplatesShapeBindingResolver.cs
@@ -69,7 +69,7 @@ public class TemplatesShapeBindingResolver : IShapeBindingResolver
         return new ShapeBinding()
         {
             BindingName = shapeType,
-            BindingSource = shapeType,
+            BindingSource = $"Templates/{shapeType}.liquid",
             BindingAsync = displayContext => _liquidTemplateManager.RenderHtmlContentAsync(template.Content, _htmlEncoder, displayContext.Value),
         };
     }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Html/ShapeDebugInfoHtmlContent.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Html/ShapeDebugInfoHtmlContent.cs
@@ -1,0 +1,35 @@
+using System.Text.Encodings.Web;
+using Cysharp.Text;
+using Microsoft.AspNetCore.Html;
+
+namespace OrchardCore.DisplayManagement.Html;
+
+internal sealed class ShapeDebugInfoHtmlContent : IHtmlContent
+{
+    private readonly IHtmlContent _content;
+    private readonly string _startComment;
+    private readonly string _endComment;
+
+    public ShapeDebugInfoHtmlContent(IHtmlContent content, string startComment, string endComment)
+    {
+        _content = content ?? HtmlString.Empty;
+        _startComment = startComment;
+        _endComment = endComment;
+    }
+
+    public void WriteTo(TextWriter writer, HtmlEncoder encoder)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.Write(_startComment);
+        _content.WriteTo(writer, encoder);
+        writer.Write(_endComment);
+    }
+
+    public override string ToString()
+    {
+        using var writer = new ZStringWriter();
+        WriteTo(writer, HtmlEncoder.Default);
+        return writer.ToString();
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/Implementation/DefaultHtmlDisplay.cs
@@ -1,6 +1,9 @@
 using System.Collections.Concurrent;
+using System.Net;
+using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Html;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement.Descriptors;
 using OrchardCore.DisplayManagement.Html;
 using OrchardCore.DisplayManagement.Shapes;
@@ -20,6 +23,7 @@ public class DefaultHtmlDisplay : IHtmlDisplay
     private readonly IThemeManager _themeManager;
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger _logger;
+    private readonly ShapeRenderingOptions _shapeRenderingOptions;
 
     public DefaultHtmlDisplay(
         IEnumerable<IShapeDisplayEvents> shapeDisplayEvents,
@@ -27,6 +31,7 @@ public class DefaultHtmlDisplay : IHtmlDisplay
         IShapeTableManager shapeTableManager,
         IServiceProvider serviceProvider,
         ILogger<DefaultHtmlDisplay> logger,
+        IOptions<ShapeRenderingOptions> shapeRenderingOptions,
         IThemeManager themeManager)
     {
         _shapeTableManager = shapeTableManager;
@@ -35,6 +40,7 @@ public class DefaultHtmlDisplay : IHtmlDisplay
         _themeManager = themeManager;
         _serviceProvider = serviceProvider;
         _logger = logger;
+        _shapeRenderingOptions = shapeRenderingOptions.Value;
     }
 
     public async Task<IHtmlContent> ExecuteAsync(DisplayContext context)
@@ -81,6 +87,9 @@ public class DefaultHtmlDisplay : IHtmlDisplay
             ServiceProvider = _serviceProvider,
         };
 
+        ShapeBinding actualBinding = null;
+        List<ShapeBinding> wrapperBindings = null;
+
         try
         {
             var shapeTable = await _themeManager.GetShapeTableAsync(_shapeTableManager);
@@ -114,7 +123,7 @@ public class DefaultHtmlDisplay : IHtmlDisplay
                 }
 
                 // Now find the actual binding to render, taking alternates into account.
-                var actualBinding = await GetShapeBindingAsync(shapeMetadata.Type, shapeMetadata.Alternates, shapeTable);
+                actualBinding = await GetShapeBindingAsync(shapeMetadata.Type, shapeMetadata.Alternates, shapeTable);
 
                 if (actualBinding == null)
                 {
@@ -135,6 +144,8 @@ public class DefaultHtmlDisplay : IHtmlDisplay
                     var frameBinding = await GetShapeBindingAsync(frameType, AlternatesCollection.Empty, shapeTable);
                     if (frameBinding != null)
                     {
+                        wrapperBindings ??= [];
+                        wrapperBindings.Add(frameBinding);
                         shapeMetadata.ChildContent = await ProcessAsync(frameBinding, shape, localContext);
                     }
                 }
@@ -180,7 +191,81 @@ public class DefaultHtmlDisplay : IHtmlDisplay
             await _shapeDisplayEvents.InvokeAsync((e, displayContext) => e.DisplayingFinalizedAsync(displayContext), displayContext, _logger);
         }
 
+        if (_shapeRenderingOptions.WriteShapeDebugInformation)
+        {
+            return AddShapeDebugInformation(shapeMetadata.ChildContent, shapeMetadata.Type, actualBinding, wrapperBindings);
+        }
+
         return shapeMetadata.ChildContent;
+    }
+
+    private static IHtmlContent AddShapeDebugInformation(IHtmlContent childContent, string shapeType, ShapeBinding actualBinding, List<ShapeBinding> wrapperBindings)
+    {
+        var renderedBindings = GetRenderedBindings(actualBinding, wrapperBindings);
+
+        if (renderedBindings.Count == 0)
+        {
+            return childContent;
+        }
+
+        return new ShapeDebugInfoHtmlContent(
+            childContent ?? HtmlString.Empty,
+            CreateStartComment(shapeType, renderedBindings),
+            CreateEndComment(shapeType));
+    }
+
+    private static List<ShapeBinding> GetRenderedBindings(ShapeBinding actualBinding, List<ShapeBinding> wrapperBindings)
+    {
+        var renderedBindings = new List<ShapeBinding>();
+
+        if (actualBinding != null)
+        {
+            renderedBindings.Add(actualBinding);
+        }
+
+        if (wrapperBindings is { Count: > 0 })
+        {
+            renderedBindings.AddRange(wrapperBindings);
+        }
+
+        return renderedBindings;
+    }
+
+    private static string CreateStartComment(string shapeType, IReadOnlyList<ShapeBinding> renderedBindings)
+    {
+        var shapeBindingDescription = string.Join(" | ", renderedBindings.Select(DescribeBinding));
+
+        return $"<!--shape-start type:{WebUtility.HtmlEncode(shapeType)} bindings:{shapeBindingDescription} -->";
+    }
+
+    private static string CreateEndComment(string shapeType)
+    {
+        return $"<!--shape-end type:{WebUtility.HtmlEncode(shapeType)} -->";
+    }
+
+    private static string DescribeBinding(ShapeBinding binding)
+    {
+        var bindingName = WebUtility.HtmlEncode(binding.BindingName);
+        var bindingSource = !string.IsNullOrEmpty(binding.BindingSource) ? WebUtility.HtmlEncode(binding.BindingSource) : "unknown";
+
+        return $"{bindingName} => {bindingSource} ({GetBindingEngine(binding.BindingSource)})";
+    }
+
+    private static string GetBindingEngine(string bindingSource)
+    {
+        var extension = Path.GetExtension(bindingSource);
+
+        if (string.Equals(extension, ".cshtml", StringComparison.OrdinalIgnoreCase))
+        {
+            return "razor";
+        }
+
+        if (string.Equals(extension, ".liquid", StringComparison.OrdinalIgnoreCase))
+        {
+            return "liquid";
+        }
+
+        return "code";
     }
 
     private static ShapeDescriptor GetShapeDescriptor(string shapeType, ShapeTable shapeTable)

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
@@ -31,6 +31,15 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class OrchardCoreBuilderExtensions
 {
     /// <summary>
+    /// Enables HTML comments that identify the shape bindings used to render output.
+    /// </summary>
+    public static OrchardCoreBuilder AddShapeDebugInformation(this OrchardCoreBuilder builder)
+    {
+        return builder.ConfigureServices(services =>
+            services.Configure<ShapeRenderingOptions>(options => options.WriteShapeDebugInformation = true));
+    }
+
+    /// <summary>
     /// Adds host and tenant level services for managing themes.
     /// </summary>
     public static OrchardCoreBuilder AddTheming(this OrchardCoreBuilder builder)
@@ -82,6 +91,7 @@ public static class OrchardCoreBuilderExtensions
 
                 services.AddScoped(typeof(IDisplayManager<>), typeof(DisplayManager<>));
                 services.AddScoped<IHtmlDisplay, DefaultHtmlDisplay>();
+                services.AddOptions<ShapeRenderingOptions>();
                 services.AddScoped<ILayoutAccessor, LayoutAccessor>();
                 services.AddScoped<IThemeManager, ThemeManager>();
                 services.AddScoped<IPageTitleBuilder, PageTitleBuilder>();

--- a/src/OrchardCore/OrchardCore.DisplayManagement/ShapeRenderingOptions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/ShapeRenderingOptions.cs
@@ -1,6 +1,6 @@
 namespace OrchardCore.DisplayManagement;
 
-public class ShapeRenderingOptions
+public sealed class ShapeRenderingOptions
 {
     public bool WriteShapeDebugInformation { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.DisplayManagement/ShapeRenderingOptions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/ShapeRenderingOptions.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.DisplayManagement;
+
+public class ShapeRenderingOptions
+{
+    public bool WriteShapeDebugInformation { get; set; }
+}

--- a/src/docs/reference/modules/DisplayManagement/README.md
+++ b/src/docs/reference/modules/DisplayManagement/README.md
@@ -102,6 +102,35 @@ Properties can be passed to a shape by adding attributes to the shape tag helper
 
 This is the same as `<shape type="MyShape" prop-foo="1" prop-bar="a" prop-content="@someHtmlContentVariable" />` where you'd have to construct `someHtmlContentVariable` separately. Of course, you can mix and match the different formats, for example, to only use `<add-property>` when you want to pass HTML content as property.
 
+### Shape debug information
+
+You can instruct Orchard Core to write HTML comments around rendered shapes. This makes it easier to determine which Razor or Liquid template produced a specific fragment in the final page output.
+
+Enable it during startup:
+
+```csharp
+services
+    .AddOrchardCms()
+    .AddShapeDebugInformation();
+```
+
+You can also enable it directly through options:
+
+```csharp
+services.Configure<ShapeRenderingOptions>(options =>
+    options.WriteShapeDebugInformation = true);
+```
+
+When enabled, rendered shapes are wrapped with comments similar to the following:
+
+```html
+<!--shape-start type:Menu bindings:Menu__Main=>Themes/Contoso/Views/Menu-Main.cshtml (razor)-->
+...
+<!--shape-end type:Menu-->
+```
+
+The start comment contains the shape type and the binding that was used. Razor bindings report the `.cshtml` path, while Liquid bindings report a virtual `.liquid` source.
+
 ### Date Time shapes
 
 #### `DateTime`

--- a/test/OrchardCore.Benchmarks/FluidShapeRenderBenchmark.cs
+++ b/test/OrchardCore.Benchmarks/FluidShapeRenderBenchmark.cs
@@ -6,6 +6,7 @@ using Fluid;
 using Fluid.Values;
 using Microsoft.AspNetCore.Html;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Implementation;
 using OrchardCore.DisplayManagement.Liquid;
@@ -24,7 +25,7 @@ public class FluidShapeRenderBenchmark
 
     static FluidShapeRenderBenchmark()
     {
-        var htmlDisplay = new DefaultHtmlDisplay(null, null, null, null, null, null);
+        var htmlDisplay = new DefaultHtmlDisplay(null, null, null, null, null, Options.Create(new ShapeRenderingOptions()), null);
 
         _serviceProvider = new ServiceCollection()
             .AddScoped<IDisplayHelper>(sp => new DisplayHelper(htmlDisplay, null, null))

--- a/test/OrchardCore.Tests/DisplayManagement/DefaultDisplayManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/DefaultDisplayManagerTests.cs
@@ -6,6 +6,7 @@ using OrchardCore.DisplayManagement.Theming;
 using OrchardCore.Environment.Extensions;
 using OrchardCore.Localization;
 using OrchardCore.Tests.Stubs;
+using Microsoft.Extensions.Options;
 
 namespace OrchardCore.Tests.DisplayManagement;
 
@@ -14,6 +15,7 @@ public class DefaultDisplayManagerTests
     private readonly ShapeTable _defaultShapeTable;
     private readonly TestShapeBindingsDictionary _additionalBindings;
     private readonly IServiceProvider _serviceProvider;
+    private readonly ShapeRenderingOptions _shapeRenderingOptions = new();
 
     public DefaultDisplayManagerTests()
     {
@@ -38,9 +40,11 @@ public class DefaultDisplayManagerTests
         serviceCollection.AddTransient(typeof(IStringLocalizer<>), typeof(StringLocalizer<>));
 
         serviceCollection.AddLogging();
+        serviceCollection.AddOptions();
 
         serviceCollection.AddSingleton(_defaultShapeTable);
         serviceCollection.AddSingleton(_additionalBindings);
+        serviceCollection.AddSingleton<IOptions<ShapeRenderingOptions>>(Options.Create(_shapeRenderingOptions));
         serviceCollection.AddWebEncoders();
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
@@ -350,6 +354,112 @@ public class DefaultDisplayManagerTests
             BindingName = bindingName,
             BindingAsync = binding,
         };
+    }
+
+    [Fact]
+    public async Task RenderShapeTemplateCommentsWhenEnabled()
+    {
+        _shapeRenderingOptions.WriteShapeDebugInformation = true;
+
+        try
+        {
+            var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
+
+            var shape = new Shape();
+            shape.Metadata.Type = "Foo";
+
+            var descriptor = new ShapeDescriptor
+            {
+                ShapeType = "Foo",
+            };
+            descriptor.Bindings["Foo"] = new ShapeBinding
+            {
+                BindingName = "Foo",
+                BindingSource = "Views/Foo.cshtml",
+                BindingAsync = ctx => Task.FromResult<IHtmlContent>(new HtmlString("Hi there!")),
+            };
+            AddShapeDescriptor(descriptor);
+
+            var result = await displayManager.ExecuteAsync(CreateDisplayContext(shape));
+
+            Assert.Equal("<!--shape-start type:Foo bindings:Foo=>Views/Foo.cshtml (razor)-->Hi there!<!--shape-end type:Foo-->", result.ToString());
+            Assert.Equal("Hi there!", shape.Metadata.ChildContent.ToString());
+        }
+        finally
+        {
+            _shapeRenderingOptions.WriteShapeDebugInformation = false;
+        }
+    }
+
+    [Fact]
+    public async Task RenderAlternateShapeTemplateCommentsUseSelectedBindingWhenEnabled()
+    {
+        _shapeRenderingOptions.WriteShapeDebugInformation = true;
+
+        try
+        {
+            var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
+
+            var shape = new Shape();
+            shape.Metadata.Type = "Foo";
+            shape.Metadata.Alternates.Add("Foo__Alternate");
+
+            var descriptor = new ShapeDescriptor
+            {
+                ShapeType = "Foo",
+            };
+            descriptor.Bindings["Foo"] = new ShapeBinding
+            {
+                BindingName = "Foo",
+                BindingSource = "Views/Foo.cshtml",
+                BindingAsync = ctx => Task.FromResult<IHtmlContent>(new HtmlString("Default")),
+            };
+            descriptor.Bindings["Foo__Alternate"] = new ShapeBinding
+            {
+                BindingName = "Foo__Alternate",
+                BindingSource = "Views/Foo-Alternate.cshtml",
+                BindingAsync = ctx => Task.FromResult<IHtmlContent>(new HtmlString("Alternate")),
+            };
+            AddShapeDescriptor(descriptor);
+
+            var result = await displayManager.ExecuteAsync(CreateDisplayContext(shape));
+
+            Assert.Equal("<!--shape-start type:Foo bindings:Foo__Alternate=>Views/Foo-Alternate.cshtml (razor)-->Alternate<!--shape-end type:Foo-->", result.ToString());
+        }
+        finally
+        {
+            _shapeRenderingOptions.WriteShapeDebugInformation = false;
+        }
+    }
+
+    [Fact]
+    public async Task RenderLiquidShapeTemplateCommentsWhenEnabled()
+    {
+        _shapeRenderingOptions.WriteShapeDebugInformation = true;
+
+        try
+        {
+            var displayManager = _serviceProvider.GetService<IHtmlDisplay>();
+
+            var shape = new Shape();
+            shape.Metadata.Type = "Foo";
+
+            _additionalBindings["Foo"] = new ShapeBinding
+            {
+                BindingName = "Foo",
+                BindingSource = "Templates/Foo.liquid",
+                BindingAsync = ctx => Task.FromResult<IHtmlContent>(new HtmlString("Liquid")),
+            };
+
+            var result = await displayManager.ExecuteAsync(CreateDisplayContext(shape));
+
+            Assert.Equal("<!--shape-start type:Foo bindings:Foo=>Templates/Foo.liquid (liquid)-->Liquid<!--shape-end type:Foo-->", result.ToString());
+        }
+        finally
+        {
+            _additionalBindings.Clear();
+            _shapeRenderingOptions.WriteShapeDebugInformation = false;
+        }
     }
 
     [Fact]

--- a/test/OrchardCore.Tests/DisplayManagement/DefaultDisplayManagerTests.cs
+++ b/test/OrchardCore.Tests/DisplayManagement/DefaultDisplayManagerTests.cs
@@ -382,7 +382,7 @@ public class DefaultDisplayManagerTests
 
             var result = await displayManager.ExecuteAsync(CreateDisplayContext(shape));
 
-            Assert.Equal("<!--shape-start type:Foo bindings:Foo=>Views/Foo.cshtml (razor)-->Hi there!<!--shape-end type:Foo-->", result.ToString());
+            Assert.Equal("<!--shape-start type:Foo bindings:Foo => Views/Foo.cshtml (razor) -->Hi there!<!--shape-end type:Foo -->", result.ToString());
             Assert.Equal("Hi there!", shape.Metadata.ChildContent.ToString());
         }
         finally
@@ -424,7 +424,7 @@ public class DefaultDisplayManagerTests
 
             var result = await displayManager.ExecuteAsync(CreateDisplayContext(shape));
 
-            Assert.Equal("<!--shape-start type:Foo bindings:Foo__Alternate=>Views/Foo-Alternate.cshtml (razor)-->Alternate<!--shape-end type:Foo-->", result.ToString());
+            Assert.Equal("<!--shape-start type:Foo bindings:Foo__Alternate => Views/Foo-Alternate.cshtml (razor) -->Alternate<!--shape-end type:Foo -->", result.ToString());
         }
         finally
         {
@@ -453,7 +453,7 @@ public class DefaultDisplayManagerTests
 
             var result = await displayManager.ExecuteAsync(CreateDisplayContext(shape));
 
-            Assert.Equal("<!--shape-start type:Foo bindings:Foo=>Templates/Foo.liquid (liquid)-->Liquid<!--shape-end type:Foo-->", result.ToString());
+            Assert.Equal("<!--shape-start type:Foo bindings:Foo => Templates/Foo.liquid (liquid) -->Liquid<!--shape-end type:Foo -->", result.ToString());
         }
         finally
         {


### PR DESCRIPTION
This pull request introduces a new feature to Orchard Core that allows developers to enable HTML comments in the rendered output, identifying which shape bindings (Razor or Liquid templates) were used to produce each fragment. This is achieved through a new `ShapeRenderingOptions` configuration, a new `ShapeDebugInfoHtmlContent` wrapper, and supporting changes in the display pipeline and documentation. Additional unit tests ensure correct behavior and coverage for this feature.

The most important changes are:

**Shape Debug Information Feature:**

* Added a new `ShapeRenderingOptions` class with a `WriteShapeDebugInformation` flag to control whether debug comments are emitted in HTML output.
* Introduced the `ShapeDebugInfoHtmlContent` class, which wraps rendered shape content with HTML comments indicating the shape type and binding source.
* Modified `DefaultHtmlDisplay` to emit debug comments around shapes when the option is enabled, including logic to describe bindings and their sources (Razor or Liquid). [[1]](diffhunk://#diff-b6b592c9fa999746a988ba083185ee99e6128628e6c1d5c52865f5ac4531e5d8R26-R34) [[2]](diffhunk://#diff-b6b592c9fa999746a988ba083185ee99e6128628e6c1d5c52865f5ac4531e5d8R43) [[3]](diffhunk://#diff-b6b592c9fa999746a988ba083185ee99e6128628e6c1d5c52865f5ac4531e5d8R90-R92) [[4]](diffhunk://#diff-b6b592c9fa999746a988ba083185ee99e6128628e6c1d5c52865f5ac4531e5d8L117-R126) [[5]](diffhunk://#diff-b6b592c9fa999746a988ba083185ee99e6128628e6c1d5c52865f5ac4531e5d8R147-R148) [[6]](diffhunk://#diff-b6b592c9fa999746a988ba083185ee99e6128628e6c1d5c52865f5ac4531e5d8R194-R270)

**Configuration and API:**

* Added the `AddShapeDebugInformation` extension method to `OrchardCoreBuilder`, allowing easy opt-in to the debug comments feature. Also ensured `ShapeRenderingOptions` is registered with DI. [[1]](diffhunk://#diff-d2440fd53ee4f28d6235c543946951a4744c4a2eefed548d27ebb5d0b4316fb2R33-R41) [[2]](diffhunk://#diff-d2440fd53ee4f28d6235c543946951a4744c4a2eefed548d27ebb5d0b4316fb2R94)
* Updated documentation to explain the new feature, how to enable it, and what the generated comments look like.

**Testing and Validation:**

* Added comprehensive unit tests to verify that shape debug comments are correctly emitted for both Razor and Liquid templates, and for alternate bindings.
* Updated test and benchmark code to accommodate the new `ShapeRenderingOptions` dependency. [[1]](diffhunk://#diff-a50d0dec9ad9daf5771b1e4799ea08d07f67bf0d6f2982bc9007fb37907b534aR9) [[2]](diffhunk://#diff-a50d0dec9ad9daf5771b1e4799ea08d07f67bf0d6f2982bc9007fb37907b534aL27-R28) [[3]](diffhunk://#diff-b753e6d3f3f899c32089c4adddabcdaff43b18c0506e3665df09f1575dce2b09R9) [[4]](diffhunk://#diff-b753e6d3f3f899c32089c4adddabcdaff43b18c0506e3665df09f1575dce2b09R18) [[5]](diffhunk://#diff-b753e6d3f3f899c32089c4adddabcdaff43b18c0506e3665df09f1575dce2b09R43-R47)

**Template Binding Source Improvements:**

* Updated the binding source for admin and regular templates to include the `.liquid` extension, improving clarity in debug output. (`AdminTemplates/{shapeType}.liquid`, `Templates/{shapeType}.liquid`) [[1]](diffhunk://#diff-f7783d01bbbcde39be085f536d6c95d47caa231a94fb55fdb20570360154363aL73-R73) [[2]](diffhunk://#diff-a9bf085ed0cbcb714ec3fb849dc281900ca4e0debd12c9149be6fab0120f7215L72-R72)
