### PR TITLE
Fix Stored XSS via Entity Decoding in Orchard Core HtmlBodyPart Summary Rendering (Lombiq Technologies: OCORE-267)

### DIFF
--- a/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Mvc.Core/Utilities/StringExtensions.cs
@@ -123,6 +123,13 @@ public static class StringExtensions
             return string.Empty;
         }
 
+        // Decoding must happen before the tags are stripped to strip out all tags from the final result. This prevents
+        // XSS by way of encoded HTML (e.g. "&lt;img src=x onerror=alert(1)&gt;").
+        if (htmlDecode)
+        {
+            html = WebUtility.HtmlDecode(html);
+        }
+
         var result = new char[html.Length];
 
         var cursor = 0;
@@ -148,11 +155,6 @@ public static class StringExtensions
         }
 
         var stringResult = new string(result, 0, cursor);
-
-        if (htmlDecode)
-        {
-            stringResult = WebUtility.HtmlDecode(stringResult);
-        }
 
         return stringResult;
     }


### PR DESCRIPTION
Fixes cross-site scripting exploit from https://hackmd.io/@longnv719/S1njQ2lyMl

tl;dr HTML encoded tags were not removed by `html.RemoveTags(htmlDecode: true)`

Simplified repro (the original from the disclosure is kind of convoluted):
1. Setup with any recipe.
2. Enable Deployments feature if not yet enabled.
3. Go to Admin > Tools > Deployments > Package Import.
4. Upload the attached JSON file: [OCORE-267.recipe.json](https://github.com/user-attachments/files/28302343/OCORE-267.recipe.json).
5. Go to `~/Contents/ContentItems/list0000000000000000000000`.
6. Observe the alert that should not happen.
7. Go to `~/Contents/ContentItems/listitem000000000000000000`.
8. Observe that the text is displayed as raw HTML  (as expected).

Note: I don't know why it was necessary to HTML decode the content of the summary, but it's been like that for 12 years so I didn't dare to change it. But I'm sure any decoding should happen _before_  tag stripping and not after it.