### PR TITLE
Ensure that Liquid template context is initialized (Lombiq Technologies: OCORE-273)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
@@ -35,7 +35,7 @@ public class DisplayUrlFilter : ILiquidFilter
 
     public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
     {
-        if (_httpContextAccessor.HttpContext == null)
+        if (_httpContextAccessor.HttpContext is not { } httpContext)
         {
             return new StringValue(string.Empty);
         }
@@ -64,7 +64,7 @@ public class DisplayUrlFilter : ILiquidFilter
         // LinkGenerator is less accurate so only use it if a view context couldn't be produced. 
         var linkUrl = context.ViewContext is ActionContext actionContext
             ? _urlHelperFactory.GetUrlHelper(actionContext).RouteUrl(routeValues)
-            : _linkGenerator.GetPathByRouteValues(_httpContextAccessor.HttpContext, string.Empty, routeValues);
+            : _linkGenerator.GetPathByRouteValues(httpContext, string.Empty, routeValues);
 
         return new StringValue(linkUrl);
     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
@@ -62,7 +62,7 @@ public class DisplayUrlFilter : ILiquidFilter
         }
 
         // LinkGenerator is less accurate so only use it if a view context couldn't be produced. 
-        var linkUrl = context.ViewContext is ActionContext actionContext
+        var linkUrl = context.ViewContext is ActionContext { RouteData.Routers.Count: > 0 } actionContext
             ? _urlHelperFactory.GetUrlHelper(actionContext).RouteUrl(routeValues)
             : _linkGenerator.GetPathByRouteValues(httpContext, string.Empty, routeValues);
 

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
@@ -61,9 +61,10 @@ public class DisplayUrlFilter : ILiquidFilter
             routeValues = contentItemMetadata.DisplayRouteValues;
         }
 
-        var urlHelper = _urlHelperFactory.GetUrlHelper(context.ViewContext);
-
-        var linkUrl = urlHelper.RouteUrl(routeValues);
+        // LinkGenerator is less accurate so only use it if a view context couldn't be produced. 
+        var linkUrl = context.ViewContext is ActionContext actionContext
+            ? _urlHelperFactory.GetUrlHelper(actionContext).RouteUrl(routeValues)
+            : _linkGenerator.GetPathByRouteValues(_httpContextAccessor.HttpContext, string.Empty, routeValues);
 
         return new StringValue(linkUrl);
     }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs
@@ -1,5 +1,6 @@
 using Fluid;
 using Fluid.Values;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Routing;
