### PR TITLE
Fix that IsEnabled was false negative (Lombiq Technologies: OCORE-270)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/DefaultSmtpOptionsConfiguration.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Email.Smtp/Services/DefaultSmtpOptionsConfiguration.cs
@@ -43,8 +43,13 @@ public sealed class DefaultSmtpOptionsConfiguration : IPostConfigureOptions<Defa
                 options.PickupDirectoryLocation = null;
                 _logger.LogCritical(e, "Unable to resolve default SMTP pickup directory location.");
             }
+            
+            options.IsEnabled = options.PickupDirectoryLocation is not null && options.ConfigurationExists();
         }
+        else
+        {
 
-        options.IsEnabled = options.PickupDirectoryLocation is not null && options.ConfigurationExists();
+            options.IsEnabled = options.ConfigurationExists();
+        }
     }
 }


### PR DESCRIPTION
Fixes #19385

When the DeliveryMethod is not SpecifiedPickupDirectory, it shouldn't matter that options.PickupDirectoryLocation is null because that setting is only relevant to the SpecifiedPickupDirectory delivery method.