### PR TITLE
Create _ViewImports.cshtml when using the CMS module project template

### DIFF
--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/template.json
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/.template.config.src/template.json
@@ -62,7 +62,6 @@
             "Settings/MyTestPartSettingsDisplayDriver.cs",
             "Settings/MyTestPartSettingsViewModel.cs",
             "ViewModels/MyTestPartViewModel.cs",
-            "Views/_ViewImports.cshtml",
             "Views/MyTestPart.Edit.cshtml",
             "Views/MyTestPart.liquid",
             "Views/MyTestPart_Summary.liquid",

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Views/MyTestPart.Edit.cshtml
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Views/MyTestPart.Edit.cshtml
@@ -1,4 +1,4 @@
-@model MyTestPartViewModel
+@model OrchardCore.Templates.Cms.Module.ViewModels.MyTestPartViewModel
 
 <div class="mb-3">
     <div class="form-check">

--- a/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Views/_ViewImports.cshtml
+++ b/src/Templates/OrchardCore.ProjectTemplates/content/OrchardCore.Templates.Cms.Module/Views/_ViewImports.cshtml
@@ -2,4 +2,3 @@
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, OrchardCore.DisplayManagement
 @addTagHelper *, OrchardCore.ResourceManagement
-@using OrchardCore.Templates.Cms.Module.ViewModels


### PR DESCRIPTION
Let the CMS module template always generate a `_ViewImports.cshtml`, even if no part is created.