### PR TITLE
Improve culture picker display for responsive layouts

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Views/AdminCulturePicker.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Views/AdminCulturePicker.cshtml
@@ -5,7 +5,17 @@
 
 <li class="nav-item">
     <div class="dropdown">
-        <button type="button" class="nav-link dropdown-toggle" id="oc-culture-picker" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-language-current-value="@Model.CurrentCulture.Name" data-cookie-name="@AdminCookieCultureProvider.MakeCookieName(ShellSettings)" data-cookie-path="@AdminCookieCultureProvider.MakeCookiePath(Context)">@Model.CurrentCulture.NativeName</button>
+        <button type="button" class="nav-link dropdown-toggle" id="oc-culture-picker" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" data-language-current-value="@Model.CurrentCulture.Name" data-cookie-name="@AdminCookieCultureProvider.MakeCookieName(ShellSettings)" data-cookie-path="@AdminCookieCultureProvider.MakeCookiePath(Context)">
+            @if (Model.CurrentCulture.Parent == System.Globalization.CultureInfo.InvariantCulture)
+            {
+                <span>@Model.CurrentCulture.NativeName</span>
+            }
+            else
+            {
+                <span class="d-none d-md-inline">@Model.CurrentCulture.NativeName</span>
+                <span class="d-md-none">@Model.CurrentCulture.Parent.NativeName</span>
+            }
+        </button>
         <ul class="dropdown-menu dropdown-menu-end position-absolute">
             @foreach (var culture in Model.SupportedCultures)
             {


### PR DESCRIPTION
This pull request updates the `AdminCulturePicker.cshtml` view to enhance how the current culture is displayed in the admin culture picker dropdown. The change improves responsiveness and clarity by adjusting what is shown based on the user's screen size and the structure of the selected culture.

**UI improvements to culture picker:**

* The current culture's native name is now conditionally rendered: if the culture has a parent (i.e., it's not a root culture), the full native name is shown on medium and larger screens, while the parent culture's native name is shown on smaller screens. If the culture is a root culture, only its native name is displayed. This makes the UI more adaptive and user-friendly on different devices.