### PR TITLE
Improve docs by correcting typos and admin navigation references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,11 +465,11 @@ public sealed class AdminMenu : AdminNavigationProvider
 
 1. Follow existing code style and conventions
 2. Include unit tests for new functionality
-3. Update documentation if adding new features
+3. Update the canonical documentation page when adding or changing user-facing features, public APIs, configuration, stereotypes, or extension points, and keep the docs aligned with the shipped code and behavior
 4. Run asset build if modifying CSS/JS: `yarn build`
 5. Ensure all tests pass: `dotnet test`
 6. Link related GitHub issues using `Fixes #IssueId`
-7. Add release notes for significant changes in `src/docs/releases/`
+7. Add release notes for significant changes in `src/docs/releases/`, but do not rely on release notes as the only documentation for a feature; release notes describe what changed, while the canonical docs describe the current behavior without transitional or versioned wording
 
 ## Useful Commands
 

--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -7,30 +7,30 @@ Orchard Core consists of two different targets:
 - **Orchard Core Framework**: An application framework for building **modular**, **multi-tenant** applications on ASP.NET Core.
 - **Orchard Core CMS**: A Web Content Management System (CMS) built on top of the Orchard Core Framework.
 
-It’s important to note the differences between the framework and the CMS. Some developers who want to develop SaaS applications will only be interested in the modular framework. Others who want to build administrable websites will focus on the CMS and build modules to enhance their sites or the whole ecosystem.
+It's important to note the differences between the framework and the CMS. Some developers who want to develop SaaS applications will only be interested in the modular framework. Others who want to build administrable websites will focus on the CMS and build modules to enhance their sites or the whole ecosystem.
 
 ## Building Software as a Service (SaaS) solutions with the Orchard Core Framework
 
-It’s very important to understand the Orchard Core Framework is distributed independently from the CMS on nuget.org. We’ve made some sample applications on <https://github.com/OrchardCMS/OrchardCore.Samples> that will guide you on how to build **modular** and **multi-tenant** applications using just Orchard Core Framework without any of the CMS specific features.
+It's very important to understand the Orchard Core Framework is distributed independently from the CMS on nuget.org. We've made some sample applications on <https://github.com/OrchardCMS/OrchardCore.Samples> that will guide you on how to build **modular** and **multi-tenant** applications using just Orchard Core Framework without any of the CMS-specific features.
 
 One of our goals is to enable community-based ecosystems of hosted applications which can be extended with modules, like e-commerce systems, blog engines and more. The Orchard Core Framework enables a modular environment that allows different teams to work on separate parts of an application and make components reusable across projects.
 
-## Building Website with Orchard Core CMS
+## Building a Website with Orchard Core CMS
 
-Orchard Core CMS is a complete rewrite of Orchard CMS on ASP.NET Core. It’s not just a port as we wanted to improve the performance drastically and align as close as possible to the development models of ASP.NET Core.
+Orchard Core CMS is a complete rewrite of Orchard CMS on ASP.NET Core. It's not just a port as we wanted to improve the performance drastically and align as close as possible to the development models of ASP.NET Core.
 
-- **Performance**. This might be the most obvious change when you start using Orchard Core CMS. It’s extremely fast for a CMS. So fast that we haven’t even cared about working on an output cache module. To give you an idea, without caching Orchard Core CMS is around 20 times faster than the previous version.
+- **Performance**. This might be the most obvious change when you start using Orchard Core CMS. It's extremely fast for a CMS. So fast that we haven't even cared about working on an output cache module. To give you an idea, without caching Orchard Core CMS is around 20 times faster than the previous version.
 
 - **Portable**. You can now develop and deploy Orchard Core CMS on Windows, Linux and macOS. We also have Docker images ready for use.
 - **Database Support**. SQL Server, MySQL, MariaDB, PostgreSQL, and SQLite. For MariaDB, select MySQL as the database type and follow all MySQL rules.
 
-- **Document database abstraction**. Orchard Core CMS still requires a relational database and is compatible with SQL Server, MySQL, PostgreSQL, and SQLite, but it’s now using a document abstraction (YesSql) that provides a document database API to store and query documents. This is a much better approach for CMS systems and helps performance significantly.
+- **Document database abstraction**. Orchard Core CMS still requires a relational database and is compatible with SQL Server, MySQL, PostgreSQL, and SQLite, but it's now using a document abstraction (YesSql) that provides a document database API to store and query documents. This is a much better approach for CMS systems and helps performance significantly.
 
 - **NuGet Packages**. Modules and themes are now shared as NuGet packages. Creating a new website with Orchard Core CMS is actually as simple as referencing a single meta package from the NuGet gallery. It also means that updating to a newer version only involves updating the version number of this package.
 
 - **Live preview**. When editing a content item, you can now see live how it will look like on your site, even before saving your content. And it also works for templates, where you can browse any page to inspect the impact of a change on templates as you type it.
 
-- **Liquid templates support**. Editors can safely change the HTML templates with the Liquid template language. It was chosen as it’s both very well documented (Jekyll, Shopify, …) and secure.
+- **Liquid templates support**. Editors can safely change the HTML templates with the Liquid template language. It was chosen as it's both very well documented (Jekyll, Shopify, …) and secure.
 
 - **Custom queries**. We wanted to provide a way for developers to access all their data as simply as possible. We created a module that lets you create custom ad-hoc SQL and Lucene queries that can be re-used to display custom content, or exposed as API endpoints. You can use it to create efficient queries, or expose your data to SPA applications.
 
@@ -38,7 +38,7 @@ Orchard Core CMS is a complete rewrite of Orchard CMS on ASP.NET Core. It’s no
 
 - **Scalability**. Because Orchard Core is a multi-tenant system, you can host as many websites as you want with a single deployment. A typical cloud machine can then host thousands of sites in parallel, with database, content, theme and user isolation.
 
-- **Workflows**. Create content approval workflows, react to webhooks, take actions when forms are submitted, and any other process you'd like to implement with a user friendly UI.
+- **Workflows**. Create content approval workflows, react to webhooks, take actions when forms are submitted, and any other process you'd like to implement with a user-friendly UI.
 
 - **GraphQL**. We provide a very flexible GraphQL API, such that any authorized external application can reuse your content, like SPA applications or static site generators.
 

