### PR TITLE
Improve orchardcore-tester skill: AutoSetup + browser setup/login guidance

### DIFF
--- a/.agents/skills/orchardcore-tester/SKILL.md
+++ b/.agents/skills/orchardcore-tester/SKILL.md
@@ -11,7 +11,16 @@ This skill guides you through testing OrchardCore CMS features using browser aut
 
 - OrchardCore repository (working directory)
 - .NET SDK 10.0+ installed
-- `playwright-cli` skill available
+- `playwright-cli` skill available, with a browser engine installed.
+  On macOS (or any machine without Chrome) use webkit:
+  ```bash
+  playwright-cli --browser webkit install
+  ```
+  Then pass `--browser webkit` on the first `open` of a session. See
+  `references/playwright-cli.md`.
+
+> The examples below show PowerShell and bash. The repo targets macOS/.NET 10;
+> bash works everywhere. Use whichever matches your shell.
 
 ## Core Workflow
 
@@ -19,9 +28,41 @@ Testing an OrchardCore feature follows these steps:
 
 1. **Build** the application
 2. **Run** the application server (background)
-3. **Setup** a test site (if needed)
+3. **Setup** a test site (AutoSetup is the recommended unattended path)
 4. **Test** the feature via browser
 5. **Verify** results and clean up
+
+## TL;DR (fastest reliable path)
+
+```bash
+# 1. build
+dotnet build src/OrchardCore.Cms.Web -c Debug -f net10.0
+
+# 2. fresh state + pick a port
+rm -rf src/OrchardCore.Cms.Web/App_Data
+PORT=$(( (RANDOM % 1000) + 5000 )); echo -n $PORT > .orchardcore-port
+
+# 3. run with AutoSetup (provisions Default tenant on first request, no wizard)
+cd src/OrchardCore.Cms.Web
+OrchardCore__OrchardCore_AutoSetup__AutoSetupPath= \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__ShellName=Default \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__SiteName=TestSite \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__SiteTimeZone=America/Los_Angeles \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminUsername=admin \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminEmail=admin@test.com \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminPassword=Password1! \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__DatabaseProvider=Sqlite \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__RecipeName=Blog \
+dotnet run -f net10.0 --no-build --urls "http://localhost:$PORT" > autosetup-console.log 2>&1 &
+cd ../..
+
+# 4. trigger + confirm
+curl -s -o /dev/null "http://localhost:$PORT/"
+grep -m1 "successfully provisioned" src/OrchardCore.Cms.Web/autosetup-console.log
+```
+
+Then log in (see Step 4 — the login password field needs the native-setter
+workaround). Full AutoSetup details and gotchas: `references/autosetup.md`.
 
 ## Step 1: Build
 
