### PR TITLE
Update missing docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,6 +217,7 @@ nav:
               - Resources: reference/modules/Resources/README.md
               - Rules: reference/modules/Rules/README.md
               - Search, Indexing, Querying:
+                  - Search: reference/modules/Search/README.md
                   - Azure AI Search: reference/modules/AzureAISearch/README.md
                   - Elasticsearch: reference/modules/Elasticsearch/README.md
                   - Indexing: reference/modules/Indexing/README.md
@@ -258,6 +259,7 @@ nav:
               - Configuration: reference/modules/Configuration/README.md
               - Cors: reference/modules/Cors/README.md
               - Custom Settings: reference/modules/CustomSettings/README.md
+              - Settings: reference/modules/Settings/README.md
               - Deployment: reference/modules/Deployment/README.md
               - Placement: reference/modules/Placement/README.md
               - Data: reference/modules/Data/README.md

--- a/src/docs/reference/modules/ArchiveLater/README.md
+++ b/src/docs/reference/modules/ArchiveLater/README.md
@@ -1,3 +1,21 @@
 # Archive Later (`OrchardCore.ArchiveLater`)
 
-Adds the ability to schedule content items to be archived at a given future date and time. Attach the Archive Later Part to any content type where you want the feature to be available.
+The `OrchardCore.ArchiveLater` module adds the ability to schedule a published content item to be unpublished (archived) automatically at a future date and time.
+
+## Usage
+
+1. Enable the `Archive Later` feature.
+2. Attach the **Archive Later Part** to any content type that should support scheduled archiving (in the content type definition).
+3. When editing a published item of that type, set the scheduled archive date and time in the editor. The value is entered in the site/local time zone and stored as UTC.
+4. To cancel a scheduled archive, clear the date or use the cancel option in the editor before the scheduled time.
+
+## How it works
+
+The part stores a single value, `ScheduledArchiveUtc`, on the content item via the `ArchiveLaterPart`.
+
+A background task (`Content Items Archiver`) runs every minute. It finds published items whose scheduled archive time has passed, clears their schedule, and unpublishes them. Because it relies on a background task, the scheduled archiving only runs while the tenant is active.
+
+!!! note
+    Archiving here means the item is **unpublished** — it is removed from the published frontend while its latest draft is preserved.
+
+See also [Publish Later](../PublishLater/README.md) for scheduling the opposite operation.

--- a/src/docs/reference/modules/Features/README.md
+++ b/src/docs/reference/modules/Features/README.md
@@ -1,3 +1,44 @@
 # Features (`OrchardCore.Features`)
 
-The Features module enables the administrator of the site to manage the installed modules as well as activate and de-activate features within those modules.
+The `OrchardCore.Features` module lets the administrator of a site manage the installed modules and enable or disable the features they provide.
+
+## Managing features
+
+Go to **Configuration** > **Features** in the admin (requires the `Manage features` permission). From there you can:
+
+- Enable a feature, which also enables any feature it depends on.
+- Disable a feature, which also disables features that depend on it.
+- See each feature's category, description and dependencies.
+
+Some features are marked as *always enabled* by their module and cannot be turned off.
+
+## Permissions
+
+| Permission         | Description                          |
+|--------------------|--------------------------------------|
+| `Manage features`  | Allows enabling and disabling features. |
+
+Granted to the `Administrator` role by default.
+
+## Enabling features with a recipe
+
+Features can be enabled or disabled from a recipe using the `Feature` step. List the feature ids to turn on or off:
+
+```json
+{
+  "steps": [
+    {
+      "name": "Feature",
+      "enable": [
+        "OrchardCore.Contents",
+        "OrchardCore.Lists"
+      ],
+      "disable": [
+        "OrchardCore.HomeRoute"
+      ]
+    }
+  ]
+}
+```
+
+This is the recommended way to compose a site's enabled feature set as part of a setup or deployment recipe.

--- a/src/docs/reference/modules/Feeds/README.md
+++ b/src/docs/reference/modules/Feeds/README.md
@@ -1,3 +1,23 @@
 # Feeds (`OrchardCore.Feeds`)
 
