### PR TITLE
Refactor RemoveContentContext with removal reason enum

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Media/Handlers/AttachedMediaFieldContentHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Media/Handlers/AttachedMediaFieldContentHandler.cs
@@ -17,7 +17,7 @@ public class AttachedMediaFieldContentHandler : ContentHandlerBase
 
     public override async Task RemovedAsync(RemoveContentContext context)
     {
-        if (context.NoActiveVersionLeft)
+        if (context.NoActiveVersionLeft && context.Reason == RemoveContentReason.Deletion)
         {
             await _attachedMediaFieldFileService.DeleteContentItemFolderAsync(context.ContentItem);
         }

--- a/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/RemoveContentContext.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement.Abstractions/Handlers/RemoveContentContext.cs
@@ -1,13 +1,53 @@
 namespace OrchardCore.ContentManagement.Handlers;
 
+/// <summary>
+/// Describes why active content item versions are being removed.
+/// </summary>
+public enum RemoveContentReason
+{
+    /// <summary>
+    /// Active versions are being removed because the content item itself is being deleted.
+    /// </summary>
+    Deletion,
+
+    /// <summary>
+    /// Active versions are being removed because a replacement version is about to be created.
+    /// </summary>
+    NewVersion,
+}
+
+/// <summary>
+/// Provides context for content handlers when active versions of a content item are being removed.
+/// </summary>
 public class RemoveContentContext : ContentContextBase
 {
-    public RemoveContentContext(ContentItem contentItem, bool noActiveVersionLeft = false) : base(contentItem)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemoveContentContext"/> class.
+    /// </summary>
+    /// <param name="contentItem">The content item whose active versions are being removed.</param>
+    /// <param name="noActiveVersionLeft">
+    /// <see langword="true"/> when no active version will remain after the current removal operation completes;
+    /// otherwise, <see langword="false"/>.
+    /// </param>
+    /// <param name="reason">The reason the active versions are being removed.</param>
+    public RemoveContentContext(ContentItem contentItem, bool noActiveVersionLeft = false, RemoveContentReason reason = RemoveContentReason.Deletion) : base(contentItem)
     {
         NoActiveVersionLeft = noActiveVersionLeft;
+        Reason = reason;
     }
 
+    /// <summary>
+    /// Gets a value indicating whether no active version will remain after the current removal operation completes.
+    /// </summary>
     public bool NoActiveVersionLeft { get; }
 
+    /// <summary>
+    /// Gets the reason the active versions are being removed.
+    /// </summary>
+    public RemoveContentReason Reason { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the removal operation should be canceled by a handler.
+    /// </summary>
     public bool Cancel { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
+++ b/src/OrchardCore/OrchardCore.ContentManagement/DefaultContentManager.cs
@@ -914,7 +914,7 @@ public class DefaultContentManager : IContentManager
             return true;
         }
 
-        var context = new RemoveContentContext(contentItem, true);
+        var context = new RemoveContentContext(contentItem, true, RemoveContentReason.Deletion);
 
         await Handlers.InvokeAsync((handler, context) => handler.RemovingAsync(context), context, _logger);
 
@@ -1219,7 +1219,7 @@ public class DefaultContentManager : IContentManager
 
         if (publishedVersion != null)
         {
-            var removeContext = new RemoveContentContext(contentItem, true);
+            var removeContext = new RemoveContentContext(contentItem, true, RemoveContentReason.NewVersion);
 
             await Handlers.InvokeAsync((handler, context) => handler.RemovingAsync(context), removeContext, _logger);
 
@@ -1247,7 +1247,7 @@ public class DefaultContentManager : IContentManager
 
         if (activeVersions.Any())
         {
-            var removeContext = new RemoveContentContext(contentItem, true);
+            var removeContext = new RemoveContentContext(contentItem, true, RemoveContentReason.NewVersion);
 
             await Handlers.InvokeAsync((handler, context) => handler.RemovingAsync(context), removeContext, _logger);
 


### PR DESCRIPTION
Added RemoveContentReason enum to clarify why content item versions are removed (deletion vs. new version). Updated RemoveContentContext and DefaultContentManager to use this reason, and adjusted AttachedMediaFieldContentHandler to only delete folders on actual deletion. Improved code documentation for clarity.

Fixes #17214