@@ -91,28 +132,69 @@ if (Test-Path ".orchardcore-pid") {
 }
 ```
 
+```bash
+# bash: find the process actually listening on the port and kill it.
+# (Backgrounding dotnet via a subshell makes $! unreliable, so resolve by port.)
+PORT=$(cat .orchardcore-port)
+PID=$(lsof -ti tcp:$PORT -sTCP:LISTEN | head -1)
+[ -n "$PID" ] && kill "$PID" && echo "Stopped OrchardCore (PID: $PID)"
+rm -f .orchardcore-pid
+```
+
 ## Step 3: Setup Test Site
 
-**Check if setup is needed**: Navigate to the app URL - if you see a setup wizard, the site needs setup.
+A fresh `App_Data` is uninitialized, so the site must be provisioned. There are
+two paths.
 
-**Reset for fresh setup** (optional):
+### Option A — AutoSetup (recommended, unattended)
+
+Provision the `Default` tenant from configuration on first request — **no
+browser, no wizard**. `OrchardCore.Cms.Web` already wires AutoSetup in
+(`Program.cs` → `.AddSetupFeatures("OrchardCore.AutoSetup")`); you just supply
+env vars when starting the app (see the TL;DR above, or run them inline with
+`dotnet run` from Step 2).
+
+Key rules (full details in `references/autosetup.md`):
+
+- Prefix is `OrchardCore__OrchardCore_AutoSetup__Tenants__0__<Option>` — `__` is
+  the separator, the single `_` in `OrchardCore_AutoSetup` is **literal**.
+- **No quotes around values** in bash inline-env form (quotes become part of the
+  value and corrupt the admin password/email).
+- `SiteTimeZone` is **required** (e.g. `America/Los_Angeles`).
+
+Confirm success with the log line:
+
+```
+The AutoSetup successfully provisioned the site 'TestSite'.
+```
+
+```bash
+grep -m1 "successfully provisioned" src/OrchardCore.Cms.Web/autosetup-console.log
+```
+
+### Option B — Interactive setup wizard (browser)
+
+Start the app **without** AutoSetup env vars, then drive the wizard with
+`playwright-cli`. The plain inputs (Site Name, User Name, Email) fill normally,
+but the **password and confirmation fields cannot be filled with `fill`/`type`**
+— use the native-setter `eval` workaround. Full step-by-step:
+`references/setup-wizard.md`. Quick shape:
+
+```bash
+PORT=$(cat .orchardcore-port)
+playwright-cli --browser webkit open "http://localhost:$PORT/"
+playwright-cli snapshot
+# fill <sitename>, <username>, <email>; pick Blog from the recipe dropdown
+# set passwords via native setter (see below / setup-wizard.md), then click Finish Setup
+```
+
+**Reset for fresh setup**:
+```bash
+rm -rf src/OrchardCore.Cms.Web/App_Data
+```
 ```powershell
 Remove-Item -Recurse -Force src/OrchardCore.Cms.Web/App_Data
 ```
-
-**Setup workflow**:
-```bash
-# Get the port
-$port = Get-Content ".orchardcore-port"
-
-playwright-cli open http://localhost:$port
-playwright-cli snapshot
-# Fill: Site Name = "Test Site", Recipe = "Blog", Username = "admin", 
-# Email = "admin@test.com", Password = "Password1!"
-# Click "Finish Setup"
-```
-
-See `references/setup-wizard.md` for detailed field mapping.
 
 ## Step 4: Test Features
 
@@ -120,14 +202,31 @@ See `references/setup-wizard.md` for detailed field mapping.
 
 ### Login to Admin
 
+The username fills normally, but the **login password field
+(`input[name="LoginForm.Password"]`) cannot be filled with `fill`/`type`** — use
+the native-setter `eval` (same limitation as the setup wizard; see
+`references/playwright-cli.md`).
+
 ```bash