-Adds capabilities for feeds like RSS feeds.
+The `OrchardCore.Feeds` module provides an extensible infrastructure for exposing content as syndication feeds, such as RSS. It does not expose any feed on its own: other modules plug into it to describe **what** to syndicate, while this module handles **how** the feed document is built and served.
+
+## How it works
+
+A feed request is served by the `Feed` controller and resolved through two extension points:
+
+- `IFeedBuilderProvider` — selects the output format. The built-in `rss` builder is provided by `OrchardCore.Feeds.Core`. The desired format is passed with the `format` query value (e.g. `format=rss`).
+- `IFeedQueryProvider` — selects the items to include, based on the request (for example, the items of a given list).
+
+The highest-priority matching builder and query are used. If neither matches, the controller returns `404`.
+
+## Feeds for lists
+
+The [Lists](../Lists/README.md) module is the most common consumer. When the `Feeds` and `Lists` features are enabled, a List content item can expose an RSS feed of its contained items.
+
+- The feed is enabled per list through the **RSS** settings on the list (`FeedMetadata`), which let you disable the feed (`DisableRssFeed`), set the number of items, or point to an external proxy URL (`FeedProxyUrl`).
+- When enabled, an auto-discovery `<link rel="alternate" type="application/rss+xml">` is added to the page `<head>` so browsers and feed readers can find the feed.
+
+## Providing your own feed
+
+To syndicate something other than lists, implement `IFeedQueryProvider` (to produce the items) and, if you need a non-RSS format, `IFeedBuilderProvider`, then register them in your module's `Startup`. Call `services.AddFeeds()` to bring in the core feed services.

--- a/src/docs/reference/modules/HomeRoute/README.md
+++ b/src/docs/reference/modules/HomeRoute/README.md
@@ -1,3 +1,32 @@
 # Home Route (`OrchardCore.HomeRoute`)
 
-Provides a way to set the route corresponding to the homepage (i.e. the URL "/") of the site. This module allows e.g. for content items to be promoted to the homepage.
+The `OrchardCore.HomeRoute` module defines the route that the homepage (the URL `/`) maps to. It registers a dynamic route on `/` that is resolved at request time from the configured home route, so any controller action or content item can act as the site's homepage.
+
+## Setting the homepage
+
+The home route is stored in the site settings (`HomeRoute`). It is most often set indirectly:
+
+- **Promote a content item to the homepage.** Content items expose a *Set as homepage* option (through the `Contents` feature), which points the home route at that item.
+- **Point to a controller action.** Modules and themes can set the home route to their own route values.
+
+## Setting it from a recipe
+
+The home route is part of the site settings, so it can be set with the `settings` recipe step using the `HomeRoute` key:
+
+```json
+{
+  "steps": [
+    {
+      "name": "settings",
+      "HomeRoute": {
+        "Area": "OrchardCore.Contents",
+        "Controller": "Item",
+        "Action": "Display",
+        "ContentItemId": "4xn8...your-content-item-id"
+      }
+    }
+  ]
+}
+```
+
+See [Settings](../Settings/README.md) for the site settings infrastructure.

--- a/src/docs/reference/modules/ResponseCompression/README.md
+++ b/src/docs/reference/modules/ResponseCompression/README.md
@@ -1,3 +1,14 @@
 # Response Compression (`OrchardCore.ResponseCompression`)
 
