### PR TITLE
Fix 2.2 to 3.0 search indexing migration gaps and document upgrade steps

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/Migrations/AzureAISearchIndexSettingsMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/Migrations/AzureAISearchIndexSettingsMigrations.cs
@@ -201,7 +201,7 @@ internal sealed class AzureAISearchIndexSettingsMigrations : DataMigration
                     {
                         var map = indexMapping.ToObject<AzureAISearchIndexMap>();
 
-                        if (azureMetadata.IndexMappings.Any(map => map.AzureFieldKey.EqualsOrdinalIgnoreCase(map.AzureFieldKey)))
+                        if (azureMetadata.IndexMappings.Any(existing => existing.AzureFieldKey.EqualsOrdinalIgnoreCase(map.AzureFieldKey)))
                         {
                             continue;
                         }

--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/Migrations/AzureAISearchIndexSettingsMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/Migrations/AzureAISearchIndexSettingsMigrations.cs
@@ -36,7 +36,12 @@ internal sealed class AzureAISearchIndexSettingsMigrations : DataMigration
 
     public static int Create()
     {
-        return 2;
+        // Return 1 (not the latest version) so that UpdateFrom1 runs and performs the conversion of legacy
+        // AzureAISearchIndexSettingsDocument data into the new index profile structure. Sites upgrading from a
+        // version that did not have this migration have no recorded version, so Create is invoked; returning the
+        // latest version here would skip UpdateFrom1 and the legacy indexes would never be migrated. For brand new
+        // installations UpdateFrom1 is a safe no-op because there is no legacy document to convert.
+        return 1;
     }
 
     public int UpdateFrom1()

--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/Migrations/PermissionMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/Migrations/PermissionMigrations.cs
@@ -1,0 +1,77 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.AzureAI;
+using OrchardCore.Data.Migration;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Scope;
+using OrchardCore.Indexing;
+using OrchardCore.Indexing.Core;
+using OrchardCore.Modules;
+using OrchardCore.Security;
+using OrchardCore.Security.Permissions;
+using OrchardCore.Security.Services;
+
+namespace OrchardCore.Search.AzureAI.Migrations;
+
+internal sealed class PermissionMigrations : DataMigration
+{
+    private const string PermissionNamePrefix = "QueryAzureAISearchIndex_";
+
+    private readonly ShellSettings _shellSettings;
+
+    public PermissionMigrations(ShellSettings shellSettings) =>
+        _shellSettings = shellSettings;
+
+    public int Create()
+    {
+        if (!_shellSettings.IsInitializing())
+        {
+            ShellScope.AddDeferredTask(ReplaceObsoletePermissionsAsync);
+        }
+
+        return 1;
+    }
+
+    /// <summary>
+    /// Selects the roles that need to be updated, and replaces their <c>QueryAzureAISearchIndex_{0}</c> permissions
+    /// with the equivalent <c>QueryIndex_{0}</c> permissions.
+    /// </summary>
+    private static async Task ReplaceObsoletePermissionsAsync(ShellScope shellScope)
+    {
+        var indexProfileManager = shellScope.ServiceProvider.GetRequiredService<IIndexProfileManager>();
+        var roleService = shellScope.ServiceProvider.GetRequiredService<IRoleService>();
+        var roleStore = shellScope.ServiceProvider.GetRequiredService<IRoleStore<IRole>>();
+
+        var allRoles = await roleService.GetRolesAsync();
+        var rolesToUpdate = allRoles
+            .Where(role => role is Role)
+            .Cast<Role>()
+            .Where(role => role.RoleClaims.Any(IsAzureAISearchIndexPermissionClaim))
+            .ToList();
+
+        foreach (var role in rolesToUpdate)
+        {
+            foreach (var claim in role.RoleClaims.Where(IsAzureAISearchIndexPermissionClaim))
+            {
+                var name = GetIndexNameFromPermissionName(claim.ClaimValue);
+                var indexProfile = await indexProfileManager.FindByNameAndProviderAsync(
+                    name,
+                    AzureAISearchConstants.ProviderName);
+
+                if (indexProfile != null)
+                {
+                    claim.ClaimValue = IndexingPermissions.CreateDynamicPermission(indexProfile).Name;
+                }
+            }
+
+            await roleStore.UpdateAsync(role, CancellationToken.None);
+        }
+    }
+
+    private static bool IsAzureAISearchIndexPermissionClaim(RoleClaim claim) =>
+        claim.ClaimType == nameof(Permission) &&
+        claim.ClaimValue.StartsWithOrdinalIgnoreCase(PermissionNamePrefix);
+
+    private static string GetIndexNameFromPermissionName(string permissionName) =>
+        permissionName[PermissionNamePrefix.Length..];
+}

--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/OrchardCore.AzureAI.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/OrchardCore.AzureAI.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Flows.Core\OrchardCore.Flows.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Module.Targets\OrchardCore.Module.Targets.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Roles.Abstractions\OrchardCore.Roles.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.AzureAI.Core\OrchardCore.AzureAI.Core.csproj" />
   </ItemGroup>
 

--- a/src/OrchardCore.Modules/OrchardCore.AzureAI/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.AzureAI/Startup.cs
@@ -40,6 +40,7 @@ public sealed class Startup : StartupBase
         services.AddAzureAISearchServices();
         services.AddSiteDisplayDriver<AzureAISearchDefaultSettingsDisplayDriver>();
         services.AddDataMigration<AzureAISearchIndexSettingsMigrations>();
+        services.AddDataMigration<PermissionMigrations>();
     }
 }
 

