### PR TITLE
Update font weight classes to use Bootstrap 5 naming fw-*

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/DashboardWidget-ContentsMetadata.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/DashboardWidget-ContentsMetadata.DetailAdmin.cshtml
@@ -18,7 +18,7 @@
 
     if (contentItem.ModifiedUtc.HasValue)
     {
-        <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: contentItem.ModifiedUtc, Format: "g"))">
+        <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: contentItem.ModifiedUtc, Format: "g"))">
             <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i> <time datetime="@modifiedUtc">@await DisplayAsync(await New.Timespan(Utc: contentItem.ModifiedUtc))</time>
         </span>
     }

--- a/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/DashboardWidget-ContentsTags.DetailAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AdminDashboard/Views/DashboardWidget-ContentsTags.DetailAdmin.cshtml
@@ -10,14 +10,14 @@
 
 @if (hasPublished)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Status"]">
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Status"]">
         <i class="fa-solid fa-check text-success" aria-hidden="true"></i> @T["Published"]
     </span>
 }
 
 @if (hasDraft)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Status"]">
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Status"]">
         <i class="fa-solid fa-pencil text-primary" aria-hidden="true"></i> @T["Draft"]
     </span>
 }

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailEventMeta.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailEventMeta.SummaryAdmin.cshtml
@@ -5,7 +5,7 @@
     var createdUtc = Model.AuditTrailEvent.CreatedUtc.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture);
 }
 
-<span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.AuditTrailEvent.CreatedUtc, Format: "g"))">
+<span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.AuditTrailEvent.CreatedUtc, Format: "g"))">
     <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i> <time datetime="@createdUtc">@await DisplayAsync(await New.Timespan(Utc: Model.AuditTrailEvent.CreatedUtc))</time>
 </span>
 
@@ -13,7 +13,7 @@
 
 @if (!string.IsNullOrEmpty(Model.AuditTrailEvent.ClientIpAddress))
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Client IP Address"]">
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Client IP Address"]">
         <i class="fa-solid fa-wifi text-secondary me-1" aria-hidden="true"></i>@Model.AuditTrailEvent.ClientIpAddress
     </span>
 }

--- a/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailEventTags.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.AuditTrail/Views/AuditTrailEventTags.SummaryAdmin.cshtml
@@ -1,12 +1,12 @@
 @model AuditTrailEventViewModel
 
-<span class="badge ta-badge font-weight-normal">
+<span class="badge ta-badge fw-normal">
     <i class="fa-solid fa-history text-secondary" aria-hidden="true"></i>
     <a href="?q=category:@Model.Descriptor.Category" data-bs-toggle="tooltip"
        title="@T["Category"]">@Model.Descriptor.LocalizedCategory(Context.RequestServices)</a>
 </span>
 
-<span class="badge ta-badge font-weight-normal">
+<span class="badge ta-badge fw-normal">
     <i class="fa-solid fa-bolt text-secondary" aria-hidden="true"></i>
     <a href="?q=event:@Model.Descriptor.Name" data-bs-toggle="tooltip"
        title="@T["Event Name"]">@Model.Descriptor.LocalizedName(Context.RequestServices)</a>

--- a/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/LocalizationPart.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentLocalization/Views/LocalizationPart.SummaryAdmin.cshtml
@@ -2,5 +2,5 @@
 
 @if (Model.LocalizationPart.Culture != null)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Culture"]"><i class="fa-solid fa-globe text-info" aria-hidden="true"></i> @Model.LocalizationPart.Culture</span>
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Culture"]"><i class="fa-solid fa-globe text-info" aria-hidden="true"></i> @Model.LocalizationPart.Culture</span>
 }

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Admin/Edit.cshtml
@@ -112,11 +112,11 @@
 
                                 @if (!string.IsNullOrEmpty(fieldDefinition.DisplayMode()))
                                 {
-                                    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fa-solid fa-tv text-info" aria-hidden="true"></i> @fieldDefinition.DisplayMode()</span>
+                                    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fa-solid fa-tv text-info" aria-hidden="true"></i> @fieldDefinition.DisplayMode()</span>
                                 }
                                 @if (!string.IsNullOrEmpty(fieldDefinition.Editor()))
                                 {
-                                    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa-solid fa-pen-to-square text-info" aria-hidden="true"></i> @fieldDefinition.Editor()</span>
+                                    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa-solid fa-pen-to-square text-info" aria-hidden="true"></i> @fieldDefinition.Editor()</span>
                                 }
                             </div>
                             <input type="hidden" asp-for="OrderedFieldNames" value="@fieldDefinition.Name" />
