### PR TITLE
Disable ImageSharp v4 Renovate updates (Lombiq Technologies: OCORE-269)

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -112,6 +112,14 @@
             ],
             enabled: false,
         },
+        // Not updating to ImageSharp v4 yet, see https://github.com/orgs/OrchardCMS/discussions/19306.
+        {
+            matchPackageNames: [
+                '/^SixLabors\\.ImageSharp.*$/',
+            ],
+            matchUpdateTypes: ['major'],
+            enabled: false,
+        },
 
         // Groups of packages that we want to update together.
         {


### PR DESCRIPTION
Not updating to ImageSharp v4 yet, see https://github.com/orgs/OrchardCMS/discussions/19306. After merging this, https://github.com/OrchardCMS/OrchardCore/pull/19313 should close itself.