-Compresses HTTP responses with gzip, just enable the feature.
+The `OrchardCore.ResponseCompression` module enables ASP.NET Core [response compression](https://learn.microsoft.com/aspnet/core/performance/response-compression) for the tenant, reducing the size of HTTP responses sent to clients.
+
+## Usage
+
+Enable the `Response Compression` feature. No further configuration is required: the module registers the response compression middleware with the default providers (gzip), with compression also enabled for HTTPS responses.
+
+## When to use it
+
+Prefer enabling compression at the reverse proxy or web server (IIS, Nginx, Kestrel front end, CDN) when one is in front of the application, as it is usually more efficient there. Use this module when no such layer handles compression, for example when the application is exposed directly.
+
+!!! warning
+    Compressing responses over HTTPS can expose the application to attacks such as [BREACH](https://learn.microsoft.com/aspnet/core/performance/response-compression#compression-with-secure-protocol). Enable this feature only if you understand and accept that risk for your dynamically generated, secured responses.

--- a/src/docs/reference/modules/Search/README.md
+++ b/src/docs/reference/modules/Search/README.md
@@ -1,0 +1,64 @@
+# Search (`OrchardCore.Search`)
+
+The `OrchardCore.Search` module provides a frontend search experience for your site. It exposes a search page and a search form, and queries an index built by one of the search providers (Lucene, Elasticsearch or Azure AI Search).
+
+This module only provides the user-facing search UI. The actual indexes are created and managed by the [`Indexing`](../Indexing/README.md) infrastructure together with a provider:
+
+- [Lucene](../Lucene/README.md)
+- [Elasticsearch](../Elasticsearch/README.md)
+- [Azure AI Search](../AzureAISearch/README.md)
+
+Enable `OrchardCore.Search` plus at least one provider feature, and create an index profile, before using the search page.
+
+## Search page
+
+The module registers a search endpoint:
+
+```
+/search/{index?}
+```
+
+- `index` (optional) — the name of the index profile to query. When omitted, the **default index** configured in the search settings is used.
+- `terms` — the search query, passed as a query string value (`/search?terms=orchard`).
+
+If no index name is supplied and no default index is configured, a warning is displayed. If the requested index does not exist, the endpoint returns `404`.
+
+Results are paged using the site's configured page size, with "previous"/"next" links generated automatically.
+
+## Settings
+
+Configure the search experience under **Search** > **Settings** > **Site Search** in the admin (requires the `Manage Search Settings` permission).
+
+| Setting               | Description                                                                                  |
+|-----------------------|----------------------------------------------------------------------------------------------|
+| `DefaultIndexProfileName` | The index profile queried when no index is specified in the URL.                         |
+| `PageTitle`           | The title displayed on the search results page.                                              |
+| `Placeholder`         | The placeholder text shown in the search input box.                                          |
+
+These settings can be exported and imported through a deployment plan using the **Search Settings** deployment step.
+
+## Permissions
+
+| Permission              | Description                                                            |
+|-------------------------|-----------------------------------------------------------------------|
+| `Manage Search Settings` | Allows configuring the site search settings.                         |
+| `Query Search Index`    | Allows querying a search index. Granted per index profile.            |
+
+Both permissions are granted to the `Administrator` role by default. To let anonymous or other roles use the search page, grant `Query Search Index` for the relevant index profile.
+
+## Search form
+
+The module ships a `SearchFormPart` and a `Search Form` widget so a search box can be placed anywhere, such as in a layer zone or on a page. The form submits a `GET` request to the `/search` endpoint with the entered `Terms`. The placeholder text is data-localizable.
+
+## Theming
+
+The search UI is rendered through shapes that you can override in your theme:
+
+| Shape            | Template            | Purpose                                  |
+|------------------|---------------------|------------------------------------------|
+| `Search`         | `Search.cshtml`     | The overall search page.                 |
+| `Search-Form`    | `Search-Form.cshtml`| The search input form.                   |
+| `Search-Results` | `Search-Results.cshtml` | The list of results.                 |
+| `Search-List`    | `Search-List.cshtml`| The container of the result items.       |
+
+Copy these templates into your theme to customize the markup. Result highlighting is provided when the underlying search provider returns highlights.

--- a/src/docs/reference/modules/Settings/README.md
+++ b/src/docs/reference/modules/Settings/README.md
@@ -1,0 +1,89 @@
+# Settings (`OrchardCore.Settings`)
+
+The `OrchardCore.Settings` module provides the **site settings** infrastructure: a single, per-tenant container of configuration that other modules contribute to. It is always enabled and cannot be disabled.
+
+Site settings are where global, site-wide options live (site name, time zone, page size, …) as opposed to per-content-item data. Modules extend these settings by adding their own groups (for example, the SMTP settings, the search settings, or the reCAPTCHA settings all appear as additional sections of the site settings).
+
+For user-defined settings managed from the admin without writing code, see [Custom Settings](../CustomSettings/README.md). For application-level (`appsettings.json`) configuration, see [Configuration](../Configuration/README.md).
+
+## General settings
+
+The built-in **General** group is available in the admin under **Settings** > **General** (requires the `Manage settings` permission). It exposes options such as:
+
+| Setting             | Description                                                                 |
+|---------------------|-----------------------------------------------------------------------------|
+| `SiteName`          | The display name of the site.                                               |
+| `PageTitleFormat`   | The format used to build the page `<title>` (Liquid).                       |
+| `BaseUrl`           | The absolute base URL used when an absolute URL must be generated.          |
+| `TimeZoneId`        | The default time zone of the site.                                          |
+| `Calendar`          | The default calendar system.                                                |
+| `PageSize`          | The default number of items per page.                                       |
+| `MaxPageSize`       | The maximum page size a client can request.                                 |
+| `MaxPagedCount`     | The maximum number of items that can be paged through.                      |
+| `UseCdn` / `CdnBaseUrl` | Whether to serve framework assets from a CDN, and the CDN base URL.     |
+| `ResourceDebugMode` | Whether to serve debuggable (non-minified) versions of resources.           |
+| `AppendVersion`     | Whether to append a version token to static asset URLs for cache busting.   |
+| `CacheMode`         | The default caching behavior for resources.                                 |
+
+A separate **Debugging** group exposes diagnostic options.
+
+## Permissions
+
+| Permission               | Description                                                                  |
+|--------------------------|------------------------------------------------------------------------------|
+| `Manage settings`        | Grants access to all site settings groups.                                   |
+| `Manage group settings`  | Grants access to a specific settings group only. Used to scope access per section. |
+
+Both are granted to the `Administrator` role by default. Modules that add a settings group typically authorize against `Manage group settings` for their own group id.
+
+## Accessing settings in code
+
+Read and write site settings through `ISiteService`:
+
+```csharp
+public class MyService
+{
+    private readonly ISiteService _siteService;
+
+    public MyService(ISiteService siteService) => _siteService = siteService;
+
+    public async Task<string> GetSiteNameAsync()
+    {
+        var site = await _siteService.GetSiteSettingsAsync();
+        return site.SiteName;
+    }
+}
+```
+
+Custom settings classes are stored in the `Properties` bag of the site settings and retrieved with `site.As<TSettings>()`. A module exposes its own group in the admin by implementing a `SiteDisplayDriver` (a display driver for `ISite`) with a matching `GroupId`.
+
+## Accessing settings in templates
+
+In Liquid, the current site settings are available through the `Site` accessor:
+
+```liquid
+{{ Site.SiteName }}
+{{ Site.PageSize }}
+```
+
+## Recipes
+
+Site settings can be set from a recipe using the `settings` step. Recognized keys map to the built-in properties; any other key is stored in the site settings `Properties` bag, which lets modules import their own settings.
+
+```json
+{
+  "steps": [
+    {
+      "name": "settings",
+      "SiteName": "My Orchard Core Site",
+      "PageSize": 10,
+      "TimeZoneId": "Europe/Paris",
+      "UseCdn": false
+    }
+  ]
+}
+```
+
+## Deployment
+
+Use the **Site Settings** deployment step to export and import the site settings between environments as part of a deployment plan.

--- a/src/docs/reference/modules/XmlRpc/README.md
+++ b/src/docs/reference/modules/XmlRpc/README.md
@@ -1,3 +1,27 @@
 # XML-RPC (`OrchardCore.XmlRpc`)
 
-Enables creation of contents from client applications such as Open Live Writer.
+The `OrchardCore.XmlRpc` module adds support for the XML-RPC protocol, allowing client applications such as [Open Live Writer](http://openlivewriter.com/) to interact with the site.
+
+The module provides two features:
+
+| Feature                       | Description                                                                 |
+|-------------------------------|-----------------------------------------------------------------------------|
+| `OrchardCore.XmlRpc`          | Provides the core XML-RPC endpoint and protocol support.                    |
+| `OrchardCore.RemotePublishing` | Adds the MetaWeblog API on top of XML-RPC, enabling remote creation and editing of content. Depends on `OrchardCore.XmlRpc`. |
+
+## Endpoints
+
+| Route                | Purpose                                  |
+|----------------------|------------------------------------------|
+| `/xmlrpc`            | The XML-RPC entry point.                 |
+| `/xmlrpc/metaweblog` | The MetaWeblog API endpoint (requires the Remote Publishing feature). |
+
+## Usage
+
+To publish from a desktop blogging client:
+
+1. Enable the `Remote Publishing` feature (it enables `XML-RPC` automatically).
+2. In the client (for example Open Live Writer), configure a new account pointing at your site, using the MetaWeblog API and the `/xmlrpc/metaweblog` endpoint.
+3. Authenticate with a site user that has the permissions required to create and publish the relevant content.
+
+The MetaWeblog API supports the typical operations used by blogging clients: retrieving recent posts, creating and editing posts, and uploading media.


### PR DESCRIPTION
### New module docs (were missing)
  | Module | Page |
  |--------|------|
  | `OrchardCore.Search` | `reference/modules/Search/README.md` — `/search/{index?}` route, site search settings (default index, page title, placeholder), permissions, search
  form widget, theming shapes |
  | `OrchardCore.Settings` | `reference/modules/Settings/README.md` — General settings, permissions, `ISiteService` API, `SiteDisplayDriver` extension, Liquid `Site`, `settings`
  recipe step, deployment step |

  Both added to the `mkdocs.yml` nav.

  ### Stub docs expanded (one-liner → full)
  | Doc | Now covers |
  |-----|-----------|
  | Feeds | feed builder/query providers, `format=rss`, Lists RSS metadata, auto-discovery `<link>` |
  | Features | Features UI, dependency cascade, `Manage features`, `Feature` recipe step |
  | XML-RPC | XML-RPC + Remote Publishing features, `/xmlrpc` routes, MetaWeblog / Open Live Writer |
  | Home Route | dynamic `/` route, promote item, `HomeRoute` setting + recipe |
  | Archive Later | part attach, `ScheduledArchiveUtc`, 1-min background archiver task |
  | Response Compression | gzip middleware, reverse-proxy guidance, BREACH warning |