### PR TITLE
Fix preview window theme toggle not working / stuck in light mode

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -53,7 +53,7 @@
 
     function setupIframeTheme(win) {
         if (!win || !win.document || !win.document.documentElement) return;
-        var tenant = document.documentElement.getAttribute('data-tenant') || 'Default';
+        var tenant = win.document.documentElement.getAttribute('data-tenant') || 'Default';
         var storageKey = tenant + '-theme';
         var stored = localStorage.getItem(storageKey);
         setIframeTheme(win, null, stored || 'auto');

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -29,6 +29,61 @@
     let iframe = document.getElementById('iframe');
     let previewRenderTimer = null, previewRendering, previewRenderData, initialized, renderPreviewUrl;
 
+    function setIframeTheme(win, stored, value) {
+        var resolved = value;
+        if (value === 'auto') {
+            resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+
+        document.documentElement.setAttribute('data-bs-theme', resolved);
+        win.document.documentElement.setAttribute('data-bs-theme', resolved);
+
+        if (stored) {
+            localStorage.setItem(stored, value);
+        }
+
+        win.document.querySelectorAll('[data-bs-theme-value]').forEach(function (btn) {
+            var isActive = btn.getAttribute('data-bs-theme-value') === value;
+            btn.classList.toggle('active', isActive);
+            btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+        });
+
+        var activeIcon = win.document.querySelector('.theme-icon-active');
+        if (activeIcon) {
+            var activeBtn = win.document.querySelector('[data-bs-theme-value="' + value + '"]');
+            if (activeBtn) {
+                var svg = activeBtn.querySelector('.theme-icon');
+                if (svg) activeIcon.innerHTML = svg.innerHTML;
+            }
+        }
+    }
+
+    function setupIframeTheme(win) {
+        if (!win || !win.document || !win.document.documentElement) return;
+
+        var tenant = document.documentElement.getAttribute('data-tenant') || 'Default';
+        var storageKey = tenant + '-theme';
+        var stored = localStorage.getItem(storageKey);
+        var initial = stored || 'auto';
+
+        setIframeTheme(win, null, initial);
+
+        win.document.addEventListener('click', function (ev) {
+            var toggle = ev.target.closest('[data-bs-theme-value]');
+            if (!toggle) return;
+
+            var value = toggle.getAttribute('data-bs-theme-value');
+            if (!value) return;
+
+            setIframeTheme(win, storageKey, value);
+
+            var themeSwitcher = win.document.getElementById('bd-theme');
+            if (themeSwitcher) {
+                themeSwitcher.focus();
+            }
+        });
+    }
+
     $(function () {
         var previewEventTimer = null;
         renderPreviewUrl = document.getElementById('renderPreviewUrl').getAttribute('data-value');
@@ -76,6 +131,7 @@
                 iframe.contentWindow.document.open();
                 iframe.contentWindow.document.write(previewRenderData);
                 iframe.contentWindow.document.close();
+                setupIframeTheme(iframe.contentWindow);
             }
             initialized = true;
         }
@@ -106,6 +162,7 @@
                         iframe.contentWindow.document.open();
                         iframe.contentWindow.document.write(data);
                         iframe.contentWindow.document.close();
+                        setupIframeTheme(iframe.contentWindow);
                         previewRenderData = data;
                     }
                     $(serverErrorWarning).hide();

--- a/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentPreview/Views/Preview/Index.cshtml
@@ -29,25 +29,18 @@
     let iframe = document.getElementById('iframe');
     let previewRenderTimer = null, previewRendering, previewRenderData, initialized, renderPreviewUrl;
 
-    function setIframeTheme(win, stored, value) {
-        var resolved = value;
-        if (value === 'auto') {
-            resolved = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-        }
-
+    function setIframeTheme(win, storageKey, value) {
+        var resolved = value === 'auto'
+            ? window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+            : value;
+        if (storageKey) localStorage.setItem(storageKey, value);
         document.documentElement.setAttribute('data-bs-theme', resolved);
         win.document.documentElement.setAttribute('data-bs-theme', resolved);
-
-        if (stored) {
-            localStorage.setItem(stored, value);
-        }
-
         win.document.querySelectorAll('[data-bs-theme-value]').forEach(function (btn) {
             var isActive = btn.getAttribute('data-bs-theme-value') === value;
             btn.classList.toggle('active', isActive);
             btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
         });
-
         var activeIcon = win.document.querySelector('.theme-icon-active');
         if (activeIcon) {
             var activeBtn = win.document.querySelector('[data-bs-theme-value="' + value + '"]');
@@ -60,27 +53,15 @@
 
     function setupIframeTheme(win) {
         if (!win || !win.document || !win.document.documentElement) return;
-
         var tenant = document.documentElement.getAttribute('data-tenant') || 'Default';
         var storageKey = tenant + '-theme';
         var stored = localStorage.getItem(storageKey);
-        var initial = stored || 'auto';
-
-        setIframeTheme(win, null, initial);
-
+        setIframeTheme(win, null, stored || 'auto');
         win.document.addEventListener('click', function (ev) {
             var toggle = ev.target.closest('[data-bs-theme-value]');
             if (!toggle) return;
-
             var value = toggle.getAttribute('data-bs-theme-value');
-            if (!value) return;
-
-            setIframeTheme(win, storageKey, value);
-
-            var themeSwitcher = win.document.getElementById('bd-theme');
-            if (themeSwitcher) {
-                themeSwitcher.focus();
-            }
+            if (value) setIframeTheme(win, storageKey, value);
         });
     }
 
@@ -131,7 +112,7 @@
                 iframe.contentWindow.document.open();
                 iframe.contentWindow.document.write(previewRenderData);
                 iframe.contentWindow.document.close();
-                setupIframeTheme(iframe.contentWindow);
+                setupIframeTheme(this.contentWindow);
             }
             initialized = true;
         }
@@ -162,10 +143,11 @@
                         iframe.contentWindow.document.open();
                         iframe.contentWindow.document.write(data);
                         iframe.contentWindow.document.close();
-                        setupIframeTheme(iframe.contentWindow);
                         previewRenderData = data;
+                        setupIframeTheme(iframe.contentWindow);
                     }
                     $(serverErrorWarning).hide();
+                    previewRendering = false;
                 })
                 .fail(function (data) {
                     if (data.responseJSON && data.responseJSON.errors) {


### PR DESCRIPTION
Bug: iframe.onload and $.post().done() both call document.open() + document.write() + document.close(). This creates a new Document where readyState jumps directly to "complete" - DOMContentLoaded never fires. The theme-manager.js attaches click handlers on DOMContentLoaded, so those handlers are gone.

The result is that the theme is not set in the Preview window and the Theme dropdown buttons cannot be interacted with.

Fix: Two functions - setIframeTheme (apply theme + update button states + icon) and setupIframeTheme (read stored theme from localStorage, wire event delegation on the iframe).