### PR TITLE
Add Allow Remember Me to Login Settings

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Controllers/AccountController.cs
@@ -139,7 +139,9 @@ public sealed class AccountController : AccountBaseController
                         }
                     }
 
-                    result = await _signInManager.PasswordSignInAsync(user, model.Password, model.RememberMe, lockoutOnFailure: true);
+                    var rememberMe = loginSettings.AllowRememberMe && model.RememberMe;
+
+                    result = await _signInManager.PasswordSignInAsync(user, model.Password, rememberMe, lockoutOnFailure: true);
 
                     if (result.Succeeded)
                     {

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/LoginFormDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/LoginFormDisplayDriver.cs
@@ -1,5 +1,6 @@
 using OrchardCore.DisplayManagement.Handlers;
 using OrchardCore.DisplayManagement.Views;
+using OrchardCore.Settings;
 using OrchardCore.Users.Models;
 using OrchardCore.Users.ViewModels;
 
@@ -7,12 +8,22 @@ namespace OrchardCore.Users.Drivers;
 
 public sealed class LoginFormDisplayDriver : DisplayDriver<LoginForm>
 {
+    private readonly ISiteService _siteService;
+
+    public LoginFormDisplayDriver(ISiteService siteService)
+    {
+        _siteService = siteService;
+    }
+
     public override IDisplayResult Edit(LoginForm model, BuildEditorContext context)
     {
         return Initialize<LoginViewModel>("LoginFormCredentials", vm =>
         {
+            var loginSettings = _siteService.GetSettings<LoginSettings>();
+
             vm.UserName = model.UserName;
             vm.RememberMe = model.RememberMe;
+            vm.AllowRememberMe = loginSettings.AllowRememberMe;
         }).Location("Content");
     }
 
@@ -20,11 +31,16 @@ public sealed class LoginFormDisplayDriver : DisplayDriver<LoginForm>
     {
         var viewModel = new LoginViewModel();
 
-        await context.Updater.TryUpdateModelAsync(viewModel, Prefix);
+        await context.Updater.TryUpdateModelAsync(viewModel, Prefix,
+            sp => sp.UserName,
+            sp => sp.Password,
+            sp => sp.RememberMe);
+
+        var loginSettings = _siteService.GetSettings<LoginSettings>();
 
         model.UserName = viewModel.UserName;
         model.Password = viewModel.Password;
-        model.RememberMe = viewModel.RememberMe;
+        model.RememberMe = loginSettings.AllowRememberMe && viewModel.RememberMe;
 
         return Edit(model, context);
     }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Drivers/LoginSettingsDisplayDriver.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Drivers/LoginSettingsDisplayDriver.cs
@@ -35,6 +35,7 @@ public sealed class LoginSettingsDisplayDriver : SiteDisplayDriver<LoginSettings
             model.AllowChangingEmail = settings.AllowChangingEmail;
             model.AllowChangingUsername = settings.AllowChangingUsername;
             model.AllowChangingPhoneNumber = settings.AllowChangingPhoneNumber;
+            model.AllowRememberMe = settings.AllowRememberMe;
         }).Location("Content:5#General")
         .RenderWhen(() => _authorizationService.AuthorizeAsync(_httpContextAccessor.HttpContext.User, UsersPermissions.ManageUsers))
         .OnGroup(SettingsGroupId);

--- a/src/OrchardCore.Modules/OrchardCore.Users/ViewModels/LoginViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Users/ViewModels/LoginViewModel.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace OrchardCore.Users.ViewModels;
 
@@ -13,4 +14,7 @@ public class LoginViewModel
     public string Password { get; set; }
 
     public bool RememberMe { get; set; }
+
+    [BindNever]
+    public bool AllowRememberMe { get; set; }
 }

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/LoginFormCredentials.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/LoginFormCredentials.cshtml
@@ -1,5 +1,8 @@
+@using OrchardCore.Users.Models
 @model LoginViewModel
-
+@{
+    var allowRememberMe = Site.GetOrCreate<LoginSettings>().AllowRememberMe;
+}
 <div class="mb-3" asp-validation-class-for="UserName">
     <label asp-for="UserName" class="form-label">@T["Username or email address"]</label>
     <input asp-for="UserName" class="form-control" autofocus tabindex="1" />