-playwright-cli open http://localhost:$port/Login
-playwright-cli snapshot
-# Fill username: admin, password: Password1!
-# Click login button
-playwright-cli open http://localhost:$port/Admin
-playwright-cli snapshot
+PORT=$(cat .orchardcore-port)
+playwright-cli --browser webkit open "http://localhost:$PORT/Login"
+playwright-cli snapshot                       # get the username/login-button refs
+
+# username: plain fill works
+playwright-cli fill <username-ref> "admin"
+
+# password: fill is a no-op here — set it via the native setter + events
+playwright-cli eval '((p)=>{var s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,"value").set; s.call(p,"Password1!"); p.dispatchEvent(new Event("input",{bubbles:true})); p.dispatchEvent(new Event("change",{bubbles:true})); return p.value.length})(document.querySelector("input[name=\"LoginForm.Password\"]"))'
+
+# submit, then confirm /Admin loads (does NOT redirect back to /Login)
+playwright-cli click <login-button-ref>
+playwright-cli open "http://localhost:$PORT/Admin"
+playwright-cli eval 'window.location.pathname'   # -> "/Admin" when authenticated
 ```
+
+> The `eval` prints a benign `result is not a function` message (it returns a
+> number); the value is still set — verify with
+> `playwright-cli eval 'document.querySelector("input[name=\"LoginForm.Password\"]").value'`.
 
 ### Common Test Scenarios
 
@@ -207,8 +306,10 @@ See `references/debugging.md` for more debugging techniques.
 
 ## References
 
+- `references/autosetup.md` - **Unattended AutoSetup** (env-var recipe, gotchas, troubleshooting)
+- `references/playwright-cli.md` - playwright-cli specifics: browser install, `eval` constraint, the password-field workaround
+- `references/setup-wizard.md` - Interactive browser setup wizard (with password workaround)
 - `references/admin-navigation.md` - Admin URLs and UI patterns
-- `references/setup-wizard.md` - Site setup details
 - `references/common-features.md` - Feature-specific testing guides
 - `references/debugging.md` - Log files and troubleshooting
 - `AGENTS.md` (repo root) - Build and development instructions

--- a/.agents/skills/orchardcore-tester/references/autosetup.md
+++ b/.agents/skills/orchardcore-tester/references/autosetup.md
@@ -1,0 +1,145 @@
+# AutoSetup (Unattended Setup) Reference
+
+This is the **recommended way to provision a test site for an agent**. AutoSetup
+provisions the `Default` tenant on first request using configuration values, so
+you never have to drive the browser setup wizard (which has a password-field
+limitation — see `setup-wizard.md`).
+
+`OrchardCore.Cms.Web` already wires AutoSetup in: `Program.cs` calls
+`.AddSetupFeatures("OrchardCore.AutoSetup")`. You only need to supply the
+configuration. The simplest way is environment variables.
+
+## How it works
+
+- The `OrchardCore.AutoSetup` feature (`src/OrchardCore.Modules/OrchardCore.AutoSetup/`)
+  reads the configuration section named `OrchardCore_AutoSetup`.
+- `AutoSetupMiddleware` triggers setup when the matched tenant is **uninitialized**
+  (i.e. a fresh `App_Data`).
+- On success you get the log line:
+  `The AutoSetup successfully provisioned the site 'TestSite'.`
+
+## Environment-variable recipe (verified working)
+
+Set these before `dotnet run`. The configuration key is built from:
+
+```
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__<OptionName>
+```
+
+Key rules (these bite people):
+
+- `__` (double underscore) is the **section separator** in .NET configuration.
+- The single `_` in `OrchardCore_AutoSetup` is **literal** — it is part of the
+  section name, not a separator. So the prefix is
+  `OrchardCore__OrchardCore_AutoSetup__`.
+- `Tenants__0__` indexes the first tenant in the `Tenants` array.
+- **Do NOT wrap values in quotes.** With env vars the quotes become literal
+  characters in the value, which silently corrupts the admin password/email and
+  makes login fail. Pass values bare.
+- `SiteTimeZone` is **required**. Omitting it fails validation with
+  `The SiteTimeZone field is required.`
+
+### bash / macOS / Linux
+
+```bash
+cd src/OrchardCore.Cms.Web
+PORT=$(cat ../../.orchardcore-port)   # or any free port
+
+OrchardCore__OrchardCore_AutoSetup__AutoSetupPath= \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__ShellName=Default \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__SiteName=TestSite \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__SiteTimeZone=America/Los_Angeles \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminUsername=admin \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminEmail=admin@test.com \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminPassword=Password1! \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__DatabaseProvider=Sqlite \
+OrchardCore__OrchardCore_AutoSetup__Tenants__0__RecipeName=Blog \
+dotnet run -f net10.0 --no-build --urls "http://localhost:$PORT" > autosetup-console.log 2>&1 &
+```
+
+The very first HTTP request to `/` triggers AutoSetup, so curl the root once and
+then wait for the provisioning log line:
+
+```bash
+curl -s -o /dev/null "http://localhost:$PORT/"
+# Poll the log until provisioning completes:
+grep -m1 "successfully provisioned" autosetup-console.log
+```
+
+### PowerShell
+
+```powershell
+cd src/OrchardCore.Cms.Web
+$port = Get-Content ..\..\.orchardcore-port
+$env:OrchardCore__OrchardCore_AutoSetup__AutoSetupPath = ""
+$env:OrchardCore__OrchardCore_AutoSetup__Tenants__0__ShellName = "Default"
+$env:OrchardCore__OrchardCore_AutoSetup__Tenants__0__SiteName = "TestSite"
+$env:OrchardCore__OrchardCore_AutoSetup__Tenants__0__SiteTimeZone = "America/Los_Angeles"
+$env:OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminUsername = "admin"
+$env:OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminEmail = "admin@test.com"
+$env:OrchardCore__OrchardCore_AutoSetup__Tenants__0__AdminPassword = "Password1!"
+$env:OrchardCore__OrchardCore_AutoSetup__Tenants__0__DatabaseProvider = "Sqlite"
+$env:OrchardCore__OrchardCore_AutoSetup__Tenants__0__RecipeName = "Blog"
+dotnet run -f net10.0 --no-build --urls "http://localhost:$port"
+```
+
+> In PowerShell, assigning `""` to `$env:...` is fine; the value is genuinely
+> empty. The "no quotes" rule above is specifically about the bare inline-env
+> form used in bash, where `KEY="value"` keeps the quotes in the value.
+
+## Tenant options
+
+All keys go under `...__Tenants__0__`. From `TenantSetupOptions`:
+
+| Option | Required | Notes |
+|--------|----------|-------|
+| `ShellName` | yes | `Default` for the root tenant. Letters only, no spaces. |
+| `SiteName` | yes | Display name, e.g. `TestSite`. |
+| `AdminUsername` | yes | e.g. `admin`. |
+| `AdminEmail` | yes | e.g. `admin@test.com`. |
+| `AdminPassword` | yes | e.g. `Password1!` (must satisfy the password policy). |
+| `DatabaseProvider` | yes | `Sqlite` is easiest (no connection string). Others: `SqlConnection`, `Postgres`, `MySql`. |
+| `RecipeName` | yes | e.g. `Blog`, `Headless`, `Agency`, `Blank`. |
+| `SiteTimeZone` | yes | e.g. `America/Los_Angeles`. **Validation fails if missing.** |
+| `DatabaseConnectionString` | only for non-Sqlite providers | |
+| `DatabaseTablePrefix` | no | |
+| `DatabaseSchema` | no | |
+| `RequestUrlHost` / `RequestUrlPrefix` | no | For non-default tenants. |
+| `FeatureProfile` | no | |
+
+Top-level option:
+
+| Option | Notes |
+|--------|-------|
+| `AutoSetupPath` | Empty = trigger on **any** request (recommended for testing). If set, must start with `/`. |
+
+## Confirming success
+
+Success is the log line (in the console output / redirected log file):
+
+```
+info: OrchardCore.AutoSetup.Services.AutoSetupService[0]
+      The AutoSetup successfully provisioned the site 'TestSite'.
+```
+
+A provisioned site also creates `src/OrchardCore.Cms.Web/App_Data/Sites/Default/`.
+After provisioning, `/` returns `302` (redirect to the homepage) and `/Login`
+returns `200`. You can then log in normally (see SKILL.md "Login to Admin").
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `The SiteTimeZone field is required.` | Add `...__Tenants__0__SiteTimeZone=...`. |
+| `The single 'Default' tenant should be provided.` | `ShellName` must be `Default` for the root tenant. |
+| `The field 'Tenants' should contain at least one tenant.` | The `OrchardCore_AutoSetup` section wasn't bound — check the literal `_` in the prefix and the `Tenants__0__` index. |
+| Provisioning succeeds but login fails with the configured password | A value was quoted in bash inline-env form, so the quotes ended up in the password. Pass values bare (no surrounding quotes). |
+| Setup never triggers | `App_Data` already has an initialized tenant. Reset it (delete `App_Data`) before starting. |
+| `DatabaseProvider` field is required | Use a valid provider value (`Sqlite`, `SqlConnection`, `Postgres`, `MySql`). |
+
+## Resetting
+
+```bash
+# stop the app first (see SKILL.md), then:
+rm -rf src/OrchardCore.Cms.Web/App_Data
+```

--- a/.agents/skills/orchardcore-tester/references/playwright-cli.md
+++ b/.agents/skills/orchardcore-tester/references/playwright-cli.md
@@ -1,0 +1,109 @@
+# playwright-cli Reference (for OrchardCore testing)
+
+`playwright-cli` is the command-line wrapper used to drive a browser for
+OrchardCore functional testing. This page documents the tool-specific gotchas
+that matter when testing OrchardCore, especially the **password-field
+limitation** that affects the setup wizard and the login form.
+
+## Browser must be installed
+
+`playwright-cli` needs a browser engine installed. On macOS (and any machine
+without Chrome) use **webkit**:
+
+```bash
+playwright-cli --browser webkit install
+```
+
+Then pass `--browser webkit` on the first command that opens a page (the choice
+sticks for the session):
+
+```bash
+playwright-cli --browser webkit open "http://localhost:$PORT/Login"
+```
+
+If you don't specify a browser and Chrome isn't installed, commands fail.
+
+## `open` navigates and discards page/form state
+
+`playwright-cli open <url>` performs a fresh navigation. Anything you typed into
+a form is lost. To re-inspect the current page **without** navigating, use
+`snapshot` (it re-reads the live DOM and returns fresh element refs):
+
+```bash
+playwright-cli snapshot
+```
+
+Element refs (e.g. `e16`) come from the latest `snapshot`/`open` output. After a
+click that re-renders part of the page, take a new `snapshot` to get fresh refs.
+
+## `eval` is a single expression
+
+`playwright-cli eval '<expr>'` wraps your text as `() => (<expr>)`. Consequences:
+
+- Only a **single expression** works. Multi-statement JavaScript using `;` or
+  `var`/`let` declarations silently does nothing.
+- To run multiple statements, wrap them in an **arrow-IIFE** that is itself a
+  single expression: `((x)=>{ ...; return ...; })(arg)`.
+- When the expression returns a non-function value (e.g. a number), the tool may
+  print a **benign** error like
+  `Error: ... result is not a function. ... 'result' is 10`. The side effects
+  (DOM writes, dispatched events) still happen — verify with a follow-up `eval`
+  that reads `.value`.
+
+Read a value:
+
+```bash
+playwright-cli eval 'document.getElementById("Password").value'
+```
+
+## Password fields cannot be filled with `fill`/`type`/`.value`
+
+**This is the key OrchardCore gotcha.** The password inputs on the setup wizard
+(`Password`, `PasswordConfirmation`) and the login form
+(`LoginForm.Password`) are standard `<input type="password">` elements wrapped in
+a Bootstrap `.input-group` with a show/hide toggle button.
+
+Observed with `--browser webkit`:
+
+- `playwright-cli fill <ref> <text>` on these password inputs is a **silent
+  no-op** — it prints no output and the value stays empty. (The same `fill`
+  works fine on plain inputs like Username, Email, Site Name.)
+- Clicking the field then `type`, and a plain `.value =` assignment, **also
+  leave the field empty**.
+- This is **not** caused by `type="password"` — toggling the field to
+  `type="text"` first does not help. It is a `playwright-cli` + webkit
+  interaction with these input-group inputs, not an OrchardCore defect (the
+  inputs are standard, accessible HTML).
+
+### Working approach: native setter + events
+
+Set the value through the native `HTMLInputElement.prototype.value` setter and
+dispatch `input` + `change` so any listeners (password-strength meter, form
+validation) react correctly:
+
+```bash
+playwright-cli eval '((p)=>{var s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,"value").set; s.call(p,"Password1!"); p.dispatchEvent(new Event("input",{bubbles:true})); p.dispatchEvent(new Event("change",{bubbles:true})); return p.value.length})(document.querySelector("input[type=\"password\"]"))'
+```
+
+Replace the selector to target the right field:
+
+- Setup wizard password: `document.getElementById("Password")`
+- Setup wizard confirmation: `document.getElementById("PasswordConfirmation")`
+- Login password: `document.querySelector("input[name=\"LoginForm.Password\"]")`
+
+Expect the benign `result is not a function` message (the IIFE returns a number).
+Verify it worked:
+
+```bash
+playwright-cli eval 'document.getElementById("Password").value'   # -> "Password1!"
+```
+
+> Prefer the AutoSetup path (`references/autosetup.md`) for provisioning so you
+> avoid the wizard password fields entirely. You still need this workaround for
+> the **login** password field when signing in through the browser.
+
+## Cleaning up the browser session
+
+```bash
+playwright-cli session-stop-all
+```

--- a/.agents/skills/orchardcore-tester/references/setup-wizard.md
+++ b/.agents/skills/orchardcore-tester/references/setup-wizard.md
@@ -1,25 +1,34 @@
-# Setup Wizard Reference
+# Setup Wizard Reference (Interactive Browser Setup)
 
 ## Overview
 
-When OrchardCore runs without existing data (no `App_Data` folder), it presents a setup wizard at the root URL.
+When OrchardCore runs without existing data (no initialized `App_Data`), it
+presents a setup wizard at the root URL. This page covers driving that wizard
+with `playwright-cli`.
+
+> **Prefer AutoSetup.** For unattended provisioning, use the AutoSetup
+> environment-variable path in `references/autosetup.md` — it avoids the wizard's
+> password-field limitation entirely. Use the interactive wizard only when you
+> specifically need to exercise the wizard UI.
 
 ## Prerequisites
 
-Before setup, ensure:
-1. Application is built: `dotnet build` from repo root
-2. No existing data: Delete `src/OrchardCore.Cms.Web/App_Data` if present
-3. Application is running: `cd src/OrchardCore.Cms.Web && dotnet run -f net10.0`
+1. Application is built: `dotnet build src/OrchardCore.Cms.Web -c Debug -f net10.0`
+2. No existing data: delete `src/OrchardCore.Cms.Web/App_Data` if present
+3. Application is running **without** AutoSetup env vars (so the wizard appears)
+4. Browser installed for `playwright-cli` (`--browser webkit` on macOS) — see
+   `references/playwright-cli.md`
 
 ## Setup Wizard Form Fields
 
 | Field | Description | Recommended Value |
 |-------|-------------|-------------------|
 | Site Name | Display name for the site | "Test Site" |
-| Recipe | Pre-configured feature set | **"Blog"** (recommended) |
-| Database | Database provider | "Sqlite" (default, easiest) |
-| Table Prefix | Database table prefix | Leave empty |
-| Connection String | DB connection (if not Sqlite) | N/A for Sqlite |
+| Recipe | Pre-configured feature set (dropdown) | **"Blog"** |
+| Default Time Zone | Site time zone (`<select>`, pre-filled) | leave default |
+| Database | Database provider (`<select>`) | "Sqlite" (default) |
+| Table Prefix | Database table prefix | leave empty |
+| Connection String | DB connection (non-Sqlite only) | N/A for Sqlite |
 | User Name | Admin username | "admin" |
 | Email | Admin email | "admin@test.com" |
 | Password | Admin password | "Password1!" |
@@ -27,81 +36,93 @@ Before setup, ensure:
 
 ## Recipe Options
 
-| Recipe | Description | Use Case |
-|--------|-------------|----------|
-| **Blog** | Blog with common features enabled | **Recommended for testing** |
-| Headless | API-only, no frontend | API testing |
-| Agency | Agency website template | Theme testing |
-| Coming Soon | Simple landing page | Minimal testing |
-| SaaS | Multi-tenant SaaS setup | Tenant testing |
-| Blank | No features enabled | Custom setup |
+| Recipe | Use Case |
+|--------|----------|
+| **Blog** | **Recommended for testing** (Media, content management, admin UI, Markdown, Autoroute, etc.) |
+| Headless | API-only testing |
+| Agency | Theme testing |
+| Coming Soon | Minimal testing |
+| SaaS | Tenant testing |
+| Blank | No features enabled |
 
-**Why "Blog"?** It pre-enables: Media, Content Management, Admin UI, Markdown, Autoroute, and other commonly tested features.
+The recipe control is a **dropdown button** backed by a hidden `RecipeName`
+input. Selecting an item runs JS that sets `RecipeName`.
 
-## Setup Workflow with playwright-cli
+## Setup Workflow with playwright-cli (verified)
 
-First, get the port from the session file:
-```powershell
-$port = Get-Content ".orchardcore-port"
-```
+Replace `$PORT` with the actual port.
 
-Then proceed with setup:
 ```bash