@@ -14,17 +15,31 @@ public class DisplayUrlFilter : ILiquidFilter
 {
     private readonly AutorouteOptions _autorouteOptions;
     private readonly IContentManager _contentManager;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly LinkGenerator _linkGenerator;
     private readonly IUrlHelperFactory _urlHelperFactory;
 
-    public DisplayUrlFilter(IOptions<AutorouteOptions> autorouteOptions, IContentManager contentManager, IUrlHelperFactory urlHelperFactory)
+    public DisplayUrlFilter(
+        IOptions<AutorouteOptions> autorouteOptions,
+        IContentManager contentManager,
+        IHttpContextAccessor httpContextAccessor,
+        LinkGenerator linkGenerator,
+        IUrlHelperFactory urlHelperFactory)
     {
         _autorouteOptions = autorouteOptions.Value;
         _contentManager = contentManager;
+        _httpContextAccessor = httpContextAccessor;
+        _linkGenerator = linkGenerator;
         _urlHelperFactory = urlHelperFactory;
     }
 
     public async ValueTask<FluidValue> ProcessAsync(FluidValue input, FilterArguments arguments, LiquidTemplateContext context)
     {
+        if (_httpContextAccessor.HttpContext == null)
+        {
+            return new StringValue(string.Empty);
+        }
+
         var contentItem = input.ToObjectValue() as ContentItem;
         RouteValueDictionary routeValues;
 

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Handlers/LiquidViewTemplateWorkflowExecutionContextHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Handlers/LiquidViewTemplateWorkflowExecutionContextHandler.cs
@@ -11,9 +11,9 @@ public class LiquidViewTemplateWorkflowExecutionContextHandler : WorkflowExecuti
 {
     public override async Task EvaluatingExpressionAsync(WorkflowExecutionExpressionContext context)
     {
-        if (context.TemplateContext is LiquidTemplateContext liquidTemplateContext &&
-            liquidTemplateContext.Services.GetRequiredService<ViewContextAccessor>()?.ViewContext is { } viewContext)
+        if (context.TemplateContext is LiquidTemplateContext liquidTemplateContext)
         {
+            var viewContext = liquidTemplateContext.Services.GetRequiredService<ViewContextAccessor>()?.ViewContext;
             await liquidTemplateContext.InitializeAsync(viewContext);
         }
     }

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Handlers/LiquidViewTemplateWorkflowExecutionContextHandler.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Handlers/LiquidViewTemplateWorkflowExecutionContextHandler.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.DisplayManagement;
+using OrchardCore.DisplayManagement.Liquid;
+using OrchardCore.Liquid;
+using OrchardCore.Workflows.Models;
+using OrchardCore.Workflows.Services;
+
+namespace OrchardCore.Workflows.Handlers;
+
+public class LiquidViewTemplateWorkflowExecutionContextHandler : WorkflowExecutionContextHandlerBase
+{
+    public override async Task EvaluatingExpressionAsync(WorkflowExecutionExpressionContext context)
+    {
+        if (context.TemplateContext is LiquidTemplateContext liquidTemplateContext &&
+            liquidTemplateContext.Services.GetRequiredService<ViewContextAccessor>()?.ViewContext is { } viewContext)
+        {
+            await liquidTemplateContext.InitializeAsync(viewContext);
+        }
+    }
+}

--- a/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
+++ b/src/OrchardCore.Modules/OrchardCore.Workflows/Startup.cs
@@ -107,3 +107,12 @@ public sealed class SessionStartup : StartupBase
         services.AddActivity<CommitTransactionTask, CommitTransactionTaskDisplayDriver>();
     }
 }
+
+[Feature("OrchardCore.Liquid")]
+public sealed class LiquidStartup : StartupBase
+{
+    public override void ConfigureServices(IServiceCollection services)
+    {
+        services.AddScoped<IWorkflowExecutionContextHandler, LiquidViewTemplateWorkflowExecutionContextHandler>();
+    }
+}

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -185,7 +185,7 @@ public static class LiquidViewTemplateExtensions
 
 public static class LiquidTemplateContextExtensions
 {
-    internal static async ValueTask EnterScopeAsync(this LiquidTemplateContext context, ViewContext viewContext, object model)
+    public static async ValueTask InitializeAsync(this LiquidTemplateContext context, ViewContext viewContext)
     {
         if (!context.IsInitialized)
         {

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -189,6 +189,14 @@ public static class LiquidTemplateContextExtensions
     {
         if (!context.IsInitialized)
         {
+            // Try to create fallback view context if none exists. This only works if an HTTP context is available.
+            if (viewContext == null &&
+                context.Services.GetRequiredService<IHttpContextAccessor>().HttpContext is { } httpContext &&
+                await httpContext.GetActionContextAsync() is { } actionContext)
+            {
+                viewContext = LiquidViewTemplateExtensions.GetViewContext(actionContext);
+            }
+            
             var localClock = context.Services.GetRequiredService<ILocalClock>();
 
             // Configure Fluid with the time zone to represent local date and times

--- a/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
+++ b/src/OrchardCore/OrchardCore.DisplayManagement.Liquid/LiquidViewTemplate.cs
@@ -210,6 +210,11 @@ public static class LiquidTemplateContextExtensions
 
             context.IsInitialized = true;
         }
+    }
+    
+    internal static async ValueTask EnterScopeAsync(this LiquidTemplateContext context, ViewContext viewContext, object model)
+    {
+        await context.InitializeAsync(viewContext);
 
         context.EnterChildScope();
 


### PR DESCRIPTION
Fixes #19394

The problem is that the `LiquidTemplateContext.ViewContext` was null and the `display_url` filter [relies on that value](https://github.com/OrchardCMS/OrchardCore/blob/33b5343aa906ee4f55d087affb5d85b2a842742c/src/OrchardCore.Modules/OrchardCore.Contents/Liquid/DisplayUrlFilter.cs#L49) to create an `IUrlHelper` instance so it kept crashing with NRE. This `LiquidTemplateContext.ViewContext` is initialized by the `EnterScopeAsync` extension method in all other usage besides workflows, but it's an `internal` method so I've extracted its initialization logic into a separate extension that can called from an `IWorkflowExecutionContextHandler` event to ensure that Liquid rendering works correctly in workflows too.