--- a/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Elasticsearch/Startup.cs
@@ -72,7 +72,6 @@ public sealed class Startup : StartupBase
         services.AddDisplayDriver<IndexProfile, ElasticsearchIndexProfileDisplayDriver>();
 
         services.AddIndexProfileHandler<ElasticsearchIndexProfileHandler>();
-        services.AddDataMigration<PermissionMigrations>();
     }
 }
 
@@ -100,6 +99,10 @@ public sealed class ContentsStartup : StartupBase
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddDataMigration<IndexingMigrations>();
+
+        // Register after IndexingMigrations so its deferred task, which rewrites obsolete per-index role
+        // permissions to the new dynamic permissions, runs after the index profiles have been created.
+        services.AddDataMigration<PermissionMigrations>();
 
         services
             .AddIndexProfileHandler<ElasticsearchContentIndexProfileHandler>()

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/DataMigrations/PermissionMigrations.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/DataMigrations/PermissionMigrations.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Data.Migration;
+using OrchardCore.Environment.Shell;
+using OrchardCore.Environment.Shell.Scope;
+using OrchardCore.Indexing;
+using OrchardCore.Indexing.Core;
+using OrchardCore.Lucene;
+using OrchardCore.Security;
+using OrchardCore.Security.Services;
+using static OrchardCore.Lucene.LuceneIndexPermissionHelper;
+
+namespace OrchardCore.Search.Lucene.DataMigrations;
+
+internal sealed class PermissionMigrations : DataMigration
+{
+    private readonly ShellSettings _shellSettings;
+
+    public PermissionMigrations(ShellSettings shellSettings) =>
+        _shellSettings = shellSettings;
+
+    public int Create()
+    {
+        if (!_shellSettings.IsInitializing())
+        {
+            ShellScope.AddDeferredTask(ReplaceObsoletePermissionsAsync);
+        }
+
+        return 1;
+    }
+
+    /// <summary>
+    /// Selects the roles that need to be updated, and replaces their <c>QueryLucene{0}Index</c> permissions with
+    /// the equivalent <c>QueryIndex_{0}</c> permissions.
+    /// </summary>
+    private static async Task ReplaceObsoletePermissionsAsync(ShellScope shellScope)
+    {
+        var indexProfileManager = shellScope.ServiceProvider.GetRequiredService<IIndexProfileManager>();
+        var roleService = shellScope.ServiceProvider.GetRequiredService<IRoleService>();
+        var roleStore = shellScope.ServiceProvider.GetRequiredService<IRoleStore<IRole>>();
+
+        var allRoles = await roleService.GetRolesAsync();
+        var rolesToUpdate = allRoles
+            .Where(role => role is Role)
+            .Cast<Role>()
+            .Where(role => role.RoleClaims.Any(IsLuceneIndexPermissionClaim))
+            .ToList();
+
+        foreach (var role in rolesToUpdate)
+        {
+            foreach (var claim in role.RoleClaims.Where(IsLuceneIndexPermissionClaim))
+            {
+                var name = GetIndexNameFromPermissionName(claim.ClaimValue);
+                var indexProfile = await indexProfileManager.FindByNameAndProviderAsync(
+                    name,
+                    LuceneConstants.ProviderName);
+
+                if (indexProfile != null)
+                {
+                    claim.ClaimValue = IndexingPermissions.CreateDynamicPermission(indexProfile).Name;
+                }
+            }
+
+            await roleStore.UpdateAsync(role, CancellationToken.None);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexPermissionHelper.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/LuceneIndexPermissionHelper.cs
@@ -1,10 +1,15 @@
 using System.Collections.Concurrent;
+using OrchardCore.Modules;
+using OrchardCore.Security;
 using OrchardCore.Security.Permissions;
 
 namespace OrchardCore.Lucene;
 
 public static class LuceneIndexPermissionHelper
 {
+    private const string PermissionNamePrefix = "QueryLucene";
+    private const string PermissionNameSuffix = "Index";
+
     private static readonly Permission _indexPermissionTemplate = new("QueryLucene{0}Index", "Query Lucene {0} Index", new[] { LuceneSearchPermissions.ManageLuceneIndexes });
 
     private static readonly ConcurrentDictionary<string, Permission> _permissions = [];
@@ -24,4 +29,12 @@ public static class LuceneIndexPermissionHelper
                 string.Format(_indexPermissionTemplate.Description, indexName),
                 _indexPermissionTemplate.ImpliedBy));
     }
+
+    internal static bool IsLuceneIndexPermissionClaim(RoleClaim claim) =>
+        claim.ClaimType == nameof(Permission) &&
+        claim.ClaimValue.StartsWithOrdinalIgnoreCase(PermissionNamePrefix) &&
+        claim.ClaimValue.EndsWithOrdinalIgnoreCase(PermissionNameSuffix);
+
+    internal static string GetIndexNameFromPermissionName(string permissionName) =>
+        permissionName[PermissionNamePrefix.Length..^PermissionNameSuffix.Length];
 }

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/OrchardCore.Lucene.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Navigation.Core\OrchardCore.Navigation.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Queries.Core\OrchardCore.Queries.Core.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Recipes.Abstractions\OrchardCore.Recipes.Abstractions.csproj" />
+    <ProjectReference Include="..\..\OrchardCore\OrchardCore.Roles.Abstractions\OrchardCore.Roles.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.ResourceManagement\OrchardCore.ResourceManagement.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Search.Abstractions\OrchardCore.Search.Abstractions.csproj" />
     <ProjectReference Include="..\..\OrchardCore\OrchardCore.Lucene.Core\OrchardCore.Lucene.Core.csproj" />

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
@@ -42,7 +42,6 @@ public sealed class Startup : StartupBase
         services.TryAddScoped<ILuceneSearchQueryService, LuceneSearchQueryService>();
         services.AddNavigationProvider<AdminMenu>();
         services.AddPermissionProvider<Permissions>();