@@ -178,11 +178,11 @@
 
                             @if (!string.IsNullOrEmpty(partDefinition.DisplayMode()))
                             {
-                                <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fa-solid fa-tv text-info" aria-hidden="true"></i> @partDefinition.DisplayMode()</span>
+                                <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Display mode"]"><i class="fa-solid fa-tv text-info" aria-hidden="true"></i> @partDefinition.DisplayMode()</span>
                             }
                             @if (!string.IsNullOrEmpty(partDefinition.Editor()))
                             {
-                                <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa-solid fa-pen-to-square text-info" aria-hidden="true"></i> @partDefinition.Editor()</span>
+                                <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Editor"]"><i class="fa-solid fa-pen-to-square text-info" aria-hidden="true"></i> @partDefinition.Editor()</span>
                             }
                         </div>
                         <input type="hidden" asp-for="OrderedPartNames" value="@partDefinition.Name" />

--- a/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Shared/DisplayTemplates/EditTypeViewModel.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.ContentTypes/Views/Shared/DisplayTemplates/EditTypeViewModel.cshtml
@@ -11,11 +11,11 @@
     <div class="me-auto">
         <a asp-route-action="Edit" asp-route-area="OrchardCore.ContentTypes" asp-route-id="@Model.Name">@localizedDisplayName</a>
 
-        <span class="badge rounded-pill ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Technical Name"]"><i class="fa-solid fa-file-alt text-danger" aria-hidden="true"></i> @Model.Name</span>
+        <span class="badge rounded-pill ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Technical Name"]"><i class="fa-solid fa-file-alt text-danger" aria-hidden="true"></i> @Model.Name</span>
 
         @if (!string.IsNullOrWhiteSpace(settings.Stereotype))
         {
-            <span class="badge rounded-pill ta-badge font-weight-normal" data-bs-toggle="tooltip" title="Stereotype"><i class="fa-solid fa-file text-info" aria-hidden="true"></i> @settings.Stereotype</span>
+            <span class="badge rounded-pill ta-badge fw-normal" data-bs-toggle="tooltip" title="Stereotype"><i class="fa-solid fa-file text-info" aria-hidden="true"></i> @settings.Stereotype</span>
         }
     </div>
     <div>

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/Content.SummaryAdmin.cshtml
@@ -32,7 +32,7 @@
                 }
             </div>
             <div class="contenttype me-1">
-                <span class="badge ta-badge font-weight-normal"><i class="fa-regular fa-file-alt text-secondary" aria-hidden="true"></i> <a asp-route-options.selectedcontenttype=@contentItem.ContentType data-bs-toggle="tooltip" title="@T["Content type"]">@contentItem.ContentType</a></span>
+                <span class="badge ta-badge fw-normal"><i class="fa-regular fa-file-alt text-secondary" aria-hidden="true"></i> <a asp-route-options.selectedcontenttype=@contentItem.ContentType data-bs-toggle="tooltip" title="@T["Content type"]">@contentItem.ContentType</a></span>
             </div>
             @if (Model.Header != null)
             {

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsMeta_SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsMeta_SummaryAdmin.cshtml
@@ -7,7 +7,7 @@
 
 @if (contentItem.ModifiedUtc.HasValue)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: contentItem.ModifiedUtc, Format: "g"))">
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: contentItem.ModifiedUtc, Format: "g"))">
         <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i> <time datetime="@modifiedUtc">@await DisplayAsync(await New.Timespan(Utc: contentItem.ModifiedUtc))</time>
     </span>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsTags_SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Contents/Views/ContentsTags_SummaryAdmin.cshtml
@@ -8,14 +8,14 @@
 }
 @if (hasPublished)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Status"]">
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Status"]">
         <i class="fa-solid fa-check text-success" aria-hidden="true"></i> @T["Published"]
     </span>
 }
 
 @if (hasDraft)
 {
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["Status"]">
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["Status"]">
         <i class="fa-solid fa-pencil text-primary" aria-hidden="true"></i> @T["Draft"]
     </span>
 }

