### PR TITLE
GraphQL UserPicker field exposes user Email/PhoneNumber without authorization (Lombiq Technologies: OCORE-248)

### DIFF
--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/UserPickerFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/UserPickerFieldQueryObjectType.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.ContentFields.Fields;
-using OrchardCore.ContentManagement;
 using OrchardCore.Users.GraphQL;
 using OrchardCore.Users.Indexes;
 using OrchardCore.Users.Models;
@@ -23,10 +22,7 @@ public class UserPickerFieldQueryObjectType : ObjectGraphType<UserPickerField>
         Field<ListGraphType<StringGraphType>, IEnumerable<string>>("userIds")
             .Description(S["user ids"])
             .PagingArguments()
-            .Resolve(resolve =>
-            {
-                return resolve.Page(resolve.Source.UserIds);
-            });
+            .Resolve(resolve => resolve.Page(resolve.Source.UserIds));
 
         Field<ListGraphType<UserType>, IEnumerable<User>>("users")
             .Description(S["the user items"])

--- a/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/UserPickerFieldQueryObjectType.cs
+++ b/src/OrchardCore.Modules/OrchardCore.ContentFields/GraphQL/Types/UserPickerFieldQueryObjectType.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using OrchardCore.Apis.GraphQL;
 using OrchardCore.ContentFields.Fields;
+using OrchardCore.Users;
 using OrchardCore.Users.GraphQL;
 using OrchardCore.Users.Indexes;
 using OrchardCore.Users.Models;
@@ -27,6 +28,7 @@ public class UserPickerFieldQueryObjectType : ObjectGraphType<UserPickerField>
         Field<ListGraphType<UserType>, IEnumerable<User>>("users")
             .Description(S["the user items"])
             .PagingArguments()
+            .RequirePermission(UsersPermissions.ViewUsers)
             .ResolveAsync(resolve =>
             {
                 var userLoader = GetOrAddUserProfileByIdDataLoader(resolve);


### PR DESCRIPTION
The `UserPickerField` GraphQL type returns referenced users through the shared `UserType`, which can contain sensitive data like phone number and anything in the custom user fields (this topic has also came up during #17507). I think it would be good to have a more granular solution in the long term, but for the time being it's important to have a permission requirement for accessing data about these users.

## Example Reproduction

1. Set up site with Blog recipe.
2. Go to Admin > Access Controll > Roles > Anonymous > Edit.
3. Check the "Execute GraphQL." permission and save.
4. Go to Admin > Design > Content Definition > Content Types > Blog Post.
5. Click Add Field and add a User Picker called "Reviewer".
6. Go to Admin > Blog, edit the blog posts, assign a user to the new Reviewer field.
7. Go to Admin > Tools > GraphiQL and paste the code below:
    ```graphql
    query MyQuery {
      blogPost {
        reviewer {
          users {
            userName
            email
            phoneNumber
            UserInfo {
              birthDate
            }
          }
        }
      }
    }
    ````
8. Click the ">" button and observe the response.
9. Open a terminal and paste this code (assumes you have `curl` and `python` installed; also note that it's an anonymous/unauthenticated query):
    ```bash
    curl 'https://localhost:5001/api/graphql?culture=en-US' \
      -k \
      -X POST \
      -H 'Accept: application/json' \
      -H 'Content-Type: application/json' \
      -d '{"query":"query MyQuery { blogPost { reviewer { users { userName email phoneNumber UserInfo { birthDate }}}}}","operationName":"MyQuery"}' | python -m json.tool
    ```

In `main` branch you will get the same results as from GraphiQL, in this branch you get the following error instead:
```json
{
    "errors": [
        {
            "message": "Authorization is required to access the node. users",
            "locations": [
                {
                    "line": 1,
                    "column": 39
                }
            ],
            "extensions": {
                "code": "VALIDATION_ERROR",
                "codes": [
                    "VALIDATION_ERROR"
                ],
                "number": "Unauthorized",
                "details": "GraphQL.Validation.ValidationError: Authorization is required to access the node. users"
            }
        }
    ]
}
```

## Acknowledgement

Originally reported by Kevin Bozell (https://github.com/bozellqp/kbozell).