-        services.AddDataMigration<PermissionMigrations>();
 
         services.Configure<LuceneOptions>(o =>
             o.Analyzers.Add(new LuceneAnalyzer(LuceneConstants.DefaultAnalyzer,
@@ -87,6 +86,10 @@ public sealed class ContentsStartup : StartupBase
     public override void ConfigureServices(IServiceCollection services)
     {
         services.AddDataMigration<IndexingMigrations>();
+
+        // Register after IndexingMigrations so its deferred task, which rewrites obsolete per-index role
+        // permissions to the new dynamic permissions, runs after the index profiles have been created.
+        services.AddDataMigration<PermissionMigrations>();
 
         services
             .AddIndexProfileHandler<LuceneContentIndexProfileHandler>()

--- a/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Lucene/Startup.cs
@@ -42,6 +42,7 @@ public sealed class Startup : StartupBase
         services.TryAddScoped<ILuceneSearchQueryService, LuceneSearchQueryService>();
         services.AddNavigationProvider<AdminMenu>();
         services.AddPermissionProvider<Permissions>();
+        services.AddDataMigration<PermissionMigrations>();
 
         services.Configure<LuceneOptions>(o =>
             o.Analyzers.Add(new LuceneAnalyzer(LuceneConstants.DefaultAnalyzer,

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -687,10 +687,12 @@ The following recipe steps were added to allow you to manage any index profile.
   * `ResetIndex` allows you to reset an index.
   * `RebuildIndex` allows you to rebuild an index.
 
-Search index-specific permissions were centralized into the Indexing module. Thus every index gets a dynamically created "Query 'index name' Index" permission. Use these to allow specific user roles to query the index, and thus also use the frontend search feature.
+Search index-specific permissions were centralized into the Indexing module. Thus every index gets a dynamically created "Query 'index name' Index" permission (named `QueryIndex_{index name}`). Use these to allow specific user roles to query the index, and thus also use the frontend search feature.
+
+The legacy per-provider query permissions (`QueryLucene{index name}Index`, `QueryElasticsearch{index name}Index`, and `QueryAzureAISearchIndex_{index name}`) are automatically migrated to the new `QueryIndex_{index name}` permission for the Lucene, Elasticsearch, and Azure AI Search providers during upgrade. Roles that were granted a per-index query permission keep their access without manual intervention.
 
 !!! warning
-    You need to update user roles and recipes to use the new permissions. If you e.g. allow Anonymous users to use the frontend search feature, not doing so will prevent such users from searching.
+    The automatic migration only converts permissions when the migrated index profile keeps the original index name. If an index name collided during the indexing migration (and was suffixed with a number to make it unique), the corresponding role permission is not migrated and must be re-assigned manually. Recipes that reference the old permission names still need to be updated to use the new `QueryIndex_{index name}` permission. If you e.g. allow Anonymous users to use the frontend search feature, not doing so will prevent such users from searching.
   
 #### Enhanced Multi-Source Indexing  
 
@@ -874,3 +876,44 @@ With the latest updates, you can now streamline this process using the `Configur
     } 
 }
 ```
+
+### Html, Markdown, and Content Fields Modules
+
+#### Liquid Rendering Decoupled from HTML Sanitization
+
+Previously, Liquid rendering in the `HtmlBodyPart`, `MarkdownBodyPart`, `HtmlField`, and `MarkdownField` was implicitly tied to HTML sanitization: Liquid was only rendered when sanitization was disabled. Liquid rendering is now controlled by a dedicated `RenderLiquid` setting that is independent of the `SanitizeHtml` setting.
+
+To preserve the existing behavior of upgraded sites, a migration initializes `RenderLiquid` to the opposite of `SanitizeHtml` for every content type that uses these parts and fields (`HtmlBodyPartSettings`, `MarkdownBodyPartSettings`, `HtmlFieldSettings`, and `MarkdownFieldSettings`). After upgrading you can enable or disable Liquid rendering and HTML sanitization independently from the part/field settings in the admin UI.
+
+### Forms Module
+
+#### Element Visibility
+
+The `Input`, `TextArea`, and `Select` form elements now include a new `FormInputElementVisibilityPart` that lets you configure advanced visibility rules for each element. The part is added automatically by a migration, so existing forms are not affected until you configure visibility rules.
+
+### Workflows Module
+
+#### Workflow Status Index Column
+
+The `WorkflowStatus` column of the `WorkflowIndex` table changed from a string to an integer to match the `WorkflowStatus` enum. A migration converts existing values (handling both numeric and enum-name representations) and recreates the `IDX_WorkflowIndex_DocumentId` index. If you query the `WorkflowIndex` table directly through raw SQL or custom `SqlQueries`, update those queries to compare `WorkflowStatus` against the integer value of the enum instead of its name.
+
+### HTTPS Module
+
+#### Strict Transport Security Mode
+
+The boolean `HttpsSettings.EnableStrictTransportSecurity` setting was replaced by the `HttpsSettings.StrictTransportSecurityMode` setting, which uses the `HttpStrictTransportSecurityMode` enum (`Disabled` or `Enabled`). A migration converts the stored boolean to the equivalent mode and removes the obsolete key. The `EnableStrictTransportSecurity` property is kept as obsolete only to support the migration and will be removed in a future release.
+
+### OpenID Module
+
+#### Pushed Authorization Requests (PAR)
+
+Support for [Pushed Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9126) was added. During upgrade, a migration:
+
+- Grants the pushed authorization endpoint permission to every existing application that already has the authorization endpoint permission, so confidential and public clients that use the authorization endpoint can continue to work when PAR is required.
+- Enables the pushed authorization endpoint at `/connect/par` in the OpenID server settings, but only when the OpenID server feature has already been configured (via a recipe or the admin UI) and no pushed authorization endpoint path has been set.
+
+If you do not want the pushed authorization endpoint enabled, review your OpenID server settings and per-application permissions after upgrading.
+
+### Audit Trail Module
+
+The `UserId` column of the audit trail index was widened from 26 to 255 characters to support longer user identifiers. The migration is skipped on SQLite, where text columns are not length-constrained.

--- a/src/docs/releases/3.0.0.md
+++ b/src/docs/releases/3.0.0.md
@@ -261,6 +261,8 @@ The default search settings were changed to require a default index ID instead o
 
 With the improvement done to the Indexing module, managing Azure AI Search indexes is now part of the indexing module. This change reduced the code complexity and simplify the user experience since we now have one UI for all indexes. Another advantage is that we are now able to add data sources other than contents.
 
+When upgrading, the Azure AI Search index settings created in a previous version are automatically converted to the new index profile structure, so existing indexes remain available under the new **Indexes** interface without manual reconfiguration.
+
 ### Lucene Module  
 
 With the improvement done to the Indexing module, managing Lucene indexes is now part of the indexing module. This change reduced the code complexity and simplify the user experience since we now have one UI for all indexes. Another advantage is that we are now able to add data sources other than contents.


### PR DESCRIPTION
## Why

While auditing the upgrade path from the latest 2.x (`release/2.2`) to the upcoming 3.0 (`main`), I found two migration defects that cause silent data/configuration loss for existing search installations, plus several behavior changes that were not covered by the 3.0.0 release notes. These would block or surprise users upgrading sites that use Lucene, Azure AI Search, or Elasticsearch.

## What changed

**Bug fixes**

- **Azure AI Search field mappings dropped on upgrade.** In `AzureAISearchIndexSettingsMigrations`, the dedup check used a lambda parameter (`map`) that shadowed the outer loop variable, so it compared every element to itself. The condition was always true once the list had one entry, so every field mapping after the first was skipped. A migrated index ended up with a single mapping instead of all of them. Fixed the predicate to compare against the new candidate (`existing => existing.AzureFieldKey.EqualsOrdinalIgnoreCase(map.AzureFieldKey)`).

- **Lucene and Azure AI per-index query permissions were not migrated.** 2.2 used per-provider permissions (`QueryLucene{name}Index`, `QueryAzureAISearchIndex_{name}`, `QueryElasticsearch{name}Index`). 3.0 centralizes these into `QueryIndex_{name}`, but only Elasticsearch shipped a `PermissionMigrations` to rewrite role claims. As a result, roles (including Anonymous) lost frontend search authorization on Lucene and Azure AI indexes after upgrade. This PR adds equivalent `PermissionMigrations` for both providers, mirroring the Elasticsearch implementation, along with the claim-detection helpers, DI registrations, and the `OrchardCore.Roles.Abstractions` project references they require.

**Documentation (`src/docs/releases/3.0.0.md`)**

Documented the previously missing migrations and behavior changes:

- Per-provider query permission auto-migration, including the name-collision caveat.
- Liquid rendering decoupled from HTML sanitization (`RenderLiquid` vs `SanitizeHtml`).
- New Forms `FormInputElementVisibilityPart`.
- `WorkflowIndex.WorkflowStatus` index column changed from string to int.
- HSTS bool setting replaced by `StrictTransportSecurityMode` enum.
- OpenID Pushed Authorization Requests auto-enable (`/connect/par` plus per-app permission grant).
- AuditTrail `UserId` column widened from 26 to 255.

## Notes for reviewers

- The new permission migrations, like the existing Elasticsearch one, only match when the migrated index profile keeps its original name. If an index name collided during the indexing migration and was suffixed with a number, that single role permission is not migrated. I documented this caveat in the release notes rather than adding collision tracking, to stay consistent with the existing Elasticsearch behavior. Open to adding collision handling to all three providers if preferred.
- There is still no automated test that opens a real 2.2 database with 3.0 binaries; the existing `MigrationsTests` is a fresh-setup recipe test. A true cross-version upgrade fixture would be valuable but is a larger effort outside this PR's scope.

## Testing

- `dotnet build` of the affected modules and the full `OrchardCore.Cms.Web` project succeeds with 0 errors.