### PR TITLE
Add "Add & Configure" buttons to add parts and field UI

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -359,7 +359,7 @@ public sealed class AdminController : Controller
             await _contentDefinitionService.AddPartToTypeAsync(partToAdd, typeViewModel.Name);
         }
 
-        await _notifier.SuccessAsync(H.Plural(partsToAdd.Length, "The \"{1}\" part has been added.", "The following parts have been added: {1}.", string.Join(", ", partsToAdd)));
+        await _notifier.SuccessAsync(H.Plural(partsToAdd.Count(), "The \"{1}\" part has been added.", "The following parts have been added: {1}.", string.Join(", ", partsToAdd)));
 
         if (!ModelState.IsValid)
         {

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -304,7 +304,7 @@ public sealed class AdminController : Controller
     }
 
     [HttpPost, ActionName("AddPartsTo")]
-    public async Task<ActionResult> AddPartsToPOST(string id)
+    public async Task<ActionResult> AddPartsToPOST(string id, [Bind(Prefix = "submit.AddAndConfigure")] string submitAddAndConfigure)
     {
         if (!await _authorizationService.AuthorizeAsync(User, ContentTypesPermissions.EditContentTypes))
         {
@@ -324,12 +324,42 @@ public sealed class AdminController : Controller
             return await AddPartsTo(id);
         }
 
-        var partsToAdd = viewModel.PartSelections.Where(ps => ps.IsSelected).Select(ps => ps.PartName);
+        if (!string.IsNullOrEmpty(submitAddAndConfigure))
+        {
+            var typePartNames = new HashSet<string>(typeViewModel.TypeDefinition.Parts.Select(p => p.IsNamedPart() ? p.Name : p.PartDefinition.Name));
+            var partToConfigure = (await GetPartsAsync(metadataPartsOnly: false))
+                .FirstOrDefault(cpd =>
+                    cpd.PartDefinition != null &&
+                    cpd.PartDefinition.GetSettings<ContentPartSettings>().Attachable &&
+                    !typePartNames.Contains(cpd.Name, StringComparer.OrdinalIgnoreCase) &&
+                    string.Equals(cpd.Name, submitAddAndConfigure, StringComparison.OrdinalIgnoreCase));
+
+            if (partToConfigure == null)
+            {
+                ModelState.AddModelError(string.Empty, S["The selected part is no longer available."]);
+                await _documentStore.CancelAsync();
+                return await AddPartsTo(id);
+            }
+
+            await _contentDefinitionService.AddPartToTypeAsync(partToConfigure.Name, typeViewModel.Name);
+            await _notifier.SuccessAsync(H["The \"{0}\" part has been added.", partToConfigure.DisplayName]);
+
+            return RedirectToAction(nameof(EditTypePart), new { id, name = partToConfigure.Name });
+        }
+
+        var partsToAdd = viewModel.PartSelections.Where(ps => ps.IsSelected).Select(ps => ps.PartName).ToArray();
+
+        if (!partsToAdd.Any())
+        {
+            return NotFound();
+        }
+
         foreach (var partToAdd in partsToAdd)
         {
             await _contentDefinitionService.AddPartToTypeAsync(partToAdd, typeViewModel.Name);
-            await _notifier.SuccessAsync(H["The \"{0}\" part has been added.", partToAdd]);
         }
+
+        await _notifier.SuccessAsync(H.Plural(partsToAdd.Length, "The \"{1}\" part has been added.", "The following parts have been added: {1}.", string.Join(", ", partsToAdd)));
 
         if (!ModelState.IsValid)
         {
@@ -341,8 +371,9 @@ public sealed class AdminController : Controller
     }
 
     [HttpPost, ActionName("AddReusablePartTo")]
-    public async Task<ActionResult> AddReusablePartToPOST(string id)
+    public async Task<ActionResult> AddReusablePartToPOST(string id, [Bind(Prefix = "submit.Save")] string submitSave)
     {
+        var saveAndConfigure = submitSave == "SaveAndConfigure";
         if (!await _authorizationService.AuthorizeAsync(User, ContentTypesPermissions.EditContentTypes))
         {
             return Forbid();
@@ -410,6 +441,11 @@ public sealed class AdminController : Controller
         await _contentDefinitionService.AddReusablePartToTypeAsync(viewModel.Name, viewModel.DisplayName, viewModel.Description, partToAdd, typeViewModel.Name);
 
         await _notifier.SuccessAsync(H["The \"{0}\" part has been added.", partToAdd]);
+
+        if (saveAndConfigure)
+        {
+            return RedirectToAction(nameof(EditTypePart), new { id, name = viewModel.Name });
+        }
 
         return RedirectToAction(nameof(Edit), new { id });
     }
@@ -641,8 +677,9 @@ public sealed class AdminController : Controller
     }
 
     [HttpPost, ActionName("AddFieldTo")]
-    public async Task<ActionResult> AddFieldToPOST(AddFieldViewModel viewModel, string id, string returnUrl = null)
+    public async Task<ActionResult> AddFieldToPOST(AddFieldViewModel viewModel, string id, string returnUrl = null, [Bind(Prefix = "submit.Save")] string submitSave = null)
     {
+        var saveAndConfigure = submitSave == "SaveAndConfigure";
         if (!await _authorizationService.AuthorizeAsync(User, ContentTypesPermissions.EditContentTypes))
         {
             return Forbid();
@@ -712,13 +749,23 @@ public sealed class AdminController : Controller
 
         await _notifier.SuccessAsync(H["The field \"{0}\" has been added.", viewModel.DisplayName]);
 
+        if (saveAndConfigure)
+        {
+            return RedirectToAction(nameof(EditField), new
+            {
+                id,
+                name = viewModel.Name,
+                returnUrl = !string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl) ? returnUrl : null,
+            });
+        }
+
         if (!string.IsNullOrEmpty(returnUrl) && Url.IsLocalUrl(returnUrl))
         {
             return this.Redirect(returnUrl, true);
         }
         else
         {
-            return RedirectToAction(nameof(EditField), new { id, viewModel.Name });
+            return RedirectToAction(nameof(EditField), new { id, name = viewModel.Name });
         }
     }
 

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Controllers/AdminController.cs
@@ -347,7 +347,7 @@ public sealed class AdminController : Controller
             return RedirectToAction(nameof(EditTypePart), new { id, name = partToConfigure.Name });
         }
 
