### PR TITLE
Revoke Existing Sessions on Sign-In/Sign-Out

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
@@ -139,6 +139,9 @@ public sealed class AccountController : AccountBaseController
                         }
                     }
 
+                    // Invalidate previous sessions by updating the security stamp before sign-in.
+                    await _userManager.UpdateSecurityStampAsync(user);
+
                     result = await _signInManager.PasswordSignInAsync(user, model.Password, model.RememberMe, lockoutOnFailure: true);
 
                     if (result.Succeeded)
@@ -149,7 +152,6 @@ public sealed class AccountController : AccountBaseController
 
                         return await LoggedInActionResultAsync(user, returnUrl);
                     }
-
                 }
 
                 if (result.RequiresTwoFactor)
@@ -194,6 +196,14 @@ public sealed class AccountController : AccountBaseController
     [HttpPost]
     public async Task<IActionResult> LogOff(string returnUrl = null)
     {
+        // Invalidate all existing sessions by updating the security stamp.
+        // This ensures that any previously captured tokens are immediately rejected.
+        var currentUser = await _userManager.GetUserAsync(HttpContext.User);
+        if (currentUser != null)
+        {
+            await _userManager.UpdateSecurityStampAsync(currentUser);
+        }
+
         await _signInManager.SignOutAsync();
 
         _logger.LogInformation(4, "User logged out.");

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/ExternalAuthenticationsController.cs
@@ -625,6 +625,10 @@ public sealed class ExternalAuthenticationsController : AccountBaseController
 
         if (result.Succeeded)
         {
+            // Invalidate previous sessions and refresh the current sign-in with the new stamp.
+            await _userManager.UpdateSecurityStampAsync(user);
+            await _signInManager.RefreshSignInAsync(user);
+
             await _loginFormEvents.InvokeAsync((e, user) => e.LoggedInAsync(user), user, _logger);
 
             var identityResult = await _signInManager.UpdateExternalAuthenticationTokensAsync(info);

--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/TwoFactorAuthenticationController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/TwoFactorAuthenticationController.cs
@@ -124,6 +124,10 @@ public sealed class TwoFactorAuthenticationController : TwoFactorAuthenticationB
 
             if (result.Succeeded)
             {
+                // Invalidate previous sessions and refresh the current sign-in with the new stamp.
+                await UserManager.UpdateSecurityStampAsync(user);
+                await SignInManager.RefreshSignInAsync(user);
+
                 await _loginFormEvents.InvokeAsync((e, user) => e.LoggedInAsync(user), user, _logger);
 
                 return await LoggedInActionResultAsync(user, model.ReturnUrl);
@@ -185,6 +189,10 @@ public sealed class TwoFactorAuthenticationController : TwoFactorAuthenticationB
 
             if (result.Succeeded)
             {
+                // Invalidate previous sessions and refresh the current sign-in with the new stamp.
+                await UserManager.UpdateSecurityStampAsync(user);
+                await SignInManager.RefreshSignInAsync(user);
+
                 await _loginFormEvents.InvokeAsync((e, user) => e.LoggedInAsync(user), user, _logger);
 
                 return await LoggedInActionResultAsync(user, model.ReturnUrl);


### PR DESCRIPTION
The issue this PR addresses is that after a user signs up, the security stamp is not updated, which prevents invalidation of existing user sessions. As a result, previously issued sessions remain valid even after logout and can persist until they naturally expire, which may take weeks.

By updating the security stamp during login and logout, we ensure that all existing sessions are properly invalidated, improving overall account security and reducing the risk of unauthorized session reuse.