-# 1. Navigate to root (shows setup wizard)
-playwright-cli open http://localhost:$port
-playwright-cli snapshot
+PORT=$(cat .orchardcore-port)
 
-# 2. Fill site name
-playwright-cli fill [sitename-ref] "Test Site"
+# 1. Open the wizard and capture refs
+playwright-cli --browser webkit open "http://localhost:$PORT/"
+playwright-cli snapshot      # note refs for the fields below
 
-# 3. Select recipe - find and click "Blog" option
-# Look for select/dropdown with recipes, select "Blog"
-playwright-cli select [recipe-ref] "Blog"
+# 2. Plain text inputs: fill works normally
+playwright-cli fill <sitename-ref> "Test Site"
+playwright-cli fill <username-ref> "admin"
+playwright-cli fill <email-ref>    "admin@test.com"
 
-# 4. Keep Sqlite default (usually pre-selected)
+# 3. Recipe: open the dropdown, then click the "Blog" item
+playwright-cli click <recipe-button-ref>
+playwright-cli snapshot      # find the "Blog" link ref
+playwright-cli click <blog-link-ref>
+playwright-cli eval 'document.getElementById("RecipeName").value'   # -> "Blog"
 
-# 5. Fill admin credentials
-playwright-cli fill [username-ref] "admin"
-playwright-cli fill [email-ref] "admin@test.com"
-playwright-cli fill [password-ref] "Password1!"
-playwright-cli fill [password-confirm-ref] "Password1!"
+# 4. Database (Sqlite) and Time Zone already have valid defaults — leave them.
 