-        var partsToAdd = viewModel.PartSelections.Where(ps => ps.IsSelected).Select(ps => ps.PartName).ToArray();
+        var partsToAdd = viewModel.PartSelections.Where(ps => ps.IsSelected).Select(ps => ps.PartName);
 
         if (!partsToAdd.Any())
         {

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/AddFieldTo.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/AddFieldTo.cshtml
@@ -51,7 +51,8 @@
 
     <div class="ocat-wrapper">
         <div class="ocat-end-offset">
-            <button class="btn btn-primary save" type="submit">@T["Save"]</button>
+            <button class="btn btn-primary save" type="submit" name="submit.Save" value="Save">@T["Save"]</button>
+            <button class="btn btn-secondary" type="submit" name="submit.Save" value="SaveAndConfigure">@T["Save &amp; Configure"]</button>
             @if (Url.IsLocalUrl(returnUrl))
             {
                 <a class="btn btn-secondary cancel" role="button" href="@returnUrl">@T["Cancel"]</a>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/AddPartsTo.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/AddPartsTo.cshtml
@@ -3,6 +3,7 @@
 @inject IDataLocalizer D
 @{
     int i = 0;
+    var hasSelectedParts = Model.PartSelections.Any(x => x.IsSelected);
     string localizedTypeName = D[Model.Type.DisplayName, "Content Types"];
 }
 <zone Name="Title"><h1>@T["Add Parts To \"{0}\"", localizedTypeName]</h1></zone>
@@ -21,10 +22,13 @@
                 @foreach (var partSelection in Model.PartSelections)
                 {
                     <li class="list-group-item list-group-item-action">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" asp-for="PartSelections[i].IsSelected">
-                            <label class="form-check-label" asp-for="PartSelections[i].IsSelected">@partSelection.PartDisplayName</label>
-                            <span class="hint dashed">@partSelection.PartDescription</span>
+                        <div class="d-flex align-items-start justify-content-between gap-3">
+                            <div class="form-check flex-grow-1">
+                                <input type="checkbox" class="form-check-input" asp-for="PartSelections[i].IsSelected">
+                                <label class="form-check-label" asp-for="PartSelections[i].IsSelected">@partSelection.PartDisplayName</label>
+                                <span class="hint dashed">@partSelection.PartDescription</span>
+                            </div>
+                            <button class="btn btn-secondary btn-sm" type="submit" name="submit.AddAndConfigure" value="@partSelection.PartName">@T["Add &amp; Configure"]</button>
                         </div>
                         <input asp-for="PartSelections[i].IsSelected" type="hidden" />
                         <input asp-for="PartSelections[i].PartName" type="hidden" />
@@ -36,8 +40,22 @@
     </div>
     <div class="ocat-wrapper">
         <div class="ocat-end-offset">
-            <button class="btn btn-primary save" type="submit">@T["Save"]</button>
+            <button id="add-selected-parts-button" class="btn btn-primary save" type="submit" name="submit.Save" value="Save" hidden="@(!hasSelectedParts)">@T["Add Selected Parts"]</button>
             <a class="btn btn-secondary cancel" role="button" asp-route-action="Edit" asp-route-id="@Model.Type.Name">@T["Cancel"]</a>
         </div>
     </div>
 </form>
+
+<script at="Foot">
+    document.addEventListener('DOMContentLoaded', function () {
+        const addSelectedPartsButton = document.getElementById('add-selected-parts-button');
+        const partSelectionCheckboxes = document.querySelectorAll('input[type="checkbox"][name$=".IsSelected"]');
+
+        const updateAddSelectedPartsButton = () => {
+            addSelectedPartsButton.hidden = !Array.from(partSelectionCheckboxes).some((checkbox) => checkbox.checked);
+        };
+
+        partSelectionCheckboxes.forEach((checkbox) => checkbox.addEventListener('change', updateAddSelectedPartsButton));
+        updateAddSelectedPartsButton();
+    });
+</script>

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/AddReusablePartTo.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/AddReusablePartTo.cshtml
@@ -68,10 +68,10 @@
         <div class="ocat-end-offset">
             @if (Model.PartSelections.Any())
             {
-                <button class="btn btn-primary save" type="submit">@T["Save"]</button>
+                <button class="btn btn-primary save" type="submit" name="submit.Save" value="Save">@T["Save"]</button>
+                <button class="btn btn-secondary" type="submit" name="submit.Save" value="SaveAndConfigure">@T["Save &amp; Configure"]</button>
             }
             <a class="btn btn-secondary cancel" role="button" asp-route-action="Edit" asp-route-id="@Model.Type.Name">@T["Cancel"]</a>
         </div>
     </div>
 </form>
-


### PR DESCRIPTION
This pull request enhances the user experience and workflow when adding parts and fields to content types in OrchardCore. It introduces new "Add & Configure" and "Save & Configure" actions, allowing users to immediately configure newly added parts or fields. The UI is improved with more dynamic controls and clearer feedback, and the backend logic is updated to support these new flows.

**User Experience Improvements:**

* Added "Add & Configure" and "Save & Configure" buttons to the `AddPartsTo`, `AddReusablePartTo`, and `AddFieldTo` views, enabling users to directly proceed to configuration after adding a part or field. [[1]](diffhunk://#diff-ac6b548d5ad842f1a0724fdb473b5af14359a389e90eb51afe55cc6e27c39703L24-R32) [[2]](diffhunk://#diff-1da44109660da85a3213a323d4fc0082e89e11dd12cf9c24f4e0f32174742c1eL54-R55) [[3]](diffhunk://#diff-95dbb6916dd645124e8e00ab13aefc17b6b21268c3b8169a76467e5ad6caecabL71-L77)
* The "Add Selected Parts" button in `AddPartsTo.cshtml` is now only visible when at least one part is selected, with dynamic show/hide logic via JavaScript for improved usability.

**Controller Logic Enhancements:**

* Updated controller actions (`AddPartsToPOST`, `AddReusablePartToPOST`, `AddFieldToPOST`) to handle new "Configure" flows, redirecting users to the appropriate edit pages when requested. [[1]](diffhunk://#diff-c0a680537959a9012f2362ae44415c480b315d7aa63039866541d613df00964fL327-R363) [[2]](diffhunk://#diff-c0a680537959a9012f2362ae44415c480b315d7aa63039866541d613df00964fL344-R376) [[3]](diffhunk://#diff-c0a680537959a9012f2362ae44415c480b315d7aa63039866541d613df00964fL644-R682) [[4]](diffhunk://#diff-c0a680537959a9012f2362ae44415c480b315d7aa63039866541d613df00964fR445-R449) [[5]](diffhunk://#diff-c0a680537959a9012f2362ae44415c480b315d7aa63039866541d613df00964fR752-R768)
* Improved feedback by consolidating notifications: when adding multiple parts, a single pluralized notification is shown instead of multiple individual ones.

**Minor Improvements:**

* Added a variable in `AddPartsTo.cshtml` to track if any parts are selected, supporting the new UI logic.

These changes streamline the content type editing workflow, making it easier and faster for users to add and immediately configure parts and fields as needed.