### PR TITLE
Replace :: with @ for separating the package from the version

### DIFF
--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -9,13 +9,13 @@ More information about `dotnet new` can be found at <https://docs.microsoft.com/
 Once the .NET Core SDK has been installed, type the following command to install the templates for creating Orchard Core web applications:
 
 ```CMD
-dotnet new install OrchardCore.ProjectTemplates::2.2.1
+dotnet new install OrchardCore.ProjectTemplates@2.2.1
 ```
 
 This will use the most stable release of Orchard Core. In order to use the latest `main` branch of Orchard Core, the following command can be used:
 
 ```CMD
-dotnet new install OrchardCore.ProjectTemplates::2.2.1-* --nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json  
+dotnet new install OrchardCore.ProjectTemplates@2.2.1-* --nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json  
 ```
 
 ## Create a new website

--- a/src/docs/guides/add-admin-menu/README.md
+++ b/src/docs/guides/add-admin-menu/README.md
@@ -19,7 +19,7 @@ There are different ways to create sites and modules for Orchard Core. You can l
 
 You can install the latest released templates using this command:
 
-```dotnet new install OrchardCore.ProjectTemplates::2.2.1-*```
+```dotnet new install OrchardCore.ProjectTemplates@2.2.1-*```
 
 !!! note
     To use the development branch of the template add `--nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json`

--- a/src/docs/guides/create-cms-application/README.md
+++ b/src/docs/guides/create-cms-application/README.md
@@ -13,7 +13,7 @@ There are different ways to create sites and modules for Orchard Core. You can l
 
 In this guide we will use our "Code Generation Templates". You can install the latest stable release of the templates using this command:
 
-```dotnet new install OrchardCore.ProjectTemplates::2.2.1-*```
+```dotnet new install OrchardCore.ProjectTemplates@2.2.1-*```
 
 !!! note
     To use the development branch of the template add `--nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json`.

--- a/src/docs/guides/create-modular-application-mvc/README.md
+++ b/src/docs/guides/create-modular-application-mvc/README.md
@@ -18,7 +18,7 @@ There are different ways to create sites and modules for Orchard Core. You can l
 
 In this guide we will use our [Code Generation Templates](../../getting-started/templates/README.md). You can install the latest stable release of the templates using this command:
 
-```dotnet new install OrchardCore.ProjectTemplates::2.2.1-*```
+```dotnet new install OrchardCore.ProjectTemplates@2.2.1-*```
 
 !!! note
     To use the development branch of the template add `--nuget-source https://nuget.cloudsmith.io/orchardcore/preview/v3/index.json`


### PR DESCRIPTION
The colon separator "::" has been deprecated in favor of the at symbol "@" for separating the package from the version