### PR TITLE
Fix CS0121 ambiguity in LocalizationOrchardHelperExtensions 

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Localization/Views/_ViewImports.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Localization/Views/_ViewImports.cshtml
@@ -3,4 +3,5 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, OrchardCore.DisplayManagement
 @addTagHelper *, OrchardCore.ResourceManagement
+@using OrchardCore.Localization
 @using OrchardCore.Localization.ViewModels

--- a/src/OrchardCore.Themes/TheAdmin/Views/_ViewImports.cshtml
+++ b/src/OrchardCore.Themes/TheAdmin/Views/_ViewImports.cshtml
@@ -8,3 +8,4 @@
 @using OrchardCore.Admin
 @using OrchardCore.Admin.Models
 @using OrchardCore.Entities
+@using OrchardCore.Localization

--- a/src/OrchardCore.Themes/TheTheme/Views/_ViewImports.cshtml
+++ b/src/OrchardCore.Themes/TheTheme/Views/_ViewImports.cshtml
@@ -7,4 +7,5 @@
 @using Microsoft.Extensions.Options
 @using OrchardCore.ContentManagement
 @using OrchardCore.ContentManagement.Routing
+@using OrchardCore.Localization
 @using OrchardCore.Menu.Models

--- a/src/OrchardCore/OrchardCore.Localization.Abstractions/LocalizationOrchardHelperExtensions.cs
+++ b/src/OrchardCore/OrchardCore.Localization.Abstractions/LocalizationOrchardHelperExtensions.cs
@@ -1,13 +1,12 @@
 using Microsoft.Extensions.DependencyInjection;
 using OrchardCore;
-using OrchardCore.Localization;
+
+namespace OrchardCore.Localization;
 
 /// <summary>
 /// Provides extension methods for <see cref="IOrchardHelper"/> related to JavaScript localization.
 /// </summary>
-#pragma warning disable CA1050 // Declare types in namespaces
 public static class LocalizationOrchardHelperExtensions
-#pragma warning restore CA1050 // Declare types in namespaces
 {
     /// <summary>
     /// Returns a merged dictionary of JavaScript localizations for the specified groups by aggregating all


### PR DESCRIPTION
by adding proper namespace

The class was intentionally placed in the global namespace to avoid requiring @using in Razor views, but the Razor SDK re-compiles global-namespace types into each module assembly (ContentFields, Html, Title), causing CS0121 ambiguity when consuming multiple OC NuGet packages in an external solution.

Moving to OrchardCore.Localization namespace eliminates the collision. Added @using OrchardCore.Localization to the Localization module, TheTheme, and TheAdmin _ViewImports.cshtml so theme and module views can call Orchard.GetJSLocalizations() without explicit using directives.

[repro.zip](https://github.com/user-attachments/files/29102401/repro.zip)
