### PR TITLE
Ship OCSG001 analyzer rule in 3.0 release

### DIFF
--- a/src/OrchardCore/OrchardCore.SourceGenerators/AnalyzerReleases.Shipped.md
+++ b/src/OrchardCore/OrchardCore.SourceGenerators/AnalyzerReleases.Shipped.md
@@ -1,0 +1,7 @@
+## Release 3.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|--------------------
+OCSG001 | Usage    | Warning  | SealedShapeTypeAnalyzer, [Documentation](https://docs.orchardcore.net/en/latest/topics/source-generators/#ocsg001-sealed-types-cant-be-used-as-proxy-based-shapes)

--- a/src/OrchardCore/OrchardCore.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/OrchardCore/OrchardCore.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -1,5 +1,0 @@
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|--------------------
-OCSG001 | Usage    | Warning  | SealedShapeTypeAnalyzer


### PR DESCRIPTION
Move OCSG001 from Unshipped to Shipped in AnalyzerReleases, marking it as officially released in 3.0 and adding its documentation link.

/cc @hishamco 