--- a/src/docs/community/owners/README.md
+++ b/src/docs/community/owners/README.md
@@ -14,7 +14,7 @@ The below table lists the different code/features areas and their owners:
 | [Hisham Bin Ateya](https://github.com/hishamco)            | Cultures, Email, Localization, RTL, Translation, UI |
 | [Jean-Philippe Tissot](https://github.com/jptissot)        | Localization, Tests                                 |
 | [Larrem Panganiban](https://github.com/larremp)            | Workshops                                           |
-| [Lukas Kabrt](https://github.com/lukaskabrt)               | Po files extractor                                  |
+| [Lukas Kabrt](https://github.com/lukaskabrt)               | PO files extractor                                  |
 | [Matias Molleja](https://github.com/matiasmolleja)         | Media                                               |
 | [Michael Petrinolis](https://github.com/MichaelPetrinolis) | External authentication providers                   |
 | [Zoltán Lehóczky](https://github.com/Piedone)              | PublishLater, Preview packages                      |

--- a/src/docs/contributing/README.md
+++ b/src/docs/contributing/README.md
@@ -4,7 +4,7 @@ First of all, thank you for thinking about contributing to Orchard Core!
 
 ## How can you contribute?
 
-One of the easiest ways to contribute is to participate in discussions under [GitHub issues](https://github.com/OrchardCMS/OrchardCore/issues). You can also contribute by submitting pull requests with code changes, reviewing pull requests by others, assisting other community members on the [discussion board](https://github.com/OrchardCMS/OrchardCore/discussions), [evangelizing Orchard Core](https://github.com/Lombiq/Orchard-Ambassadors-Toolbox) in your own communities, or help organizing events.
+One of the easiest ways to contribute is to participate in discussions under [GitHub issues](https://github.com/OrchardCMS/OrchardCore/issues). You can also contribute by submitting pull requests with code changes, reviewing pull requests by others, assisting other community members on the [discussion board](https://github.com/OrchardCMS/OrchardCore/discussions), [evangelizing Orchard Core](https://github.com/Lombiq/Orchard-Ambassadors-Toolbox) in your own communities, or helping organize events.
 
 - [Opening and managing issues](managing-issues.md)
 - [Contributing code](contributing-code.md)

--- a/src/docs/contributing/contributing-to-orchardcore-net.md
+++ b/src/docs/contributing/contributing-to-orchardcore-net.md
@@ -1,10 +1,10 @@
-# Contributing orchardcore.net
+# Contributing to orchardcore.net
 
 Did you know that Orchard Core's official website, [orchardcore.net](https://orchardcore.net), is also an open-source project? And, of course, it's built using Orchard Core itself!
 
 ## How to start
 
-To start, just clone the [Orchard Core Website repository](https://github.com/OrchardCMS/OrchardCore.Website). Instructions on working with the app are available in its Readme. Happy coding!
+To start, just clone the [Orchard Core Website repository](https://github.com/OrchardCMS/OrchardCore.Website). Instructions on working with the app are available in its README. Happy coding!
 
 
 !!! tip

--- a/src/docs/getting-started/README.md
+++ b/src/docs/getting-started/README.md
@@ -13,7 +13,7 @@ In this article, we are going to see how easy it is to create a CMS Web applicat
 In Visual Studio (or [any other .NET IDE](../getting-started/development-tools.md)), create a new empty .NET web application, e.g. `Cms.Web`. Do not check "Place solution and project in the same directory", because later when you create modules and themes you will want them to live alongside the web application within the solution.
 
 !!! note
-    If you want to use the `preview` packages, [configure the OrchardCore Preview url in your Package sources](preview-package-source.md).
+    If you want to use the `preview` packages, [configure the OrchardCore Preview URL in your Package sources](preview-package-source.md).
 
 To add a reference to the package, right-click on the project and click on `Manage NuGet packages...`, check `Include prerelease` if required. If you added the preview source above, select this from the `Package Source` selection in the top right.  In the `Browse` tab, search for `OrchardCore.Application.Cms.Targets` and `Install` the package.
 
@@ -92,7 +92,7 @@ app.UseOrchardCore();
 
 Finally, remove the default `Pages` and/or `Views` folder to allow OrchardCore to render the views from the active theme.
 
-## Setup your application
+## Set up your application
 
 Launch your application (Ctrl+F5). The setup page is displayed.
 
@@ -108,4 +108,4 @@ Enter the required information about the site:
 
 Submit the form and your site is generated after a few seconds.
 
-Then, you can access to the admin using the `/admin` url. Enjoy.
+Then, you can access the admin using the `/admin` URL. Enjoy.

--- a/src/docs/getting-started/starter-recipes.md
+++ b/src/docs/getting-started/starter-recipes.md
@@ -11,7 +11,7 @@ The first package `OrchardCore.Application.Cms.Core.Targets` is intended for use
 - Developing a Headless Web Site
 - Developing a Themed Web Site from scratch
 
-The `Core.Targets` package contains the minimum you need to setup an Orchard Core installation.
+The `Core.Targets` package contains the minimum you need to set up an Orchard Core installation.
 It contains `TheAdmin` theme, and two recipes to base your installation on, but no front end themes.
 
 !!! tip
@@ -23,7 +23,7 @@ The second package `OrchardCore.Application.Cms.Targets` contains all of the abo
 - Setup recipes for the Themes
 - Multiple CMS Starter Themes
 
-Recipes in Orchard Core help you get your site setup by enabling features,
+Recipes in Orchard Core help you set up your site by enabling features,
 and / or creating content types, and content for your site.
 
 Orchard Core Themes can contain Razor or Liquid views, and by default use

--- a/src/docs/getting-started/templates/README.md
+++ b/src/docs/getting-started/templates/README.md
@@ -1,6 +1,6 @@
 # Code Generation Templates
 
-Orchard Core Templates uses `dotnet new` template configurations for creating new websites, themes and modules from the command shell.
+Orchard Core Templates use `dotnet new` template configurations for creating new websites, themes and modules from the command shell.
 
 More information about `dotnet new` can be found at <https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new>
 
@@ -22,7 +22,7 @@ dotnet new install OrchardCore.ProjectTemplates@2.2.1-* --nuget-source https://n
 
 ### From Command Shell (automated way)
 
-#### Generate an Orchard Cms Web Application
+#### Generate an Orchard CMS Web Application
 
 ```CMD
 dotnet new occms
@@ -30,7 +30,7 @@ dotnet new occms
 
 The above command will use the default options.
 
-You can pass the following CLI parameters to setup options:
+You can pass the following CLI parameters for setup options:
 
 ```CMD
 Orchard Core Cms Web App (C#)
@@ -73,7 +73,7 @@ Now that we created a new Web Application we need to add proper dependencies so 
 Orchard Core can be added through two distinct NuGet meta packages: `OrchardCore.Application.Cms.Core.Targets` and `OrchardCore.Application.Cms.Targets`. For additional information regarding these packages, please refer to [this link](../starter-recipes.md). You must add one of these NuGet packages in your Web Application.
 
 !!! note
-    If you want to use the `preview` packages, [configure the OrchardCore Preview url in your Package sources](../preview-package-source.md)
+    If you want to use the `preview` packages, [configure the OrchardCore Preview URL in your Package sources](../preview-package-source.md)
 
 ![image](../assets/images/templates/orchard-screencast-2.gif)
 
@@ -117,7 +117,7 @@ dotnet new ocmodulecms
 
 The above command will use the default options.
 
-You can pass the following CLI parameters to setup options:
+You can pass the following CLI parameters for setup options:
 
 ```CMD
 Orchard Core Module (C#)
@@ -156,7 +156,7 @@ Fire up Visual Studio, open Orchard Core solution file (`.sln`), select `Orchard
 For marking this new Class Library as an Orchard Module, we will now need to reference `OrchardCore.Module.Targets` NuGet package.
 
 !!! note
-    If you want to use the `preview` packages, [configure the OrchardCore Preview url in your Package sources](../preview-package-source.md)
+    If you want to use the `preview` packages, [configure the OrchardCore Preview URL in your Package sources](../preview-package-source.md)
 
 Each of these `*.Targets` NuGet packages are used to mark a Class Library as a specific Orchard Core functionality.  
 `OrchardCore.Module.Targets` is the one we are interested in for now.  

--- a/src/docs/getting-started/theme.md
+++ b/src/docs/getting-started/theme.md
@@ -33,10 +33,10 @@ The theme should be available in the `Active themes` admin page, and can be set 
 
 ## How to enable Razor templates in my theme?
 
-The themes we have in source code uses only `Liquid` files so their .csproj only reference :
+The themes we have in source code use only `Liquid` files, so their .csproj files only reference:
 
 `<Project Sdk="Microsoft.NET.Sdk">`
 
-If you want to use Razor templates in your theme you simply need to change this .csproj first line for :
+If you want to use Razor templates in your theme, you simply need to change this .csproj first line to:
 
 `<Project Sdk="Microsoft.NET.Sdk.Razor">`

--- a/src/docs/guides/add-admin-menu/README.md
+++ b/src/docs/guides/add-admin-menu/README.md
@@ -181,7 +181,7 @@ Application started. Press Ctrl+C to shut down.
 
 Open a browser on <https://localhost:5001>
 
-If you have not already setup your site, select __Blank Site__ as the recipe, and use __SQLite__ as the database.
+If you have not already set up your site, select __Blank Site__ as the recipe, and use __SQLite__ as the database.
 
 Once your site is ready, you should see a __The page could not be found.__ message which is expected for a __Blank Site__ recipe.
 

--- a/src/docs/guides/create-admin-theme/README.md
+++ b/src/docs/guides/create-admin-theme/README.md
@@ -10,7 +10,7 @@ You will build a custom theme which uses `TheAdmin` as a base theme.
 
 ## What you will need
 
-- An existing Orchard Core website that has already been setup.
+- An existing Orchard Core website that has already been set up.
 
 ## Creating an Orchard Core Theme
 

--- a/src/docs/guides/create-blazor-cms/README.md
+++ b/src/docs/guides/create-blazor-cms/README.md
@@ -31,7 +31,7 @@ dotnet sln add ./BlazorCms
 
 ![Setup Default Orchard Core site](./images/image-002.PNG)
 
-- Once the setup is complete, log in to the admin and create a new content type as following. (By navigating to `Content` -> `Content Definition` -> `Content Types`) 
+- Once the setup is complete, log in to the admin and create a new content type as following. (By navigating to `Design` -> `Content Definition` -> `Content Types`) 
     - Create a 'MarkdownPage' content type.
     - Add Parts 
         - TitlePart

--- a/src/docs/guides/create-blazor-cms/README.md
+++ b/src/docs/guides/create-blazor-cms/README.md
@@ -11,11 +11,11 @@ In this article, you will learn how to use Orchard CMS as a decoupled CMS with t
 - Orchard Core's [code generation templates](../../getting-started/templates/README.md)
 - Knowledge of [getting started with Orchard Core CMS](../../getting-started/README.md)
 - Be familiar with C# and HTML.
-- Basic knowledge of Orchard Cms modules, e.g. creating content definition, creating content, executing recipes.
+- Basic knowledge of Orchard Core CMS modules, e.g. creating content definitions, creating content, and executing recipes.
 
 ### Create Orchard Core CMS Application
  
-- Create a new Orchard Core CMS Application and set up the default site using a `headless` recipe. Follow [create orchard cms application guide](https://docs.orchardcore.net/en/latest/docs/guides/create-cms-application/) to create a new Orchard Core website.
+- Create a new Orchard Core CMS application and set up the default site using a `headless` recipe. Follow the [Create an Orchard Core CMS website guide](https://docs.orchardcore.net/en/latest/docs/guides/create-cms-application/) to create a new Orchard Core website.
 - Alternatively, you can run the following commands to create a new Orchard Core application. 
 
 ```shell
@@ -787,12 +787,12 @@ Navigate to `Multi-Tenancy` -> `Tenants` and add a new tenant with the following
 ![Create first tenant](./images/create-tenant.png)
 
 - Tenant name: FirstTenant
-- Url Prefix: tenant01
+- URL Prefix: tenant01
 - Recipe: Headless site
 
 ![Create first tenant](./images/first-tenant.png)
 
-Now setup the first tenant, by clicking on the `Setup` button.
+Now set up the first tenant by clicking the `Setup` button.
 
 ![Setup new tenant](./images/setup-first-tenant.png)
 
@@ -800,8 +800,8 @@ Now setup the first tenant, by clicking on the `Setup` button.
 
 After setup is finished, you can access the first tenant by navigating to `https://localhost:5001/tenant01`. Since Orchard listens to ```/``` (and on ```/tenant01/```), it presents the login screen. You can log in with the user you just created in the setup procedure.
 
-# The base url
-In App.razor in the razor class library that contains our Blazor App, we need to add the base url to the base tag. This is necessary because the Blazor App is served from a subpath of the Orchard Core application.
+# The base URL
+In App.razor in the Razor class library that contains our Blazor app, we need to add the base URL to the base tag. This is necessary because the Blazor app is served from a subpath of the Orchard Core application.
 
 ```razor
 <base href="/" />
@@ -858,13 +858,13 @@ The `NavigationManager` is injected into the App component and the base path is 
 > - Using the ShellScope (Context.Settings.RequestUrlPrefix)
 > - Using the settings of ISiteService (Site.BaseUrl). This can be set in the admin UI.
 
-The example contains a page with the url ```baseurl``` that demonstrates the various methods. 
+The example contains a page with the URL `baseurl` that demonstrates the various methods.
 
-![Base url retrievement](./images/base-url-page.png)
+![Base URL retrieval](./images/base-url-page.png)
 
 > NOTE:
 >
-> The base url can be specified as an absolute path, or as a relative path.
+> The base URL can be specified as an absolute path or as a relative path.
 >
 > NOTE:
 >

--- a/src/docs/guides/create-cms-application/README.md
+++ b/src/docs/guides/create-cms-application/README.md
@@ -1,6 +1,6 @@
 # Creating an Orchard Core CMS website
 
-In this guide you will setup Orchard Core as a Content Management System from a project template.
+In this guide you will set up Orchard Core as a Content Management System from a project template.
 
 ## What you will need
 
@@ -26,7 +26,7 @@ This creates a new Orchard Core CMS project in a folder named `MySite`.
 
 ## Setting up the site
 
-The application has been created by the template, but it has not been setup yet.
+The application has been created by the template, but it has not been set up yet.
 
 Run the application by executing this command:
 

--- a/src/docs/guides/create-liquid-widget/README.md
+++ b/src/docs/guides/create-liquid-widget/README.md
@@ -19,7 +19,7 @@ You will add a Liquid Widget to the Content Type Definitions and create a templa
 
 - Navigate to the Orchard Core CMS admin area <https://localhost:5001/admin>
 
-- Through the admin menu select _Content -> Content Definition -> Content Types_
+- Through the admin menu select _Design -> Content Definition -> Content Types_
 
 - Select `Create new type` and enter the Display Name `Liquid Widget`. The technical name will auto populate, removing the spaces. Then select `Create`
 

--- a/src/docs/guides/decoupled-cms/README.md
+++ b/src/docs/guides/decoupled-cms/README.md
@@ -173,7 +173,7 @@ Let's create a new content type named `Blog Post` and add some necessary content
 - From the running website, open the url `/admin`.
 - In the login screen, enter the user credentials that were used during the setup.
 - You are presented with the administrative side of the site.
-- In the left menu, select __Content Definition__ then __Content Types__.
+- In the left menu, select __Design__ then __Content Definition__ then __Content Types__.
 - Click on __Create new type__ in the top right corner
 - In __Display Name__ enter `Blog Post`. The __Technical Name__ will be generated automatically with the value `BlogPost`, like this:
 
@@ -319,7 +319,7 @@ Even though we can load blog posts from their Content Item Id, this is not user 
 
 In Orchard Core CMS the __Alias Part__ allows to provide a custom user friendly text to identify a content item.
 
-- In the admin section of the site, open __Content Definition__ > __Content Types__ > __Blog Post__
+- In the admin section of the site, open __Design__ > __Content Definition__ > __Content Types__ > __Blog Post__
 - At the bottom of the page, select __Add Parts__
 - Select __Alias__ and click __Save__
 - Move __Alias__ under __Title__ and save

--- a/src/docs/guides/decoupled-cms/README.md
+++ b/src/docs/guides/decoupled-cms/README.md
@@ -214,7 +214,7 @@ This shows that we now have a new blog post content item named `This is a new da
 
 ## Rendering content on the website
 
-The next step is to create a custom Razor Page that will display any blog post with a custom url.
+The next step is to create a custom Razor Page that will display any blog post with a custom URL.
 
 ### Creating a custom Razor Page
 
@@ -232,10 +232,10 @@ The next step is to create a custom Razor Page that will display any blog post w
 }
 ```
 
-- Open the url `/blogpost/1` to display the previous page.
+- Open the URL `/blogpost/1` to display the previous page.
 
 !!! info "Accessing route values"
-    In the route, url segment named `{id}` is automatically assigned to the `Id` property that is rendered with the `@Id` syntax.
+    In the route, the URL segment named `{id}` is automatically assigned to the `Id` property that is rendered with the `@Id` syntax.
 
 ### Loading a Blog Post from its identifier
 
@@ -261,11 +261,11 @@ Each content item in Orchard Core has a unique and immutable Content Item Identi
 ```
 
 - In the Content Items page, click on the blog post we created in the previous section.
-- Find the part of the url after `/ContentItems/`, which is `4tavbc16br9mx2htvyggzvzmd3` in the following screenshot:
+- Find the part of the URL after `/ContentItems/`, which is `4tavbc16br9mx2htvyggzvzmd3` in the following screenshot:
 
 ![Content Item id](images/content-item-id.jpg)
 
-- Open the url `/blogpost/[YOUR_ID]` by replacing the `[YOUR_ID]` section with the values for your own blog post.
+- Open the URL `/blogpost/[YOUR_ID]` by replacing the `[YOUR_ID]` section with the values for your own blog post.
 - The page should display the actual title of the blog post.
 
 ![Blog Post by Id](images/blogpost-id.jpg)
@@ -350,7 +350,7 @@ We can now update the Razor Page to use the alias instead of the content item id
 
 The changes consist in using the `slug` name in both the route and the local property, and also use a new method to load a content item with an alias.
 
-- Open the page `/blogpost/new-day` which should display the exact same result, but using a more SEO and user friendly url.
+- Open the page `/blogpost/new-day` which should display the exact same result, but using a more SEO- and user-friendly URL.
 
 ### Generating the slug using a custom pattern
 
@@ -376,7 +376,7 @@ The alias is now `this-is-a-new-day`:
 ![This Is A New Day](images/this-is-a-new-day.jpg)
 
 !!! note "Assignment"
-    Create a new Blog Post with a __Title__ and verify that the alias is auto-generated, and that it can be displayed using its own custom url.
+    Create a new Blog Post with a __Title__ and verify that the alias is auto-generated, and that it can be displayed using its own custom URL.
 
 ## Configuring the Preview feature for Blog Posts
 

--- a/src/docs/guides/gulp-pipeline/README.md
+++ b/src/docs/guides/gulp-pipeline/README.md
@@ -179,9 +179,8 @@ The following example processes all files with a `.js` extension in the `Assets`
 
 ## Separate output files for each input file
 
-In many cases you will want to process many input files in the exact same way but keep them in separate output files. You could do this by declaring a separate asset group for each pair of input/output files. However this can be extremely tedious and error prone to write, and even more so to maintain over time as you add or remove assets to your extention, especially if you have a large number of asset files.
-
-The pipeline makes this easier by allowing you to use the `@` characted instead of a file name the output file path of your asset group. The `@` character disables the bundling step and basically translates to "the same filename as whatever input asset file is currently being processed". When combined with glob wildcards this can make it a lot easier to manage your assets:
+In many cases you will want to process many input files in the exact same way but keep them in separate output files. You could do this by declaring a separate asset group for each pair of input/output files. However this can be extremely tedious and error-prone to write, and even more so to maintain over time as you add or remove assets to your extension, especially if you have a large number of asset files.
+The pipeline makes this easier by allowing you to use the `@` character instead of a file name in the output file path of your asset group. The `@` character disables the bundling step and basically translates to "the same filename as whatever input asset file is currently being processed". When combined with glob wildcards this can make it a lot easier to manage your assets:
 
 ```js
 [

--- a/src/docs/guides/lucene-query-syntax/README.md
+++ b/src/docs/guides/lucene-query-syntax/README.md
@@ -75,7 +75,7 @@ To search, type the field name (e.g., Subtitle) followed by a colon ":".
 `Subtitle:What is Lorem Ipsum?`
 
 
-![text field searche](images/text-field.PNG)
+![text field search](images/text-field.PNG)
 
 
 ## Wildcard Searches
@@ -114,5 +114,4 @@ The search will find terms that begin with "type" and end with "ing" or "service
 `/type.*ing?/`
 
 ![regular expressions](images/regular-expresions.PNG)
-
 

--- a/src/docs/guides/query-content-items-based-on-taxonomy/README.md
+++ b/src/docs/guides/query-content-items-based-on-taxonomy/README.md
@@ -16,7 +16,7 @@ You will use a Razor file to call this query.
 
 To make this sample a little more interesting, we're going to edit the BlogPost content type to allow multiple Category assignments.
 
-Go to Content > Content Definition > Content Types and click to edit Blog Post. Then click Edit next to the "Category" Taxonomy field. Uncheck `Unique` and click `Save`. While we're here, since we want to make the 2 taxonomy fields (Category and Tags) searchable, you can do that now. Click to edit Category, then check the box for `Include this element in the index.`
+Go to Design > Content Definition > Content Types and click to edit Blog Post. Then click Edit next to the "Category" Taxonomy field. Uncheck `Unique` and click `Save`. While we're here, since we want to make the 2 taxonomy fields (Category and Tags) searchable, you can do that now. Click to edit Category, then check the box for `Include this element in the index.`
 
 Now do the same for the `Tags` field on the Blog Post content type.
 

--- a/src/docs/reference/README.md
+++ b/src/docs/reference/README.md
@@ -1,11 +1,11 @@
 # Modules Reference
 
-This is a comprehensive reference for the modules and their features available in Orchard Core. Under each of these pages, you'll find an overview of the given module with documentation on how to use and extend them.
+This is a comprehensive reference for the modules and their features available in Orchard Core. Under each of these pages, you'll find an overview of the given module with documentation on how to use and extend it.
 
 Check out the reference pages for each module under the following categories in the menu:
 
 - CMS Modules: Modules that contain content management features that all interact with content items in some way. E.g. the base content management module, the media management module, or modules related to search and indexing are here.
-- Core Modules: Modules that usually provide some fundamental features for a web app which is not connected to content management, or framework-like functionality that you can build on. These modules include e.g. user and role management, or the UI localization and background task management infrastructure.
+- Core Modules: Modules that usually provide some fundamental features for a web app that is not connected to content management, or framework-like functionality that you can build on. These modules include e.g. user and role management, or the UI localization and background task management infrastructure.
 
 The above distinction is also present in the Orchard Core source code with solution folders. However, this is just a logical categorization and technically all the modules are alike.
 
@@ -41,7 +41,7 @@ Here's a categorized overview of all built-in Orchard Core features at a glance.
     - [Overview](modules/Users/README.md)
     - [Custom User Settings](modules/Users/CustomUserSettings/README.md)
     - [Notifications](modules/Notifications/README.md)
-    - [Ticket store](modules/Users/TicketStore.md)
+    - [Ticket Store](modules/Users/TicketStore.md)
 - [OpenId](modules/OpenId/README.md)
 - [Roles](modules/Roles/README.md)
 
@@ -126,7 +126,7 @@ Here's a categorized overview of all built-in Orchard Core features at a glance.
 - [Deployment](modules/Deployment/README.md)
 - [Diagnostics](modules/Diagnostics/README.md)
 - [Remote Deployment](modules/Deployment.Remote/README.md)
-- [Sms](modules/Sms/README.md)
+- [SMS](modules/Sms/README.md)
 - [Azure Communication SMS](modules/Sms.Azure/README.md)
 
 ### Localization

--- a/src/docs/reference/branding/README.md
+++ b/src/docs/reference/branding/README.md
@@ -4,7 +4,7 @@ Here you can find some guidelines and graphic assets for Orchard Core's branding
 
 # Branding Guidelines
 
-When referring to Orchard Core please use one of the logo variations, without altering anything apart from the resolution (so don't change the colors, aspect ratio, graphics, or anything else). Further information on how to use these assets and colors see the [Branding Guidelines (PDF)](assets/orchard-core-branding-guidelines.pdf) (and [here's the AI version](assets/orchard-core-branding-guidelines.ai)).
+When referring to Orchard Core, please use one of the logo variations, without altering anything apart from the resolution (so don't change the colors, aspect ratio, graphics, or anything else). For further information on how to use these assets and colors, see the [Branding Guidelines (PDF)](assets/orchard-core-branding-guidelines.pdf) (and [here's the AI version](assets/orchard-core-branding-guidelines.ai)).
 
 # Logo Variations
 
@@ -32,7 +32,7 @@ Other formats:
 
 ## Light Logo
 
-The background of this logo in the below display is set to black so it's actually visible but otherwise it has a transparent background.
+The background of this logo in the display below is set to black so it's actually visible, but otherwise it has a transparent background.
 
 <img src="assets/logo/light/orchard-core-logo-light.png" alt="Light Orchard Core logo" style="background-color: #000;">
 
@@ -65,7 +65,7 @@ Other formats:
 
 ## Light Symbol Logo
 
-The background of this logo in the below display is set to black so it's actually visible but otherwise it has a transparent background.
+The background of this logo in the display below is set to black so it's actually visible, but otherwise it has a transparent background.
 
 <img src="assets/logo/symbol/light/orchard-core-symbol-logo-light.png" alt="Light Orchard Core symbol logo" style="background-color: #000;">
 

--- a/src/docs/reference/glossary/README.md
+++ b/src/docs/reference/glossary/README.md
@@ -1,8 +1,8 @@
 # Glossary
 
-List of terms and concepts that you can find in Orchard Core.
+A list of terms and concepts that you can find in Orchard Core.
 
-They are grouped by roles: User, Theme designer, Administrator.
+They are grouped by roles: user, theme designer, administrator.
 
 ## Authenticated users
 
@@ -12,11 +12,11 @@ A single document containing some content of a specific content type, that can b
 
 ### Content Item Version
 
-A single document that represent a specific version of a content item. These can be draft, published, or pasts versions
+A single document that represents a specific version of a content item. These can be draft, published, or past versions.
 
 ### Content Type
 
-Define the list of Content Parts and Content Fields a content item can be made of. An analogy is to compare them to classes, whose instances are the content items.
+Defines the list of Content Parts and Content Fields a content item can be made of. An analogy is to compare them to classes, whose instances are the content items.
 
 ### Content Part
 
@@ -38,7 +38,7 @@ A field can have different Editors (Ex: The value of a Numeric Field can be set 
 
 ### Autoroute
 
-A part that dynamically creates and registers a url to access a content item. It can use a Liquid pattern to be automatically generated.
+A part that dynamically creates and registers a URL to access a content item. It can use a Liquid pattern to be automatically generated.
 See [Autoroute](../modules/Autoroute/README.md)
 
 ### Bag
@@ -47,7 +47,7 @@ A collection of content items of a certain type in a parent content item. The co
 
 ### List
 
-A list of content items to a parent container (Ex: A blog contains a list of blog posts). The content items are referenced.
+A list of content items in a parent container (Ex: A blog contains a list of blog posts). The content items are referenced.
 See [Lists](../modules/Lists/README.md)
 
 ### Taxonomy
@@ -62,27 +62,27 @@ See [Admin menu](../modules/AdminMenu/README.md)
 
 ### Alias
 
-A part that allows you to specify an alias. A way to identify an item with a key that you can call to retrieve it, instead of an Id.  
+A part that allows you to specify an alias. A way to identify an item with a key that you can call to retrieve it, instead of an ID.
 See [Alias](../modules/Alias/README.md)
 
 ### Content Preview
 
-Allows to Preview and Live Edit a content.  
+Allows content preview and live editing.
 See [Content Preview](../modules/ContentPreview/README.md)
 
 ### Indexing
 
-Define the way the content will be indexed in order to search it from a query.  
+Defines the way the content will be indexed in order to search it from a query.
 See [Indexing](../modules/Indexing/README.md)
 
 ### Query
 
-Parameterized Lucene or Sql query defined in admin.  
+Parameterized Lucene or SQL query defined in admin.
 See [Queries](../modules/Queries/README.md)
 
 ### Tenant
 
-An independent subsite with its own url.  
+An independent subsite with its own URL.
 One instance can have multiple tenants.  
 They can only be managed in the Default one.  
 See [Tenants](../modules/Tenants/README.md)
@@ -91,7 +91,7 @@ See [Tenants](../modules/Tenants/README.md)
 
 ### Theme
 
-A module that contains assets (Images, Styles, Scripts) and views used to customize the display.  
+A module that contains assets (images, styles, scripts) and views used to customize the display.
 It can also contain a recipe to initialize some content types and content items.
 
 ### Liquid
@@ -101,12 +101,12 @@ See [Liquid](../modules/Liquid/README.md)
 
 ### Alternate
 
-An override of content type or part or field using a file in a Theme.  
+An override of a content type, part, or field using a file in a theme.
 See [Alternates](../modules/Templates/README.md#shape-differentiators)
 
 ### Placement
 
-A mapping file to set the order of appearance or hide contents for a specific content type or Part/Field name or display type in a Theme.  
+A mapping file to set the order of appearance or hide content for a specific content type, part/field name, or display type in a theme.
 See [Placement](../modules/Placement/README.md)
 
 ### Assets

--- a/src/docs/reference/libraries/README.md
+++ b/src/docs/reference/libraries/README.md
@@ -1,6 +1,6 @@
 # Libraries
 
-The below table lists the different .NET libraries used in Orchard Core:
+The table below lists the different .NET libraries used in Orchard Core:
 
 | Library                                                                                                                                                                                                                    | Usage                                                                                                                                                   | License                                                                           |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
@@ -46,7 +46,7 @@ The below table lists the different .NET libraries used in Orchard Core:
 | [YesSql](https://github.com/sebastienros/yessql)                                                                                                                                                                           | .NET document database working on any RDBMS.                                                                                                            | [MIT](https://github.com/sebastienros/yessql/blob/dev/LICENSE)                    |
 | [ZString](https://github.com/Cysharp/ZString)                                                                                                                                                                              | Zero Allocation StringBuilder for .NET Core and Unity.                                                                                                  | [MIT](https://github.com/Cysharp/ZString/blob/master/LICENSE)                     |
 
-The below table lists the different libraries used as Resources:
+The table below lists the different libraries used as resources:
 
 | Library | Usage | License |
 |--- | --- | --- |

--- a/src/docs/reference/modules/Admin/README.md
+++ b/src/docs/reference/modules/Admin/README.md
@@ -4,7 +4,7 @@ The Admin module provides an admin dashboard for your site.
 
 ## Custom Admin prefix
 
-If you want to specify another prefix in the urls to access the admin section, you can change it by using this option in the `appsettings.json`:
+If you want to specify another prefix in the URLs to access the admin section, you can change it by using this option in the `appsettings.json`:
 
 ```json
   "OrchardCore": {

--- a/src/docs/reference/modules/AdminMenu/README.md
+++ b/src/docs/reference/modules/AdminMenu/README.md
@@ -30,7 +30,7 @@ You can disable an Admin Node and neither it nor their descendants will be shown
 
 At the time of writing this document there are 3 Admin Node Types provided out of the box by Orchard Core:
 
-1. **Link Admin Node**: It provides a simple menu item. The user can add a text, a url and a Font Awesome icon class so that the current admin theme can use them when rendering the menu item. At the moment TheAdmin theme is using that icon class only for first level menu items.
+1. **Link Admin Node**: It provides a simple menu item. The user can add a text, a URL, and a Font Awesome icon class so that the current admin theme can use them when rendering the menu item. At the moment TheAdmin theme is using that icon class only for first level menu items.
 This link is the only one provided by the OrchardCore.AdminMenu module itself.
 
 2. **Content Types Admin Node**: It provides a list of menu items containing a menu item for each content type. The links point to the Index action in the Contents Controller.
@@ -62,7 +62,7 @@ The Admin Menu that OrchardCore provides out of the box it's built broadly speak
 
 ## Deployment Plan Step and Recipe Step
 
-The module provides an Admin Menu Deployment Step. So an admin user can expend some time configuring a custom admin menu, add it to a deployment plan, export a json file, and use the generated json on a setup recipe. This way the sites that are built using that recipe will have the admin menu as the user prepared it.
+The module provides an Admin Menu Deployment Step. So an admin user can spend some time configuring a custom admin menu, add it to a deployment plan, export a JSON file, and use the generated JSON on a setup recipe. This way the sites that are built using that recipe will have the admin menu as the user prepared it.
 
 ## Permissions
 

--- a/src/docs/reference/modules/Apis.GraphQL.Abstractions/README.md
+++ b/src/docs/reference/modules/Apis.GraphQL.Abstractions/README.md
@@ -124,7 +124,7 @@ public sealed class Startup : StartupBase
 
 The main thing to take away from this class is that all Input Types must inherit off of InputObjectGraphType.
 
-When an input part is registered, it adds in that part as the parent query, in this instance the autoroutePart, as shown below;
+When an input part is registered, it adds in that part as the parent query, in this instance the autoroutePart, as shown below:
 
 ```json
 {

--- a/src/docs/reference/modules/AutoSetup/README.md
+++ b/src/docs/reference/modules/AutoSetup/README.md
@@ -47,12 +47,12 @@ Auto-Setup parameters are defined in `appsettings.json`. Example excerpt:
 
 | Parameter       | Description                                                                                                                         |
 |-----------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| `AutoSetupPath` | The URL To Trigger AutoSetup For Each Tenant. If empty, auto-setup will be triggered on first tenant request e.g: /, /tenant-prefix |
+| `AutoSetupPath` | The URL to trigger AutoSetup for each tenant. If empty, auto-setup will be triggered on the first tenant request, e.g. `/`, `/tenant-prefix` |
 | `Tenants`       | The list of the tenants to install.                                                                                                 |
 
 | Parameter                  | Description                                                                                                                                                                                                               |
 |----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ShellName`                | The technical shell / tenant name. It can not be empty and must contain characters only. Use "Default" for the default tenant.                                                                                            |
+| `ShellName`                | The technical shell / tenant name. It cannot be empty and must contain characters only. Use "Default" for the default tenant.                                                                                            |
 | `SiteName`                 | The name of the site.                                                                                                                                                                                                     |
 | `AdminUsername`            | The tenant username of the super user.                                                                                                                                                                                    |
 | `AdminEmail`               | The email of the tenant super user.                                                                                                                                                                                       |
@@ -61,14 +61,14 @@ Auto-Setup parameters are defined in `appsettings.json`. Example excerpt:
 | `DatabaseConnectionString` | The connection string.                                                                                                                                                                                                    |
 | `DatabaseTablePrefix`      | The database table prefix. Can be used to install a tenant on the same database.                                                                                                                                          |
 | `RecipeName`               | The tenant installation Recipe name.                                                                                                                                                                                      |
-| `RequestUrlHost`           | The tenant host url.                                                                                                                                                                                                      |
-| `RequestUrlPrefix`         | The tenant url prefix.                                                                                                                                                                                                    |
+| `RequestUrlHost`           | The tenant host URL.                                                                                                                                                                                                      |
+| `RequestUrlPrefix`         | The tenant URL prefix.                                                                                                                                                                                                    |
 | `FeatureProfile`           | Optionally, the name of the feature profile used by default. Only applicable if the "Feature Profiles" feature is used. See the [documentation of the Tenants module](../Tenants/README.md#feature-profiles) for details. |
 
 !!! note
-    Tenants array must contain the root tenant with `ShellName` equals to `Default`.  
+    Tenants array must contain the root tenant with `ShellName` equal to `Default`.
     Each tenant will be installed on demand (on the first tenant request).  
-    If AutoSetupPath is provided, it must be used to trigger the installation for each tenant e.g:
+    If AutoSetupPath is provided, it must be used to trigger the installation for each tenant, e.g.:
     `/autosetup` - trigger installation of the Root tenant.
     `/mytenant/autosetup` - auto-install mytenant.
 

--- a/src/docs/reference/modules/Autoroute/README.md
+++ b/src/docs/reference/modules/Autoroute/README.md
@@ -10,7 +10,7 @@ Then, go to the definition of a Content Type and edit the Autoroute Part:
 
 - Enter a Pattern using a Liquid expression that will represent the generated slug.
 
-For example, for a content with a `TitlePart` that will use it to generate the slug :
+For example, for content with a `TitlePart` that will use it to generate the slug:
 
 ```liquid
 {{ ContentItem | display_text | slugify }}
@@ -62,7 +62,7 @@ The `AutoroutePart` supports routing of content items which are children of a pa
 
 A _container_ content item is a parent content item, which _contains_ child content items.
 
-For example :
+For example:
 
 - A content item with a `BagPart` attached is a _container or parent_ content item.
 
@@ -72,13 +72,13 @@ For example :
 
 A _contained_ content item refers to a content item which is _contained_ inside a _container_ content item.
 
-For example :
+For example:
 
 - Content items _contained_ inside a `BagPart` are considered _contained or child_ content items.
 
 - `Terms` of a `Taxonomy` are _contained_ by the `Taxonomy`.
 
-_Contained_ content items are stored as part of the json inside the _container_ document.
+_Contained_ content items are stored as part of the JSON inside the _container_ document.
 
 ### Supported Containers
 
@@ -99,19 +99,19 @@ Optionally, add the `AutoroutePart` to the content type definition of the _conta
 
 #### Path Generation
 
-By default when the `AutoroutePart` is added to a _container_ content item and `Route Contained Items` is enabled the generated route will be made up of the _container_ segment, then the `ContentItemId` of the _contained_ content item, and if present, the `DisplayText`.
+By default, when the `AutoroutePart` is added to a _container_ content item and `Route Contained Items` is enabled, the generated route will be made up of the _container_ segment, then the `ContentItemId` of the _contained_ content item, and if present, the `DisplayText`.
 
-For example :
+For example:
 `https://www.mysite.com/categories/47twnxzx9hs5k3dyn9j1mc5rny-travel`
 
 To configure a friendly slug for the child content items add the `AutoroutePart` to the content type definition for those content types.
 
 You are then able to use the `Liquid` pattern to generate a friendly slug.
 
-For example :
+For example:
 `https://www.mysite.com/categories/travel`
 
-Routing is, by default, relative to the parent, and there is no `Liquid` filter for the parent as there is with the `ListPart`
+Routing is, by default, relative to the parent, and there is no `Liquid` filter for the parent as there is with the `ListPart`.
 
 #### AutoroutePart Settings
 
@@ -127,9 +127,9 @@ Enable this on a `contained` content type definition, i.e. the child, to allow t
 
 ##### Allow Absolute Path
 
-Enabled `AllowAbsolutePath` to allow a user to set a path as absolute.
+Enable `AllowAbsolutePath` to allow a user to set a path as absolute.
 
-By default _container_ routing will build a url relative to the _containers_ route.
+By default, _container_ routing will build a URL relative to the _container_ route.
 
 ##### Allow Disabled
 
@@ -141,7 +141,7 @@ Use this option when you have a _container_ with two `BagParts` and routing shou
 
 ##### Disabled
 
-Content editors can select to disabled route generation for a particular _contained_ content item.
+Content editors can select to disable route generation for a particular _contained_ content item.
 
 ##### Route Contained Items
 

--- a/src/docs/reference/modules/BackgroundTasks/README.md
+++ b/src/docs/reference/modules/BackgroundTasks/README.md
@@ -2,7 +2,7 @@
 
 This module provides tools to manage background tasks. This includes an admin UI to show which background tasks are registered with the ability to enable and disable them.
 
-After enabling the feature, you'll be able to manage background tasks under Configuration → Tasks → Background Tasks. This includes the following:
+After enabling the feature, you'll be able to manage background tasks under Tools → Background Tasks. This includes the following:
 
 - Enable or disable a task.
 - Change the schedule of the task, i.e. how frequently it runs, with [cron expressions](https://en.wikipedia.org/wiki/Cron#Cron_expression).

--- a/src/docs/reference/modules/Configuration/README.md
+++ b/src/docs/reference/modules/Configuration/README.md
@@ -4,11 +4,11 @@ Orchard Core extends ASP.NET Core `IConfiguration` with `IShellConfiguration` to
 
 To learn more about ASP.NET Core `IConfiguration` visit <https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration>.
 
-Note that while this documentation page explains configuration happening in the root web app project on the example of `OrchardCore.Cms.Web.csproj` if you use Orchard from NuGet packages in your own web app then same is available in that web app project too.
+Note that while this documentation page explains configuration in the root web app project by using `OrchardCore.Cms.Web.csproj` as an example, if you use Orchard from NuGet packages in your own web app, the same is available in that web app project too.
 
 ## Configuration Sources
 
-Orchard Core built on top of ASP.NET Core Configuration framework, which support a variety of different configuration options. Developers are not limited to using a single configuration source. In fact several may be set up together such that a default configuration is overridden by settings from another source if they are present.
+Orchard Core is built on top of the ASP.NET Core configuration framework, which supports a variety of different configuration options. Developers are not limited to using a single configuration source. In fact, several may be set up together such that a default configuration is overridden by settings from another source if they are present.
 
 The Configuration Sources are loaded in the order described in [Configuration Sources Order](#configuration-sources-order) below.
 
@@ -173,8 +173,8 @@ These settings can also be located in an `App_Data/appsettings.json` folder (not
 
 ### `IShellConfiguration` in the Individual Tenants Folder
 
-These settings are mutable and written during the setup for the Tenant. For this reason reading from Environment Name is not supported.
-Additionally these `appsettings.json` files do not need the `OrchardCore` section
+These settings are mutable and written during the setup for the tenant. For this reason, reading from Environment Name is not supported.
+Additionally, these `appsettings.json` files do not need the `OrchardCore` section.
 
 ```json
 {

--- a/src/docs/reference/modules/ContentTypes/README.md
+++ b/src/docs/reference/modules/ContentTypes/README.md
@@ -229,7 +229,7 @@ Content types can be configured with a category and thumbnail for use in block p
 
 Content types can be organized into categories. To set a category:
 
-1. Navigate to **Content Definition** → **Content Types**
+1. Navigate to **Design** → **Content Definition** → **Content Types**
 2. Edit the content type
 3. In the **Content Type Settings** section, set the **Category** field
 
@@ -247,7 +247,7 @@ Content types with the same category are grouped together in the picker's sideba
 
 Content types can display a thumbnail image in block pickers. To set a thumbnail:
 
-1. Navigate to **Content Definition** → **Content Types**
+1. Navigate to **Design** → **Content Definition** → **Content Types**
 2. Edit the content type
 3. In the **Content Type Settings** section, set the **Thumbnail Path** field to an image path (e.g., `/media/thumbnails/my-widget.png`)
 

--- a/src/docs/reference/modules/DisplayManagement/README.md
+++ b/src/docs/reference/modules/DisplayManagement/README.md
@@ -185,4 +185,3 @@ Tag helper example:
 
 ### Related Articles
 - [Placement](../Placement/README.md)
-

--- a/src/docs/reference/modules/Facebook/README.md
+++ b/src/docs/reference/modules/Facebook/README.md
@@ -44,8 +44,9 @@ If no value is provided, setup Meta app to use the default path /signin-facebook
 
 ## Users Registration
 
-- If you want to enable new users to register to the site through their Meta login, the `OrchardCore.Users.Registration` feature must be enabled and setup accordingly.
-- An existing user can link his account to his Meta login through the External Logins link from User menu
+- Enable the `OrchardCore.Users.Registration` feature when you also want local site registration.
+- New external-user creation and profile generation are controlled from the Users module's [`ExternalRegistrationSettings`](../Users/README.md#external-authentication-settings).
+- An existing user can link the account through the External Logins link from the user menu.
 
 ## Meta Social Plugins Widgets
 

--- a/src/docs/reference/modules/Flow/BagPart.md
+++ b/src/docs/reference/modules/Flow/BagPart.md
@@ -27,7 +27,7 @@ To enable the blocks editor for a BagPart, set the **Editor** option to `Blocks`
 
 This can be done in the admin UI:
 
-1. Navigate to **Content Definition** → **Content Types**
+1. Navigate to **Design** → **Content Definition** → **Content Types**
 2. Edit the content type containing the BagPart
 3. Click **Edit** on the BagPart
 4. Set the **Editor** field to `Blocks`

--- a/src/docs/reference/modules/Flow/README.md
+++ b/src/docs/reference/modules/Flow/README.md
@@ -76,7 +76,7 @@ To enable the blocks editor for a FlowPart or BagPart, set the **Editor** option
 
 This can be done in the admin UI:
 
-1. Navigate to **Content Definition** → **Content Types**
+1. Navigate to **Design** → **Content Definition** → **Content Types**
 2. Edit the content type containing the FlowPart or BagPart
 3. Click **Edit** on the FlowPart or BagPart
 4. Set the **Editor** field to `Blocks`

--- a/src/docs/reference/modules/Forms/README.md
+++ b/src/docs/reference/modules/Forms/README.md
@@ -23,7 +23,7 @@ Creating a form typically involves the following steps:
 
 ### Configuring Form Visibility
 
-Once your form’s basic structure is in place, you can enhance it with conditional visibility rules. These allow you to hide or show certain fields based on the values of other fields. For example:
+Once your form's basic structure is in place, you can enhance it with conditional visibility rules. These allow you to hide or show certain fields based on the values of other fields. For example:
 
 1. In the **Form editor**, select the input widget you want to control and expand its **Visibility Settings** pane.  
 2. Choose an **Action**:

--- a/src/docs/reference/modules/GitHub/README.md
+++ b/src/docs/reference/modules/GitHub/README.md
@@ -20,8 +20,9 @@ If no value is provided, setup Authorization callback URL in GitHub app to use t
 
 ## Users Registration
 
-- If you want to enable new users to register to the site through their GitHub account, the `OrchardCore.Users.Registration` feature must be enabled and setup accordingly.
-- An existing user can link his account to his GitHub account through the External Logins link from User menu.
+- Enable the `OrchardCore.Users.Registration` feature when you also want local site registration.
+- New external-user creation and profile generation are controlled from the Users module's [`ExternalRegistrationSettings`](../Users/README.md#external-authentication-settings).
+- An existing user can link the account through the External Logins link from the user menu.
 
 ## Recipe Configuration
 

--- a/src/docs/reference/modules/Google/README.md
+++ b/src/docs/reference/modules/Google/README.md
@@ -54,8 +54,9 @@ If no value is provided, setup Callback URL in Google API to use the default pat
 
 ## Users Registration
 
-+ If you want to enable new users to register to the site through their Google account, the `OrchardCore.Users.Registration` feature must be enabled and setup accordingly.
-+ An existing user can link his account to his Google account through the External Logins link from User menu.
+- Enable the `OrchardCore.Users.Registration` feature when you also want local site registration.
+- New external-user creation and profile generation are controlled from the Users module's [`ExternalRegistrationSettings`](../Users/README.md#external-authentication-settings).
+- An existing user can link the account through the External Logins link from the user menu.
 
 ## Google Settings Configuration
 

--- a/src/docs/reference/modules/KeyVault.Azure/README.md
+++ b/src/docs/reference/modules/KeyVault.Azure/README.md
@@ -1,6 +1,6 @@
 # Azure Key Vault (`OrchardCore.Azure.KeyVault`)
 
-The Azure Key Vault configuration provider adds app configuration values from the Azure Key Vault in order to safeguard your cryptographic keys and secrets used by your app. It also contains custom override of the DefaultKeyVaultManager class that retrieves secrets from Azure Key Vault and translates --- to an underscore (_)  and -- to a colon (:). Both underscores and colons are illegal characters in Azure KeyVault.
+The Azure Key Vault configuration provider adds app configuration values from the Azure Key Vault in order to safeguard your cryptographic keys and secrets used by your app. It also contains a custom override of the DefaultKeyVaultManager class that retrieves secrets from Azure Key Vault and translates --- to an underscore (_) and -- to a colon (:). Both underscores and colons are illegal characters in Azure Key Vault.
 
 Example:
 Key Vault Input: "OrchardCore--OrchardCore---Shells---Database--ConnectionString".
@@ -11,7 +11,7 @@ See <https://github.com/OrchardCMS/OrchardCore/issues/6359>.
 
 By default, the Azure Key Vault configuration provider uses the [Azure Identity library](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/identity/Azure.Identity/README.md) for Microsoft Entra ID (Azure Active Directory) token authentication support across the Azure SDK. At this time, the OrchardCore.Azure.KeyVault only supports the DefaultAzureCredential setting, which is appropriate for most scenarios where the application is intended to be run in Azure.
 
-When debugging or executing locally, developers have several options for authenticating with Azure Key Vault. To authenticate in Visual Studio select the Tools > Options menu to launch the Options dialog. Then navigate to the Azure Service Authentication options to sign in with your Microsoft Entra ID account. Developers using Visual Studio Code can use the [Azure Account Extension], to authenticate via the IDE.
+When debugging or executing locally, developers have several options for authenticating with Azure Key Vault. To authenticate in Visual Studio, select the Tools > Options menu to launch the Options dialog. Then navigate to the Azure Service Authentication options to sign in with your Microsoft Entra ID account. Developers using Visual Studio Code can use the [Azure Account Extension] to authenticate via the IDE.
 
 ## Configuration
 

--- a/src/docs/reference/modules/Localize/README.md
+++ b/src/docs/reference/modules/Localize/README.md
@@ -23,8 +23,8 @@ PO files are found at these locations:
 
 `[CultureName]` can be either the culture neutral part, e.g. `fr`, or the full one, e.g. `fr-CA`.
 
-It is suggested to put your localization files in the `/Localization/` folder if you are using docker.  
-Especially if mounting a volume at `/App_Data/` as mounting hides pre-existing files.
+It is suggested to put your localization files in the `/Localization/` folder if you are using Docker.
+Especially if mounting a volume at `/App_Data/`, as mounting hides pre-existing files.
 
 !!! note
     If you edit a .po file, you need to restart the application to make your change effective.

--- a/src/docs/reference/modules/Media.Azure/README.md
+++ b/src/docs/reference/modules/Media.Azure/README.md
@@ -113,7 +113,7 @@ worldwide, and each of these will maintain their own cache, so while a local CDN
 another PoP may not, until it is requested. At this stage the Media Cache will, if necessary, refetch the
 asset from Azure Blog Storage, on the fly, and provide it to the CDN PoP.
 
-CDN providers also clear their caches at pre-determined times of their own devising, so while CDN’s
+CDN providers also clear their caches at pre-determined times of their own devising, so while CDN's
 are a valuable caching and performance asset, it is important that they are always be able to
 re-fetch the source file, as and when required, which the Media Cache Module will automatically handle.
 

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -224,13 +224,13 @@ To use [Image Anchors](#image-anchors), use the `GetAnchors` helper extension me
 
 ### Razor image resizing tag helpers
 
-To use the image tag helpers add `@addTagHelper *, OrchardCore.Media` to `_ViewImports.cshtml`, and take a direct reference to the `OrchardCore.Media` nuget package.
+To use the image tag helpers, add `@addTagHelper *, OrchardCore.Media` to `_ViewImports.cshtml`, and take a direct reference to the `OrchardCore.Media` NuGet package.
 
 `asset-src` is used to obtain the correct URL for the asset and set the `src` attribute. Width, height, resize mode, quality and format can be set using `img-width`, `img-height`, `img-resize-mode`, `img-quality`, and `img-format` respectively. e.g.:
 
 `<img asset-src="Model.Paths[0]" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" img-quality="50" img-format="Jpg" />`
 
-Alternatively the Asset Url can be resolved independently and the `src` attribute used:
+Alternatively the Asset URL can be resolved independently and the `src` attribute used:
 
 `<img src="@Orchard.AssetUrl(Model.Paths[0])" alt="..." img-width="100" img-height="240" img-resize-mode="Crop" img-quality="50" img-format="Jpg" />`
 
@@ -260,7 +260,7 @@ To use a [Image Anchor](#image-anchors) set the `asset-src` property and the `im
 
 `<img asset-src="Model.Paths[0]" alt="..." asp-append-version="true" />`
 
-Alternatively the Asset Url can be resolved independently and the `src` attribute used:
+Alternatively the Asset URL can be resolved independently and the `src` attribute used:
 
 `<img src="@Orchard.AssetUrl(Model.Paths[0])" alt="..." asp-append-version="true" />`
 
@@ -427,11 +427,11 @@ services.Configure<StaticFileOptions>(o => ...);
 
 ## Media Profiles
 
-Media profiles allow you to defined preset image resizing and formatting commands.
+Media profiles allow you to define preset image resizing and formatting commands.
 
 You can create a media profile from the _Media -> Profiles_ menu.
 
-When specifying a media profile with either the liquid, razor helper, or tag helper you provide the profile name, and any additional commands which you want to apply to the media item.
+When specifying a media profile with either the Liquid, Razor helper, or tag helper, you provide the profile name and any additional commands which you want to apply to the media item.
 
 === "Liquid"
 
@@ -518,7 +518,15 @@ When the query string is signed with a token any width, height value may be used
 Media can be optionally indexed for search as well if files are referenced via Media Fields. The following data can be indexed for each file referenced from a Media Field:
 
 - Media Text
-- Textual content of PDF files
+- Text extracted from additional file formats when the corresponding indexing feature is enabled
+
+File extraction is available through explicit features:
+
+- `OrchardCore.Media.Indexing.Pdf` for `.pdf`
+- `OrchardCore.Media.Indexing.Text` for `.txt` and `.md`
+- `OrchardCore.Media.Indexing.OpenXML` for `.docx` and `.pptx`
+
+Enable the feature that corresponds to the file types you want to extract and index.
 
 !!! note
     Standalone files, i.e. files that are just uploaded to the Media Library but never referenced from a content item via a Media Field, can't be indexed.
@@ -616,7 +624,13 @@ To increase the limit, you can use one of the following approaches:
 
 ## Media Indexing
 
-The `Media Indexing` feature extends the media indexing capability to also encompass searching within files with the following extensions `.txt`, `.md`, `.docx`, and `.pptx`.
+The base `Media Indexing` feature indexes media text stored by media fields. Additional file extraction is enabled by feature:
+
+| Feature | File types |
+|---|---|
+| `OrchardCore.Media.Indexing.Pdf` | `.pdf` |
+| `OrchardCore.Media.Indexing.Text` | `.txt`, `.md` |
+| `OrchardCore.Media.Indexing.OpenXML` | `.docx`, `.pptx` |
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/BQHUlvPFRR4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/src/docs/reference/modules/Microsoft.Authentication/README.md
+++ b/src/docs/reference/modules/Microsoft.Authentication/README.md
@@ -1,6 +1,6 @@
 # Microsoft Authentication (`OrchardCore.Microsoft.Authentication`)
 
-This module configures Orchard to support Microsoft Account and/or Microsoft Microsoft Entra ID (Azure Active Directory) accounts.
+This module configures Orchard to support Microsoft Account and/or Microsoft Entra ID (Azure Active Directory) accounts.
 
 ## Microsoft Account
 
@@ -92,8 +92,9 @@ The Microsoft Entra ID can be set during recipes using the settings step. Here i
 
 ## User Registration
 
-- If you want to enable new users to register to the site through their Microsoft Account and/or Microsoft Microsoft Entra ID login, the `OrchardCore.Users.Registration` feature must be enabled and setup accordingly.
-- Apart from during login, existing users can link their account to their Microsoft Account and/or Microsoft Microsoft Entra ID login through the External Logins link from User menu.
+- Enable the `OrchardCore.Users.Registration` feature when you want local site registration in addition to Microsoft Account or Microsoft Entra ID authentication.
+- New external-user creation and profile generation are controlled from the Users module's [`ExternalRegistrationSettings`](../Users/README.md#external-authentication-settings).
+- Apart from during login, existing users can link their account to their Microsoft Account and/or Microsoft Entra ID login through the External Logins link from User menu.
 
 ### Settings Recipe Step
 

--- a/src/docs/reference/modules/Notifications/README.md
+++ b/src/docs/reference/modules/Notifications/README.md
@@ -30,10 +30,10 @@ Available Options and Their Definitions:
 
 ## Notification Methods
 
-There are many methods to send notifications to a user (e.x., Email, Web Push, Mobile Push, SMS, etc.) Any notification sent will be centralized in the notification center before being dispatched to users according to their specified preferences.
+There are many methods to send notifications to a user (e.g., Email, Web Push, Mobile Push, SMS, etc.). Any notification sent will be centralized in the notification center before being dispatched to users according to their specified preferences.
 
 !!! info
-When multiple notification methods are enabled, the user can opt-in/out any method they wishes to receive by editing their profile.
+When multiple notification methods are enabled, the user can opt in/out of any method they wish to receive by editing their profile.
 
 ### Email Notifications
 
@@ -44,14 +44,14 @@ When using `Email Notifications` feature, you must also configure the [Email Ser
 
 ### SMS Notifications
 
-The `SMS Notifications` feature offers a means to inform users by dispatching notifications through phone via SMS provider.
+The `SMS Notifications` feature offers a means to inform users by dispatching notifications by phone via an SMS provider.
 
 !!! note
 When using `SMS Notifications` feature, you must also configure the [SMS Services](../Sms/README.md).
 
 ## Adding Custom Notification Provider
 
-To add a new notification method like `Web Push`, `Mobile Push` or `SMS`, you can simply implement the `INotificationMethodProvider` interface. Then, register your new implementation. For example, in the `Email Notifications` feature we register the email notification provider like this
+To add a new notification method like `Web Push`, `Mobile Push`, or `SMS`, you can simply implement the `INotificationMethodProvider` interface. Then, register your new implementation. For example, in the `Email Notifications` feature, we register the email notification provider like this:
 
 ```csharp
 [Feature("OrchardCore.Notifications.Email")]
@@ -66,7 +66,7 @@ public class EmailNotificationsStartup : StartupBase
 
 ## How to send a notification
 
-You can send notification to a user via code by injecting `INotificationService` then calling the `SendAsync(...)` method. Alternatively, you can use workflows to notify a user about an event that took place.
+You can send a notification to a user via code by injecting `INotificationService`, then calling the `SendAsync(...)` method. Alternatively, you can use workflows to notify a user about an event that took place.
 
 ```csharp
 using OrchardCore.Notifications;

--- a/src/docs/reference/modules/OpenId/README.md
+++ b/src/docs/reference/modules/OpenId/README.md
@@ -64,7 +64,7 @@ to allow third-party resource servers to use the JWT tokens produced by the Orch
 - Allow Client Credentials Flow: It requires that the Token Endpoint is enabled. More info at <https://tools.ietf.org/html/rfc6749#section-1.3.4>
 - Allow Authorization Code Flow: It requires that the Authorization and Token Endpoints are enabled. More info at <http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth>
 - Allow Implicit Flow: It requires that the Authorization Endpoint is enabled. More info at <http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth>
-- Allow Refresh Token Flow: It allows to refresh access token using a refresh token. It can be used in combination with Password Flow, Authorization Code Flow and Hybrid Flow. More info at <http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens>
+- Allow Refresh Token Flow: It allows refreshing the access token using a refresh token. It can be used in combination with Password Flow, Authorization Code Flow, and Hybrid Flow. More info at <http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens>
 - Require Proof Key for Code Exchange: Global setting that applies PKCE to all registered clients whether or not the 'Require PKCE' flag was set in the Application settings page.
 
 A sample of OpenID Connect Settings recipe step:
@@ -117,14 +117,14 @@ OpenID Connect apps require the following configuration.
   - Allow Client Credentials Flow: It requires that the Token Endpoint is enabled. More info at <https://tools.ietf.org/html/rfc6749#section-1.3.4>
   - Allow Authorization Code Flow: It requires that the Authorization and Token Endpoints are enabled. More info at <http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth>
   - Allow Implicit Flow: It requires that the Authorization Endpoint is enabled. More info at <http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth>
-  - Allow Refresh Token Flow: It allows to refresh access token using a refresh token. It can be used in combination with Password Flow, Authorization Code Flow and Hybrid Flow. More info at <http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens>
+  - Allow Refresh Token Flow: It allows refreshing the access token using a refresh token. It can be used in combination with Password Flow, Authorization Code Flow, and Hybrid Flow. More info at <http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens>
 - Normalized RoleNames: This configuration is only required if Client Credentials Flow is enabled. It determines the roles assigned to the app when it is authenticated using that flow.
 - Redirect Options: Those options are only required when Implicit Flow, Authorization Code Flow or Allow Hybrid Flow is required.
 - Logout Redirect Uri: logout callback URL.
 - Redirect Uri: callback URL.
 - Skip Consent: sets whether a consent form has to be completed by the user after log in.
 - Advanced Parameters: Allows setting additional parameters that can be sent with the authorize request. Note: The default parameters are set from the options above.
-- Require PKCE: Applies PKCE for the registered application.  Ensure that the client library being used suppports PKCE.  
+- Require PKCE: Applies PKCE for the registered application. Ensure that the client library being used supports PKCE.
 
 A sample of OpenID Connect App recipe step:
 
@@ -279,7 +279,7 @@ A sample of Token Validation Settings recipe step:
 ## OIDC Client
 
 Authenticates users from an external OpenID Connect identity provider.
-If the site allows to register new users, a local user is linked and the external login is linked.
+If the site allows new users to register, a local user and the external login are linked.
 If an "email" claim is received, and a local user is found, then the external login is linked to that account, after authenticating.
 
 ### OpenId Configuration

--- a/src/docs/reference/modules/Placements/README.md
+++ b/src/docs/reference/modules/Placements/README.md
@@ -22,7 +22,7 @@ You can also choose to store placements in a file by enabling 'Placements file s
 
 Placements are defined by shape name.
 For each shape you can define a set of placements rules.
-Placements rules is a JSON array, similar to a `placement.json` file entry, as defined in the [Placement documentation](../Placement/README.md#format).
+Placement rules are a JSON array, similar to a `placement.json` file entry, as defined in the [Placement documentation](../Placement/README.md#format).
 
 ## Video
 

--- a/src/docs/reference/modules/ReCaptcha/README.md
+++ b/src/docs/reference/modules/ReCaptcha/README.md
@@ -39,7 +39,7 @@ you can create your own implementation of the IDetectRobots interface and it wil
 
 ## Using with a form post with Content-Type = "application/json" from a javascript framework
 
-The ReCaptcha api uses the data-callback attribute to return the token generated when validating the ReCaptcha widget. This allows to post that token from an Angular, Vue.js form post. If you want to validate the ReCaptcha from the Workflow task you will need to pass the token in the header of your request as "g-recaptcha-response".
+The ReCaptcha API uses the data-callback attribute to return the token generated when validating the ReCaptcha widget. This allows posting that token from an Angular or Vue.js form post. If you want to validate the ReCaptcha from the Workflow task, you will need to pass the token in the header of your request as "g-recaptcha-response".
 
 ## Shapes
 

--- a/src/docs/reference/modules/Recipes/README.md
+++ b/src/docs/reference/modules/Recipes/README.md
@@ -63,7 +63,7 @@ These helpers allow dynamic expressions inside recipe values using a special syn
 | `localization` | `"value": "[localization:WelcomeTitle]"`                                            | Retrieves localized strings by key.                                                                                    |
 | `uuid`         | `"Id": "[js:uuid()]"`                                                               | Generates a new unique identifier (UUID/GUID).                                                                         |
 | `base64`       | `"data": "[js:base64('ew0KICAgICJ0eXBlIjogIkNvbnRlbnRJdGVtL0Jsb2dQb3N0Ig0KfQ==')]"` | Decodes the specified string from Base64 encoding. Use https://www.base64-image.de/ to convert your files to base64.   |
-| `html`         | `"html": "[js:html('&lt;p&gt;Hello &amp; welcome&lt;/p&gt;')]"`                     | Decodes the specified string from HTML encoding..                                                                      |
+| `html`         | `"html": "[js:html('&lt;p&gt;Hello &amp; welcome&lt;/p&gt;')]"`                     | Decodes the specified string from HTML encoding.                                                                       |
 | `gzip`         | `"data": "[js:gzip('data')]"`                                                       | Decodes the specified string from gzip/base64 encoding. Use http://www.txtwizard.net/compression to gzip your strings. |
 
 ---
@@ -457,7 +457,7 @@ Recipe files must be stored in a `Migrations` folder within your project, and th
 
 ### Example: Media Asset Migration
 
-Let's say we want to deploy media assets as part of a module. Here’s how we’d structure this:
+Let's say we want to deploy media assets as part of a module. Here's how we'd structure this:
 
 #### Migration Class
 

--- a/src/docs/reference/modules/Resources/README.md
+++ b/src/docs/reference/modules/Resources/README.md
@@ -29,12 +29,12 @@ Enabling UseCdn will configure the `IResourceManager` to provide any scripts or 
 
 ### `ResourceDebugMode`
 
-When enabled will serve scripts or styles, that have a CDN configured, or a debug-src, from the local server in non minified format.  
+When enabled, this will serve scripts or styles that have a CDN configured, or a debug-src, from the local server in non-minified format.
 This will also disable the `CdnBaseUrl` prepending.
 
 ### `CdnBaseUrl`
 
-When supplied this will prepend local resources served via the `IResourceManager` or Tag Helpers with the absolute url provided. This will be disabled in `ResourceDebugMode`
+When supplied, this will prepend local resources served via the `IResourceManager` or Tag Helpers with the absolute URL provided. This will be disabled in `ResourceDebugMode`.
 
 ## Named Resources
 
@@ -188,7 +188,7 @@ This will use the latest available version between `3.4` and `3.5`. If the versi
 settings.UseAppendVersion(true);
 ```
 
-This will append a version string that is calculated at runtime as an SHA256 hash of the file, the calculation cached, and appended to the url as part of the query string, e.g. `my-script.js?v=eER9OO6zWGKaIq1RlNjImsrWN9y2oTgQKg2TrJnDUWk`
+This will append a version string that is calculated at runtime as an SHA256 hash of the file, with the calculation cached, and appended to the URL as part of the query string, e.g. `my-script.js?v=eER9OO6zWGKaIq1RlNjImsrWN9y2oTgQKg2TrJnDUWk`
 
 #### Register custom script
 

--- a/src/docs/reference/modules/Roles/README.md
+++ b/src/docs/reference/modules/Roles/README.md
@@ -49,11 +49,11 @@ A sample of a roles configuration step:
 }
 ```
 
-As of version 3.0, the `Roles` recipe includes the ability to define specific permission behaviors, giving you greater control over how permissions are managed within a role. The following behaviors are available:
+The `Roles` recipe step supports specific permission behaviors so you can control how permissions are managed within a role. The following behaviors are available:
 
 - **Replace**: This behavior removes all existing permissions associated with the role and replaces them with the new permissions from the `Permissions` collection. This is the default behavior.
 - **Add**: This behavior adds the new permission(s) from the `Permissions` collection to the role, but only if they do not already exist. Existing permissions are left unchanged.
-- **Remove**: This behavior removes the specified permission(s) from the role’s existing permissions based on the `Permissions` collection.
+- **Remove**: This behavior removes the specified permission(s) from the role's existing permissions based on the `Permissions` collection.
 
 ### Example: Adding a New Permission to a Role
 

--- a/src/docs/reference/modules/Scripting/README.md
+++ b/src/docs/reference/modules/Scripting/README.md
@@ -121,7 +121,7 @@ var plainText = decrypt(encryptedValue);
 | `isHomepage(): Boolean`          | Returns true if the current request Url is the current homepage                                                                      |
 | `isAnonymous(): Boolean`         | Returns true if there is no authenticated user on the current request                                                                |
 | `isAuthenticated(): Boolean`     | Returns true if there is an authenticated user on the current request                                                                |
-| `url(url: String): Boolean`      | Returns true if the current url matches the provided url. Add a `*` to the end of the url parameter to match any url that start with |
+| `url(url: String): Boolean`      | Returns true if the current URL matches the provided URL. Add a `*` to the end of the URL parameter to match any URL that starts with the provided value. |
 | `culture(name: String): Boolean` | Returns true if the current culture name or the current culture's parent name matches the `name` argument                            |
 
 #### Queries (`OrchardCore.Queries`)

--- a/src/docs/reference/modules/Shortcodes/README.md
+++ b/src/docs/reference/modules/Shortcodes/README.md
@@ -16,7 +16,7 @@ Shortcode templates are designed to be able to override a code based Shortcode o
 |--------------------|------------------------------------------------------------------------------------------|
 | `Name`             | The name of your Shortcode, without brackets.                                            |
 | `Hint`             | The hint to display for your Shortcode.                                                  |
-| `Usage`            | An html string to describe the usage and arguments for your Shortcode.                   |
+| `Usage`            | An HTML string to describe the usage and arguments for your Shortcode.                   |
 | `Categories`       | The categories your Shortcode falls under.                                               |
 | `Return Shortcode` | The Shortcode value to return from the Shortcode picker when selected. Defaults to Name. |
 | `Content`          | The Liquid template for your Shortcode.                                                  |
@@ -137,7 +137,7 @@ This will render an image tag for the file `my-image.jpg` in the site's media fo
 The following parameters can be used:
 
 - **alt:** Adds alternative text to your image for the benefit of readers who can't see the image and also good for SEO.
-- **class:** Adds an html class attribute to the image tag for styling.
+- **class:** Adds an HTML class attribute to the image tag for styling.
 - **append_version:** Adds a cache busting query string parameter if set to `true`, i.e. `append_version="true"`.
 - **format:** Change the file format from the original file. Can be jpeg, png, gif or bmp.
 - **quality:** Sets the encoding quality to use for jpeg images. The higher the quality, the larger the file size will be. The value can be from 0 to 100 and defaults to 75.

--- a/src/docs/reference/modules/Taxonomies/README.md
+++ b/src/docs/reference/modules/Taxonomies/README.md
@@ -357,7 +357,7 @@ For instance if a field has two selected terms, there will be two records with a
 
 ## Tags
 
-Tags are a editor and display mode option for taxonomies to allow tagging of content items while editing.
+Tags are an editor and display mode option for taxonomies to allow tagging of content items while editing.
 
 When using the `Tags` mode the display text property of the tag is stored as well as the `TermContentItemId`.
 

--- a/src/docs/reference/modules/Templates/README.md
+++ b/src/docs/reference/modules/Templates/README.md
@@ -339,7 +339,7 @@ This template is called when a content part is rendered for a given stereo type,
 
 ### `[Stereotype]_[DisplayType]__[PartType]__[PartName]`
 
-This template is called when a content part is a re-usable named part and rendered for a given stereotype, with or without a given display type.
+This template is called when a content part is a reusable named part and rendered for a given stereotype, with or without a given display type.
 
 #### Stereotype with Part Type Examples
 
@@ -350,7 +350,7 @@ This template is called when a content part is a re-usable named part and render
 
 ### `[Stereotype]_[DisplayType]__[PartType]__[ShapeType]`
 
-This template is called when a custom shape type is rendered  for a given stereotype type, with or without a given display type.
+This template is called when a custom shape type is rendered for a given stereotype type, with or without a given display type.
 
 #### Stereotype with Part Name and Shape Examples
 
@@ -361,7 +361,7 @@ This template is called when a custom shape type is rendered  for a given stereo
 
 ### `[Stereotype]_[DisplayType]__[PartType]__[PartName]__[ShapeType]`
 
-This template is called for re-usable named content part with  custom shape type and rendered for a given stereotype type, with or without a given display type.
+This template is called for a reusable named content part with a custom shape type and rendered for a given stereotype type, with or without a given display type.
 
 #### Stereotype with Part Name and Custom Shape Examples
 

--- a/src/docs/reference/modules/Tenants/README.md
+++ b/src/docs/reference/modules/Tenants/README.md
@@ -1,6 +1,6 @@
 # Tenants (`OrchardCore.Tenants`)
 
-The `Tenants` module allows to manage tenants from the admin.
+The `Tenants` module allows you to manage tenants from the admin.
 
 ## Static File Provider Feature
 

--- a/src/docs/reference/modules/Themes/README.md
+++ b/src/docs/reference/modules/Themes/README.md
@@ -5,7 +5,7 @@ It also explains the fundamental theming concepts, namely __Shapes__, __Alternat
 
 ## Goals
 
-Let's assume we want to add a portfolio section to our Blog where we could list all the projects we are working on, and be able to manage these projects individually, as opposed to having an static page where we would have to copy-paste the HTML for each project.
+Let's assume we want to add a portfolio section to our Blog where we could list all the projects we are working on, and be able to manage these projects individually, as opposed to having a static page where we would have to copy-paste the HTML for each project.
 
 The portfolio should have its own URL like `/portfolio`, and should display the projects in a predefined order.
 
@@ -56,7 +56,7 @@ Now we can configure the `Portfolio` content type to only accept `Project` conte
 
 Click __Edit__ for the __Bag__ part. Check __Project__ and click __Save__.
 
-Click __Edit__ for the __Autoroute__ part. Enter `{{ ContentItem | display_text | slugify }}` and check __Allow custom path__. Click __Save__. This will generate a customizable url or used what the user defines.
+Click __Edit__ for the __Autoroute__ part. Enter `{{ ContentItem | display_text | slugify }}` and check __Allow custom path__. Click __Save__. This will generate a customizable URL or use the one the user defines.
 
 Take the time to drag and drop the __Title__ part at the top of the list such that it will appear first in the editor. Then click __Save__.
 
@@ -68,7 +68,7 @@ Click on __New__, then __Portfolio__.
 
 Give it a title like `My Project`.
 
-In __Permalink__ enter `portfolio`. This will be the url to display this content item.
+In __Permalink__ enter `portfolio`. This will be the URL to display this content item.
 
 As you click on __Add Item__ you'll notice that only __Project__ is available as configured in the `Bag` part for `Portfolio`.
 
@@ -84,9 +84,9 @@ At that point it already looks like something that could be shipped, and all the
 
 ### Loading the portfolio from the database
 
-When the url `/portfolio` is requested, a custom action is called to render the content item that is associated with this URL.  
-The URL got associated with the portfolio thanks to the __Autoroute__ part that provides this mechanism.  
-The autoroute registers a custom URL and stores the associated content item id.  
+When the URL `/portfolio` is requested, a custom action is called to render the content item that is associated with this URL.
+The URL is associated with the portfolio thanks to the __Autoroute__ part that provides this mechanism.
+The autoroute registers a custom URL and stores the associated content item ID.
 At this point the action will issue a database request to load the portfolio in its entirety, including the projects, as this is how it was modeled with the __Bag__ part.
 
 ### How a Content Item is displayed

--- a/src/docs/reference/modules/Themes/README.md
+++ b/src/docs/reference/modules/Themes/README.md
@@ -34,7 +34,7 @@ This article will explain how to do it with a `BagPart` as it will provide the b
 - a `Text` field to store the link to the project;
 - a `Markdown` part to provide a description in markdown format.
 
-In the admin, select __Content Definition__ then __Content Types__ and create a new type named `Project`. Click __Create__.
+In the admin, select __Design__ then __Content Definition__ then __Content Types__ and create a new type named `Project`. Click __Create__.
 
 Select __Title__ and __Markdown__ for the parts we can add already, then click __Save__.
 
@@ -48,7 +48,7 @@ Take the time to drag and drop the __Title__ part at the top of the list such th
 
 At that point you could already create all the Project content items you want very easily. However we need to create a `Portfolio` type to contain and organize them.
 
-In the admin, select __Content Definition__ then __Content Types__ and create a new type named `Portfolio`. Click __Create__.
+In the admin, select __Design__ then __Content Definition__ then __Content Types__ and create a new type named `Portfolio`. Click __Create__.
 
 Select __Title__, __Autoroute__ and __Bag__, then click __Save__.
 

--- a/src/docs/reference/modules/Users/README.md
+++ b/src/docs/reference/modules/Users/README.md
@@ -49,7 +49,7 @@ This ensures user names are rendered consistently while making use of OrchardCor
 
 ## Two-factor Authentication
 
-Starting with version 1.7, OrchardCore is shipped with everything you need to secure your app with two-factor authentication. To use two-factor authentication, simply enable "Two-Factor Email Method" and/or "Two-Factor Authenticator App Method" features. You can configure the process based on your need by navigating to `Settings` → `Security` → `User Login`. Click on the "Two-Factor Authentication" tab and update the settings as needed.
+Orchard Core includes the features needed to secure your app with two-factor authentication. To use two-factor authentication, enable "Two-Factor Email Method" and/or "Two-Factor Authenticator App Method". Configure the process from `Settings` → `Security` → `User Login` on the "Two-Factor Authentication" tab.
 
 ## User Localization
 

--- a/src/docs/reference/modules/X/README.md
+++ b/src/docs/reference/modules/X/README.md
@@ -36,8 +36,9 @@ If no value is provided, setup Callback URL in Twitter app to use the default pa
 
 ### Users Registration
 
-- If you want to enable new users to register to the site through their Twitter account, the `OrchardCore.Users.Registration` feature must be enabled and setup accordingly.
-- An existing user can link his account to his Twitter account through the External Logins link from User menu.
+- Enable the `OrchardCore.Users.Registration` feature when you also want local site registration.
+- New external-user creation and profile generation are controlled from the Users module's [`ExternalRegistrationSettings`](../Users/README.md#external-authentication-settings).
+- An existing user can link the account through the External Logins link from the user menu.
 
 ## Recipe Configuration
 

--- a/src/docs/releases/1.0.0-beta1.md
+++ b/src/docs/releases/1.0.0-beta1.md
@@ -29,7 +29,7 @@ Release date: November 21st 2017
 - Creating ContentPart alternates automatically [#1135](https://github.com/OrchardCMS/OrchardCore/pull/1135)
 - Issue a ChallengeResult for admin pages [#1132](https://github.com/OrchardCMS/OrchardCore/pull/1132)
 - Update vscode settings [#1126](https://github.com/OrchardCMS/OrchardCore/pull/1126)
-- Allows to congifure a global tenant middleware. [#1113](https://github.com/OrchardCMS/OrchardCore/pull/1113)
+- Allows you to configure a global tenant middleware. [#1113](https://github.com/OrchardCMS/OrchardCore/pull/1113)
 - Fix agency.recipe.json's hardcoded contentItemIds [#1122](https://github.com/OrchardCMS/OrchardCore/pull/1122)
 - Prevents recipes from being copied twice. [#1114](https://github.com/OrchardCMS/OrchardCore/pull/1114)
 - Adding support for ORCHARD_APP_DATA environment variable [#1111](https://github.com/OrchardCMS/OrchardCore/pull/1111)

--- a/src/docs/releases/1.0.0-beta3.md
+++ b/src/docs/releases/1.0.0-beta3.md
@@ -51,7 +51,7 @@ Release date: April 4th 2019
 - Add guides section to docs [#3309](https://github.com/OrchardCMS/OrchardCore/pull/3309)
 - Fix wrong language label of this repository [#3303](https://github.com/OrchardCMS/OrchardCore/pull/3303)
 - Fixing LoadingAsync for known parts [#3308](https://github.com/OrchardCMS/OrchardCore/pull/3308)
-- Setting liquid encodings explicitely [#3315](https://github.com/OrchardCMS/OrchardCore/pull/3315)
+- Setting liquid encodings explicitly [#3315](https://github.com/OrchardCMS/OrchardCore/pull/3315)
 - Fixing plural translation exceptions [#3316](https://github.com/OrchardCMS/OrchardCore/pull/3316)
 - Improving functional tests log [#3298](https://github.com/OrchardCMS/OrchardCore/pull/3298)
 - Allows to get more application's module file infos. [#3296](https://github.com/OrchardCMS/OrchardCore/pull/3296)

--- a/src/docs/releases/1.6.0.md
+++ b/src/docs/releases/1.6.0.md
@@ -56,7 +56,7 @@ New feature was added to provide a way to send notification messages to the user
 
 ### `OrchardCore.Contents` Module
 
-Prior this release, a user with `ViewContent` permission and has access to the dashboard, automatically gets access to "Content Items". Now, to be able to list contents on the dashboard, a user needs `ListContent` permission instead.
+Prior to this release, a user with `ViewContent` permission and access to the dashboard automatically got access to "Content Items". Now, to be able to list content on the dashboard, a user needs `ListContent` permission instead.
 
 ### Setting for `TheAdmin` theme
 

--- a/src/docs/releases/1.7.0.md
+++ b/src/docs/releases/1.7.0.md
@@ -36,7 +36,7 @@ Here is a list of the fields that were changed.
 - `WorkflowTypeIndex.DocumentId`.
 
 The `YesSql.ISession.GetAsync<T>(int id, ...)` has already been updated to `GetAsync<T>(long id, ...)`, this was not a breaking change as
-an implicit convertion is done as needed but it is recommended to now pass a `long` id parameter. The `ISession.GetAsync<T>(int[] ids, ...)`
+an implicit conversion is done as needed but it is recommended to now pass a `long` id parameter. The `ISession.GetAsync<T>(int[] ids, ...)`
 has already been updated to `GetAsync<T>(long[] ids, ...)`, for backward compatibility an extension method still accepting an `int[]` array
 has been created but it is recommended to use the method of the updated `ISession` interface.
 

--- a/src/docs/releases/1.8.0.md
+++ b/src/docs/releases/1.8.0.md
@@ -14,20 +14,20 @@ This release removes support for `net6.0` and `net7.0`. Only `net8.0` is support
 
 ### TheAdmin Theme
 
-The `TheAdmin` theme was upgraded to Bootstrap 5.3.2. Here is a list of the breaking changes
+The `TheAdmin` theme was upgraded to Bootstrap 5.3.2. Here is a list of the breaking changes:
 
 - The `bg-primary` class was changed to `text-bg-theme`.
 - The `darkmode` theme is now called `dark`.
 - The `default` theme is now called `light`.
-- By default, the theme is set to `auto` which allows us to use the default device color preference.
+- By default, the theme is set to `auto`, which allows you to use the default device color preference.
 - Material-icons are no longer included.
 - The `DarkModeService.cs` was replaced with `ThemeTogglerService`.
 - The property named `DisplayDarkMode` in `AdminSettings` was replaced with `DisplayThemeToggler`.
-- Bootstrap is no longer compiled in `TheAdmin.css`. Bootstrap are loaded independently for performance and maintainability reasons.
+- Bootstrap is no longer compiled in `TheAdmin.css`. Bootstrap is loaded independently for performance and maintainability reasons.
 
 ### Workflow Module
 
-A new option for restarting a specific Workflow instance has been incorporated, involving adjustments to both the `IActivity` and `IWorkflowManager` interfaces.The following method was added to `IWorkflowManager` interface.
+A new option for restarting a specific Workflow instance has been incorporated, involving adjustments to both the `IActivity` and `IWorkflowManager` interfaces. The following method was added to the `IWorkflowManager` interface.
 
 - `Task<WorkflowExecutionContext> RestartWorkflowAsync(WorkflowType workflowType, IDictionary<string, object> input = null, string correlationId = null)`
 
@@ -84,7 +84,7 @@ public class ToggleThemeNavbarDisplayDriver : DisplayDriver<Navbar>
 }
 ```
 
- Additionally, the follow shapes have been removed
+ Additionally, the following shapes have been removed:
 
 - `ContentCulturePickerContainer`
 - `AdminCulturePickerContainer`

--- a/src/docs/releases/2.0.0.md
+++ b/src/docs/releases/2.0.0.md
@@ -561,7 +561,7 @@ In this example, (if the admin prefix remains the default "Admin") you can reach
 
 ### Users Module
 
-Added a new User Localization feature that allows to be able to configure the culture per user from the admin UI.
+Added a new User Localization feature that allows users to configure the culture per user from the admin UI.
 
 ### Navbar
 

--- a/src/docs/releases/2.1.0.md
+++ b/src/docs/releases/2.1.0.md
@@ -10,11 +10,11 @@ This release includes critical bug fixes that enhance stability and performance,
 
 #### `JsonOptions` Configuration
 
-A key change in version 2.0 is the shift from **Newtonsoft.Json** to **System.Text.Json**. Previously, we configured the default `JsonOptions` to match the settings used for document serialization. In this release, however, we’ve reverted that approach, and the `JsonOptions` are no longer configured by default. This change provides greater flexibility, allowing you to customize JSON serialization as needed.
+A key change in version 2.0 is the shift from **Newtonsoft.Json** to **System.Text.Json**. Previously, we configured the default `JsonOptions` to match the settings used for document serialization. In this release, however, we've reverted that approach, and the `JsonOptions` are no longer configured by default. This change provides greater flexibility, allowing you to customize JSON serialization as needed.
 
 If your Minimal API returns YesSql documents, entities (implementations of `IEntity`) or content (implementations of `IContent`), such as `ContentItem`, `User`, `Query`, or `Notification`, you may need to use `DocumentJsonSerializerOptions` for proper serialization. For example, when using Minimal API, instead of returning the result with `TypedResults.Ok(entity)`, you should use `Results.Json(entity, options.Value.SerializerOptions)`, resolving `IOptions<DocumentJsonSerializerOptions>` from the IoC container.
 
-For scenarios using `ApiController` to return YesSql documents or entities, we’ve introduced new output formatters, `DocumentSystemTextJsonOutputFormatter` and `ContentSystemTextJsonOutputFormatter`, to automatically handle document serialization to JSON correctly.
+For scenarios using `ApiController` to return YesSql documents or entities, we've introduced new output formatters, `DocumentSystemTextJsonOutputFormatter` and `ContentSystemTextJsonOutputFormatter`, to automatically handle document serialization to JSON correctly.
 
 These changes are non-breaking and you shouldn't need to change working 2.0.x code.
 
@@ -114,7 +114,7 @@ The `Administrator` role no longer registers permission-based claims by default 
 
 will return `false` for administrators, even though they still have full access. Non-admin users, however, may return `true` if they have the claim. 
 
-For backward compatibility, the current behavior still allows this code to return `true` for administrators, but this will change in a future major release. To avoid potential issues, it’s recommended to use the `has_permission` filter for permission checks going forward:
+For backward compatibility, the current behavior still allows this code to return `true` for administrators, but this will change in a future major release. To avoid potential issues, it's recommended to use the `has_permission` filter for permission checks going forward:
 
 ```liquid
 {% assign isAuthorized = User | has_permission: "AccessAdminPanel" %}

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -67,7 +67,7 @@ Previously, emails sent from Orchard Core could have either a plain text body, o
 
 When interacting with email-related services from code, `MailMessage`, the class representing an e-mail, exposed a `string` `Body` property. This could contain either plain text or HTML, which was indicated by `IsHtmlBody`.
 
-These two properties have now been replaced by the `TextBody` and `HtmlBody` properties, which contains a plain text and/or HTML body.
+These two properties have now been replaced by the `TextBody` and `HtmlBody` properties, which contain a plain-text and/or HTML body.
 
 #### Email Result
 
@@ -138,7 +138,7 @@ See the [Admin Theme Conventions](../reference/themes/admin-theme.md) documentat
 
 #### GraphQL Library Upgrade
 
-The `GraphQL` libraries have been upgraded from version 7 to version 8. Below are important changes and considerations for your implementation:
+The `GraphQL` libraries have been upgraded from version 7 to version 8. Below are the important changes and considerations for your implementation:
 
 1. **Removal of Default Implementation**:  
    The `IContentTypeBuilder` interface previously included a default implementation for the `Clear()` method. This implementation has been removed. If you have a custom implementation of `IContentTypeBuilder`, you must now provide your own `Clear()` method. The method can remain empty if no specific actions are needed.
@@ -253,9 +253,9 @@ The latest update adds support for **Total Hits Count** in Elasticsearch queries
 
 The signature in the `ISearchService` interface was changed from `Task<SearchResult> SearchAsync(string indexName, string term, int start, int size)` to `Task<SearchResult> SearchAsync(IndexEntity index, string term, int start, int size)`.
 
-The route `/search/{indexName?}` was change to accept index id instead of name. The route is now `/search/{indexId?}`. This change was made to ensure that the search functionality works correctly with the new `IndexEntity` class, which is now used to represent indexes in the system.
+The route `/search/{indexName?}` was changed to accept an index ID instead of a name. The route is now `/search/{indexId?}`. This change was made to ensure that the search functionality works correctly with the new `IndexEntity` class, which is now used to represent indexes in the system.
 
-The default search settings was changed to require default index-id instead of a provider name.
+The default search settings were changed to require a default index ID instead of a provider name.
 
 ### Azure Search AI Module  
 
@@ -553,7 +553,7 @@ For more details, see the [Configuration documentation](../reference/modules/Con
 
 #### Fallback to Parent Culture
 
-The `Localization` module allows the user to control the fallback to the parent culture when a translation is not available in the current culture. The default behavior in ASP.NET Core is that the culture automatically falls back to its parent if not exist, but now you have the control to make this feature on or off.
+The `Localization` module allows the user to control the fallback to the parent culture when a translation is not available in the current culture. The default behavior in ASP.NET Core is that the culture automatically falls back to its parent if it does not exist, but now you can turn this feature on or off.
 
 ### Reverse Proxy Module
 
@@ -692,7 +692,7 @@ Search index-specific permissions were centralized into the Indexing module. Thu
   
 #### Enhanced Multi-Source Indexing  
 
-To create a custom source, you'll need to implement the `IIndexManager`, `IDocumentIndexManager` and `IIndexNameProvider` interfaces and register them as following
+To create a custom source, you'll need to implement the `IIndexManager`, `IDocumentIndexManager` and `IIndexNameProvider` interfaces and register them as follows:
 
 To register a new source, you can add the following code to your `Startup.cs` file:
 
@@ -729,7 +729,7 @@ Now, the Elasticsearch module supports multiple authentication types for connect
 
 The following recipe steps were deprecated:
 
-- Both `lucene-index` and `LuceneIndexSettings` steps, which was used to create a Lucene index. Instead, please use the `CreateOrUpdateIndexProfile` step to create or update an index.
+- Both `lucene-index` and `LuceneIndexSettings` steps, which were used to create a Lucene index. Instead, please use the `CreateOrUpdateIndexProfile` step to create or update an index.
 - `lucene-index-reset` step, which was used to create a Lucene query. Instead, please use the `ResetIndex` step to create a query.
 - `lucene-index-rebuild` step, which was used to create a Lucene query. Instead, please use the `RebuildIndex` step to create a query.
 

--- a/src/docs/topics/docker/README.md
+++ b/src/docs/topics/docker/README.md
@@ -13,11 +13,11 @@ For Ubuntu/Linux users : <https://docs.docker.com/engine/install/ubuntu/>
 
 ## What you will build
 
-You will build Docker images and containers from command shell using `docker` and `docker-compose` commands. Images are built from Orchard Core source code targeting a specific OS. Then we can deploy "containers" from them. This allow you to see how Orchard Core respond in different environments or also deploy Orchard Core on a production server eventually.
+You will build Docker images and containers from command shell using `docker` and `docker-compose` commands. Images are built from Orchard Core source code targeting a specific OS. Then we can deploy "containers" from them. This allows you to see how Orchard Core responds in different environments or also deploy Orchard Core on a production server eventually.
 
 ## Dockerfile
 
-The Dockerfile that is provided in the Orchard Core source code is using an intermediate image to build Orchard Core in a specific environment which contains the .NET SDK. Then we create the "real" image by using only the ASP.NET core runtime.
+The Dockerfile that is provided in the Orchard Core source code is using an intermediate image to build Orchard Core in a specific environment which contains the .NET SDK. Then we create the "real" image by using only the ASP.NET Core runtime.
 
 ```dockerfile
 # Create an intermediate image using .NET Core SDK

--- a/src/docs/topics/red-hat-ecosystem-catalog-certification/README.md
+++ b/src/docs/topics/red-hat-ecosystem-catalog-certification/README.md
@@ -11,7 +11,7 @@ Note that Orchard has to be certified as a non-containerized app. Containerized 
 To begin, set up the basics on the [Certified Technology Portal](https://connect.redhat.com/account/dashboard). If you need access to it, please let us know. Then, these are the steps:
 
 1. Create an Azure RHEL (latest major version) Azure VM. You can find this by searching for "Red Hat Enterprise Linux" in the Marketplace, and then setting up the official image provided by Red Hat. Be sure to keep HTTP and HTTPS ports open. (While you don't need an Azure VM, doing it this way makes things simpler than a local virtualized setup, for example.)
-2. Connect with [MobaXterm](https://mobaxterm.mobatek.net/) or your terminal of choice, using the VM’s public IP, “azureuser” as the user, and the private key PEM file Azure lets you download when creating the VM.
+2. Connect with [MobaXterm](https://mobaxterm.mobatek.net/) or your terminal of choice, using the VM's public IP, “azureuser” as the user, and the private key PEM file Azure lets you download when creating the VM.
 3. Open up port 80:
 
     ```console


### PR DESCRIPTION
<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->

This pull request focuses on improving documentation quality and consistency across various Orchard Core documentation files. The changes address grammar, terminology, clarity, and outdated admin navigation references so the docs are easier to read and more accurate for users and contributors.

**Documentation consistency and clarity improvements:**

* Standardized terminology (e.g., "URL" instead of "url", "set up" vs. "setup", "Cms" → "CMS", and consistent references to "README") and corrected grammar throughout documentation files for improved readability.

**Canonical documentation navigation corrections:**

* Updated canonical documentation pages to reflect the current admin menu structure.
* Corrected outdated references so content type management now points to **Design → Content Definition → Content Types** where applicable.
* Corrected background task management references to **Tools → Background Tasks**.

**Contribution guidelines enhancements:**

* Updated contribution instructions to clarify the difference between canonical documentation and release notes, and emphasized keeping documentation aligned with shipped code and behavior.
* Improved phrasing for ways to contribute, making it more inclusive and grammatically correct.

**Community documentation corrections:**

* Fixed a minor typo in the code/features ownership table ("Po" → "PO") for accuracy.

These updates collectively improve the accuracy, consistency, and professionalism of the Orchard Core documentation.