### PR TITLE
Improve Dashboard documentation

### DIFF
--- a/src/docs/reference/modules/AdminDashboard/README.md
+++ b/src/docs/reference/modules/AdminDashboard/README.md
@@ -1,6 +1,25 @@
 # Admin Dashboard (`OrchardCore.AdminDashboard`)
 
-Admin widgets are created using content items and can be secured like any other content item. To create a content type as a dashboard widget, set the stereotype to `DashboardWidget`.
+The `OrchardCore.AdminDashboard` module lets you compose the landing page of the admin area (`/admin`) from widgets. Each widget is a regular content item, so it can be edited, secured, versioned and localized like any other content.
+
+This page describes the options available to customize the dashboard: permissions, the built-in widget types, widget configuration, arranging widgets, and how to override their look.
+
+## Permissions
+
+| Permission             | Description                                                                 |
+|------------------------|-----------------------------------------------------------------------------|
+| `AccessAdminDashboard` | Allows viewing the admin dashboard and its widgets.                         |
+| `ManageAdminDashboard` | Allows adding, editing, arranging and removing dashboard widgets. Implies `AccessAdminDashboard`. |
+
+By default `ManageAdminDashboard` is granted to the `Administrator` role, while `AccessAdminDashboard` is also granted to the `Editor`, `Moderator`, `Author` and `Contributor` roles.
+
+A user with only `AccessAdminDashboard` additionally needs the `ViewContent` permission (or a per-type view permission) on a widget for that widget to be displayed.
+
+## Dashboard widgets
+
+Admin widgets are created using content items and can be secured like any other content item. To create a content type that can be used as a dashboard widget, set its stereotype to `DashboardWidget`.
+
+Adding the `DashboardPart` to the type is optional: the module attaches it automatically to every type whose stereotype is `DashboardWidget`. `DashboardPart` is what stores the position and size of the widget.
 
 ### Creating a New Widget
 
@@ -13,9 +32,21 @@ To create a new widget of the recently created content type, perform the followi
 
 Please note that users lacking the `ManageAdminDashboard` permission will require the `AccessAdminDashboard` permission to view the admin dashboard, in addition to the `ViewContent` or permission.
 
+### Built-in widget types
+
+The module ships with a few widget types you can use out of the box:
+
+| Content type           | Description                                                                 |
+|------------------------|-----------------------------------------------------------------------------|
+| `HtmlDashboardWidget`  | A widget whose body is authored with the `HtmlBodyPart`. Useful for links, notes or any custom HTML. |
+| `ContentsMetadata`     | Displays the metadata (author, dates, …) of content items.                  |
+| `ContentsTags`         | Displays the tags of content items.                                         |
+
+You can create your own widget types at any time by adding a content type with the `DashboardWidget` stereotype.
+
 ### Widget Configuration
 
-Each widget has the following customizable settings:
+Each widget has the following customizable settings, stored on the `DashboardPart`:
 
 | Option     | Description                                                                                                                                                               |
 |------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -23,7 +54,16 @@ Each widget has the following customizable settings:
 | `Width`    | An integer value between 1 and 6, representing the widget's width on the screen. Please note that 1 indicates (1/6) of the screen, while 6 signifies full screen width.   |
 | `Height`   | An integer value between 1 and 6, representing the widget's height on the screen. Please note that 1 indicates (1/6) of the screen, while 6 signifies full screen height. |
 
-### Styling
+### Arranging widgets
+
+In `Manage Dashboard` mode, widgets can be reordered and resized directly from the UI:
+
+- Drag a widget by its handle to change its `Position`.
+- Resize a widget to change its `Width` and `Height`.
+
+Changes are persisted to each widget's `DashboardPart` when saved. Both the latest and published versions are updated so the arrangement is reflected immediately on the dashboard.
+
+## Styling
 
 If you wish to modify the look of your widget, consider incorporating a template named `DashboardWidget-{ContentType}.DetailAdmin.cshtml`, where `{ContentType}` represents the specific technical name of your content type. Below is an illustration of a template that introduces spacing around the widget:
 
@@ -65,6 +105,43 @@ If you wish to modify the look of your widget, consider incorporating a template
     }
 </div>
 ```
+
+## Provisioning widgets with a recipe
+
+Dashboard widgets are content items, so they can be created from a recipe using the `content` step. This is handy to ship a default dashboard with your site. The following sample adds an `HtmlDashboardWidget` with a list of links, positioned first and two rows tall:
+
+```json
+{
+  "steps": [
+    {
+      "name": "content",
+      "data": [
+        {
+          "ContentItemId": "[js: uuid()]",
+          "ContentType": "HtmlDashboardWidget",
+          "DisplayText": "Orchard Core",
+          "Latest": true,
+          "Published": true,
+          "HtmlDashboardWidget": {},
+          "DashboardPart": {
+            "Position": 0.0,
+            "Width": 1.0,
+            "Height": 2.0
+          },
+          "HtmlBodyPart": {
+            "Html": "<ul class=\"list-group list-group-flush\">\n\t<li class=\"list-group-item\"><a href=\"https://orchardcore.net\" target=\"_blank\">Orchard Core site</a></li>\n\t<li class=\"list-group-item\"><a href=\"https://docs.orchardcore.net\" target=\"_blank\">Orchard Core docs</a></li>\n</ul>"
+          },
+          "TitlePart": {
+            "Title": "Orchard Core"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+A ready-to-use `dashboard-widgets-samples` recipe is included with the module.
 
 ### Videos
 


### PR DESCRIPTION
 Added sections:
  - Permissions table : AccessAdminDashboard vs ManageAdminDashboard, default role grants, ViewContent requirement.
  - Dashboard widgets : noted DashboardPart auto-attached to any DashboardWidget stereotype type.
  - Built-in widget types : HtmlDashboardWidget, ContentsMetadata, ContentsTags.
  - Arranging widgets : drag/resize in Manage mode, persists to DashboardPart (latest + published).
  - Provisioning widgets with a recipe : content step sample + dashboard-widgets-samples recipe pointer

Related to #19356