-# 6. Submit setup
-playwright-cli click [finish-setup-ref]
+# 5. Password fields: fill DOES NOT WORK here (see playwright-cli.md).
+#    Use the native-setter eval for BOTH password and confirmation.
+playwright-cli eval '((p)=>{var s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,"value").set; s.call(p,"Password1!"); p.dispatchEvent(new Event("input",{bubbles:true})); p.dispatchEvent(new Event("change",{bubbles:true})); return p.value.length})(document.getElementById("Password"))'
+playwright-cli eval '((p)=>{var s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,"value").set; s.call(p,"Password1!"); p.dispatchEvent(new Event("input",{bubbles:true})); p.dispatchEvent(new Event("change",{bubbles:true})); return p.value.length})(document.getElementById("PasswordConfirmation"))'
 
-# 7. Wait for setup to complete and verify
-playwright-cli snapshot
+# verify both
+playwright-cli eval 'document.getElementById("Password").value+"|"+document.getElementById("PasswordConfirmation").value'
+
+# 6. Submit
+playwright-cli click <finish-setup-ref>
+
+# 7. Verify: page title becomes "Blog - Test Site" (or similar)
+playwright-cli eval 'window.location.pathname+" | "+document.title'
 ```
+
+> The `eval` calls print a benign `result is not a function` message because the
+> arrow-IIFE returns a number — the value is still set. Always confirm with the
+> follow-up read in step 5.
+
+## Why the password workaround is needed
+
+The password inputs are standard `<input type="password">` elements inside a
+Bootstrap `.input-group` with a show/hide toggle. With `playwright-cli` +
+webkit, `fill`/`type`/`.value` are silent no-ops on these inputs (they work on
+the plain Site Name / User Name / Email inputs). The native-setter `eval` is the
+reliable way to populate them. Full details and selectors:
+`references/playwright-cli.md`.
 
 ## Post-Setup Verification
 
-After setup completes:
-1. You should be redirected to the site homepage or admin
-2. Navigate to `/Admin` to verify admin access
-3. Check `/Admin/Features` to see enabled features
+1. After submit you are redirected to the site homepage; the title reflects the
+   recipe and site name (e.g. "Blog - Test Site").
+2. `src/OrchardCore.Cms.Web/App_Data/Sites/Default/` now exists.
+3. Log in at `/Login` (the login password field needs the same native-setter
+   workaround) and confirm `/Admin` loads without redirecting to `/Login`.
 
 ## Resetting for Fresh Setup
 
-To start over with a clean installation:
-
-```powershell
-# Stop the running application
-if (Test-Path ".orchardcore-pid") {
-    Stop-Process -Id (Get-Content ".orchardcore-pid") -Force -ErrorAction SilentlyContinue
-    Remove-Item ".orchardcore-pid" -Force
-}
-
-# Delete App_Data
-Remove-Item -Recurse -Force src/OrchardCore.Cms.Web/App_Data
-
-# Restart application (see SKILL.md Step 2)
+```bash
+# Stop the running app (see SKILL.md), then:
+rm -rf src/OrchardCore.Cms.Web/App_Data
+# Restart the app (without AutoSetup env vars to get the wizard).
 ```
 
 ## Common Setup Issues
 
 | Issue | Solution |
 |-------|----------|
