### PR TITLE
Enhance media authorization and update permissions documentation

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Controllers/AdminController.cs
@@ -163,7 +163,8 @@ public sealed class AdminController : Controller
 
     public async Task<ActionResult<object>> GetMediaItem(string path)
     {
-        if (!await _authorizationService.AuthorizeAsync(User, MediaPermissions.ManageMediaFolder, (object)path)
+        if (!await _authorizationService.AuthorizeAsync(User, MediaPermissions.ManageMedia)
+            || !await _authorizationService.AuthorizeAsync(User, MediaPermissions.ManageMediaFolder, (object)path)
             || (HttpContext.IsSecureMediaEnabled() && !await _authorizationService.AuthorizeAsync(User, MediaPermissions.ViewMedia, (object)(path ?? string.Empty))))
         {
             return Forbid();
@@ -188,7 +189,8 @@ public sealed class AdminController : Controller
     [MediaSizeLimit]
     public async Task<IActionResult> Upload(string path, string extensions)
     {
-        if (!await _authorizationService.AuthorizeAsync(User, MediaPermissions.ManageMediaFolder, (object)path)
+        if (!await _authorizationService.AuthorizeAsync(User, MediaPermissions.ManageMedia)
+            || !await _authorizationService.AuthorizeAsync(User, MediaPermissions.ManageMediaFolder, (object)path)
             || (HttpContext.IsSecureMediaEnabled() && !await _authorizationService.AuthorizeAsync(User, MediaPermissions.ViewMedia, (object)(path ?? string.Empty))))
         {
             return Forbid();

--- a/src/OrchardCore.Modules/OrchardCore.Media/Services/ViewMediaFolderAuthorizationHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Services/ViewMediaFolderAuthorizationHandler.cs
@@ -155,7 +155,7 @@ public sealed class ViewMediaFolderAuthorizationHandler : AuthorizationHandler<P
             // Authorize by using the content item permission. The user must have access to the content item to allow its media
             // as well.
             var contentItemId = attachedMediaPathParts.Length > 1 ? attachedMediaPathParts[1] : null;
-            var contentItem = !string.IsNullOrEmpty(contentItemId) ? await _contentManager.GetAsync(contentItemId) : null;
+            var contentItem = !string.IsNullOrEmpty(contentItemId) ? await _contentManager.GetAsync(contentItemId, VersionOptions.Latest) : null;
 
             // Disallow if content item is not found or allowed
             if (contentItem is not null)

--- a/src/OrchardCore/OrchardCore.Media.Core/MediaPermissions.cs
+++ b/src/OrchardCore/OrchardCore.Media.Core/MediaPermissions.cs
@@ -10,9 +10,9 @@ public static class MediaPermissions
 
     public static readonly Permission ManageOwnMedia = new("ManageOwnMediaContent", "Manage Own Media", [ManageOthersMedia]);
 
-    public static readonly Permission ManageMedia = new("ManageMediaContent", "Manage Media", [ManageOwnMedia]);
-
     public static readonly Permission ManageAttachedMediaFieldsFolder = new("ManageAttachedMediaFieldsFolder", "Manage Attached Media Fields Folder", [ManageMediaFolder]);
+
+    public static readonly Permission ManageMedia = new("ManageMediaContent", "Manage Media", [ManageOwnMedia, ManageAttachedMediaFieldsFolder]);
 
     public static readonly Permission ManageMediaProfiles = new("ManageMediaProfiles", "Manage Media Profiles");
 

--- a/src/docs/reference/modules/ContentFields/README.md
+++ b/src/docs/reference/modules/ContentFields/README.md
@@ -43,7 +43,7 @@ Fields support different editors for input and display modes for output:
 You can create custom editors and display modes by following the patterns in the "Creating Custom Fields" section.
 
 !!! note
-    The `MediaField`'s `Attached` editor is documented in the Media module. It stores files under `mediafields/` and requires the `ManageAttachedMediaFieldsFolder` permission.
+    The `MediaField`'s `Attached` editor is documented in the [Media module](../Media/README.md). It stores files under `mediafields/` and requires the `ManageAttachedMediaFieldsFolder` permission.
 
 ## Usage
 

--- a/src/docs/reference/modules/ContentFields/README.md
+++ b/src/docs/reference/modules/ContentFields/README.md
@@ -42,6 +42,9 @@ Fields support different editors for input and display modes for output:
 
 You can create custom editors and display modes by following the patterns in the "Creating Custom Fields" section.
 
+!!! note
+    The `MediaField`'s `Attached` editor is documented in the Media module. It stores files under `mediafields/` and requires the `ManageAttachedMediaFieldsFolder` permission.
+
 ## Usage
 
 From a `Content` template, you can reference a field's value like this

--- a/src/docs/reference/modules/Media/README.md
+++ b/src/docs/reference/modules/Media/README.md
@@ -541,13 +541,42 @@ To set up indexing for Media do the following:
 3. Configure the new field to be used for search. You can do this from the admin under Search, Settings, Search, and adding the name of the new field under "Default search fields" (arriving at something like "Content.ContentItem.FullText, BlogPost.File.MediaText, BlogPost.File.FileText").
 4. Try searching for content only available in the Media Text of selected media files, or referenced PDF files. You should see corresponding results.
 
+## Manage Media Permissions
+
+The Media module uses a small permission hierarchy to distinguish between media library access, folder management, and read-only access.
+
+`ManageMediaContent` is the minimum permission required to open and use the Media Library. If a user does not have this permission, the library cannot be accessed and none of the media actions in the library are available.
+
+The available media permissions are:
+
+| Permission | Description | Notes |
+| --- | --- | --- |
+| `ManageMediaFolder` | Manage All Media Folders | Grants the broadest media folder management access. Viewing permissions are also implied by it. |
+| `ManageOthersMediaContent` | Manage Media For Others | Implied by `ManageMediaFolder`. Lets a user manage media owned by others. |
+| `ManageOwnMediaContent` | Manage Own Media | Implied by `ManageOthersMediaContent`. Lets a user manage their own media. |
+| `ManageAttachedMediaFieldsFolder` | Manage Attached Media Fields Folder | Implied by `ManageMediaFolder`. Used for files stored under `mediafields/`. |
+| `ManageMediaContent` | Manage Media | Minimum permission for opening the Media Library. Implied by `ManageOwnMediaContent` and `ManageAttachedMediaFieldsFolder`. |
+| `ManageMediaProfiles` | Manage Media Profiles | Controls media profile management. |
+| `ViewMediaOptions` | View Media Options | Controls visibility of media options. |
+| `ManageAssetCache` | Manage Asset Cache Folder | Controls the media asset cache folder. |
+| `ViewMediaContent` | View media content in all folders | Implied by `ManageMediaFolder`. Also acts as the base view permission for Secure Media folders. |
+| `ViewRootMediaContent` | View media content in the root folder | Implied by `ViewMediaContent`. |
+| `ViewOthersMediaContent` | View others media content | Implied by `ManageMediaFolder`. |
+| `ViewOwnMediaContent` | View own media content | Implied by `ViewOthersMediaContent`. |
+
+The `ManageMediaFolder` permission is the broadest media permission and effectively grants all folder access. Because of that, it also implies the view permissions used by Secure Media.
+
+The `ViewMediaContent`, `ViewRootMediaContent`, `ViewOthersMediaContent`, and `ViewOwnMediaContent` permissions are only available when the **Secure Media** feature is enabled.
+
 ## Secure Media
 
-The Secure Media feature enhances security and control over media files within the Media module. 
+The Secure Media feature enhances security and control over media files within the Media module.
 
-When enabled, administrators can set view permissions for the root media folder and each first-level folder within the media root. This allows for restricting access to media folders based on user roles, ensuring that only authorized users can view or manage media files within specific folders.
+When enabled, administrators can add finer-grained view permissions for the root media folder and each first-level folder within the media root. This allows access to be restricted by folder even inside the Media Library, ensuring that only authorized users can view or manage media files in specific locations.
 
-New permissions to allow users to view their own media files, view media files uploaded by others, or both are created too. You can manage these among the other permissions with the [Roles module](../Roles/README.md).
+New permissions to allow users to view their own media files, view media files uploaded by others, or both are created too. These are additional permissions on top of `ManageMediaContent`, not a replacement for it. You can manage them among the other permissions with the [Roles module](../Roles/README.md).
+
+These view permissions only exist when the **Secure Media** feature is enabled.
 
 Media files attached to content items will also adhere to the `ViewContent` permission of the respective content item automatically.
 
@@ -590,6 +619,8 @@ For new uploads, the stored file name is hash-based, while cloned content items 
 When the **Secure Media** feature is enabled, files under `mediafields/` automatically inherit the `ViewContent` permission of the associated content item. In other words, access to an attached file follows access to the content item that owns it.
 
 This means you don't need to grant separate folder permissions for attached uploads. If a user can't view the content item, Secure Media also prevents access to the attached file URL.
+
+Using the **Attached** editor requires the `ManageAttachedMediaFieldsFolder` permission. This permission is separate from the general `ManageMediaContent` permission and covers the `mediafields/` storage used by attached uploads.
 
 Use the **Attached** editor when the file should belong to a specific content item and automatically follow that item's `ViewContent` permission.
 


### PR DESCRIPTION
This pull request enhances the media permissions system in OrchardCore, clarifies permission requirements in the documentation, and improves authorization logic for media actions. The changes strengthen security and provide clearer guidance for developers and administrators.

**Media Permissions Improvements:**

* Expanded the `ManageMediaContent` permission (`ManageMedia`) to also be implied by `ManageAttachedMediaFieldsFolder`, making it a prerequisite for accessing the Media Library when managing attached media fields.
* Updated authorization checks in `AdminController.cs` to require both `ManageMedia` and `ManageMediaFolder` permissions for media actions, improving security and ensuring correct permission enforcement. That check was removed by #18945 but all actions require that basic check. <a>[1]</a> <a>[2]</a>  

**Documentation Updates:**

* Added detailed documentation about the media permission hierarchy, clarifying the purpose and relationships between permissions such as `ManageMediaContent`, `ManageMediaFolder`, and `ManageAttachedMediaFieldsFolder`.
* Documented that the `Attached` editor for `MediaField` requires the `ManageAttachedMediaFieldsFolder` permission, and explained its use and storage location. <a>[1]</a> <a>[2]</a>
* Added a direct link in the Content Fields documentation note to the Media module reference page for the `MediaField` `Attached` editor.

**Authorization Logic Enhancement:**

* Changed retrieval of content items in `ViewMediaFolderAuthorizationHandler` to always fetch the latest version, ensuring authorization checks are up-to-date. Otherwise, editing draft content items will not display attached images, when the secure media feature is enabled.

Fixes #16912