--- a/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Features/Views/Admin/Features.cshtml
@@ -159,7 +159,7 @@
                                                         .Select(f => f.Descriptor.Name)
                                                         .FirstOrDefault() ?? string.Empty;
 
-                                                    <span class="badge ta-badge font-weight-normal">
+                                                    <span class="badge ta-badge fw-normal">
                                                         @dependencyName
                                                     </span>
                                                 }

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/Views/IndexProfile.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/Views/IndexProfile.DefaultMeta.SummaryAdmin.cshtml
@@ -8,7 +8,7 @@
     var createdAt = Model.Value.CreatedUtc.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture);
 }
 
-<span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.CreatedUtc, Format: "g"))">
+<span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.CreatedUtc, Format: "g"))">
     <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i>
     <time datetime="@createdAt">@await DisplayAsync(await New.Timespan(Utc: Model.Value.CreatedUtc))</time>
 </span>

--- a/src/OrchardCore.Modules/OrchardCore.Indexing/Views/IndexProfile.DefaultTags.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Indexing/Views/IndexProfile.DefaultTags.SummaryAdmin.cshtml
@@ -3,10 +3,10 @@
 
 @model ShapeViewModel<IndexProfile>
 
-<span class="badge ta-badge bg-warning-subtle font-weight-normal" data-bs-toggle="tooltip" title="@T["Provider"]">
+<span class="badge ta-badge bg-warning-subtle fw-normal" data-bs-toggle="tooltip" title="@T["Provider"]">
     <i class="text-secondary me-1" aria-hidden="true"></i>@Model.Value.ProviderName
 </span>
 
-<span class="badge ta-badge bg-primary-subtle font-weight-normal" data-bs-toggle="tooltip" title="@T["Type"]">
+<span class="badge ta-badge bg-primary-subtle fw-normal" data-bs-toggle="tooltip" title="@T["Type"]">
     <i class="text-secondary me-1" aria-hidden="true"></i>@Model.Value.Type
 </span>

--- a/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsMeta_SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Notifications/Views/NotificationsMeta_SummaryAdmin.cshtml
@@ -3,6 +3,6 @@
 @using OrchardCore.ContentManagement
 @using System.Globalization
 
-<span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Notification.CreatedUtc, Format: "g"))">
+<span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Notification.CreatedUtc, Format: "g"))">
     <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i> <time datetime="@Model.Notification.CreatedUtc.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture)">@await DisplayAsync(await New.Timespan(Utc: Model.Notification.CreatedUtc))</time>
 </span>