@@ -15,12 +18,15 @@
     <span asp-validation-for="Password" class="text-danger"></span>
 </div>
 
-<div class="mb-3">
-    <div class="form-check">
-        <input asp-for="RememberMe" class="form-check-input" tabindex="3">
-        <label asp-for="RememberMe" class="form-check-label">@T["Remember me"]</label>
+@if (allowRememberMe)
+{
+    <div class="mb-3">
+        <div class="form-check">
+            <input asp-for="RememberMe" class="form-check-input" tabindex="3">
+            <label asp-for="RememberMe" class="form-check-label">@T["Remember me"]</label>
+        </div>
     </div>
-</div>
+}
 
 <script at="Foot">
     let togglePassword = document.querySelector('#togglePassword');

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/LoginSettings.Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/LoginSettings.Edit.cshtml
@@ -11,6 +11,15 @@
 <div class="ocat-wrapper">
     <div class="ocat-end-offset">
         <div class="form-check">
+            <input asp-for="AllowRememberMe" type="checkbox" class="form-check-input">
+            <label class="form-check-label" asp-for="AllowRememberMe">@T["Allow user to be remembered during login"]</label>
+        </div>
+    </div>
+</div>
+
+<div class="ocat-wrapper">
+    <div class="ocat-end-offset">
+        <div class="form-check">
             <input asp-for="AllowChangingUsername" type="checkbox" class="form-check-input">
             <label class="form-check-label" asp-for="AllowChangingUsername">@T["Allow user to change their username"]</label>
         </div>

--- a/src/OrchardCore/OrchardCore.Users.Core/Models/LoginSettings.cs
+++ b/src/OrchardCore/OrchardCore.Users.Core/Models/LoginSettings.cs
@@ -12,6 +12,8 @@ public class LoginSettings
 
     public bool AllowChangingEmail { get; set; }
 
+    public bool AllowRememberMe { get; set; } = true;
+
     [DefaultValue(true)]
     public bool AllowChangingPhoneNumber { get; set; } = true;
 }


### PR DESCRIPTION
This pull request adds support for configuring whether the "Remember Me" option is available on the login form via a new `AllowRememberMe` setting in `LoginSettings`. The changes ensure that the "Remember Me" checkbox is only shown and respected if allowed by site settings, and provide a UI option for administrators to enable or disable this feature.

**Login "Remember Me" feature configuration:**

* Added a new `AllowRememberMe` property (defaulting to `true`) to the `LoginSettings` model, enabling site administrators to control whether users can opt to be remembered during login.
* Updated the login form view (`LoginFormCredentials.cshtml`) to display the "Remember Me" checkbox only if `AllowRememberMe` is enabled in site settings. [[1]](diffhunk://#diff-2dcbeabb523e6ed4ca6fa56ed496877f0d8401833733e2b4a0af7ea4c2e134faR1-R5) [[2]](diffhunk://#diff-2dcbeabb523e6ed4ca6fa56ed496877f0d8401833733e2b4a0af7ea4c2e134faR21-R29)
* Modified the login logic in `AccountController` so that the "Remember Me" option is only honored if allowed by settings.
* Enhanced the `LoginFormDisplayDriver` to read and apply the `AllowRememberMe` setting when building and updating the login form model, ensuring that the checkbox state is consistent with site configuration.
* Added a checkbox for `AllowRememberMe` to the login settings admin UI, allowing administrators to toggle this feature. [[1]](diffhunk://#diff-3b013a1ef4347c42ab002f1fe150a6fb5d618a19f79d46f47a2496f040538f71R11-R19) [[2]](diffhunk://#diff-4ed0868e094813f236fba8925c2a6e5c1f0febd0407c77ac201a307b3b2bee4dR38)

**ViewModel and binding improvements:**

* Added an `AllowRememberMe` property (with `[BindNever]` attribute) to the `LoginViewModel` to prevent client-side tampering and to pass the setting to the view. [[1]](diffhunk://#diff-422540de4b0cf8496f9c9121c5bbb2cf322ca66bc2ab7574519a4df8d5f9a851R17-R19) [[2]](diffhunk://#diff-422540de4b0cf8496f9c9121c5bbb2cf322ca66bc2ab7574519a4df8d5f9a851R2)
