### PR TITLE
Add site settings to enable/disable Write shape debug information

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/AdminMenu.cs
@@ -7,10 +7,16 @@ namespace OrchardCore.Settings;
 
 public sealed class AdminMenu : AdminNavigationProvider
 {
-    private static readonly RouteValueDictionary _routeValues = new()
+    private static readonly RouteValueDictionary _generalRouteValues = new()
     {
         { "area", "OrchardCore.Settings" },
         { "groupId", DefaultSiteSettingsDisplayDriver.GroupId },
+    };
+
+    private static readonly RouteValueDictionary _debuggingRouteValues = new()
+    {
+        { "area", "OrchardCore.Settings" },
+        { "groupId", DebugSettingsDisplayDriver.GroupId },
     };
 
     internal readonly IStringLocalizer S;
@@ -33,7 +39,14 @@ public sealed class AdminMenu : AdminNavigationProvider
                         .Add(S["General"], "1", entry => entry
                             .AddClass("general")
                             .Id("general")
-                            .Action("Index", "Admin", _routeValues)
+                            .Action("Index", "Admin", _generalRouteValues)
+                            .Permission(SettingsPermissions.ManageGroupSettings)
+                            .LocalNav()
+                        )
+                        .Add(S["Debugging"], "2", entry => entry
+                            .AddClass("debugging")
+                            .Id("debugging")
+                            .Action("Index", "Admin", _debuggingRouteValues)
                             .Permission(SettingsPermissions.ManageGroupSettings)
                             .LocalNav()
                         ),
@@ -54,7 +67,14 @@ public sealed class AdminMenu : AdminNavigationProvider
                 .Add(S["General"], "before", general => general
                     .AddClass("general")
                     .Id("general")
-                    .Action("Index", "Admin", _routeValues)
+                    .Action("Index", "Admin", _generalRouteValues)
+                    .Permission(SettingsPermissions.ManageGroupSettings)
+                    .LocalNav()
+                )
+                .Add(S["Debugging"], "after", debugging => debugging
+                    .AddClass("debugging")
+                    .Id("debugging")
+                    .Action("Index", "Admin", _debuggingRouteValues)
                     .Permission(SettingsPermissions.ManageGroupSettings)
                     .LocalNav()
                 )

--- a/src/OrchardCore.Modules/OrchardCore.Settings/DebugSettings.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/DebugSettings.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.Settings;
+
+public sealed class DebugSettings
+{
+    public bool WriteShapeDebugInformation { get; set; }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DebugSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Drivers/DebugSettingsDisplayDriver.cs
@@ -1,0 +1,49 @@
+using OrchardCore.DisplayManagement.Entities;
+using OrchardCore.DisplayManagement.Handlers;
+using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Settings.ViewModels;
+
+namespace OrchardCore.Settings.Drivers;
+
+public sealed class DebugSettingsDisplayDriver : SiteDisplayDriver<DebugSettings>
+{
+    public const string GroupId = "debugging";
+
+    private readonly IShellReleaseManager _shellReleaseManager;
+
+    protected override string SettingsGroupId
+        => GroupId;
+
+    public DebugSettingsDisplayDriver(IShellReleaseManager shellReleaseManager)
+    {
+        _shellReleaseManager = shellReleaseManager;
+    }
+
+    public override IDisplayResult Edit(ISite site, DebugSettings settings, BuildEditorContext context)
+    {
+        context.AddTenantReloadWarningWrapper();
+
+        return Initialize<DebugSettingsViewModel>("DebugSettings_Edit", model =>
+        {
+            model.WriteShapeDebugInformation = settings.WriteShapeDebugInformation;
+        }).Location("Content:5")
+        .OnGroup(SettingsGroupId);
+    }
+
+    public override async Task<IDisplayResult> UpdateAsync(ISite site, DebugSettings settings, UpdateEditorContext context)
+    {
+        var model = new DebugSettingsViewModel();
+
+        await context.Updater.TryUpdateModelAsync(model, Prefix);
+
+        if (settings.WriteShapeDebugInformation != model.WriteShapeDebugInformation)
+        {
+            _shellReleaseManager.RequestRelease();
+        }
+
+        settings.WriteShapeDebugInformation = model.WriteShapeDebugInformation;
+
+        return Edit(site, settings, context);
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Settings/ShapeRenderingOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/ShapeRenderingOptionsConfiguration.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Options;
+using OrchardCore.DisplayManagement;
+
+namespace OrchardCore.Settings;
+
+public sealed class ShapeRenderingOptionsConfiguration : IConfigureOptions<ShapeRenderingOptions>
+{
+    private readonly ISiteService _siteService;
+
+    public ShapeRenderingOptionsConfiguration(ISiteService siteService)
+    {
+        _siteService = siteService;
+    }
+
+    public void Configure(ShapeRenderingOptions options)
+    {
+        var settings = _siteService.GetSettings<DebugSettings>();
+
+        options.WriteShapeDebugInformation = settings.WriteShapeDebugInformation;
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using OrchardCore.Deployment;
+using OrchardCore.DisplayManagement;
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.Liquid;
 using OrchardCore.Modules;
@@ -75,6 +76,7 @@ public sealed class Startup : StartupBase
 
         // Site Settings editor
         services.AddSiteDisplayDriver<DefaultSiteSettingsDisplayDriver>();
+        services.AddSiteDisplayDriver<DebugSettingsDisplayDriver>();
         services.AddSiteDisplayDriver<ButtonsSettingsDisplayDriver>();
         services.AddNavigationProvider<AdminMenu>();
 
@@ -86,7 +88,19 @@ public sealed class Startup : StartupBase
 
         services.AddTransient<IPostConfigureOptions<ResourceOptions>, ResourceOptionsConfiguration>();
         services.AddTransient<IPostConfigureOptions<PagerOptions>, PagerOptionsConfiguration>();
+        services.AddTransient<IConfigureOptions<ShapeRenderingOptions>, ShapeRenderingOptionsConfiguration>();
 
         services.AddScoped<IModularTenantEvents, PreloadSiteSettingsTenantEventHandler>();
+    }
+}
+
+[RequireFeatures("OrchardCore.Deployment")]
+public sealed class DeploymentStartup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddSiteSettingsPropertyDeploymentStep<DebugSettings, DeploymentStartup>(
+            S => S["Debugging settings"],
+            S => S["Exports the debugging settings."]);
     }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Settings/ViewModels/DebugSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/ViewModels/DebugSettingsViewModel.cs
@@ -1,0 +1,6 @@
+namespace OrchardCore.Settings.ViewModels;
+
+public sealed class DebugSettingsViewModel
+{
+    public bool WriteShapeDebugInformation { get; set; }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Settings/Views/DebugSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/Views/DebugSettings.Edit.cshtml
@@ -1,0 +1,11 @@
+@model OrchardCore.Settings.ViewModels.DebugSettingsViewModel
+
+<div class="ocat-wrapper" asp-validation-class-for="WriteShapeDebugInformation">
+    <div class="ocat-end-offset">
+        <div class="form-check">
+            <input asp-for="WriteShapeDebugInformation" class="form-check-input" type="checkbox" />
+            <label asp-for="WriteShapeDebugInformation" class="form-check-label">@T["Write shape debug information"]</label>
+        </div>
+        <span class="hint">@T["Wrap rendered shapes in HTML comments to help identify the template or binding that produced each fragment."]</span>
+    </div>
+</div>

--- a/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement/OrchardCoreBuilderExtensions.cs
@@ -31,15 +31,6 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class OrchardCoreBuilderExtensions
 {
     /// <summary>
-    /// Enables HTML comments in rendered output that identify the shape bindings used during rendering.
-    /// </summary>
-    public static OrchardCoreBuilder EnableShapeDebugInformation(this OrchardCoreBuilder builder)
-    {
-        return builder.ConfigureServices(services =>
-            services.Configure<ShapeRenderingOptions>(options => options.WriteShapeDebugInformation = true));
-    }
-
-    /// <summary>
     /// Adds host and tenant level services for managing themes.
     /// </summary>
     public static OrchardCoreBuilder AddTheming(this OrchardCoreBuilder builder)

--- a/src/docs/reference/modules/DisplayManagement/README.md
+++ b/src/docs/reference/modules/DisplayManagement/README.md
@@ -106,20 +106,7 @@ This is the same as `<shape type="MyShape" prop-foo="1" prop-bar="a" prop-conten
 
 You can instruct Orchard Core to write HTML comments around rendered shapes. This makes it easier to determine which Razor or Liquid template produced a specific fragment in the final page output.
 
-Enable it during startup:
-
-```csharp
-services
-    .AddOrchardCms()
-    .EnableShapeDebugInformation();
-```
-
-You can also enable it directly through options:
-
-```csharp
-services.Configure<ShapeRenderingOptions>(options =>
-    options.WriteShapeDebugInformation = true);
-```
+Enable it per site from **Settings** -> **Debugging** by checking **Write shape debug information**. The setting is disabled by default.
 
 When enabled, rendered shapes are wrapped with comments similar to the following:
 

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -764,6 +764,10 @@ Each method in the chain returns the same builder instance, so all methods are a
 
 For more details, see the [Placement documentation](../reference/modules/Placement/README.md#fluent-location-api).
 
+#### Shape Debugging Site Setting
+
+Site owners can now enable or disable shape debugging from **Settings** -> **Debugging** without changing application startup code. When enabled, Orchard Core writes HTML comments around rendered shapes so you can inspect which shape binding or template produced a fragment on a running site.
+
 ### OpenID Module
 
 Added the `RequireEndSessionConfirmation` option to the OpenID server settings. When disabled, end-users are signed out without a confirmation prompt if a valid `id_token_hint` matching the current session is provided. The option defaults to `true`, preserving the previous behavior.

--- a/test/OrchardCore.Tests/Settings/ShapeRenderingOptionsConfigurationTests.cs
+++ b/test/OrchardCore.Tests/Settings/ShapeRenderingOptionsConfigurationTests.cs
@@ -1,0 +1,48 @@
+using OrchardCore.DisplayManagement;
+using OrchardCore.Entities;
+using OrchardCore.Settings;
+
+namespace OrchardCore.Tests.Settings;
+
+public class ShapeRenderingOptionsConfigurationTests
+{
+    [Fact]
+    public void ConfigureDisablesShapeDebugInformationByDefault()
+    {
+        var site = new SiteSettings();
+        var siteService = new Mock<ISiteService>();
+        siteService.Setup(x => x.GetSiteSettingsAsync())
+            .ReturnsAsync(site);
+
+        var sut = new ShapeRenderingOptionsConfiguration(siteService.Object);
+        var options = new ShapeRenderingOptions
+        {
+            WriteShapeDebugInformation = true,
+        };
+
+        sut.Configure(options);
+
+        Assert.False(options.WriteShapeDebugInformation);
+    }
+
+    [Fact]
+    public void ConfigureEnablesShapeDebugInformationWhenConfiguredInSiteSettings()
+    {
+        var site = new SiteSettings();
+        site.Put(new DebugSettings
+        {
+            WriteShapeDebugInformation = true,
+        });
+
+        var siteService = new Mock<ISiteService>();
+        siteService.Setup(x => x.GetSiteSettingsAsync())
+            .ReturnsAsync(site);
+
+        var sut = new ShapeRenderingOptionsConfiguration(siteService.Object);
+        var options = new ShapeRenderingOptions();
+
+        sut.Configure(options);
+
+        Assert.True(options.WriteShapeDebugInformation);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new site-level "Debugging" settings group that allows site owners to enable or disable shape debugging (HTML comments around rendered shapes) directly from the admin UI, instead of requiring code changes. It adds the necessary backend, UI, configuration, deployment, and test support for the new `DebugSettings` feature, and updates documentation accordingly.

**New Debugging Settings Feature:**

- Added a new `DebugSettings` model and `DebugSettingsDisplayDriver` to expose the "Write shape debug information" option in the admin UI under **Settings → Debugging**. This allows enabling/disabling shape debugging per site. [[1]](diffhunk://#diff-6f626826f74d319d1133c200f8da8adb39ff5d24c1f8224d1ad62dbf59fde599R1-R6) [[2]](diffhunk://#diff-68bbf46e0599f70e650c6facbfa5e950c681dec64c137189725fc16d554c67d2R1-R49) [[3]](diffhunk://#diff-7db19fe43ccc2d7186b3abb1a29e58d7a733f762012da1c36bd79bf113ba6427R1-R6) [[4]](diffhunk://#diff-cfa880df0c0c93bdd0fb24357d6303f5f5aad401869f8afb2515123648c59f2dR1-R11)
- Updated the admin navigation (`AdminMenu`) to include a new "Debugging" section alongside "General" settings. [[1]](diffhunk://#diff-4c7adee665c76a051fa7683cbc1397425ae3f8067f2e4125a3d26d572d613debL10-R21) [[2]](diffhunk://#diff-4c7adee665c76a051fa7683cbc1397425ae3f8067f2e4125a3d26d572d613debL36-R49) [[3]](diffhunk://#diff-4c7adee665c76a051fa7683cbc1397425ae3f8067f2e4125a3d26d572d613debL57-R77)

**Configuration and Integration:**

- Introduced `ShapeRenderingOptionsConfiguration` to bind the `DebugSettings` value to `ShapeRenderingOptions`, ensuring the selected setting is respected at runtime. Registered this configuration in `Startup.cs`. [[1]](diffhunk://#diff-486aca305f5bd0b81cc82b6feaaf9a59a7c3eabf488284954bc951e380956f7cR1-R21) [[2]](diffhunk://#diff-837b90a9fc0a78ee4723ebf79225b1e16039540985acd4ea5fa74e3261261e62R91-R106)
- Registered the new display driver and configuration services in the module startup. [[1]](diffhunk://#diff-837b90a9fc0a78ee4723ebf79225b1e16039540985acd4ea5fa74e3261261e62R79) [[2]](diffhunk://#diff-837b90a9fc0a78ee4723ebf79225b1e16039540985acd4ea5fa74e3261261e62R91-R106)
- Added deployment support for exporting/importing the debugging settings via deployment steps.

**Documentation and API Cleanup:**

- Updated documentation to instruct users to enable shape debugging via the admin UI instead of startup code, and removed the obsolete `EnableShapeDebugInformation` extension method. [[1]](diffhunk://#diff-d2440fd53ee4f28d6235c543946951a4744c4a2eefed548d27ebb5d0b4316fb2L33-L41) [[2]](diffhunk://#diff-08bf202e7ca5c1c7d3f6e62efbf0a593d3dff162d9f8c2ddf0adc0334a72bfffL109-R109) [[3]](diffhunk://#diff-3e9feb8b3f91522919c97b27096772f57a252e983294d4d7b2d0eff690e98144R767-R770)

**Testing:**

- Added unit tests to verify that shape debugging is disabled by default and can be enabled via site settings.