-| Setup page doesn't appear | Check if App_Data exists; delete it |
-| "Port already in use" | Stop other instances or use different port |
-| Recipe dropdown empty | Check browser console for JS errors |
-| Setup fails silently | Check terminal/console for .NET errors |
+| Setup page doesn't appear | `App_Data` already initialized — delete it. |
+| Wizard appears but you wanted unattended | You set AutoSetup env vars but `App_Data` already had a tenant; reset `App_Data`. |
+| Password field stays empty | Use the native-setter `eval`, not `fill`/`type` (see above). |
+| "Port already in use" | Stop other instances or use a different port. |
+| Recipe dropdown does nothing | Click the dropdown button first, then the item link; verify the hidden `RecipeName`. |
+| Submit appears to do nothing | Confirm both password fields are set and meet the policy; check the browser console (`playwright-cli console error`). |


### PR DESCRIPTION
## Summary

Reworks the `orchardcore-tester` skill so an agent can reliably stand up an OrchardCore site for browser-based functional testing via **both** paths. All guidance was reproduced live against the running app on macOS (.NET 10, `playwright-cli --browser webkit`).

### What changed (docs only)
- **New `references/autosetup.md`** — the recommended unattended path. Documents the `OrchardCore__OrchardCore_AutoSetup__Tenants__0__…` env-var recipe, including:
  - `__` is the separator; the single `_` in `OrchardCore_AutoSetup` is **literal**.
  - **No quotes** around values in bash inline-env form (quotes get baked into the admin password/email and break login).
  - `SiteTimeZone` is **required** (validation fails without it).
  - Success log line: `The AutoSetup successfully provisioned the site 'TestSite'.`
  - Full option table (from `TenantSetupOptions`) and troubleshooting.
