### PR TITLE
Docs : Link icons, Add Linkedin OC group

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,12 +32,14 @@ extra:
   social:
     - icon: fontawesome/solid/leaf
       link: https://orchardcore.net
-    - icon: fontawesome/brands/github-alt
+    - icon: fontawesome/brands/github
       link: https://github.com/OrchardCMS/OrchardCore
     - icon: fontawesome/brands/discord
       link: https://orchardcore.net/discord
-    - icon: fontawesome/brands/twitter
+    - icon: fontawesome/brands/x-twitter
       link: https://twitter.com/OrchardCMS
+    - icon: fontawesome/brands/linkedin
+      link: https://www.linkedin.com/groups/13605669/
 
 # Repository
 repo_name: OrchardCMS/OrchardCore


### PR DESCRIPTION
Current footer of https://docs.orchardcore.net/en/latest/:

<img width="318" height="70" alt="image" src="https://github.com/user-attachments/assets/049b2d05-36e3-4bbc-928a-a9ba0c282104" />

After:

<img width="390" height="70" alt="image" src="https://github.com/user-attachments/assets/d18f7854-6575-4f44-8b34-475fdf683be5" />

