### PR TITLE
Unseal DebugSettingsViewModel, add an analyzer to detect invalid sealing, and document analyzer release tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -26,6 +26,7 @@ assignees: ''
       - Highlights and goals of the release.
       - Prerequisites for running the new version.
       - Upgrade steps and any breaking changes.
+  - **Update Analyzer Release Tracking Files**: For analyzer projects (for example, `src/OrchardCore/OrchardCore.SourceGenerators`), move the rules being released from `AnalyzerReleases.Unshipped.md` to `AnalyzerReleases.Shipped.md`. Keep `AnalyzerReleases.Unshipped.md` checked in and reserve it for rules that have not shipped yet.
   - **Update Documentation Navigation**: Add the release notes page to the `mkdocs.yml` navigation and remove it from `not_in_nav`.
   - **Version Mentions**: Update all references to the new version throughout the documentation, including:
     - [Status in the root README](https://docs.orchardcore.net/en/latest/#status)

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -27,6 +27,7 @@ assignees: ''
       - Highlights and goals of the release.
       - Prerequisites for running the new version.
       - Upgrade steps and any breaking changes.
+  - **Update Analyzer Release Tracking Files**: For analyzer projects (for example, `src/OrchardCore/OrchardCore.SourceGenerators`), move the rules being released from `AnalyzerReleases.Unshipped.md` to `AnalyzerReleases.Shipped.md`. Keep `AnalyzerReleases.Unshipped.md` checked in and reserve it for rules that have not shipped yet.
   - **Update Documentation Navigation**: Add the release notes page to `mkdocs.yml` navigation and remove it from `not_in_nav`.
   - **Version Mentions**: Update all references to the new version throughout the documentation, including:
     - [Status in the root README](https://docs.orchardcore.net/en/latest/#status)

--- a/src/OrchardCore.Modules/OrchardCore.Settings/ViewModels/DebugSettingsViewModel.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Settings/ViewModels/DebugSettingsViewModel.cs
@@ -1,6 +1,6 @@
 namespace OrchardCore.Settings.ViewModels;
 
-public sealed class DebugSettingsViewModel
+public class DebugSettingsViewModel
 {
     public bool WriteShapeDebugInformation { get; set; }
 }

--- a/src/OrchardCore/OrchardCore.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/OrchardCore/OrchardCore.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,5 @@
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+OCSG001 | Usage    | Warning  | SealedShapeTypeAnalyzer

--- a/src/OrchardCore/OrchardCore.SourceGenerators/OrchardCore.SourceGenerators.csproj
+++ b/src/OrchardCore/OrchardCore.SourceGenerators/OrchardCore.SourceGenerators.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
@@ -15,6 +15,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="AnalyzerReleases.Shipped.md" />
+    <AdditionalFiles Include="AnalyzerReleases.Unshipped.md" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/OrchardCore/OrchardCore.SourceGenerators/SealedShapeTypeAnalyzer.cs
+++ b/src/OrchardCore/OrchardCore.SourceGenerators/SealedShapeTypeAnalyzer.cs
@@ -1,0 +1,118 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace OrchardCore.DisplayManagement.SourceGenerators;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class SealedShapeTypeAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "OCSG001";
+
+    private const string IShapeMetadataName = "OrchardCore.DisplayManagement.IShape";
+    private const string ShapeFactoryExtensionsMetadataName = "OrchardCore.DisplayManagement.ShapeFactoryExtensions";
+    private const string DisplayDriverBaseMetadataName = "OrchardCore.DisplayManagement.Handlers.DisplayDriverBase";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Sealed types can't be used as proxy-based shapes",
+        "Type '{0}' is sealed and does not implement IShape, so OrchardCore can't create a proxy-based shape for this '{1}' call",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "OrchardCore creates strongly typed shapes by subclassing the model type with Castle DynamicProxy. Sealed types that do not implement IShape fail at runtime. Remove the sealed modifier, implement IShape, or use a non-proxy shape creation pattern such as View, Copy, or Dynamic.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [Rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    {
+        var invocation = (IInvocationOperation)context.Operation;
+        var targetMethod = invocation.TargetMethod;
+
+        if (!IsProxyBasedShapeMethod(targetMethod.OriginalDefinition))
+        {
+            return;
+        }
+
+        if (targetMethod.TypeArguments.Length == 0)
+        {
+            return;
+        }
+
+        var modelType = targetMethod.TypeArguments[0];
+        if (modelType is not INamedTypeSymbol namedType || !namedType.IsSealed)
+        {
+            return;
+        }
+
+        var iShapeType = context.Compilation.GetTypeByMetadataName(IShapeMetadataName);
+        if (iShapeType is not null && namedType.AllInterfaces.Contains(iShapeType, SymbolEqualityComparer.Default))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            Rule,
+            invocation.Syntax.GetLocation(),
+            namedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+            targetMethod.Name));
+    }
+
+    private static bool IsProxyBasedShapeMethod(IMethodSymbol method)
+    {
+        if (method.TypeParameters.Length == 0 || !method.TypeParameters[0].HasReferenceTypeConstraint)
+        {
+            return false;
+        }
+
+        var containingType = method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        if (containingType == $"global::{DisplayDriverBaseMetadataName}" && method.Name == "Initialize")
+        {
+            return true;
+        }
+
+        if (containingType != $"global::{ShapeFactoryExtensionsMetadataName}" || method.Name != "CreateAsync")
+        {
+            return false;
+        }
+
+        foreach (var parameter in method.Parameters)
+        {
+            if (IsDelegateReceivingModel(parameter.Type, method.TypeParameters[0]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsDelegateReceivingModel(ITypeSymbol type, ITypeParameterSymbol modelTypeParameter)
+    {
+        if (type is not INamedTypeSymbol namedType || !namedType.IsGenericType || namedType.TypeArguments.Length == 0)
+        {
+            return false;
+        }
+
+        if (!SymbolEqualityComparer.Default.Equals(namedType.TypeArguments[0], modelTypeParameter))
+        {
+            return false;
+        }
+
+        var originalDefinition = namedType.ConstructedFrom.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+        return originalDefinition is "global::System.Action<T>"
+            or "global::System.Action<T1, T2>"
+            or "global::System.Func<T, global::System.Threading.Tasks.ValueTask>"
+            or "global::System.Func<T1, T2, global::System.Threading.Tasks.ValueTask>";
+    }
+}

--- a/src/docs/topics/source-generators/README.md
+++ b/src/docs/topics/source-generators/README.md
@@ -37,10 +37,12 @@ var shape = await shapeFactory.CreateAsync("MyShape", args);
 ```
 
 **Requirements:**
+
 - The class must be marked as `partial`
 - At least one public instance property with a getter
 
 **Benefits:**
+
 - ✅ **No reflection** - Direct property access via switch expressions
 - ✅ **Compile-time code generation** - Errors caught at build time
 - ✅ **Lazy evaluation** - Properties accessed on-demand
@@ -60,6 +62,7 @@ var shape = await factory.CreateAsync("MyShape", new
 ```
 
 **Requirements:**
+
 - .NET 9.0 or later
 - C# 13 or later
 
@@ -75,6 +78,43 @@ var args = Arguments.From(new { Title = "Test", Count = 5 });
 ```
 
 This is suitable for prototyping or infrequent usage where performance isn't critical.
+
+## Build-Time Analyzers
+
+`OrchardCore.SourceGenerators` also ships analyzers that catch invalid OrchardCore shape patterns during build.
+
+### OCSG001: Sealed types can't be used as proxy-based shapes
+
+OrchardCore creates strongly typed shapes by subclassing the model type with Castle DynamicProxy. If a view model used with proxy-based shape APIs is `sealed` and does not implement `IShape`, the proxy cannot be generated and shape creation fails at runtime.
+
+!!! note
+    `OCSG` stands for `OrchardCore Source Generators`.
+
+The `OCSG001` analyzer makes this discoverable at build time for APIs such as `Initialize<TModel>(...)` and proxy-based `CreateAsync<TModel>(...)` overloads.
+
+```csharp
+public sealed class DebugSettingsViewModel
+{
+    public bool WriteShapeDebugInformation { get; set; }
+}
+
+return Initialize<DebugSettingsViewModel>("DebugSettings_Edit", model =>
+{
+    model.WriteShapeDebugInformation = settings.WriteShapeDebugInformation;
+});
+```
+
+This produces a build warning similar to:
+
+```text
+warning OCSG001: Type 'DebugSettingsViewModel' is sealed and does not implement IShape, so OrchardCore can't create a proxy-based shape for this 'Initialize' call
+```
+
+**Ways to fix it:**
+
+- Remove the `sealed` modifier from the shape model.
+- Implement `IShape` on the model if it is intentionally a shape type.
+- Use a non-proxy pattern such as `View(...)`, `Copy(...)`, or `Dynamic(...)` when a proxy-backed shape is not required.
 
 
 ## Real-World Examples
@@ -146,6 +186,7 @@ public partial class MyData : PropertyBasedNamedEnumerable
 ```
 
 **Key Features:**
+
 - Extends `PropertyBasedNamedEnumerable` helper class that implements all `INamedEnumerable<object>` logic
 - Properties accessed directly via switch expression (no reflection)
 - Property names stored as static array
@@ -176,6 +217,7 @@ var shape = await factory.CreateAsync("MyShape", args);
 ```
 
 ### Benefits of Migration
+
 - ✅ **Better IntelliSense** - Strongly typed arguments with autocomplete
 - ✅ **Compile-time safety** - Typos caught at build time
 - ✅ **Reusability** - Named types can be reused across multiple shapes
@@ -204,6 +246,7 @@ return Arguments.From(
 ```
 
 This clever trick:
+
 1. Creates a "shape" instance with default values
 2. Compiler infers the anonymous type from the shape
 3. Casts the parameter to that type
@@ -232,6 +275,7 @@ obj/Debug/net10.0/generated/
 ### PropertyBasedNamedEnumerable Helper Class
 
 Generated classes extend this abstract base class which:
+
 - Implements all `INamedEnumerable<object>` members
 - Uses linear search for property lookups (simple and efficient for typical 2-15 properties)
 - Handles enumeration and collection operations
@@ -262,6 +306,7 @@ public bool TryGetValue(string key, out object value)
 **Why linear search?**
 
 For typical OrchardCore shape arguments (2-15 properties):
+
 - **Simplicity** - Easy to understand and maintain
 - **No allocation overhead** - No dictionary initialization unless needed
 - **Good cache locality** - Sequential memory access
@@ -333,6 +378,7 @@ Production code with reusable types?
 Generates `INamedEnumerable<object>` implementations for types marked with `[GenerateArguments]`.
 
 **What it generates:**
+
 - Extends `PropertyBasedNamedEnumerable` base class
 - Static property names array
 - Property count override
@@ -351,6 +397,14 @@ Intercepts `Arguments.From(anonymousType)` calls and optimizes them using type i
 **Status:** ✅ Stable (.NET 9+)
 
 **Generated Code Size:** ~20 lines per call site
+
+### SealedShapeTypeAnalyzer
+
+Reports `OCSG001` when a sealed non-`IShape` model is passed to OrchardCore APIs that create proxy-based strongly typed shapes.
+
+**Status:** ✅ Stable
+
+**Purpose:** Catch runtime Castle DynamicProxy failures at build time
 
 ## Advanced Usage
 


### PR DESCRIPTION
This pull request introduces a new Roslyn analyzer to the `OrchardCore.SourceGenerators` project that detects invalid usage of sealed types as proxy-based shapes, along with related documentation, release-process guidance, and project file updates. The analyzer helps catch runtime errors at build time by warning when a sealed class that does not implement `IShape` is used with proxy-based shape creation APIs. Documentation has been expanded to describe the analyzer and its warning, and minor code changes were made to support the analyzer.

**Analyzer and Diagnostic Infrastructure:**

* Added new analyzer `SealedShapeTypeAnalyzer` (`OCSG001`) to detect sealed types (not implementing `IShape`) used with proxy-based shape APIs, reporting a warning at build time to prevent runtime failures.
* Registered the new analyzer rule in `AnalyzerReleases.Unshipped.md` and included analyzer release files in the `.csproj` for proper packaging and tracking.

**Documentation Updates:**

* Expanded `README.md` to document the new analyzer, including explanation, example code, sample warning output, and remediation steps. Also added a new section on build-time analyzers and referenced `OCSG001` throughout the documentation.
* Updated `.github/ISSUE_TEMPLATE/release.md` and `.github/ISSUE_TEMPLATE/patch_release.md` to document how analyzer projects should move released entries from `AnalyzerReleases.Unshipped.md` to `AnalyzerReleases.Shipped.md` while keeping `AnalyzerReleases.Unshipped.md` for unreleased rules.

**Code Changes for Analyzer Testing:**

* Changed `DebugSettingsViewModel` from `sealed` to non-sealed in `DebugSettingsViewModel.cs` to ensure compatibility with proxy-based shape creation.