### PR TITLE
Fix theme extensions not appearing when manifest includes additional Feature attributes

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -148,7 +148,7 @@
                                                 @foreach (var d in missingDependencies)
                                                 {
                                                     <span class="badge text-bg-warning">
-                                                        @d
+                                                        @d.Name
                                                     </span>
                                                 }
                                             </div>

--- a/src/OrchardCore/OrchardCore.Features.Core/Services/FeatureService.cs
+++ b/src/OrchardCore/OrchardCore.Features.Core/Services/FeatureService.cs
@@ -62,7 +62,10 @@ public class FeatureService
                 EnabledByDependencyOnly = moduleFeatureInfo.EnabledByDependencyOnly,
                 IsAlwaysEnabled = alwaysEnabledFeatures.Contains(moduleFeatureInfo),
                 EnabledDependentFeatures = dependentFeatures.Where(x => x.Id != moduleFeatureInfo.Id && enabledFeatures.Contains(x)).ToList(),
-                FeatureDependencies = featureDependencies.Where(d => d.Id != moduleFeatureInfo.Id).ToList(),
+                // Exclude the feature itself and any theme-type features from the dependency list
+                // shown on the Features admin page.  Theme dependencies are managed separately
+                // through the Themes admin page and should not appear as missing module dependencies.
+                FeatureDependencies = featureDependencies.Where(d => d.Id != moduleFeatureInfo.Id && !d.IsTheme()).ToList(),
             };
 
             moduleFeatures.Add(moduleFeature);

--- a/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
+++ b/src/OrchardCore/OrchardCore/Extensions/Features/FeaturesProvider.cs
@@ -24,6 +24,55 @@ public class FeaturesProvider : IFeaturesProvider
         var features = manifestInfo.ModuleInfo.Features;
         if (features.Count > 0)
         {
+            // When explicit [Feature] attributes are present but none of them carries the
+            // extension's own Id, the extension is missing a "main" feature.  Without it
+            // IsTheme() can never return true (it requires featureInfo.Id == featureInfo.Extension.Id),
+            // and the Themes admin page cannot find the theme.  Modules avoid this because they
+            // always include their own Id as the first explicit [Feature]; themes historically did
+            // not.  Synthesize the main feature from the module-level metadata — exactly as the
+            // else-branch does for single-feature extensions — and prepend it so it remains first.
+            if (!features.Any(f => f.Id == extensionInfo.Id))
+            {
+                var mainContext = new FeatureBuildingContext
+                {
+                    FeatureId = extensionInfo.Id,
+                    FeatureName = manifestInfo.Name,
+                    Category = manifestInfo.ModuleInfo.Categorize(),
+                    Description = manifestInfo.ModuleInfo.Describe(),
+                    ExtensionInfo = extensionInfo,
+                    ManifestInfo = manifestInfo,
+                    Priority = manifestInfo.ModuleInfo.Prioritize(),
+                    FeatureDependencyIds = manifestInfo.ModuleInfo.Dependencies,
+                    DefaultTenantOnly = manifestInfo.ModuleInfo.DefaultTenantOnly,
+                    IsAlwaysEnabled = manifestInfo.ModuleInfo.IsAlwaysEnabled,
+                    EnabledByDependencyOnly = manifestInfo.ModuleInfo.EnabledByDependencyOnly,
+                };
+
+                foreach (var builder in _featureBuilderEvents)
+                {
+                    builder.Building(mainContext);
+                }
+
+                var mainFeatureInfo = new FeatureInfo(
+                    mainContext.FeatureId,
+                    mainContext.FeatureName,
+                    mainContext.Priority,
+                    mainContext.Category,
+                    mainContext.Description,
+                    mainContext.ExtensionInfo,
+                    mainContext.FeatureDependencyIds,
+                    mainContext.DefaultTenantOnly,
+                    mainContext.IsAlwaysEnabled,
+                    mainContext.EnabledByDependencyOnly);
+
+                foreach (var builder in _featureBuilderEvents)
+                {
+                    builder.Built(mainFeatureInfo);
+                }
+
+                featuresInfos.Add(mainFeatureInfo);
+            }
+
             foreach (var feature in features)
             {
                 if (string.IsNullOrWhiteSpace(feature.Id))

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -813,3 +813,10 @@ With the latest updates, you can now streamline this process using the `Configur
     } 
 }
 ```
+
+## Bug fixes
+
+- Fixed theme extensions disappearing from the Themes admin page when the
+  assembly manifest included additional `[Feature]` attributes alongside
+  `[Theme]`. Extra features now appear correctly with their category and
+  Enable button in the Features admin. See [#19160](https://github.com/OrchardCMS/OrchardCore/issues/19160).


### PR DESCRIPTION
## Summary

Fixes #19160.

A theme assembly declaring both `[Theme]` and additional `[Feature]` assembly
attributes produced three visible failures:

1. **Theme missing from Themes admin**. `FeaturesProvider.GetFeatures()`
   skipped main-feature synthesis when any `[Feature]` attribute was present,
   so no feature with `Id == extensionInfo.Id` existed on the extension.

2. **Category column shows type name**. The missing-dependency badge in
   `Features.cshtml` rendered `@d` (no `ToString()` override on `IFeatureInfo`),
   producing the fully-qualified type name instead of a display name.

3. **Enable button missing**. `ThemeFeatureBuilderEvents` injects the base
   theme as a dependency on each extra feature. `FeatureService` excludes themes
   from `Model.Features`, so the base-theme dependency appeared as a missing
   module dependency, causing `missingDependencies.Any() = true`.

## Changes

| File | Change |
|------|--------|
| `FeaturesProvider.cs` | Synthesize and prepend the main theme feature when explicit `[Feature]` attrs do not already include `extensionInfo.Id`. Guard prevents any effect on regular modules. |
| `FeatureService.cs` | Filter theme features from `FeatureDependencies` (`&& !d.IsTheme()`). |
| `Features.cshtml` | Render `@d.Name` instead of `@d` in the missing-dependency badge. |