--- a/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Index.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Roles/Views/Admin/Index.cshtml
@@ -36,7 +36,7 @@
 
                         @if (entry.IsSystemRole)
                         {
-                            <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@T["The '{0}' role cannot be deleted.", entry.Name]">
+                            <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@T["The '{0}' role cannot be deleted.", entry.Name]">
                                 <i class="fa-solid fa-shield text-secondary me-1" aria-hidden="true"></i>@T["System"]
                             </span>
                         }

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/ManageTenantActionTags.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/ManageTenantActionTags.cshtml
@@ -7,33 +7,33 @@
 <a class="text-break" href="@ViewContext.HttpContext.GetEncodedUrl(Model.Value)">@Model.Value.Name</a>
 @if (!string.IsNullOrEmpty(Model.Value.Category))
 {
-    <span class="badge ta-badge font-weight-normal"><i class="fa-solid fa-tag text-info" aria-hidden="true"></i> @Model.Value.Category</span>
+    <span class="badge ta-badge fw-normal"><i class="fa-solid fa-tag text-info" aria-hidden="true"></i> @Model.Value.Category</span>
 }
 @if (!string.IsNullOrEmpty(Model.Value.ShellSettings["DatabaseProvider"]))
 {
-    <span class="badge ta-badge font-weight-normal"><i class="fa-solid fa-database text-info" aria-hidden="true"></i> @Model.Value.ShellSettings["DatabaseProvider"]</span>
+    <span class="badge ta-badge fw-normal"><i class="fa-solid fa-database text-info" aria-hidden="true"></i> @Model.Value.ShellSettings["DatabaseProvider"]</span>
 }
 @if (!string.IsNullOrEmpty(Model.Value.ShellSettings["RecipeName"]))
 {
-    <span class="badge ta-badge font-weight-normal"><i class="fa-solid fa-image text-info" aria-hidden="true"></i> @Model.Value.ShellSettings["RecipeName"]</span>
+    <span class="badge ta-badge fw-normal"><i class="fa-solid fa-image text-info" aria-hidden="true"></i> @Model.Value.ShellSettings["RecipeName"]</span>
 }
 <a asp-controller="Admin" asp-action="Index" asp-route-Options.Status="@Model.Value.ShellSettings.State">
     @switch (Model.Value.ShellSettings.State)
     {
         case TenantState.Uninitialized:
-            <span class="badge ta-badge font-weight-normal"><i class="fa-solid fa-gear text-secondary" aria-hidden="true"></i> @T["Uninitialized"]</span>
+            <span class="badge ta-badge fw-normal"><i class="fa-solid fa-gear text-secondary" aria-hidden="true"></i> @T["Uninitialized"]</span>
             break;
         case TenantState.Initializing:
-            <span class="badge ta-badge font-weight-normal"><i class="fa-solid fa-hourglass-start text-info" aria-hidden="true"></i> @T["Initializing"]</span>
+            <span class="badge ta-badge fw-normal"><i class="fa-solid fa-hourglass-start text-info" aria-hidden="true"></i> @T["Initializing"]</span>
             break;
         case TenantState.Running:
-            <span class="badge ta-badge font-weight-normal"><i class="fa-solid fa-check text-success" aria-hidden="true"></i> @T["Running"]</span>
+            <span class="badge ta-badge fw-normal"><i class="fa-solid fa-check text-success" aria-hidden="true"></i> @T["Running"]</span>
             break;
         case TenantState.Disabled:
-            <span class="badge ta-badge font-weight-normal"><i class="fa-solid fa-xmark text-danger" aria-hidden="true"></i> @T["Disabled"]</span>
+            <span class="badge ta-badge fw-normal"><i class="fa-solid fa-xmark text-danger" aria-hidden="true"></i> @T["Disabled"]</span>
             break;
         case TenantState.Invalid:
-            <span class="badge ta-badge font-weight-normal"><i class="fa-solid fa-triangle-exclamation text-warning" aria-hidden="true"></i> @T["Invalid"]</span>
+            <span class="badge ta-badge fw-normal"><i class="fa-solid fa-triangle-exclamation text-warning" aria-hidden="true"></i> @T["Invalid"]</span>
             break;
     }
 </a>

--- a/src/OrchardCore.Modules/OrchardCore.Tenants/Views/ProfileFeatureTags.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Tenants/Views/ProfileFeatureTags.cshtml
@@ -21,5 +21,5 @@
 
 @foreach (var featureProfile in featureProfiles)
 {
-    <span class="badge ta-badge font-weight-normal" title="@T["Feature Profile"]"><i class="fa-solid fa-layer-group text-info" aria-hidden="true"></i> @featureProfile.Name</span>
+    <span class="badge ta-badge fw-normal" title="@T["Feature Profile"]"><i class="fa-solid fa-layer-group text-info" aria-hidden="true"></i> @featureProfile.Name</span>
 }

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/RewriteRule.DefaultMeta.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/RewriteRule.DefaultMeta.SummaryAdmin.cshtml
@@ -8,7 +8,7 @@
     var createdAt = Model.Value.CreatedUtc.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture);
 }
 
-<span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.CreatedUtc, Format: "g"))">
+<span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@await DisplayAsync(await New.DateTime(Utc: Model.Value.CreatedUtc, Format: "g"))">
     <i class="fa-solid fa-calendar text-secondary" aria-hidden="true"></i> <time datetime="@createdAt">@await DisplayAsync(await New.Timespan(Utc: Model.Value.CreatedUtc))</time>
 </span>
 

--- a/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/RewriteRule.DefaultTags.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.UrlRewriting/Views/RewriteRule.DefaultTags.SummaryAdmin.cshtml
@@ -3,6 +3,6 @@
 
 @model ShapeViewModel<RewriteRule>
 
