### PR TITLE
Fix ambiguous string.Join overload in Features.cshtml

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -117,7 +117,7 @@
                             .Where(d => !Model.Features.Any(f => f.Descriptor.Id == d.Id));
                         var showDisable = !feature.Descriptor.EnabledByDependencyOnly && !isAlwaysEnabled && categoryName != "Core" && featureName != Application.ModuleName;
                         var showEnable = !feature.Descriptor.EnabledByDependencyOnly && !missingDependencies.Any() && featureId != "OrchardCore.Setup" && featureId != "OrchardCore.AutoSetup";
-                        var featureSearchText = string.Join(" ", [
+                        var featureSearchText = string.Join(" ", (string[])[
                             categoryName,
                             featureName,
                             featureId,

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -117,14 +117,13 @@
                             .Where(d => !Model.Features.Any(f => f.Descriptor.Id == d.Id));
                         var showDisable = !feature.Descriptor.EnabledByDependencyOnly && !isAlwaysEnabled && categoryName != "Core" && featureName != Application.ModuleName;
                         var showEnable = !feature.Descriptor.EnabledByDependencyOnly && !missingDependencies.Any() && featureId != "OrchardCore.Setup" && featureId != "OrchardCore.AutoSetup";
-                        var featureSearchText = string.Join(" ", (string[])[
+                        var featureSearchText = string.Join(" ",
                             categoryName,
                             featureName,
                             featureId,
                             feature.Descriptor.Description ?? string.Empty,
                             dependenciesNames,
-                            string.Join(" ", missingDependencies.Select(d => d.Id)),
-                        ]);
+                            string.Join(" ", missingDependencies.Select(d => d.Id)));
 
                         <li class="list-group-item"
                             data-search-text="@featureSearchText"


### PR DESCRIPTION
Cast collection expression to string[] to resolve ambiguity between ReadOnlySpan<object?> and ReadOnlySpan<string?> overloads introduced in newer .NET versions.

<!--- Please make sure that you're familiar with our contribution guidelines before submitting a pull request: https://docs.orchardcore.net/en/latest/contributing/. -->