- **New `references/playwright-cli.md`** — tool specifics: browser install / `--browser webkit`, `open` discards form state (use `snapshot`), the `eval` single-expression / arrow-IIFE constraint and the benign `result is not a function` message, and the **password-field workaround**.
- **`references/setup-wizard.md`** — rewritten with the verified interactive flow (recipe dropdown handling + native-setter `eval` for both password fields).
- **`SKILL.md`** — adds a copy-pasteable TL;DR, an AutoSetup-first Step 3, the login native-setter workaround, bash variants, and the new references.

### Key finding: password fields
The setup-wizard `Password`/`PasswordConfirmation` and login `LoginForm.Password` inputs **cannot** be populated by `playwright-cli fill`/`type`/`.value` under webkit (silent no-op), while plain inputs (Site Name, Username, Email) fill fine. The working approach is the native setter + dispatched `input`/`change` events:

```bash
playwright-cli eval '((p)=>{var s=Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype,"value").set; s.call(p,"Password1!"); p.dispatchEvent(new Event("input",{bubbles:true})); p.dispatchEvent(new Event("change",{bubbles:true})); return p.value.length})(document.querySelector("input[name=\"LoginForm.Password\"]"))'
```

### Why no code fix
The inputs are standard, accessible `<input type="password">` elements inside a Bootstrap `.input-group`; they already reflect value and raise events for real input. The limitation is a `playwright-cli` + webkit interaction, not an OrchardCore defect, and altering the markup to suit one CLI tool would not be a clean/safe change. So the behavior is documented with a reliable workaround instead.

### Verification
Both paths were driven end-to-end on a fresh `App_Data` following the docs verbatim:
- AutoSetup → provisioned + admin login reaches `/Admin`.
- Interactive wizard → site provisioned ("Blog - Test Site") + login reaches `/Admin`.

All test artifacts are gitignored and were cleaned up; no product code is touched.