-<span class="badge ta-badge bg-warning-subtle font-weight-normal" data-bs-toggle="tooltip" title="@T["Source"]">
+<span class="badge ta-badge bg-warning-subtle fw-normal" data-bs-toggle="tooltip" title="@T["Source"]">
     <i class="text-secondary me-1" aria-hidden="true"></i>@Model.Value.Source
 </span>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserDisplayName.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserDisplayName.SummaryAdmin.cshtml
@@ -1,4 +1,4 @@
-<span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@Model.Title">
+<span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@Model.Title">
     @await DisplayAsAsync(Model, "UserDisplayNameIcon")
     @await DisplayAsAsync(Model, "UserDisplayNameText")
 </span>

--- a/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenuItems-SignedUser.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Users/Views/UserMenuItems-SignedUser.cshtml
@@ -1,6 +1,6 @@
 <li>
     <h6 class="dropdown-header">
-        @T["Signed in as"] <span class="font-weight-bold">@User.Identity.Name</span>
+        @T["Signed in as"] <span class="fw-bold">@User.Identity.Name</span>
     </h6>
 </li>
 <li>

--- a/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.SummaryAdmin.cshtml
+++ b/src/OrchardCore.Modules/OrchardCore.Widgets/Views/Widget.SummaryAdmin.cshtml
@@ -19,7 +19,7 @@
                 }
             </div>
             <div class="contenttype me-1">
-                <span class="badge ta-badge font-weight-normal">
+                <span class="badge ta-badge fw-normal">
                     <i class="fa-regular fa-file-alt text-secondary" aria-hidden="true"></i> @contentItem.ContentType
                 </span>
             </div>

--- a/src/docs/reference/modules/Templates/README.md
+++ b/src/docs/reference/modules/Templates/README.md
@@ -735,7 +735,7 @@ This morphing behavior allows you to customize the icon and text independently b
 === "Razor"
 
     ```cshtml
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="@Model.Title">
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="@Model.Title">
         @await DisplayAsAsync(Model, "UserDisplayNameIcon")
         @await DisplayAsAsync(Model, "UserDisplayNameText")
     </span>
@@ -744,7 +744,7 @@ This morphing behavior allows you to customize the icon and text independently b
 === "Liquid"
 
     ```liquid
-    <span class="badge ta-badge font-weight-normal" data-bs-toggle="tooltip" title="{{ Model.Title }}">
+    <span class="badge ta-badge fw-normal" data-bs-toggle="tooltip" title="{{ Model.Title }}">
         {{ "UserDisplayNameIcon" | shape_new | shape_render }}
         {{ "UserDisplayNameText" | shape_new | shape_render }}
     </span>
@@ -940,7 +940,7 @@ Create a user-specific template for a particular username (e.g., for user "admin
     **Filename:** `UserDisplayName-admin.SummaryAdmin.cshtml`
 
     ```cshtml
-    <span class="badge ta-badge font-weight-normal text-danger" data-bs-toggle="tooltip" title="@Model.Title">
+    <span class="badge ta-badge fw-normal text-danger" data-bs-toggle="tooltip" title="@Model.Title">
         <i class="fa-solid fa-user-shield" aria-hidden="true"></i>
         <strong>@Model.UserName</strong>
     </span>
@@ -951,7 +951,7 @@ Create a user-specific template for a particular username (e.g., for user "admin
     **Filename:** `UserDisplayName-admin.SummaryAdmin.liquid`
 
     ```liquid
-    <span class="badge ta-badge font-weight-normal text-danger" data-bs-toggle="tooltip" title="{{ Model.Title }}">
+    <span class="badge ta-badge fw-normal text-danger" data-bs-toggle="tooltip" title="{{ Model.Title }}">
         <i class="fa-solid fa-user-shield" aria-hidden="true"></i>
         <strong>{{ Model.UserName }}</strong>
     </span>


### PR DESCRIPTION
Replaced all `font-weight-*` classes with `fw-*` across Razor views and documentation for Bootstrap 5 compatibility and consistent styling.

**Note:** An alternative approach would be to remove these classes entirely, as they have been undefined for several years. However, updating them to the correct Bootstrap 5 equivalents may affect the current appearance of the admin dashboard.

Fixes #19408